### PR TITLE
Fix Colossal Croaker ranged pull strings

### DIFF
--- a/data/json/monster_special_attacks/monster_attacks.json
+++ b/data/json/monster_special_attacks/monster_attacks.json
@@ -105,8 +105,8 @@
     "grab_data": { "exclusive_grab": true, "pull_chance": 100, "pull_weight_ratio": 0.75 },
     "no_dmg_msg_u": "",
     "no_dmg_msg_npc": "",
-    "miss_msg_u": "The %s's arms fly out at you, but you dodge!",
-    "miss_msg_npc": "The %s's arms fly out at <npcname>, but they dodge!"
+    "miss_msg_u": "%s's arms fly out at you, but you dodge!",
+    "miss_msg_npc": "%s's arms fly out at <npcname>, but they dodge!"
   },
   {
     "type": "monster_attack",

--- a/data/json/monsters/reptile_amphibian.json
+++ b/data/json/monsters/reptile_amphibian.json
@@ -124,7 +124,13 @@
     "zombify_into": "mon_frog_mother",
     "grab_strength": 50,
     "special_attacks": [
-      { "id": "ranged_pull", "cooldown": 10, "range": 3 },
+      {
+        "id": "ranged_pull",
+        "cooldown": 10,
+        "range": 3,
+        "miss_msg_u": "%s's tongue flies out at you, but you dodge!",
+        "miss_msg_npc": "%s's tongue flies out at <npcname>, but they dodge!"
+      },
       { "type": "leap", "cooldown": 10, "move_cost": 0, "max_range": 12, "min_consider_range": 2 }
     ],
     "anger_triggers": [ "STALK", "PLAYER_WEAK", "PLAYER_CLOSE" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
``The The colossal croaker's arms fly out at turkey, but they dodge!``
It's a lot to unpack, isn't it?
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- removed the redundant ``The`` in the ranged pull's messages
- added custom messages for Colossal Croaker that change arms to tongue... I am assuming it doesn't just outstretch it's forelimbs?
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
