### PR TITLE
Jsonify succession cooldown + fix some bad bugs!

### DIFF
--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -976,6 +976,15 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_FACTION_SUCCESSION_COOLDOWN",
+    "eoc_type": "EVENT",
+    "required_event": "game_begin",
+    "//": "If you're looking to change the cooldown simply replace the below value with how long the cooldown should be, in seconds.",
+    "//2": "7,776,000 seconds = 90 days",
+    "effect": [ { "math": [ "time_between_succession", "=", "7776000" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_FACTION_SUCCESSION_IMMEDIATE",
     "eoc_type": "EVENT",
     "required_event": "broken_bone",

--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -981,7 +981,7 @@
     "required_event": "game_begin",
     "//": "If you're looking to change the cooldown simply replace the below value with how long the cooldown should be, in seconds.",
     "//2": "7,776,000 seconds = 90 days",
-    "effect": [ { "math": [ "time_between_succession", "=", "7776000" ] } ]
+    "effect": [ { "math": [ "time_between_succession", "=", "u_val('time: 90 d')" ] } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -958,7 +958,7 @@
     "type": "effect_on_condition",
     "id": "EOC_FACTION_SUCCESSION_CHANGE_INIT",
     "eoc_type": "EVENT",
-    "required_event": "game_begin",
+    "required_event": "game_start",
     "effect": [
       { "remove_active_mission": "MISSION_CAMP_LEADERSHIP_CHANGE" },
       { "assign_mission": "MISSION_CAMP_LEADERSHIP_CHANGE" }

--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -989,15 +989,15 @@
     "eoc_type": "EVENT",
     "required_event": "broken_bone",
     "//1": "Only run EOC if character is currently on succession cooldown!",
-    "condition": { "u_compare_time_since_var": "time_of_last_succession", "type": "timer", "op": "<", "time": "90 d" },
-    "//2": "Remove the mission tracking that you can't change char, push the timer back 90 days so changing is immediately available.",
+    "condition": { "math": [ "u_val('time_since_var', 'var_name: timer_time_of_last_succession')", "<", "time_between_succession" ] },
+    "//2": "Remove the mission tracking that you can't change char, push the timer back by [cooldown length] so changing is immediately available.",
     "effect": [
       { "remove_active_mission": "MISSION_CAMP_LEADERSHIP_CHANGE" },
       {
         "u_message": "You've been badly wounded.  It might be better to rest for a while and let someone else scavenge. (Changing characters is now available at any camp board.)",
         "type": "mixed"
       },
-      { "u_adjust_var": "time_of_last_succession", "type": "timer", "adjustment": -7776000 }
+      { "math": [ "u_timer_time_of_last_succession", "-=", "time_between_succession" ] }
     ]
   }
 ]

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -181,8 +181,12 @@ static const std::string camp_om_fortifications_trench_parameter = faction_wall_
 static const std::string camp_om_fortifications_spiked_trench_parameter =
     faction_wall_level_n_1_string;
 
+static const std::string var_time_between_succession =
+    "npctalk_var_time_between_succession";
+
 static const std::string var_timer_time_of_last_succession =
     "npctalk_var_timer_time_of_last_succession";
+
 
 //  These strings are matched against recipe group 'building_type'. Definite candidates for JSON definitions of
 //  the various UI strings corresponding to these groups.
@@ -1511,10 +1515,13 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
 
 void basecamp::choose_new_leader()
 {
-    // TODO: This is stupid as heck
+    // This is ugly, but dialogue vars are stored as strings, even if they hold data for times.
     time_point last_succession_time = time_point::from_turn( std::stoi(
                                           get_player_character().get_value( var_timer_time_of_last_succession ) ) );
-    time_point next_succession_chance = last_succession_time + 90_days;
+    time_duration succession_cooldown = time_duration::from_turns( std::stof(
+                                            get_globals().get_global_value(
+                                                    var_time_between_succession ) ) );
+    time_point next_succession_chance = last_succession_time + succession_cooldown;
     int current_time_int = to_seconds<int>( calendar::turn - calendar::turn_zero );
     if( next_succession_chance >= calendar::turn ) {
         popup( _( "It's too early for that.  A new leader can be chosen in %s days." ),

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1516,7 +1516,7 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
 void basecamp::choose_new_leader()
 {
     // This is ugly, but dialogue vars are stored as strings, even if they hold data for times.
-    time_point last_succession_time = time_point::from_turn( std::stoi(
+    time_point last_succession_time = time_point::from_turn( std::stof(
                                           get_player_character().get_value( var_timer_time_of_last_succession ) ) );
     time_duration succession_cooldown = time_duration::from_turns( std::stof(
                                             get_globals().get_global_value(


### PR DESCRIPTION
#### Summary
Mods "Faction succession cooldown is now a json value, and can be modded as such"

#### Purpose of change
More power to json

Fix some pretty nasty bugs I found in my recent work

#### Describe the solution
This PR is (currently) 4 commits, each commit should build properly and function individually as advertised.

6436583a2d3326c4dad71e4b78e853e7792d5a9d: Move the succession cooldown to json. Very importantly it must not be read as an integer value (std::stoi) or else we wind up with a regression of #65522

7db200d1b58aea1eac631905cc48844905038554: Extends the fix for reading very large numbers to the existing dialog var `timer_time_of_last_succession`

26c370854b9218057d44d3fdbed648503ef35d43: Makes EOC_FACTION_SUCCESSION_CHANGE_INIT only fire once, on the initial game start. Previously if you saved the game and reloaded it would fire again, setting your cooldown to 90 days even if you had been off cooldown!

7e0a890f9b32d446dd4e79e83154c5b6bdd40754: Just cleans up EOC_FACTION_SUCCESSION_IMMEDIATE to make it easier to mod or manipulate the cooldown otherwise (and also looks much better with the sexy math functions)

#### Describe alternatives you've considered


#### Testing
Reloaded and started new games under a variety of conditions to make sure each of these commits works

Recommend testing: Start new game, confirm global var for cooldown timer is set. Forward time 10 days to lower remaining cooldown to 80 days. Save, quit, load to check again and confirm remaining cooldown is still 80 days and not reset to 90. Then break character's limb and confirm cooldown is instantly refreshed.

#### Additional context
