### PR TITLE
fix widget error if player has no body part

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -768,15 +768,27 @@ int widget::get_var_value( const avatar &ava ) const
             break;
         case widget_var::bp_hp:
             // HP for body part
-            value = ava.get_part_hp_cur( only_bp() );
+            if( ava.has_part( only_bp() ) ) {
+                value = ava.get_part_hp_cur( only_bp() );
+            } else {
+                value = 0;
+            }
             break;
         case widget_var::bp_warmth:
             // Body part warmth/temperature
-            value = ava.get_part_temp_cur( only_bp() );
+            if( ava.has_part( only_bp() ) ) {
+                value = ava.get_part_temp_cur( only_bp() );
+            } else {
+                value = 0;
+            }
             break;
         case widget_var::bp_wetness:
             // Body part wetness
-            value = ava.get_part_wetness( only_bp() );
+            if( ava.has_part( only_bp() ) ) {
+                value = ava.get_part_wetness( only_bp() );
+            } else {
+                value = 0;
+            }
             break;
         case widget_var::focus:
             value = ava.get_focus();


### PR DESCRIPTION
#### Summary
Interface "fix widget error if player has no body part"

#### Purpose of change
When I used debug trait "Debug No Torso", widget::get_var_value errors because it does not check body part exists.

#### Describe the solution
check if body part exists same as widget::set_default_var_range.

#### Describe alternatives you've considered

#### Testing
Game begin. Enable "Debug No Torso", widget does not errors.

#### Additional context
