### PR TITLE
Implement part of gha_test_only.sh in CTest

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,9 +28,18 @@ if (BUILD_TESTING)
         endif()
         target_link_libraries(cata_test-tiles PRIVATE cataclysm-tiles-common)
         add_test(NAME test-tiles
-                COMMAND sh -c
-                "$<TARGET_FILE:cata_test-tiles> --rng-seed time"
+                COMMAND cata_test-tiles --rng-seed time
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+        # ctest -C RelWithDebInfo -j 2 -V -L ^gha$
+        list(APPEND _n 1 2)
+        list(APPEND _args "[slow] ~starting_items" "~[slow] ~[.],starting_items")
+        foreach(n args IN ZIP_LISTS _n _args)
+            add_test(NAME test-tiles-gha-${n}
+                    COMMAND cata_test-tiles --min-duration 20 --use-colour yes --rng-seed time
+                    --user-dir=test_user_dir_${n} ${args}
+                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+            set_tests_properties(test-tiles-gha-${n} PROPERTIES LABELS "gha")
+        endforeach()
     endif ()
 
     if (CURSES)
@@ -40,8 +49,7 @@ if (BUILD_TESTING)
         endif()
         target_link_libraries(cata_test PRIVATE cataclysm-common)
         add_test(NAME test
-                COMMAND sh -c
-                "$<TARGET_FILE:cata_test> --rng-seed time"
+                COMMAND cata_test --rng-seed time
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
     endif ()
 endif ()


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Add tests same as done by `build-scripts\gha_test_only.sh`, but under CTest control.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Using CTest, I can run such tests under IDE, command line, Windows.
Need to port the `get_all_mods.py` part and the ASAN/UBSAN. For future PRs.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Can't change CTest prefix lines, so must rely on `:1`, `:2`, etc.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Run in Visual Studio 2022 and vscode using your .devcontainer/ .
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->