### PR TITLE
Adjust windbreaker to be nylon, less warm and encumbering

### DIFF
--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -1497,7 +1497,7 @@
     "color": "cyan",
     "armor": [
       { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 2, 5 ] },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 2, 5 ] }
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 2, 2 ] }
     ],
     "pocket_data": [
       {

--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -1487,17 +1487,17 @@
     "type": "ARMOR",
     "name": { "str": "windbreaker" },
     "description": "A light synthetic jacket with a hood.  Not very warm, but will keep out the rain.",
-    "weight": "197 g",
+    "weight": "280 g",
     "volume": "2250 ml",
     "price": 1000,
     "price_postapoc": 150,
-    "material": [ "plastic" ],
+    "material": [ "nylon" ],
     "symbol": "[",
     "looks_like": "jacket_light",
     "color": "cyan",
     "armor": [
-      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 6, 9 ] },
-      { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 6, 7 ] }
+      { "covers": [ "torso" ], "coverage": 100, "encumbrance": [ 2, 5 ] },
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 100, "encumbrance": [ 2, 5 ] }
     ],
     "pocket_data": [
       {
@@ -1522,10 +1522,10 @@
         "moves": 80
       }
     ],
-    "warmth": 25,
-    "material_thickness": 0.3,
+    "warmth": 10,
+    "material_thickness": 0.25,
     "environmental_protection": 2,
-    "flags": [ "VARSIZE", "POCKETS", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF", "SOFT" ]
+    "flags": [ "VARSIZE", "POCKETS", "HOOD", "OUTER", "WATERPROOF", "RAINPROOF" ]
   },
   {
     "id": "judo_gi",

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -2237,8 +2237,9 @@
     "difficulty": 3,
     "time": "3 h",
     "autolearn": true,
-    "using": [ [ "tailoring_nylon_patchwork", 5 ], [ "fastener_large", 1 ] ],
-    "proficiencies": [ { "proficiency": "prof_closures" } ]
+    "using": [ [ "tailoring_nylon_patchwork", 7 ], [ "fastener_large", 1 ] ],
+    "proficiencies": [ { "proficiency": "prof_closures" } ],
+    "byproducts": [ [ "scrap_nylon", 50 ] ],
   },
   {
     "result": "wool_hoodie",

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -2239,7 +2239,7 @@
     "autolearn": true,
     "using": [ [ "tailoring_nylon_patchwork", 7 ], [ "fastener_large", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" } ],
-    "byproducts": [ [ "scrap_nylon", 50 ] ],
+    "byproducts": [ [ "scrap_nylon", 50 ] ]
   },
   {
     "result": "wool_hoodie",

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -2228,6 +2228,19 @@
     "tools": [ [ [ "forge", 64 ] ], [ [ "metalworking_tongs", -1 ] ] ]
   },
   {
+    "result": "jacket_windbreaker",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "3 h",
+    "autolearn": true,
+    "using": [ [ "tailoring_nylon_patchwork", 5 ], [ "fastener_large", 1 ] ],
+    "proficiencies": [ { "proficiency": "prof_closures" } ]
+  },
+  {
     "result": "wool_hoodie",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Windbreaker is nylon instead of plastic"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Windbreaker was an old item back when plastic was a stand-in for anything made of synthetic fibers. We've had synthetic fabric / nylon for a loooooong time so it's time to adjust it.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make it  synthetic fabric (this represents like, gore tex or something, that is both breathable and waterproof). Lowered encumbrance to 1-2 fitted since 3 encumbrance was that of a hoodie (1mm thick cotton). Made it 0.25mm instead of 0.3mm since nylon sheets are 0.25 and added a crafting recipe. Lowered warmth to 10 since both its material thickness suggests, and item description specifically mentions, that it's not very warm.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->