### PR TITLE
Itemgroups can seal their containers

### DIFF
--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -107,7 +107,7 @@ static item_pocket::pocket_type guess_pocket_for( const item &container, const i
 
 static void put_into_container(
     Item_spawn_data::ItemList &items, std::size_t num_items,
-    const std::optional<itype_id> &container_type,
+    const std::optional<itype_id> &container_type, const bool sealed,
     time_point birthday, Item_spawn_data::overflow_behaviour on_overflow,
     const std::string &context )
 {
@@ -150,6 +150,9 @@ static void put_into_container(
         }
     }
     ctr.add_automatic_whitelist();
+    if( sealed ) {
+        ctr.seal();
+    }
 
     excess.emplace_back( std::move( ctr ) );
     items.erase( items.end() - num_items, items.end() );
@@ -267,7 +270,7 @@ std::size_t Single_item_creator::create( ItemList &list,
         }
     }
     const std::size_t items_created = list.size() - prev_list_size;
-    put_into_container( list, items_created, container_item, birthday, on_overflow, context() );
+    put_into_container( list, items_created, container_item, sealed, birthday, on_overflow, context() );
     return list.size() - prev_list_size;
 }
 
@@ -732,7 +735,7 @@ std::size_t Item_group::create( Item_spawn_data::ItemList &list,
         }
     }
     const std::size_t items_created = list.size() - prev_list_size;
-    put_into_container( list, items_created, container_item, birthday, on_overflow, context() );
+    put_into_container( list, items_created, container_item, sealed, birthday, on_overflow, context() );
 
     return list.size() - prev_list_size;
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Itemgroups can seal containers"

#### Purpose of change

Sealing was only implemented for item modifiers on group entries but not for groups themselves. That is an issue for #60885.

#### Describe the solution

The data is already there, so just use it. It's possible that some groups are now sealed that aren't intended to be because it defaults to sealed.

#### Describe alternatives you've considered



#### Testing

<details>
<summary>Test with `cannedfood` group without this change in current experimental:</summary>

![before](https://github.com/CleverRaven/Cataclysm-DDA/assets/38702195/44be2883-3172-45d9-91cb-1bea33cf3ceb)

</details>

<details>
<summary>Without this change in #60885 (only groups with single items or liquids are sealed):</summary>

![without](https://github.com/CleverRaven/Cataclysm-DDA/assets/38702195/fd701968-9cfc-4e49-b7d0-bb5023020f62)

</details>

<details>
<summary>With this change in #60885:</summary>

![after](https://github.com/CleverRaven/Cataclysm-DDA/assets/38702195/3f107f70-70f5-4ee1-b2ba-ffad819d87d6)

</details>

#### Additional context

It's possible there are still cases of containers that should be sealed but aren't. That will likely mean that the rules for sealing need some touching up, but that can be done once such cases are identified.