### PR TITLE
Allow leg tourniquets for mutants with tails

### DIFF
--- a/data/json/items/tool_armor.json
+++ b/data/json/items/tool_armor.json
@@ -98,7 +98,7 @@
     "sided": true,
     "material": [ "wood", "leather" ],
     "use_action": { "target": "tourniquet_lower_XL", "msg": "You adjust the tourniquet.", "menu_text": "Adjust", "type": "transform" },
-    "flags": [ "WATER_FRIENDLY", "OUTER", "TOURNIQUET" ],
+    "flags": [ "WATER_FRIENDLY", "OUTER", "TOURNIQUET", "ALLOWS_TAIL" ],
     "armor": [ { "encumbrance": 70, "coverage": 10, "covers": [ "leg_l", "leg_r" ] } ]
   },
   {
@@ -110,7 +110,7 @@
     "looks_like": "tourniquet_lower",
     "sided": true,
     "use_action": { "target": "tourniquet_lower_XS", "msg": "You adjust the tourniquet.", "menu_text": "Adjust", "type": "transform" },
-    "flags": [ "WATER_FRIENDLY", "OUTER", "TOURNIQUET", "OVERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "OUTER", "TOURNIQUET", "OVERSIZE", "ALLOWS_TAIL" ]
   },
   {
     "id": "tourniquet_lower_XS",
@@ -121,7 +121,7 @@
     "looks_like": "tourniquet_lower",
     "sided": true,
     "use_action": { "target": "tourniquet_upper", "msg": "You adjust the tourniquet.", "menu_text": "Adjust", "type": "transform" },
-    "flags": [ "WATER_FRIENDLY", "OUTER", "TOURNIQUET", "UNDERSIZE" ]
+    "flags": [ "WATER_FRIENDLY", "OUTER", "TOURNIQUET", "UNDERSIZE", "ALLOWS_TAIL" ]
   },
   {
     "id": "makeshift_blindfold",


### PR DESCRIPTION
#### Summary
Bugfixes "Tailed mutants can use leg tourniquets"

#### Purpose of change
* Fixes #67124

#### Describe the solution
Add the `ALLOWS_TAIL` flag to all the leg tourniquets, this allows them to be worn on legs even when a tail mutation is present (as long as the tail mutation checks for this flag, which they all should)

#### Describe alternatives you've considered


#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/13a31e4e-3e3a-4449-9cd3-9721ca91a505)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/5396ec2b-08fa-4ae9-bcaa-732ef47f3503)

Tourniquets don't seem to actually help stop the bleeding, but they seem to reduce the rate at which the character bleeds. As far as I can tell, that's how they're supposed to work. (Edit: Venera confirms that is how they are supposed to work, so this checks out!)

#### Additional context
