### PR TITLE
[Magiclysm] Change the Utility Molding spell to allow selecting the starting tool

### DIFF
--- a/data/mods/Magiclysm/Spells/earthshaper.json
+++ b/data/mods/Magiclysm/Spells/earthshaper.json
@@ -558,14 +558,14 @@
     "name": "Utility Molding (Hammer)",
     "description": "Spawn the Utility molding hammer.  It's a bug if you have this spell directly.",
     "valid_targets": [ "self" ],
-    "flags": [ "SOMATIC", "LOUD" ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
     "effect_str": "eshaper_hammer",
     "shape": "blast",
-    "spell_class": "EARTHSHAPER",
-    "min_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] }
+    "min_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] },
+    "max_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] }
   },
   {
     "id": "eshaper_spawn_pickaxe",
@@ -573,14 +573,14 @@
     "name": "Utility Molding (Pickaxe)",
     "description": "Spawn the Utility molding pickaxe.  It's a bug if you have this spell directly.",
     "valid_targets": [ "self" ],
-    "flags": [ "SOMATIC", "LOUD" ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
     "effect_str": "eshaper_pickaxe",
     "shape": "blast",
-    "spell_class": "EARTHSHAPER",
-    "min_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] }
+    "min_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] },
+    "max_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] }
   },
   {
     "id": "eshaper_spawn_axe",
@@ -588,14 +588,14 @@
     "name": "Utility Molding (Axe)",
     "description": "Spawn the Utility molding axe.  It's a bug if you have this spell directly.",
     "valid_targets": [ "self" ],
-    "flags": [ "SOMATIC", "LOUD" ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
     "effect_str": "eshaper_ax",
     "shape": "blast",
-    "spell_class": "EARTHSHAPER",
-    "min_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] }
+    "min_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] },
+    "max_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] }
   },
   {
     "id": "eshaper_spawn_knife",
@@ -603,14 +603,14 @@
     "name": "Utility Molding (Knife)",
     "description": "Spawn the Utility molding knife.  It's a bug if you have this spell directly.",
     "valid_targets": [ "self" ],
-    "flags": [ "SOMATIC", "LOUD" ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
     "effect_str": "eshaper_knife",
     "shape": "blast",
-    "spell_class": "EARTHSHAPER",
-    "min_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] }
+    "min_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] },
+    "max_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] }
   },
   {
     "id": "eshaper_spawn_shovel",
@@ -618,14 +618,14 @@
     "name": "Utility Molding (Shovel)",
     "description": "Spawn the Utility molding shovel.  It's a bug if you have this spell directly.",
     "valid_targets": [ "self" ],
-    "flags": [ "SOMATIC", "LOUD" ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
     "min_damage": 1,
     "max_damage": 1,
     "effect": "spawn_item",
     "effect_str": "eshaper_shovel",
     "shape": "blast",
-    "spell_class": "EARTHSHAPER",
-    "min_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] }
+    "min_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] },
+    "max_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] }
   },
   {
     "id": "eshaper_melee_damage",

--- a/data/mods/Magiclysm/Spells/earthshaper.json
+++ b/data/mods/Magiclysm/Spells/earthshaper.json
@@ -486,8 +486,8 @@
     "flags": [ "SOMATIC", "LOUD" ],
     "min_damage": 1,
     "max_damage": 1,
-    "effect": "spawn_item",
-    "effect_str": "eshaper_hammer",
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_EARTHSHAPER_UTILITY_MOLDING",
     "shape": "blast",
     "spell_class": "EARTHSHAPER",
     "energy_source": "MANA",
@@ -502,6 +502,160 @@
     "min_duration": 576000,
     "max_duration": 8640000,
     "duration_increment": 576000
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EARTHSHAPER_UTILITY_MOLDING",
+    "effect": [
+      {
+        "run_eoc_selector": [
+          "EOC_EARTHSHAPER_UTILITY_MOLDING_HAMMER",
+          "EOC_EARTHSHAPER_UTILITY_MOLDING_PICKAXE",
+          "EOC_EARTHSHAPER_UTILITY_MOLDING_AXE",
+          "EOC_EARTHSHAPER_UTILITY_MOLDING_KNIFE",
+          "EOC_EARTHSHAPER_UTILITY_MOLDING_SHOVEL"
+        ],
+        "names": [ "Summon Hammer", "Summon Pickaxe", "Summon Axe", "Summon Knife", "Summon Shovel" ],
+        "keys": [ "1", "2", "3", "4", "5" ],
+        "descriptions": [
+          "Transform the living earth into a hammer.",
+          "Transform the living earth into a pickaxe.",
+          "Transform the living earth into an axe.",
+          "Transform the living earth into a knife.",
+          "Transform the living earth into a shovel."
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EARTHSHAPER_UTILITY_MOLDING_HAMMER",
+    "effect": [
+      { "u_remove_item_with": "eshaper_pickaxe" },
+      { "u_remove_item_with": "eshaper_ax" },
+      { "u_remove_item_with": "eshaper_knife" },
+      { "u_remove_item_with": "eshaper_shovel" },
+      { "u_cast_spell": { "id": "eshaper_spawn_hammer" } }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EARTHSHAPER_UTILITY_MOLDING_PICKAXE",
+    "effect": [
+      { "u_remove_item_with": "eshaper_hammer" },
+      { "u_remove_item_with": "eshaper_ax" },
+      { "u_remove_item_with": "eshaper_knife" },
+      { "u_remove_item_with": "eshaper_shovel" },
+      { "u_cast_spell": { "id": "eshaper_spawn_pickaxe" } }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EARTHSHAPER_UTILITY_MOLDING_AXE",
+    "effect": [
+      { "u_remove_item_with": "eshaper_hammer" },
+      { "u_remove_item_with": "eshaper_pickaxe" },
+      { "u_remove_item_with": "eshaper_knife" },
+      { "u_remove_item_with": "eshaper_shovel" },
+      { "u_cast_spell": { "id": "eshaper_spawn_axe" } }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EARTHSHAPER_UTILITY_MOLDING_KNIFE",
+    "effect": [
+      { "u_remove_item_with": "eshaper_hammer" },
+      { "u_remove_item_with": "eshaper_pickaxe" },
+      { "u_remove_item_with": "eshaper_ax" },
+      { "u_remove_item_with": "eshaper_shovel" },
+      { "u_cast_spell": { "id": "eshaper_spawn_knife" } }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EARTHSHAPER_UTILITY_MOLDING_SHOVEL",
+    "effect": [
+      { "u_remove_item_with": "eshaper_hammer" },
+      { "u_remove_item_with": "eshaper_pickaxe" },
+      { "u_remove_item_with": "eshaper_ax" },
+      { "u_remove_item_with": "eshaper_knife" },
+      { "u_cast_spell": { "id": "eshaper_spawn_shovel" } }
+    ]
+  },
+  {
+    "id": "eshaper_spawn_hammer",
+    "type": "SPELL",
+    "name": "Utility Molding (Hammer)",
+    "description": "Spawn the Utility molding hammer.  It's a bug if you have this spell directly.",
+    "valid_targets": [ "self" ],
+    "flags": [ "SOMATIC", "LOUD" ],
+    "min_damage": 1,
+    "max_damage": 1,
+    "effect": "spawn_item",
+    "effect_str": "eshaper_hammer",
+    "shape": "blast",
+    "spell_class": "EARTHSHAPER",
+    "min_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] }
+  },
+  {
+    "id": "eshaper_spawn_pickaxe",
+    "type": "SPELL",
+    "name": "Utility Molding (Pickaxe)",
+    "description": "Spawn the Utility molding pickaxe.  It's a bug if you have this spell directly.",
+    "valid_targets": [ "self" ],
+    "flags": [ "SOMATIC", "LOUD" ],
+    "min_damage": 1,
+    "max_damage": 1,
+    "effect": "spawn_item",
+    "effect_str": "eshaper_pickaxe",
+    "shape": "blast",
+    "spell_class": "EARTHSHAPER",
+    "min_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] }
+  },
+  {
+    "id": "eshaper_spawn_axe",
+    "type": "SPELL",
+    "name": "Utility Molding (Axe)",
+    "description": "Spawn the Utility molding axe.  It's a bug if you have this spell directly.",
+    "valid_targets": [ "self" ],
+    "flags": [ "SOMATIC", "LOUD" ],
+    "min_damage": 1,
+    "max_damage": 1,
+    "effect": "spawn_item",
+    "effect_str": "eshaper_ax",
+    "shape": "blast",
+    "spell_class": "EARTHSHAPER",
+    "min_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] }
+  },
+  {
+    "id": "eshaper_spawn_knife",
+    "type": "SPELL",
+    "name": "Utility Molding (Knife)",
+    "description": "Spawn the Utility molding knife.  It's a bug if you have this spell directly.",
+    "valid_targets": [ "self" ],
+    "flags": [ "SOMATIC", "LOUD" ],
+    "min_damage": 1,
+    "max_damage": 1,
+    "effect": "spawn_item",
+    "effect_str": "eshaper_knife",
+    "shape": "blast",
+    "spell_class": "EARTHSHAPER",
+    "min_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] }
+  },
+  {
+    "id": "eshaper_spawn_shovel",
+    "type": "SPELL",
+    "name": "Utility Molding (Shovel)",
+    "description": "Spawn the Utility molding shovel.  It's a bug if you have this spell directly.",
+    "valid_targets": [ "self" ],
+    "flags": [ "SOMATIC", "LOUD" ],
+    "min_damage": 1,
+    "max_damage": 1,
+    "effect": "spawn_item",
+    "effect_str": "eshaper_shovel",
+    "shape": "blast",
+    "spell_class": "EARTHSHAPER",
+    "min_duration": { "math": [ "( (u_val('spell_level', 'spell: eshaper_spawn_tools') * 576000) + 576000)" ] }
   },
   {
     "id": "eshaper_melee_damage",

--- a/data/mods/Magiclysm/Spells/earthshaper.json
+++ b/data/mods/Magiclysm/Spells/earthshaper.json
@@ -530,57 +530,27 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_EARTHSHAPER_UTILITY_MOLDING_HAMMER",
-    "effect": [
-      { "u_remove_item_with": "eshaper_pickaxe" },
-      { "u_remove_item_with": "eshaper_ax" },
-      { "u_remove_item_with": "eshaper_knife" },
-      { "u_remove_item_with": "eshaper_shovel" },
-      { "u_cast_spell": { "id": "eshaper_spawn_hammer" } }
-    ]
+    "effect": [ { "u_cast_spell": { "id": "eshaper_spawn_hammer" } } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_EARTHSHAPER_UTILITY_MOLDING_PICKAXE",
-    "effect": [
-      { "u_remove_item_with": "eshaper_hammer" },
-      { "u_remove_item_with": "eshaper_ax" },
-      { "u_remove_item_with": "eshaper_knife" },
-      { "u_remove_item_with": "eshaper_shovel" },
-      { "u_cast_spell": { "id": "eshaper_spawn_pickaxe" } }
-    ]
+    "effect": [ { "u_cast_spell": { "id": "eshaper_spawn_pickaxe" } } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_EARTHSHAPER_UTILITY_MOLDING_AXE",
-    "effect": [
-      { "u_remove_item_with": "eshaper_hammer" },
-      { "u_remove_item_with": "eshaper_pickaxe" },
-      { "u_remove_item_with": "eshaper_knife" },
-      { "u_remove_item_with": "eshaper_shovel" },
-      { "u_cast_spell": { "id": "eshaper_spawn_axe" } }
-    ]
+    "effect": [ { "u_cast_spell": { "id": "eshaper_spawn_axe" } } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_EARTHSHAPER_UTILITY_MOLDING_KNIFE",
-    "effect": [
-      { "u_remove_item_with": "eshaper_hammer" },
-      { "u_remove_item_with": "eshaper_pickaxe" },
-      { "u_remove_item_with": "eshaper_ax" },
-      { "u_remove_item_with": "eshaper_shovel" },
-      { "u_cast_spell": { "id": "eshaper_spawn_knife" } }
-    ]
+    "effect": [ { "u_cast_spell": { "id": "eshaper_spawn_knife" } } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_EARTHSHAPER_UTILITY_MOLDING_SHOVEL",
-    "effect": [
-      { "u_remove_item_with": "eshaper_hammer" },
-      { "u_remove_item_with": "eshaper_pickaxe" },
-      { "u_remove_item_with": "eshaper_ax" },
-      { "u_remove_item_with": "eshaper_knife" },
-      { "u_cast_spell": { "id": "eshaper_spawn_shovel" } }
-    ]
+    "effect": [ { "u_cast_spell": { "id": "eshaper_spawn_shovel" } } ]
   },
   {
     "id": "eshaper_spawn_hammer",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Change the Utility Molding spell to allow selecting the starting tool"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

run_eoc_selector exists
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change the Utility Molding spell so that rather than always summoning a hammer and requiring the player to activate to the proper tool, allow the player to choose which tool is summoned when the spell is first cast. Other tools are removed, so the player can only have one tool at a time. The previous behavior of allowing the tool to transform is retained (I did not replace the transform function on the items because EoC use_actions lack fields like "need_wielding" )
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Doing nothing
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/f1981180-fd44-479a-91a0-3dde9ea916a6)

Everything works. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->