### PR TITLE
Typo Correction in Blaze industries.

### DIFF
--- a/data/mods/BlazeIndustries/items/vehicle/blaze_other.json
+++ b/data/mods/BlazeIndustries/items/vehicle/blaze_other.json
@@ -9,7 +9,7 @@
     "color": "cyan",
     "symbol": "]",
     "material": [ "steel", "plastic" ],
-    "volume": "200 L",
+    "volume": "2000 L",
     "category": "veh_parts",
     "price": 80000,
     "price_postapoc": 1000,


### PR DESCRIPTION
#### Summary
Bugfixes "Typo Correction in Blaze industries mod so shelving matches intended volume."


#### Purpose of change
Shelving is supposed to have 2000L volume, it had 200. 

#### Describe the solution

added a single zero. 
#### Describe alternatives you've considered

#### Testing


#### Additional context


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->