### PR TITLE
AIM: Fix some instances of stack changing list positions when moving items

### DIFF
--- a/src/advanced_inv_listitem.cpp
+++ b/src/advanced_inv_listitem.cpp
@@ -28,7 +28,7 @@ advanced_inv_listitem::advanced_inv_listitem( const std::vector<item_location> &
     area( area ),
     id( list.front()->typeId() ),
     items( list ),
-    name( list.front()->tname( list.size() ) ),
+    name( list.front()->tname( 1 ) ),
     name_without_prefix( list.front()->tname( 1, false ) ),
     autopickup( get_auto_pickup().has_rule( & * list.front() ) ),
     stacks( list.size() ),


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "AIM: Fix some instances of stack changing list positions while moving items"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
In the AIM, sometimes when moving items around the selected item stack would inexplicably change positions on the list, making you now select a different item and potentially leading to mistakes. This only occurs when you move one item of a selected item stack of 2 and there's a similar item listed next to it (like a battery with a different charge count).
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
One cause of this problem is that `advanced_inv_listitem.name` uses `tname()` with a variable `quantity`. For example, a stack of two medium batteries is internally sorted as "medium batteries", which is alphabetically listed before "medium battery", so when the stack count changes from 2 to 1 it also changes its sorting order, making it move around. This plural string is not actually visible to the user at all, as `advanced_inv_listitem.name` is used only for sorting and the AIM itself doesn't use plurals, so there's no reason to use a plural name for sorting. The fix is to always use a quantity of 1 for the sort name.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
This PR doesn't fix every instance of items changing list positions; it can also be caused by the internal order of the items. For example, if you move four batteries of differing charges to a location in this order: 500, 499, 500, 499, then the 500 charge battery will still change positions underneath the 499 as they are moved. Fixing that would take a lot more work, though, and I wanted to just fix one specific instance of the issue with this PR.

Items with charges use a different `advanced_inv_listitem.name` assignment that also sends stack count to `tname()`, so I was going to change that too, but on testing it seems like charge items never use the plural name anyway - a stack of nuts and bolts always uses the sort string of "nut and bolt" no matter how many charges are in the stack - so I left it alone.

This PR will actually be necessary for #66871, so cables can be sorted properly in the AIM. I didn't want to stuff this bugfix into an already-large PR, though.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Didn't see any weirdness when moving things around.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/6759778/4ba60869-08bd-45d9-ac9e-8fdcd0df6b0f)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
