### PR TITLE
Craftable beast samples

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -1338,6 +1338,7 @@
       { "item": "hk_mp5", "prob": 50, "charges-min": 0, "charges-max": 30 },
       { "item": "hk_mp5k", "prob": 10, "charges-min": 0, "charges-max": 30 },
       { "item": "hk_mp5sd", "prob": 5, "charges-min": 0, "charges-max": 30 },
+      { "item": "fn_p90", "prob": 25, "charges-min": 0, "charges-max": 0 },
       { "item": "mossberg_930", "variant": "m1014", "prob": 10, "charges-min": 0, "charges-max": 8 },
       { "item": "modular_m4_carbine", "variant": "modular_m4a1", "prob": 35, "charges-min": 0, "charges-max": 30 },
       { "item": "as50", "prob": 5, "charges-min": 0, "charges-max": 10 },

--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -1338,7 +1338,6 @@
       { "item": "hk_mp5", "prob": 50, "charges-min": 0, "charges-max": 30 },
       { "item": "hk_mp5k", "prob": 10, "charges-min": 0, "charges-max": 30 },
       { "item": "hk_mp5sd", "prob": 5, "charges-min": 0, "charges-max": 30 },
-      { "item": "fn_p90", "prob": 25, "charges-min": 0, "charges-max": 0 },
       { "item": "mossberg_930", "variant": "m1014", "prob": 10, "charges-min": 0, "charges-max": 8 },
       { "item": "modular_m4_carbine", "variant": "modular_m4a1", "prob": 35, "charges-min": 0, "charges-max": 30 },
       { "item": "as50", "prob": 5, "charges-min": 0, "charges-max": 10 },

--- a/data/json/recipes/chem/mutagens.json
+++ b/data/json/recipes/chem/mutagens.json
@@ -330,7 +330,7 @@
     "difficulty": 7,
     "time": "3 h",
     "batch_time_factors": [ 80, 20 ],
-    "book_learn": [ [ "recipe_animal", 6 ] ],
+    "book_learn": [ [ "", 6 ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry" },
       { "proficiency": "prof_organic_chemistry" },
@@ -366,7 +366,7 @@
     "difficulty": 7,
     "time": "2 h",
     "batch_time_factors": [ 20, 5 ],
-    "book_learn": [ [ "recipe_serum", 6 ], [ "recipe_animal", 6 ] ],
+    "book_learn": [ [ "recipe_serum", 6 ], [ "", 6 ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry" },
       { "proficiency": "prof_organic_chemistry" },
@@ -1397,10 +1397,10 @@
     "subcategory": "CSC_CHEM_MUTAGEN",
     "skill_used": "chemistry",
     "skills_required": [ "survival", 3 ],
-    "difficulty": 6,
+    "difficulty": 5,
     "time": "30 m",
     "batch_time_factors": [ 20, 5 ],
-    "book_learn": [ [ "recipe_animal", 6 ] ],
+    "book_learn": [ [ "recipe_animal", 5 ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry" },
       { "proficiency": "prof_organic_chemistry" },

--- a/data/json/recipes/chem/mutagens.json
+++ b/data/json/recipes/chem/mutagens.json
@@ -1410,9 +1410,9 @@
     "using": [ [ "serum_production_standard", 20 ] ],
     "components": [
       [ [ "feline_sample", 1 ], [ "lupine_sample", 1 ], [ "ursine_sample", 1 ] ],
-      [ [ "feline_sample", 1 ], [ "lupine_sample", 1 ], [ "ursine_sample", 1 ] ],
-      [ [ "feline_sample", 1 ], [ "lupine_sample", 1 ], [ "ursine_sample", 1 ] ],
-      [ [ "feline_sample", 1 ], [ "lupine_sample", 1 ], [ "ursine_sample", 1 ] ]
+      [ [ "feline_sample", 1 ] ],
+      [ [ "lupine_sample", 1 ] ],
+      [ [ "ursine_sample", 1 ] ]
     ],
     "flags": [ "SECRET" ]
   },

--- a/data/json/recipes/chem/mutagens.json
+++ b/data/json/recipes/chem/mutagens.json
@@ -1408,10 +1408,10 @@
       { "proficiency": "prof_chem_synth" }
     ],
     "using": [ [ "serum_production_standard", 20 ] ],
-    "components": [ 
-      [ [ "feline_sample", 1 ], [ "lupine_sample", 1 ], [ "ursine_sample", 1 ] ], 
-      [ [ "feline_sample", 1 ], [ "lupine_sample", 1 ], [ "ursine_sample", 1 ] ], 
-      [ [ "feline_sample", 1 ], [ "lupine_sample", 1 ], [ "ursine_sample", 1 ] ], 
+    "components": [
+      [ [ "feline_sample", 1 ], [ "lupine_sample", 1 ], [ "ursine_sample", 1 ] ],
+      [ [ "feline_sample", 1 ], [ "lupine_sample", 1 ], [ "ursine_sample", 1 ] ],
+      [ [ "feline_sample", 1 ], [ "lupine_sample", 1 ], [ "ursine_sample", 1 ] ],
       [ [ "feline_sample", 1 ], [ "lupine_sample", 1 ], [ "ursine_sample", 1 ] ]
     ],
     "flags": [ "SECRET" ]

--- a/data/json/recipes/chem/mutagens.json
+++ b/data/json/recipes/chem/mutagens.json
@@ -1392,6 +1392,33 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
+    "result": "beast_sample",
+    "category": "CC_CHEM",
+    "subcategory": "CSC_CHEM_MUTAGEN",
+    "skill_used": "chemistry",
+    "skills_required": [ "survival", 3 ],
+    "difficulty": 6,
+    "time": "30 m",
+    "batch_time_factors": [ 20, 5 ],
+    "book_learn": [ [ "recipe_animal", 6 ] ],
+    "proficiencies": [
+      { "proficiency": "prof_intro_chemistry" },
+      { "proficiency": "prof_organic_chemistry" },
+      { "proficiency": "prof_intro_chem_synth" },
+      { "proficiency": "prof_chem_synth" }
+    ],
+    "using": [ [ "serum_production_standard", 20 ] ],
+    "components": [ 
+      [ [ "feline_sample", 1 ], [ "lupine_sample", 1 ], [ "ursine_sample", 1 ] ], 
+      [ [ "feline_sample", 1 ], [ "lupine_sample", 1 ], [ "ursine_sample", 1 ] ], 
+      [ [ "feline_sample", 1 ], [ "lupine_sample", 1 ], [ "ursine_sample", 1 ] ], 
+      [ [ "feline_sample", 1 ], [ "lupine_sample", 1 ], [ "ursine_sample", 1 ] ]
+    ],
+    "flags": [ "SECRET" ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
     "result": "slime_sample",
     "category": "CC_CHEM",
     "subcategory": "CSC_CHEM_MUTAGEN",

--- a/data/json/recipes/chem/mutagens.json
+++ b/data/json/recipes/chem/mutagens.json
@@ -330,7 +330,7 @@
     "difficulty": 7,
     "time": "3 h",
     "batch_time_factors": [ 80, 20 ],
-    "book_learn": [ [ "", 6 ] ],
+    "book_learn": [ [ "recipe_animal", 6 ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry" },
       { "proficiency": "prof_organic_chemistry" },
@@ -366,7 +366,7 @@
     "difficulty": 7,
     "time": "2 h",
     "batch_time_factors": [ 20, 5 ],
-    "book_learn": [ [ "recipe_serum", 6 ], [ "", 6 ] ],
+    "book_learn": [ [ "recipe_serum", 6 ], [ "recipe_animal", 6 ] ],
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry" },
       { "proficiency": "prof_organic_chemistry" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The monsters that drop the beast samples are somewhat rare, and sometimes survivor is just drowned in other predator samples. Given that the Beast mutation line looks like a mix of the other carnivorous lines (Lupine, Feline, Ursine), it is plausible that scientists synthesized some of their beast samples from those lines by mixing and refining their samples.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds a pretty pricey beast sample recipe that utilises gear used for creating primers and 4 carnivore samples, using at least one of each 3 lines' samples. The carnivore samples can be obtained in quantity in labs, and gear requirement makes it less usable as main source of beast mutagen (at least, in the beginning).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Make the recipe use 3 samples, one per each line so resulting sample is not "biased" towards a specific line (tho additional sample could be for other reasons, but in design the 4th sample is to allow the player to use more of samples he has a lot of).

Assuming that Beast line is in no way related to other carnivore lines.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
None for now.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->