### PR TITLE
Make makeshift bodypillow a variant

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -3019,18 +3019,15 @@
         "name": { "str": "VTuber body pillow" },
         "description": "A big, body-sized pillow with a print of a popular anime VTuber on the front and their scantily-clad version on the back.",
         "weight": 1
+      },
+      {
+        "id": "bodypillow_makeshift",
+        "name": { "str": "makeshift body pillow" },
+        "description": "A big, body-sized pillow.  Someone drew a vaguely humanoid figure on it.  Its heartwarming smile fills you with joy.",
+        "weight": 0
       }
     ],
     "category": "other"
-  },
-  {
-    "type": "GENERIC",
-    "id": "bodypillow_makeshift",
-    "copy-from": "bodypillow",
-    "name": { "str": "makeshift body pillow" },
-    "description": "A big, body-sized pillow.  Someone drew a vaguely humanoid figure on it.  Its heartwarming smile fills you with joy.",
-    "price": 100,
-    "price_postapoc": 50
   },
   {
     "type": "GENERIC",

--- a/data/json/obsoletion/migration_items.json
+++ b/data/json/obsoletion/migration_items.json
@@ -199,5 +199,11 @@
     "id": "survivor_light_on",
     "type": "MIGRATION",
     "replace": "wearable_light_on"
+  },
+  {
+    "id": "bodypillow_makeshift",
+    "type": "MIGRATION",
+    "replace": "bodypillow",
+    "variant": "bodypillow_makeshift"
   }
 ]

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -69,7 +69,8 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "bodypillow_makeshift",
+    "result": "bodypillow",
+    "variant": "bodypillow_makeshift",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_OTHER",
     "skill_used": "tailor",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I used the makeshift bodypillow as an argument in #67191, and #67209 has made it possible. So now we're gonna have a use case of variant crafting in the basegame as opposed to only the test mods.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Turns the makeshift bodypillow into a variant via migration (has 0 weight so it shouldn't spawn in the world) and audits the recipe to use the new variant crafting system
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
