### PR TITLE
Fix handflare burning out crash

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1314,11 +1314,10 @@ std::optional<int> firestarter_actor::use( Character *p, item &it, bool t,
 
     // TODO: fix point types
     tripoint_bub_ms pos( spos );
-    float light = light_mod( p->pos() );
-    if( !prep_firestarter_use( *p, pos ) ) {
+    if( !p || !prep_firestarter_use( *p, pos ) ) {  // if invoked from active item processing, do nothing.
         return std::nullopt;
     }
-
+    float light = light_mod( p->pos() );
     double skill_level = p->get_skill_level( skill_survival );
     /** @EFFECT_SURVIVAL speeds up fire starting */
     float moves_modifier = std::pow( 0.8, std::min( 5.0, skill_level ) );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1314,7 +1314,8 @@ std::optional<int> firestarter_actor::use( Character *p, item &it, bool t,
 
     // TODO: fix point types
     tripoint_bub_ms pos( spos );
-    if( !p || !prep_firestarter_use( *p, pos ) ) {  // if invoked from active item processing, do nothing.
+    if( !p || !prep_firestarter_use( *p,
+                                     pos ) ) {  // if invoked from active item processing, do nothing.
         return std::nullopt;
     }
     float light = light_mod( p->pos() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #67045

When the handflare burns out, it will be "invoked" that eventually calls `firestarter_actor::use`. This behavior has been there before 0.G. But this will crash the game now, as `firestarter_actor::use` will have a null character pointer.

#66866 will also solve this. 

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

If invoked from active item processing ( with a null character *p), just do nothing and return.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Wait for #66866 to be merged.

But this kind of validation should exist anyway, as the pointer CAN be nullptr.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Crash fixed.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->