### PR TITLE
Update IFAK pouch weight and max item length

### DIFF
--- a/data/json/items/containers.json
+++ b/data/json/items/containers.json
@@ -3384,6 +3384,7 @@
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
+        "magazine_well": "400 ml",
         "max_contains_volume": "3200 ml",
         "max_contains_weight": "4000 g",
         "max_item_length": "20 cm",

--- a/data/json/items/containers.json
+++ b/data/json/items/containers.json
@@ -3346,7 +3346,7 @@
     "name": { "str": "first aid kit box", "str_pl": "first aid kit boxes" },
     "looks_like": "ifak_pouch",
     "description": "A plastic box designed to contain a first aid kit.",
-    "weight": "50 g",
+    "weight": "200 g",
     "volume": "2900 ml",
     "price": 0,
     "price_postapoc": 0,
@@ -3358,6 +3358,7 @@
         "pocket_type": "CONTAINER",
         "max_contains_volume": "2700 ml",
         "max_contains_weight": "3 kg",
+        "max_item_length": "20 cm",
         "rigid": true,
         "moves": 100
       }
@@ -3372,7 +3373,8 @@
     "name": { "str": "IFAK pouch", "str_pl": "IFAK pouches" },
     "looks_like": "1st_aid_box",
     "description": "A fabric pouch designed to contain a personalized trauma kit.  These supplies are used to address immediate life-threatening conditions.",
-    "weight": "5 g",
+    "//": "Was introduced without anchoring to a real example, but is similar to this: https://www.amazon.com/Livans-Tactical-Rip-Away-Military-Emergency/dp/B07Y7BRB83",
+    "weight": "329 g",
     "volume": "1250 ml",
     "price": 0,
     "price_postapoc": 10,
@@ -3384,6 +3386,7 @@
         "pocket_type": "CONTAINER",
         "max_contains_volume": "3200 ml",
         "max_contains_weight": "4000 g",
+        "max_item_length": "20 cm",
         "moves": 100,
         "rigid": false
       }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Updates IFAK pouch weight and max item length"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

IFAK puch did not have max item length defined (it is autocalculated) and its weight was unrealistically low (5 g for a 3L Kordura pouch). This PR changes it, basing the dimensions and weight on these pouches: https://www.amazon.com/Livans-Tactical-Rip-Away-Military-Emergency/dp/B07Y7BRB83 and https://www.officer.com/tactical/ems-hazmat/first-aid-kits-supplies/product/21124343/tasmanian-tiger-distributed-by-proforce-equipment-inc-the-ifak-pouch-vl-l-an-individual-improved-first-aid-kit

Most IFAKs are actually smaller than the ones in the links, though, but that is not concern of this PR.

Updates first aid kit box in same areas, but the numbers are an arbitrary approximation there. Still better than it was IMO.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Updates IFAK pouch weight and max item length (weight raised to 329 g, taken off a slightly smaller bag, but is vastly closer to real weight, max item length is 20 cm, taken off two smaller bags), does same for first aid kit.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Adding a small IFAK pouch/replacing current IFAK with small IFAK.

Having featherlight IFAK pouches with autocalculated max item length.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
None for now.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->