### PR TITLE
Keybindings fixes

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -51,3 +51,5 @@ files:
     - dseguin
   'src/ui_manager.*':
     - Qrox
+  'data/raw/keybindings.json':
+    - Qrox

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -865,9 +865,9 @@
   },
   {
     "type": "keybinding",
-    "id": "ADD_MOD",
+    "id": "MOVE_MOD_DOWN",
     "category": "MODMANAGER_DIALOG",
-    "name": "Move selected mod up",
+    "name": "Move selected mod down",
     "bindings": [
       { "input_method": "keyboard_any", "key": "=" },
       { "input_method": "keyboard_char", "key": "+" },
@@ -876,9 +876,9 @@
   },
   {
     "type": "keybinding",
-    "id": "REMOVE_MOD",
+    "id": "MOVE_MOD_UP",
     "category": "MODMANAGER_DIALOG",
-    "name": "Move selected mod down",
+    "name": "Move selected mod up",
     "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
   },
   {

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -586,7 +586,7 @@
     "id": "TOGGLE_CLOTH",
     "category": "SORT_ARMOR",
     "name": "Toggle armor visibility on character sprite",
-    "bindings": [ { "input_method": "keyboard_any", "key": "H" } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "H" }, { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -1531,7 +1531,7 @@
     "id": "CHOOSE_CITY",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Choose character starting city",
-    "bindings": [ { "input_method": "keyboard_any", "key": "C" } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "C" }, { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -3376,7 +3376,7 @@
     "id": "CHANGE_FACTION",
     "category": "ZONES_MANAGER",
     "name": "Change shown faction",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F" } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "F" }, { "input_method": "keyboard_code", "key": "f", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -3603,7 +3603,7 @@
     "id": "MARK_WITH_COUNT",
     "category": "INVENTORY",
     "name": "Select a specific amount of highlighted item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "!" } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "!" }, { "input_method": "keyboard_code", "key": "1", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -4277,7 +4277,7 @@
     "category": "WISH_ITEM",
     "id": "SNIPPET",
     "name": "Choose snippet",
-    "bindings": [ { "input_method": "keyboard_any", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "S" }, { "input_method": "keyboard_code", "key": "s", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -363,9 +363,9 @@
     "category": "AUTO_PICKUP",
     "name": "Move rule up",
     "bindings": [
+      { "input_method": "keyboard_any", "key": "=" },
       { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
     ]
   },
   {
@@ -490,9 +490,9 @@
     "category": "SAFEMODE",
     "name": "Move rule up",
     "bindings": [
+      { "input_method": "keyboard_any", "key": "=" },
       { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
     ]
   },
   {
@@ -782,9 +782,9 @@
     "category": "SOKOBAN",
     "name": "Next level",
     "bindings": [
+      { "input_method": "keyboard_any", "key": "=" },
       { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
     ]
   },
   {
@@ -869,9 +869,9 @@
     "category": "MODMANAGER_DIALOG",
     "name": "Move selected mod up",
     "bindings": [
+      { "input_method": "keyboard_any", "key": "=" },
       { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
     ]
   },
   {
@@ -3073,9 +3073,9 @@
     "category": "LIST_ITEMS",
     "name": "Increase priority",
     "bindings": [
+      { "input_method": "keyboard_any", "key": "=" },
       { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
     ]
   },
   {
@@ -3293,9 +3293,9 @@
     "category": "ZONES_MANAGER",
     "name": "Move zone up",
     "bindings": [
+      { "input_method": "keyboard_any", "key": "=" },
       { "input_method": "keyboard_char", "key": "+" },
-      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" },
-      { "input_method": "keyboard_code", "key": "=", "mod": [ "shift" ] }
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
     ]
   },
   {
@@ -3555,7 +3555,11 @@
     "id": "INCREASE_COUNT",
     "category": "INVENTORY",
     "name": "Increase selected amount for the highlighted item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "+" } ]
+    "bindings": [
+      { "input_method": "keyboard_any", "key": "=" },
+      { "input_method": "keyboard_char", "key": "+" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_PLUS" }
+    ]
   },
   {
     "type": "keybinding",
@@ -3569,7 +3573,7 @@
     "id": "DECREASE_COUNT",
     "category": "INVENTORY",
     "name": "Decrease selected amount for the highlighted item",
-    "bindings": [ { "input_method": "keyboard_any", "key": "-" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "-" }, { "input_method": "keyboard_code", "key": "KEYPAD_MINUS" } ]
   },
   {
     "type": "keybinding",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2044,7 +2044,7 @@
     "id": "SHOW_HIDE_CONTENTS_ALL",
     "category": "INVENTORY",
     "name": "Show/hide all contents",
-    "bindings": [ { "input_method": "keyboard_char", "key": "E" } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "E" }, { "input_method": "keyboard_code", "key": "e", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
@@ -3589,7 +3589,10 @@
     "id": "PREV_COLUMN",
     "category": "INVENTORY",
     "name": "Previous column",
-    "bindings": [ { "input_method": "keyboard_char", "key": "BACKTAB" } ]
+    "bindings": [
+      { "input_method": "keyboard_char", "key": "BACKTAB" },
+      { "input_method": "keyboard_code", "key": "TAB", "mod": [ "shift" ] }
+    ]
   },
   {
     "type": "keybinding",
@@ -3708,7 +3711,7 @@
     "id": "EXAMINE_CONTENTS",
     "category": "ADVANCED_INVENTORY",
     "name": "Examine items in container",
-    "bindings": [ { "input_method": "keyboard_char", "key": "o" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "o" } ]
   },
   {
     "type": "keybinding",
@@ -4221,14 +4224,14 @@
     "id": "SCROLL_MISSION_INFO_UP",
     "category": "FACTIONS",
     "name": "Scroll camp mission info up",
-    "bindings": [ { "input_method": "keyboard_char", "key": "[" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "[" } ]
   },
   {
     "type": "keybinding",
     "id": "SCROLL_MISSION_INFO_DOWN",
     "category": "FACTIONS",
     "name": "Scroll camp mission info down",
-    "bindings": [ { "input_method": "keyboard_char", "key": "]" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "]" } ]
   },
   {
     "type": "keybinding",

--- a/src/mod_manager_ui.cpp
+++ b/src/mod_manager_ui.cpp
@@ -177,7 +177,7 @@ void mod_ui::try_shift( char direction, size_t &selection, std::vector<mod_id> &
     int selshift = 0;
 
     // shift up (towards 0)
-    if( direction == '+' && can_shift_up( selection, active_list ) ) {
+    if( direction == '-' && can_shift_up( selection, active_list ) ) {
         // see if the mod at selection-1 is a) a core, or b) is depended on by this mod
         newsel = selection - 1;
         oldsel = selection;
@@ -185,7 +185,7 @@ void mod_ui::try_shift( char direction, size_t &selection, std::vector<mod_id> &
         selshift = -1;
     }
     // shift down (towards active_list.size()-1)
-    else if( direction == '-' && can_shift_down( selection, active_list ) ) {
+    else if( direction == '+' && can_shift_down( selection, active_list ) ) {
         newsel = selection;
         oldsel = selection + 1;
 

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -997,8 +997,8 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
         ctxt.register_action( "PREV_TAB" );
     }
     ctxt.register_action( "CONFIRM", to_translation( "Activate / deactivate mod" ) );
-    ctxt.register_action( "ADD_MOD" );
-    ctxt.register_action( "REMOVE_MOD" );
+    ctxt.register_action( "MOVE_MOD_UP" );
+    ctxt.register_action( "MOVE_MOD_DOWN" );
     ctxt.register_action( "SAVE_DEFAULT_MODS" );
     ctxt.register_action( "VIEW_MOD_DESCRIPTION" );
     ctxt.register_action( "FILTER" );
@@ -1388,12 +1388,12 @@ int worldfactory::show_worldgen_tab_modselection( const catacurses::window &win,
                     active_header = 0;
                 }
             }
-        } else if( action == "ADD_MOD" ) {
+        } else if( action == "MOVE_MOD_DOWN" ) {
             if( active_header == 1 && active_mod_order.size() > 1 ) {
                 mman_ui->try_shift( '+', cursel[1], active_mod_order );
             }
             recalc_start = true;
-        } else if( action == "REMOVE_MOD" ) {
+        } else if( action == "MOVE_MOD_UP" ) {
             if( active_header == 1 && active_mod_order.size() > 1 ) {
                 mman_ui->try_shift( '-', cursel[1], active_mod_order );
             }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Add missing keybindings to key code mode and adjust existing ones.

#### Describe the solution
1. Convert "keyboard_any" bindings with invalid qwerty key code into "keyboard_char" and "keyboard_code" bindings.
2. For bindings with only "keyboard_char", add missing "keyboard_code" bindings or convert to "keyboard_any" bindings.
3. Add '=' to directional keybindings previously bound to "+". "+" is kept for symbol mode in case the player is using a different keyboard layout, but "shift =" is removed from key code mode because the mode only supports qwerty layout currently so the shift key is not needed. Also add a missing "KEYPAD_MINUS" to an action bound to "-".
4. Fix incorrect direction of '-'/'+' keys in mod manager
5. Add myself as a reviewer of keybindings.json so I can suggest corrections to the file in the future.

#### Describe alternatives you've considered

#### Testing
Tested as many bindings as possible in key code mode and symbol mode. Some bindings are hard to reach so I double checked the code to ensure they are fine.

#### Additional context
