### PR TITLE
'Experiment' start and extra_mut_scen starts don't reveal the nearest city

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -698,6 +698,7 @@
       "CHITIN",
       "ELECTRORECEPTORS"
     ],
+    "reveal_locale": false,
     "flags": [ "LONE_START" ]
   },
   {

--- a/data/mods/extra_mut_scen/mutation_scenarios.json
+++ b/data/mods/extra_mut_scen/mutation_scenarios.json
@@ -261,7 +261,8 @@
       "WINGS_STUB",
       "XS",
       "XXXL"
-    ]
+    ],
+    "reveal_locale": false
   },
   {
     "type": "scenario",


### PR DESCRIPTION
#### Summary
Balance "'Experiment' start and extra_mut_scen starts don't reveal the nearest city"

#### Purpose of change
The description of start and the professions implies you are a mutant who was either vatgrown or spent a very long time in the lab. Feels weird to have them start with knowledge of a town, especially since they have been wandering aimlessly for hours or days since leaving the lab.

#### Describe the solution
Add the flag that removes knowledge of the nearest city.

#### Describe alternatives you've considered
Leaving as is, developing the lore a bit more.

#### Testing
Tested, started with no knowledge of the nearest city on my usual wolf mutant start,

#### Additional context
Sincerely, a mutant start main,