### PR TITLE
Damage types: armour/material fixes

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -1343,6 +1343,29 @@
     ]
   },
   {
+    "id": "test_zentai_resist_stab_cut",
+    "type": "ARMOR",
+    "name": { "str": "test zentai" },
+    "description": "Full-body suit completely covering all body parts, including the head, mouth, and eyes.",
+    "weight": "300 g",
+    "volume": "500 ml",
+    "price": 2500,
+    "price_postapoc": 50,
+    "material": [ "lycra_resist_override_stab" ],
+    "symbol": "[",
+    "color": "dark_gray",
+    "warmth": 20,
+    "material_thickness": 1,
+    "environmental_protection": 10,
+    "flags": [ "VARSIZE", "SKINTIGHT", "WATER_FRIENDLY" ],
+    "armor": [
+      {
+        "coverage": 100,
+        "covers": [ "head", "mouth", "eyes", "torso", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]
+      }
+    ]
+  },
+  {
     "id": "test_zentai_resist_test_fire",
     "type": "ARMOR",
     "name": { "str": "test zentai" },

--- a/data/mods/TEST_DATA/materials.json
+++ b/data/mods/TEST_DATA/materials.json
@@ -5,5 +5,12 @@
     "name": "Lycra",
     "copy-from": "lycra",
     "resist": { "bash": 2, "cut": 2, "acid": 9, "heat": 2, "bullet": 2, "test_fire": 2 }
+  },
+  {
+    "type": "material",
+    "id": "lycra_resist_override_stab",
+    "name": "Lycra",
+    "copy-from": "lycra",
+    "resist": { "bash": 2, "cut": 2, "stab": 50, "acid": 9, "heat": 2, "bullet": 2 }
   }
 ]

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8493,9 +8493,9 @@ float item::_resist( const damage_type_id &dmg_type, bool to_self, int resist_va
         return _environmental_resist( dmg_type, to_self, resist_value, bp_null, armor_mats );
     }
 
+    std::optional<std::pair<damage_type_id, float>> derived;
     if( !dmg_type->derived_from.first.is_null() ) {
-        return dmg_type->derived_from.second * _resist( dmg_type->derived_from.first, to_self,
-                resist_value, bp_null, armor_mats, avg_thickness );
+        derived = dmg_type->derived_from;
     }
 
     float resist = 0.0f;
@@ -8513,7 +8513,13 @@ float item::_resist( const damage_type_id &dmg_type, bool to_self, int resist_va
                 int internal_roll;
                 resist_value < 0 ? internal_roll = rng( 0, 99 ) : internal_roll = resist_value;
                 if( internal_roll < m->cover ) {
-                    resist += m->id->resist( dmg_type ) * m->thickness;
+                    float tmp_add = 0.f;
+                    if( derived.has_value() && !m->id->has_dedicated_resist( dmg_type ) ) {
+                        tmp_add = m->id->resist( derived->first ) * m->thickness * derived->second;
+                    } else {
+                        tmp_add = m->id->resist( dmg_type ) * m->thickness;
+                    }
+                    resist += tmp_add;
                 }
             }
             return ( resist + mod ) * damage_scale;
@@ -8525,7 +8531,13 @@ float item::_resist( const damage_type_id &dmg_type, bool to_self, int resist_va
     if( !mats.empty() ) {
         const int total = type->mat_portion_total == 0 ? 1 : type->mat_portion_total;
         for( const auto &m : mats ) {
-            resist += m.first->resist( dmg_type ) * m.second;
+            float tmp_add = 0.f;
+            if( derived.has_value() && !m.first->has_dedicated_resist( dmg_type ) ) {
+                tmp_add = m.first->resist( derived->first ) * m.second * derived->second;
+            } else {
+                tmp_add = m.first->resist( dmg_type ) * m.second;
+            }
+            resist += tmp_add;
         }
         // Average based portion of materials
         resist /= total;
@@ -8544,6 +8556,11 @@ float item::_environmental_resist( const damage_type_id &dmg_type, const bool to
         return std::numeric_limits<float>::max();
     }
 
+    std::optional<std::pair<damage_type_id, float>> derived;
+    if( !dmg_type->derived_from.first.is_null() ) {
+        derived = dmg_type->derived_from;
+    }
+
     float resist = 0.0f;
     float mod = get_clothing_mod_val_for_damage_type( dmg_type );
 
@@ -8551,7 +8568,13 @@ float item::_environmental_resist( const damage_type_id &dmg_type, const bool to
         // If we have armour portion materials for this body part, use that instead
         if( !armor_mats.empty() ) {
             for( const part_material *m : armor_mats ) {
-                resist += m->id->resist( dmg_type ) * m->cover * 0.01f;
+                float tmp_add = 0.f;
+                if( derived.has_value() && !m->id->has_dedicated_resist( dmg_type ) ) {
+                    tmp_add = m->id->resist( derived->first ) * m->cover * 0.01f * derived->second;
+                } else {
+                    tmp_add = m->id->resist( dmg_type ) * m->cover * 0.01f;
+                }
+                resist += tmp_add;
             }
             const int env = get_env_resist( base_env_resist );
             if( env < 10 ) {
@@ -8567,7 +8590,13 @@ float item::_environmental_resist( const damage_type_id &dmg_type, const bool to
         // Not sure why cut and bash get an armor thickness bonus but acid/fire doesn't,
         // but such is the way of the code.
         for( const auto &m : mats ) {
-            resist += m.first->resist( dmg_type ) * m.second;
+            float tmp_add = 0.f;
+            if( derived.has_value() && !m.first->has_dedicated_resist( dmg_type ) ) {
+                tmp_add = m.first->resist( derived->first ) * m.second * derived->second;
+            } else {
+                tmp_add = m.first->resist( dmg_type ) * m.second;
+            }
+            resist += tmp_add;
         }
         // Average based portion of materials
         resist /= total;

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -145,11 +145,10 @@ void material_type::load( const JsonObject &jsobj, const std::string_view )
 void material_type::finalize_all()
 {
     material_data.finalize();
-}
-
-void material_type::finalize()
-{
-    finalize_damage_map( _resistances.resist_vals );
+    for( const material_type &mtype : material_data.get_all() ) {
+        material_type &mt = const_cast<material_type &>( mtype );
+        finalize_damage_map( mt._resistances.resist_vals );
+    }
 }
 
 void material_type::check() const
@@ -209,6 +208,12 @@ itype_id material_type::repaired_with() const
 float material_type::resist( const damage_type_id &dmg_type ) const
 {
     return _resistances.type_resist( dmg_type );
+}
+
+bool material_type::has_dedicated_resist( const damage_type_id &dmg_type ) const
+{
+    return std::find( _res_was_loaded.begin(), _res_was_loaded.end(),
+                      dmg_type ) != _res_was_loaded.end();
 }
 
 std::string material_type::bash_dmg_verb() const

--- a/src/material.h
+++ b/src/material.h
@@ -120,7 +120,6 @@ class material_type
 
         void load( const JsonObject &jsobj, std::string_view src );
         static void finalize_all();
-        void finalize();
         void check() const;
 
         material_id ident() const;
@@ -135,6 +134,8 @@ class material_type
         std::optional<itype_id> salvaged_into() const;
         itype_id repaired_with() const;
         float resist( const damage_type_id &dmg_type ) const;
+        // whether this material has an explicitly defined resistance for the specified damage type
+        bool has_dedicated_resist( const damage_type_id &dmg_type ) const;
         std::string bash_dmg_verb() const;
         std::string cut_dmg_verb() const;
         std::string dmg_adj( int damage_level ) const;

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1302,6 +1302,30 @@ TEST_CASE( "armor_protection", "[iteminfo][armor][protection]" )
              );
     }
 
+    SECTION( "check that material resistances are properly overriden" ) {
+        // Zentai suit, material:lycra_resist_override_stab, thickness:1
+        // 2/2/2/50 bash/cut/bullet/stab x 1 thickness
+        item zentai( "test_zentai_resist_stab_cut" );
+        REQUIRE( zentai.get_covered_body_parts().any() );
+        expected_armor_values( zentai, 2, 2, 50, 2, 9, 2, 10 );
+
+        // Protection info displayed on two lines
+        CHECK( item_info_str( zentai, protection ) ==
+               "--\n"
+               "<color_c_white>Protection for</color>: The <color_c_cyan>arms</color>. The <color_c_cyan>eyes</color>. The <color_c_cyan>feet</color>. The <color_c_cyan>hands</color>. The <color_c_cyan>head</color>. The <color_c_cyan>legs</color>. The <color_c_cyan>mouth</color>. The <color_c_cyan>torso</color>.\n"
+               "<color_c_white>Coverage</color>: <color_c_light_blue>Close to skin</color>.\n"
+               "  Default:  <color_c_yellow>100</color>\n"
+               "<color_c_white>Protection</color>:\n"
+               "  Bash: <color_c_yellow>2.00</color>\n"
+               "  Cut: <color_c_yellow>2.00</color>\n"
+               "  Ballistic: <color_c_yellow>2.00</color>\n"
+               "  Pierce: <color_c_yellow>50.00</color>\n"
+               "  Acid: <color_c_yellow>9.00</color>\n"
+               "  Fire: <color_c_yellow>2.00</color>\n"
+               "  Environmental: <color_c_yellow>10</color>\n"
+             );
+    }
+
     SECTION( "complex protection from physical and environmental damage" ) {
         item super_tanktop( "test_complex_tanktop" );
         REQUIRE( super_tanktop.get_covered_body_parts().any() );

--- a/tests/materials_test.cpp
+++ b/tests/materials_test.cpp
@@ -15,6 +15,8 @@ static const damage_type_id damage_heat( "heat" );
 static const damage_type_id damage_stab( "stab" );
 
 static const material_id material_glass( "glass" );
+static const material_id material_lycra( "lycra" );
+static const material_id material_lycra_resist_override_stab( "lycra_resist_override_stab" );
 static const material_id material_plastic( "plastic" );
 static const material_id material_steel( "steel" );
 static const material_id material_wood( "wood" );
@@ -104,4 +106,15 @@ TEST_CASE( "Glass_portion_breakability", "[material] [slow]" )
         check_near( "Chance of glass breaking", static_cast<float>( shatter_count ) / num_iters, 0.42f,
                     0.08f );
     }
+}
+
+TEST_CASE( "Override_derived_resistance", "[material]" )
+{
+    // Materials don't store derived resistances, instead they're derived at the item level.
+    // Just check that this is still the case.
+    REQUIRE( damage_stab->derived_from.first == damage_cut );
+    CHECK( material_lycra->resist( damage_cut ) == 1.f );
+    CHECK( material_lycra->resist( damage_stab ) == 0.f );
+    CHECK( material_lycra_resist_override_stab->resist( damage_cut ) == 2.f );
+    CHECK( material_lycra_resist_override_stab->resist( damage_stab ) == 50.f );
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
There are a few bugs in the way items calculate resistance to certain damage types:
1. Item resistance for damage types that are derived from a different damage type (e.g. "stab") use the derived value regardless of whether the resistance is explicitly defined. So for a material you can set a "cut" resistance of 2 and a "stab" resistance of 10, but the final "stab" resistance for the item will be based on 1.6 (0.8 x "cut").
2. The material resistance map wasn't being properly processed by `finalize_damage_map()`. It turns out `generic_factory::finalize()` isn't calling `material_type::finalize()`.

#### Describe the solution
1. Don't bother with recursion in `item::_resist()`. Instead, handle the derived resistance values for each material.
2. Call `finalize_damage_map()` in `material_type::finalize_all()`.

#### Describe alternatives you've considered
Instead of deriving the resistance at the item level, we could make the material store the derived values. Might be a bit misleading if someone omits material resistance values.

#### Testing
Added a couple of test cases for sanity checking.

Also loaded up the game with a lycra stab resistance set to 500:

![Screenshot from 2023-07-20 01-09-39](https://github.com/CleverRaven/Cataclysm-DDA/assets/12537966/07f55701-ff59-4c31-9bfc-4ebd3fb0346b)

#### Additional context
