### PR TITLE
[Sky Island] Fix Exit Point not Disappearing after teleporting home issue

### DIFF
--- a/data/mods/Sky_Island/missions_and_mapgen.json
+++ b/data/mods/Sky_Island/missions_and_mapgen.json
@@ -57,13 +57,12 @@
     "//": "Actually creates the extract by first choosing a location, then assigning a mission there.  It will also clean up that spot later so the exit room doesn't remain for future expeditions.",
     "effect": [
       { "run_eocs": [ "EOC_Random_Loc_Extract" ] },
-      { "assign_mission": "MISSION_REACH_EXTRACT" },
       {
         "revert_location": { "global_val": "OM_missionspot" },
         "time_in_future": "infinite",
         "key": "return_portal_close"
       },
-      { "mapgen_update": "mapgen_dummyplace", "target_var": { "global_val": "OM_missionspot" } }
+      { "assign_mission": "MISSION_REACH_EXTRACT" }
     ]
   },
   {
@@ -94,7 +93,6 @@
         "time_in_future": "infinite",
         "key": "return_portal_close"
       },
-      { "mapgen_update": "mapgen_dummyplace", "target_var": { "global_val": "OM_missionspot" } },
       {
         "weighted_list_eocs": [
           [ "EOC_bonusmission_1", { "const": 45 } ],


### PR DESCRIPTION


#### Summary
Bugfixes "[Sky Island] fix the issue of exit points not disappearing after teleporting home"

#### Purpose of change

Fixes #67040 

#### Describe the solution

Apply the patch given in the issue.

#### Describe alternatives you've considered

Litter the world with more exit points.

#### Testing

I applied the patch onto my build and do as follows:
1. make a new world
2. get down into the world
3. teleport into 2 of the exit points and mark them with map note
4. get back to the sky island with the exit point
5. go down into the world again and teleport to the previous exit points marked with mapnote
6. see that it is disappears as expected.

I also checked the warp shard spawn place, it's also disappears as expected.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->