### PR TITLE
heavily nerf ADS bionic

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -14,9 +14,9 @@
     "description": "A thin forcefield surrounds your body, continually draining power.  Everything loses velocity when penetrating this field, which results in reduced amount of dealt damage at the cost of your bionic energy.  Bullets and stabbing attacks will lose more velocity than cutting attacks and those in turn more than bashing attacks.",
     "occupied_bodyparts": [ [ "torso", 10 ], [ "head", 1 ], [ "arm_l", 1 ], [ "arm_r", 1 ], [ "leg_l", 2 ], [ "leg_r", 2 ] ],
     "flags": [ "BIONIC_TOGGLED", "BIONIC_NPC_USABLE" ],
-    "act_cost": "10 J",
-    "react_cost": "10 J",
-    "trigger_cost": "25kJ",
+    "act_cost": "1 kJ",
+    "react_cost": "1 kJ",
+    "trigger_cost": "10 kJ",
     "time": "1 s"
   },
   {

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -188,17 +188,17 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
         if( has_active_bionic( bio_ads ) ) {
             if( elem.amount > 0 && get_power_level() > bio_ads->power_trigger ) {
                 if( elem.type == STATIC( damage_type_id( "bash" ) ) ) {
-                    mod_power_level( std::min( units::from_kilojoule( elem.amount ), -bio_ads->power_trigger ) );
+                    mod_power_level( elem.amount, -bio_ads->power_trigger ) );
                     elem.amount -= rng( 1, 2 );
                     add_msg_if_player( m_good,
                                        _( "The defensive forcefield surrounding you ripples as it reduces the velocity of the incoming attack." ) );
                 } else if( elem.type == STATIC( damage_type_id( "cut" ) ) ) {
-                    mod_power_level( std::min( units::from_kilojoule( elem.amount ), -bio_ads->power_trigger ) );
+                    mod_power_level( std::min( elem.amount, -bio_ads->power_trigger ) );
                     elem.amount -= rng( 2, 6 );
                     add_msg_if_player( m_good,
                                        _( "The defensive forcefield surrounding you ripples as it reduces the velocity of the incoming attack." ) );
                 } else if( elem.type == STATIC( damage_type_id( "stab" ) ) || STATIC( damage_type_id( "bullet" ) ) {
-                    mod_power_level( std::min( units::from_kilojoule( elem.amount ), -bio_ads->power_trigger ) );
+                    mod_power_level( std::min( elem.amount, -bio_ads->power_trigger ) );
                     elem.amount -= rng( 4, 12 );
                     add_msg_if_player( m_good,
                                        _( "The defensive forcefield surrounding you ripples as it reduces the velocity of the incoming attack." ) );

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -186,20 +186,20 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
 
         // The bio_ads CBM absorbs damage before hitting armor
         if( has_active_bionic( bio_ads ) ) {
+            bool absorbed = false;
             if( elem.amount > 0 && get_power_level() > bio_ads->power_trigger ) {
                 if( elem.type == STATIC( damage_type_id( "bash" ) ) ) {
-                    mod_power_level( elem.amount, -bio_ads->power_trigger ) );
-                    elem.amount -= rng( 1, 2 );
-                    add_msg_if_player( m_good,
-                                       _( "The defensive forcefield surrounding you ripples as it reduces the velocity of the incoming attack." ) );
+                    elem.amount -= rng( 1, 4 );
+                    absorbed = true;
                 } else if( elem.type == STATIC( damage_type_id( "cut" ) ) ) {
-                    mod_power_level( std::min( elem.amount, -bio_ads->power_trigger ) );
-                    elem.amount -= rng( 2, 6 );
-                    add_msg_if_player( m_good,
-                                       _( "The defensive forcefield surrounding you ripples as it reduces the velocity of the incoming attack." ) );
+                    elem.amount -= rng( 2, 8 );
+                    absorbed = true;
                 } else if( elem.type == STATIC( damage_type_id( "stab" ) ) || STATIC( damage_type_id( "bullet" ) ) {
-                    mod_power_level( std::min( elem.amount, -bio_ads->power_trigger ) );
-                    elem.amount -= rng( 4, 12 );
+                    elem.amount -= rng( 4, 16 );
+                    absorbed = true;
+                }
+                if( absorbed ) {
+                    mod_power_level( -bio_ads->power_trigger );
                     add_msg_if_player( m_good,
                                        _( "The defensive forcefield surrounding you ripples as it reduces the velocity of the incoming attack." ) );
                 }

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -187,17 +187,17 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
         // The bio_ads CBM absorbs damage before hitting armor
         if( has_active_bionic( bio_ads ) ) {
             if( elem.amount > 0 && get_power_level() > bio_ads->power_trigger ) {
-                if( elem.type == damage_type::BASH ) {
+                if( elem.type == STATIC( damage_type_id( "bash" ) ) ) {
                     elem.amount -= rng( 1, 4 );
                     mod_power_level( -bio_ads->power_trigger );
                     add_msg_if_player( m_good,
                                        _( "The defensive forcefield surrounding you ripples as it reduces the velocity of the incoming attack." ) );
-                } else if( elem.type == damage_type::CUT ) {
+                } else if( elem.type == STATIC( damage_type_id( "cut" ) ) ) {
                     elem.amount -= rng( 2, 8 );
                     mod_power_level( -bio_ads->power_trigger );
                     add_msg_if_player( m_good,
                                        _( "The defensive forcefield surrounding you ripples as it reduces the velocity of the incoming attack." ) );
-                } else if( elem.type == damage_type::STAB || elem.type == damage_type::BULLET ) {
+                } else if( elem.type == STATIC( damage_type_id( "stab" ) ) || STATIC( damage_type_id( "bullet" ) ) {
                     elem.amount -= rng( 4, 16 );
                     mod_power_level( -bio_ads->power_trigger );
                     add_msg_if_player( m_good,

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -194,7 +194,8 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 } else if( elem.type == STATIC( damage_type_id( "cut" ) ) ) {
                     elem.amount -= rng( 2, 8 );
                     absorbed = true;
-                } else if( elem.type == STATIC( damage_type_id( "stab" ) ) || STATIC( damage_type_id( "bullet" ) ) ) {
+                } else if( elem.type == STATIC( damage_type_id( "stab" ) ) ||
+                           STATIC( damage_type_id( "bullet" ) ) ) {
                     elem.amount -= rng( 4, 16 );
                     absorbed = true;
                 }

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -194,7 +194,7 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 } else if( elem.type == STATIC( damage_type_id( "cut" ) ) ) {
                     elem.amount -= rng( 2, 8 );
                     absorbed = true;
-                } else if( elem.type == STATIC( damage_type_id( "stab" ) ) || STATIC( damage_type_id( "bullet" ) ) {
+                } else if( elem.type == STATIC( damage_type_id( "stab" ) ) || STATIC( damage_type_id( "bullet" ) ) ) {
                     elem.amount -= rng( 4, 16 );
                     absorbed = true;
                 }

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -199,7 +199,7 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                     absorbed = true;
                 }
                 if( absorbed ) {
-                    mod_power_level( -bio_ads->power_trigger );
+                mod_power_level( -bio_ads->power_trigger );
                     add_msg_if_player( m_good,
                                        _( "The defensive forcefield surrounding you ripples as it reduces the velocity of the incoming attack." ) );
                 }

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -199,7 +199,7 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                     absorbed = true;
                 }
                 if( absorbed ) {
-                mod_power_level( -bio_ads->power_trigger );
+                    mod_power_level( -bio_ads->power_trigger );
                     add_msg_if_player( m_good,
                                        _( "The defensive forcefield surrounding you ripples as it reduces the velocity of the incoming attack." ) );
                 }

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -188,18 +188,18 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
         if( has_active_bionic( bio_ads ) ) {
             if( elem.amount > 0 && get_power_level() > bio_ads->power_trigger ) {
                 if( elem.type == STATIC( damage_type_id( "bash" ) ) ) {
-                    elem.amount -= rng( 1, 4 );
-                    mod_power_level( -bio_ads->power_trigger );
+                    mod_power_level( std::min( units::from_kilojoule( elem.amount ), -bio_ads->power_trigger ) );
+                    elem.amount -= rng( 1, 2 );
                     add_msg_if_player( m_good,
                                        _( "The defensive forcefield surrounding you ripples as it reduces the velocity of the incoming attack." ) );
                 } else if( elem.type == STATIC( damage_type_id( "cut" ) ) ) {
-                    elem.amount -= rng( 2, 8 );
-                    mod_power_level( -bio_ads->power_trigger );
+                    mod_power_level( std::min( units::from_kilojoule( elem.amount ), -bio_ads->power_trigger ) );
+                    elem.amount -= rng( 2, 6 );
                     add_msg_if_player( m_good,
                                        _( "The defensive forcefield surrounding you ripples as it reduces the velocity of the incoming attack." ) );
                 } else if( elem.type == STATIC( damage_type_id( "stab" ) ) || STATIC( damage_type_id( "bullet" ) ) {
-                    elem.amount -= rng( 4, 16 );
-                    mod_power_level( -bio_ads->power_trigger );
+                    mod_power_level( std::min( units::from_kilojoule( elem.amount ), -bio_ads->power_trigger ) );
+                    elem.amount -= rng( 4, 12 );
                     add_msg_if_player( m_good,
                                        _( "The defensive forcefield surrounding you ripples as it reduces the velocity of the incoming attack." ) );
                 }

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -191,26 +191,32 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 // Assuming it absorbs damage at 10% efficiency, it can absorb at most 2500 J of energy
                 // Taking muzzle energy of 5.56mm ammo as a reference, 1936 J is equal to 44 damage
                 // Having this in mind, let's make 2500 J equal to 50 damage, which will be the maximum damage ADS can absorb
-                // costs energy equal to the 10x damage^2, before it is reduced, regardless of how much it is reduced
+                // while good for setting a sane max limit it means low damage attacks become too cheap to block.
+                // therefore, make the bionic linear so that worst case is 25 kj to reduce 50 damage
+                // costs energy equal to the 500xdamage, before it is reduced, regardless of how much it is reduced
                 // a 50 damage attack would incur the whole 25kJ. A 12 damage attack would cost 1440j
                 const int max_absorption = 50;
                 units::energy power_cost = units::from_joule( std::max( -25000.0f,
-                                           elem.amount * elem.amount * -10 ) );
+                                           elem.amount * -500 ) );
+                float ads_factor = 1.0f;
 
                 // If damage is higher than maximum absorption capability, lower the damage by a flat amount of this capability
                 // Otherwise, divide the damage by X times, depending on damage type
                 // FIXME: Harcoded damage types
                 if( elem.type == STATIC( damage_type_id( "bash" ) ) ) {
-                    elem.amount = elem.amount > max_absorption ? elem.amount - max_absorption : elem.amount / 2;
+                    ads_factor = 0.75f;
                 } else if( elem.type == STATIC( damage_type_id( "cut" ) ) ) {
-                    elem.amount = elem.amount > max_absorption ? elem.amount - max_absorption : elem.amount / 3;
+                    ads_factor = 0.5f;
                 } else if( elem.type == STATIC( damage_type_id( "stab" ) ) ||
                            elem.type == STATIC( damage_type_id( "bullet" ) ) ) {
-                    elem.amount = elem.amount > max_absorption ? elem.amount - max_absorption : elem.amount / 4;
+                    ads_factor = 0.25;
                 }
-                mod_power_level( power_cost );
-                add_msg_if_player( m_good,
-                                   _( "The defensive forcefield surrounding your body ripples as it reduces velocity of incoming attack." ) );
+                if( ads_factor < 1.0f ) {
+                    elem.amount = elem.amount * ads_factor;
+                    mod_power_level( power_cost );
+                    add_msg_if_player( m_good,
+                                       _( "The defensive forcefield surrounding your body ripples as it reduces velocity of incoming attack." ) );
+                }
             }
             if( elem.amount < 0 ) {
                 elem.amount = 0;

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -204,12 +204,13 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 // Otherwise, divide the damage by X times, depending on damage type
                 // FIXME: Harcoded damage types
                 if( elem.type == STATIC( damage_type_id( "bash" ) ) ) {
-                    ads_factor = std::min( max_absorption, elem.amount) * 0.25f;
+                    ads_factor = std::min( max_absorption, elem.amount ) * 0.25f;
                 } else if( elem.type == STATIC( damage_type_id( "cut" ) ) ) {
-                    ads_factor = std::min( max_absorption, elem.amount) * 0.5f;
+                    ads_factor = std::min( max_absorption, elem.amount ) * 0.5f;
                 } else if( elem.type == STATIC( damage_type_id( "stab" ) ) ||
                            elem.type == STATIC( damage_type_id( "bullet" ) ) ) {
-                    ads_factor = std::min( max_absorption, elem.amount) * 0.75f;                }
+                    ads_factor = std::min( max_absorption, elem.amount ) * 0.75f;
+                }
                 if( ads_factor > 0.0f ) {
                     elem.amount = elem.amount - ads_factor;
                     mod_power_level( power_cost );

--- a/src/character_armor.cpp
+++ b/src/character_armor.cpp
@@ -195,24 +195,23 @@ const weakpoint *Character::absorb_hit( const weakpoint_attack &, const bodypart
                 // therefore, make the bionic linear so that worst case is 25 kj to reduce 50 damage
                 // costs energy equal to the 500xdamage, before it is reduced, regardless of how much it is reduced
                 // a 50 damage attack would incur the whole 25kJ. A 12 damage attack would cost 1440j
-                const int max_absorption = 50;
+                const int max_absorption = 40;
                 units::energy power_cost = units::from_joule( std::max( -25000.0f,
                                            elem.amount * -500 ) );
-                float ads_factor = 1.0f;
+                float ads_factor = 0.0f;
 
                 // If damage is higher than maximum absorption capability, lower the damage by a flat amount of this capability
                 // Otherwise, divide the damage by X times, depending on damage type
                 // FIXME: Harcoded damage types
                 if( elem.type == STATIC( damage_type_id( "bash" ) ) ) {
-                    ads_factor = 0.75f;
+                    ads_factor = std::min( max_absorption, elem.amount) * 0.25f;
                 } else if( elem.type == STATIC( damage_type_id( "cut" ) ) ) {
-                    ads_factor = 0.5f;
+                    ads_factor = std::min( max_absorption, elem.amount) * 0.5f;
                 } else if( elem.type == STATIC( damage_type_id( "stab" ) ) ||
                            elem.type == STATIC( damage_type_id( "bullet" ) ) ) {
-                    ads_factor = 0.25;
-                }
-                if( ads_factor < 1.0f ) {
-                    elem.amount = elem.amount * ads_factor;
+                    ads_factor = std::min( max_absorption, elem.amount) * 0.75f;                }
+                if( ads_factor > 0.0f ) {
+                    elem.amount = elem.amount - ads_factor;
                     mod_power_level( power_cost );
                     add_msg_if_player( m_good,
                                        _( "The defensive forcefield surrounding your body ripples as it reduces velocity of incoming attack." ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "ADS is less invincible"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Active defense bionic was broken level strong making you nearly unkillable for a low power cost.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Revert functionality to previous method.
No longer provides percentage guaranteed damage reduction (50% for bash, 66% for cut, 75% for stab/bullet) at power cost of damage^2 * 10J. Now provides 1-4 random bash res, 2-8 random cut res and 4-16 random bullet res (avg. 2.5/5/10) at cost of 10 KJ per damage type absorbed, with a base power cost upkeep of 1KW instead of 10W. 
Making it random is preferable because it does not mean you can absolutely 100% of the time take 0 damage but it will still typically reduce incoming damage by a lot. You just don't want to use it to charge a turret in melee because you know the turret cannot hurt you.

Also bugfixes it triggering on damage types it doesn't absorb like electric damage.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Completely remove from the game the sci fi deflector shield bionic.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiled and confirmed it works the way I want it to.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->