### PR TITLE
Fix: single value for environmental damage resist in body status window

### DIFF
--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -540,10 +540,13 @@ void bodygraph_display::prepare_infotext( bool reset_pos )
         txt.insert( txt.begin(), res_avail > 4 ? 4 : res_avail, ' ' );
         return txt;
     };
+    auto get_env_str = [&]( const damage_type_id & dt ) -> std::string {
+        return colorize( string_format( "    %5.2f", info.best_case.type_resist( dt ) ), c_white );
+    };
     for( const damage_type &dt : damage_type::get_all() ) {
         if( info.best_case.type_resist( dt.id ) > 1 ) {
             info_txt.emplace_back( string_format( "  %s:", uppercase_first_letter( dt.name.translated() ) ) );
-            info_txt.emplace_back( get_res_str( dt.id ) );
+            info_txt.emplace_back( dt.env ? get_env_str( dt.id ) : get_res_str( dt.id ) );
         }
     }
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
- Fixes #66930

BombasticSlacks pointed out the cause of the issue. Environmental damage resistances don't use the roll value the same way as regular damage resistances, so it doesn't make sense to use it for worst/median/best protection values.

#### Describe the solution
Use a flat value of zero to avoid overriding environmental damage resistance. The protection displayed is just a sum for each piece of armour on that body part.

#### Describe alternatives you've considered

#### Testing
Loaded the save from the linked issue and checked the status window. Acid and fire protection only show the actual protection value

![Screenshot from 2023-07-26 23-24-32](https://github.com/CleverRaven/Cataclysm-DDA/assets/12537966/faeabc2a-d6b3-4575-a75b-ebaf6de9482c)

#### Additional context
