### PR TITLE
Allow 'PARROT_AT_DANGER' to select player or NPC as target

### DIFF
--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4463,11 +4463,12 @@ bool mattack::parrot( monster *z )
 
 bool mattack::parrot_at_danger( monster *parrot )
 {
-    for ( Creature &creature : g->all_creatures() ) {
-        if ( !creature.is_hallucination() ) {
-            if ( creature.is_avatar() || creature.is_npc() ) {
-                Character* character = creature.as_character();
-                if (one_in( 20 ) && character->attitude_to( *parrot ) == Creature::Attitude::HOSTILE && parrot->sees( *character) ) {
+    for( Creature &creature : g->all_creatures() ) {
+        if( !creature.is_hallucination() ) {
+            if( creature.is_avatar() || creature.is_npc() ) {
+                Character *character = creature.as_character();
+                if( one_in( 20 ) && character->attitude_to( *parrot ) == Creature::Attitude::HOSTILE &&
+                    parrot->sees( *character ) ) {
                     parrot_common( parrot );
                     return true;
                 }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4472,12 +4472,11 @@ bool mattack::parrot_at_danger( monster *parrot )
                     parrot_common( parrot );
                     return true;
                 }
-            }
-            else {
-                monster* monster = creature.as_monster();
-                if ( one_in( 20 ) && ( monster->faction->attitude( parrot->faction ) == mf_attitude::MFA_HATE ||
-                    ( monster->anger > 0 &&
-                        monster->faction->attitude( parrot->faction ) == mf_attitude::MFA_BY_MOOD ) ) &&
+            } else {
+                monster *monster = creature.as_monster();
+                if( one_in( 20 ) && ( monster->faction->attitude( parrot->faction ) == mf_attitude::MFA_HATE ||
+                                      ( monster->anger > 0 &&
+                                        monster->faction->attitude( parrot->faction ) == mf_attitude::MFA_BY_MOOD ) ) &&
                     parrot->sees( *monster ) ) {
                     parrot_common( parrot );
                     return true;

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4463,13 +4463,25 @@ bool mattack::parrot( monster *z )
 
 bool mattack::parrot_at_danger( monster *parrot )
 {
-    for( monster &monster : g->all_monsters() ) {
-        if( one_in( 20 ) && ( monster.faction->attitude( parrot->faction ) == mf_attitude::MFA_HATE ||
-                              ( monster.anger > 0 &&
-                                monster.faction->attitude( parrot->faction ) == mf_attitude::MFA_BY_MOOD ) ) &&
-            parrot->sees( monster ) ) {
-            parrot_common( parrot );
-            return true;
+    for ( Creature &creature : g->all_creatures() ) {
+        if ( !creature.is_hallucination() ) {
+            if ( creature.is_avatar() || creature.is_npc() ) {
+                Character* character = creature.as_character();
+                if (one_in( 20 ) && character->attitude_to( *parrot ) == Creature::Attitude::HOSTILE && parrot->sees( *character) ) {
+                    parrot_common( parrot );
+                    return true;
+                }
+            }
+            else {
+                monster* monster = creature.as_monster();
+                if ( one_in( 20 ) && ( monster->faction->attitude( parrot->faction ) == mf_attitude::MFA_HATE ||
+                    ( monster->anger > 0 &&
+                        monster->faction->attitude( parrot->faction ) == mf_attitude::MFA_BY_MOOD ) ) &&
+                    parrot->sees( *monster ) ) {
+                    parrot_common( parrot );
+                    return true;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #61931
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
We start with a 'creature'  and first determine whether the creature is an hallucination. Then, we differentiate between non monsters  and  monsters .Make the monster parrot correctly.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![B8$FY`NWATEL`O}}N)VW1T2](https://github.com/CleverRaven/Cataclysm-DDA/assets/112397151/49e67a10-11d3-4a93-a907-36699cd0fdc4)
![WHX1`CCBQQAKA@HX UJLI}R](https://github.com/CleverRaven/Cataclysm-DDA/assets/112397151/a1112283-51ab-4ae5-908c-81754a9a7ad2)

Generate a hostile cunning feral, he  parrot  to  player and npc correctly.  When you get close, you can hear what he's saying. For other monsters, the reaction was also as expected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->