### PR TITLE
"relative": can be used with qualities

### DIFF
--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -1011,8 +1011,8 @@
         "rigid": true
       }
     ],
-    "delete": { "qualities": [ [ "COOK", 3 ] ] },
-    "extend": { "qualities": [ [ "HAMMER", 1 ], [ "COOK", 2 ] ] },
+    "extend": { "qualities": [ [ "HAMMER", 1 ] ] },
+    "relative": { "qualities": [ [ "COOK", -1 ] ] },
     "melee_damage": { "bash": 12 },
     "//": "Based on https://www.amazon.com/Lodge-Skillet-Pre-Seasoned-Ready-Stove/dp/B00006JSUA/ref=sr_1_5?crid=SPLV6RIP18RL&keywords=cast%2Biron%2Bfrying%2Bpan&qid=1688243417&sprefix=cast%2Biron%2Bfrying%2Bp%2Caps%2C491&sr=8-5&th=1 BUT volume calculated as a cylinder - 2 inches height x 10.68 inches diameter"
   },
@@ -1039,8 +1039,7 @@
         "rigid": true
       }
     ],
-    "delete": { "qualities": [ [ "COOK", 3 ] ] },
-    "extend": { "qualities": [ [ "COOK", 2 ] ] },
+    "relative": { "qualities": [ [ "COOK", -1 ] ] },
     "melee_damage": { "bash": 8 }
   },
   {
@@ -1066,8 +1065,7 @@
         "rigid": true
       }
     ],
-    "delete": { "qualities": [ [ "COOK", 3 ] ] },
-    "extend": { "qualities": [ [ "COOK", 2 ] ] },
+    "relative": { "qualities": [ [ "COOK", -1 ] ] },
     "melee_damage": { "bash": 7 }
   },
   {
@@ -1140,7 +1138,7 @@
     "weight": "728 g",
     "volume": "1575 ml",
     "pocket_data": [ { "max_contains_volume": "1500 ml", "max_contains_weight": "2 kg", "watertight": true, "rigid": true } ],
-    "delete": { "qualities": [ [ "COOK", 3 ] ] },
+    "delete": { "qualities": [ "COOK" ] },
     "melee_damage": { "bash": 5 }
   },
   {
@@ -1156,7 +1154,7 @@
     "volume": "3100 ml",
     "melee_damage": { "bash": 5 },
     "pocket_data": [ { "max_contains_volume": "3000 ml", "max_contains_weight": "6 kg", "watertight": true, "rigid": true } ],
-    "delete": { "qualities": [ [ "COOK", 3 ] ] }
+    "delete": { "qualities": [ "COOK" ] }
   },
   {
     "id": "colander_steel",
@@ -1330,8 +1328,7 @@
         "rigid": true
       }
     ],
-    "delete": { "qualities": [ [ "COOK", 3 ] ] },
-    "extend": { "qualities": [ [ "COOK", 2 ] ] },
+    "relative": { "qualities": [ [ "COOK", -1 ] ] },
     "melee_damage": { "bash": 7 }
   },
   {

--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -725,7 +725,7 @@
     "copy-from": "multi_cooker",
     "name": { "str": "multi-cooker - cooking", "str_pl": "multi-cookers - cooking" },
     "description": "A professional-grade multi-cooker, with a battery slot for camping trips or tailgating.  There is a dish cooking inside it.",
-    "delete": { "qualities": [ [ "CONTAIN", 1 ] ] }
+    "delete": { "qualities": [ "CONTAIN" ] }
   },
   {
     "id": "oil_cooker",

--- a/data/mods/Magiclysm/items/black_dragon_items.json
+++ b/data/mods/Magiclysm/items/black_dragon_items.json
@@ -167,7 +167,7 @@
     "armor": [ { "covers": [ "head" ], "coverage": 100, "encumbrance": 32 } ],
     "material_thickness": 5,
     "environmental_protection": 3,
-    "delete": { "qualities": [ [ "GLARE", 1 ] ], "flags": [ "SUN_GLASSES" ] }
+    "delete": { "qualities": [ "GLARE" ], "flags": [ "SUN_GLASSES" ] }
   },
   {
     "id": "helmet_black_dragon_hide",

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4573,16 +4573,16 @@ void Item_factory::extend_qualities_from_json( const JsonObject &jo, const std::
 void Item_factory::delete_qualities_from_json( const JsonObject &jo, const std::string_view member,
         itype &def )
 {
-    for( JsonArray curr : jo.get_array( member ) ) {
-        const auto iter = def.qualities.find( quality_id( curr.get_string( 0 ) ) );
-        if( iter != def.qualities.end() && iter->second == curr.get_int( 1 ) ) {
+    for( std::string curr : jo.get_array( member ) ) {
+        const auto iter = def.qualities.find( quality_id( curr ) );
+        if( iter != def.qualities.end() ) {
             def.qualities.erase( iter );
         }
     }
 }
 
-void Item_factory::relative_qualities_from_json( const JsonObject &jo, const std::string_view member,
-        itype &def )
+void Item_factory::relative_qualities_from_json( const JsonObject &jo,
+        const std::string_view member, itype &def )
 {
     for( JsonArray curr : jo.get_array( member ) ) {
         const quality_id key = quality_id( curr.get_string( 0 ) );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4235,6 +4235,11 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
             tmp.allow_omitted_members();
             delete_qualities_from_json( tmp, "qualities", def );
         }
+        if( jo.has_object( "relative" ) ) {
+            JsonObject tmp = jo.get_object( "relative" );
+            tmp.allow_omitted_members();
+            relative_qualities_from_json( tmp, "qualities", def );
+        }
     }
 
     if( jo.has_member( "charged_qualities" ) ) {
@@ -4572,6 +4577,19 @@ void Item_factory::delete_qualities_from_json( const JsonObject &jo, const std::
         const auto iter = def.qualities.find( quality_id( curr.get_string( 0 ) ) );
         if( iter != def.qualities.end() && iter->second == curr.get_int( 1 ) ) {
             def.qualities.erase( iter );
+        }
+    }
+}
+
+void Item_factory::relative_qualities_from_json( const JsonObject &jo, const std::string_view member,
+        itype &def )
+{
+    for( JsonArray curr : jo.get_array( member ) ) {
+        const quality_id key = quality_id( curr.get_string( 0 ) );
+        if( def.qualities.find( quality_id( key ) ) != def.qualities.end() ) {
+            def.qualities[ key ] += curr.get_int( 1 );
+        } else {
+            jo.throw_error_at( member, "Quality specified wasn't inherited" );
         }
     }
 }

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -365,6 +365,7 @@ class Item_factory
         void set_qualities_from_json( const JsonObject &jo, const std::string &member, itype &def );
         void extend_qualities_from_json( const JsonObject &jo, std::string_view member, itype &def );
         void delete_qualities_from_json( const JsonObject &jo, std::string_view member, itype &def );
+        void relative_qualities_from_json( const JsonObject &jo, std::string_view member, itype &def );
         void set_properties_from_json( const JsonObject &jo, std::string_view member, itype &def );
         void set_techniques_from_json( const JsonObject &jo, const std::string_view &member, itype &def );
         void extend_techniques_from_json( const JsonObject &jo, std::string_view member, itype &def );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

```
"delete": { "qualities": [ [ "BUTCHER", 8 ] ] },
"extend": { "qualities": [ [ "BUTCHER", 10 ] ] },
```
looks stupid and isn't even that useful bc you have to specify the correct value you inherited

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

You can now change inherited qualities values like `"relative": { "qualities": [ [ "HAMMER", -1 ], [ "SAW_M", 1 ] ] }` to add 1 metal sawing and removing 1 hammering
You also don't need to specify a quality level when deleting an inherited quality so `"delete": { "qualities": [ [ "COOK", 3 ], [ "DRILL", 1 ] ] },` becomes `"delete": { "qualities": [ "COOK", "DRILL" ] },`

Attempted to find everywhere this is being used inc. mods and change it, tests should throw any others anyway tho

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked positive and negative numbers work as expected
Checked new delete method works

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->