### PR TITLE
Pstorm distance fix

### DIFF
--- a/data/json/portal_storm_effect_on_condition.json
+++ b/data/json/portal_storm_effect_on_condition.json
@@ -26,7 +26,28 @@
     "id": "EOC_PORTAL_STORM_WARN_OR_CAUSE_RECURRING",
     "recurrence": [ { "global_val": "ps_min_woc", "default": "5 days" }, { "global_val": "ps_max_woc", "default": "18 days" } ],
     "global": true,
-    "effect": { "run_eocs": "EOC_CAUSE_EARLY_PORTAL_STORM" }
+    "effect": {
+      "run_eocs": [
+        {
+          "id": "EOC_CAUSE_EARLY_PORTAL_STORM"
+        },
+        {
+          "id": "EOC_FIRST_PORTAL_STORM",
+          "condition": {
+            "or": [
+              { "math": [ "portal_storm_distant_distance", "<=", "200" ] },
+              { "math": [ "portal_storm_close_distance", "<=", "100" ] },
+              { "math": [ "portal_storm_distance", "<=", "50" ] }
+            ]
+          },
+          "effect": [
+            { "math": [ "portal_storm_distant_distance", "=", "200" ] },
+            { "math": [ "portal_storm_close_distance", "=", "100" ] },
+            { "math": [ "portal_storm_distance", "=", "50" ] }
+          ]
+        }
+      ]
+    } 
   },
   {
     "type": "effect_on_condition",

--- a/data/json/portal_storm_effect_on_condition.json
+++ b/data/json/portal_storm_effect_on_condition.json
@@ -35,9 +35,9 @@
           "id": "EOC_FIRST_PORTAL_STORM",
           "condition": {
             "or": [
-              { "math": [ "portal_storm_distant_distance", "<=", "200" ] },
-              { "math": [ "portal_storm_close_distance", "<=", "100" ] },
-              { "math": [ "portal_storm_distance", "<=", "50" ] }
+              { "math": [ "portal_storm_distant_distance", "<", "200" ] },
+              { "math": [ "portal_storm_close_distance", "<", "100" ] },
+              { "math": [ "portal_storm_distance", "<", "50" ] }
             ]
           },
           "effect": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Add an EOC for default portal storm distance values"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Portal storms stop changing weather outside of a very small area (starts at 1 square) after EOC_PORTAL_EXPAND runs at the end of a storm for the first time. This adds an EOC to fix that issue. Fixes #66598
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added an EOC to EOC_PORTAL_STORM_WARN_OR_CAUSE_RECURRING that checks if any of portal_storm_distant_distance, portal_storm_close_distance, and portal_storm_distance are lower than or equal to the default values (200, 100, 50 respectively) in weather_type.json. If they are, sets them to those values.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Check and set these default values elsewhere. I am not very familiar with the codebase so I didn't do this.

In addition to that, include some kind of check for the current value of portal_storm_distance etc. for already existing games that have those values at e.g. 5 or more. Did not do this since it'd only be relevant for in-progress games that have had many portal storms already and would add clutter that has no effect on new games.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Created a new world, started a new character, debug ran EOC_PORTAL_STORM_WARN_OR_CAUSE_RECURRING. Debug checked var_list.output for expected portal_storm_distance etc. values. Debug ran EOC_PORTAL_EXPAND. Checked var_list for expected values again. Debug ran EOC_PORTAL_STORM_WARN_OR_CAUSE_RECURRING and checked var_list for expected values again. All values and functionality is as expected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
This should work for new games and for existing games since the EOC checks if it should run every time EOC_PORTAL_STORM_WARN_OR_CAUSE_RECURRING runs, which is what kicks off a portal storm every time. Scenarios that start with a portal storm via other EOCs use the default values already and should have the appropriate defaults set the next time a portal storm starts.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->