### PR TITLE
[Magiclysm] Reading the Earthbones spell fix

### DIFF
--- a/data/mods/Magiclysm/Spells/earthshaper.json
+++ b/data/mods/Magiclysm/Spells/earthshaper.json
@@ -665,7 +665,7 @@
   {
     "id": "earthshaper_map_real",
     "type": "SPELL",
-    "name": "Earthshaper Real Spell",
+    "name": "Reading the Earthbones Real Spell",
     "description": "This is the spell that actually fires when you cast Reading the Earthbones.  It's a bug if you have it.",
     "valid_targets": [ "none" ],
     "message": "The secrets of the living earth are revealed to you.",

--- a/data/mods/Magiclysm/Spells/earthshaper.json
+++ b/data/mods/Magiclysm/Spells/earthshaper.json
@@ -659,123 +659,20 @@
     "type": "effect_on_condition",
     "id": "EOC_EARTHSHAPER_MAP",
     "condition": { "compare_int": [ { "u_val": "pos_z" }, "<=", { "const": 0 } ] },
-    "effect": {
-      "switch": { "u_val": "spell_level", "spell": "earthshaper_reveal_world_map" },
-      "cases": [
-        { "case": 0, "effect": { "u_cast_spell": { "id": "earthshaper_map_1" } } },
-        { "case": 2, "effect": { "u_cast_spell": { "id": "earthshaper_map_2" } } },
-        { "case": 4, "effect": { "u_cast_spell": { "id": "earthshaper_map_3" } } },
-        { "case": 6, "effect": { "u_cast_spell": { "id": "earthshaper_map_4" } } },
-        { "case": 8, "effect": { "u_cast_spell": { "id": "earthshaper_map_5" } } },
-        { "case": 10, "effect": { "u_cast_spell": { "id": "earthshaper_map_6" } } },
-        { "case": 12, "effect": { "u_cast_spell": { "id": "earthshaper_map_7" } } },
-        { "case": 14, "effect": { "u_cast_spell": { "id": "earthshaper_map_8" } } }
-      ]
-    },
+    "effect": [ { "u_cast_spell": { "id": "earthshaper_map_real" } } ],
     "false_effect": [ { "u_message": "Without a direct connection to the living earth, the spell fails." } ]
   },
   {
-    "id": "earthshaper_map_1",
+    "id": "earthshaper_map_real",
     "type": "SPELL",
-    "name": "Earthshape EOC cast #1",
-    "description": "This is one of the spells that actually fires when you cast Reading the Earthbones.  It's a bug if you have it.",
-    "valid_targets": [ "none" ],
-    "message": "The secrets of the living earth are revealed to you.",
-    "flags": [ "NO_HANDS", "CONCENTRATE", "SILENT" ],
-    "effect": "map",
-    "shape": "blast",
-    "max_level": 1,
-    "min_aoe": 10
-  },
-  {
-    "id": "earthshaper_map_2",
-    "type": "SPELL",
-    "name": "Earthshape EOC cast #2",
+    "name": "Earthshaper Real Spell",
     "description": "This is the spell that actually fires when you cast Reading the Earthbones.  It's a bug if you have it.",
     "valid_targets": [ "none" ],
     "message": "The secrets of the living earth are revealed to you.",
-    "flags": [ "NO_HANDS", "CONCENTRATE", "SILENT" ],
+    "flags": [ "NO_HANDS", "SILENT" ],
     "effect": "map",
     "shape": "blast",
     "max_level": 1,
-    "min_aoe": 14
-  },
-  {
-    "id": "earthshaper_map_3",
-    "type": "SPELL",
-    "name": "Earthshape EOC cast #3",
-    "description": "This is the spell that actually fires when you cast Reading the Earthbones.  It's a bug if you have it.",
-    "valid_targets": [ "none" ],
-    "message": "The secrets of the living earth are revealed to you.",
-    "flags": [ "NO_HANDS", "CONCENTRATE", "SILENT" ],
-    "effect": "map",
-    "shape": "blast",
-    "max_level": 1,
-    "min_aoe": 18
-  },
-  {
-    "id": "earthshaper_map_4",
-    "type": "SPELL",
-    "name": "Earthshape EOC cast #4",
-    "description": "This is the spell that actually fires when you cast Reading the Earthbones.  It's a bug if you have it.",
-    "valid_targets": [ "none" ],
-    "message": "The secrets of the living earth are revealed to you.",
-    "flags": [ "NO_HANDS", "CONCENTRATE", "SILENT" ],
-    "effect": "map",
-    "shape": "blast",
-    "max_level": 1,
-    "min_aoe": 22
-  },
-  {
-    "id": "earthshaper_map_5",
-    "type": "SPELL",
-    "name": "Earthshape EOC cast #5",
-    "description": "This is the spell that actually fires when you cast Reading the Earthbones.  It's a bug if you have it.",
-    "valid_targets": [ "none" ],
-    "message": "The secrets of the living earth are revealed to you.",
-    "flags": [ "NO_HANDS", "CONCENTRATE", "SILENT" ],
-    "effect": "map",
-    "shape": "blast",
-    "max_level": 1,
-    "min_aoe": 26
-  },
-  {
-    "id": "earthshaper_map_6",
-    "type": "SPELL",
-    "name": "Earthshape EOC cast #6",
-    "description": "This is the spell that actually fires when you cast Reading the Earthbones.  It's a bug if you have it.",
-    "valid_targets": [ "none" ],
-    "message": "The secrets of the living earth are revealed to you.",
-    "flags": [ "NO_HANDS", "CONCENTRATE", "SILENT" ],
-    "effect": "map",
-    "shape": "blast",
-    "max_level": 1,
-    "min_aoe": 30
-  },
-  {
-    "id": "earthshaper_map_7",
-    "type": "SPELL",
-    "name": "Earthshape EOC cast #7",
-    "description": "This is the spell that actually fires when you cast Reading the Earthbones.  It's a bug if you have it.",
-    "valid_targets": [ "none" ],
-    "message": "The secrets of the living earth are revealed to you.",
-    "flags": [ "NO_HANDS", "CONCENTRATE", "SILENT" ],
-    "effect": "map",
-    "shape": "blast",
-    "max_level": 1,
-    "min_aoe": 35
-  },
-  {
-    "id": "earthshaper_map_8",
-    "type": "SPELL",
-    "name": "Earthshape EOC cast #8",
-    "description": "This is the spell that actually fires when you cast Reading the Earthbones.  It's a bug if you have it.",
-    "valid_targets": [ "none" ],
-    "message": "The secrets of the living earth are revealed to you.",
-    "flags": [ "NO_HANDS", "CONCENTRATE", "SILENT" ],
-    "effect": "map",
-    "shape": "blast",
-    "max_level": 1,
-    "min_aoe": 40
+    "min_aoe": { "math": [ "( 7 + (u_val('spell_level', 'spell: earthshaper_reveal_world_map') * 2.2) )" ] }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Reading the Earthbones spell fix"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

When I wrote https://github.com/CleverRaven/Cataclysm-DDA/pull/63680 , I had to make a bunch of different Earthshaper subspells to get Reading the Earthbones to work correctly.  Now that math works in spells, that's not necessary anymore.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change the eight subspells to a single spell that scales, 7 + 2.2 * spell level.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Doing nothing
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->