### PR TITLE
Player activity related event

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -330,6 +330,28 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_character_finished_activity_event_test",
+    "eoc_type": "EVENT",
+    "required_event": "character_finished_activity",
+    "effect": [
+      { "set_string_var": { "context_val": "activity" }, "target_var": { "global_val": "key1" } },
+      { "math": [ "key2", "=", "_canceled" ] },
+      { "set_string_var": "activity finished", "target_var": { "global_val": "key3" } }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_character_starts_activity_event_test",
+    "eoc_type": "EVENT",
+    "required_event": "character_starts_activity",
+    "effect": [
+      { "set_string_var": { "context_val": "activity" }, "target_var": { "global_val": "key1" } },
+      { "math": [ "key2", "=", "_resume" ] },
+      { "set_string_var": "activity start", "target_var": { "global_val": "key3" } }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_increment_var_var",
     "//": "tests adding a variable, that's in another variable",
     "effect": [

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -85,6 +85,7 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | character_casts_spell |  | { "character", `character_id` }, { "spell", `spell_id` }, { "difficulty", `int` }, { "cost", `int` }, { "cast_time", `int` }, { "damage", `int` }, |
 | character_consumes_item |  | { "character", `character_id` }, { "itype", `itype_id` }, |
 | character_eats_item |  | { "character", `character_id` }, { "itype", `itype_id` }, |
+| character_finished_activity | Triggered when character finished or chanceled activity | { "character", `character_id` }, { "activity", `activity_id` }, { "canceled", `bool` } |
 | character_forgets_spell |  | { "character", `character_id` }, { "spell", `spell_id` } |
 | character_gains_effect |  | { "character", `character_id` }, { "effect", `efftype_id` }, |
 | character_gets_headshot |  | { "character", `character_id` } |
@@ -98,6 +99,7 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | character_ranged_attacks_character | |  { "attacker", `character_id` },  { "weapon", `itype_id` }, { "victim", `character_id` }, { "victim_name", `string` }, |
 | character_ranged_attacks_monster | | { "attacker", `character_id` }, { "weapon", `itype_id` }, { "victim_type", `mtype_id` }, |
 | character_smashes_tile | | { "character", `character_id` },  { "terrain", `ter_str_id` },  { "furniture", `furn_str_id` }, |
+| character_starts_activity | Triggered when character starts or resumes activity | { "character", `character_id` }, { "activity", `activity_id` }, { "resume", `bool` } |
 | character_takes_damage | | { "character", `character_id` }, { "damage", `int` }, |
 | character_triggers_trap | | { "character", `character_id` }, { "trap", `trap_str_id` }, |
 | character_wakes_up | | { "character", `character_id` }, |

--- a/src/activity_type.cpp
+++ b/src/activity_type.cpp
@@ -34,6 +34,12 @@ const activity_type &string_id<activity_type>::obj() const
     return found->second;
 }
 
+template<>
+bool string_id<activity_type>::is_valid() const
+{
+    return activity_type_all.find( *this ) != activity_type_all.end();
+}
+
 namespace io
 {
 template<>

--- a/src/cata_variant.cpp
+++ b/src/cata_variant.cpp
@@ -37,6 +37,7 @@ std::string enum_to_string<cata_variant_type>( cata_variant_type type )
         // *INDENT-OFF*
         case cata_variant_type::void_: return "void";
         case cata_variant_type::achievement_id: return "achievement_id";
+        case cata_variant_type::activity_id: return "activity_id";
         case cata_variant_type::addiction_id: return "addiction_id";
         case cata_variant_type::bionic_id: return "bionic_id";
         case cata_variant_type::body_part: return "body_part";

--- a/src/cata_variant.h
+++ b/src/cata_variant.h
@@ -36,6 +36,7 @@ enum class debug_menu_index : int;
 enum class cata_variant_type : int {
     void_, // Special type for empty variants
     achievement_id,
+    activity_id,
     addiction_id,
     bionic_id,
     body_part,
@@ -187,7 +188,7 @@ struct convert_enum {
 };
 
 // These are the specializations of convert for each value type.
-static_assert( static_cast<int>( cata_variant_type::num_types ) == 47,
+static_assert( static_cast<int>( cata_variant_type::num_types ) == 48,
                "This assert is a reminder to add conversion support for any new types to the "
                "below specializations" );
 
@@ -201,6 +202,9 @@ struct convert<cata_variant_type::void_> {
 
 template<>
 struct convert<cata_variant_type::achievement_id> : convert_string_id<achievement_id> {};
+
+template<>
+struct convert<cata_variant_type::activity_id> : convert_string_id<activity_id> {};
 
 template<>
 struct convert<cata_variant_type::addiction_id> : convert_string_id<addiction_id> {};

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -26,6 +26,7 @@ std::string enum_to_string<event_type>( event_type data )
         case event_type::character_consumes_item: return "character_consumes_item";
         case event_type::character_eats_item: return "character_eats_item";
         case event_type::character_casts_spell: return "character_casts_spell";
+        case event_type::character_finished_activity: return "character_finished_activity";
         case event_type::character_forgets_spell: return "character_forgets_spell";
         case event_type::character_gains_effect: return "character_gains_effect";
         case event_type::character_gets_headshot: return "character_gets_headshot";
@@ -43,6 +44,7 @@ std::string enum_to_string<event_type>( event_type data )
         case event_type::character_ranged_attacks_monster:
                                                  return "character_ranged_attacks_monster";
         case event_type::character_smashes_tile: return "character_smashes_tile";
+        case event_type::character_starts_activity: return "character_starts_activity";
         case event_type::character_takes_damage: return "character_takes_damage";
         case event_type::character_triggers_trap: return "character_triggers_trap";
         case event_type::character_wakes_up: return "character_wakes_up";
@@ -131,7 +133,7 @@ DEFINE_EVENT_HELPER_FIELDS( event_spec_empty )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character_item )
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 94,
+static_assert( static_cast<int>( event_type::num_event_types ) == 96,
                "This static_assert is a reminder to add a definition below when you add a new "
                "event_type.  If your event_spec specialization inherits from another struct for "
                "its fields definition then you probably don't need a definition here." );
@@ -148,6 +150,7 @@ DEFINE_EVENT_FIELDS( avatar_moves )
 DEFINE_EVENT_FIELDS( broken_bone )
 DEFINE_EVENT_FIELDS( broken_bone_mends )
 DEFINE_EVENT_FIELDS( buries_corpse )
+DEFINE_EVENT_FIELDS( character_finished_activity )
 DEFINE_EVENT_FIELDS( character_forgets_spell )
 DEFINE_EVENT_FIELDS( character_casts_spell )
 DEFINE_EVENT_FIELDS( character_gains_effect )
@@ -161,6 +164,7 @@ DEFINE_EVENT_FIELDS( character_melee_attacks_monster )
 DEFINE_EVENT_FIELDS( character_ranged_attacks_character )
 DEFINE_EVENT_FIELDS( character_ranged_attacks_monster )
 DEFINE_EVENT_FIELDS( character_smashes_tile )
+DEFINE_EVENT_FIELDS( character_starts_activity )
 DEFINE_EVENT_FIELDS( character_takes_damage )
 DEFINE_EVENT_FIELDS( character_triggers_trap )
 DEFINE_EVENT_FIELDS( character_wakes_up )

--- a/src/event.h
+++ b/src/event.h
@@ -41,6 +41,7 @@ enum class event_type : int {
     character_casts_spell,
     character_consumes_item,
     character_eats_item,
+    character_finished_activity,
     character_forgets_spell,
     character_gains_effect,
     character_gets_headshot,
@@ -54,6 +55,7 @@ enum class event_type : int {
     character_ranged_attacks_character,
     character_ranged_attacks_monster,
     character_smashes_tile,
+    character_starts_activity,
     character_takes_damage,
     character_triggers_trap,
     character_wakes_up,
@@ -179,7 +181,7 @@ struct event_spec_character_item {
     };
 };
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 94,
+static_assert( static_cast<int>( event_type::num_event_types ) == 96,
                "This static_assert is to remind you to add a specialization for your new "
                "event_type below" );
 
@@ -284,6 +286,16 @@ struct event_spec<event_type::character_casts_spell> {
             { "cast_time", cata_variant_type::int_},
             { "damage", cata_variant_type::int_}
 
+        }
+    };
+};
+
+template<>
+struct event_spec<event_type::character_finished_activity> {
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = { {
+            { "character", cata_variant_type::character_id },
+            { "activity", cata_variant_type::activity_id },
+            { "canceled", cata_variant_type::bool_ }
         }
     };
 };
@@ -405,6 +417,16 @@ struct event_spec<event_type::character_smashes_tile> {
             { "character", cata_variant_type::character_id },
             { "terrain", cata_variant_type::ter_str_id },
             { "furniture", cata_variant_type::furn_str_id },
+        }
+    };
+};
+
+template<>
+struct event_spec<event_type::character_starts_activity> {
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = { {
+            { "character", cata_variant_type::character_id },
+            { "activity", cata_variant_type::activity_id },
+            { "resume", cata_variant_type::bool_ }
         }
     };
 };

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -1097,6 +1097,7 @@ void memorial_logger::notify( const cata::event &e )
         case event_type::avatar_moves:
         case event_type::character_consumes_item:
         case event_type::character_eats_item:
+        case event_type::character_finished_activity:
         case event_type::character_gets_headshot:
         case event_type::character_heals_damage:
         case event_type::character_melee_attacks_character:
@@ -1104,6 +1105,7 @@ void memorial_logger::notify( const cata::event &e )
         case event_type::character_ranged_attacks_character:
         case event_type::character_ranged_attacks_monster:
         case event_type::character_smashes_tile:
+        case event_type::character_starts_activity:
         case event_type::character_takes_damage:
         case event_type::character_wakes_up:
         case event_type::character_wears_item:

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -12,6 +12,7 @@
 #include "construction.h"
 #include "effect_on_condition.h"
 #include "field.h"
+#include "event_bus.h"
 #include "game.h"
 #include "item.h"
 #include "itype.h"
@@ -214,6 +215,7 @@ void player_activity::start_or_resume( Character &who, bool resuming )
     }
     // last, as start function may have changed the type
     synchronize_type_with_actor();
+    get_event_bus().send<event_type::character_starts_activity>( who.getID(), type, resuming );
 }
 
 void player_activity::do_turn( Character &you )
@@ -366,6 +368,7 @@ void player_activity::do_turn( Character &you )
                 debugmsg( "Must use an activation eoc for player activities.  Otherwise, create a non-recurring effect_on_condition for this with its condition and effects, then have a recurring one queue it." );
             }
         }
+        get_event_bus().send<event_type::character_finished_activity>( you.getID(), type, false );
         if( actor ) {
             actor->finish( *this, you );
         } else {
@@ -391,6 +394,7 @@ void player_activity::canceled( Character &who )
     if( *this && actor ) {
         actor->canceled( *this, who );
     }
+    get_event_bus().send<event_type::character_finished_activity>( who.getID(), type, true );
 }
 
 float player_activity::exertion_level() const

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -12,6 +12,7 @@
 
 static const activity_id ACT_ADD_VARIABLE_COMPLETE( "ACT_ADD_VARIABLE_COMPLETE" );
 static const activity_id ACT_ADD_VARIABLE_DURING( "ACT_ADD_VARIABLE_DURING" );
+static const activity_id ACT_GENERIC_EOC( "ACT_GENERIC_EOC" );
 
 static const effect_on_condition_id
 effect_on_condition_EOC_TEST_TRANSFORM_LINE( "EOC_TEST_TRANSFORM_LINE" );
@@ -676,7 +677,7 @@ TEST_CASE( "EOC_run_with_test_queue", "[eoc]" )
     CHECK( d.get_value( "npctalk_var_key3" ).empty() );
 }
 
-TEST_CASE( "EOC_spell_event", "[eoc]" )
+TEST_CASE( "EOC_event_test", "[eoc]" )
 {
     clear_avatar();
     clear_map();
@@ -689,6 +690,7 @@ TEST_CASE( "EOC_spell_event", "[eoc]" )
     REQUIRE( globvars.get_global_value( "npctalk_var_key2" ).empty() );
     REQUIRE( globvars.get_global_value( "npctalk_var_key3" ).empty() );
 
+    // character_casts_spell
     spell temp_spell( spell_test_eoc_spell );
     temp_spell.set_level( get_avatar(), 5 );
     temp_spell.cast_all_effects( get_avatar(), tripoint() );
@@ -696,6 +698,21 @@ TEST_CASE( "EOC_spell_event", "[eoc]" )
     CHECK( globvars.get_global_value( "npctalk_var_key1" ) == "45" );
     CHECK( globvars.get_global_value( "npctalk_var_key2" ) == "100" );
     CHECK( globvars.get_global_value( "npctalk_var_key3" ) == "5" );
+
+    // character_starts_activity
+    globvars.clear_global_values();
+    get_avatar().assign_activity( ACT_GENERIC_EOC, 1 );
+
+    CHECK( globvars.get_global_value( "npctalk_var_key1" ) == "ACT_GENERIC_EOC" );
+    CHECK( globvars.get_global_value( "npctalk_var_key2" ) == "0" );
+    CHECK( globvars.get_global_value( "npctalk_var_key3" ) == "activity start" );
+
+    // character_finished_activity
+    get_avatar().cancel_activity();
+
+    CHECK( globvars.get_global_value( "npctalk_var_key1" ) == "ACT_GENERIC_EOC" );
+    CHECK( globvars.get_global_value( "npctalk_var_key2" ) == "1" );
+    CHECK( globvars.get_global_value( "npctalk_var_key3" ) == "activity finished" );
 }
 
 TEST_CASE( "EOC_spell_exp", "[eoc]" )


### PR DESCRIPTION
#### Summary
Features "Player activity related event"

#### Purpose of change
Makes using player activity more advanced from EOC. 

#### Describe the solution
Add following player activity related events.
`character_starts_activity`
`character_finished_activity`

#### Describe alternatives you've considered
Monitoring player activity from EOC every turn. It takes extra load and makes processing become unnecessarily complicated.

#### Testing
`character_starts_activity` and `character_finished_activity` events are captured from EOC.

#### Additional context
