### PR TITLE
Fix: parse missing fields for translation

### DIFF
--- a/data/json/effect_on_condition.json
+++ b/data/json/effect_on_condition.json
@@ -400,7 +400,7 @@
     "type": "effect_on_condition",
     "eoc_type": "AVATAR_DEATH",
     "condition": {
-      "and": [ { "npc_allies_global": 1 }, { "u_query": "You have died. Continue as one of your followers?", "default": false } ]
+      "and": [ { "npc_allies_global": 1 }, { "u_query": "You have died.  Continue as one of your followers?", "default": false } ]
     },
     "effect": [ "take_control_menu" ]
   },

--- a/lang/string_extractor/parsers/condition.py
+++ b/lang/string_extractor/parsers/condition.py
@@ -1,0 +1,20 @@
+from ..write_text import write_text
+
+
+def parse_condition(conditions, origin):
+    if not type(conditions) is list:
+        conditions = [conditions]
+    for cond in conditions:
+        if type(cond) is dict:
+            if "u_query" in cond:
+                write_text(cond["u_query"], origin,
+                           comment="Query message shown in a popup")
+            if "npc_query" in cond:
+                write_text(cond["npc_query"], origin,
+                           comment="Query message shown in a popup")
+            if "and" in cond:
+                parse_condition(cond["and"], origin)
+            if "or" in cond:
+                parse_condition(cond["or"], origin)
+            if "not" in cond:
+                parse_condition(cond["not"], origin)

--- a/lang/string_extractor/parsers/condition.py
+++ b/lang/string_extractor/parsers/condition.py
@@ -6,10 +6,11 @@ def parse_condition(conditions, origin):
         conditions = [conditions]
     for cond in conditions:
         if type(cond) is dict:
-            if "u_query" in cond:
+            # if *_query is an object, the message is taken from elsewhere
+            if "u_query" in cond and type(cond["u_query"]) is str:
                 write_text(cond["u_query"], origin,
                            comment="Query message shown in a popup")
-            if "npc_query" in cond:
+            if "npc_query" in cond and type(cond["npc_query"]) is str:
                 write_text(cond["npc_query"], origin,
                            comment="Query message shown in a popup")
             if "and" in cond:

--- a/lang/string_extractor/parsers/effect_on_condition.py
+++ b/lang/string_extractor/parsers/effect_on_condition.py
@@ -1,7 +1,10 @@
 from .effect import parse_effect
+from .condition import parse_condition
 
 
 def parse_effect_on_condition(json, origin):
     parse_effect(json["effect"], origin)
     if "false_effect" in json:
         parse_effect(json["false_effect"], origin)
+    if "condition" in json:
+        parse_condition(json["condition"], origin)

--- a/lang/string_extractor/parsers/recipe.py
+++ b/lang/string_extractor/parsers/recipe.py
@@ -1,3 +1,4 @@
+from .effect_on_condition import parse_effect_on_condition
 from ..write_text import write_text
 
 
@@ -33,7 +34,15 @@ def parse_recipe(json, origin):
         write_text(json["description"], origin,
                    comment="Description of recipe crafting \"{}\""
                    .format(result_hint(json)))
+    if "name" in json:
+        write_text(json["name"], origin,
+                   comment="Custom name for recipe crafting \"{}\""
+                   .format(result_hint(json)))
     if "blueprint_name" in json:
         write_text(json["blueprint_name"], origin,
                    comment="Blueprint name of recipe crafting \"{}\""
                    .format(result_hint(json)))
+    if "result_eocs" in json:
+        for eoc in json["result_eocs"]:
+            if type(eoc) is dict:
+                parse_effect_on_condition(eoc, origin)

--- a/lang/string_extractor/parsers/use_action.py
+++ b/lang/string_extractor/parsers/use_action.py
@@ -9,6 +9,7 @@ use_action_msg_keys = [
     "charges_extinguish_message",
     "deactive_msg",
     "descriptions",
+    "description",
     "done_message",
     "failure_message",
     "friendly_msg",

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -254,7 +254,7 @@ translation_or_var get_translation_or_var( const JsonValue &jv, const std::strin
         const JsonObject &jo = jv.get_object();
         if( jo.has_member( "mutator" ) ) {
             // if we have a mutator then process that here.
-            ret_val.function = conditional_t::get_get_string( jo );
+            ret_val.function = conditional_t::get_get_translation( jo );
         } else {
             ret_val.var_val = read_var_info( jo );
             ret_val.default_val = default_val;
@@ -1504,17 +1504,19 @@ void conditional_t::set_math( const JsonObject &jo, const std::string_view membe
     };
 }
 
-std::function<std::string( const dialogue & )> conditional_t::get_get_string( const JsonObject &jo )
+template<class T>
+static std::function<T( const dialogue & )> get_get_str_( const JsonObject &jo,
+        std::function<T( const std::string & )> ret_func )
 {
     if( jo.get_string( "mutator" ) == "mon_faction" ) {
         str_or_var mtypeid = get_str_or_var( jo.get_member( "mtype_id" ), "mtype_id" );
-        return [mtypeid]( const dialogue & d ) {
-            return ( static_cast<mtype_id>( mtypeid.evaluate( d ) ) )->default_faction.str();
+        return [mtypeid, ret_func]( const dialogue & d ) {
+            return ret_func( ( static_cast<mtype_id>( mtypeid.evaluate( d ) ) )->default_faction.str() );
         };
     } else if( jo.get_string( "mutator" ) == "game_option" ) {
         str_or_var option = get_str_or_var( jo.get_member( "option" ), "option" );
-        return [option]( const dialogue & d ) {
-            return get_option<std::string>( option.evaluate( d ) );
+        return [option, ret_func]( const dialogue & d ) {
+            return ret_func( get_option<std::string>( option.evaluate( d ) ) );
         };
     } else if( jo.get_string( "mutator" ) == "valid_technique" ) {
         std::vector<str_or_var> blacklist;
@@ -1528,40 +1530,89 @@ std::function<std::string( const dialogue & )> conditional_t::get_get_string( co
         bool dodge_counter = jo.get_bool( "dodge_counter", false );
         bool block_counter = jo.get_bool( "block_counter", false );
 
-        return [blacklist, crit, dodge_counter, block_counter]( const dialogue & d ) {
+        return [blacklist, crit, dodge_counter, block_counter, ret_func]( const dialogue & d ) {
             std::vector<matec_id> bl;
             bl.reserve( blacklist.size() );
             for( const str_or_var &sv : blacklist ) {
                 bl.emplace_back( sv.evaluate( d ) );
             }
-            return d.actor( false )->get_random_technique( *d.actor( true )->get_creature(), crit,
-                    dodge_counter, block_counter, bl ).str();
+            return ret_func( d.actor( false )->get_random_technique( *d.actor( true )->get_creature(),
+                             crit, dodge_counter, block_counter, bl ).str() );
         };
-    } else if( jo.get_string( "mutator" ) == "ma_technique_description" ) {
+    } else if( jo.get_string( "mutator" ) == "loc_relative_u" ) {
+        str_or_var target = get_str_or_var( jo.get_member( "target" ), "target" );
+        return [target, ret_func]( const dialogue & d ) {
+            tripoint_abs_ms char_pos = get_map().getglobal( d.actor( false )->pos() );
+            tripoint_abs_ms target_pos = char_pos + tripoint::from_string( target.evaluate( d ) );
+            return ret_func( target_pos.to_string() );
+        };
+    }
+
+    return nullptr;
+}
+
+template<class T>
+static std::function<T( const dialogue & )> get_get_translation_( const JsonObject &jo,
+        std::function<T( const translation & )> ret_func )
+{
+    if( jo.get_string( "mutator" ) == "ma_technique_description" ) {
         str_or_var ma = get_str_or_var( jo.get_member( "matec_id" ), "matec_id" );
 
-        return [ma]( const dialogue & d ) {
-            return matec_id( ma.evaluate( d ) )->description.translated();
+        return [ma, ret_func]( const dialogue & d ) {
+            return ret_func( matec_id( ma.evaluate( d ) )->description );
         };
     } else if( jo.get_string( "mutator" ) == "ma_technique_name" ) {
         str_or_var ma = get_str_or_var( jo.get_member( "matec_id" ), "matec_id" );
 
-        return [ma]( const dialogue & d ) {
-            return matec_id( ma.evaluate( d ) )->name.translated();
-        };
-    } else if( jo.get_string( "mutator" ) == "loc_relative_u" ) {
-        str_or_var target = get_str_or_var( jo.get_member( "target" ), "target" );
-        return [target]( const dialogue & d ) {
-            tripoint_abs_ms char_pos = get_map().getglobal( d.actor( false )->pos() );
-            tripoint_abs_ms target_pos = char_pos + tripoint::from_string( target.evaluate( d ) );
-            return target_pos.to_string();
+        return [ma, ret_func]( const dialogue & d ) {
+            return ret_func( matec_id( ma.evaluate( d ) )->name );
         };
     }
 
-    jo.throw_error( "unrecognized string mutator in " + jo.str() );
-    return []( const dialogue & ) {
-        return "INVALID";
-    };
+    return nullptr;
+}
+
+std::function<translation( const dialogue & )> conditional_t::get_get_translation(
+    const JsonObject &jo )
+{
+    auto ret_func = get_get_str_<translation>( jo, []( const std::string & s ) {
+        return no_translation( s );
+    } );
+
+    if( !ret_func ) {
+        ret_func = get_get_translation_<translation>( jo, []( const translation & t ) {
+            return t;
+        } );
+        if( !ret_func ) {
+            jo.throw_error( "unrecognized string mutator in " + jo.str() );
+            return []( const dialogue & ) {
+                return translation();
+            };
+        }
+    }
+
+    return ret_func;
+}
+
+std::function<std::string( const dialogue & )> conditional_t::get_get_string( const JsonObject &jo )
+{
+    auto ret_func = get_get_str_<std::string>( jo, []( const std::string & s ) {
+        return s;
+    } );
+
+    if( !ret_func ) {
+        ret_func = get_get_translation_<std::string>( jo, []( const translation & t ) {
+            return t.translated();
+        } );
+        if( !ret_func ) {
+            jo.throw_error( "unrecognized string mutator in " + jo.str() );
+            return []( const dialogue & ) {
+                return "INVALID";
+            };
+        }
+    }
+
+    return ret_func;
 }
 
 template<class J>

--- a/src/condition.h
+++ b/src/condition.h
@@ -57,6 +57,8 @@ const std::unordered_set<std::string> complex_conds = { {
 
 str_or_var get_str_or_var( const JsonValue &jv, const std::string &member, bool required = true,
                            const std::string &default_val = "" );
+translation_or_var get_translation_or_var( const JsonValue &jv, const std::string &member,
+        bool required = true, const translation &default_val = {} );
 dbl_or_var get_dbl_or_var( const JsonObject &jo, const std::string &member, bool required = true,
                            double default_val = 0.0 );
 dbl_or_var_part get_dbl_or_var_part( const JsonValue &jv, const std::string &member,

--- a/src/condition.h
+++ b/src/condition.h
@@ -206,6 +206,7 @@ struct conditional_t {
         void set_compare_num( const JsonObject &jo, std::string_view member );
         void set_math( const JsonObject &jo, std::string_view member );
         static std::function<std::string( const dialogue & )> get_get_string( const JsonObject &jo );
+        static std::function<translation( const dialogue & )> get_get_translation( const JsonObject &jo );
         template<class J>
         static std::function<double( dialogue & )> get_get_dbl( J const &jo );
         static std::function<double( dialogue & )> get_get_dbl( const std::string &value,

--- a/src/dialogue_helpers.cpp
+++ b/src/dialogue_helpers.cpp
@@ -103,6 +103,35 @@ std::string str_or_var::evaluate( dialogue const &d ) const
     return "";
 }
 
+std::string translation_or_var::evaluate( dialogue const &d ) const
+{
+    if( function.has_value() ) {
+        return function.value()( d );
+    }
+    if( str_val.has_value() ) {
+        return str_val.value().translated();
+    }
+    if( var_val.has_value() ) {
+        std::string val = read_var_value( var_val.value(), d );
+        if( !val.empty() ) {
+            return val;
+        }
+        if( default_val.has_value() ) {
+            return default_val.value().translated();
+        }
+        std::string var_name = var_val.value().name;
+        if( var_name.find( "npctalk_var" ) != std::string::npos ) {
+            var_name = var_name.substr( 12 );
+        }
+        debugmsg( "No default value provided for str_or_var_part while encountering unused "
+                  "variable %s.  Add a \"default_str\" member to prevent this.  %s",
+                  var_name, d.get_callstack() );
+        return "";
+    }
+    debugmsg( "No valid value for str_or_var_part.  %s", d.get_callstack() );
+    return "";
+}
+
 double dbl_or_var_part::evaluate( dialogue &d ) const
 {
     if( dbl_val.has_value() ) {

--- a/src/dialogue_helpers.cpp
+++ b/src/dialogue_helpers.cpp
@@ -74,6 +74,7 @@ var_info process_variable( const std::string &type )
     return var_info( vt, "npctalk_var_" + ret_str );
 }
 
+template<>
 std::string str_or_var::evaluate( dialogue const &d ) const
 {
     if( function.has_value() ) {
@@ -103,10 +104,11 @@ std::string str_or_var::evaluate( dialogue const &d ) const
     return "";
 }
 
+template<>
 std::string translation_or_var::evaluate( dialogue const &d ) const
 {
     if( function.has_value() ) {
-        return function.value()( d );
+        return function.value()( d ).translated();
     }
     if( str_val.has_value() ) {
         return str_val.value().translated();

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -153,20 +153,12 @@ struct abstract_str_or_var {
     std::optional<T> str_val;
     std::optional<var_info> var_val;
     std::optional<T> default_val;
-    std::optional<std::function<std::string( const dialogue & )>> function;
-    virtual ~abstract_str_or_var() = default;
-    virtual std::string evaluate( dialogue const & ) const {
-        return std::string();
-    }
+    std::optional<std::function<T( const dialogue & )>> function;
+    std::string evaluate( dialogue const & ) const;
 };
 
-struct str_or_var : abstract_str_or_var<std::string> {
-    std::string evaluate( dialogue const &d ) const override;
-};
-
-struct translation_or_var : abstract_str_or_var<translation> {
-    std::string evaluate( dialogue const &d ) const override;
-};
+using str_or_var = abstract_str_or_var<std::string>;
+using translation_or_var = abstract_str_or_var<translation>;
 
 struct eoc_math {
     enum class oper : int {

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -8,6 +8,7 @@
 #include "global_vars.h"
 #include "math_parser.h"
 #include "rng.h"
+#include "translation.h"
 #include "type_id.h"
 
 struct dialogue;
@@ -147,13 +148,24 @@ std::string read_var_value( const var_info &info, const dialogue &d );
 
 var_info process_variable( const std::string &type );
 
-
-struct str_or_var {
-    std::optional<std::string> str_val;
+template<class T>
+struct abstract_str_or_var {
+    std::optional<T> str_val;
     std::optional<var_info> var_val;
-    std::optional<std::string> default_val;
+    std::optional<T> default_val;
     std::optional<std::function<std::string( const dialogue & )>> function;
-    std::string evaluate( dialogue const &d ) const;
+    virtual ~abstract_str_or_var() = default;
+    virtual std::string evaluate( dialogue const & ) const {
+        return std::string();
+    }
+};
+
+struct str_or_var : abstract_str_or_var<std::string> {
+    std::string evaluate( dialogue const &d ) const override;
+};
+
+struct translation_or_var : abstract_str_or_var<translation> {
+    std::string evaluate( dialogue const &d ) const override;
 };
 
 struct eoc_math {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5371,7 +5371,7 @@ std::unique_ptr<iuse_actor> effect_on_conditons_actor::clone() const
 
 void effect_on_conditons_actor::load( const JsonObject &obj )
 {
-    description = obj.get_string( "description" );
+    obj.read( "description", description );
     obj.read( "menu_text", menu_text );
     for( JsonValue jv : obj.get_array( "effect_on_conditions" ) ) {
         eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, "" ) );
@@ -5388,7 +5388,7 @@ std::string effect_on_conditons_actor::get_name() const
 
 void effect_on_conditons_actor::info( const item &, std::vector<iteminfo> &dump ) const
 {
-    dump.emplace_back( "DESCRIPTION", description );
+    dump.emplace_back( "DESCRIPTION", description.translated() );
 }
 
 std::optional<int> effect_on_conditons_actor::use( Character *p, item &it, bool t,

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -1148,7 +1148,7 @@ class effect_on_conditons_actor : public iuse_actor
 {
     public:
         std::vector<effect_on_condition_id> eocs;
-        std::string description;
+        translation description;
         translation menu_text;
         explicit effect_on_conditons_actor( const std::string &type = "effect_on_conditions" ) : iuse_actor(
                 type ) {}


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
- Fixes #67072

#### Describe the solution
Added some parsing for various fields that were missing in the pot file.

Also made some code corrections to account for those translations.

#### Describe alternatives you've considered

#### Testing
Running `lang/update_pot.sh` reads the missing fields and adds them to `lang/po/cataclysm-dda.pot`.

Also tested in-game by adding a French translation for a `"u_query"` message:

![Screenshot from 2023-07-21 12-12-28](https://github.com/CleverRaven/Cataclysm-DDA/assets/12537966/21ceeda2-8d19-48de-9406-260dde1668fb)

#### Additional context
