### PR TITLE
Prevent workout duration overflow

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3649,7 +3649,11 @@ bool workout_activity_actor::query_keep_training( player_activity &act, Characte
         default:
             query_int( length, _( "Train for how long (minutes): " ) );
             elapsed += act.moves_total - act.moves_left;
-            act.moves_total = to_moves<int>( length * 1_minutes );
+            duration = 0_minutes;
+            if( length > 0 ) {
+                duration = length * 1_minutes;
+            }
+            act.moves_total = to_moves<int>( duration );
             act.moves_left = act.moves_total;
             return true;
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Can no longer get stuck for days thinking about working out if you're a WIMP with NEGATIVE WORKOUT TIME"

#### Purpose of change
* Closes #67052
(Unfortunately there is not much that can reasonably be done to rescue their save)

Workout activity can set negative moves with negative input. There's a safety check for this, but not if you're **resuming** working out. player_activity::do_turn *exponentially increases* the negative moves until it overflows. And frustratingly enough to finding this bug, can also overflow it back into the positives quite easily.

#### Describe the solution
Don't let the workout activity set negative moves.

#### Describe alternatives you've considered
Maybe player_activity::do_turn should be proofed against this too? It might be easier (and better/safer) to safeguard it 'downstream' than to make sure each of our *dozens* of activity actors isn't sending it garbage values. Or maybe even *do both* - check the activity actors and 'downstream' in player_activity::do_turn.

But I didn't want to make huge changes, so this just patches up the workout activity actor.

#### Testing
Do some exercise - as in the video, 1 minute, -1 minute, -1 minute, -1 minute, don't ask again ---> does not softlock, instantly allows you to exit

Do some exercise - 10 minutes (takes 10 minutes), resume with -5 minutes (takes no time), resume with 15 minutes(takes 15 minutes), resume with -5 minutes (takes no time), don't ask again ---> does not softlock, instantly allows you to exit

#### Additional context
At one point during testing I had a displayed speed of ~46,000 so it is possible that the player could make one super-fast fridge smash if they had been carrying a fridge before abusing this to overflow their available moves to a very high **positive** value?

If you abuse this bug in BN or something and become the flash of fridge smashing please @ me I want to know