### PR TITLE
change chewing gum to not be a stimulant

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -693,7 +693,6 @@
     "stack_size": 100,
     "symbol": "*",
     "color": "pink",
-    "stim": 1,
     "fun": 2,
     "flags": [ "NO_INGEST" ],
     "use_action": [ "CHEW" ]

--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -679,25 +679,6 @@
     "flags": [ "NO_INGEST", "NPC_SAFE", "IRREPLACEABLE_CONSUMABLE" ]
   },
   {
-    "id": "gum",
-    "type": "COMESTIBLE",
-    "comestible_type": "MED",
-    "name": { "str_sp": "chewing gum" },
-    "description": "Bright pink sugar-free chewing gum.",
-    "category": "food",
-    "weight": "3 g",
-    "volume": "250 ml",
-    "price": 100,
-    "price_postapoc": 100,
-    "charges": 10,
-    "stack_size": 100,
-    "symbol": "*",
-    "color": "pink",
-    "fun": 2,
-    "flags": [ "NO_INGEST" ],
-    "use_action": [ "CHEW" ]
-  },
-  {
     "id": "handrolled_cig",
     "type": "COMESTIBLE",
     "comestible_type": "MED",

--- a/data/json/items/comestibles/other.json
+++ b/data/json/items/comestibles/other.json
@@ -28,6 +28,25 @@
     "flags": [ "INEDIBLE" ]
   },
   {
+    "id": "gum",
+    "type": "COMESTIBLE",
+    "comestible_type": "FOOD",
+    "name": { "str_sp": "chewing gum" },
+    "description": "Bright pink sugar-free chewing gum.",
+    "category": "food",
+    "weight": "3 g",
+    "volume": "250 ml",
+    "price": 100,
+    "price_postapoc": 100,
+    "charges": 10,
+    "stack_size": 100,
+    "symbol": "*",
+    "color": "pink",
+    "fun": 2,
+    "flags": [ "NO_INGEST" ],
+    "use_action": [ "CHEW" ]
+  },
+  {
     "type": "COMESTIBLE",
     "id": "slime_scrap",
     "category": "other",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Chewing gum is (not) a stimulant"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Chewing gum counted as a stimulant; given the description this was unexpected. Now it's not a stimulant.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Removed `"stim": 1,`  from chewing gum in med.json.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded game started before the fix, consumed chewing gum, no stimulant effect. Made new character, spawned and consumed chewing gum, no stimulant effect.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->