### PR TITLE
Stop aphids eating their own honeydew

### DIFF
--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -2578,7 +2578,7 @@
     "proportional": { "hp": 0.5, "speed": 1.1, "morale": 0.67, "melee_dice_sides": 0.5 },
     "volume": "96 ml",
     "weight": "96 g",
-    "special_attacks": [ [ "EAT_FOOD", 400 ], [ "EAT_CROP", 600 ] ],
+    "special_attacks": [ [ "EAT_CROP", 600 ] ],
     "delete": {
       "reproduction": { "baby_monster": "mon_aphid", "baby_count": 1, "baby_timer": 20 },
       "baby_flags": [ "SPRING", "SUMMER" ]
@@ -2617,7 +2617,7 @@
     "dissect": "dissect_insect_sample_single",
     "regen_morale": true,
     "fear_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT", "FIRE", "PLAYER_CLOSE" ],
-    "special_attacks": [ [ "EAT_FOOD", 60 ], [ "EAT_CROP", 80 ] ],
+    "special_attacks": [ [ "EAT_CROP", 80 ] ],
     "reproduction": { "baby_monster": "mon_aphid_small", "baby_count": 1, "baby_timer": 20 },
     "baby_flags": [ "SPRING", "SUMMER" ],
     "biosignature": { "biosig_item": "honeydew", "biosig_timer": 600 },

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -472,8 +472,10 @@ bool mattack::eat_food( monster *z )
             if( !z->has_flag( mon_flag_EATS ) && z->type->baby_egg != item.type->get_id() ) {
                 int consumed = 1;
                 if( item.count_by_charges() ) {
+                    add_msg_if_player_sees( *z, _( "The %1s eats the %2s." ), z->name(), item.display_name() );
                     here.use_charges( p, 1, item.type->get_id(), consumed );
                 } else {
+                    add_msg_if_player_sees( *z, _( "The %1s gobbles up the %2s." ), z->name(), item.display_name() );
                     here.use_amount( p, 1, item.type->get_id(), consumed );
                 }
                 return true;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Stop aphids from eating their own honeydew"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Aphids were eating their own honeydew as soon as they produced it, because they have EAT_FOOD. This was not a new issue, but nobody ever noticed it because EAT_FOOD was completely not working for a very long time.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Removes EAT_FOOD from aphids. They have EAT_CROP, so they're fine. Real-life aphids don't eat your food, they just eat live plants.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Make EAT_FOOD ignore honeydew somehow. This would be undesirable as ants should be eating honeydew via EAT_FOOD.

Added messaging to EAT_FOOD. I had already added it in #66294 but I forgot to display it in some cases.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Spawned some aphids and ants. Tossed some honeydew around. The aphids ignored it and the ants ate it.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
