### PR TITLE
More monsters fight back if cornered

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -48,6 +48,18 @@
   },
   {
     "type": "effect_type",
+    "id": "spooked",
+    "name": [ "Cornered Fighter Spooked" ],
+    "desc": [ "AI tag to let CORNERED_FIGHTER monsters try to flee.  This is a bug if you have it." ]
+  },
+  {
+    "type": "effect_type",
+    "id": "spooked_recent",
+    "name": [ "Cornered Fighter Recently Spooked" ],
+    "desc": [ "AI tag to allow CORNERED_FIGHTER monsters to turn and fight.  This is a bug if you have it." ]
+  },
+  {
+    "type": "effect_type",
     "id": "dragging",
     "name": [ "Dragging" ],
     "show_in_info": true,

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -113,7 +113,7 @@
     "//": "220 days gestation period, the mother and cubs remain together for 16-17 months.",
     "baby_flags": [ "SPRING" ],
     "special_attacks": [ [ "EAT_FOOD", 20 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "BASHES", "PUSH_MON" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "BASHES", "PUSH_MON", "CORNERED_FIGHTER" ],
     "armor": { "bash": 2, "electric": 1 }
   },
   {
@@ -273,7 +273,7 @@
     "symbol": "b",
     "color": "brown",
     "aggression": 20,
-    "morale": 40,
+    "morale": 20,
     "aggro_character": false,
     "melee_skill": 5,
     "melee_dice": 2,
@@ -286,11 +286,11 @@
     "baby_flags": [ "SPRING", "SUMMER", "AUTUMN", "WINTER" ],
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 2 },
     "path_settings": { "max_dist": 10 },
-    "anger_triggers": [ "PLAYER_WEAK", "FRIEND_ATTACKED" ],
+    "anger_triggers": [ "PLAYER_WEAK", "FRIEND_ATTACKED", "HURT" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
     "zombify_into": "mon_zpig_brute",
     "special_attacks": [ [ "EAT_FOOD", 20 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "PET_MOUNTABLE", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "PET_MOUNTABLE", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "CORNERED_FIGHTER" ],
     "armor": { "bash": 2, "cut": 1 }
   },
   {
@@ -781,7 +781,8 @@
       "WARM",
       "PET_WONT_FOLLOW",
       "MILKABLE",
-      "CAN_BE_CULLED"
+      "CAN_BE_CULLED",
+      "CORNERED_FIGHTER"
     ],
     "armor": { "bash": 2, "electric": 1 }
   },
@@ -975,7 +976,8 @@
       "SEES",
       "SMELLS",
       "SWARMS",
-      "WARM"
+      "WARM",
+      "CORNERED_FIGHTER"
     ]
   },
   {
@@ -999,7 +1001,8 @@
     "vision_night": 4,
     "harvest": "dog_small_with_skull",
     "upgrades": { "age_grow": 42, "into": "mon_dog" },
-    "extend": { "flags": [ "NO_BREED" ] }
+    "extend": { "flags": [ "NO_BREED" ] },
+    "delete": { "flags": [ "CORNERED_FIGHTER" ] }
   },
   {
     "id": "mon_dog_bull",
@@ -1034,7 +1037,8 @@
       "PATH_AVOID_DANGER_1",
       "SEES",
       "SMELLS",
-      "WARM"
+      "WARM",
+      "CORNERED_FIGHTER"
     ]
   },
   {
@@ -1106,7 +1110,8 @@
       "PATH_AVOID_DANGER_1",
       "SEES",
       "SMELLS",
-      "WARM"
+      "WARM",
+      "CORNERED_FIGHTER"
     ]
   },
   {
@@ -1183,7 +1188,8 @@
       "SEES",
       "SMELLS",
       "SWARMS",
-      "WARM"
+      "WARM",
+      "CORNERED_FIGHTER"
     ]
   },
   {
@@ -1268,7 +1274,8 @@
       "PATH_AVOID_DANGER_1",
       "SEES",
       "SMELLS",
-      "WARM"
+      "WARM",
+      "CORNERED_FIGHTER"
     ]
   },
   {
@@ -1575,7 +1582,8 @@
       "PATH_AVOID_DANGER_1",
       "SEES",
       "SMELLS",
-      "WARM"
+      "WARM",
+      "CORNERED_FIGHTER"
     ]
   },
   {
@@ -1652,7 +1660,8 @@
       "PATH_AVOID_DANGER_1",
       "SEES",
       "SMELLS",
-      "WARM"
+      "WARM",
+      "CORNERED_FIGHTER"
     ]
   },
   {
@@ -1729,7 +1738,8 @@
       "PATH_AVOID_DANGER_1",
       "SEES",
       "SMELLS",
-      "WARM"
+      "WARM",
+      "CORNERED_FIGHTER"
     ]
   },
   {
@@ -1804,7 +1814,8 @@
       "PATH_AVOID_DANGER_1",
       "SEES",
       "SMELLS",
-      "WARM"
+      "WARM",
+      "CORNERED_FIGHTER"
     ]
   },
   {
@@ -2164,7 +2175,7 @@
     "families": [ "prof_intro_biology" ],
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 8 },
     "special_attacks": [ [ "EAT_CROP", 60 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "PET_MOUNTABLE", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "PET_MOUNTABLE", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CORNERED_FIGHTER" ],
     "armor": { "bash": 4, "cut": 1, "bullet": 1, "electric": 1 }
   },
   {
@@ -2239,7 +2250,7 @@
     "dissect": "dissect_cattle_sample_large",
     "families": [ "prof_intro_biology" ],
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 8 },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CORNERED_FIGHTER" ],
     "armor": { "bash": 14, "cut": 1, "bullet": 10, "electric": 1 }
   },
   {
@@ -2434,7 +2445,18 @@
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
     "zombify_into": "mon_zombie_pig",
     "special_attacks": [ [ "EAT_FOOD", 20 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "PET_MOUNTABLE", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "CAN_BE_CULLED" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "PET_MOUNTABLE",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "WARM",
+      "KEENNOSE",
+      "CAN_BE_CULLED",
+      "CORNERED_FIGHTER"
+    ]
   },
   {
     "id": "mon_rabbit",
@@ -2758,7 +2780,7 @@
     "path_settings": { "max_dist": 10 },
     "anger_triggers": [ "STALK", "FRIEND_ATTACKED", "FRIEND_DIED", "PLAYER_WEAK", "PLAYER_CLOSE", "PLAYER_NEAR_BABY" ],
     "zombify_into": "mon_zolf",
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "KEENNOSE", "CORNERED_FIGHTER" ],
     "armor": { "bash": 1 }
   },
   {
@@ -2823,7 +2845,7 @@
     "biosignature": { "biosig_item": "feces_manure", "biosig_timer": 12 },
     "baby_flags": [ "WINTER", "AUTUMN" ],
     "special_attacks": [ [ "EAT_CROP", 60 ] ],
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CORNERED_FIGHTER" ],
     "armor": { "electric": 1 }
   },
   {
@@ -2913,7 +2935,18 @@
     "placate_triggers": [ "PLAYER_WEAK" ],
     "special_attacks": [ [ "EAT_CROP", 120 ] ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "PET_WONT_FOLLOW", "MILKABLE", "CAN_BE_CULLED" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "WARM",
+      "PET_WONT_FOLLOW",
+      "MILKABLE",
+      "CAN_BE_CULLED",
+      "CORNERED_FIGHTER"
+    ]
   },
   {
     "id": "mon_ferret",

--- a/data/json/monsters/mi-go.json
+++ b/data/json/monsters/mi-go.json
@@ -44,7 +44,8 @@
       "ARTHROPOD_BLOOD",
       "PATH_AVOID_DANGER_1",
       "CAN_OPEN_DOORS",
-      "PRIORITIZE_TARGETS"
+      "PRIORITIZE_TARGETS",
+      "CORNERED_FIGHTER"
     ],
     "armor": { "bash": 4, "cut": 12, "bullet": 10, "electric": 2 }
   },
@@ -100,7 +101,8 @@
       "ARTHROPOD_BLOOD",
       "PATH_AVOID_DANGER_1",
       "CAN_OPEN_DOORS",
-      "PRIORITIZE_TARGETS"
+      "PRIORITIZE_TARGETS",
+      "CORNERED_FIGHTER"
     ],
     "armor": { "bash": 4, "cut": 12, "bullet": 10, "electric": 3 }
   },
@@ -150,7 +152,8 @@
       "ARTHROPOD_BLOOD",
       "PATH_AVOID_DANGER_1",
       "CAN_OPEN_DOORS",
-      "PRIORITIZE_TARGETS"
+      "PRIORITIZE_TARGETS",
+      "CORNERED_FIGHTER"
     ],
     "armor": { "bash": 5, "cut": 13, "bullet": 10, "electric": 3 }
   },
@@ -209,7 +212,8 @@
       "ARTHROPOD_BLOOD",
       "PATH_AVOID_DANGER_1",
       "CAN_OPEN_DOORS",
-      "PRIORITIZE_TARGETS"
+      "PRIORITIZE_TARGETS",
+      "CORNERED_FIGHTER"
     ],
     "armor": { "bash": 17, "cut": 22, "bullet": 18, "electric": 4 }
   },
@@ -268,7 +272,8 @@
       "ARTHROPOD_BLOOD",
       "PATH_AVOID_DANGER_1",
       "CAN_OPEN_DOORS",
-      "PRIORITIZE_TARGETS"
+      "PRIORITIZE_TARGETS",
+      "CORNERED_FIGHTER"
     ],
     "armor": { "bash": 19, "cut": 27, "bullet": 22, "electric": 6 }
   },

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3188,7 +3188,6 @@ void monster::process_effects()
             }
         }
     }
-    
 
 
     if( has_flag( mon_flag_PHOTOPHOBIC ) && get_map().ambient_light_at( pos() ) >= 30.0f ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3164,19 +3164,24 @@ void monster::process_effects()
                         add_effect( effect_spooked, 3_turns, false );
                         add_effect( effect_spooked_recent, 9_turns, false );
                     }
-                    if( guy ) {
-                        monster_attitude att = attitude( guy );
-                        if( ( friendly == 0 ) && ( att == MATT_FOLLOW || att == MATT_FLEE ) && !has_effect( effect_spooked ) ) {
-                            if( !has_effect( effect_spooked_recent ) ) {
-                                add_effect( effect_spooked, 3_turns, false );
-                                add_effect( effect_spooked_recent, 9_turns, false );
-                            }
-                            else {
-                                if( morale < type->morale ) {
-                                    morale = type->morale;
-                                    anger = type->agro;
-                                }           
-                            }
+                } else {
+                    if( morale < type->morale ) {
+                        morale = type->morale;
+                        anger = type->agro;
+                    }
+                }
+            }
+            if( guy ) {
+                monster_attitude att = attitude( guy );
+                if( ( friendly == 0 ) && ( att == MATT_FOLLOW || att == MATT_FLEE ) &&
+                    !has_effect( effect_spooked ) ) {
+                    if( !has_effect( effect_spooked_recent ) ) {
+                        add_effect( effect_spooked, 3_turns, false );
+                        add_effect( effect_spooked_recent, 9_turns, false );
+                    } else {
+                        if( morale < type->morale ) {
+                            morale = type->morale;
+                            anger = type->agro;
                         }
                     }
             }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3151,41 +3151,6 @@ void monster::process_effects()
         }
     }
 
-//     if( has_flag( mon_flag_CORNERED_FIGHTER ) && ( morale <= 0 || anger <= 10  ) ) {
-//         if( !has_effect( effect_spooked_recent ) ) {
-//             add_msg( m_good, _( "The mi-go gets spooked!" ), name() );
-//             add_effect( effect_spooked, 2_turns, false );
-//             add_effect( effect_spooked_recent, 20_turns, false );
-//         }
-//         if( has_effect( effect_spooked_recent ) ) {
-//             add_msg( m_good, _( "The mi-go is immune to spookage and qualifies for cornered_fighter!" ), name() );
-//             map &here = get_map();
-//             creature_tracker &creatures = get_creature_tracker();
-//                 for( const tripoint &p : here.points_in_radius( pos(), 2 ) ) {
-//                     //const monster *const mon = creatures.creature_at<monster>( p );
-//                     const Character *const guy = creatures.creature_at<Character>( p );
-//                     //    if( mon ) {
-//                     //        if( mon->faction->attitude( faction ) != MFA_FRIENDLY ) {
-//                     //            if( morale < type->morale ) {
-//                     //                morale = type->morale;
-//                     //                anger = type->agro;
-//                     //        }
-//                         if( guy ) {
-//                             if( friendly == 0 && !has_effect( effect_spooked ) ) {
-//                             add_msg( m_good, _( "The mi-go is reacting to the presence of a guy!" ), name() );
-//                                 if( morale < type->morale ) {
-//                                     add_msg( m_good, _( "The mi-go recovers its morale" ), name() );
-//                                     morale = type->morale;
-//                                     anger = type->agro;
-//                                 }
-//                             }
-//                         }
-//                     }
-//                 }
-//             }
-//      // }
-//    // }
-
     if( has_flag( mon_flag_CORNERED_FIGHTER ) ) {
         map &here = get_map();
         creature_tracker &creatures = get_creature_tracker();

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3184,6 +3184,7 @@ void monster::process_effects()
                             anger = type->agro;
                         }
                     }
+                }
             }
     }
     

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3186,6 +3186,7 @@ void monster::process_effects()
                     }
                 }
             }
+        }
     }
     
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -108,6 +108,8 @@ static const efftype_id effect_photophobia( "photophobia" );
 static const efftype_id effect_poison( "poison" );
 static const efftype_id effect_ridden( "ridden" );
 static const efftype_id effect_run( "run" );
+static const efftype_id effect_spooked( "spooked" );
+static const efftype_id effect_spooked_recent( "spooked_recent" );
 static const efftype_id effect_stunned( "stunned" );
 static const efftype_id effect_supercharged( "supercharged" );
 static const efftype_id effect_tied( "tied" );
@@ -3149,27 +3151,80 @@ void monster::process_effects()
         }
     }
 
-    if( has_flag( mon_flag_CORNERED_FIGHTER ) && ( morale + anger ) < 0 ) {
-        if( friendly == 0 && rl_dist( pos(), player_character.pos() ) <= 2 ) {
-            if( morale < type->morale ) {
-                morale = type->morale;
-                anger = type->agro;
-            }
-        }
+//     if( has_flag( mon_flag_CORNERED_FIGHTER ) && ( morale <= 0 || anger <= 10  ) ) {
+//         if( !has_effect( effect_spooked_recent ) ) {
+//             add_msg( m_good, _( "The mi-go gets spooked!" ), name() );
+//             add_effect( effect_spooked, 2_turns, false );
+//             add_effect( effect_spooked_recent, 20_turns, false );
+//         }
+//         if( has_effect( effect_spooked_recent ) ) {
+//             add_msg( m_good, _( "The mi-go is immune to spookage and qualifies for cornered_fighter!" ), name() );
+//             map &here = get_map();
+//             creature_tracker &creatures = get_creature_tracker();
+//                 for( const tripoint &p : here.points_in_radius( pos(), 2 ) ) {
+//                     //const monster *const mon = creatures.creature_at<monster>( p );
+//                     const Character *const guy = creatures.creature_at<Character>( p );
+//                     //    if( mon ) {
+//                     //        if( mon->faction->attitude( faction ) != MFA_FRIENDLY ) {
+//                     //            if( morale < type->morale ) {
+//                     //                morale = type->morale;
+//                     //                anger = type->agro;
+//                     //        }
+//                         if( guy ) {
+//                             if( friendly == 0 && !has_effect( effect_spooked ) ) {
+//                             add_msg( m_good, _( "The mi-go is reacting to the presence of a guy!" ), name() );
+//                                 if( morale < type->morale ) {
+//                                     add_msg( m_good, _( "The mi-go recovers its morale" ), name() );
+//                                     morale = type->morale;
+//                                     anger = type->agro;
+//                                 }
+//                             }
+//                         }
+//                     }
+//                 }
+//             }
+//      // }
+//    // }
+
+    if( has_flag( mon_flag_CORNERED_FIGHTER ) ) {
         map &here = get_map();
         creature_tracker &creatures = get_creature_tracker();
-        for( const tripoint &p : here.points_in_radius( pos(), 2 ) ) {
-            const monster *const mon = creatures.creature_at<monster>( p );
-            if( mon ) {
-                if( mon->faction->attitude( faction ) != MFA_FRIENDLY ) {
-                    if( morale < type->morale ) {
-                        morale = type->morale;
-                        anger = type->agro;
+            for( const tripoint &p : here.points_in_radius( pos(), 2 ) ) {
+                const monster *const mon = creatures.creature_at<monster>( p );
+                const Character *const guy = creatures.creature_at<Character>( p );
+                    if( mon && mon != this && mon->faction->attitude( faction ) != MFA_FRIENDLY && !has_effect( effect_spooked ) && morale <= 0 ) {
+                        if( !has_effect( effect_spooked_recent ) ) {
+                            if( !has_effect( effect_spooked_recent ) ) {
+                                add_effect( effect_spooked, 3_turns, false );
+                                add_effect( effect_spooked_recent, 9_turns, false );
+                            }
+                        }
+                        else {
+                                if( morale < type->morale ) {
+                                    morale = type->morale;
+                                    anger = type->agro;
+                                }    
+                        }
                     }
-                }
+                    if( guy ) {
+                        monster_attitude att = attitude( guy );
+                        if( ( friendly == 0 ) && ( att == MATT_FOLLOW || att == MATT_FLEE ) && !has_effect( effect_spooked ) ) {
+                            if( !has_effect( effect_spooked_recent ) ) {
+                                add_effect( effect_spooked, 3_turns, false );
+                                add_effect( effect_spooked_recent, 9_turns, false );
+                            }
+                            else {
+                                if( morale < type->morale ) {
+                                    morale = type->morale;
+                                    anger = type->agro;
+                                }           
+                            }
+                        }
+                    }
             }
-        }
     }
+    
+
 
     if( has_flag( mon_flag_PHOTOPHOBIC ) && get_map().ambient_light_at( pos() ) >= 30.0f ) {
         add_msg_if_player_sees( *this, m_good, _( "The shadow withers in the light!" ), name() );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3154,22 +3154,15 @@ void monster::process_effects()
     if( has_flag( mon_flag_CORNERED_FIGHTER ) ) {
         map &here = get_map();
         creature_tracker &creatures = get_creature_tracker();
-            for( const tripoint &p : here.points_in_radius( pos(), 2 ) ) {
-                const monster *const mon = creatures.creature_at<monster>( p );
-                const Character *const guy = creatures.creature_at<Character>( p );
-                    if( mon && mon != this && mon->faction->attitude( faction ) != MFA_FRIENDLY && !has_effect( effect_spooked ) && morale <= 0 ) {
-                        if( !has_effect( effect_spooked_recent ) ) {
-                            if( !has_effect( effect_spooked_recent ) ) {
-                                add_effect( effect_spooked, 3_turns, false );
-                                add_effect( effect_spooked_recent, 9_turns, false );
-                            }
-                        }
-                        else {
-                                if( morale < type->morale ) {
-                                    morale = type->morale;
-                                    anger = type->agro;
-                                }    
-                        }
+        for( const tripoint &p : here.points_in_radius( pos(), 2 ) ) {
+            const monster *const mon = creatures.creature_at<monster>( p );
+            const Character *const guy = creatures.creature_at<Character>( p );
+            if( mon && mon != this && mon->faction->attitude( faction ) != MFA_FRIENDLY &&
+                !has_effect( effect_spooked ) && morale <= 0 ) {
+                if( !has_effect( effect_spooked_recent ) ) {
+                    if( !has_effect( effect_spooked_recent ) ) {
+                        add_effect( effect_spooked, 3_turns, false );
+                        add_effect( effect_spooked_recent, 9_turns, false );
                     }
                     if( guy ) {
                         monster_attitude att = attitude( guy );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "More monsters fight back if cornered"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#66294 introduced the CORNERED_FIGHTER flag, which gives monsters the ability to switch back to hostile if they're unable to escape an enemy they want to flee. It had several limitations, such as not working on NPCs and in some cases not giving the monster enough time to escape.

#### Describe the solution

* Improves the CORNERED_FIGHTER code in monster.cpp so that cornered monsters will now spend 3 turns trying to flee (or tracking, if that's what their AI calls for) before turning and fighting. They can attempt to flee again 9 turns later. This is done via a pair of AI effects, spooked and spooked_recent. The code can now also check for NPCs as well as the player and other monsters.
* Adds CORNERED_FIGHTER to all mi-go except the scouts.
* Adds CORNERED_FIGHTER to bears, boars, moose, reindeer, pigs, cows, coyotes, some dogs, and llamas.
* Does NOT add CORNERED_FIGHTER to any animal which uses HIT_AND_RUN.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

This is a marked improvement to monster behavior, but there are still some issues. Mi-go in the daytime for instance will often run away for ten seconds and then come sprinting right back. They did this before this PR though, so one thing at a time.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Spawned mi-go and tried fighting them. When wounded they would switch to flee or tracking as expected, but if an attacker stayed near or pursued them, they would flip hositle again after a couple of seconds, rather than standing there cowering while getting beaten down.

Went into a cockroach basement with a flashlight out and spooked the little guys away, then pursued them into corners to make sure they'd still go hostile.

Spawned a bear and tried attacking it. Once it tried to flee, if I stayed near it it would go hostile.

Walked up to a moose and punched it. The moose punched back.

Walked up to some boars. They quickly fled, but fought back when engaged in melee.

Spawned mi-go and zombies to watch them duke it out. The mi-go would try to flee when injured, but would fight back if it couldn't.

Attacked some dogs and pigs. They still are pretty skittish, but would bite me once or twice if they couldn't get away.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->