### PR TITLE
mapgen: use dbl_or_var for variable weights

### DIFF
--- a/doc/MAPGEN.md
+++ b/doc/MAPGEN.md
@@ -245,9 +245,21 @@ in [`ants.json`](../data/json/mapgen/bugs/ants.json).
 (optional) When the game randomly picks mapgen functions, each function's weight value determines how rare it is. 1000
 is the default, so adding something with weight '500' will make it appear about half as often as others using the default weight. (An insanely high value like 10000000 is useful for testing.)
 
-Values: number - *0 disables*
+Values: number or [variable object](NPCs.md#variable-object) - *0 disables*
 
 Default: 1000
+
+Examples:
+```json
+    "//": "disable this variant"
+    "weight": 0,
+    "//2": "constant weight"
+    "weight": 500,
+    "//3": "evaluated dynamically from global variable"
+    "weight": { "global_val": "my_weight" },
+    "//4": "evaluated dynamically from math expression"
+    "weight": { "math": [ "my_weight * u_val('time_since_cataclysm: days')" ] }
+```
 
 
 ## How "overmap_terrain" variables affect mapgen

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -201,6 +201,27 @@ struct dbl_or_var_part {
     std::optional<talk_effect_fun_t> arithmetic_val;
     std::optional<eoc_math> math_val;
     double evaluate( dialogue &d ) const;
+
+    bool is_constant() const {
+        return dbl_val.has_value();
+    }
+
+    double constant() const {
+        if( !dbl_val ) {
+            debugmsg( "this dbl_or_var is not a constant" );
+            return 0;
+        }
+        return *dbl_val;
+    }
+
+    explicit operator bool() const {
+        return dbl_val || var_val || arithmetic_val || math_val;
+    }
+
+    dbl_or_var_part() = default;
+    // construct from numbers
+    template <class D, typename std::enable_if_t<std::is_arithmetic_v<D>>* = nullptr>
+    explicit dbl_or_var_part( D d ) : dbl_val( d ) {}
 };
 
 struct dbl_or_var {
@@ -208,6 +229,23 @@ struct dbl_or_var {
     dbl_or_var_part min;
     dbl_or_var_part max;
     double evaluate( dialogue &d ) const;
+
+    bool is_constant() const {
+        return !max && min.is_constant();
+    }
+
+    double constant() const {
+        return min.constant();
+    }
+
+    explicit operator bool() const {
+        return static_cast<bool>( min );
+    }
+
+    dbl_or_var() = default;
+    // construct from numbers
+    template <class D, typename std::enable_if_t<std::is_arithmetic_v<D>>* = nullptr>
+    explicit dbl_or_var( D d ) : min( d ) {}
 };
 
 struct duration_or_var_part {

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -26,6 +26,7 @@
 #include "colony.h"
 #include "common_types.h"
 #include "computer.h"
+#include "condition.h"
 #include "coordinate_conversions.h"
 #include "coordinates.h"
 #include "cuboid_rectangle.h"
@@ -55,7 +56,6 @@
 #include "mapgen_functions.h"
 #include "mapgendata.h"
 #include "mapgenformat.h"
-#include "math_parser_jmath.h"
 #include "memory_fast.h"
 #include "mission.h"
 #include "mongroup.h"
@@ -341,7 +341,12 @@ class mapgen_basic_container
         bool generate( mapgendata &dat, const int hardcoded_weight ) {
             for( const std::shared_ptr<mapgen_function> &ptr : mapgens_to_recalc_ ) {
                 dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
-                weights_.add_or_replace( ptr, ptr->weight * ptr->weight_function->eval( d ) );
+                int const weight = ptr->weight.evaluate( d );
+                if( weight >= 1 ) {
+                    weights_.add_or_replace( ptr, weight );
+                } else {
+                    weights_.remove( ptr );
+                }
             }
 
             if( hardcoded_weight > 0 &&
@@ -363,13 +368,14 @@ class mapgen_basic_container
          */
         void setup() {
             for( const std::shared_ptr<mapgen_function> &ptr : mapgens_ ) {
-                int weight = ptr->weight;
-                if( weight < 1 ) {
-                    continue; // rejected!
-                }
-                weights_.add( ptr, weight );
-
-                if( !ptr->weight_function.is_empty() ) {
+                cata_assert( ptr->weight );
+                if( ptr->weight.is_constant() ) {
+                    int const weight = ptr->weight.constant();
+                    if( weight < 1 ) {
+                        continue; // rejected!
+                    }
+                    weights_.add( ptr, weight );
+                } else {
                     mapgens_to_recalc_.push_back( ptr );
                 }
 
@@ -625,10 +631,7 @@ std::shared_ptr<mapgen_function>
 load_mapgen_function( const JsonObject &jio, const std::string &id_base, const point &offset,
                       const point &total )
 {
-    jmath_func_id weight_func;
-    int weight;
-    optional( jio, false, "weight_func", weight_func );
-    optional( jio, false, "weight", weight, 1000 );
+    dbl_or_var weight = get_dbl_or_var( jio, "weight", false,  1000 );
 
     if( jio.get_bool( "disabled", false ) ) {
         jio.allow_omitted_members();
@@ -637,7 +640,7 @@ load_mapgen_function( const JsonObject &jio, const std::string &id_base, const p
     const std::string mgtype = jio.get_string( "method" );
     if( mgtype == "builtin" ) {
         if( const building_gen_pointer ptr = get_mapgen_cfunction( jio.get_string( "name" ) ) ) {
-            return std::make_shared<mapgen_function_builtin>( ptr, weight_func, weight );
+            return std::make_shared<mapgen_function_builtin>( ptr, std::move( weight ) );
         } else {
             jio.throw_error_at( "name", "function does not exist" );
         }
@@ -648,7 +651,7 @@ load_mapgen_function( const JsonObject &jio, const std::string &id_base, const p
         JsonObject jo = jio.get_object( "object" );
         jo.allow_omitted_members();
         return std::make_shared<mapgen_function_json>(
-                   jo, weight_func, weight, "mapgen " + id_base, offset, total );
+                   jo, std::move( weight ), "mapgen " + id_base, offset, total );
     } else {
         jio.throw_error_at( "method", R"(invalid value: must be "builtin" or "json")" );
     }
@@ -829,9 +832,9 @@ mapgen_function_json_base::mapgen_function_json_base(
 
 mapgen_function_json_base::~mapgen_function_json_base() = default;
 
-mapgen_function_json::mapgen_function_json( const JsonObject &jsobj, jmath_func_id weight_func,
-        const int w, const std::string &context, const point &grid_offset, const point &grid_total )
-    : mapgen_function( weight_func, w )
+mapgen_function_json::mapgen_function_json( const JsonObject &jsobj,
+        dbl_or_var w, const std::string &context, const point &grid_offset, const point &grid_total )
+    : mapgen_function( std::move( w ) )
     , mapgen_function_json_base( jsobj, context )
     , fill_ter( t_null )
     , rotation( 0 )
@@ -7847,8 +7850,7 @@ mapgen_parameters get_map_special_params( const std::string &mapgen_id )
 int register_mapgen_function( const std::string &key )
 {
     if( const building_gen_pointer ptr = get_mapgen_cfunction( key ) ) {
-        return oter_mapgen.add( key, std::make_shared<mapgen_function_builtin>( ptr,
-                                jmath_func_id() ) );
+        return oter_mapgen.add( key, std::make_shared<mapgen_function_builtin>( ptr ) );
     }
     return -1;
 }

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -14,6 +14,7 @@
 
 #include "cata_variant.h"
 #include "coordinates.h"
+#include "dialogue_helpers.h"
 #include "jmapgen_flags.h"
 #include "json.h"
 #include "memory_fast.h"
@@ -37,11 +38,10 @@ using building_gen_pointer = void ( * )( mapgendata & );
 class mapgen_function
 {
     public:
-        int weight;
-        jmath_func_id weight_function;
+        dbl_or_var weight;
     protected:
-        explicit mapgen_function( const jmath_func_id w_func, const int w ) : weight( w ),
-            weight_function( w_func ) { }
+        explicit mapgen_function( dbl_or_var w ) : weight( std::move( w ) ) { }
+        explicit mapgen_function( int w ) : weight( w ) { }
     public:
         virtual ~mapgen_function() = default;
         virtual void setup() { } // throws
@@ -64,9 +64,11 @@ class mapgen_function_builtin : public virtual mapgen_function
     public:
         building_gen_pointer fptr;
         explicit mapgen_function_builtin( building_gen_pointer ptr,
-                                          const jmath_func_id w_func, int w = 1000 ) : mapgen_function( w_func, w ),
-            fptr( ptr ) {
-        }
+                                          int w = 1000 ) : mapgen_function( w ),
+            fptr( ptr ) { }
+        explicit mapgen_function_builtin( building_gen_pointer ptr,
+                                          dbl_or_var w ) : mapgen_function( std::move( w ) ),
+            fptr( ptr ) { }
         void generate( mapgendata &mgd ) override;
 };
 
@@ -484,7 +486,7 @@ class mapgen_function_json : public mapgen_function_json_base, public virtual ma
         bool expects_predecessor() const override;
         void generate( mapgendata & ) override;
         mapgen_parameters get_mapgen_params( mapgen_parameter_scope ) const override;
-        mapgen_function_json( const JsonObject &jsobj, jmath_func_id weight_func, int w,
+        mapgen_function_json( const JsonObject &jsobj, dbl_or_var w,
                               const std::string &context,
                               const point &grid_offset, const point &grid_total );
         ~mapgen_function_json() override = default;

--- a/src/weighted_list.h
+++ b/src/weighted_list.h
@@ -47,6 +47,18 @@ template <typename W, typename T> struct weighted_list {
             return nullptr;
         }
 
+        void remove( const T &obj ) {
+            auto const itr_end = std::remove_if( objects.begin(),
+            objects.end(), [&obj]( typename decltype( objects )::value_type const & itr ) {
+                return itr.obj == obj;
+            } );
+            for( auto removed = itr_end; removed != objects.end(); ++removed ) {
+                total_weight -= removed->weight;
+            }
+            objects.erase( itr_end, objects.end() );
+            invalidate_precalc();
+        }
+
         /**
          * This will check to see if the given object is already in the weighted
            list. If it is, we update its weight with the new weight value. If it

--- a/src/weighted_list.h
+++ b/src/weighted_list.h
@@ -48,11 +48,11 @@ template <typename W, typename T> struct weighted_list {
         }
 
         void remove( const T &obj ) {
-            auto const itr_end = std::remove_if( objects.begin(),
+            auto itr_end = std::remove_if( objects.begin(),
             objects.end(), [&obj]( typename decltype( objects )::value_type const & itr ) {
                 return itr.obj == obj;
             } );
-            for( auto removed = itr_end; removed != objects.end(); ++removed ) {
+            for( decltype( itr_end ) removed = itr_end; removed != objects.end(); ++removed ) {
                 total_weight -= removed->weight;
             }
             objects.erase( itr_end, objects.end() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I'm not happy with the usage of `jmath_function` from #66890. It has already been noted on discord that it's limited to functions with no parameters and that severely limits function reusability. For example, if you want to change just a constant for a certain mapgen, you have to redefine the entire function.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Use `dbl_or_var` for weight with the necessary glue to make sure constant weights don't have any extra overhead.

<details>
<summary>So instead of defining variants like this</summary>

```json
  {
    "type": "mapgen",
    "method": "json",
    "om_terrain": [ "mil_surplus" ],
    "//": "Blorg variant",
    "weight": 1,
    "weight_func": "my_func_with_var_blorg",
```
```json
  {
    "type": "mapgen",
    "method": "json",
    "om_terrain": [ "mil_surplus" ],
    "//": "Bombs variant",
    "weight": 1,
    "weight_func": "my_func_with_var_bombs",
```

</details>

with duplicated definitions for `my_func_...` and a potentially deceptive `weight`

<details>
<summary>You can now do it like this</summary>

```json
  {
    "type": "mapgen",
    "method": "json",
    "om_terrain": [ "mil_surplus" ],
    "//": "Blorg variant",
    "weight": { "math": [ "my_func( mil_surplus_var_blorg )" ] },
```

```json
  {
    "type": "mapgen",
    "method": "json",
    "om_terrain": [ "mil_surplus" ],
    "//": "Bombs variant",
    "weight": { "math": [ "my_func( mil_surplus_var_bombs )" ] },
```
</details>

and define the `jmath_function` `my_func` only once.

I've also fixed an oversight from the original solution: if a variant's weight evaluates to less than 1, it is now removed from the list instead of continuing to use the old weight.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Game doesn't break completely on load.

<details>
<summary>Using this change:</summary>

```diff
diff --git a/data/json/mapgen/mil_surplus.json b/data/json/mapgen/mil_surplus.json
index ab726e6f7d..2eb61fd979 100644
--- a/data/json/mapgen/mil_surplus.json
+++ b/data/json/mapgen/mil_surplus.json
@@ -82,7 +82,7 @@
     "method": "json",
     "om_terrain": [ "mil_surplus" ],
     "//": "Boarded up variant",
-    "weight": 500,
+    "weight": { "math": [ "mil_surplus_var" ] },
     "object": {
       "fill_ter": "t_thconc_floor",
       "rows": [
```

</details>

1. add 6 `mill_surplus` to the overmap, teleport to generate them, and confirm none of them are boarded up
2. set value of global var `mil_surplus_var` to 10000000
3. redo step 1 and confirm the new `mil_surplus` are all boarded up
4. set value of global var `mil_surplus_var` to 0
5. redo step 1 and confirm none of the new `mil_surplus`es are boarded up, again

I'd like to automate the test but there's not enough introspection and I'd have to hack it with terrain test. I'll see if I can follow up with that some time.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
Kinda like [this](https://www.youtube.com/watch?v=tAM1LvsJZ9U&t=9s)

@bombasticSlacks @Procyonae 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->