### PR TITLE
Refactor test for npcs boarding player vehicles

### DIFF
--- a/data/mods/TEST_DATA/npc_boarding_test.json
+++ b/data/mods/TEST_DATA/npc_boarding_test.json
@@ -1,0 +1,82 @@
+[
+  {
+    "type": "test_data",
+    "npc_boarding_data": {
+      "npc tries to board a vehicle, door on back, windshield on front": {
+        "player_pos": [ 60, 60, 0 ],
+        "npc_pos": [ 62, 60, 0 ],
+        "npc_target": [ 60, 61, 0 ],
+        "vehicle": "boarding_test_veh_windshield"
+      },
+      "npc tries to board a vehicle, door on back, board on front": {
+        "player_pos": [ 60, 60, 0 ],
+        "npc_pos": [ 62, 60, 0 ],
+        "npc_target": [ 60, 61, 0 ],
+        "vehicle": "boarding_test_veh_board"
+      },
+      "npc tries to board a vehicle, door on front": {
+        "player_pos": [ 60, 60, 0 ],
+        "npc_pos": [ 62, 60, 0 ],
+        "npc_target": [ 60, 61, 0 ],
+        "vehicle": "boarding_test_veh_door"
+      }
+    }
+  },
+  {
+    "id": "boarding_test_veh_windshield",
+    "type": "vehicle",
+    "name": "NPC Boarding Test Vehicle",
+    "parts": [
+      { "x": 0, "y": -1, "parts": [ "frame", "board" ] },
+      { "x": 0, "y": 0, "parts": [ "frame", "seat" ] },
+      { "x": 0, "y": 1, "parts": [ "frame", "seat" ] },
+      { "x": 0, "y": 2, "parts": [ "frame", "board" ] },
+      { "x": 1, "y": -1, "parts": [ "frame", "windshield" ] },
+      { "x": 1, "y": 0, "parts": [ "frame", "windshield" ] },
+      { "x": 1, "y": 1, "parts": [ "frame", "windshield" ] },
+      { "x": 1, "y": 2, "parts": [ "frame", "windshield" ] },
+      { "x": -1, "y": -1, "parts": [ "frame", "board" ] },
+      { "x": -1, "y": 0, "parts": [ "frame", "door" ] },
+      { "x": -1, "y": 1, "parts": [ "frame", "board" ] },
+      { "x": -1, "y": 2, "parts": [ "frame", "board" ] }
+    ]
+  },
+  {
+    "id": "boarding_test_veh_board",
+    "type": "vehicle",
+    "name": "NPC Boarding Test Vehicle",
+    "parts": [
+      { "x": 0, "y": -1, "parts": [ "frame", "board" ] },
+      { "x": 0, "y": 0, "parts": [ "frame", "seat" ] },
+      { "x": 0, "y": 1, "parts": [ "frame", "seat" ] },
+      { "x": 0, "y": 2, "parts": [ "frame", "board" ] },
+      { "x": 1, "y": -1, "parts": [ "frame", "board" ] },
+      { "x": 1, "y": 0, "parts": [ "frame", "board" ] },
+      { "x": 1, "y": 1, "parts": [ "frame", "board" ] },
+      { "x": 1, "y": 2, "parts": [ "frame", "board" ] },
+      { "x": -1, "y": -1, "parts": [ "frame", "board" ] },
+      { "x": -1, "y": 0, "parts": [ "frame", "door" ] },
+      { "x": -1, "y": 1, "parts": [ "frame", "board" ] },
+      { "x": -1, "y": 2, "parts": [ "frame", "board" ] }
+    ]
+  },
+  {
+    "id": "boarding_test_veh_door",
+    "type": "vehicle",
+    "name": "NPC Boarding Test Vehicle",
+    "parts": [
+      { "x": 0, "y": -1, "parts": [ "frame", "board" ] },
+      { "x": 0, "y": 0, "parts": [ "frame", "seat" ] },
+      { "x": 0, "y": 1, "parts": [ "frame", "seat" ] },
+      { "x": 0, "y": 2, "parts": [ "frame", "board" ] },
+      { "x": 1, "y": -1, "parts": [ "frame", "windshield" ] },
+      { "x": 1, "y": 0, "parts": [ "frame", "windshield" ] },
+      { "x": 1, "y": 1, "parts": [ "frame", "door" ] },
+      { "x": 1, "y": 2, "parts": [ "frame", "windshield" ] },
+      { "x": -1, "y": -1, "parts": [ "frame", "board" ] },
+      { "x": -1, "y": 0, "parts": [ "frame", "board" ] },
+      { "x": -1, "y": 1, "parts": [ "frame", "board" ] },
+      { "x": -1, "y": 2, "parts": [ "frame", "board" ] }
+    ]
+  }
+]

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -564,6 +564,7 @@ std::unique_ptr<vehicle> map::detach_vehicle( vehicle *veh )
             }
             dirty_vehicle_list.erase( veh );
             rebuild_vehicle_level_caches();
+            set_pathfinding_cache_dirty( z );
             return result;
         }
     }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -6675,6 +6675,7 @@ vehicle *map::add_vehicle( const vproto_id &type, const tripoint &p, const units
         add_vehicle_to_cache( placed_vehicle );
 
         rebuild_vehicle_level_caches();
+        set_pathfinding_cache_dirty( p.z );
         placed_vehicle->place_zones( *this );
     }
     return placed_vehicle;

--- a/src/test_data.cpp
+++ b/src/test_data.cpp
@@ -7,6 +7,7 @@ std::map<vproto_id, std::vector<double>> test_data::drag_data;
 std::map<vproto_id, efficiency_data> test_data::eff_data;
 std::map<itype_id, double> test_data::expected_dps;
 std::map<spawn_type, std::vector<container_spawn_test_data>> test_data::container_spawn_data;
+std::map<std::string, npc_boarding_test_data> test_data::npc_boarding_data;
 
 void efficiency_data::deserialize( const JsonObject &jo )
 {
@@ -37,6 +38,14 @@ void container_spawn_test_data::deserialize( const JsonObject &jo )
     if( jo.has_member( "charges" ) ) {
         jo.read( "charges", charges );
     }
+}
+
+void npc_boarding_test_data::deserialize( const JsonObject &jo )
+{
+    jo.read( "vehicle", veh_prototype );
+    jo.read( "player_pos", player_pos );
+    jo.read( "npc_pos", npc_pos );
+    jo.read( "npc_target", npc_target );
 }
 
 void test_data::load( const JsonObject &jo )
@@ -100,5 +109,11 @@ void test_data::load( const JsonObject &jo )
             container_spawn_data[spawn_type::map].insert( container_spawn_data[spawn_type::map].end(),
                     test_map.begin(), test_map.end() );
         }
+    }
+
+    if( jo.has_object( "npc_boarding_data" ) ) {
+        std::map<std::string, npc_boarding_test_data> new_boarding_data;
+        jo.read( "npc_boarding_data", new_boarding_data );
+        npc_boarding_data.insert( new_boarding_data.begin(), new_boarding_data.end() );
     }
 }

--- a/src/test_data.h
+++ b/src/test_data.h
@@ -6,6 +6,7 @@
 #include <set>
 #include <vector>
 
+#include "point.h"
 #include "type_id.h"
 
 class JsonObject;
@@ -39,6 +40,15 @@ struct container_spawn_test_data {
     void deserialize( const JsonObject &jo );
 };
 
+struct npc_boarding_test_data {
+    vproto_id veh_prototype;
+    tripoint player_pos;
+    tripoint npc_pos;
+    tripoint npc_target;
+
+    void deserialize( const JsonObject &jo );
+};
+
 class test_data
 {
     public:
@@ -48,6 +58,7 @@ class test_data
         static std::map<vproto_id, efficiency_data> eff_data;
         static std::map<itype_id, double> expected_dps;
         static std::map<spawn_type, std::vector<container_spawn_test_data>> container_spawn_data;
+        static std::map<std::string, npc_boarding_test_data> npc_boarding_data;
 
         static void load( const JsonObject &jo );
 };

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -24,9 +24,11 @@
 #include "npc_class.h"
 #include "npctalk.h"
 #include "overmapbuffer.h"
+#include "pathfinding.h"
 #include "pimpl.h"
 #include "player_helpers.h"
 #include "point.h"
+#include "test_data.h"
 #include "text_snippets.h"
 #include "type_id.h"
 #include "units.h"
@@ -44,7 +46,6 @@ static const trait_id trait_WEB_WEAVER( "WEB_WEAVER" );
 static const vpart_id vpart_frame( "frame" );
 static const vpart_id vpart_seat( "seat" );
 
-static const vproto_id vehicle_prototype_ambulance( "ambulance" );
 static const vproto_id vehicle_prototype_none( "none" );
 
 static void on_load_test( npc &who, const time_duration &from, const time_duration &to )
@@ -315,75 +316,105 @@ static void check_npc_movement( const tripoint &origin )
     }
 }
 
-TEST_CASE( "npc-board-player-vehicle" )
+static npc *make_companion( const tripoint &npc_pos )
 {
-    // Place the player at the center of the map
-    const tripoint player_pos( 60, 60, 0 );
-    g->place_player( player_pos );
-    // Clear the map so the NPC can move unimpeded and there are no obstacles
-    clear_map();
-
-    map &here = get_map();
-    Character &pc = get_player_character();
-
-    // Place the NPC outside the door and down one
-    tripoint npc_pos = player_pos + point( -2, -1 );
-
-    // Place an ambulance at the player's position, rotated correctly, 100% fuel, perfect condition
-    vehicle *veh = here.add_vehicle( vehicle_prototype_ambulance, player_pos, -90_degrees, 100, 2 );
-    // And make sure the game knows the player is in it so the NPC can follow
-    here.board_vehicle( player_pos, &pc );
-    REQUIRE( veh != nullptr );
-
-    // Create the NPC
     shared_ptr_fast<npc> guy = make_shared_fast<npc>();
     guy->normalize();
     guy->randomize();
-    // Spawn the NPC in the location desired
     guy->spawn_at_precise( tripoint_abs_ms( get_map().getabs( npc_pos ) ) );
     overmap_buffer.insert_npc( guy );
     g->load_npcs();
     guy->companion_mission_role_id.clear();
-    // Ensure they aren't trying to guard anything
     guy->guard_pos = std::nullopt;
-    // Reset the NPC, so they don't need to eat, or want to play with their items
     clear_character( *guy );
-    // But set them back to the desired position, because clear_character also sets position
     guy->setpos( npc_pos );
-
-    // Make the NPC a follower of the player
     talk_function::follow( *guy );
 
-    //And ensure the NPC has been placed at that location
-    npc *companion = get_creature_tracker().creature_at<npc>( npc_pos );
-    REQUIRE( companion != nullptr );
+    return get_creature_tracker().creature_at<npc>( npc_pos );
+}
 
-    /* Uncomment for some extra info when test fails
-    debug_mode = true;
-    debugmode::enabled_filters.clear();
-    debugmode::enabled_filters.emplace_back( debugmode::DF_NPC );
-    REQUIRE( debugmode::enabled_filters.size() == 1 );
-    */
+TEST_CASE( "npc-board-player-vehicle" )
+{
+    REQUIRE_FALSE( test_data::npc_boarding_data.empty() );
 
-    // Give the NPC 20 moves to board the vehicle
-    for( int i = 0; i < 20; ++i ) {
-        companion->moves = 100;
-        /* Uncommment for extra debug info
-            tripoint npc_pos = companion->pos();
-            optional_vpart_position vp = here.veh_at( npc_pos );
-            vehicle *veh = veh_pointer_or_null( vp );
-            add_msg( m_info, "%s is at %d %d %d and sees t: %s, f: %s, v: %s (%s)",
-                     companion->name, npc_pos.x, npc_pos.y, npc_pos.z,
-                     here.tername( npc_pos ),
-                     here.furnname( npc_pos ),
-                     vp ? remove_color_tags( vp->part_displayed()->part().name() ) : "",
-                     veh ? veh->name : " " );
-        */
-        companion->move();
+    for( std::pair<const std::string, npc_boarding_test_data> &given : test_data::npc_boarding_data ) {
+        GIVEN( given.first ) {
+            npc_boarding_test_data &data = given.second;
+            g->place_player( data.player_pos );
+            clear_map();
+            map &here = get_map();
+            Character &pc = get_player_character();
+
+            vehicle *veh = here.add_vehicle( data.veh_prototype, data.player_pos, 0_degrees, 100, 2 );
+            REQUIRE( veh != nullptr );
+            here.board_vehicle( data.player_pos, &pc );
+            REQUIRE( pc.in_vehicle );
+
+            npc *companion = make_companion( data.npc_pos );
+            REQUIRE( companion != nullptr );
+            REQUIRE( companion->get_attitude() == NPCATT_FOLLOW );
+            REQUIRE( companion->path_settings->allow_open_doors );
+            REQUIRE( companion->path_settings->allow_unlock_doors );
+
+            /* Uncomment for some extra info when test fails
+            debug_mode = true;
+            debugmode::enabled_filters.clear();
+            debugmode::enabled_filters.emplace_back( debugmode::DF_NPC );
+            REQUIRE( debugmode::enabled_filters.size() == 1 );
+            */
+
+            int turns = 0;
+            while( turns++ < 100 && companion->pos() != data.npc_target ) {
+                companion->moves = 100;
+                /* Uncommment for extra debug info
+                tripoint npc_pos = companion->pos();
+                optional_vpart_position vp = here.veh_at( npc_pos );
+                vehicle *veh = veh_pointer_or_null( vp );
+                add_msg( m_info, "%s is at %d %d %d and sees t: %s, f: %s, v: %s (%s)",
+                         companion->name, npc_pos.x, npc_pos.y, npc_pos.z,
+                         here.tername( npc_pos ),
+                         here.furnname( npc_pos ),
+                         vp ? remove_color_tags( vp->part_displayed()->part().name() ) : "",
+                         veh ? veh->name : " " );
+                */
+                companion->move();
+            }
+
+            CAPTURE( companion->path );
+            if( !companion->path.empty() ) {
+                tripoint &p = companion->path.front();
+
+                int part = -1;
+                const vehicle *veh = here.veh_at_internal( p, part );
+                if( veh ) {
+                    const vehicle_part &vp = veh->part( part );
+                    CHECK_FALSE( vp.info().has_flag( VPFLAG_OPENABLE ) );
+
+                    std::string part_name = remove_color_tags( vp.name() );
+                    UNSCOPED_INFO( "target tile: " << p.to_string() << " - vehicle part : " << part_name );
+
+                    int hp = vp.hp();
+                    int bash = companion->path_settings->bash_strength;
+                    UNSCOPED_INFO( "part hp: " << hp << " - bash strength: " << bash );
+
+                    const auto vpobst = vpart_position( const_cast<vehicle &>( *veh ), part ).obstacle_at_part();
+                    part = vpobst ? vpobst->part_index() : -1;
+                    int open = veh->next_part_to_open( part, true );
+                    int lock = veh->next_part_to_unlock( part, true );
+
+                    if( open >= 0 ) {
+                        const vehicle_part &vp_open = veh->part( open );
+                        UNSCOPED_INFO( "open part " << vp_open.name() );
+                    }
+                    if( lock >= 0 ) {
+                        const vehicle_part &vp_lock = veh->part( lock );
+                        UNSCOPED_INFO( "lock part " << vp_lock.name() );
+                    }
+                }
+            }
+            CHECK( companion->pos() == data.npc_target );
+        }
     }
-
-    // This should be the seat next to the player!
-    REQUIRE( companion->pos() == player_pos + point( 2, 0 ) );
 }
 
 TEST_CASE( "npc-movement" )


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #66968

#### Describe the solution

- jsonzie the test for fun and easier possible future expansion (like vehicles with z-levels)
- replace the ambulance with a custom test vehicle
- dirty pathfinding cache when placing or removing vehicles
- remove comments that aren't really necessary or helpful

#### Describe alternatives you've considered

Only replacing the vehicle, dirtying the cache and adjusting the points accordingly.

#### Testing

Ran `./Cataclysm-test-vcpkg-static-Release-x64.exe activity_interruption_by_distractions,npc-board-player-vehicle --order lex` and it passes. Without dirtying the cache it fails. Thanks a ton to @andrei8l for identifying this.

#### Additional context

