### PR TITLE
flags_any Helper Check To Make Road Unhardcoding More Readable

### DIFF
--- a/doc/MAPGEN.md
+++ b/doc/MAPGEN.md
@@ -1149,6 +1149,7 @@ Place_nested allows for limited conditional spawning of chunks based on the `"id
 | neighbors          | (optional) Any of the neighboring overmaps that should be checked before placing the chunk.  Each direction is associated with a list of overmap `"id"` substrings.  See [JSON_INFO.md](JSON_INFO.md#Starting-locations) "terrain" section to do more advanced searches.
 | joins              | (optional) Any mutable overmap special joins that should be checked before placing the chunk.  Each direction is associated with a list of join `"id"` strings.
 | flags              | (optional) Any overmap terrain flags that should be checked before placing the chunk.  Each direction is associated with a list of `oter_flags` flags.
+| flags_any          | (optional) Identical to flags except only requires a single direction to pass.  Useful to check if there's at least one of a flag in cardinal or orthoganal directions etc.
 
 
 The adjacent overmaps which can be checked in this manner are:
@@ -1162,17 +1163,19 @@ Example:
 
 ```json
   "place_nested": [
-    { "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 0, "neighbors": { "north": [ "empty_rock", "field" ] } },
-    { "chunks": [ "gate_south" ], "x": 0, "y": 0, "neighbors": { "north": [ { "om_terrain": "fort", "om_terrain_match_type": "PREFIX" }, "mansion" ] } },
-    { "chunks": [ "gate_north" ], "x": 0, "y": 0, "joins": { "north": [ "interior_to_exterior" ] } },
-    { "else_chunks": [ "concrete_wall_ns" ], "x": 0, "y": 0, "flags": { "north_west": [ "RIVER", "LAKE", "LAKE_SHORE" ] } }
+    { "chunks": [ "nest1" ], "x": 0, "y": 0, "neighbors": { "north": [ "empty_rock", "field" ] } },
+    { "chunks": [ "nest2" ], "x": 0, "y": 0, "neighbors": { "north": [ { "om_terrain": "fort", "om_terrain_match_type": "PREFIX" }, "mansion" ] } },
+    { "chunks": [ "nest3" ], "x": 0, "y": 0, "joins": { "north": [ "interior_to_exterior" ] } },
+    { "chunks": [ "nest4" ], "x": 0, "y": 0, "flags": { "north": [ "RIVER" ] }, "flags_any": { "north_east": [ "RIVER" ], "north_west": [ "RIVER" ] } },
+    { "else_chunks": [ "nest5" ], "x": 0, "y": 0, "flags": { "north_west": [ "RIVER", "LAKE", "LAKE_SHORE" ] } }
   ],
 ```
 The code excerpt above will place chunks as follows:
-* `"concrete_wall_ew"` if the north neighbor's om terrain contains `"field"` or `"empty_rock"`.
-* `"gate_south"` if the north neighbor has the prefix `"fort"` or contains `"mansion"`, so for example "fort_1a_north" and "mansion_t2u" would match but "house_fortified" wouldn't.
-* `"gate_north"` if the join `"interior_to_exterior"` was used to the north during mutable overmap placement.
-* `"concrete_wall_ns"`if the north west neighboring overmap terrain has neither the "RIVER", "LAKE" nor "LAKE_SHORE" flags.
+* `"nest1"` if the north neighbor's om terrain contains `"field"` or `"empty_rock"`.
+* `"nest2"` if the north neighbor has the prefix `"fort"` or contains `"mansion"`, so for example `"fort_1a_north"` and `"mansion_t2u"` would match but `"house_fortified"` wouldn't.
+* `"nest3"` if the north neighboring overmap terrain has a flag `"RIVER"` and either of the north east or north west neighboring overmap terrains have a `"RIVER"` flag.
+* `"nest4"` if the join `"interior_to_exterior"` was used to the north during mutable overmap placement.
+* `"nest5"` if the north west neighboring overmap terrain has neither the `"RIVER"`, `"LAKE"` nor `"LAKE_SHORE"` flags.
 
 
 ### Place monster corpse from a monster group with "place_corpses"

--- a/doc/MAPGEN.md
+++ b/doc/MAPGEN.md
@@ -1173,8 +1173,8 @@ Example:
 The code excerpt above will place chunks as follows:
 * `"nest1"` if the north neighbor's om terrain contains `"field"` or `"empty_rock"`.
 * `"nest2"` if the north neighbor has the prefix `"fort"` or contains `"mansion"`, so for example `"fort_1a_north"` and `"mansion_t2u"` would match but `"house_fortified"` wouldn't.
-* `"nest3"` if the north neighboring overmap terrain has a flag `"RIVER"` and either of the north east or north west neighboring overmap terrains have a `"RIVER"` flag.
-* `"nest4"` if the join `"interior_to_exterior"` was used to the north during mutable overmap placement.
+* `"nest3"` if the join `"interior_to_exterior"` was used to the north during mutable overmap placement.
+* `"nest4"` if the north neighboring overmap terrain has a flag `"RIVER"` and either of the north east or north west neighboring overmap terrains have a `"RIVER"` flag.
 * `"nest5"` if the north west neighboring overmap terrain has neither the `"RIVER"`, `"LAKE"` nor `"LAKE_SHORE"` flags.
 
 

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3458,7 +3458,7 @@ class jmapgen_nested : public jmapgen_piece
                                     JsonObject jo = entry.get_object();
                                     dir_neighbor.first = jo.get_string( "om_terrain" );
                                     dir_neighbor.second = jo.get_enum_value<ot_match_type>( "om_terrain_match_type",
-                                                           ot_match_type::contains );
+                                                          ot_match_type::contains );
                                 }
                                 dir_neighbors.insert( dir_neighbor );
                             }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3571,7 +3571,6 @@ class jmapgen_nested : public jmapgen_piece
                     return true;
                 }
         };
-        
         // TO DO: Remove this and replace it with a smarter logical syntax for neighbor_join_check and neighbor_flag_check
         class neighbor_flag_any_check
         {
@@ -3583,7 +3582,7 @@ class jmapgen_nested : public jmapgen_piece
                         cata::flat_set<oter_flags> dir_neighbours;
                         std::string location = io::enum_to_string( dir );
                         optional( jsi, false, location, dir_neighbours );
-                        if( !dir_neighbours.empty() ) { 
+                        if( !dir_neighbours.empty() ) {
                             neighbors[dir] = std::move( dir_neighbours );
                         }
                     }
@@ -3658,7 +3657,8 @@ class jmapgen_nested : public jmapgen_piece
         }
         const weighted_int_list<mapgen_value<nested_mapgen_id>> &get_entries(
         const mapgendata &dat ) const {
-            if( neighbor_oters.test( dat ) && neighbor_joins.test( dat ) && neighbor_flags.test( dat ) && neighbor_flags_any.test( dat ) ) {
+            if( neighbor_oters.test( dat ) && neighbor_joins.test( dat ) && neighbor_flags.test( dat ) &&
+                neighbor_flags_any.test( dat ) ) {
                 return entries;
             } else {
                 return else_entries;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3447,29 +3447,29 @@ class jmapgen_nested : public jmapgen_piece
                 explicit neighbor_oter_check( const JsonObject &jsi ) {
                     for( direction dir : all_enum_values<direction>() ) {
                         std::string location = io::enum_to_string( dir );
-                        cata::flat_set<std::pair<std::string, ot_match_type>> dir_neighbours;
+                        cata::flat_set<std::pair<std::string, ot_match_type>> dir_neighbors;
                         if( !jsi.has_string( location ) ) {
                             for( const JsonValue entry : jsi.get_array( location ) ) {
-                                std::pair<std::string, ot_match_type> dir_neighbour;
+                                std::pair<std::string, ot_match_type> dir_neighbor;
                                 if( entry.test_string() ) {
-                                    dir_neighbour.first = entry.get_string();
-                                    dir_neighbour.second = ot_match_type::contains;
+                                    dir_neighbor.first = entry.get_string();
+                                    dir_neighbor.second = ot_match_type::contains;
                                 } else {
                                     JsonObject jo = entry.get_object();
-                                    dir_neighbour.first = jo.get_string( "om_terrain" );
-                                    dir_neighbour.second = jo.get_enum_value<ot_match_type>( "om_terrain_match_type",
+                                    dir_neighbor.first = jo.get_string( "om_terrain" );
+                                    dir_neighbor.second = jo.get_enum_value<ot_match_type>( "om_terrain_match_type",
                                                            ot_match_type::contains );
                                 }
-                                dir_neighbours.insert( dir_neighbour );
+                                dir_neighbors.insert( dir_neighbor );
                             }
                         } else {
-                            std::pair<std::string, ot_match_type> dir_neighbour;
-                            dir_neighbour.first = jsi.get_string( location );
-                            dir_neighbour.second = ot_match_type::contains;
-                            dir_neighbours.insert( dir_neighbour );
+                            std::pair<std::string, ot_match_type> dir_neighbor;
+                            dir_neighbor.first = jsi.get_string( location );
+                            dir_neighbor.second = ot_match_type::contains;
+                            dir_neighbors.insert( dir_neighbor );
                         }
-                        if( !dir_neighbours.empty() ) {
-                            neighbors[dir] = std::move( dir_neighbours );
+                        if( !dir_neighbors.empty() ) {
+                            neighbors[dir] = std::move( dir_neighbors );
                         }
                     }
                 }
@@ -3503,11 +3503,11 @@ class jmapgen_nested : public jmapgen_piece
             public:
                 explicit neighbor_join_check( const JsonObject &jsi ) {
                     for( cube_direction dir : all_enum_values<cube_direction>() ) {
-                        cata::flat_set<std::string> dir_neighbours =
+                        cata::flat_set<std::string> dir_neighbors =
                             jsi.get_tags<std::string, cata::flat_set<std::string>>(
                                 io::enum_to_string( dir ) );
-                        if( !dir_neighbours.empty() ) {
-                            neighbors[dir] = std::move( dir_neighbours );
+                        if( !dir_neighbors.empty() ) {
+                            neighbors[dir] = std::move( dir_neighbors );
                         }
                     }
                 }
@@ -3542,11 +3542,11 @@ class jmapgen_nested : public jmapgen_piece
             public:
                 explicit neighbor_flag_check( const JsonObject &jsi ) {
                     for( direction dir : all_enum_values<direction>() ) {
-                        cata::flat_set<oter_flags> dir_neighbours;
+                        cata::flat_set<oter_flags> dir_neighbors;
                         std::string location = io::enum_to_string( dir );
-                        optional( jsi, false, location, dir_neighbours );
-                        if( !dir_neighbours.empty() ) {
-                            neighbors[dir] = std::move( dir_neighbours );
+                        optional( jsi, false, location, dir_neighbors );
+                        if( !dir_neighbors.empty() ) {
+                            neighbors[dir] = std::move( dir_neighbors );
                         }
                     }
                 }
@@ -3579,17 +3579,16 @@ class jmapgen_nested : public jmapgen_piece
             public:
                 explicit neighbor_flag_any_check( const JsonObject &jsi ) {
                     for( direction dir : all_enum_values<direction>() ) {
-                        cata::flat_set<oter_flags> dir_neighbours;
+                        cata::flat_set<oter_flags> dir_neighbors;
                         std::string location = io::enum_to_string( dir );
-                        optional( jsi, false, location, dir_neighbours );
-                        if( !dir_neighbours.empty() ) {
-                            neighbors[dir] = std::move( dir_neighbours );
+                        optional( jsi, false, location, dir_neighbors );
+                        if( !dir_neighbors.empty() ) {
+                            neighbors[dir] = std::move( dir_neighbors );
                         }
                     }
                 }
 
                 bool test( const mapgendata &dat ) const {
-                    bool any_direction_has_flag = false;
                     for( const std::pair<const direction, cata::flat_set<oter_flags>> &p :
                          neighbors ) {
                         const direction dir = p.first;
@@ -3598,11 +3597,12 @@ class jmapgen_nested : public jmapgen_piece
                         cata_assert( !allowed_flags.empty() );
 
                         for( const oter_flags &allowed_flag : allowed_flags ) {
-                            any_direction_has_flag |=
-                                dat.neighbor_at( dir )->has_flag( allowed_flag );
+                            if( dat.neighbor_at( dir )->has_flag( allowed_flag ) ) {
+                                return true;
+                            }
                         }
                     }
-                    return any_direction_has_flag;
+                    return false;
                 }
         };
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

While I'm able to hack this already with a combination of #66873 and nests for every individual direction to check, there are multiple instances where I need to just check if there is at least one cardinally adjacent SIDEWALK which currently needs 8 nests that just do "if there's SIDEWALK this way do the thing, else carry on checking" that passes to the next nest that tests the next direction and so on, which makes it both seem more intimidating than it needs to for future contributors while also making it less legible and more lines for reviewers

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Just adds a flags_any field that works identically to flags except it only needs one of the given directions to have the flags specified, can be used alongside the existing checks
Adds documentation for it
The new check is purposefully separate from flags so you can combine the two until a more complete solution is in place

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I'd rather add a more comprehensive syntax for all possible logic with the checks but I can't come up with anything sensible, if someone can think of something now or in the future please replace this

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked it works in game by trying to place a random 24x24 nest over a map with

```
"place_nested": [
  { "chunks": [ "24x24_fence1" ], "x": 0, "y": 0, "flags_any": { "north": [ "SIDEWALK" ], "east": [ "SIDEWALK" ], "south": [ "SIDEWALK" ], "west": [ "SIDEWALK" ] } }
],
```

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->