### PR TITLE
Fix "--check-mods" not good at dealing with dep chain

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -524,7 +524,7 @@ bool game::check_mod_data( const std::vector<mod_id> &opts, loading_ui &ui )
             // Load any dependencies and de-duplicate them
             std::vector<mod_id> dep_vector = tree.get_dependencies_of_X_as_strings( mod.ident );
             std::set<mod_id> dep_set( dep_vector.begin(), dep_vector.end() );
-            for( auto &dep : dep_set ) {
+            for( const auto &dep : dep_set ) {
                 load_data_from_dir( dep->path, dep->ident.str(), ui );
             }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -521,8 +521,10 @@ bool game::check_mod_data( const std::vector<mod_id> &opts, loading_ui &ui )
         try {
             load_core_data( ui );
 
-            // Load any dependencies
-            for( auto &dep : tree.get_dependencies_of_X_as_strings( mod.ident ) ) {
+            // Load any dependencies and de-duplicate them
+            std::vector<mod_id> dep_vector = tree.get_dependencies_of_X_as_strings( mod.ident );
+            std::set<mod_id> dep_set( dep_vector.begin(), dep_vector.end() );
+            for( auto &dep : dep_set ) {
                 load_data_from_dir( dep->path, dep->ident.str(), ui );
             }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
"--check-mods" commandline option is not very good at dealing with mods dependency chain. 

If I run cataclysm-tiles with option "--check-mods Arcana", no error will appear. If I create mod A whose deps are dda, arcana and magiclysm, and I run cataclysm-tiles with option "--check-mods A", it will falsely report that some arcana json files aren't correct. 

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Deduplicate the dependency chain using std::set.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
No more fake alarms.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->