### PR TITLE
Two new civilians: parent and hospitalized

### DIFF
--- a/data/json/mapgen/hospital.json
+++ b/data/json/mapgen/hospital.json
@@ -194,6 +194,7 @@
           { "item": "surgery", "chance": 60 }
         ]
       },
+      "monster": { "B": { "monster": "mon_civilian_icu", "chance": 10 } },
       "place_monster": [
         { "group": "GROUP_HOSPITAL", "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 15, 20 ] },
         { "group": "GROUP_HOSPITAL", "x": [ 25, 46 ], "y": [ 1, 22 ], "repeat": [ 15, 20 ] },

--- a/data/json/mapgen/nursing_home.json
+++ b/data/json/mapgen/nursing_home.json
@@ -192,6 +192,7 @@
           { "item": "magazines", "chance": 20, "repeat": [ 0, 1 ] }
         ]
       },
+      "monster": { "3": { "monster": "mon_civilian_icu", "chance": 10 }, "8": { "monster": "mon_civilian_icu", "chance": 10 } },
       "vendingmachines": { "?": { "item_group": "vending_drink", "lootable": true }, ",": { "item_group": "vending_food", "lootable": true } },
       "palettes": [ "nursing_home_palette" ],
       "place_monster": [
@@ -413,6 +414,7 @@
       },
       "vendingmachines": { "?": { "item_group": "vending_drink", "lootable": true }, ",": { "item_group": "vending_food", "lootable": true } },
       "palettes": [ "nursing_home_sh_palette" ],
+      "monster": { "3": { "monster": "mon_civilian_icu", "chance": 10 }, "8": { "monster": "mon_civilian_icu", "chance": 10 } },
       "place_monster": [
         { "group": "GROUP_NURSING_HOME", "x": [ 1, 20 ], "y": [ 6, 23 ], "repeat": [ 5, 8 ] },
         { "group": "GROUP_NURSING_HOME", "x": [ 1, 13 ], "y": [ 24, 39 ], "repeat": [ 4, 6 ] },

--- a/data/json/mapgen/urban_35_hospital.json
+++ b/data/json/mapgen/urban_35_hospital.json
@@ -110,6 +110,12 @@
           "failures": [ { "action": "destroy_blood" } ]
         }
       },
+      "monster": {
+        "^": { "monster": "mon_civilian_icu", "chance": 10 },
+        "ւ": { "monster": "mon_civilian_icu", "chance": 10 },
+        "Г": { "monster": "mon_civilian_icu", "chance": 10 },
+        "Я": { "monster": "mon_civilian_icu", "chance": 10 }
+      },
       "place_monsters": [
         { "monster": "GROUP_HOSPITAL", "x": [ 1, 22 ], "y": [ 5, 22 ], "density": 0.6 },
         { "monster": "GROUP_HOSPITAL", "x": [ 25, 31 ], "y": [ 5, 22 ], "density": 0.6 },
@@ -222,6 +228,12 @@
           "options": [ { "name": "Analyze blood", "action": "blood_anal" } ],
           "failures": [ { "action": "destroy_blood" } ]
         }
+      },
+      "monster": {
+        "^": { "monster": "mon_civilian_icu", "chance": 10 },
+        "ւ": { "monster": "mon_civilian_icu", "chance": 10 },
+        "Г": { "monster": "mon_civilian_icu", "chance": 10 },
+        "Я": { "monster": "mon_civilian_icu", "chance": 10 }
       },
       "place_monsters": [
         { "monster": "GROUP_HOSPITAL", "x": [ 1, 22 ], "y": [ 1, 22 ], "density": 0.6 },
@@ -338,6 +350,12 @@
           { "item": "hospital_medical_items", "chance": 20, "repeat": [ 1, 2 ] }
         ]
       },
+      "monster": {
+        "^": { "monster": "mon_civilian_icu", "chance": 10 },
+        "ւ": { "monster": "mon_civilian_icu", "chance": 10 },
+        "Г": { "monster": "mon_civilian_icu", "chance": 10 },
+        "Я": { "monster": "mon_civilian_icu", "chance": 10 }
+      },
       "place_monsters": [
         { "monster": "GROUP_ZOMBIE", "x": [ 1, 22 ], "y": [ 5, 22 ], "density": 0.5 },
         { "monster": "GROUP_ZOMBIE", "x": [ 25, 43 ], "y": [ 16, 22 ], "density": 0.5 },
@@ -440,6 +458,12 @@
           { "item": "cleaning", "chance": 20, "repeat": [ 1, 2 ] },
           { "item": "hospital_medical_items", "chance": 20, "repeat": [ 1, 2 ] }
         ]
+      },
+      "monster": {
+        "^": { "monster": "mon_civilian_icu", "chance": 10 },
+        "ւ": { "monster": "mon_civilian_icu", "chance": 10 },
+        "Г": { "monster": "mon_civilian_icu", "chance": 10 },
+        "Я": { "monster": "mon_civilian_icu", "chance": 10 }
       },
       "place_monsters": [
         { "monster": "GROUP_ZOMBIE", "x": [ 1, 22 ], "y": [ 5, 22 ], "density": 0.5 },
@@ -545,6 +569,12 @@
           { "item": "cleaning", "chance": 20, "repeat": [ 1, 2 ] },
           { "item": "hospital_medical_items", "chance": 20, "repeat": [ 1, 2 ] }
         ]
+      },
+      "monster": {
+        "^": { "monster": "mon_civilian_icu", "chance": 10 },
+        "ւ": { "monster": "mon_civilian_icu", "chance": 10 },
+        "Г": { "monster": "mon_civilian_icu", "chance": 10 },
+        "Я": { "monster": "mon_civilian_icu", "chance": 10 }
       },
       "place_monsters": [
         { "monster": "GROUP_ZOMBIE", "x": [ 1, 22 ], "y": [ 5, 22 ], "density": 0.5 },
@@ -662,6 +692,12 @@
           { "item": "cleaning", "chance": 20, "repeat": [ 1, 2 ] },
           { "item": "hospital_medical_items", "chance": 20, "repeat": [ 1, 2 ] }
         ]
+      },
+      "monster": {
+        "^": { "monster": "mon_civilian_icu", "chance": 10 },
+        "ւ": { "monster": "mon_civilian_icu", "chance": 10 },
+        "Г": { "monster": "mon_civilian_icu", "chance": 10 },
+        "Я": { "monster": "mon_civilian_icu", "chance": 10 }
       },
       "place_monsters": [
         { "monster": "GROUP_ZOMBIE", "x": [ 1, 22 ], "y": [ 5, 22 ], "density": 0.5 },

--- a/data/json/monsters/civilians.json
+++ b/data/json/monsters/civilians.json
@@ -145,7 +145,13 @@
       { "monster": "mon_civilian_stationary", "weight": 30, "cost_multiplier": 0, "ends": "3 days" },
       { "monster": "mon_civilian_zombiefighter", "weight": 16, "cost_multiplier": 0, "ends": "3 days" },
       { "monster": "mon_civilian_police", "weight": 4, "cost_multiplier": 3, "ends": "3 days" },
-      { "monster": "mon_civilian_parent", "weight": 20, "cost_multiplier": 0, "ends": "2 days", "pack_size": [ 1, 2 ] },
+      {
+        "monster": "mon_civilian_parent",
+        "weight": 20,
+        "cost_multiplier": 0,
+        "ends": "2 days",
+        "pack_size": [ 1, 2 ]
+      },
       { "monster": "mon_civilian_parent", "weight": 20, "cost_multiplier": 0, "starts": "2 days" },
       { "monster": "mon_civilian_panic", "weight": 40, "cost_multiplier": 0, "ends": "2 days", "pack_size": [ 1, 5 ] },
       {

--- a/data/json/monsters/civilians.json
+++ b/data/json/monsters/civilians.json
@@ -104,6 +104,28 @@
     "melee_damage": [ { "damage_type": "bash", "amount": 4 } ]
   },
   {
+    "id": "mon_civilian_icu",
+    "type": "MONSTER",
+    "name": { "str": "hospitalized human" },
+    "description": "This being is severely ill in some form or another, requiring intensive care that is not available anymore after the Cataclysm.  There is nothing you can do for them.",
+    "chat_topics": [ "TALK_CIVILIAN_ICU" ],
+    "speed": 0,
+    "//": "So they are not perpetually fleeing despite lying in a hospital bed",
+    "morale": 0,
+    "upgrades": { "into": "mon_zombie_crawler", "into_group": "GROUP_NULL" },
+    "delete": { "flags": [ "SEES", "HEARS" ] },
+    "copy-from": "mon_civilian_stationary"
+  },
+  {
+    "id": "mon_civilian_parent",
+    "type": "MONSTER",
+    "name": { "str": "gawky guardian" },
+    "special_attacks": [ [ "PARROT", 0 ] ],
+    "description": "Obsessed with finding their offspring, they scour the environment for certain death.",
+    "chat_topics": [ "TALK_CIVILIAN_PARENT" ],
+    "copy-from": "mon_civilian_panic"
+  },
+  {
     "name": "GROUP_CIVILIANS_UPGRADE",
     "type": "monstergroup",
     "monsters": [
@@ -123,7 +145,9 @@
       { "monster": "mon_civilian_stationary", "weight": 30, "cost_multiplier": 0, "ends": "3 days" },
       { "monster": "mon_civilian_zombiefighter", "weight": 16, "cost_multiplier": 0, "ends": "3 days" },
       { "monster": "mon_civilian_police", "weight": 4, "cost_multiplier": 3, "ends": "3 days" },
-      { "monster": "mon_civilian_panic", "weight": 60, "cost_multiplier": 0, "ends": "2 days", "pack_size": [ 1, 5 ] },
+      { "monster": "mon_civilian_parent", "weight": 20, "cost_multiplier": 0, "ends": "2 days", "pack_size": [ 1, 2 ] },
+      { "monster": "mon_civilian_parent", "weight": 20, "cost_multiplier": 0, "starts": "2 days" },
+      { "monster": "mon_civilian_panic", "weight": 40, "cost_multiplier": 0, "ends": "2 days", "pack_size": [ 1, 5 ] },
       {
         "monster": "mon_civilian_panic",
         "weight": 60,

--- a/data/json/npcs/civilians/civilians.json
+++ b/data/json/npcs/civilians/civilians.json
@@ -24,7 +24,7 @@
     ],
     "responses": [
       { "text": "Are you crazy?  Get out of here!", "topic": "TALK_CIVILIAN_FIGHTER_EVAC" },
-      { "text": "[Leave them to their futile fight]", "topic": "TALK_DONE" }
+      { "text": "[Leave them to their futile fight.]", "topic": "TALK_DONE" }
     ]
   },
   {
@@ -41,6 +41,33 @@
       "Don't worry, I'm with the police<punc>",
       "&The officer scans the area, looking for trouble.  They have a dangerous glint in their eyes."
     ],
-    "responses": [ { "text": "[Back away]", "topic": "TALK_DONE" } ]
+    "responses": [ { "text": "[Back away.]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CIVILIAN_ICU",
+    "dynamic_line": "&They are still breathing but unable to move and speak.  You are unsure if they are even fully conscious and yet shudder at the thought of being trapped inside your body.",
+    "responses": [
+      { "text": "[Leave them to their ultimate fate.]", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CIVILIAN_PARENT_EVAC",
+    "dynamic_line": "No!  I just know it, they are still alive!",
+    "responses": [ { "text": "[Let them keep on searching.]", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CIVILIAN_PARENT",
+    "dynamic_line": [
+      "Have you seen my child?",
+      "I am not leaving without my little one!",
+      "Where is my kid?"
+    ],
+    "responses": [
+      { "text": "Your child is likely dead by now and you should get to safety!", "topic": "TALK_CIVILIAN_PARENT_EVAC" },
+      { "text": "[Let them keep on searching.]", "topic": "TALK_DONE" }
+    ]
   }
 ]

--- a/data/json/npcs/civilians/civilians.json
+++ b/data/json/npcs/civilians/civilians.json
@@ -47,9 +47,7 @@
     "type": "talk_topic",
     "id": "TALK_CIVILIAN_ICU",
     "dynamic_line": "&They are still breathing but unable to move and speak.  You are unsure if they are even fully conscious and yet shudder at the thought of being trapped inside your body.",
-    "responses": [
-      { "text": "[Leave them to their ultimate fate.]", "topic": "TALK_DONE" }
-    ]
+    "responses": [ { "text": "[Leave them to their ultimate fate.]", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
@@ -60,11 +58,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_CIVILIAN_PARENT",
-    "dynamic_line": [
-      "Have you seen my child?",
-      "I am not leaving without my little one!",
-      "Where is my kid?"
-    ],
+    "dynamic_line": [ "Have you seen my child?", "I am not leaving without my little one!", "Where is my kid?" ],
     "responses": [
       { "text": "Your child is likely dead by now and you should get to safety!", "topic": "TALK_CIVILIAN_PARENT_EVAC" },
       { "text": "[Let them keep on searching.]", "topic": "TALK_DONE" }

--- a/data/json/speech.json
+++ b/data/json/speech.json
@@ -2784,5 +2784,29 @@
     "speaker": [ "mon_civilian_zombiefighter" ],
     "sound": "an unrestrained warcry.",
     "volume": 35
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_civilian_parent" ],
+    "sound": "\"Honey, where are you?\"",
+    "volume": 25
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_civilian_parent" ],
+    "sound": "\"Honey, you need to hurry!\"",
+    "volume": 25
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_civilian_parent" ],
+    "sound": "\"I am not leaving without you!\"",
+    "volume": 25
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_civilian_parent" ],
+    "sound": "someone calling for their child.",
+    "volume": 25
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Two new civilians: Parent and hospitalized varieties"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Flavor and making it seem a bit more real.
We already have the scenario of being left behind and there are plenty of people who were hurt due to or during the Cataclysm, some severely enough to need intensive care.

And people looking for left behind loved ones are also a scenario I consider quite plausible, thus the new parent civilian.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

- Hospitalized variant:
  - Blind, deaf and immobile, will always upgrade to a crawling zombie.
  - Can only be found in hospitals and nursing homes for obvious reasons.
- Parent variant:
  - Standard civilian, basically a very slightly modified panicked person.
  - Why would people not get to safety? Because they are not leaving without their loved ones.
  - I kept the dialogue intentionally "vague" because there is no way to store misc per-monster variables and they would otherwise randomly switch between e.g having a son and a daughter.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Not using these silly alliterations.

There is a tiny issue I found: Some of the hospital beds are actual 2x1 `f_bed` and there is a small possibility that two of them may spawn on the same bed. However, this is not worth the effort to fix imo.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Applied changes locally. Also, thank you RNG for producing this dark piece:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/59517351/3a75781f-db72-4ee4-9221-f0de6f3f930a)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
