### PR TITLE
Fix message in ter_furn_data don't be translated

### DIFF
--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -230,8 +230,9 @@ void ter_furn_transform::transform( map &m, const tripoint_bub_ms &location ) co
         next_furn(
             furn_at_loc->id );
     const trap_str_id trap_at_loc = m.maptile_at( location ).get_trap().id();
-    std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>> trap_potential = next_trap(
-                trap_at_loc );
+    std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>> trap_potential =
+        next_trap(
+            trap_at_loc );
 
     const field &field_at_loc = m.field_at( location );
     for( const auto &fld : field_at_loc ) {

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -213,7 +213,8 @@ ter_furn_transform::next_trap(
     return next( trap_transform, trap );
 }
 
-std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_trap(
+std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>>
+ter_furn_transform::next_trap(
     const std::string &flag ) const
 {
     return next( trap_flag_transform, flag );

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -171,7 +171,8 @@ std::optional<std::pair<T, std::pair<std::optional<translation>, bool>>> ter_fur
     return std::nullopt;
 }
 
-std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_ter(
+std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>>
+ter_furn_transform::next_ter(
     const ter_str_id &ter ) const
 {
     return next( ter_transform, ter );

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -79,7 +79,7 @@ template<class T>
 void ter_furn_data<T>::load( const JsonObject &jo )
 {
     load_transform_results( jo, "result", list );
-    message = jo.get_string( "message", "" );
+    jo.read( "message", message, false );
     message_good = jo.get_bool( "message_good", true );
 }
 
@@ -158,7 +158,7 @@ std::optional<ter_furn_data<T>> ter_furn_transform::find_transform( const
 }
 
 template<class T, class K>
-std::optional<std::pair<T, std::pair<std::string, bool>>> ter_furn_transform::next( const
+std::optional<std::pair<T, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next( const
         std::map<K, ter_furn_data<T>> &list,
         const K &key ) const
 {
@@ -170,44 +170,44 @@ std::optional<std::pair<T, std::pair<std::string, bool>>> ter_furn_transform::ne
     return std::nullopt;
 }
 
-std::optional<std::pair<ter_str_id, std::pair<std::string, bool>>> ter_furn_transform::next_ter(
+std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_ter(
     const ter_str_id &ter ) const
 {
     return next( ter_transform, ter );
 }
 
-std::optional<std::pair<ter_str_id, std::pair<std::string, bool>>> ter_furn_transform::next_ter(
+std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_ter(
     const std::string &flag ) const
 {
     return next( ter_flag_transform, flag );
 }
 
-std::optional<std::pair<furn_str_id, std::pair<std::string, bool>>> ter_furn_transform::next_furn(
+std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_furn(
     const furn_str_id &furn ) const
 {
     return next( furn_transform, furn );
 }
 
-std::optional<std::pair<furn_str_id, std::pair<std::string, bool>>> ter_furn_transform::next_furn(
+std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_furn(
     const std::string &flag ) const
 {
     return next( furn_flag_transform, flag );
 }
 
-std::optional<std::pair<field_type_id, std::pair<std::string, bool>>>
+std::optional<std::pair<field_type_id, std::pair<std::optional<translation>, bool>>>
 ter_furn_transform::next_field(
     const field_type_id &field ) const
 {
     return next( field_transform, field );
 }
 
-std::optional<std::pair<trap_str_id, std::pair<std::string, bool>>> ter_furn_transform::next_trap(
+std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_trap(
     const trap_str_id &trap ) const
 {
     return next( trap_transform, trap );
 }
 
-std::optional<std::pair<trap_str_id, std::pair<std::string, bool>>> ter_furn_transform::next_trap(
+std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_trap(
     const std::string &flag ) const
 {
     return next( trap_flag_transform, flag );
@@ -217,25 +217,25 @@ void ter_furn_transform::transform( map &m, const tripoint_bub_ms &location ) co
 {
     avatar &you = get_avatar();
     const ter_id ter_at_loc = m.ter( location );
-    std::optional<std::pair<ter_str_id, std::pair<std::string, bool>>> ter_potential = next_ter(
+    std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>> ter_potential = next_ter(
                 ter_at_loc->id );
     const furn_id furn_at_loc = m.furn( location );
-    std::optional<std::pair<furn_str_id, std::pair<std::string, bool>>> furn_potential = next_furn(
+    std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>> furn_potential = next_furn(
                 furn_at_loc->id );
     const trap_str_id trap_at_loc = m.maptile_at( location ).get_trap().id();
-    std::optional<std::pair<trap_str_id, std::pair<std::string, bool>>> trap_potential = next_trap(
+    std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>> trap_potential = next_trap(
                 trap_at_loc );
 
     const field &field_at_loc = m.field_at( location );
     for( const auto &fld : field_at_loc ) {
-        std::optional<std::pair<field_type_id, std::pair<std::string, bool>>> field_potential = next_field(
+        std::optional<std::pair<field_type_id, std::pair<std::optional<translation>, bool>>> field_potential = next_field(
                     fld.first );
         if( field_potential ) {
             m.add_field( location, field_potential->first, fld.second.get_field_intensity(),
                          fld.second.get_field_age(), true );
             m.remove_field( location, fld.first );
-            if( you.sees( location ) ) {
-                you.add_msg_if_player( field_potential->second.first,
+            if( you.sees( location ) && field_potential->second.first.has_value() ) {
+                you.add_msg_if_player( field_potential->second.first.value().translated(),
                                        field_potential->second.second ? m_good : m_bad );
             }
         }
@@ -279,21 +279,21 @@ void ter_furn_transform::transform( map &m, const tripoint_bub_ms &location ) co
 
     if( ter_potential ) {
         m.ter_set( location, ter_potential->first );
-        if( you.sees( location ) ) {
-            you.add_msg_if_player( ter_potential->second.first, ter_potential->second.second ? m_good : m_bad );
+        if( you.sees( location ) && ter_potential->second.first.has_value() ) {
+            you.add_msg_if_player( ter_potential->second.first.value().translated(), ter_potential->second.second ? m_good : m_bad );
         }
     }
     if( furn_potential ) {
         m.furn_set( location, furn_potential->first );
-        if( you.sees( location ) ) {
-            you.add_msg_if_player( furn_potential->second.first,
+        if( you.sees( location ) && furn_potential->second.first.has_value() ) {
+            you.add_msg_if_player( furn_potential->second.first.value().translated(),
                                    furn_potential->second.second ? m_good : m_bad );
         }
     }
     if( trap_potential ) {
         m.trap_set( location, trap_potential->first );
-        if( you.sees( location ) ) {
-            you.add_msg_if_player( trap_potential->second.first,
+        if( you.sees( location ) && trap_potential->second.first.has_value() ) {
+            you.add_msg_if_player( trap_potential->second.first.value().translated(),
                                    trap_potential->second.second ? m_good : m_bad );
         }
     }

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -206,7 +206,8 @@ ter_furn_transform::next_field(
     return next( field_transform, field );
 }
 
-std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_trap(
+std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>>
+ter_furn_transform::next_trap(
     const trap_str_id &trap ) const
 {
     return next( trap_transform, trap );

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -288,7 +288,8 @@ void ter_furn_transform::transform( map &m, const tripoint_bub_ms &location ) co
     if( ter_potential ) {
         m.ter_set( location, ter_potential->first );
         if( you.sees( location ) && ter_potential->second.first.has_value() ) {
-            you.add_msg_if_player( ter_potential->second.first.value().translated(), ter_potential->second.second ? m_good : m_bad );
+            you.add_msg_if_player( ter_potential->second.first.value().translated(),
+                                   ter_potential->second.second ? m_good : m_bad );
         }
     }
     if( furn_potential ) {

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -178,7 +178,8 @@ ter_furn_transform::next_ter(
     return next( ter_transform, ter );
 }
 
-std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_ter(
+std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>>
+ter_furn_transform::next_ter(
     const std::string &flag ) const
 {
     return next( ter_flag_transform, flag );

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -224,8 +224,9 @@ void ter_furn_transform::transform( map &m, const tripoint_bub_ms &location ) co
 {
     avatar &you = get_avatar();
     const ter_id ter_at_loc = m.ter( location );
-    std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>> ter_potential = next_ter(
-                ter_at_loc->id );
+    std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>> ter_potential =
+        next_ter(
+            ter_at_loc->id );
     const furn_id furn_at_loc = m.furn( location );
     std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>> furn_potential =
         next_furn(

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -192,7 +192,8 @@ ter_furn_transform::next_furn(
     return next( furn_transform, furn );
 }
 
-std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_furn(
+std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>>
+ter_furn_transform::next_furn(
     const std::string &flag ) const
 {
     return next( furn_flag_transform, flag );

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -158,7 +158,7 @@ std::optional<ter_furn_data<T>> ter_furn_transform::find_transform( const
 }
 
 template<class T, class K>
-std::optional<std::pair<T, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next( const
+std::optional<std::pair<T, std::pair<translation, bool>>> ter_furn_transform::next( const
         std::map<K, ter_furn_data<T>> &list,
         const K &key ) const
 {
@@ -170,44 +170,44 @@ std::optional<std::pair<T, std::pair<std::optional<translation>, bool>>> ter_fur
     return std::nullopt;
 }
 
-std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_ter(
+std::optional<std::pair<ter_str_id, std::pair<translation, bool>>> ter_furn_transform::next_ter(
     const ter_str_id &ter ) const
 {
     return next( ter_transform, ter );
 }
 
-std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_ter(
+std::optional<std::pair<ter_str_id, std::pair<translation, bool>>> ter_furn_transform::next_ter(
     const std::string &flag ) const
 {
     return next( ter_flag_transform, flag );
 }
 
-std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_furn(
+std::optional<std::pair<furn_str_id, std::pair<translation, bool>>> ter_furn_transform::next_furn(
     const furn_str_id &furn ) const
 {
     return next( furn_transform, furn );
 }
 
-std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_furn(
+std::optional<std::pair<furn_str_id, std::pair<translation, bool>>> ter_furn_transform::next_furn(
     const std::string &flag ) const
 {
     return next( furn_flag_transform, flag );
 }
 
-std::optional<std::pair<field_type_id, std::pair<std::optional<translation>, bool>>>
+std::optional<std::pair<field_type_id, std::pair<translation, bool>>>
 ter_furn_transform::next_field(
     const field_type_id &field ) const
 {
     return next( field_transform, field );
 }
 
-std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_trap(
+std::optional<std::pair<trap_str_id, std::pair<translation, bool>>> ter_furn_transform::next_trap(
     const trap_str_id &trap ) const
 {
     return next( trap_transform, trap );
 }
 
-std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_trap(
+std::optional<std::pair<trap_str_id, std::pair<translation, bool>>> ter_furn_transform::next_trap(
     const std::string &flag ) const
 {
     return next( trap_flag_transform, flag );
@@ -217,25 +217,25 @@ void ter_furn_transform::transform( map &m, const tripoint_bub_ms &location ) co
 {
     avatar &you = get_avatar();
     const ter_id ter_at_loc = m.ter( location );
-    std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>> ter_potential = next_ter(
+    std::optional<std::pair<ter_str_id, std::pair<translation, bool>>> ter_potential = next_ter(
                 ter_at_loc->id );
     const furn_id furn_at_loc = m.furn( location );
-    std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>> furn_potential = next_furn(
+    std::optional<std::pair<furn_str_id, std::pair<translation, bool>>> furn_potential = next_furn(
                 furn_at_loc->id );
     const trap_str_id trap_at_loc = m.maptile_at( location ).get_trap().id();
-    std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>> trap_potential = next_trap(
+    std::optional<std::pair<trap_str_id, std::pair<translation, bool>>> trap_potential = next_trap(
                 trap_at_loc );
 
     const field &field_at_loc = m.field_at( location );
     for( const auto &fld : field_at_loc ) {
-        std::optional<std::pair<field_type_id, std::pair<std::optional<translation>, bool>>> field_potential = next_field(
+        std::optional<std::pair<field_type_id, std::pair<translation, bool>>> field_potential = next_field(
                     fld.first );
         if( field_potential ) {
             m.add_field( location, field_potential->first, fld.second.get_field_intensity(),
                          fld.second.get_field_age(), true );
             m.remove_field( location, fld.first );
-            if( you.sees( location ) && field_potential->second.first.has_value() ) {
-                you.add_msg_if_player( field_potential->second.first.value().translated(),
+            if( you.sees( location ) && !field_potential->second.first.empty() ) {
+                you.add_msg_if_player( field_potential->second.first.translated(),
                                        field_potential->second.second ? m_good : m_bad );
             }
         }
@@ -279,21 +279,22 @@ void ter_furn_transform::transform( map &m, const tripoint_bub_ms &location ) co
 
     if( ter_potential ) {
         m.ter_set( location, ter_potential->first );
-        if( you.sees( location ) && ter_potential->second.first.has_value() ) {
-            you.add_msg_if_player( ter_potential->second.first.value().translated(), ter_potential->second.second ? m_good : m_bad );
+        if( you.sees( location ) && !ter_potential->second.first.empty() ) {
+            you.add_msg_if_player( ter_potential->second.first.translated(),
+                                   ter_potential->second.second ? m_good : m_bad );
         }
     }
     if( furn_potential ) {
         m.furn_set( location, furn_potential->first );
-        if( you.sees( location ) && furn_potential->second.first.has_value() ) {
-            you.add_msg_if_player( furn_potential->second.first.value().translated(),
+        if( you.sees( location ) && !furn_potential->second.first.empty() ) {
+            you.add_msg_if_player( furn_potential->second.first.translated(),
                                    furn_potential->second.second ? m_good : m_bad );
         }
     }
     if( trap_potential ) {
         m.trap_set( location, trap_potential->first );
-        if( you.sees( location ) && trap_potential->second.first.has_value() ) {
-            you.add_msg_if_player( trap_potential->second.first.value().translated(),
+        if( you.sees( location ) && !trap_potential->second.first.empty() ) {
+            you.add_msg_if_player( trap_potential->second.first.translated(),
                                    trap_potential->second.second ? m_good : m_bad );
         }
     }

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -226,8 +226,9 @@ void ter_furn_transform::transform( map &m, const tripoint_bub_ms &location ) co
     std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>> ter_potential = next_ter(
                 ter_at_loc->id );
     const furn_id furn_at_loc = m.furn( location );
-    std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>> furn_potential = next_furn(
-                furn_at_loc->id );
+    std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>> furn_potential =
+        next_furn(
+            furn_at_loc->id );
     const trap_str_id trap_at_loc = m.maptile_at( location ).get_trap().id();
     std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>> trap_potential = next_trap(
                 trap_at_loc );

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -158,9 +158,10 @@ std::optional<ter_furn_data<T>> ter_furn_transform::find_transform( const
 }
 
 template<class T, class K>
-std::optional<std::pair<T, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next( const
-        std::map<K, ter_furn_data<T>> &list,
-        const K &key ) const
+std::optional<std::pair<T, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next(
+    const
+    std::map<K, ter_furn_data<T>> &list,
+    const K &key ) const
 {
     const std::optional<ter_furn_data<T>> result = find_transform( list, key );
     if( result.has_value() ) {

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -236,8 +236,9 @@ void ter_furn_transform::transform( map &m, const tripoint_bub_ms &location ) co
 
     const field &field_at_loc = m.field_at( location );
     for( const auto &fld : field_at_loc ) {
-        std::optional<std::pair<field_type_id, std::pair<std::optional<translation>, bool>>> field_potential = next_field(
-                    fld.first );
+        std::optional<std::pair<field_type_id, std::pair<std::optional<translation>, bool>>> field_potential
+            = next_field(
+                  fld.first );
         if( field_potential ) {
             m.add_field( location, field_potential->first, fld.second.get_field_intensity(),
                          fld.second.get_field_age(), true );

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -185,7 +185,8 @@ ter_furn_transform::next_ter(
     return next( ter_flag_transform, flag );
 }
 
-std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>> ter_furn_transform::next_furn(
+std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>>
+ter_furn_transform::next_furn(
     const furn_str_id &furn ) const
 {
     return next( furn_transform, furn );

--- a/src/magic_ter_furn_transform.h
+++ b/src/magic_ter_furn_transform.h
@@ -21,10 +21,10 @@ class ter_furn_data
 {
     public:
         weighted_int_list<T> list;
-        std::optional<translation> message;
+        translation message;
         bool message_good = false;
         ter_furn_data() = default;
-        ter_furn_data( const weighted_int_list<T> &list, const std::optional<translation> &message,
+        ter_furn_data( const weighted_int_list<T> &list, const translation &message,
                        const bool message_good ) :
             list( list ), message( message ), message_good( message_good ) {}
 
@@ -47,19 +47,19 @@ class ter_furn_transform
 
         std::map<field_type_id, ter_furn_data<field_type_id>> field_transform;
 
-        std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>> next_ter(
+        std::optional<std::pair<ter_str_id, std::pair<translation, bool>>> next_ter(
             const ter_str_id &ter ) const;
-        std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>> next_ter(
+        std::optional<std::pair<ter_str_id, std::pair<translation, bool>>> next_ter(
             const std::string &flag ) const;
-        std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>> next_furn(
+        std::optional<std::pair<furn_str_id, std::pair<translation, bool>>> next_furn(
             const furn_str_id &furn ) const;
-        std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>> next_furn(
+        std::optional<std::pair<furn_str_id, std::pair<translation, bool>>> next_furn(
             const std::string &flag ) const;
-        std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>> next_trap(
+        std::optional<std::pair<trap_str_id, std::pair<translation, bool>>> next_trap(
             const trap_str_id &trap ) const;
-        std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>> next_trap(
+        std::optional<std::pair<trap_str_id, std::pair<translation, bool>>> next_trap(
             const std::string &flag ) const;
-        std::optional<std::pair<field_type_id, std::pair<std::optional<translation>, bool>>> next_field(
+        std::optional<std::pair<field_type_id, std::pair<translation, bool>>> next_field(
             const field_type_id &field )
         const;
 
@@ -68,7 +68,7 @@ class ter_furn_transform
                                      const K &key ) const;
 
         template <class T, class K>
-        std::optional<std::pair<T, std::pair<std::optional<translation>, bool>>> next( const std::map<K, ter_furn_data<T>>
+        std::optional<std::pair<T, std::pair<translation, bool>>> next( const std::map<K, ter_furn_data<T>>
                 &list,
                 const K &key ) const;
 

--- a/src/magic_ter_furn_transform.h
+++ b/src/magic_ter_furn_transform.h
@@ -68,9 +68,10 @@ class ter_furn_transform
                                      const K &key ) const;
 
         template <class T, class K>
-        std::optional<std::pair<T, std::pair<std::optional<translation>, bool>>> next( const std::map<K, ter_furn_data<T>>
-                &list,
-                const K &key ) const;
+        std::optional<std::pair<T, std::pair<std::optional<translation>, bool>>> next(
+            const std::map<K, ter_furn_data<T>>
+            &list,
+            const K &key ) const;
 
     public:
 

--- a/src/magic_ter_furn_transform.h
+++ b/src/magic_ter_furn_transform.h
@@ -21,10 +21,10 @@ class ter_furn_data
 {
     public:
         weighted_int_list<T> list;
-        std::string message;
+        std::optional<translation> message;
         bool message_good = false;
         ter_furn_data() = default;
-        ter_furn_data( const weighted_int_list<T> &list, const std::string &message,
+        ter_furn_data( const weighted_int_list<T> &list, const std::optional<translation> &message,
                        const bool message_good ) :
             list( list ), message( message ), message_good( message_good ) {}
 
@@ -47,19 +47,19 @@ class ter_furn_transform
 
         std::map<field_type_id, ter_furn_data<field_type_id>> field_transform;
 
-        std::optional<std::pair<ter_str_id, std::pair<std::string, bool>>> next_ter(
+        std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>> next_ter(
             const ter_str_id &ter ) const;
-        std::optional<std::pair<ter_str_id, std::pair<std::string, bool>>> next_ter(
+        std::optional<std::pair<ter_str_id, std::pair<std::optional<translation>, bool>>> next_ter(
             const std::string &flag ) const;
-        std::optional<std::pair<furn_str_id, std::pair<std::string, bool>>> next_furn(
+        std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>> next_furn(
             const furn_str_id &furn ) const;
-        std::optional<std::pair<furn_str_id, std::pair<std::string, bool>>> next_furn(
+        std::optional<std::pair<furn_str_id, std::pair<std::optional<translation>, bool>>> next_furn(
             const std::string &flag ) const;
-        std::optional<std::pair<trap_str_id, std::pair<std::string, bool>>> next_trap(
+        std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>> next_trap(
             const trap_str_id &trap ) const;
-        std::optional<std::pair<trap_str_id, std::pair<std::string, bool>>> next_trap(
+        std::optional<std::pair<trap_str_id, std::pair<std::optional<translation>, bool>>> next_trap(
             const std::string &flag ) const;
-        std::optional<std::pair<field_type_id, std::pair<std::string, bool>>> next_field(
+        std::optional<std::pair<field_type_id, std::pair<std::optional<translation>, bool>>> next_field(
             const field_type_id &field )
         const;
 
@@ -68,7 +68,7 @@ class ter_furn_transform
                                      const K &key ) const;
 
         template <class T, class K>
-        std::optional<std::pair<T, std::pair<std::string, bool>>> next( const std::map<K, ter_furn_data<T>>
+        std::optional<std::pair<T, std::pair<std::optional<translation>, bool>>> next( const std::map<K, ter_furn_data<T>>
                 &list,
                 const K &key ) const;
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix message in ter_furn_data don't be translated"

#### Purpose of change
Message in ter_furn_data is not translated, in spite of translation exists.

#### Describe the solution
convert type of message from std::string to translation.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Game runs, message is translated actually.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->