### PR TITLE
New transparent plastics, material adjustments

### DIFF
--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -11,7 +11,7 @@
     "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
     "bash_dmg_verb": "dented",
     "cut_dmg_verb": "gouged",
-    "resist": { "bash": 4, "cut": 6, "acid": 10, "heat": 6, "bullet": 6 }
+    "resist": { "bash": 4, "cut": 5, "acid": 10, "heat": 6, "bullet": 3 }
   },
   {
     "type": "material",
@@ -885,7 +885,7 @@
       { "fuel": 0, "smoke": 0, "burn": 1000, "volume_per_turn": "5000 ml", "//": "More like shattering than melting" }
     ],
     "burn_products": [ [ "glass_shard", 0.5 ] ],
-    "resist": { "bash": 3, "cut": 4, "acid": 10, "heat": 3, "bullet": 3 },
+    "resist": { "bash": 3, "cut": 4, "acid": 10, "heat": 3, "bullet": 1 },
     "repair_difficulty": 7
   },
   {
@@ -907,7 +907,7 @@
       { "fuel": 0, "smoke": 0, "burn": 1000, "volume_per_turn": "5000 ml", "//": "More like shattering than melting" }
     ],
     "burn_products": [ [ "glass_shard", 0.5 ] ],
-    "resist": { "bash": 3, "cut": 4, "acid": 10, "heat": 3, "bullet": 3 }
+    "resist": { "bash": 3, "cut": 4, "acid": 10, "heat": 3, "bullet": 1 }
   },
   {
     "type": "material",
@@ -1509,6 +1509,7 @@
     "id": "plastic",
     "name": "Plastic",
     "//": "Most common plastics are around 1",
+    "//2": "This one represents various non-resistant household plastics, found in your pen, keyboard, charger etc.",
     "density": 1.0,
     "specific_heat_liquid": 1.6,
     "specific_heat_solid": 1.6,
@@ -1526,8 +1527,26 @@
       { "fuel": 0.4, "smoke": 3, "burn": 0.003 },
       { "fuel": 1, "smoke": 5, "burn": 0.008 }
     ],
-    "resist": { "bash": 2, "cut": 2, "acid": 9, "heat": 1, "bullet": 2 },
+    "resist": { "bash": 2, "cut": 2, "acid": 9, "heat": 1, "bullet": 1 },
     "repair_difficulty": 3
+  },
+  {
+    "type": "material",
+    "id": "hard_plastic_transp",
+    "copy-from": "plastic",
+    "name": "Transparent Impact Resistant Plastic",
+    "//2": "This one represents various transparent impact-resistant plastics, like polycarbonate.  Prime material for visors and safety goggles.",
+    "resist": { "bash": 4, "cut": 3, "acid": 9, "heat": 1, "bullet": 1.5 },
+    "repair_difficulty": 4
+  },
+  {
+    "type": "material",
+    "id": "composite_transp",
+    "copy-from": "plastic",
+    "name": "Transparent Bullet Resistant Composite",
+    "//2": "This one represents specialised transparent bulletproof composites, mostly employed on military vehicles and in high-value construction (banks).",
+    "resist": { "bash": 5, "cut": 4, "acid": 9, "heat": 1, "bullet": 2 },
+    "repair_difficulty": 5
   },
   {
     "type": "material",
@@ -1548,7 +1567,7 @@
       { "fuel": 0.4, "smoke": 3, "burn": 0.003 },
       { "fuel": 1, "smoke": 5, "burn": 0.008 }
     ],
-    "resist": { "bash": 0.75, "cut": 0.5, "acid": 9, "heat": 1, "bullet": 0.5 },
+    "resist": { "bash": 1, "cut": 0.5, "acid": 9, "heat": 1, "bullet": 0.5 },
     "repair_difficulty": 5
   },
   {

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -192,7 +192,7 @@ TEST_CASE( "Ranged_coverage_vs_bullet", "[coverage] [ranged]" )
 
     SECTION( "No ranged coverage vs. ranged attack" ) {
         const float dmg = get_avg_bullet_dmg( "test_hazmat_suit_noranged" );
-        ( "Average damage", dmg, 17.2f, 0.2f );
+        check_near( "Average damage", dmg, 17.2f, 0.2f );
     }
 }
 
@@ -200,14 +200,14 @@ TEST_CASE( "Proportional_armor_material_resistances", "[material]" )
 {
     SECTION( "Mostly steel armor vs. melee" ) {
         const float dmg = get_avg_melee_dmg( "test_swat_mostly_steel" );
-        ( "Average damage", dmg, 4.0f, 0.2f );
+        check_near( "Average damage", dmg, 4.0f, 0.2f );
     }
 
     SECTION( "Mostly cotton armor vs. melee" ) {
         const float dmg = get_avg_melee_dmg( "test_swat_mostly_cotton" );
         // more variance on this test since it has a 5% chance of blocking with
         // high protection steel
-        ( "Average damage", dmg, 14.4f, 0.4f );
+        check_near( "Average damage", dmg, 14.4f, 0.4f );
     }
 
     SECTION( "Multi material segmented armor vs. melee" ) {
@@ -247,7 +247,7 @@ TEST_CASE( "Off_Limb_Ghost_ablative_vest", "[coverage]" )
         dude.wear_item( full, false );
         damage_instance du_full = damage_instance( damage_bullet, 100.0f );
         dude.absorb_hit( weakpoint_attack(), bodypart_id( "leg_l" ), du_full );
-        ( "Damage Protected", du_full.total_damage(), 0.0f, 0.1f );
+        check_near( "Damage Protected", du_full.total_damage(), 0.0f, 0.1f );
     }
 }
 

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -187,12 +187,12 @@ TEST_CASE( "Ranged_coverage_vs_bullet", "[coverage] [ranged]" )
 {
     SECTION( "Full melee and ranged coverage vs. ranged attack" ) {
         const float dmg = get_avg_bullet_dmg( "test_hazmat_suit" );
-        check_near( "Average damage", dmg, 13.6f, 0.2f );
+        check_near( "Average damage", dmg, 15.4f, 0.2f );
     }
 
     SECTION( "No ranged coverage vs. ranged attack" ) {
         const float dmg = get_avg_bullet_dmg( "test_hazmat_suit_noranged" );
-        check_near( "Average damage", dmg, 17.2f, 0.2f );
+        ( "Average damage", dmg, 17.2f, 0.2f );
     }
 }
 
@@ -200,14 +200,14 @@ TEST_CASE( "Proportional_armor_material_resistances", "[material]" )
 {
     SECTION( "Mostly steel armor vs. melee" ) {
         const float dmg = get_avg_melee_dmg( "test_swat_mostly_steel" );
-        check_near( "Average damage", dmg, 4.0f, 0.2f );
+        ( "Average damage", dmg, 4.0f, 0.2f );
     }
 
     SECTION( "Mostly cotton armor vs. melee" ) {
         const float dmg = get_avg_melee_dmg( "test_swat_mostly_cotton" );
         // more variance on this test since it has a 5% chance of blocking with
         // high protection steel
-        check_near( "Average damage", dmg, 14.4f, 0.4f );
+        ( "Average damage", dmg, 14.4f, 0.4f );
     }
 
     SECTION( "Multi material segmented armor vs. melee" ) {
@@ -247,7 +247,7 @@ TEST_CASE( "Off_Limb_Ghost_ablative_vest", "[coverage]" )
         dude.wear_item( full, false );
         damage_instance du_full = damage_instance( damage_bullet, 100.0f );
         dude.absorb_hit( weakpoint_attack(), bodypart_id( "leg_l" ), du_full );
-        check_near( "Damage Protected", du_full.total_damage(), 0.0f, 0.1f );
+        ( "Damage Protected", du_full.total_damage(), 0.0f, 0.1f );
     }
 }
 

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1279,11 +1279,11 @@ TEST_CASE( "armor_protection", "[iteminfo][armor][protection]" )
 
     SECTION( "moderate protection from physical and environmental damage" ) {
         // Hazmat suit, material:plastic, thickness:2
-        // 2/2/2 bash/cut/bullet x 2 thickness
+        // 2/2/1 bash/cut/bullet x 2 thickness
         // 9/1/20 acid/fire/env
         item hazmat( "test_hazmat_suit" );
         REQUIRE( hazmat.get_covered_body_parts().any() );
-        expected_armor_values( hazmat, 4, 4, 3.2, 4, 9, 1, 20 );
+        expected_armor_values( hazmat, 4, 4, 3.2, 2, 9, 1, 20 );
 
         // Protection info displayed on two lines
         CHECK( item_info_str( hazmat, protection ) ==

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1294,7 +1294,7 @@ TEST_CASE( "armor_protection", "[iteminfo][armor][protection]" )
                "<color_c_white>Protection</color>:\n"
                "  Bash: <color_c_yellow>4.00</color>\n"
                "  Cut: <color_c_yellow>4.00</color>\n"
-               "  Ballistic: <color_c_yellow>4.00</color>\n"
+               "  Ballistic: <color_c_yellow>2.00</color>\n"
                "  Pierce: <color_c_yellow>3.20</color>\n"
                "  Acid: <color_c_yellow>9.00</color>\n"
                "  Fire: <color_c_yellow>1.00</color>\n"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Increase plastic variety, adjust plastics to be more realistic in terms of protection"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Partially fixes issues mentioned in #66139 and comments to #66179.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. Split the generic plastic into household plastic with 0.5x bullet protection of current one, impact resistant transparent plastic (non-reinforced polycarb) 0.75x bullet protection of current one and plastic composite (polycarbonate composite) with 1x bullet protection of current one;
2. Buff bash resist of plastic padding. In its current state it does its job (bash protection) even worse than aramids in terms of bash protection per unit of weight/volume/mm;
3. Tone down thermoplastic resin bullet resistance. It is essentially better rigid Kevlar right now, while experimental evidence shows the opposite;
4. Nerf to ground silica glass (household glass) bullet resistance.


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Have common household plastics be as resistant as polycarbonate safety glass. Have football helmets protect from bullets better than army helmets.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
None for now.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

#### Additional context

Why glass does not deserve 3 bullet protection:
https://www.youtube.com/watch?v=PD1vkhFO4Dg&t=420s

Pull out your napkins. The panes in question are mentioned to be 0.125 inches thick. 9 mm FMJ bullet (28 effective damage) destroyed 11. 11 panes is ~35 mm of glass, which in game translates to ~105 bullet armor (3 bullet armor per mm of glass). Meaning that in game bullet would stop at 4th pane at most. Cutting bullet res to 1 per mm produces MUCH more realistic results, making 35 mm of glass give 35 ballistic armor. If the panes were stacked back to back/there was a monolithic 35 mm thick pane in experiment, a 9mm bullet could realistically get stopped by that amount of glass. But not 4 panes of glass stopping a 9 mm round, like it is in game.

Why plastic does not deserve 2 bullet protection:
https://www.youtube.com/watch?v=OpDIoFHZfRs

Composite 3 inch glass from uparmored HMMWV (FRAG 5/6/7) stops an FMJ .50 bullet in video. When using in-game values, Barrett gives about 154 damage vs about 150 of generic plastic at 3 inch thickness. The results are close to real life, BUT: the plastic in game is supposed to be your usual everyday plastic, not composite ballistic polycarbonate specifically made to be in an armored windshield, and add in the fact the thickness itself gives some additional protective value through added rigidity (polycarb in a 20 mm thick visor wouldn't be as protective as a solid 3 inch brick of composite), and don't forget that if that 3 inch panel was worn, some energy of .50 BMG would still make it through and possibly deal some damage.

Why thermoplastic resin should not have 6 bullet resistance:
https://www.youtube.com/watch?v=TzRQgfXVdBA
https://www.youtube.com/watch?v=cVEdUl9AsR8

In both cases, a football helmet was pierced by a .22 LR rimfire cartridge (13 damage at best). At the same time, ingame football helmet provides ballistic protection that is unrealistically close to that of an army helmet on protected parts (army helmet has 31.5 bullet resistance on crown, football helmet provides 25, enough to reduce damage from 9 mm round to single digits, and fully stop anything smaller).

Non-reinforced polycarbonate should have 1.5 bullet resistance per mm per this:
https://totalshield.com/blog/polycarbonate-ballistic-performance-how-strong-is-polycarbonate/#:~:text=Ballistic%20Resistance%20Standards%3A%20The%20Bottom,357%20magnum.

1.25 inches is ~32 mm of polycarbonate, which should fully stop multiple impacts of .44 Magnum (~40 damage) per the article. So, 1-1.5 ballistic protection per mm (32 mm giving 32-48 ballistic protection) looks like a fitting value.

On the other note, 3.125 mm of tempered steel in game is ~24.3 armor, yet IRL it can withstand multiple .44 magnum shots per this resource... To fully stop a .44 Magnum shot plate of this thickness needs ~14 ballistic protection per mm.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->