### PR TITLE
Grab break message fixes

### DIFF
--- a/src/character_escape.cpp
+++ b/src/character_escape.cpp
@@ -274,14 +274,14 @@ bool Character::try_remove_grab( bool attacking )
                     add_msg_if_player( m_info, martial_arts_data->get_grab_break( *this ).avatar_message.translated(),
                                        grabber->disp_name() );
                 } else {
-                    add_msg_player_or_npc( m_good, _( "You break the %s grab on your %s!" ),
-                                           _( "<npcname> the %s grab on their %s!" ), grabber->disp_name( true ),
+                    add_msg_player_or_npc( m_good, _( "You break %s grab on your %s!" ),
+                                           _( "<npcname> breaks %s grab on their %s!" ), grabber->disp_name( true ),
                                            eff.get_bp()->name );
                 }
                 // Remove only this one grab
                 remove_effect( eff.get_id(), eff.get_bp() );
             } else {
-                add_msg_player_or_npc( m_bad, _( "You try to break the %s grab on your %s, but fail!" ),
+                add_msg_player_or_npc( m_bad, _( "You try to break %s grab on your %s, but fail!" ),
                                        _( "<npcname> tries to break out of the grab, but fails!" ), grabber->disp_name( true ),
                                        eff.get_bp()->name );
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "add verb and remove doubled the from grab break messages"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Npc grab break message currently looks like "Npcname the the zombie's grab on their left leg!", player message looks like "You break the the zombie's grab on your left leg!". This adds the verb "breaks" to the npc message and removes doubled up "the" from both.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add and remove words
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled, got player and npc grabbed, observed the messages:
![grabbreak01](https://github.com/CleverRaven/Cataclysm-DDA/assets/2456481/78d402f2-879a-46da-ba8c-5a42477db335)
![grabbreak2](https://github.com/CleverRaven/Cataclysm-DDA/assets/2456481/09745f5a-02a3-45bc-affa-af1925841e98)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->