### PR TITLE
Make bone broth better by extracting more calcium using acified water.

### DIFF
--- a/data/json/items/comestibles/soup.json
+++ b/data/json/items/comestibles/soup.json
@@ -40,7 +40,7 @@
     "symbol": "~",
     "quench": 30,
     "calories": 43,
-    "description": "A tasty and nutritious broth made from bones.",
+    "description": "A tasty and nutritious broth made from bones, with added vinegar to extract more calcium.",
     "price": 350,
     "price_postapoc": 25,
     "material": [ "bone" ],
@@ -50,7 +50,7 @@
     "phase": "liquid",
     "flags": [ "EATEN_HOT", "NUTRIENT_OVERRIDE", "NO_SALVAGE" ],
     "fun": 10,
-    "vitamins": [ [ "calcium", 1 ], [ "iron", 1 ] ]
+    "vitamins": [ [ "calcium", 7 ], [ "iron", 1 ] ]
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/recipes/food/canned.json
+++ b/data/json/recipes/food/canned.json
@@ -357,7 +357,7 @@
     "//": "this was using 20 bones (2.3kg), so it was lowered.  Bone broth uses 1:2-1:4 bone:water per weight.",
     "using": [ [ "canning_high_heat", 1, "LIST" ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 1u of canning_high_heat.",
-    "components": [ [ [ "jar_glass_sealed", 1 ] ], [ [ "water_clean", 2 ] ], [ [ "bone_edible", 2, "LIST" ] ] ]
+    "components": [ [ [ "jar_glass_sealed", 1 ] ], [ [ "water_clean", 2 ] ], [ [ "bone_edible", 2, "LIST" ] ], [ [ "vinegar", 2 ] ] ]
   },
   {
     "type": "recipe",
@@ -629,7 +629,12 @@
     "//": "this was using 120 bones (13.8kg), so it was lowered.  Bone broth uses 1:2-1:4 bone:water per weight.",
     "using": [ [ "canning_high_heat", 6, "LIST" ] ],
     "//1": "pressure canning is measured in 0.5 liter quantities, so 6u of canning_high_heat.",
-    "components": [ [ [ "jar_3l_glass_sealed", 1 ] ], [ [ "water_clean", 12 ] ], [ [ "bone_edible", 12, "LIST" ] ] ]
+    "components": [
+      [ [ "jar_3l_glass_sealed", 1 ] ],
+      [ [ "water_clean", 12 ] ],
+      [ [ "bone_edible", 12, "LIST" ] ],
+      [ [ "vinegar", 12 ] ]
+    ]
   },
   {
     "type": "recipe",
@@ -2453,7 +2458,7 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_preservation" }, { "proficiency": "prof_food_canning" } ],
     "contained": true,
     "batch_time_factors": [ 83, 5 ],
-    "components": [ [ [ "bone_edible", 2, "LIST" ] ], [ [ "water_clean", 3 ] ] ],
+    "components": [ [ [ "bone_edible", 2, "LIST" ] ], [ [ "water_clean", 3 ] ], [ [ "vinegar", 2 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 2u of canning_metal.",
     "using": [ [ "canning_metal", 2, "LIST" ], [ "tincan_medium", 1 ] ]
   },
@@ -2473,7 +2478,7 @@
     "container": "can_food",
     "charges": 1,
     "batch_time_factors": [ 83, 5 ],
-    "components": [ [ [ "bone_edible", 2, "LIST" ] ], [ [ "water_clean", 2 ] ] ],
+    "components": [ [ [ "bone_edible", 2, "LIST" ] ], [ [ "water_clean", 2 ] ], [ [ "vinegar", 2 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 1u of canning_metal.",
     "using": [ [ "canning_metal", 1, "LIST" ], [ "tincan_small", 1 ] ]
   },
@@ -2493,7 +2498,7 @@
     "container": "can_food_big",
     "charges": 12,
     "batch_time_factors": [ 83, 5 ],
-    "components": [ [ [ "bone_edible", 12, "LIST" ] ], [ [ "water_clean", 16 ] ] ],
+    "components": [ [ [ "bone_edible", 12, "LIST" ] ], [ [ "water_clean", 16 ] ], [ [ "vinegar", 12 ] ] ],
     "//1": "tincan canning is measured in 0.25 liter quantities, so 12u of canning_metal.",
     "using": [ [ "canning_metal", 12, "LIST" ], [ "tincan_large", 1 ] ]
   },

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -3539,7 +3539,7 @@
     "qualities": [ { "id": "COOK", "level": 3 } ],
     "tools": [ [ [ "water_boiling_heat", 11, "LIST" ] ] ],
     "//": "this was using 10 bones (2.3kg), so it was lowered.  Bone broth uses minimum 1:2-1:4 bone:water per weight.  2u for the water + 10u for the 60min boiling + 1u for the bone.",
-    "components": [ [ [ "bone_edible", 2, "LIST" ] ], [ [ "water", 2 ], [ "water_clean", 2 ] ] ]
+    "components": [ [ [ "bone_edible", 2, "LIST" ] ], [ [ "water", 2 ], [ "water_clean", 2 ] ], [ [ "vinegar", 2 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Make bone broth better by extracting more calcium using acified water"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

There are few good natural sources of calcium in the game and I wanted to wanted to make bone broth a better source of calcium. 

In many cultures (such as many Asian cultures) they prescribe the use vinegar to extract more calcium from bone broth, especially for pregnancy and postpartum periods.

This has been confirmed to work in several studies. The one I use for the numbers in this PR is "Essential and toxic metals in animal bone broths":

* https://doi.org/10.1080%2F16546628.2017.1347478
* https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5533136/ (alt link)

See Figure 1. for the dramatic increase using acified water compared to un-acified:

https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5533136/figure/F0001/

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

TL;DR:

We add 1 unit of vinegar per 1 unit bone to the recipe to make it extract more calcium from the bones as per the study.

Math:

The acified water used in the study:

> acidified water that was made by mixing 20 ml of table vinegar with 1 l of deionized (DI)

One serving of vinegar in game is 2500 / 160 = 15.625 ml, which is close to the 20 ml used in the study, so we can just add 1 unit of vinegar to the recipe.

The cooking time in the study I looked at was 2h, which is about the cooking time of 9x non-canned bone broth in game. This seems reasonable to me. 

The bones used in the study was:

> The animal bones in this evaluation were the rear leg (femur) and rib bones of domestic pigs (both white and black) and bovine leg (femur) bones, all of which were purchased from a local meat market. The white and black pigs were raised in Taiwan and typically fed on forage and food waste, respectively, while the bovine bone was imported from Australia, which was the most common source of local supplies.

This seems reasonably close to the bones we would get in game to me.

Results for boiling in acidic water for 2 hours (Table 1. in the study) in mg/kg.

```
Pig (white) 241 ± 11.8
Pig (black) 252 ± 19.05
Bovine      274 ± 48.3
```

The average of the three means values is 255.66 mg/kg.

The serving size in game is 267 mg, so 255.66 / 1000 * 267 ~= 68 mg calcium per serving. The RDA for calcium is 1000 mg for adults (according to the study), so it would be 68/1000 = 6.8 % RDA calcium per serving size, which we can round to 7 %.

They also studied the effect on iron, but it was not that much different than from non-acified water (Figure 1). At around 200 μg/kg it's pretty negligible. 

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

I considered making new recipes instead of updating the old ones. But then we would have 12 bone broth recipes including the canned versions, which seems kind of much for such a niche recipe.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. -->

Game loads and recipe works as expected.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->