### PR TITLE
math: minor cleanup for inline bool ops

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -234,6 +234,12 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_math_test_inline_condition",
+    "condition": { "math": [ "u_val('stamina') == 500" ] },
+    "effect": [ { "math": [ "_noop", "=", "0" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_math_test_greater_increment",
     "condition": { "math": [ "math_test", ">", "0" ] },
     "effect": [ { "math": [ "math_test", "+=", "1" ] } ],

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -1392,7 +1392,7 @@ If `operator` is `=`, `+=`, `-=`, `*=`, `/=`, or `%=` the operation is an assign
 `lhs` must be an [assignment target](#assignment-target). `rhs` is evaluated and stored in the assignment target from `lhs`.
 
 
-If `operator` is `==`, `>=`, `<=`, `>`, or `<`, the operation is a comparison:
+If `operator` is `==`, `!=`, `>=`, `<=`, `>`, or `<`, the operation is a comparison:
 ```JSON
 "condition": { "math": [ "u_val('stamina') * 2", ">=", "5000 + rand( 300 )" ] },
 ```
@@ -1438,7 +1438,7 @@ Common math functions are supported:
 Function composition is also supported, for example `sin( rng(0, max( 0.5, u_sin_var ) ) )`
 
 #### Ternary and inline boolean operators
-Inline comparison operators evaluate as 1 for true and 0 for false.
+Inline [comparison operators](#three-strings--assignment-or-comparison) evaluate as 1 for true and 0 for false.
 
 Ternary operators take the form `condition ? true_value : false_value`. They are right-associative so a chained ternary like `a ? b : c ? d :e` is parsed as `a ? b : (c ? d : e)`.
 

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -2886,7 +2886,7 @@ void eoc_math::_validate_type( JsonArray const &objects, type_t type_ ) const
         if( action == oper::assign ) {
             objects.throw_error(
                 R"(Assignment operator "=" can't be used in a conditional statement.  Did you mean to use "=="? )" );
-        } else {
+        } else if( action != oper::ret ) {
             objects.throw_error( "Only comparison operators can be used in conditional statements" );
         }
     } else if( type_ == type_t::ret && action > oper::ret ) {

--- a/src/math_parser_impl.h
+++ b/src/math_parser_impl.h
@@ -260,6 +260,11 @@ inline double neq( double l, double r )
     return static_cast<double>( l != r );
 }
 
+inline double b_neg( double /* zero */, double r )
+{
+    return static_cast<double>( float_equals( r, 0 ) );
+}
+
 } // namespace math_opers
 
 constexpr std::array<binary_op, 15> binary_ops{
@@ -279,9 +284,10 @@ constexpr std::array<binary_op, 15> binary_ops{
     binary_op{ "^", 4, binary_op::associativity::right, math_opers::math_pow },
 };
 
-constexpr std::array<unary_op, 2> prefix_unary_ops{
+constexpr std::array<unary_op, 3> prefix_unary_ops{
     unary_op{ "+", math_opers::pos },
     unary_op{ "-", math_opers::neg },
+    unary_op{ "!", math_opers::b_neg },
 };
 
 #endif // CATA_SRC_MATH_PARSER_IMPL_H

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -45,6 +45,8 @@ effect_on_condition_EOC_math_test_equals_assign( "EOC_math_test_equals_assign" )
 static const effect_on_condition_id
 effect_on_condition_EOC_math_test_greater_increment( "EOC_math_test_greater_increment" );
 static const effect_on_condition_id
+effect_on_condition_EOC_math_test_inline_condition( "EOC_math_test_inline_condition" );
+static const effect_on_condition_id
 effect_on_condition_EOC_math_var( "EOC_math_var" );
 static const effect_on_condition_id
 effect_on_condition_EOC_math_weighted_list( "EOC_math_weighted_list" );
@@ -170,8 +172,10 @@ TEST_CASE( "EOC_math_integration", "[eoc][math_parser]" )
     CHECK( effect_on_condition_EOC_math_var->test_condition( d ) );
 
     CHECK_FALSE( effect_on_condition_EOC_math_test_equals_assign->test_condition( d ) );
+    CHECK_FALSE( effect_on_condition_EOC_math_test_inline_condition->test_condition( d ) );
     get_avatar().set_stamina( 500 );
     CHECK( effect_on_condition_EOC_math_test_equals_assign->test_condition( d ) );
+    CHECK( effect_on_condition_EOC_math_test_inline_condition->test_condition( d ) );
     effect_on_condition_EOC_math_test_equals_assign->activate( d );
     CHECK( std::stod( globvars.get_global_value( "npctalk_var_math_test" ) ) == Approx( 9 ) );
     effect_on_condition_EOC_math_switch_math->activate( d );

--- a/tests/math_parser_test.cpp
+++ b/tests/math_parser_test.cpp
@@ -61,6 +61,10 @@ TEST_CASE( "math_parser_parsing", "[math_parser]" )
     CHECK( testexp.eval( d ) == Approx( 5 ) );
     CHECK( testexp.parse( "2+-3" ) ); // equivalent to 2+(-3)
     CHECK( testexp.eval( d ) == Approx( -1 ) );
+    CHECK( testexp.parse( "!1" ) );
+    CHECK( testexp.eval( d ) == Approx( 0 ) );
+    CHECK( testexp.parse( "!(1 == 0)" ) );
+    CHECK( testexp.eval( d ) == Approx( 1 ) );
 
     //ternary
     CHECK( testexp.parse( "0?1:2" ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I added inline comparison operators in #66180 but forgot to handle the unary `!` so it's treated as variable
I also didn't consider that inline boolean ops can be used for EOC conditions

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add the unary negation operator `!`.
Allow return expressions in EOC conditions. So
```JSON
    "condition": { "math": [ "u_val('stamina') == 500" ] },
```
is now accepted and equivalent to
```JSON
   "condition": { "math": [ "u_val('stamina')", "==", "500" ] },
```


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Updated test unit

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
