### PR TITLE
npc-board-player-vehicle fix

### DIFF
--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -44,8 +44,8 @@ static const trait_id trait_WEB_WEAVER( "WEB_WEAVER" );
 static const vpart_id vpart_frame( "frame" );
 static const vpart_id vpart_seat( "seat" );
 
-static const vproto_id vehicle_prototype_test_van( "test_van" );
 static const vproto_id vehicle_prototype_none( "none" );
+static const vproto_id vehicle_prototype_test_van( "test_van" );
 
 static void on_load_test( npc &who, const time_duration &from, const time_duration &to )
 {

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -358,12 +358,10 @@ TEST_CASE( "npc-board-player-vehicle" )
     npc *companion = get_creature_tracker().creature_at<npc>( npc_pos );
     REQUIRE( companion != nullptr );
 
-    
     debug_mode = true;
     debugmode::enabled_filters.clear();
     debugmode::enabled_filters.emplace_back( debugmode::DF_NPC );
     REQUIRE( debugmode::enabled_filters.size() == 1 );
-    
 
     // Give the NPC 20 moves to board the vehicle
     for( int i = 0; i < 20; ++i ) {

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -44,7 +44,7 @@ static const trait_id trait_WEB_WEAVER( "WEB_WEAVER" );
 static const vpart_id vpart_frame( "frame" );
 static const vpart_id vpart_seat( "seat" );
 
-static const vproto_id vehicle_prototype_ambulance( "ambulance" );
+static const vproto_id vehicle_prototype_test_van( "test_van" );
 static const vproto_id vehicle_prototype_none( "none" );
 
 static void on_load_test( npc &who, const time_duration &from, const time_duration &to )
@@ -329,8 +329,8 @@ TEST_CASE( "npc-board-player-vehicle" )
     // Place the NPC outside the door and down one
     tripoint npc_pos = player_pos + point( -2, -1 );
 
-    // Place an ambulance at the player's position, rotated correctly, 100% fuel, perfect condition
-    vehicle *veh = here.add_vehicle( vehicle_prototype_ambulance, player_pos, -90_degrees, 100, 2 );
+    // Place a cube van at the player's position, rotated correctly, 100% fuel, perfect condition
+    vehicle *veh = here.add_vehicle( vehicle_prototype_test_van, player_pos, -90_degrees, 100, 2 );
     // And make sure the game knows the player is in it so the NPC can follow
     here.board_vehicle( player_pos, &pc );
     REQUIRE( veh != nullptr );

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -358,17 +358,17 @@ TEST_CASE( "npc-board-player-vehicle" )
     npc *companion = get_creature_tracker().creature_at<npc>( npc_pos );
     REQUIRE( companion != nullptr );
 
-    /* Uncomment for some extra info when test fails
+    
     debug_mode = true;
     debugmode::enabled_filters.clear();
     debugmode::enabled_filters.emplace_back( debugmode::DF_NPC );
     REQUIRE( debugmode::enabled_filters.size() == 1 );
-    */
+    
 
     // Give the NPC 20 moves to board the vehicle
     for( int i = 0; i < 20; ++i ) {
         companion->moves = 100;
-        /* Uncommment for extra debug info
+        
             tripoint npc_pos = companion->pos();
             optional_vpart_position vp = here.veh_at( npc_pos );
             vehicle *veh = veh_pointer_or_null( vp );
@@ -378,7 +378,7 @@ TEST_CASE( "npc-board-player-vehicle" )
                      here.furnname( npc_pos ),
                      vp ? remove_color_tags( vp->part_displayed()->part().name() ) : "",
                      veh ? veh->name : " " );
-        */
+        
         companion->move();
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #66968

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Swaps the ambulance out for test_van as that has the same size and shape but only 2 seats while still testing the NPC doesn't get stuck in the back

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Ran the test locally a bunch of times with no fails

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->