### PR TITLE
[MoM] Add psionic feral PARROT lines

### DIFF
--- a/data/mods/MindOverMatter/monsters/feral_lab_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_lab_psychics.json
@@ -35,6 +35,7 @@
     "zombify_into": "mon_zombie_scientist",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT", "PLAYER_CLOSE" ],
     "special_attacks": [
+      [ "PARROT_AT_DANGER", 15 ],
       {
         "id": "psi_drbrain_flashbang",
         "type": "spell",
@@ -99,15 +100,15 @@
     "volume": "62500 ml",
     "weight": "81500 g",
     "hp": 120,
-    "speed": 115,
+    "speed": 110,
     "material": [ "flesh" ],
     "color": "pink",
     "symbol": "@",
     "aggression": 30,
     "morale": 100,
-    "melee_skill": 7,
+    "melee_skill": 6,
     "melee_dice": 2,
-    "melee_dice_sides": 6,
+    "melee_dice_sides": 5,
     "melee_damage": [ { "damage_type": "bash", "amount": 6 } ],
     "attack_cost": 85,
     "weakpoint_sets": [ "wps_humanoid_body" ],
@@ -123,9 +124,10 @@
     "zombify_into": "mon_zombie_survivor",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "special_attacks": [
-      { "id": "smash", "attack_upper": true, "throw_strength": 50, "cooldown": 10 },
-      [ "BIO_OP_DISARM", 10 ],
-      { "id": "bio_op_takedown", "cooldown": 15 }
+      [ "PARROT_AT_DANGER", 15 ],
+      { "id": "smash", "attack_upper": true, "throw_strength": 50, "cooldown": 15 },
+      [ "BIO_OP_DISARM", 15 ],
+      { "id": "bio_op_takedown", "cooldown": 20 }
     ],
     "flags": [
       "SEES",

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -143,6 +143,7 @@
     "zombify_into": "mon_zombie_survivor",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "special_attacks": [
+      [ "PARROT_AT_DANGER", 10 ],
       { "id": "smash", "attack_upper": true, "throw_strength": 50, "cooldown": 10 },
       {
         "type": "leap",
@@ -435,6 +436,7 @@
     "luminance": 50,
     "upgrades": { "half_life": 45, "into": "mon_feral_human_pyrokin2" },
     "special_attacks": [
+      [ "PARROT_AT_DANGER", 10 ],
       {
         "id": "psi_pyrokin2_flameblast",
         "type": "spell",
@@ -516,6 +518,7 @@
     },
     "luminance": 200,
     "special_attacks": [
+      [ "PARROT_AT_DANGER", 10 ],
       {
         "id": "psi_pyrokin3_flameblast",
         "type": "spell",
@@ -826,6 +829,7 @@
       "message": "As the %1$s dies, a scream fills your mind!"
     },
     "special_attacks": [
+      [ "PARROT_AT_DANGER", 10 ],
       {
         "id": "psi_telepath2_scream",
         "type": "spell",
@@ -1022,6 +1026,7 @@
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "luminance": 25,
     "special_attacks": [
+      [ "PARROT_AT_DANGER", 10 ],
       {
         "id": "psi_teleport3_slow",
         "type": "spell",

--- a/data/mods/MindOverMatter/snippets/speech.json
+++ b/data/mods/MindOverMatter/snippets/speech.json
@@ -1,0 +1,128 @@
+[
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_human_pyrokin3", "mon_feral_human_pyrokin2" ],
+    "sound": "the crackle of flames.",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_human_pyrokin3", "mon_feral_human_pyrokin2" ],
+    "sound": "\"Must…burn…\"",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_human_teep2" ],
+    "sound": "a low droning hum inside your head.",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_human_teep2" ],
+    "sound": "a tuneless whistling inside your head.",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_human_teep2" ],
+    "sound": "an inarticulate cry inside your head.",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_human_teep2" ],
+    "sound": "quiet laughter inside your head.",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_human_bio3", "mon_feral_security_captain_psychic" ],
+    "sound": "\"Kill…\"",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_human_clair2", "mon_feral_human_clair3" ],
+    "sound": "\"I… see…\"",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_human_clair3" ],
+    "sound": "\"You… see…\"",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_human_clair3" ],
+    "sound": "\"Can you see?\"",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_human_porter3" ],
+    "sound": "\"Lost between…\"",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_human_porter3" ],
+    "sound": "\"So… cold…\"",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_human_porter3" ],
+    "sound": "\"So… dark…\"",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_scientist_psychic" ],
+    "sound": "quiet laughter.",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_scientist_psychic" ],
+    "sound": "\"Yes…\"",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_scientist_psychic" ],
+    "sound": "\"A test subject…\"",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_scientist_psychic" ],
+    "sound": "\"Ah, yes…\"",
+    "volume": 10
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_security_captain_psychic", "mon_feral_security_psychic" ],
+    "sound": "\"Stop!\"",
+    "volume": 15
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_security_captain_psychic", "mon_feral_security_psychic" ],
+    "sound": "\"This is a restricted area!\"",
+    "volume": 15
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_security_captain_psychic", "mon_feral_security_psychic" ],
+    "sound": "\"Authorized personnel only!\"",
+    "volume": 15
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_feral_security_captain_psychic", "mon_feral_security_psychic" ],
+    "sound": "\"Leave!\"",
+    "volume": 15
+  }
+]

--- a/data/mods/MindOverMatter/snippets/speech.json
+++ b/data/mods/MindOverMatter/snippets/speech.json
@@ -8,7 +8,7 @@
   {
     "type": "speech",
     "speaker": [ "mon_feral_human_pyrokin3", "mon_feral_human_pyrokin2" ],
-    "sound": "\"Must…burn…\"",
+    "sound": "\"Must… burn…\"",
     "volume": 10
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Add psionic feral parrots"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
 Thanks to https://github.com/CleverRaven/Cataclysm-DDA/pull/67015, I went and added a few parrot lines for some of the psionic ferals. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
See above.

I also slightly increased the cooldowns on the Ψ Division guard's abilities and reduced their speed.  Ψ Division captain is unchanged.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Psionics ferals are all like this: 😐
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

They say the lines and it's not a constant flood.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Only real problem is that the lines that are supposed to be telepathic still give a direction that you hear them from, but that's minor really. 

Name changed to reflect that it's psionic feral PARROT lines, not telekinetic feral tropical birds. 

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->