### PR TITLE
HP widgets gets equivalent bodypart

### DIFF
--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -419,11 +419,11 @@ void bodygraph_display::prepare_partlist()
     for( const auto &bgp : id->parts ) {
         for( const bodypart_id &bid : bgp.second.bodyparts ) {
             partlist.emplace_back( bid, static_cast<const sub_body_part_type *>( nullptr ),
-                                   &bgp.second, u->has_part( bid ) );
+                                   &bgp.second, u->has_part( bid, body_part_filter::equivalent ) );
         }
         for( const sub_bodypart_id &sid : bgp.second.sub_bodyparts ) {
             const bodypart_id bid = sid->parent.id();
-            partlist.emplace_back( bid, &*sid, &bgp.second, u->has_part( bid ) );
+            partlist.emplace_back( bid, &*sid, &bgp.second, u->has_part( bid, body_part_filter::equivalent ) );
         }
     }
     std::sort( partlist.begin(), partlist.end(),
@@ -627,7 +627,7 @@ std::vector<std::string> get_bodygraph_lines( const Character &u,
     std::vector<std::string> ret;
 
     // Bodypart not present on character
-    if( !!id->parent_bp && !u.has_part( *id->parent_bp ) ) {
+    if( !!id->parent_bp && !u.has_part( *id->parent_bp, body_part_filter::equivalent ) ) {
         std::string txt = string_format( u.is_avatar() ?
                                          //~ 1$ = 2nd person pronoun (You), 2$ = body part (left arm)
                                          _( "%1$s do not have a %2$s." ) :
@@ -658,12 +658,12 @@ std::vector<std::string> get_bodygraph_lines( const Character &u,
                 bgp = &iter->second;
                 bool missing_section = true;
                 for( const bodypart_id &bp : iter->second.bodyparts ) {
-                    if( u.has_part( bp ) ) {
+                    if( u.has_part( bp, body_part_filter::equivalent ) ) {
                         missing_section = false;
                     }
                 }
                 for( const sub_bodypart_id &sp : iter->second.sub_bodyparts ) {
-                    if( u.has_part( sp->parent ) ) {
+                    if( u.has_part( sp->parent, body_part_filter::equivalent ) ) {
                         missing_section = false;
                     }
                 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3813,7 +3813,7 @@ int Character::avg_encumb_of_limb_type( body_part_type::type part_type ) const
 
 int Character::encumb( const bodypart_id &bp ) const
 {
-    if( !has_part( bp ) ) {
+    if( !has_part( bp, body_part_filter::equivalent ) ) {
         debugmsg( "INFO: Tried to check encumbrance of a bodypart that does not exist." );
         return 0;
     }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -2131,9 +2131,9 @@ void Creature::calc_all_parts_hp( float hp_mod, float hp_adjustment, int str_max
     }
 }
 
-bool Creature::has_part( const bodypart_id &id ) const
+bool Creature::has_part( const bodypart_id &id, body_part_filter filter ) const
 {
-    return get_part_id( id ) != body_part_bp_null;
+    return get_part_id( id, filter, true ) != body_part_bp_null;
 }
 
 bodypart *Creature::get_part( const bodypart_id &id )
@@ -2191,10 +2191,11 @@ static void set_part_helper( Creature &c, const bodypart_id &id,
     }
 }
 
-bodypart_id Creature::get_part_id( const bodypart_id &id ) const
+bodypart_id Creature::get_part_id( const bodypart_id &id,
+                                   body_part_filter filter, bool suppress_debugmsg ) const
 {
     auto found = body.find( id.id() );
-    if( found == body.end() ) {
+    if( found == body.end() && filter >= body_part_filter::equivalent ) {
         // try to find an equivalent part in the body map
         for( const std::pair<const bodypart_str_id, bodypart> &bp : body ) {
             if( id->part_side == bp.first->part_side &&
@@ -2205,18 +2206,20 @@ bodypart_id Creature::get_part_id( const bodypart_id &id ) const
 
         // try to find the next best thing
         std::pair<bodypart_id, float> best = { body_part_bp_null, 0.0f };
-        for( const std::pair<const bodypart_str_id, bodypart> &bp : body ) {
-            for( const std::pair<const body_part_type::type, float> &mp : bp.first->limbtypes ) {
-                // if the secondary limb type matches and is better than the current
-                if( mp.first == id->primary_limb_type() && mp.second > best.second ) {
-                    // give an inflated bonus if the part sides match
-                    float bonus = id->part_side == bp.first->part_side ? 1.0f : 0.0f;
-                    best = { bp.first, mp.second + bonus };
+        if( filter >= body_part_filter::next_best ) {
+            for( const std::pair<const bodypart_str_id, bodypart> &bp : body ) {
+                for( const std::pair<const body_part_type::type, float> &mp : bp.first->limbtypes ) {
+                    // if the secondary limb type matches and is better than the current
+                    if( mp.first == id->primary_limb_type() && mp.second > best.second ) {
+                        // give an inflated bonus if the part sides match
+                        float bonus = id->part_side == bp.first->part_side ? 1.0f : 0.0f;
+                        best = { bp.first, mp.second + bonus };
+                    }
                 }
             }
         }
 
-        if( best.first == body_part_bp_null ) {
+        if( best.first == body_part_bp_null && !suppress_debugmsg ) {
             debugmsg( "Could not find equivalent bodypart id %s in %s's body", id.id().c_str(), get_name() );
         }
 

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -2195,37 +2195,37 @@ bodypart_id Creature::get_part_id( const bodypart_id &id,
                                    body_part_filter filter, bool suppress_debugmsg ) const
 {
     auto found = body.find( id.id() );
-    if( found == body.end() && filter >= body_part_filter::equivalent ) {
-        // try to find an equivalent part in the body map
+    if( found != body.end() ) {
+        return found->first;
+    }
+    // try to find an equivalent part in the body map
+    if( filter >= body_part_filter::equivalent ) {
         for( const std::pair<const bodypart_str_id, bodypart> &bp : body ) {
             if( id->part_side == bp.first->part_side &&
                 id->primary_limb_type() == bp.first->primary_limb_type() ) {
                 return bp.first;
             }
         }
-
-        // try to find the next best thing
-        std::pair<bodypart_id, float> best = { body_part_bp_null, 0.0f };
-        if( filter >= body_part_filter::next_best ) {
-            for( const std::pair<const bodypart_str_id, bodypart> &bp : body ) {
-                for( const std::pair<const body_part_type::type, float> &mp : bp.first->limbtypes ) {
-                    // if the secondary limb type matches and is better than the current
-                    if( mp.first == id->primary_limb_type() && mp.second > best.second ) {
-                        // give an inflated bonus if the part sides match
-                        float bonus = id->part_side == bp.first->part_side ? 1.0f : 0.0f;
-                        best = { bp.first, mp.second + bonus };
-                    }
+    }
+    // try to find the next best thing
+    std::pair<bodypart_id, float> best = { body_part_bp_null, 0.0f };
+    if( filter >= body_part_filter::next_best ) {
+        for( const std::pair<const bodypart_str_id, bodypart> &bp : body ) {
+            for( const std::pair<const body_part_type::type, float> &mp : bp.first->limbtypes ) {
+                // if the secondary limb type matches and is better than the current
+                if( mp.first == id->primary_limb_type() && mp.second > best.second ) {
+                    // give an inflated bonus if the part sides match
+                    float bonus = id->part_side == bp.first->part_side ? 1.0f : 0.0f;
+                    best = { bp.first, mp.second + bonus };
                 }
             }
         }
-
-        if( best.first == body_part_bp_null && !suppress_debugmsg ) {
-            debugmsg( "Could not find equivalent bodypart id %s in %s's body", id.id().c_str(), get_name() );
-        }
-
-        return best.first;
     }
-    return found->first;
+    if( best.first == body_part_bp_null && !suppress_debugmsg ) {
+        debugmsg( "Could not find equivalent bodypart id %s in %s's body", id.id().c_str(), get_name() );
+    }
+
+    return best.first;
 }
 
 int Creature::get_part_hp_cur( const bodypart_id &id ) const

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -2133,7 +2133,7 @@ void Creature::calc_all_parts_hp( float hp_mod, float hp_adjustment, int str_max
 
 bool Creature::has_part( const bodypart_id &id ) const
 {
-    return body.count( id.id() );
+    return get_part_id( id ) != body_part_bp_null;
 }
 
 bodypart *Creature::get_part( const bodypart_id &id )

--- a/src/creature.h
+++ b/src/creature.h
@@ -224,6 +224,12 @@ struct enum_traits<get_body_part_flags> {
     static constexpr bool is_flag_enum = true;
 };
 
+enum class body_part_filter : int {
+    strict = 0,
+    equivalent = 1,
+    next_best = 2
+};
+
 using scheduled_effect = struct scheduled_effect_t {
     efftype_id eff_id;
     time_duration dur;
@@ -783,14 +789,15 @@ class Creature : public viewer
                                 int dex_max = 0,  int per_max = 0,  int int_max = 0, int healthy_mod = 0,
                                 int fat_to_max_hp = 0 );
         // Does not fire debug message if part does not exist
-        bool has_part( const bodypart_id &id ) const;
+        bool has_part( const bodypart_id &id, body_part_filter filter = body_part_filter::strict ) const;
         // A debug message will be fired if part does not exist.
         // Check with has_part first if a part may not exist.
         bodypart *get_part( const bodypart_id &id );
         const bodypart *get_part( const bodypart_id &id ) const;
 
         // get the body part id that matches for the character
-        bodypart_id get_part_id( const bodypart_id &id ) const;
+        bodypart_id get_part_id( const bodypart_id &id,
+                                 body_part_filter filter = body_part_filter::next_best, bool suppress_debugmsg = false ) const;
 
         int get_part_hp_cur( const bodypart_id &id ) const;
         int get_part_hp_max( const bodypart_id &id ) const;

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1514,7 +1514,7 @@ static std::pair<std::string, nc_color> get_bodygraph_bp_sym_color( const Charac
 nc_color display::get_bodygraph_bp_color( const Character &u, const bodypart_id &bid,
         const bodygraph_var var )
 {
-    if( !u.has_part( bid ) ) {
+    if( !u.has_part( bid, body_part_filter::equivalent ) ) {
         return c_black; // character is missing this part
     }
 

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -705,7 +705,7 @@ void widget::set_default_var_range( const avatar &ava )
         case widget_var::bp_hp:
             // HP for body part
             _var_min = 0;
-            if( ava.has_part( only_bp() ) ) {
+            if( ava.has_part( only_bp(), body_part_filter::equivalent ) ) {
                 _var_max = ava.get_part_hp_max( only_bp() );
             } else {
                 _var_max = 0;
@@ -768,7 +768,7 @@ int widget::get_var_value( const avatar &ava ) const
             break;
         case widget_var::bp_hp:
             // HP for body part
-            if( ava.has_part( only_bp() ) ) {
+            if( ava.has_part( only_bp(), body_part_filter::equivalent ) ) {
                 value = ava.get_part_hp_cur( only_bp() );
             } else {
                 value = 0;
@@ -776,7 +776,7 @@ int widget::get_var_value( const avatar &ava ) const
             break;
         case widget_var::bp_warmth:
             // Body part warmth/temperature
-            if( ava.has_part( only_bp() ) ) {
+            if( ava.has_part( only_bp(), body_part_filter::equivalent ) ) {
                 value = ava.get_part_temp_cur( only_bp() );
             } else {
                 value = 0;
@@ -784,7 +784,7 @@ int widget::get_var_value( const avatar &ava ) const
             break;
         case widget_var::bp_wetness:
             // Body part wetness
-            if( ava.has_part( only_bp() ) ) {
+            if( ava.has_part( only_bp(), body_part_filter::equivalent ) ) {
                 value = ava.get_part_wetness( only_bp() );
             } else {
                 value = 0;


### PR DESCRIPTION
#### Summary
Bugfixes "HP widgets gets equivalent bodypart"

#### Purpose of change
HP widgets and body graph don't check any equivalent bodypart like "Debug Big Head" exists. So player is regarded as no head.

#### Describe the solution
Add ability that checking equivalent bodypart exists to Creature::has_part.
Make HP widgets and body graph check equivalent bodypart exists.

#### Describe alternatives you've considered

#### Testing
Enable "Debug Big Head", HP widgets and body graph don't miss player's head.

#### Additional context
