### PR TITLE
[Magiclysm] Elves fight back when cornered and size change

### DIFF
--- a/data/mods/Magiclysm/monsters/holiday_magiclysm.json
+++ b/data/mods/Magiclysm/monsters/holiday_magiclysm.json
@@ -63,7 +63,7 @@
     "default_faction": "elves",
     "bodytype": "human",
     "volume": "123 ml",
-    "weight": "38 kg"
+    "weight": "38 kg",
     "hp": 45,
     "speed": 100,
     "material": [ "flesh" ],

--- a/data/mods/Magiclysm/monsters/holiday_magiclysm.json
+++ b/data/mods/Magiclysm/monsters/holiday_magiclysm.json
@@ -63,7 +63,7 @@
     "default_faction": "elves",
     "bodytype": "human",
     "volume": "123 ml",
-    "weight": "121 kg",
+    "weight": "73 kg",
     "hp": 45,
     "speed": 100,
     "material": [ "flesh" ],

--- a/data/mods/Magiclysm/monsters/holiday_magiclysm.json
+++ b/data/mods/Magiclysm/monsters/holiday_magiclysm.json
@@ -63,7 +63,7 @@
     "default_faction": "elves",
     "bodytype": "human",
     "volume": "123 ml",
-    "weight": "38 kg",
+    "weight": "38 kg"
     "hp": 45,
     "speed": 100,
     "material": [ "flesh" ],

--- a/data/mods/Magiclysm/monsters/holiday_magiclysm.json
+++ b/data/mods/Magiclysm/monsters/holiday_magiclysm.json
@@ -81,7 +81,7 @@
     "families": [ "prof_wp_demihuman" ],
     "weakpoint_sets": [ "wps_humanoid_body" ],
     "path_settings": { "avoid_traps": true, "avoid_sharp": true },
-    "flags": [ "SEES", "HEARS", "SMELLS", "PATH_AVOID_DANGER_1", "WARM" ],
+    "flags": [ "SEES", "HEARS", "SMELLS", "PATH_AVOID_DANGER_1", "WARM", "CORNERED_FIGHTER" ],
     "armor": { "bash": 6, "cut": 2, "bullet": 3 }
   },
   {

--- a/data/mods/Magiclysm/monsters/holiday_magiclysm.json
+++ b/data/mods/Magiclysm/monsters/holiday_magiclysm.json
@@ -63,7 +63,7 @@
     "default_faction": "elves",
     "bodytype": "human",
     "volume": "123 ml",
-    "weight": "73 kg",
+    "weight": "38 kg",
     "hp": 45,
     "speed": 100,
     "material": [ "flesh" ],


### PR DESCRIPTION
#### Summary
Balance "Workshop Elves will fight back in the off chance they are pushed into a corner"

#### Purpose of change
Workshop Elves, although afraid of humans, should fight back when there is no where else to run instead of only getting angry if their friends die.

#### Describe the solution

Add the new CORNERED_FIGHTER flag

#### Describe alternatives you've considered

Giving them Small_Hide as well, but they're too big to reasonably hide behind stuff.

#### Testing

Very small flag change, shouldn't break anything.