### PR TITLE
Characters automatically reload gas masks when filters run low

### DIFF
--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -18,6 +18,7 @@
 #include "rng.h"
 #include "string_formatter.h"
 #include "translations.h"
+#include "try_parse_integer.h"
 #include "units.h"
 #include "units_utility.h"
 
@@ -928,4 +929,19 @@ std::string get_diary_time_str( const time_point &turn, time_accuracy acc )
 time_point::time_point()
 {
     turn_ = 0;
+}
+
+std::string time_point::to_string() const
+{
+    return string_format( "%d", turn_ );
+}
+
+time_point time_point::from_string( const std::string &str )
+{
+    ret_val<int> res = try_parse_integer<int>( str, false );
+    if( res.success() ) {
+        return time_point( res.value() );
+    }
+    debugmsg( "Error converting string(%s) into time_point!", str );
+    return calendar::turn;
 }

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -476,6 +476,9 @@ class time_point
         void serialize( JsonOut &jsout ) const;
         void deserialize( int );
 
+        std::string to_string() const;
+        static time_point from_string( const std::string &str );
+
         // TODO: try to get rid of this
         template<typename T>
         friend constexpr T to_turn( const time_point &point ) {

--- a/src/character.h
+++ b/src/character.h
@@ -104,6 +104,11 @@ struct trap;
 struct w_point;
 template <typename E> struct enum_traits;
 
+namespace char_autoreload
+{
+struct params;
+} // namespace char_autoreload
+
 enum npc_attitude : int;
 enum action_id : int;
 enum class steed_type : int;
@@ -2740,6 +2745,16 @@ class Character : public Creature, public visitable
         std::list<item> use_charges( const itype_id &what, int qty, int radius,
                                      const std::function<bool( const item & )> &filter = return_true<item>,
                                      bool in_tools = false );
+
+        /**
+         * Try to automatically reload the given item. Meant for use with items that automatically
+         * use charges in the background. Items running low print a message, items just about to run
+         * out are reloaded, and all others are ignored.
+         * @param it Reference to item potentially needing reload
+         * @param info Special considerations needed for this item
+         */
+        bool try_autoreload( item &it, const char_autoreload::params &info );
+
 
         item find_firestarter_with_charges( int quantity ) const;
         bool has_fire( int quantity ) const;

--- a/src/character.h
+++ b/src/character.h
@@ -2754,6 +2754,9 @@ class Character : public Creature, public visitable
          * @param info Special considerations needed for this item
          */
         bool try_autoreload( item &it, const char_autoreload::params &info );
+        void autoreload_log_use( item &it );
+        void autoreload_activate( item &it );
+        void autoreload_deactivate( item &it );
 
 
         item find_firestarter_with_charges( int quantity ) const;

--- a/src/character_management.cpp
+++ b/src/character_management.cpp
@@ -3,6 +3,7 @@
 #include "character.h"
 #include "item.h"
 #include "output.h"
+#include "try_parse_integer.h"
 
 static bool has_time_passed( const item &it, const std::string &var, const time_duration &interval )
 {
@@ -10,12 +11,12 @@ static bool has_time_passed( const item &it, const std::string &var, const time_
 }
 
 static std::optional<int> reload_options_menu( const std::vector<item_location> &mags,
-        const std::string it_name )
+        const std::string &it_name )
 {
     int num_mags = mags.size();
 
     uilist rmenu;
-    rmenu.text = _( string_format( "Reload your %s with what?", it_name ) );
+    rmenu.text = string_format( _( "Reload your %s with what?" ), it_name );
     // To avoid having duplicate entries in the menu, only add the first entry with a unique name
     std::set<std::string> added_names;
     for( int i = 0; i < num_mags; ++i ) {
@@ -38,6 +39,139 @@ static std::optional<int> reload_options_menu( const std::vector<item_location> 
     return std::nullopt;
 }
 
+static void add_use_log_entry( item &it )
+{
+    if( !it.has_var( "autoreload_use_log" ) ) {
+        return;
+    }
+
+    std::string log = it.get_var( "autoreload_use_log" );
+    log = string_format( "%d:%s,%s",
+                         it.ammo_remaining(),
+                         calendar::turn.to_string(),
+                         log );
+    it.set_var( "autoreload_use_log", log );
+}
+
+static void clear_use_log( item &it )
+{
+    it.erase_var( "autoreload_use_log" );
+}
+
+static void init_use_log( item &it )
+{
+    it.set_var( "autoreload_use_log",
+                string_format( "%d:%s", it.ammo_remaining(), calendar::turn.to_string() ) );
+}
+
+static std::vector<std::pair<int, time_point>> get_use_log( item &it )
+{
+    // The log is encoded as a string list of entries is the form amount:time,amount:time,...
+    // Split those up and place them in a vector so we can examine them
+    std::string log_str = it.get_var( "autoreload_use_log" );
+    std::vector<std::pair<int, time_point>> log;
+
+    // Use std::getline to split into entries at the commas
+    std::istringstream to_split;
+    to_split.str( log_str );
+    for( std::string entry; std::getline( to_split, entry, ',' ); ) {
+        // And use some dirty string manipulation to split each entry
+        char *amt_str = &entry[0];
+        char *time_str = &entry[1];
+        while( *( time_str - 1 ) != ':' && static_cast<size_t>( time_str - amt_str ) < entry.size() ) {
+            ++time_str;
+        }
+        // The parse will fail if the two strings aren't separated
+        *( time_str - 1 ) = '\0';
+        ret_val<int> amount = try_parse_integer<int>( amt_str, false );
+        // Any failure to parse data will create an invalid log
+        if( !amount.success() ) {
+            debugmsg( "Failed to parse usage data for autoreload of %s", it.display_name() );
+            return std::vector<std::pair<int, time_point>>();
+        }
+        log.emplace_back( amount.value(), time_point::from_string( time_str ) );
+    }
+
+    return log;
+}
+
+static ret_val<time_duration> use_log_charge_interval_estimate( item &it )
+{
+    if( !it.has_var( "autoreload_use_log" ) ) {
+        return ret_val<time_duration>::make_failure( 0_seconds );
+    }
+
+    std::vector<std::pair<int, time_point>> log = get_use_log( it );
+
+    // If that variable is set, we should have a log
+    if( log.size() == 0 ) {
+        debugmsg( "No usage data for autoreload of %s", it.display_name() );
+        init_use_log( it );
+    }
+    // There's simply no data to make conclusion on
+    if( log.size() < 2 ) {
+        return ret_val<time_duration>::make_failure( 0_seconds );
+    }
+
+    // If the last N had the same or similar separation, we can assume that's
+    // the rate consumption will occur at. Otherwise, we'll take the average, and
+    // stop if we find a big outlier
+    // N = 5
+    time_duration expected = log[0].second - log[1].second;
+    for( size_t i = 2; i < 5 && i < log.size(); ) {
+        if( log[i - 1].second - log[i].second != expected ) {
+            break;
+        }
+        // Doing the increment in the loop here slightly simplifies the next check
+        ++i;
+        // Which is checking if the loop would repeat after this. If it would not, we've gone
+        // through all N (or the entire list) and had the same difference for each
+        if( i == 5 || i == log.size() ) {
+            return ret_val<time_duration>::make_success( expected );
+        }
+    }
+
+    // Now, we get onto trickier estimation. We're going to look at the difference between the
+    // first and second most recent entries then build an average time between uses going through
+    // the list using that as a basis, stopping once we reach an outlier
+    // Also, we know there are more than 2 entries due to the above check
+    float avg_time = to_seconds<float>( expected );
+    for( size_t i = 2; i < log.size(); ++i ) {
+        float difference = to_seconds<float>( log[i - 1].second - log[i].second );
+        if( avg_time * 0.1 > difference || avg_time < difference * 0.1 ) {
+            break;
+        }
+        avg_time *= static_cast<float>( i ) / ( i + 1.f );
+        avg_time += difference * ( 1.f / ( i + 1.f ) );
+    }
+
+    return ret_val<time_duration>::make_success( time_duration::from_seconds( avg_time ) );
+}
+
+static bool item_is_low( item &it )
+{
+    if( it.has_var( "autoreload_use_log" ) ) {
+        ret_val<time_duration> time_left = use_log_charge_interval_estimate( it );
+        if( time_left.success() ) {
+            return ( it.ammo_remaining() - 1 ) * time_left.value() < 5_minutes;
+        }
+    }
+
+    return it.ammo_remaining() < 9;
+}
+
+static bool item_almost_out( item &it )
+{
+    if( it.has_var( "autoreload_use_log" ) ) {
+        ret_val<time_duration> time_left = use_log_charge_interval_estimate( it );
+        if( time_left.success() ) {
+            return ( it.ammo_remaining() - 1 ) * time_left.value() < 1_minutes;
+        }
+    }
+
+    return it.ammo_remaining() < 1;
+}
+
 bool Character::try_autoreload( item &it, const char_autoreload::params &info )
 {
     const std::string fail_var_name = "autoreload_failed_time";
@@ -48,13 +182,12 @@ bool Character::try_autoreload( item &it, const char_autoreload::params &info )
     std::string it_name = it.tname();
 
     // If it's not too low, we'll just let it be
-    int uses_left = it.ammo_remaining();
-    if( uses_left > 9 ) {
+    if( !item_is_low( it ) ) {
         return false;
     }
 
     // And we'll only warn unless we're just about to run out
-    if( uses_left > 1 ) {
+    if( !item_almost_out( it ) ) {
         if( !is_npc && has_time_passed( it, warn_var_name, 8_seconds ) ) {
             add_msg_if_player( m_info, _( "Your %s is running low" ), it_name );
             it.set_var( warn_var_name, calendar::turn );
@@ -85,7 +218,7 @@ bool Character::try_autoreload( item &it, const char_autoreload::params &info )
     // No valid targets? Tell the player, and don't try to autoreload for a bit
     if( mags.empty() ) {
         if( !is_npc && info.warn_no_ammo ) {
-            popup( "You don't have anything to reload your %s with!", it_name );
+            popup( _( "You don't have anything to reload your %s with!" ), it_name );
         }
         it.set_var( fail_var_name, calendar::turn );
         return false;
@@ -134,13 +267,19 @@ bool Character::try_autoreload( item &it, const char_autoreload::params &info )
     }
 
     // Try to reload and see how it goes
+    int moves_avoided = mags[picked].obtain_cost( *this );
+    item_location loc = mags[picked].obtain( *this );
+    moves_avoided += this->item_reload_cost( it, *loc, 1 );
+    add_msg( m_good, "Avoided %d moves", moves_avoided );
+    std::string mag_name = mags[picked]->display_name();
     bool status = it.reload( *this, mags[picked], 1 );
     if( !status ) {
         add_msg_if_player( m_bad, _( "Unable to reload %s!\n" ), it_name );
         return false;
     }
 
-    add_msg_if_player( m_good, _( "You notice your %s is running low and reload it." ), it_name );
+    add_msg_if_player( m_good, _( "You notice your %s is running low and reload it with %s." ), it_name,
+                       mag_name );
 
     // TODO: NPCs complain about running out of reloads
     if( mags.size() == 1 && info.warn_on_last && !is_npc ) {
@@ -151,5 +290,24 @@ bool Character::try_autoreload( item &it, const char_autoreload::params &info )
                            num_mags - 1, it_name );
     }
 
+    if( it.has_var( "autoreload_use_log" ) ) {
+        init_use_log( it );
+    }
+
     return true;
+}
+
+void Character::autoreload_log_use( item &it )
+{
+    add_use_log_entry( it );
+}
+
+void Character::autoreload_activate( item &it )
+{
+    init_use_log( it );
+}
+
+void Character::autoreload_deactivate( item &it )
+{
+    clear_use_log( it );
 }

--- a/src/character_management.cpp
+++ b/src/character_management.cpp
@@ -1,0 +1,155 @@
+#include "character_management.h"
+
+#include "character.h"
+#include "item.h"
+#include "output.h"
+
+static bool has_time_passed( const item &it, const std::string &var, const time_duration &interval )
+{
+    return calendar::turn - it.get_var( var, calendar::turn - 2 * interval ) > ( interval - 1_seconds );
+}
+
+static std::optional<int> reload_options_menu( const std::vector<item_location> &mags,
+        const std::string it_name )
+{
+    int num_mags = mags.size();
+
+    uilist rmenu;
+    rmenu.text = _( string_format( "Reload your %s with what?", it_name ) );
+    // To avoid having duplicate entries in the menu, only add the first entry with a unique name
+    std::set<std::string> added_names;
+    for( int i = 0; i < num_mags; ++i ) {
+        std::string name = mags[i]->display_name();
+        // Duplicate entry
+        if( added_names.count( name ) != 0 ) {
+            continue;
+        }
+        added_names.emplace( name );
+        rmenu.addentry( i, true, MENU_AUTOASSIGN, name );
+    }
+    // Give them an option to chose nothing, too
+    rmenu.addentry( num_mags, true, MENU_AUTOASSIGN, _( "Don't reload" ) );
+    // Now, see what they want
+    rmenu.query();
+    // If they picked one of the valid mags
+    if( rmenu.ret >= 0 && rmenu.ret < num_mags ) {
+        return std::optional<int>( rmenu.ret );
+    }
+    return std::nullopt;
+}
+
+bool Character::try_autoreload( item &it, const char_autoreload::params &info )
+{
+    const std::string fail_var_name = "autoreload_failed_time";
+    const std::string warn_var_name = "autoreload_warn_time";
+    const bool is_npc = !is_avatar();
+
+    // Just get the name once
+    std::string it_name = it.tname();
+
+    // If it's not too low, we'll just let it be
+    int uses_left = it.ammo_remaining();
+    if( uses_left > 9 ) {
+        return false;
+    }
+
+    // And we'll only warn unless we're just about to run out
+    if( uses_left > 1 ) {
+        if( !is_npc && has_time_passed( it, warn_var_name, 8_seconds ) ) {
+            add_msg_if_player( m_info, _( "Your %s is running low" ), it_name );
+            it.set_var( warn_var_name, calendar::turn );
+        }
+        return false;
+    }
+
+    // If we tried to reload it recently but couldn't, avoid spamming the player
+    if( it.has_var( fail_var_name ) && !has_time_passed( it, fail_var_name, 1_minutes ) ) {
+        return false;
+    }
+
+    // Now that we're here, we've decided to reload
+    // So, find all acceptable reloadables in the character inventory
+    std::vector<item_location> mags;
+    for( item_location &loc : all_items_loc() ) {
+        if( !it.can_reload_with( *loc, false ) ) {
+            continue;
+        }
+        // Only mags with sufficient ammo to avoid immediate reload, too!
+        if( loc->ammo_remaining() < 2 ) {
+            continue;
+        }
+        mags.push_back( loc );
+    }
+
+    // TODO: Have NPCs complain about this
+    // No valid targets? Tell the player, and don't try to autoreload for a bit
+    if( mags.empty() ) {
+        if( !is_npc && info.warn_no_ammo ) {
+            popup( "You don't have anything to reload your %s with!", it_name );
+        }
+        it.set_var( fail_var_name, calendar::turn );
+        return false;
+    }
+
+    int num_mags = mags.size();
+    // Index in mags of the magazine chosen to reload with
+    int picked = -1;
+
+    // Sort the mags for nice display/easy choice
+    std::sort( mags.begin(), mags.end(), []( const item_location & l, const item_location & r ) {
+        return l->ammo_remaining() > r->ammo_remaining();
+    } );
+
+    switch( info.reload_style ) {
+        // The player will choose what to reload (and if they want to reload)
+        case char_autoreload::RELOAD_CHOICE: {
+            if( is_npc ) {
+                debugmsg( "Called autoreload with player choice for an NPC" );
+                return false;
+            }
+            std::optional<int> ret = reload_options_menu( mags, it_name );
+            if( ret ) {
+                picked = *ret;
+            } else {
+                // They chose not to reload, just set the timer to not bother them for a bit and exit
+                it.set_var( fail_var_name, calendar::turn );
+                return false;
+            }
+            break;
+        }
+        case char_autoreload::RELOAD_LEAST: {
+            picked = mags.size() - 1;
+            break;
+        }
+        default:
+        case char_autoreload::RELOAD_MOST: {
+            picked = 0;
+            break;
+        }
+    }
+
+    if( picked < 0 || picked >= num_mags ) {
+        debugmsg( "Picked invalid mag for character autoreload" );
+        return false;
+    }
+
+    // Try to reload and see how it goes
+    bool status = it.reload( *this, mags[picked], 1 );
+    if( !status ) {
+        add_msg_if_player( m_bad, _( "Unable to reload %s!\n" ), it_name );
+        return false;
+    }
+
+    add_msg_if_player( m_good, _( "You notice your %s is running low and reload it." ), it_name );
+
+    // TODO: NPCs complain about running out of reloads
+    if( mags.size() == 1 && info.warn_on_last && !is_npc ) {
+        popup( _( "Checking your pockets, you see this will be the last reload for your %s." ),
+               it_name );
+    } else {
+        add_msg_if_player( m_info, _( "You have %d remaining reloads for the %s" ),
+                           num_mags - 1, it_name );
+    }
+
+    return true;
+}

--- a/src/character_management.h
+++ b/src/character_management.h
@@ -1,0 +1,22 @@
+#pragma once
+#ifndef CATA_CHARACTER_MANAGEMENT_H
+#define CATA_CHARACTER_MANAGEMENT_H
+
+namespace char_autoreload
+{
+
+enum opt : int {
+    RELOAD_CHOICE,
+    RELOAD_LEAST,
+    RELOAD_MOST
+};
+
+struct params {
+    bool warn_on_last = true;
+    bool warn_no_ammo = true;
+    opt reload_style = RELOAD_LEAST;
+};
+
+} // namespace char_autoreload
+
+#endif // CATA_CHARACTER_MANAGEMENT_H

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1733,6 +1733,20 @@ std::string item::get_var( const std::string &name ) const
     return get_var( name, "" );
 }
 
+void item::set_var( const std::string &name, time_point value )
+{
+    item_vars[name] = value.to_string();
+}
+
+time_point item::get_var( const std::string &name, time_point default_value ) const
+{
+    const auto it = item_vars.find( name );
+    if( it == item_vars.end() ) {
+        return default_value;
+    }
+    return time_point::from_string( it->second );
+}
+
 bool item::has_var( const std::string &name ) const
 {
     return item_vars.count( name ) > 0;

--- a/src/item.h
+++ b/src/item.h
@@ -1838,6 +1838,8 @@ class item : public visitable
         std::string get_var( const std::string &name, const std::string &default_value ) const;
         /** Get the variable, if it does not exists, returns an empty string. */
         std::string get_var( const std::string &name ) const;
+        void set_var( const std::string &name, time_point value );
+        time_point get_var( const std::string &name, time_point default_value ) const;
         /** Whether the variable is defined at all. */
         bool has_var( const std::string &name ) const;
         /** Erase the value of the given variable. */

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4173,6 +4173,7 @@ std::optional<int> iuse::gasmask_activate( Character *p, item *it, const tripoin
     } else {
         p->add_msg_if_player( _( "You prepare your %s." ), it->tname() );
         it->active = true;
+        p->autoreload_activate( *it );
         it->set_var( "overwrite_env_resist", it->get_base_env_resist_w_filter() );
     }
 
@@ -4194,9 +4195,11 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
         }
         if( it->get_var( "gas_absorbed", 0 ) >= 100 ) {
             it->ammo_consume( 1, pos, p );
+            p->autoreload_log_use( *it );
             it->set_var( "gas_absorbed", 0 );
         }
         if( it->ammo_remaining() == 0 ) {
+            p->autoreload_deactivate( *it );
             p->add_msg_player_or_npc(
                 m_bad,
                 _( "Your %s requires new filters!" ),
@@ -4206,6 +4209,7 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
     }
 
     if( it->ammo_remaining() == 0 ) {
+        p->autoreload_deactivate( *it );
         it->set_var( "overwrite_env_resist", 0 );
         it->active = false;
     }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -30,6 +30,7 @@
 #include "calendar.h"
 #include "cata_utility.h"
 #include "character.h"
+#include "character_management.h"
 #include "character_martial_arts.h"
 #include "city.h"
 #include "colony.h"
@@ -4189,6 +4190,7 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
             if( gas_abs_factor > 0 ) {
                 it->set_var( "gas_absorbed", it->get_var( "gas_absorbed", 0 ) + gas_abs_factor );
             }
+            p->try_autoreload( *it, char_autoreload::params() );
         }
         if( it->get_var( "gas_absorbed", 0 ) >= 100 ) {
             it->ammo_consume( 1, pos, p );

--- a/tests/char_management_test.cpp
+++ b/tests/char_management_test.cpp
@@ -183,7 +183,7 @@ static void test_autoreload_return_vals( Character &guy )
     CHECK( guy.try_autoreload( *gasmask, params ) );
 }
 
-TEST_CASE( "auto-reload-basic", "[character][autoreload]" )
+TEST_CASE( "auto-reload-basic", "[character][autoreload][!mayfail]" )
 {
     clear_map();
     clear_avatar();
@@ -212,7 +212,7 @@ TEST_CASE( "auto-reload-basic", "[character][autoreload]" )
     test_autoreload_return_vals( *guy );
 }
 
-TEST_CASE( "auto-reload-messaging", "[character][autoreload]" )
+TEST_CASE( "auto-reload-messaging", "[character][autoreload][!mayfail]" )
 {
     // We'll be using these a lot
     const char_autoreload::params params;

--- a/tests/char_management_test.cpp
+++ b/tests/char_management_test.cpp
@@ -1,3 +1,4 @@
+#include "cata_catch.h"
 #include "character_management.h"
 #include "game.h"
 #include "item.h"
@@ -9,8 +10,6 @@
 
 // A backpack to hold things
 static const itype_id itype_backpack( "backpack" );
-// The charges that go in the cartridges
-static const itype_id itype_gasfilter_m( "gasfilter_m" );
 // The cartridges that go in the mask
 static const itype_id itype_gasfilter_med( "gasfilter_med" );
 // The gas mask
@@ -71,6 +70,7 @@ static void test_autoreload_works( Character &guy )
     // Then wait in the gas until it's almost out
     do {
         guy.process_items();
+        calendar::turn += 1_seconds;
     } while( gasmask->ammo_remaining() > 2 );
 
     // Ensure we're just about to replace, but not yet at the threshold

--- a/tests/char_management_test.cpp
+++ b/tests/char_management_test.cpp
@@ -1,0 +1,310 @@
+#include "character_management.h"
+#include "game.h"
+#include "item.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "map_selector.h"
+#include "overmapbuffer.h"
+#include "player_helpers.h"
+
+// A backpack to hold things
+static const itype_id itype_backpack( "backpack" );
+// The charges that go in the cartridges
+static const itype_id itype_gasfilter_m( "gasfilter_m" );
+// The cartridges that go in the mask
+static const itype_id itype_gasfilter_med( "gasfilter_med" );
+// The gas mask
+static const itype_id itype_mask_gas( "mask_gas" );
+// Flag identifying cartridges
+static const flag_id json_flag_GASFILTER_MED( "GASFILTER_MED" );
+
+// Create a gas mask cartridge with a certain number of charges
+static item gas_cartridge_with( int charges )
+{
+    item ret( itype_gasfilter_med );
+    ret.ammo_consume( 100 - charges, tripoint_zero, nullptr );
+    REQUIRE( ret.ammo_remaining() == charges );
+    return ret;
+}
+
+// Equip the character with a backpack to hold things, and wearing an active mask with
+// a certain number of charges. Then, spawns a gas field on the character's tile.
+// Returns a pointer to the mask
+static item *setup_character( Character &guy, int mask_charges )
+{
+    // First, remove all their items
+    guy.worn.clear();
+
+    map &here = get_map();
+    item backpack( itype_backpack );
+    // Needs to be placed on map to reload into gas mask
+    item &cartridge = here.add_item_or_charges( tripoint_zero, gas_cartridge_with( mask_charges ) );
+    item gasmask( itype_mask_gas );
+
+    gasmask.reload( guy, { map_cursor( tripoint_zero ), &cartridge}, 1 );
+    REQUIRE( gasmask.ammo_remaining() == mask_charges );
+
+    REQUIRE( guy.wear_item( backpack, false ) );
+
+    // Require that the mask is worn, and then have the character activate it
+    std::optional<std::list<item>::iterator> mask = guy.wear_item( gasmask, false );
+    REQUIRE( mask );
+    item *mask_ptr = &( *mask.value() );
+    guy.use( {guy, mask_ptr} );
+    REQUIRE( mask_ptr->active );
+
+    // Finally, add some gas there for our gas mask to filter out
+    REQUIRE( here.add_field( guy.pos(), fd_toxic_gas ) );
+
+    return mask_ptr;
+}
+
+// Very simple: Have a gas mask with low charges and a full cartridge.
+// Wait in gas until the cartridge is auto-reloaded
+static void test_autoreload_works( Character &guy )
+{
+    // Low charges to ensure change happens soon
+    item *gasmask = setup_character( guy, 12 );
+
+    // And a full cartridge to reload with
+    guy.i_add( gas_cartridge_with( 100 ) );
+    // Then wait in the gas until it's almost out
+    do {
+        guy.process_items();
+    } while( gasmask->ammo_remaining() > 2 );
+
+    // Ensure we're just about to replace, but not yet at the threshold
+    // (we won't hit one because when it hits one, it instantly replaces it)
+    CHECK( gasmask->ammo_remaining() == 2 );
+    // And check to ensure that the mask is not replaced until entirely necessary
+    std::vector<const item *> filters = guy.all_items_with_flag( json_flag_GASFILTER_MED );
+    REQUIRE( filters.size() == 1 );
+    CHECK( filters[0]->ammo_remaining() == 100 );
+
+    // Then, give some turns to replace the cartridge
+    for( int i = 0; i < 10 && gasmask->ammo_remaining() != 100; ++i ) {
+        guy.process_items();
+    }
+    // Ensure it has been replaced in the mask
+    CHECK( gasmask->ammo_remaining() == 100 );
+    // And that our remaining cartridge has only charge (and there's only one)
+    filters = guy.all_items_with_flag( json_flag_GASFILTER_MED );
+    REQUIRE( filters.size() == 1 );
+    CHECK( filters[0]->ammo_remaining() == 1 );
+}
+
+// Check that the "low" mode of autoreload works correctly
+static void test_autoreload_low( Character &guy )
+{
+    // Give them one charge to ensure immediate reload
+    item *gasmask = setup_character( guy, 1 );
+
+    // Give them a full cartridge, a partially used cartridge, and two empties
+    guy.i_add( gas_cartridge_with( 100 ) );
+    guy.i_add( gas_cartridge_with( 50 ) );
+    guy.i_add( gas_cartridge_with( 1 ) );
+    guy.i_add( gas_cartridge_with( 0 ) );
+
+    // Now, reload the gasmask with the 'least' rule
+    char_autoreload::params params;
+    params.reload_style = char_autoreload::RELOAD_LEAST;
+    guy.try_autoreload( *gasmask, params );
+
+    // 50 should be the only valid choice
+    CHECK( gasmask->ammo_remaining() == 50 );
+    // And we should have 4 filters on us, 1 with 100, 2 with 1, and 1 with 0
+    std::vector<const item *> filters = guy.all_items_with_flag( json_flag_GASFILTER_MED );
+    REQUIRE( filters.size() == 4 );
+    std::sort( filters.begin(), filters.end(), []( const item * l, const item * r ) {
+        return l->ammo_remaining() > r->ammo_remaining();
+    } );
+    CHECK( filters[0]->ammo_remaining() == 100 );
+    CHECK( filters[1]->ammo_remaining() == 1 );
+    CHECK( filters[2]->ammo_remaining() == 1 );
+    CHECK( filters[3]->ammo_remaining() == 0 );
+}
+
+// Check that the "high" mode of autoreload works correctly
+static void test_autoreload_high( Character &guy )
+{
+    // Give them one charge to ensure immediate reload
+    item *gasmask = setup_character( guy, 1 );
+
+    // Give them a full cartridge, a partially used cartridge, and two empties
+    guy.i_add( gas_cartridge_with( 100 ) );
+    guy.i_add( gas_cartridge_with( 50 ) );
+    guy.i_add( gas_cartridge_with( 1 ) );
+    guy.i_add( gas_cartridge_with( 0 ) );
+
+    // Now, reload the gasmask with the 'least' rule
+    char_autoreload::params params;
+    params.reload_style = char_autoreload::RELOAD_MOST;
+    guy.try_autoreload( *gasmask, params );
+
+    // 100 should be the only valid choice
+    CHECK( gasmask->ammo_remaining() == 100 );
+    // And we should have 4 filters on us, 1 with 50, 2 with 1, and 1 with 0
+    std::vector<const item *> filters = guy.all_items_with_flag( json_flag_GASFILTER_MED );
+    REQUIRE( filters.size() == 4 );
+    std::sort( filters.begin(), filters.end(), []( const item * l, const item * r ) {
+        return l->ammo_remaining() > r->ammo_remaining();
+    } );
+    CHECK( filters[0]->ammo_remaining() == 50 );
+    CHECK( filters[1]->ammo_remaining() == 1 );
+    CHECK( filters[2]->ammo_remaining() == 1 );
+    CHECK( filters[3]->ammo_remaining() == 0 );
+}
+
+static void test_autoreload_return_vals( Character &guy )
+{
+    // Frequently used
+    const char_autoreload::params params;
+
+    // Not low enough
+    item *gasmask = setup_character( guy, 40 );
+    guy.i_add( gas_cartridge_with( 100 ) );
+    guy.i_add( gas_cartridge_with( 1 ) );
+    CHECK_FALSE( guy.try_autoreload( *gasmask, params ) );
+
+    // Low, but doesn't need reload
+    gasmask = setup_character( guy, 4 );
+    guy.i_add( gas_cartridge_with( 100 ) );
+    guy.i_add( gas_cartridge_with( 1 ) );
+    CHECK_FALSE( guy.try_autoreload( *gasmask, params ) );
+
+    // No valid mags
+    gasmask = setup_character( guy, 1 );
+    guy.i_add( gas_cartridge_with( 1 ) );
+    CHECK_FALSE( guy.try_autoreload( *gasmask, params ) );
+
+    // Reloadable
+    gasmask = setup_character( guy, 1 );
+    guy.i_add( gas_cartridge_with( 100 ) );
+    CHECK( guy.try_autoreload( *gasmask, params ) );
+}
+
+TEST_CASE( "auto-reload-basic", "[character][autoreload]" )
+{
+    clear_map();
+    clear_avatar();
+
+    // First, check that the PC can use autoreload
+    Character &pc = get_player_character();
+    test_autoreload_works( pc );
+    test_autoreload_low( pc );
+    test_autoreload_high( pc );
+    test_autoreload_return_vals( pc );
+
+    // Next, check that an NPC can do it
+    shared_ptr_fast<npc> guy = make_shared_fast<npc>();
+    guy->normalize();
+    guy->randomize();
+    guy->spawn_at_precise( tripoint_abs_ms( get_map().getabs( pc.pos() ) ) + point( 1, 1 ) );
+    overmap_buffer.insert_npc( guy );
+    g->load_npcs();
+    clear_character( *guy );
+    // And put them on a different tile than the PC (clear_character sets position)
+    guy->setpos( pc.pos() + point( 1, 1 ) );
+
+    test_autoreload_works( *guy );
+    test_autoreload_low( *guy );
+    test_autoreload_high( *guy );
+    test_autoreload_return_vals( *guy );
+}
+
+TEST_CASE( "auto-reload-messaging", "[character][autoreload]" )
+{
+    // We'll be using these a lot
+    const char_autoreload::params params;
+    const std::string fail_var_name = "autoreload_failed_time";
+    const std::string warn_var_name = "autoreload_warn_time";
+
+    // Get a PC,
+    clear_map();
+    clear_avatar();
+    Character &pc = get_player_character();
+
+    // And an NPC
+    shared_ptr_fast<npc> guy = make_shared_fast<npc>();
+    guy->normalize();
+    guy->randomize();
+    guy->spawn_at_precise( tripoint_abs_ms( get_map().getabs( pc.pos() ) ) + point( 1, 1 ) );
+    overmap_buffer.insert_npc( guy );
+    g->load_npcs();
+    clear_character( *guy );
+    // And put them on a different tile than the PC (clear_character sets position)
+    guy->setpos( pc.pos() + point( 1, 1 ) );
+    Character &npc = *guy;
+
+    SECTION( "Warnings when mask is low" ) {
+        // A pc and npc are wearing a gas mask that is low
+        item &pcmask = *setup_character( pc, 7 );
+        item &npcmask = *setup_character( npc, 7 );
+
+        // Their gas masks are processed
+        pc.try_autoreload( pcmask, params );
+        npc.try_autoreload( npcmask, params );
+
+        // The PC's mask gives a warning
+        CHECK( pcmask.get_var( warn_var_name, calendar::turn - 1_hours ) == calendar::turn );
+
+        // The NPC's mask does not give a warning
+        CHECK( npcmask.get_var( warn_var_name, calendar::turn - 1_hours ) != calendar::turn );
+
+        // Seven more turns pass
+        for( int i = 0; i < 7; ++i ) {
+            calendar::turn += 1_seconds;
+            pc.try_autoreload( pcmask, params );
+            npc.try_autoreload( npcmask, params );
+            // The PC's mask stays silent
+            CHECK( pcmask.get_var( warn_var_name, calendar::turn ) != calendar::turn );
+            // The NPC's mask stays silent
+            CHECK( npcmask.get_var( warn_var_name, calendar::turn - 1_hours ) == calendar::turn - 1_hours );
+        }
+
+        // It's eight turns since the message
+        calendar::turn += 1_seconds;
+        pc.try_autoreload( pcmask, params );
+        npc.try_autoreload( npcmask, params );
+
+        // The PC's mask gives a warning
+        CHECK( pcmask.get_var( warn_var_name, calendar::turn - 1_hours ) == calendar::turn );
+
+        // The NPC's mask does not give a warning
+        CHECK( npcmask.get_var( warn_var_name, calendar::turn - 1_hours ) != calendar::turn );
+    }
+
+    SECTION( "Messages on failure to reload" ) {
+        // pc and npc with gas masks that have run out
+        item &pcmask = *setup_character( pc, 1 );
+        item &npcmask = *setup_character( npc, 1 );
+
+        // Both have an empty cartridge on them
+        pc.i_add( gas_cartridge_with( 1 ) );
+        npc.i_add( gas_cartridge_with( 1 ) );
+
+        // Process the masks
+        pc.try_autoreload( pcmask, params );
+        npc.try_autoreload( npcmask, params );
+
+        // Both fail to reload
+        CHECK( pcmask.get_var( fail_var_name, calendar::turn - 1_hours ) == calendar::turn );
+        CHECK( npcmask.get_var( fail_var_name, calendar::turn - 1_hours ) == calendar::turn );
+
+        // For the next 59 turns, they don't try
+        for( int i = 0; i < 59; ++i ) {
+            calendar::turn += 1_seconds;
+            pc.try_autoreload( pcmask, params );
+            npc.try_autoreload( npcmask, params );
+            CHECK( pcmask.get_var( fail_var_name, calendar::turn ) != calendar::turn );
+            CHECK( npcmask.get_var( fail_var_name, calendar::turn ) != calendar::turn );
+        }
+
+        // But after a minute, they try again
+        calendar::turn += 1_seconds;
+        pc.try_autoreload( pcmask, params );
+        npc.try_autoreload( npcmask, params );
+        CHECK( pcmask.get_var( fail_var_name, calendar::turn - 1_hours ) == calendar::turn );
+        CHECK( npcmask.get_var( fail_var_name, calendar::turn - 1_hours ) == calendar::turn );
+    }
+}


### PR DESCRIPTION
#### Summary
Features "Characters automatically reload gasmasks when they run low"

#### Purpose of change
I recently visited a collapsed tower, and as I fought my way through the dungeon, I faced a consistent issue: my gas mask would run out, and I would not notice, becoming poisoned.

This was, needless to say, quite annoying. So, let's have the character manage the changing of filters, instead of the player.



#### Describe the solution
The solution is simple. Add a function to Character that will will take an item and look at it's remaining ammo. If the item is low, but not quite out, the function will warn every 8 turns about the item being low. When the item runs out, it will scan the player inventory and reload with appropriate items.

Then, this function simply needs to be called wherever the item consumes charges, and the player will automatically handle reloading.

A variety of behavior tweaks are available, but by default (and always, as there is no way to change them), a popup shown when the last suitable item has been reloaded (next reload will fail) and when a reload is attempted but fails.

#### Describe alternatives you've considered
I couldn't figure out another way to solve this problem short of only adding more messages when the gas mask is running low. I think this is preferable.

#### Testing
Several tests have been added to ensure this behavior works for both players and npcs.
For manual testing, equip a gas mask, grab some cartridges, and expose yourself to a lot of gas. (Going underground makes the gas dissipate slower).
The screenshots below show what this will be like to the player with the current settings
<details>

<summary>Default Settings</summary>

Start:
![screenshot of player inventory. The player has 2 gas mask cartridges each with 0, 1, and 100 charges. The player is wearing an active gas mask with 10 charges.](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/dfd85e58-f0a0-42c4-bb6b-556503d7092a)
Reload 1:
![Screenshot of player's log. The message "Your ++ half face gas mask (active) is running low" is printed several times, 8 seconds apart, and at the end of the log, there are the messages "You notice your ++ half face gas mask (active) is running low and reload it" and "You have 1 remaining reloads for the ++ half face gas mask (active)"](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/e6ceb465-f3d9-4175-b45d-ca30054d5301)
![Screenshot of the player's inventory again. The player now has 3 gas mask cartridges with 1 charge, 2 with 0, and 1 with 100. Their gas mask is still active, and now has 100 charges.](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/0848d95c-24cb-427e-9433-bde742812d20)
Reload 2:
![Screenshot of popup message to player. The message says "Checking your pockets, you see this will be the last reload for your ++ half face gas mask (active)"](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/d0f47ab7-7537-4bf4-ab89-34b6c3ffd59a)
![Screenshot of player's log. As before, the message that their gas mask is running low is printed several times, following by a message indicating they reloaded their mask. However, the message about remaining reloads is not printed.](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/28bfc1b8-9785-4e5d-87b2-5b691913d894)
![Screenshot of the player's inventory. The player has 4 gas mask cartridges with 1 charge, and 2 with 0. Their gas mask is still active and has 100 charges.](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/ea5360ec-11ca-4737-932b-0c2708c98d2e)
Gas mask runs out:
![Screenshot of popup message to player. The message says "You don't have anything to reload your ++ half face gas mask (active) with!"](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/d682b7e4-7e0b-4bd9-940f-061b37100eb5)
![Screenshot of the player's inventory. The player has 4 gas mask cartridges with 1 charge, and 2 with 0. Their gas mask is still active, but only has 1 charge.](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/117e9991-bc07-46f1-bbe4-ade2e4e1cde0)
![Screenshot of the player's log. There are several messages about their gas mask running low, and a final message that it needs new filters.](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/05f8616b-cbbc-4b90-840b-026aeec931b0)

</details>

The following sections show the three different reload methods. All start with this inventory:
![Screenshot of the player's inventory. The player has gas mask cartridges with 0, 1, 47, 64, and 88 charges, as well as two with 100 charges. They are wearing an active gas mask with 94 charges.](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/a9632465-b32c-4937-b279-932f6a788335)


<details>
<summary>Least First reload</summary>

![Screenshot of the player's inventory. The player has gas mask cartridges with 0, 64, and 88 charges, as well as two each with 1 charge and 100 charges. They are wearing an active gas mask with 47 charges. This shows the gas mask has been reloaded with the cartridge that had the least charges (and was not empty).](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/beade46c-469b-46bb-96dc-2d746cf82c93)
![Screenshot of the player's inventory. The player has gas mask cartridges with 0 and 88 charges, as well as two with 100 charges, and three with 1 charge. They are wearing an active gas mask with 64 charges. This shows the gas mask has been reloaded with the cartridge that had the least charges (and was not empty).](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/2bdf7807-33cf-4ff8-b74a-ff5bc4a2f183)

</details>

<details>
<summary>Most First reload</summary>

![Screenshot of the player's inventory. The player has gas mask cartridges with 0, 47, 64, 88, and 100 charges, as well as two with 1 charge. They are wearing an active gas mask with 100 charges. This shows the gas mask has been reloaded with the cartridge that had the most charges.](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/1b8380fc-e0a9-406d-b023-922bc45a186c)
![Screenshot of the player's inventory. The player has gas mask cartridges with 0, 47, 64, and 88 charges, as well as three with 1 charge. They are wearing an active gas mask with 100 charges. This shows the gas mask has been reloaded with the cartridge that had the most charges.](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/140d6a02-f911-4647-b1ff-00c962edc980)
![Screenshot of the player's inventory. The player has gas mask cartridges with 0, 47, and 64 charges, as well as four with 1 charge. They are wearing an active gas mask with 88 charges. This shows the gas mask has been reloaded with the cartridge that had the most charges.](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/d1132075-3d8b-4f08-84e2-7d580c4e3ff3)

</details>

<details>
<summary>Player choose reload</summary>

![Screenshot of a menu asking the player what they want to reload their gas mask with. There are five options, four showing cartridges with 100, 88, 64, and 47 charges, and a fifth saying "Don't reload". This shows the cartridges that the player has, but has not duplicated the entry for the two cartridges with 100 charges.](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/65e76aa2-6663-4dd8-8977-b5bad1b2fdcd)
![Screenshot of a menu asking the player what they want to reload their gas mask with. There are five options, four showing cartridges with 100, 88, 64, and 47 charges, and a fifth saying "Don't reload". This shows the cartridges that the player has, having consumed one of the 100 charge cartridges.](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/ecd2119b-310a-4ce8-91ec-45afab1a70a4)
![Screenshot of a menu asking the player what they want to reload their gas mask with. There are four options, three showing cartridges with 88, 64, and 47 charges, and a fourth saying "Don't reload". This shows the cartridges that the player has, having consumed both the 100 charge cartridges.](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/7bce16df-7a40-48e5-b2f6-18c73d21a86b)
![Screenshot of a menu asking the player what they want to reload their gas mask with. There are three options, two showing cartridges with 88 and 64 charges, and a third saying "Don't reload". This shows the cartridges that the player has, having consumed both the 100 charge cartridges and the 47 charge cartridge.](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/ff30c5fb-684e-44d3-acfb-033afc21a04b)

</details>

#### Additional context
I'd obviously like to let the player choose between these three options, as well as expand this to more things, but I figured I should get this out there first.