### PR TITLE
Fix vehicle keybindings

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -51,5 +51,5 @@ files:
     - dseguin
   'src/ui_manager.*':
     - Qrox
-  'data/raw/keybindings.json':
+  'data/raw/keybindings{.json,/**}':
     - Qrox

--- a/data/raw/keybindings/vehicle.json
+++ b/data/raw/keybindings/vehicle.json
@@ -39,7 +39,7 @@
     "type": "keybinding",
     "category": "VEHICLE",
     "name": "Pull handbrake",
-    "bindings": [ { "input_method": "keyboard_any", "key": "H" } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "H" }, { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] } ]
   },
   {
     "id": "USE_WORKBENCH",
@@ -88,21 +88,21 @@
     "type": "keybinding",
     "category": "VEHICLE",
     "name": "Toggle autoclave",
-    "bindings": [ { "input_method": "keyboard_any", "key": "C" } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "C" }, { "input_method": "keyboard_code", "key": "c", "mod": [ "shift" ] } ]
   },
   {
     "id": "TOGGLE_WASHING_MACHINE",
     "type": "keybinding",
     "category": "VEHICLE",
     "name": "Toggle washing machine",
-    "bindings": [ { "input_method": "keyboard_any", "key": "W" } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "W" }, { "input_method": "keyboard_code", "key": "w", "mod": [ "shift" ] } ]
   },
   {
     "id": "TOGGLE_DISHWASHER",
     "type": "keybinding",
     "category": "VEHICLE",
     "name": "Toggle dishwasher",
-    "bindings": [ { "input_method": "keyboard_any", "key": "D" } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "D" }, { "input_method": "keyboard_code", "key": "d", "mod": [ "shift" ] } ]
   },
   {
     "id": "GET_ITEMS",
@@ -151,21 +151,21 @@
     "type": "keybinding",
     "category": "VEHICLE",
     "name": "Purify water in vehicle tank",
-    "bindings": [ { "input_method": "keyboard_any", "key": "P" } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "P" }, { "input_method": "keyboard_code", "key": "p", "mod": [ "shift" ] } ]
   },
   {
     "id": "USE_CAPTURE_MONSTER_VEH",
     "type": "keybinding",
     "category": "VEHICLE",
     "name": "Capture or release a creature",
-    "bindings": [ { "input_method": "keyboard_any", "key": "G" } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "G" }, { "input_method": "keyboard_code", "key": "g", "mod": [ "shift" ] } ]
   },
   {
     "id": "USE_ANIMAL_CTRL",
     "type": "keybinding",
     "category": "VEHICLE",
     "name": "Harness an animal",
-    "bindings": [ { "input_method": "keyboard_any", "key": "H" } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "H" }, { "input_method": "keyboard_code", "key": "h", "mod": [ "shift" ] } ]
   },
   {
     "id": "USE_PLANTER",
@@ -256,7 +256,7 @@
     "type": "keybinding",
     "category": "VEHICLE",
     "name": "Toggle space heater",
-    "bindings": [ { "input_method": "keyboard_any", "key": "J" } ]
+    "bindings": [ { "input_method": "keyboard_char", "key": "J" }, { "input_method": "keyboard_code", "key": "j", "mod": [ "shift" ] } ]
   },
   {
     "id": "TOGGLE_HEATED_TANK",

--- a/src/veh_utils.h
+++ b/src/veh_utils.h
@@ -42,7 +42,6 @@ struct veh_menu_item {
     bool _keep_menu_open = false;
     std::optional<char> _hotkey_char = std::nullopt;
     std::optional<std::string> _hotkey_action = std::nullopt;
-    std::optional<input_event> _hotkey_event = std::nullopt;
     std::function<void()> _on_submit;
 
     veh_menu_item &text( const std::string &text );
@@ -52,7 +51,6 @@ struct veh_menu_item {
     veh_menu_item &skip_locked_check( bool skip_locked_check = true );
     veh_menu_item &hotkey( char hotkey_char );
     veh_menu_item &hotkey( const std::string &action );
-    veh_menu_item &hotkey( const input_event &ev );
     veh_menu_item &hotkey_auto();
     veh_menu_item &on_submit( const std::function<void()> &on_submit );
     veh_menu_item &keep_menu_open( bool keep_menu_open = true );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2434,9 +2434,9 @@ std::optional<vpart_reference> vpart_position::part_with_tool( const itype_id &t
         if( vp.part().is_broken() ) {
             continue;
         }
-        const std::map<item, input_event> tools = vehicle().prepare_tools( vp.part() );
+        const std::map<item, int> tools = vehicle().prepare_tools( vp.part() );
         if( std::find_if( tools.begin(), tools.end(),
-        [&tool_type]( const std::pair<const item, input_event> &pair ) {
+        [&tool_type]( const std::pair<const item, int> &pair ) {
         return pair.first.typeId() == tool_type;
         } ) != tools.end() ) {
             return vp;
@@ -2445,16 +2445,16 @@ std::optional<vpart_reference> vpart_position::part_with_tool( const itype_id &t
     return std::optional<vpart_reference>();
 }
 
-std::map<item, input_event> vpart_position::get_tools() const
+std::map<item, int> vpart_position::get_tools() const
 {
-    std::map<item, input_event> res;
+    std::map<item, int> res;
     for( const int part_idx : this->vehicle().parts_at_relative( this->mount(), false ) ) {
         const vehicle_part &vp = this->vehicle().part( part_idx );
         if( vp.is_broken() ) {
             continue;
         }
-        for( const auto &[tool_item, ev] : this->vehicle().prepare_tools( vp ) ) {
-            res[tool_item] = ev;
+        for( const auto &[tool_item, hk] : this->vehicle().prepare_tools( vp ) ) {
+            res[tool_item] = hk;
         }
     }
     return res;
@@ -5593,22 +5593,18 @@ const std::vector<item> &vehicle::get_tools( const vehicle_part &vp ) const
     return vp.tools;
 }
 
-std::map<item, input_event> vehicle::prepare_tools( const vehicle_part &vp ) const
+std::map<item, int> vehicle::prepare_tools( const vehicle_part &vp ) const
 {
-    std::map<item, input_event> res;
+    std::map<item, int> res;
     for( const std::pair<itype_id, int> &pair : vp.info().get_pseudo_tools() ) {
         item it( pair.first, calendar::turn );
-        const input_event ev( pair.second, input_event_t::keyboard_char );
         prepare_tool( it );
-        res.emplace( it, pair.second > 0 ? ev : input_event( -1, input_event_t::error ) );
+        res.emplace( it, pair.second > 0 ? pair.second : -1 );
     }
     for( const item &it_src : vp.tools ) {
         item it( it_src ); // make a copy
-        const input_event ev = it.invlet > 0
-                               ? input_event( it.invlet, input_event_t::keyboard_char )
-                               : input_event();
         prepare_tool( it );
-        res.emplace( it, ev );
+        res.emplace( it, it.invlet > 0 ? it.invlet : 0 );
     }
     return res;
 }

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1748,7 +1748,7 @@ class vehicle
         * marked with PSEUDO flags, pseudo_magazine_mod and pseudo_magazine attached, magazines filled
         * with the first ammo type required by the tool. pseudo tools are mapped to their hotkey if exists.
         */
-        std::map<item, input_event> prepare_tools( const vehicle_part &vp ) const;
+        std::map<item, int> prepare_tools( const vehicle_part &vp ) const;
 
         /**
          * Update an item's active status, for example when adding

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -2057,18 +2057,18 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         }
     }
 
-    for( const auto&[tool_item, hotkey_event] : vp.get_tools() ) {
+    for( const auto&[tool_item, hk] : vp.get_tools() ) {
         const itype_id &tool_type = tool_item.typeId();
         if( !tool_type->has_use() ) {
             continue; // passive tool
         }
-        if( !hotkey_event.sequence.empty() && hotkey_event.sequence.front() == -1 ) {
+        if( hk == -1 ) {
             continue; // skip old passive tools
         }
         const auto &[tool_ammo, ammo_amount] = tool_ammo_available( tool_type );
         menu.add( string_format( _( "Use %s" ), tool_type->nname( 1 ) ) )
         .enable( ammo_amount >= tool_item.typeId()->charges_to_use() )
-        .hotkey( hotkey_event )
+        .hotkey( hk )
         .skip_locked_check( tool_ammo.is_null() || tool_ammo->ammo->type != ammo_battery )
         .on_submit( [this, vppos, tool_type] { use_vehicle_tool( *this, vppos, tool_type ); } );
     }
@@ -2251,7 +2251,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
             Character &you = get_player_character();
             vehicle_part &vp = part( vp_idx );
             std::set<itype_id> allowed_types = vp.info().toolkit_info->allowed_types;
-            for( const std::pair<const item, input_event> &pair : prepare_tools( vp ) )
+            for( const std::pair<const item, int> &pair : prepare_tools( vp ) )
             {
                 allowed_types.erase( pair.first.typeId() ); // one tool of each kind max
             }

--- a/src/vpart_position.h
+++ b/src/vpart_position.h
@@ -91,7 +91,7 @@ class vpart_position
         // Finds vpart_reference to inner part with specified tool
         std::optional<vpart_reference> part_with_tool( const itype_id &tool_type ) const;
         // Returns a list of all tools provided by vehicle and their hotkey
-        std::map<item, input_event> get_tools() const;
+        std::map<item, int> get_tools() const;
         // Forms inventory for inventory::form_from_map
         void form_inventory( inventory &inv ) const;
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I missed `data/raw/keybindings/vehicle.json` in #66938.

#### Describe the solution
1. Replace capital letter `keyboard_any` bindings with the corresponding `keyboard_char` and `keyboard_code` bindings.
2. Update the vehicle menu code to correctly handle the keybindings in key code mode instead of always generating symbol mode bindings.
3. Update the match pattern in `reviewers.yml` to include files in the `data/raw/keybindings` directory

#### Describe alternatives you've considered

#### Testing
Installed various vehicle parts with pseudo tools, attached various tools to a vehicle mounted workshop, opened vehicle interaction menu, and the hotkeys were correctly generated in both symbol and key code modes.

#### Additional context
