### PR TITLE
Recipe: variants for results

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -1456,6 +1456,116 @@
     ]
   },
   {
+    "id": "test_waist_apron_long",
+    "type": "ARMOR",
+    "name": { "str": "long waist apron" },
+    "description": "A long waist apron made of cotton.",
+    "price_postapoc": 50,
+    "to_hit": 1,
+    "symbol": "[",
+    "looks_like": "vest_leather",
+    "volume": "1750 ml",
+    "weight": "226 g",
+    "price": 1000,
+    "material": [ "cotton" ],
+    "color": "white",
+    "warmth": 2,
+    "material_thickness": 2,
+    "environmental_protection": 1,
+    "flags": [ "POCKETS", "BELTED" ],
+    "armor": [
+      { "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ], "coverage": 100, "encumbrance": [ 1, 1 ] },
+      {
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_draped_l", "leg_draped_r" ],
+        "coverage": 70,
+        "encumbrance": 2,
+        "volume_encumber_modifier": 0.3
+      }
+    ],
+    "variant_type": "generic",
+    "variants": [
+      {
+        "id": "generic_apron_cotton",
+        "name": { "str": "long waist apron" },
+        "description": "It's colored white, like the ones commonly used by chefs, professional or otherwise.",
+        "weight": 50,
+        "append": true
+      },
+      {
+        "id": "black_apron_cotton",
+        "name": { "str": "black long waist apron" },
+        "description": "It's colored black, commonly used by chefs working in the night or who just want to look cool.",
+        "color": "dark_gray",
+        "weight": 25,
+        "append": true
+      },
+      {
+        "id": "blue_apron_cotton",
+        "name": { "str": "blue long waist apron" },
+        "description": "It's a royal blue color, commonly used by supermarket workers around the world.",
+        "color": "blue",
+        "weight": 15,
+        "append": true
+      },
+      {
+        "id": "red_apron_cotton",
+        "name": { "str": "red long waist apron" },
+        "description": "It's colored red.",
+        "color": "red",
+        "weight": 10,
+        "append": true
+      },
+      {
+        "id": "pink_apron_cotton",
+        "name": { "str": "pink long waist apron" },
+        "description": "It's colored neon pink, commonly used by women or men who like pink.",
+        "color": "pink",
+        "weight": 3,
+        "append": true
+      },
+      {
+        "id": "floral_apron_cotton",
+        "name": { "str": "floral long waist apron" },
+        "description": "It has a floral design and colored yellow, perfect for cooking outdoors.",
+        "color": "yellow",
+        "weight": 2,
+        "append": true
+      },
+      {
+        "id": "camo_apron_cotton",
+        "name": { "str": "camo long waist apron" },
+        "description": "It has a camouflage pattern, perfect for chefs who want to hide in the wild.",
+        "color": "green",
+        "weight": 2,
+        "append": true
+      },
+      {
+        "id": "skull_apron",
+        "name": { "str": "skull long waist apron" },
+        "description": "It's colored black with a skull and roses pattern.  Makes you feel more fashionable just by wearing it.",
+        "color": "dark_gray",
+        "weight": 1,
+        "append": true
+      },
+      {
+        "id": "maid_apron",
+        "name": { "str": "maid long waist apron" },
+        "description": "It's colored white with black frilly decorations, commonly used with a maid dress or alone for nighttime activities.",
+        "weight": 1,
+        "append": true
+      },
+      {
+        "id": "gothic_apron",
+        "name": { "str": "gothic long waist apron" },
+        "description": "It has a jet-black color with dark red decorations, perfect for cosplay or an adventurous gourmet.",
+        "color": "light_red",
+        "weight": 1,
+        "append": true
+      }
+    ]
+  },
+  {
     "id": "test_umbrella",
     "type": "GENERIC",
     "category": "tools",

--- a/data/mods/TEST_DATA/recipes.json
+++ b/data/mods/TEST_DATA/recipes.json
@@ -252,5 +252,32 @@
     "time": "10 d",
     "proficiencies": [ { "proficiency": "prof_carving", "time_multiplier": 2, "skill_penalty": 0 } ],
     "components": [ [ [ "2x4", 1 ] ] ]
+  },
+  {
+    "//": "Non-variant version",
+    "result": "test_waist_apron_long",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "difficulty": 1,
+    "time": "2 h",
+    "autolearn": true,
+    "using": [ [ "tailoring_cotton_patchwork", 6 ] ]
+  },
+  {
+    "//": "Variant version",
+    "result": "test_waist_apron_long",
+    "type": "recipe",
+    "variant": "pink_apron_cotton",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "difficulty": 1,
+    "time": "2 h",
+    "autolearn": true,
+    "using": [ [ "tailoring_cotton_patchwork", 6 ] ]
   }
 ]

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -1835,6 +1835,7 @@ Crafting recipes are defined as a JSON object with the following fields:
 "category": "CC_WEAPON",     // Category of crafting recipe. CC_NONCRAFT used for disassembly recipes
 "subcategory": "CSC_WEAPON_PIERCING",
 "id_suffix": "",             // Optional (default: empty string). Some suffix to make the ident of the recipe unique. The ident of the recipe is "<id-of-result><id_suffix>".
+"variant": "javelin_striped", // Optional (default: empty string). Specifies a variant of the result that this recipe will always produce. This will append the variant's id to the recipe ident "<id-of-result>_<variant_id>".
 "override": false,           // Optional (default: false). If false and the ident of the recipe is already used by another recipe, loading of recipes fails. If true and a recipe with the ident is already defined, the existing recipe is replaced by the new recipe.
 "delete_flags": [ "CANNIBALISM" ], // Optional (default: empty list). Flags specified here will be removed from the resultant item upon crafting. This will override flag inheritance, but *will not* delete flags that are part of the item type itself.
 "skill_used": "fabrication", // Skill trained and used for success checks

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -707,6 +707,9 @@ item_info_data recipe_result_info_cache::get_result_data( const recipe *rec, con
     if( dummy_result.is_null() ) {
         result_description = rec->description.translated();
     }
+    if( !rec->variant().empty() ) {
+        dummy_result.set_itype_variant( rec->variant() );
+    }
     //Check if recipe result is a clothing item that can be properly fitted
     if( dummy_result.has_flag( flag_VARSIZE ) && !dummy_result.has_flag( flag_FIT ) ) {
         //Check if it can actually fit.  If so, list the fitted info

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -89,6 +89,7 @@ class recipe
 
     private:
         itype_id result_ = itype_id::NULL_ID();
+        std::string variant_;
 
         int64_t time = 0; // in movement points (100 per turn)
 
@@ -108,6 +109,10 @@ class recipe
 
         const itype_id &result() const {
             return result_;
+        }
+
+        const std::string &variant() const {
+            return variant_;
         }
 
         const itype_id &container_id() const {

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -98,6 +98,9 @@ static const recipe_id recipe_makeshift_funnel( "makeshift_funnel" );
 static const recipe_id recipe_sushi_rice( "sushi_rice" );
 static const recipe_id recipe_test_tallow( "test_tallow" );
 static const recipe_id recipe_test_tallow2( "test_tallow2" );
+static const recipe_id recipe_test_waist_apron_long( "test_waist_apron_long" );
+static const recipe_id
+recipe_test_waist_apron_long_pink_apron_cotton( "test_waist_apron_long_pink_apron_cotton" );
 static const recipe_id recipe_vambrace_larmor( "vambrace_larmor" );
 static const recipe_id recipe_water_clean( "water_clean" );
 
@@ -2198,5 +2201,61 @@ TEST_CASE( "recipes_inherit_rot_of_components_properly", "[crafting][rot]" )
                 CHECK( dehydrated_meat->get_relative_rot() == 0.01 );
             }
         }
+    }
+}
+
+TEST_CASE( "variant_crafting_recipes", "[crafting][slow]" )
+{
+    constexpr int max_iters = 50;
+    Character &player_character = get_player_character();
+
+    SECTION( "crafting non-variant recipe" ) {
+        std::map<std::string, int> variant_counts;
+        for( int i = 0; i < max_iters; i++ ) {
+            std::vector<item> tools;
+            tools.emplace_back( itype_sewing_kit );
+            tools.emplace_back( "scissors" );
+            tools.insert( tools.end(), 10, item( "sheet_cotton" ) );
+            tools.insert( tools.end(), 10, item( "thread" ) );
+            prep_craft( recipe_test_waist_apron_long, tools, true );
+            actually_test_craft( recipe_test_waist_apron_long, INT_MAX, 10 );
+            item_location apron = player_character.get_wielded_item();
+
+            REQUIRE( apron->type->get_id() == recipe_test_waist_apron_long->result() );
+            REQUIRE( apron->has_itype_variant() );
+
+            if( variant_counts.count( apron->itype_variant().id ) == 0 ) {
+                variant_counts[apron->itype_variant().id] = 0;
+            }
+            variant_counts[apron->itype_variant().id]++;
+        }
+        int variants_captured = 0;
+        for( const std::pair<std::string, int> var_count : variant_counts ) {
+            CHECK( var_count.second < max_iters );
+            variants_captured++;
+        }
+        CHECK( variants_captured > 1 );
+    }
+
+    SECTION( "crafting variant recipe" ) {
+        int specific_variant_count = 0;
+        for( int i = 0; i < max_iters; i++ ) {
+            std::vector<item> tools;
+            tools.emplace_back( itype_sewing_kit );
+            tools.emplace_back( "scissors" );
+            tools.insert( tools.end(), 10, item( "sheet_cotton" ) );
+            tools.insert( tools.end(), 10, item( "thread" ) );
+            prep_craft( recipe_test_waist_apron_long_pink_apron_cotton, tools, true );
+            actually_test_craft( recipe_test_waist_apron_long_pink_apron_cotton, INT_MAX, 10 );
+            item_location apron = player_character.get_wielded_item();
+
+            REQUIRE( apron->type->get_id() == recipe_test_waist_apron_long_pink_apron_cotton->result() );
+            REQUIRE( apron->has_itype_variant() );
+
+            if( apron->itype_variant().id == "pink_apron_cotton" ) {
+                specific_variant_count++;
+            }
+        }
+        CHECK( specific_variant_count == max_iters );
     }
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
- Resolves #67191

Folks are requesting the ability to make a recipe result in a specific variant of an item.

#### Describe the solution
Adds an optional field to the recipe definition called `"variant"`, which specifies a variant id of the result item. The recipe will always produce this variant when crafted.

If a variant is defined, the recipe's `ident` is appended with the variant id (with a `_` before the variant string). The variant string comes before the `id_suffix`. The resulting ident appears as `<recipe_ident><variant_id><id_suffix>`

When crafting a recipe with a variant, the name listed in the recipe list is pulled from the variant, as well as the item's info on the right:

```json
{
  "//": "Variant version",
  "result": "waist_apron_long",
  "type": "recipe",
  "variant": "pink_apron_cotton",
  "activity_level": "LIGHT_EXERCISE",
  "category": "CC_ARMOR",
  "subcategory": "CSC_ARMOR_TORSO",
  "skill_used": "tailor",
  "difficulty": 1,
  "time": "2 h",
  "autolearn": true,
  "using": [ [ "tailoring_cotton_patchwork", 6 ] ]
}
```

![Screenshot from 2023-07-27 01-56-12](https://github.com/CleverRaven/Cataclysm-DDA/assets/12537966/c03bd6e3-2857-4778-8ef6-0289e6d3c23e)

#### Describe alternatives you've considered


#### Testing
Added a test case to compare results between non-variant and variant recipes:
```
tests/cata_test "variant_crafting_recipes"
```

Also tested in-game with the JSON and screenshot posted above.

#### Additional context
