### PR TITLE
Make formatter enable ANSI colors in stdout on Windows

### DIFF
--- a/tools/format/format_main.cpp
+++ b/tools/format/format_main.cpp
@@ -15,11 +15,27 @@
 #include <string>
 
 #if defined(_WIN32)
+#include <Windows.h>
+
 static void erase_char( std::string &s, const char &c )
 {
     s.erase( std::remove( s.begin(), s.end(), c ), s.end() );
 }
 #endif
+
+static bool enable_stdout_ansi_colors()
+{
+#if defined(_WIN32)
+    // enable ANSI colors on windows consoles https://superuser.com/a/1529908
+    DWORD dwMode;
+    GetConsoleMode( GetStdHandle( STD_OUTPUT_HANDLE ), &dwMode );
+    dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    // may fail on Windows 10 earlier than 1511
+    return SetConsoleMode( GetStdHandle( STD_OUTPUT_HANDLE ), dwMode );
+#else
+    return true;
+#endif
+}
 
 int main( int argc, char *argv[] )
 {
@@ -35,6 +51,10 @@ int main( int argc, char *argv[] )
     json_error_output_colors = supports_color
                                ? json_error_output_colors_t::ansi_escapes
                                : json_error_output_colors_t::no_colors;
+
+    if( !enable_stdout_ansi_colors() ) {
+        json_error_output_colors = json_error_output_colors_t::no_colors;
+    }
 
     std::stringstream in;
     std::stringstream out;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes https://discord.com/channels/598523535169945603/598529174302490644/1130820653495353434

#### Describe the solution

Call winapi SetConsoleMode to enable ANSI colors

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested conhost (console/powershell), windows terminal, VS built-in shell and redirecting output to file

#### Additional context

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/6560075/fdfcbc23-7be8-4e5c-9521-66745bdf9d01)
