### PR TITLE
Add a spell-using feral human to Magiclysm

### DIFF
--- a/data/mods/Magiclysm/Spells/monsterspells.json
+++ b/data/mods/Magiclysm/Spells/monsterspells.json
@@ -236,10 +236,6 @@
     "min_damage": 1,
     "max_damage": 1,
     "message": "",
-    "extra_effects": [
-      { "id": "blinding_flash" },
-      { "id": "ethereal_grasp" },
-      { "id": "point_flare" }
-    ]
+    "extra_effects": [ { "id": "blinding_flash" }, { "id": "ethereal_grasp" }, { "id": "point_flare" } ]
   }
 ]

--- a/data/mods/Magiclysm/Spells/monsterspells.json
+++ b/data/mods/Magiclysm/Spells/monsterspells.json
@@ -222,5 +222,24 @@
     "min_aoe": 90,
     "max_aoe": 270,
     "damage_type": "bash"
+  },
+  {
+    "type": "SPELL",
+    "id": "spell_feral_wizard_base",
+    "name": "Wild Magic Monster Sorcery",
+    "description": "Causes one of the spells to be cast, used for the feral wizard.",
+    "valid_targets": [ "hostile" ],
+    "effect": "none",
+    "shape": "blast",
+    "base_casting_time": 100,
+    "flags": [ "WONDER", "NO_PROJECTILE" ],
+    "min_damage": 1,
+    "max_damage": 1,
+    "message": "",
+    "extra_effects": [
+      { "id": "blinding_flash" },
+      { "id": "ethereal_grasp" },
+      { "id": "point_flare" }
+    ]
   }
 ]

--- a/data/mods/Magiclysm/monstergroups.json
+++ b/data/mods/Magiclysm/monstergroups.json
@@ -40,6 +40,15 @@
   },
   {
     "type": "monstergroup",
+    "name": "GROUP_FERAL",
+    "//": "default ferals",
+    "default": "mon_feral_human_crowbar",
+    "monsters": [
+      { "monster": "mon_feral_human_magician", "weight": 2, "cost_multiplier": 2 }
+    ]
+  },
+  {
+    "type": "monstergroup",
     "name": "GROUP_SWAMP",
     "is_animal": true,
     "monsters": [

--- a/data/mods/Magiclysm/monstergroups.json
+++ b/data/mods/Magiclysm/monstergroups.json
@@ -43,9 +43,7 @@
     "name": "GROUP_FERAL",
     "//": "default ferals",
     "default": "mon_feral_human_crowbar",
-    "monsters": [
-      { "monster": "mon_feral_human_magician", "weight": 2, "cost_multiplier": 2 }
-    ]
+    "monsters": [ { "monster": "mon_feral_human_magician", "weight": 2, "cost_multiplier": 2 } ]
   },
   {
     "type": "monstergroup",

--- a/data/mods/Magiclysm/monsters/zombified_monsters.json
+++ b/data/mods/Magiclysm/monsters/zombified_monsters.json
@@ -205,5 +205,70 @@
     },
     "proportional": { "volume": 1.01, "weight": 0.95 },
     "extend": { "flags": [ "PATH_AVOID_DANGER_1" ], "special_attacks": [ { "type": "leap", "cooldown": 7, "max_range": 2 } ] }
+  },
+  {
+    "id": "mon_feral_human_magician",
+    "type": "MONSTER",
+    "name": { "str": "feral wizard" },
+    "description": "Stumbling about with strange ravings and odd motions, this crazed individual walks among the dead as one of their own.  Occaisional flashes and sparks erupt from their twisted and grimy fingers as they perform arcane motions.",
+    "default_faction": "zombie",
+    "looks_like": "chud",
+    "bodytype": "human",
+    "species": [ "HUMAN" ],
+    "volume": "62500 ml",
+    "weight": "81500 g",
+    "hp": 80,
+    "speed": 100,
+    "material": [ "flesh" ],
+    "symbol": "@",
+    "color": "magenta",
+    "aggression": 30,
+    "morale": 100,
+    "melee_skill": 2,
+    "melee_dice": 1,
+    "melee_dice_sides": 3,
+    "weakpoint_sets": [ "wps_humanoid_body" ],
+    "families": [ "prof_intro_biology", "prof_physiology" ],
+    "dodge": 1,
+    "harvest": "human",
+    "dissect": "dissect_human_sample_single",
+    "vision_day": 30,
+    "vision_night": 3,
+    "path_settings": { "max_dist": 30, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
+    "special_attacks": [ { "type": "spell", "spell_data": { "id": "spell_feral_wizard_base" }, "cooldown": 4 } ],
+    "death_drops": {
+      "subtype": "distribution",
+      "items": [
+        { "group": "enchanted_small_items", "prob": 5 },
+        { "group": "feral_humans_death_drops_pipe", "prob": 100 },
+        { "group": "enchanted_wands_lesser", "prob": 3 }
+      ]
+    },
+    "upgrades": { "half_life": 90, "into_group": "GROUP_ZOMBIE_UPGRADE" },
+    "zombify_into": "mon_zombie",
+    "fungalize_into": "mon_feral_human_pipe_fungal_infected",
+    "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "WARM",
+      "BASHES",
+      "GROUP_BASH",
+      "HUMAN",
+      "CAN_OPEN_DOORS",
+      "PATH_AVOID_DANGER_1"
+    ]
+  },
+  {
+    "id": "mon_feral_human_magician_fungal_corpse",
+    "type": "MONSTER",
+    "description": "Delicate fungal stalks sprout in rows from sores covering this person's body, and their facial expression is pure agony.",
+    "copy-from": "mon_feral_human_magician",
+    "default_faction": "fungus",
+    "upgrades": { "half_life": 14, "into_group": "GROUP_NULL", "into": "mon_fungaloid" },
+    "special_attacks": [ [ "FUNGUS", 40 ] ],
+    "death_function": { "effect": { "id": "death_fungus", "hit_self": true } },
+    "extend": { "flags": [ "NO_FUNG_DMG", "IMMOBILE" ] }
   }
 ]

--- a/data/mods/Magiclysm/monsters/zombified_monsters.json
+++ b/data/mods/Magiclysm/monsters/zombified_monsters.json
@@ -248,17 +248,7 @@
     "zombify_into": "mon_zombie",
     "fungalize_into": "mon_feral_human_pipe_fungal_infected",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "flags": [
-      "SEES",
-      "HEARS",
-      "SMELLS",
-      "WARM",
-      "BASHES",
-      "GROUP_BASH",
-      "HUMAN",
-      "CAN_OPEN_DOORS",
-      "PATH_AVOID_DANGER_1"
-    ]
+    "flags": [ "SEES", "HEARS", "SMELLS", "WARM", "BASHES", "GROUP_BASH", "HUMAN", "CAN_OPEN_DOORS", "PATH_AVOID_DANGER_1" ]
   },
   {
     "id": "mon_feral_human_magician_fungal_corpse",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Add a spell-using feral human to Magiclysm."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Add a new feral enemy which can use spells.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The feral magician is an extremely rare enemy which spawns with other ferals, and is capable of using Blinding Flash, Ethereal Grasp, and Point Flare, casting with the same frequency as the lizardfolk shaman. In addition to the usual loot of ferals, you can sometimes find minor magical items or wands on it when killed.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned one in and fought it. However, for some reason, neither it nor the lizardfold shaman would cast any of their magic, just rushing straight to melee. I believe this might be caused by something outside of the PR which I don't know of.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
None at the moment.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->