### PR TITLE
Unhardcode mx_house_wasp

### DIFF
--- a/data/json/mapgen/map_extras/house_wasp.json
+++ b/data/json/mapgen/map_extras/house_wasp.json
@@ -1,0 +1,209 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "mx_house_wasp",
+    "object": {
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "ter_furn_transforms": { " ": { "transform": "remove_door" } },
+      "nested": {
+        " ": [
+          { "chunks": [ [ "null", 2 ], [ "1x1_remove_window", 1 ] ] },
+          { "chunks": [ [ "null", 7 ], [ "1x1_wall_to_paper", 1 ] ] }
+        ]
+      },
+      "place_nested": [
+        { "chunks": [ "3x3_wasp_pod" ], "x": [ 1, 20 ], "y": [ 1, 20 ] },
+        { "chunks": [ "3x3_wasp_pod" ], "x": [ 1, 20 ], "y": [ 1, 20 ] },
+        { "chunks": [ "3x3_wasp_pod" ], "x": [ 1, 20 ], "y": [ 1, 20 ] },
+        { "chunks": [ "3x3_wasp_pod" ], "x": [ 1, 20 ], "y": [ 1, 20 ] },
+        { "chunks": [ "3x3_wasp_pod" ], "x": [ 1, 20 ], "y": [ 1, 20 ] },
+        { "chunks": [ "3x3_wasp_pod" ], "x": [ 1, 20 ], "y": [ 1, 20 ] },
+        { "chunks": [ "3x3_wasp_pod" ], "x": [ 1, 20 ], "y": [ 1, 20 ] },
+        { "chunks": [ "3x3_wasp_pod" ], "x": [ 1, 20 ], "y": [ 1, 20 ] },
+        { "chunks": [ "3x3_wasp_pod", "null" ], "x": [ 1, 20 ], "y": [ 1, 20 ] },
+        { "chunks": [ "3x3_wasp_pod", "null" ], "x": [ 1, 20 ], "y": [ 1, 20 ] },
+        { "chunks": [ "3x3_wasp_pod", "null" ], "x": [ 1, 20 ], "y": [ 1, 20 ] },
+        { "chunks": [ "3x3_wasp_pod", "null" ], "x": [ 1, 20 ], "y": [ 1, 20 ] }
+      ],
+      "place_monster": [ { "group": "GROUP_WASP_QUEEN", "x": [ 0, 23 ], "y": [ 0, 23 ] } ],
+      "place_monsters": [ { "monster": "GROUP_DERMATIK", "chance": 20, "x": 22, "y": 22, "density": 0.1 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "3x3_wasp_pod",
+    "object": {
+      "mapgensize": [ 3, 3 ],
+      "rows": [
+        "123",
+        "4 6",
+        "789"
+      ],
+      "parameters": {
+        "opening": { "type": "string", "default": { "distribution": [ "1", "2", "3", "4", "6", "7", "8", "9" ] }, "scope": "nest" }
+      },
+      "terrain": {
+        "1": {
+          "switch": { "param": "opening", "fallback": "0" },
+          "cases": {
+            "1": "t_null",
+            "2": "t_paper",
+            "3": "t_paper",
+            "4": "t_paper",
+            "6": "t_paper",
+            "7": "t_paper",
+            "8": "t_paper",
+            "9": "t_paper"
+          }
+        },
+        "2": {
+          "switch": { "param": "opening", "fallback": "0" },
+          "cases": {
+            "1": "t_paper",
+            "2": "t_null",
+            "3": "t_paper",
+            "4": "t_paper",
+            "6": "t_paper",
+            "7": "t_paper",
+            "8": "t_paper",
+            "9": "t_paper"
+          }
+        },
+        "3": {
+          "switch": { "param": "opening", "fallback": "0" },
+          "cases": {
+            "1": "t_paper",
+            "2": "t_paper",
+            "3": "t_null",
+            "4": "t_paper",
+            "6": "t_paper",
+            "7": "t_paper",
+            "8": "t_paper",
+            "9": "t_paper"
+          }
+        },
+        "4": {
+          "switch": { "param": "opening", "fallback": "0" },
+          "cases": {
+            "1": "t_paper",
+            "2": "t_paper",
+            "3": "t_paper",
+            "4": "t_null",
+            "6": "t_paper",
+            "7": "t_paper",
+            "8": "t_paper",
+            "9": "t_paper"
+          }
+        },
+        "6": {
+          "switch": { "param": "opening", "fallback": "0" },
+          "cases": {
+            "1": "t_paper",
+            "2": "t_paper",
+            "3": "t_paper",
+            "4": "t_paper",
+            "6": "t_null",
+            "7": "t_paper",
+            "8": "t_paper",
+            "9": "t_paper"
+          }
+        },
+        "7": {
+          "switch": { "param": "opening", "fallback": "0" },
+          "cases": {
+            "1": "t_paper",
+            "2": "t_paper",
+            "3": "t_paper",
+            "4": "t_paper",
+            "6": "t_paper",
+            "7": "t_null",
+            "8": "t_paper",
+            "9": "t_paper"
+          }
+        },
+        "8": {
+          "switch": { "param": "opening", "fallback": "0" },
+          "cases": {
+            "1": "t_paper",
+            "2": "t_paper",
+            "3": "t_paper",
+            "4": "t_paper",
+            "6": "t_paper",
+            "7": "t_paper",
+            "8": "t_null",
+            "9": "t_paper"
+          }
+        },
+        "9": {
+          "switch": { "param": "opening", "fallback": "0" },
+          "cases": {
+            "1": "t_paper",
+            "2": "t_paper",
+            "3": "t_paper",
+            "4": "t_paper",
+            "6": "t_paper",
+            "7": "t_paper",
+            "8": "t_paper",
+            "9": "t_null"
+          }
+        }
+      },
+      "place_monster": [ { "group": "GROUP_WASP_GUARD", "x": 1, "y": 1 } ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "1x1_remove_window",
+    "object": { "mapgensize": [ 1, 1 ], "place_ter_furn_transforms": [ { "transform": "remove_window", "x": 0, "y": 0 } ] }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "1x1_wall_to_paper",
+    "object": { "mapgensize": [ 1, 1 ], "place_ter_furn_transforms": [ { "transform": "wall_to_paper", "x": 0, "y": 0 } ] }
+  },
+  {
+    "type": "ter_furn_transform",
+    "id": "remove_door",
+    "terrain": [ { "result": "t_door_frame", "valid_flags": [ "DOOR", "BARRICADABLE_DOOR_DAMAGED", "BARRICADABLE_DOOR" ] } ]
+  },
+  {
+    "type": "ter_furn_transform",
+    "id": "remove_window",
+    "terrain": [ { "result": [ "t_window_frame" ], "valid_flags": [ "WINDOW" ] } ]
+  },
+  {
+    "type": "ter_furn_transform",
+    "id": "wall_to_paper",
+    "terrain": [ { "result": [ "t_paper" ], "valid_flags": [ "WALL" ] } ]
+  }
+]

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -228,7 +228,7 @@
     "type": "map_extra",
     "name": { "str": "Wasp Nest" },
     "description": "Wasp nest is here.",
-    "generator": { "generator_method": "map_extra_function", "generator_id": "mx_house_wasp" },
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_house_wasp" },
     "min_max_zlevel": [ 0, 10 ],
     "sym": "W",
     "color": "yellow",

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -124,7 +124,6 @@ static const map_extra_id map_extra_mx_reed( "mx_reed" );
 static const map_extra_id map_extra_mx_roadworks( "mx_roadworks" );
 static const map_extra_id map_extra_mx_shrubbery( "mx_shrubbery" );
 
-static const mongroup_id GROUP_DERMATIK( "GROUP_DERMATIK" );
 static const mongroup_id GROUP_FISH( "GROUP_FISH" );
 static const mongroup_id GROUP_FUNGI_FUNGALOID( "GROUP_FUNGI_FUNGALOID" );
 static const mongroup_id GROUP_JABBERWOCK( "GROUP_JABBERWOCK" );
@@ -134,8 +133,6 @@ static const mongroup_id GROUP_MIL_WEAK( "GROUP_MIL_WEAK" );
 static const mongroup_id GROUP_NETHER_PORTAL( "GROUP_NETHER_PORTAL" );
 static const mongroup_id GROUP_STRAY_DOGS( "GROUP_STRAY_DOGS" );
 static const mongroup_id GROUP_TURRET_SPEAKER( "GROUP_TURRET_SPEAKER" );
-static const mongroup_id GROUP_WASP_GUARD( "GROUP_WASP_GUARD" );
-static const mongroup_id GROUP_WASP_QUEEN( "GROUP_WASP_QUEEN" );
 
 static const mtype_id mon_wolf( "mon_wolf" );
 

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -111,7 +111,6 @@ static const map_extra_id map_extra_mx_corpses( "mx_corpses" );
 static const map_extra_id map_extra_mx_dead_vegetation( "mx_dead_vegetation" );
 static const map_extra_id map_extra_mx_grove( "mx_grove" );
 static const map_extra_id map_extra_mx_helicopter( "mx_helicopter" );
-static const map_extra_id map_extra_mx_house_wasp( "mx_house_wasp" );
 static const map_extra_id map_extra_mx_jabberwock( "mx_jabberwock" );
 static const map_extra_id map_extra_mx_looters( "mx_looters" );
 static const map_extra_id map_extra_mx_mayhem( "mx_mayhem" );
@@ -286,45 +285,6 @@ static void dead_vegetation_parser( map &m, const tripoint &loc )
             m.spawn_item( loc, itype_stick_long );
         }
     }
-}
-
-static bool mx_house_wasp( map &m, const tripoint &/*loc*/ )
-{
-    for( int i = 0; i < SEEX * 2; i++ ) {
-        for( int j = 0; j < SEEY * 2; j++ ) {
-            if( m.ter( point( i, j ) ) == t_door_c || m.ter( point( i, j ) ) == t_door_locked ) {
-                m.ter_set( point( i, j ), t_door_frame );
-            }
-            if( m.ter( point( i, j ) ) == t_window_domestic && !one_in( 3 ) ) {
-                m.ter_set( point( i, j ), t_window_frame );
-            }
-            if( m.ter( point( i, j ) ) == t_wall && one_in( 8 ) ) {
-                m.ter_set( point( i, j ), t_paper );
-            }
-        }
-    }
-    const int num_pods = rng( 8, 12 );
-    for( int i = 0; i < num_pods; i++ ) {
-        const point pod( rng( 1, SEEX * 2 - 2 ), rng( 1, SEEY * 2 - 2 ) );
-        point non;
-        while( non.x == 0 && non.y == 0 ) {
-            non.x = rng( -1, 1 );
-            non.y = rng( -1, 1 );
-        }
-        for( int x = -1; x <= 1; x++ ) {
-            for( int y = -1; y <= 1; y++ ) {
-                if( ( x != non.x || y != non.y ) && ( x != 0 || y != 0 ) ) {
-                    m.ter_set( pod + point( x, y ), t_paper );
-                }
-            }
-        }
-        m.place_spawns( GROUP_WASP_GUARD, 1, pod, pod, 1, true );
-    }
-    m.place_spawns( GROUP_WASP_QUEEN, 1, point_zero, point( SEEX, SEEY ), 1, true );
-    m.place_spawns( GROUP_DERMATIK, 5, { SEEX * 2 - 1, SEEY * 2 - 1 }, { SEEX * 2 - 1, SEEY * 2 - 1 },
-                    0.1f );
-
-    return true;
 }
 
 static void delete_items_at_mount( vehicle &veh, const point &pt )
@@ -2397,7 +2357,6 @@ static FunctionMap builtin_functions = {
     { map_extra_mx_minefield, mx_minefield },
     { map_extra_mx_helicopter, mx_helicopter },
     { map_extra_mx_portal_in, mx_portal_in },
-    { map_extra_mx_house_wasp, mx_house_wasp },
     { map_extra_mx_jabberwock, mx_jabberwock },
     { map_extra_mx_grove, mx_grove },
     { map_extra_mx_shrubbery, mx_shrubbery },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Hardcoded stuff bad

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Should work almost identically. Expanded walls/doors/windows it affects and the number of pods is binomially distributed between 8 and 12 instead of uniformly.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/e568bea7-ebbb-4a5d-a441-50e6f22221a3)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/34c750f0-29f6-45bd-a1bf-7d41eaace4a5)
(Boosted rates)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
