### PR TITLE
Fix kevlar requirements of survivor gear crafts

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -1512,7 +1512,7 @@
     "type": "ARMOR",
     "name": { "str": "pair of cut-resistant arm sleeves", "str_pl": "pairs of cut-resistant arm sleeves" },
     "description": "A long pair of cut-resistant Kevlar sleeves with thumbholes.  Useful for chainsaw protection.",
-    "weight": "113 g",
+    "weight": "450 g",
     "copy-from": "armguard_soft",
     "price": 1200,
     "material": [ "kevlar" ]

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -1240,8 +1240,7 @@
     "weight": "1519 g",
     "copy-from": "chaps_leather",
     "price": 7800,
-    "material": [ "kevlar" ],
-    "material_thickness": 1
+    "material": [ "kevlar" ]
   },
   {
     "id": "fencing_pants",

--- a/data/json/recipes/armor/bespoke_armor/survivor.json
+++ b/data/json/recipes/armor/bespoke_armor/survivor.json
@@ -9,15 +9,14 @@
     "difficulty": 6,
     "time": "10 h",
     "autolearn": true,
-    "using": [ [ "sewing_kevlar", 200 ], [ "fabric_lycra", 20 ], [ "fabric_fauxfur", 20 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 130 ], [ "fabric_lycra", 20 ], [ "fabric_fauxfur", 20 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },
       { "proficiency": "prof_polymerworking" },
       { "proficiency": "prof_elastics" }
-    ],
-    "components": [ [ [ "sheet_kevlar", 130 ] ] ]
+    ]
   },
   {
     "result": "xs_wsurvivor_jumpsuit_nofur",
@@ -25,9 +24,8 @@
     "activity_level": "LIGHT_EXERCISE",
     "copy-from": "wsurvivor_jumpsuit_nofur",
     "time": "10 h",
-    "using": [ [ "sewing_kevlar", 150 ], [ "fabric_lycra", 15 ], [ "fabric_fauxfur", 15 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
-    "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "FABRIC_CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar", 100 ] ] ]
+    "using": [ [ "tailoring_kevlar_fabric", 100 ], [ "fabric_lycra", 15 ], [ "fabric_fauxfur", 15 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "FABRIC_CUT", "level": 2 } ]
   },
   {
     "result": "xl_wsurvivor_jumpsuit_nofur",
@@ -35,9 +33,8 @@
     "activity_level": "LIGHT_EXERCISE",
     "copy-from": "wsurvivor_jumpsuit_nofur",
     "time": "11 h 36 m",
-    "using": [ [ "sewing_kevlar", 300 ], [ "fabric_lycra", 30 ], [ "fabric_fauxfur", 30 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
-    "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
-    "components": [ [ [ "sheet_kevlar", 200 ] ] ]
+    "using": [ [ "tailoring_kevlar_fabric", 200 ], [ "fabric_lycra", 30 ], [ "fabric_fauxfur", 30 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ]
   },
   {
     "result": "h20survivor_jumpsuit",
@@ -138,31 +135,28 @@
     "difficulty": 5,
     "time": "6 h",
     "autolearn": true,
-    "using": [ [ "sewing_kevlar", 100 ], [ "fabric_lycra", 20 ], [ "fabric_nylon", 30 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 130 ], [ "fabric_lycra", 20 ], [ "fabric_nylon", 30 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },
       { "proficiency": "prof_polymerworking" },
       { "proficiency": "prof_elastics" }
     ],
-    "qualities": [ { "id": "FABRIC_CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar", 130 ] ] ]
+    "qualities": [ { "id": "FABRIC_CUT", "level": 2 } ]
   },
   {
     "result": "xs_lsurvivor_jumpsuit",
     "type": "recipe",
     "copy-from": "lsurvivor_jumpsuit",
     "time": "6 h",
-    "using": [ [ "sewing_kevlar", 75 ], [ "fabric_lycra", 15 ], [ "fabric_nylon", 23 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
-    "components": [ [ [ "sheet_kevlar", 100 ] ] ]
+    "using": [ [ "tailoring_kevlar_fabric", 100 ], [ "fabric_lycra", 15 ], [ "fabric_nylon", 23 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ]
   },
   {
     "result": "xl_lsurvivor_jumpsuit",
     "type": "recipe",
     "copy-from": "lsurvivor_jumpsuit",
     "time": "7 h",
-    "using": [ [ "sewing_kevlar", 150 ], [ "fabric_lycra", 30 ], [ "fabric_nylon", 45 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
-    "components": [ [ [ "sheet_kevlar", 200 ] ] ]
+    "using": [ [ "tailoring_kevlar_fabric", 200 ], [ "fabric_lycra", 30 ], [ "fabric_nylon", 45 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ]
   },
   {
     "result": "survivor_jumpsuit",
@@ -174,14 +168,13 @@
     "difficulty": 6,
     "time": "7 h",
     "autolearn": true,
-    "using": [ [ "sewing_kevlar", 150 ], [ "fabric_lycra", 20 ], [ "fabric_nylon", 30 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 220 ], [ "fabric_lycra", 20 ], [ "fabric_nylon", 30 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },
       { "proficiency": "prof_polymerworking" },
       { "proficiency": "prof_elastics" }
-    ],
-    "components": [ [ [ "sheet_kevlar", 220 ] ] ]
+    ]
   },
   {
     "result": "xssurvivor_jumpsuit",
@@ -189,8 +182,7 @@
     "copy-from": "survivor_jumpsuit",
     "activity_level": "LIGHT_EXERCISE",
     "time": "7 h",
-    "using": [ [ "sewing_kevlar", 112 ], [ "fabric_lycra", 15 ], [ "fabric_nylon", 23 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
-    "components": [ [ [ "sheet_kevlar", 155 ] ] ]
+    "using": [ [ "tailoring_kevlar_fabric", 155 ], [ "fabric_lycra", 15 ], [ "fabric_nylon", 23 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ]
   },
   {
     "result": "xlsurvivor_jumpsuit",
@@ -198,8 +190,7 @@
     "copy-from": "survivor_jumpsuit",
     "activity_level": "LIGHT_EXERCISE",
     "time": "8 h 10 m",
-    "using": [ [ "sewing_kevlar", 200 ], [ "fabric_lycra", 30 ], [ "fabric_nylon", 45 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
-    "components": [ [ [ "sheet_kevlar", 310 ] ] ]
+    "using": [ [ "tailoring_kevlar_fabric", 310 ], [ "fabric_lycra", 30 ], [ "fabric_nylon", 45 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ]
   },
   {
     "result": "wsurvivor_jumpsuit",
@@ -211,7 +202,7 @@
     "difficulty": 6,
     "time": "10 h",
     "autolearn": true,
-    "using": [ [ "sewing_kevlar", 200 ], [ "fabric_lycra", 20 ], [ "fabric_fur_pelt", 3 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 130 ], [ "fabric_lycra", 20 ], [ "fabric_fur_pelt", 3 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
     "proficiencies": [
       { "proficiency": "prof_furriery" },
@@ -219,8 +210,7 @@
       { "proficiency": "prof_closures_waterproofing" },
       { "proficiency": "prof_polymerworking" },
       { "proficiency": "prof_elastics" }
-    ],
-    "components": [ [ [ "sheet_kevlar", 130 ] ] ]
+    ]
   },
   {
     "result": "xs_wsurvivor_jumpsuit",
@@ -228,9 +218,8 @@
     "copy-from": "wsurvivor_jumpsuit",
     "activity_level": "LIGHT_EXERCISE",
     "time": "10 h",
-    "using": [ [ "sewing_kevlar", 150 ], [ "fabric_lycra", 15 ], [ "fabric_fur_pelt", 2 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
-    "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
-    "components": [ [ [ "sheet_kevlar", 100 ] ] ]
+    "using": [ [ "tailoring_kevlar_fabric", 100 ], [ "fabric_lycra", 15 ], [ "fabric_fur_pelt", 2 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ]
   },
   {
     "result": "xl_wsurvivor_jumpsuit",
@@ -238,9 +227,8 @@
     "copy-from": "wsurvivor_jumpsuit",
     "activity_level": "LIGHT_EXERCISE",
     "time": "11 h 36 m",
-    "using": [ [ "sewing_kevlar", 300 ], [ "fabric_lycra", 30 ], [ "fabric_fur_pelt", 5 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
-    "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
-    "components": [ [ [ "sheet_kevlar", 200 ] ] ]
+    "using": [ [ "tailoring_kevlar_fabric", 200 ], [ "fabric_lycra", 30 ], [ "fabric_fur_pelt", 5 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ]
   },
   {
     "result": "survivor_rig",
@@ -277,29 +265,26 @@
     "time": "12 h 20 m",
     "autolearn": true,
     "book_learn": [ [ "tailor_portfolio", 7 ], [ "textbook_fireman", 7 ] ],
-    "using": [ [ "sewing_kevlar", 200 ], [ "fabric_nomex", 30 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [ [ "tailoring_kevlar_fabric", 130 ], [ "fabric_nomex", 30 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },
       { "proficiency": "prof_polymerworking" }
-    ],
-    "components": [ [ [ "sheet_kevlar", 130 ] ] ]
+    ]
   },
   {
     "result": "xs_fsurvivor_jumpsuit",
     "type": "recipe",
     "copy-from": "fsurvivor_jumpsuit",
     "time": "12 h 20 m",
-    "using": [ [ "sewing_kevlar", 150 ], [ "fabric_nomex", 23 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
-    "components": [ [ [ "sheet_kevlar", 100 ] ] ]
+    "using": [ [ "tailoring_kevlar_fabric", 100 ], [ "fabric_nomex", 23 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ]
   },
   {
     "result": "xl_fsurvivor_jumpsuit",
     "type": "recipe",
     "copy-from": "fsurvivor_jumpsuit",
     "time": "14 h 18 m",
-    "using": [ [ "sewing_kevlar", 300 ], [ "fabric_nomex", 30 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
-    "components": [ [ [ "sheet_kevlar", 200 ] ] ]
+    "using": [ [ "tailoring_kevlar_fabric", 200 ], [ "fabric_nomex", 30 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ]
   },
   {
     "result": "survivor_adhoc_leather_shirt",

--- a/data/json/recipes/armor/bespoke_armor/survivor.json
+++ b/data/json/recipes/armor/bespoke_armor/survivor.json
@@ -9,7 +9,13 @@
     "difficulty": 6,
     "time": "10 h",
     "autolearn": true,
-    "using": [ [ "tailoring_kevlar_fabric", 130 ], [ "fabric_lycra", 20 ], [ "fabric_fauxfur", 20 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [
+      [ "tailoring_kevlar_fabric", 130 ],
+      [ "fabric_lycra", 20 ],
+      [ "fabric_fauxfur", 20 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ]
+    ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
@@ -24,7 +30,13 @@
     "activity_level": "LIGHT_EXERCISE",
     "copy-from": "wsurvivor_jumpsuit_nofur",
     "time": "10 h",
-    "using": [ [ "tailoring_kevlar_fabric", 100 ], [ "fabric_lycra", 15 ], [ "fabric_fauxfur", 15 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [
+      [ "tailoring_kevlar_fabric", 100 ],
+      [ "fabric_lycra", 15 ],
+      [ "fabric_fauxfur", 15 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ]
+    ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 }, { "id": "FABRIC_CUT", "level": 2 } ]
   },
   {
@@ -33,7 +45,13 @@
     "activity_level": "LIGHT_EXERCISE",
     "copy-from": "wsurvivor_jumpsuit_nofur",
     "time": "11 h 36 m",
-    "using": [ [ "tailoring_kevlar_fabric", 200 ], [ "fabric_lycra", 30 ], [ "fabric_fauxfur", 30 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [
+      [ "tailoring_kevlar_fabric", 200 ],
+      [ "fabric_lycra", 30 ],
+      [ "fabric_fauxfur", 30 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ]
+    ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ]
   },
   {
@@ -135,7 +153,13 @@
     "difficulty": 5,
     "time": "6 h",
     "autolearn": true,
-    "using": [ [ "tailoring_kevlar_fabric", 130 ], [ "fabric_lycra", 20 ], [ "fabric_nylon", 30 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [
+      [ "tailoring_kevlar_fabric", 130 ],
+      [ "fabric_lycra", 20 ],
+      [ "fabric_nylon", 30 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ]
+    ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },
@@ -149,14 +173,26 @@
     "type": "recipe",
     "copy-from": "lsurvivor_jumpsuit",
     "time": "6 h",
-    "using": [ [ "tailoring_kevlar_fabric", 100 ], [ "fabric_lycra", 15 ], [ "fabric_nylon", 23 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ]
+    "using": [
+      [ "tailoring_kevlar_fabric", 100 ],
+      [ "fabric_lycra", 15 ],
+      [ "fabric_nylon", 23 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ]
+    ]
   },
   {
     "result": "xl_lsurvivor_jumpsuit",
     "type": "recipe",
     "copy-from": "lsurvivor_jumpsuit",
     "time": "7 h",
-    "using": [ [ "tailoring_kevlar_fabric", 200 ], [ "fabric_lycra", 30 ], [ "fabric_nylon", 45 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ]
+    "using": [
+      [ "tailoring_kevlar_fabric", 200 ],
+      [ "fabric_lycra", 30 ],
+      [ "fabric_nylon", 45 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ]
+    ]
   },
   {
     "result": "survivor_jumpsuit",
@@ -168,7 +204,13 @@
     "difficulty": 6,
     "time": "7 h",
     "autolearn": true,
-    "using": [ [ "tailoring_kevlar_fabric", 220 ], [ "fabric_lycra", 20 ], [ "fabric_nylon", 30 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [
+      [ "tailoring_kevlar_fabric", 220 ],
+      [ "fabric_lycra", 20 ],
+      [ "fabric_nylon", 30 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ]
+    ],
     "proficiencies": [
       { "proficiency": "prof_closures" },
       { "proficiency": "prof_closures_waterproofing" },
@@ -182,7 +224,13 @@
     "copy-from": "survivor_jumpsuit",
     "activity_level": "LIGHT_EXERCISE",
     "time": "7 h",
-    "using": [ [ "tailoring_kevlar_fabric", 155 ], [ "fabric_lycra", 15 ], [ "fabric_nylon", 23 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ]
+    "using": [
+      [ "tailoring_kevlar_fabric", 155 ],
+      [ "fabric_lycra", 15 ],
+      [ "fabric_nylon", 23 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ]
+    ]
   },
   {
     "result": "xlsurvivor_jumpsuit",
@@ -190,7 +238,13 @@
     "copy-from": "survivor_jumpsuit",
     "activity_level": "LIGHT_EXERCISE",
     "time": "8 h 10 m",
-    "using": [ [ "tailoring_kevlar_fabric", 310 ], [ "fabric_lycra", 30 ], [ "fabric_nylon", 45 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ]
+    "using": [
+      [ "tailoring_kevlar_fabric", 310 ],
+      [ "fabric_lycra", 30 ],
+      [ "fabric_nylon", 45 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ]
+    ]
   },
   {
     "result": "wsurvivor_jumpsuit",
@@ -202,7 +256,13 @@
     "difficulty": 6,
     "time": "10 h",
     "autolearn": true,
-    "using": [ [ "tailoring_kevlar_fabric", 130 ], [ "fabric_lycra", 20 ], [ "fabric_fur_pelt", 3 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [
+      [ "tailoring_kevlar_fabric", 130 ],
+      [ "fabric_lycra", 20 ],
+      [ "fabric_fur_pelt", 3 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ]
+    ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
     "proficiencies": [
       { "proficiency": "prof_furriery" },
@@ -218,7 +278,13 @@
     "copy-from": "wsurvivor_jumpsuit",
     "activity_level": "LIGHT_EXERCISE",
     "time": "10 h",
-    "using": [ [ "tailoring_kevlar_fabric", 100 ], [ "fabric_lycra", 15 ], [ "fabric_fur_pelt", 2 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [
+      [ "tailoring_kevlar_fabric", 100 ],
+      [ "fabric_lycra", 15 ],
+      [ "fabric_fur_pelt", 2 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ]
+    ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ]
   },
   {
@@ -227,7 +293,13 @@
     "copy-from": "wsurvivor_jumpsuit",
     "activity_level": "LIGHT_EXERCISE",
     "time": "11 h 36 m",
-    "using": [ [ "tailoring_kevlar_fabric", 200 ], [ "fabric_lycra", 30 ], [ "fabric_fur_pelt", 5 ], [ "fastener_large", 1 ], [ "clasps", 8 ] ],
+    "using": [
+      [ "tailoring_kevlar_fabric", 200 ],
+      [ "fabric_lycra", 30 ],
+      [ "fabric_fur_pelt", 5 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ]
+    ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ]
   },
   {

--- a/data/json/recipes/armor/torso.json
+++ b/data/json/recipes/armor/torso.json
@@ -806,12 +806,11 @@
     "skills_required": [ "fabrication", 5 ],
     "time": "12 h 10 m",
     "autolearn": true,
-    "using": [ [ "sewing_standard", 135 ], [ "tailoring_canvas_patchwork", 19 ] ],
+    "using": [ [ "sewing_kevlar", 135 ], [ "tailoring_canvas_patchwork", 19 ], [ "tailoring_kevlar_fabric", 50 ] ],
     "components": [
       [ [ "coat_rain", 1 ] ],
       [ [ "duster", 1 ] ],
-      [ [ "stab_vest", 1 ], [ "sheet_kevlar", 100 ] ],
-      [ [ "sheet_kevlar", 25 ] ],
+      [ [ "stab_vest", 1 ], [ "sheet_kevlar", 75 ], [ "sheet_kevlar_patchwork", 75 ] ],
       [
         [ "tacvest", 1 ],
         [ "legrig", 1 ],
@@ -836,12 +835,11 @@
     "type": "recipe",
     "copy-from": "duster_survivor",
     "time": "12 h 10 m",
-    "using": [ [ "sewing_standard", 101 ], [ "tailoring_canvas_patchwork", 14 ] ],
+    "using": [ [ "sewing_kevlar", 101 ], [ "tailoring_canvas_patchwork", 14 ], [ "tailoring_kevlar_fabric", 40 ] ],
     "components": [
       [ [ "coat_rain", 1 ] ],
       [ [ "duster", 1 ], [ "xs_duster", 1 ] ],
-      [ [ "stab_vest", 1 ], [ "sheet_kevlar", 90 ] ],
-      [ [ "sheet_kevlar", 20 ] ],
+      [ [ "stab_vest", 1 ], [ "sheet_kevlar", 70 ], [ "sheet_kevlar_patchwork", 70 ] ],
       [
         [ "tacvest", 1 ],
         [ "legrig", 1 ],
@@ -861,12 +859,11 @@
     "type": "recipe",
     "copy-from": "duster_survivor",
     "time": "13 h 40 m",
-    "using": [ [ "sewing_standard", 175 ], [ "tailoring_canvas_patchwork", 26 ] ],
+    "using": [ [ "sewing_kevlar", 175 ], [ "tailoring_canvas_patchwork", 26 ], [ "tailoring_kevlar_fabric", 75 ] ],
     "components": [
       [ [ "coat_rain", 2 ] ],
       [ [ "xl_duster", 1 ] ],
-      [ [ "stab_vest", 1 ], [ "sheet_kevlar", 140 ] ],
-      [ [ "sheet_kevlar", 35 ] ],
+      [ [ "stab_vest", 1 ], [ "sheet_kevlar", 80 ], [ "sheet_kevlar_patchwork", 80 ] ],
       [
         [ "tacvest", 1 ],
         [ "legrig", 1 ],
@@ -1535,12 +1532,11 @@
     "skills_required": [ "fabrication", 5 ],
     "time": "10 h 20 m",
     "autolearn": true,
-    "using": [ [ "tailoring_cotton_patchwork", 12 ] ],
+    "using": [ [ "sewing_kevlar", 75 ], [ "tailoring_kevlar_fabric", 20 ] ],
     "components": [
       [ [ "coat_rain", 1 ] ],
       [ [ "duster", 1 ], [ "sleeveless_duster", 1 ] ],
-      [ [ "stab_vest", 1 ], [ "sheet_kevlar", 90 ] ],
-      [ [ "sheet_kevlar", 20 ] ],
+      [ [ "stab_vest", 1 ], [ "sheet_kevlar", 75 ], [ "sheet_kevlar_patchwork", 75 ] ],
       [
         [ "tacvest", 1 ],
         [ "legrig", 1 ],
@@ -1713,12 +1709,11 @@
     "skills_required": [ "fabrication", 5 ],
     "time": "11 h 45 m",
     "autolearn": true,
-    "using": [ [ "tailoring_canvas_patchwork", 12 ] ],
+    "using": [ [ "sewing_kevlar", 75 ], [ "tailoring_kevlar_fabric", 20 ] ],
     "components": [
       [ [ "coat_rain", 1 ] ],
       [ [ "trenchcoat", 1 ], [ "sleeveless_trenchcoat", 1 ] ],
-      [ [ "stab_vest", 1 ], [ "sheet_kevlar", 100 ] ],
-      [ [ "sheet_kevlar", 20 ] ],
+      [ [ "stab_vest", 1 ], [ "sheet_kevlar", 75 ], [ "sheet_kevlar_patchwork", 75 ] ],
       [
         [ "tacvest", 1 ],
         [ "legrig", 1 ],
@@ -2020,12 +2015,11 @@
     "skills_required": [ "fabrication", 5 ],
     "time": "10 h 30 m",
     "autolearn": true,
-    "using": [ [ "tailoring_canvas_patchwork", 16 ] ],
+    "using": [ [ "sewing_kevlar", 75 ], [ "tailoring_kevlar_fabric", 60 ] ],
     "components": [
       [ [ "coat_rain", 1 ] ],
       [ [ "trenchcoat", 1 ] ],
-      [ [ "stab_vest", 1 ], [ "sheet_kevlar", 110 ] ],
-      [ [ "sheet_kevlar", 25 ] ],
+      [ [ "stab_vest", 1 ], [ "sheet_kevlar", 75 ], [ "sheet_kevlar_patchwork", 75 ] ],
       [
         [ "tacvest", 1 ],
         [ "legrig", 1 ],

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -7516,5 +7516,95 @@
     "time": "45 m",
     "qualities": [ { "id": "WRENCH", "level": 2 } ],
     "components": [ [ [ "alternator_truck", 1 ] ], [ [ "i4_diesel", 1 ] ], [ [ "frame", 1 ] ], [ [ "jerrycan_big", 1 ] ] ]
+  },
+  {
+    "result": "apron_cut_resistant",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "skill_used": "tailor",
+    "time": "10 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 6 ] ], [ [ "thread_kevlar", 30 ] ]  ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "armguard_cut_resistant",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "skill_used": "tailor",
+    "time": "8 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 2 ] ], [ [ "thread_kevlar", 15 ] ]  ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "chaps_cut_resistant",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "skill_used": "tailor",
+    "time": "16 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 18 ] ], [ [ "thread_kevlar", 40 ] ]  ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "stab_vest",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "skill_used": "tailor",
+    "time": "20 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 35 ] ], [ [ "thread_kevlar", 75 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "bite_suit",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "skill_used": "tailor",
+    "time": "60 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 200 ] ], [ [ "thread_kevlar", 300 ] ], [ [ "sheet_denim_patchwork", 20 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "motorbike_pants",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "skill_used": "tailor",
+    "time": "5 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 3 ] ], [ [ "thread_kevlar", 12 ] ], [ [ "sheet_denim_patchwork", 2 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "bunker_pants",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "skill_used": "tailor",
+    "time": "32 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 14 ] ], [ [ "thread_kevlar", 40 ] ], [ [ "sheet_nomex_patchwork", 16 ] ], [ [ "sheet_lycra_patchwork", 6 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "bunker_coat",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "skill_used": "tailor",
+    "time": "36 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 16 ] ], [ [ "thread_kevlar", 45 ] ], [ [ "sheet_nomex_patchwork", 18 ] ], [ [ "sheet_lycra_patchwork", 6 ] ] ],
+    "flags": [ "BLIND_HARD" ]
+  },
+  {
+    "result": "entry_suit",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "skill_used": "tailor",
+    "time": "45 m",
+    "qualities": [ { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 25 ] ], [ [ "thread_kevlar", 60 ] ], [ [ "sheet_nomex_patchwork", 32 ] ] ],
+    "flags": [ "BLIND_HARD" ]
   }
 ]

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -7534,7 +7534,7 @@
     "skill_used": "tailor",
     "time": "8 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar_patchwork", 2 ] ], [ [ "thread_kevlar", 15 ] ] ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 4 ] ], [ [ "thread_kevlar", 20 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -7564,7 +7564,7 @@
     "skill_used": "tailor",
     "time": "60 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar_patchwork", 200 ] ], [ [ "thread_kevlar", 300 ] ], [ [ "sheet_denim_patchwork", 20 ] ] ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 100 ] ], [ [ "thread_kevlar", 300 ] ], [ [ "sheet_denim_patchwork", 20 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -7522,9 +7522,9 @@
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",
     "skill_used": "tailor",
-    "time": "10 m",
+    "time": "15 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar_patchwork", 6 ] ], [ [ "thread_kevlar", 30 ] ] ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 20 ] ], [ [ "thread_kevlar", 80 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {
@@ -7532,9 +7532,9 @@
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",
     "skill_used": "tailor",
-    "time": "8 m",
+    "time": "10 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar_patchwork", 4 ] ], [ [ "thread_kevlar", 20 ] ] ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 15 ] ], [ [ "thread_kevlar", 50 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {
@@ -7542,9 +7542,9 @@
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",
     "skill_used": "tailor",
-    "time": "16 m",
+    "time": "20 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar_patchwork", 18 ] ], [ [ "thread_kevlar", 40 ] ] ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 50 ] ], [ [ "thread_kevlar", 150 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {
@@ -7554,7 +7554,7 @@
     "skill_used": "tailor",
     "time": "20 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar_patchwork", 35 ] ], [ [ "thread_kevlar", 75 ] ] ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 40 ] ], [ [ "thread_kevlar", 130 ] ], [ [ "sheet_nylon_patchwork", 10 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {
@@ -7562,9 +7562,9 @@
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",
     "skill_used": "tailor",
-    "time": "60 m",
+    "time": "90 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar_patchwork", 100 ] ], [ [ "thread_kevlar", 300 ] ], [ [ "sheet_denim_patchwork", 20 ] ] ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 180 ] ], [ [ "thread_kevlar", 500 ] ], [ [ "sheet_denim_patchwork", 40 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {
@@ -7572,9 +7572,9 @@
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",
     "skill_used": "tailor",
-    "time": "5 m",
+    "time": "8 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar_patchwork", 3 ] ], [ [ "thread_kevlar", 12 ] ], [ [ "sheet_denim_patchwork", 2 ] ] ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 4 ] ], [ [ "thread_kevlar", 15 ] ], [ [ "sheet_denim_patchwork", 2 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {
@@ -7585,9 +7585,9 @@
     "time": "32 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [
-      [ [ "sheet_kevlar_patchwork", 14 ] ],
-      [ [ "thread_kevlar", 40 ] ],
-      [ [ "sheet_nomex_patchwork", 16 ] ],
+      [ [ "sheet_kevlar_patchwork", 22 ] ],
+      [ [ "thread_kevlar", 65 ] ],
+      [ [ "sheet_nomex_patchwork", 22 ] ],
       [ [ "sheet_lycra_patchwork", 6 ] ]
     ],
     "flags": [ "BLIND_HARD" ]
@@ -7600,9 +7600,9 @@
     "time": "36 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
     "components": [
-      [ [ "sheet_kevlar_patchwork", 16 ] ],
-      [ [ "thread_kevlar", 45 ] ],
-      [ [ "sheet_nomex_patchwork", 18 ] ],
+      [ [ "sheet_kevlar_patchwork", 20 ] ],
+      [ [ "thread_kevlar", 60 ] ],
+      [ [ "sheet_nomex_patchwork", 20 ] ],
       [ [ "sheet_lycra_patchwork", 6 ] ]
     ],
     "flags": [ "BLIND_HARD" ]
@@ -7612,9 +7612,9 @@
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",
     "skill_used": "tailor",
-    "time": "45 m",
+    "time": "60 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar_patchwork", 25 ] ], [ [ "thread_kevlar", 60 ] ], [ [ "sheet_nomex_patchwork", 32 ] ] ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 30 ] ], [ [ "thread_kevlar", 90 ] ], [ [ "sheet_nomex_patchwork", 30 ] ] ],
     "flags": [ "BLIND_HARD" ]
   }
 ]

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -7524,7 +7524,7 @@
     "skill_used": "tailor",
     "time": "10 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar_patchwork", 6 ] ], [ [ "thread_kevlar", 30 ] ]  ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 6 ] ], [ [ "thread_kevlar", 30 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {
@@ -7534,7 +7534,7 @@
     "skill_used": "tailor",
     "time": "8 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar_patchwork", 2 ] ], [ [ "thread_kevlar", 15 ] ]  ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 2 ] ], [ [ "thread_kevlar", 15 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {
@@ -7544,7 +7544,7 @@
     "skill_used": "tailor",
     "time": "16 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar_patchwork", 18 ] ], [ [ "thread_kevlar", 40 ] ]  ],
+    "components": [ [ [ "sheet_kevlar_patchwork", 18 ] ], [ [ "thread_kevlar", 40 ] ] ],
     "flags": [ "BLIND_HARD" ]
   },
   {
@@ -7584,7 +7584,12 @@
     "skill_used": "tailor",
     "time": "32 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar_patchwork", 14 ] ], [ [ "thread_kevlar", 40 ] ], [ [ "sheet_nomex_patchwork", 16 ] ], [ [ "sheet_lycra_patchwork", 6 ] ] ],
+    "components": [
+      [ [ "sheet_kevlar_patchwork", 14 ] ],
+      [ [ "thread_kevlar", 40 ] ],
+      [ [ "sheet_nomex_patchwork", 16 ] ],
+      [ [ "sheet_lycra_patchwork", 6 ] ]
+    ],
     "flags": [ "BLIND_HARD" ]
   },
   {
@@ -7594,7 +7599,12 @@
     "skill_used": "tailor",
     "time": "36 m",
     "qualities": [ { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_kevlar_patchwork", 16 ] ], [ [ "thread_kevlar", 45 ] ], [ [ "sheet_nomex_patchwork", 18 ] ], [ [ "sheet_lycra_patchwork", 6 ] ] ],
+    "components": [
+      [ [ "sheet_kevlar_patchwork", 16 ] ],
+      [ [ "thread_kevlar", 45 ] ],
+      [ [ "sheet_nomex_patchwork", 18 ] ],
+      [ [ "sheet_lycra_patchwork", 6 ] ]
+    ],
     "flags": [ "BLIND_HARD" ]
   },
   {

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -269,7 +269,7 @@ TEST_CASE( "unskilled_shooter_accuracy", "[ranged] [balance] [slow]" )
     SECTION( "an unskilled shooter with a common smg" ) {
         arm_shooter( shooter, "mp40semi" );
         test_shooting_scenario( shooter, 4, 5, 18 );
-        test_fast_shooting( shooter, 80, 0.15 );
+        test_fast_shooting( shooter, 80, 0.04 );
     }
     SECTION( "an unskilled shooter with a common rifle" ) {
         arm_shooter( shooter, "ar15" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "kevlar jumpsuits use the correct requirement"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #a-complaint-on-reddit
Survivor gear was using only regular sheets, rather than patchwork sheets OR regular sheets.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change requirements to be either.
Also added many deconstruction recipes for various kevlar stuff. This is roughly their weight in sheets, with a higher time to represent the careful deconstruction. 
Fixed a couple kevlar items that were wrong. Chainsaw Chaps were 1mm while their weight suggested they were 3mm thick, and 3mm was how thick the leather chaps were too so I changed them to be 3mm. Cut resistant sleeves were too light, being the weight of 0.5mm while being 2mm thick. I quadrupled its weight so that it properly matches the weight of 2mm thick kevlar sleeves.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Get rid of the lycra underlayer and continue to tweak survivor suit balance in general.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
