### PR TITLE
Spawn quivers in the hunting supply stores

### DIFF
--- a/data/json/itemgroups/main.json
+++ b/data/json/itemgroups/main.json
@@ -198,4 +198,13 @@
       { "item": "bolt_cf", "prob": 100 }
     ]
   }
+  {
+    "type": "item_group",
+    "id": "archery_quivers",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "quiver", "prob": 100 },
+      { "item": "quiver_large", "prob": 50 }
+    ]
+  }
 ]

--- a/data/json/itemgroups/main.json
+++ b/data/json/itemgroups/main.json
@@ -202,10 +202,6 @@
     "type": "item_group",
     "id": "archery_quivers",
     "subtype": "distribution",
-    "entries": [
-      { "item": "quiver", "prob": 100 },
-      { "item": "quiver_large", "prob": 50 },
-      { "item": "nylon_quiver", "prob": 10 }
-    ]
+    "entries": [ { "item": "quiver", "prob": 100 }, { "item": "quiver_large", "prob": 50 }, { "item": "nylon_quiver", "prob": 10 } ]
   }
 ]

--- a/data/json/itemgroups/main.json
+++ b/data/json/itemgroups/main.json
@@ -202,9 +202,6 @@
     "type": "item_group",
     "id": "archery_quivers",
     "subtype": "distribution",
-    "entries": [
-      { "item": "quiver", "prob": 100 },
-      { "item": "quiver_large", "prob": 50 }
-    ]
+    "entries": [ { "item": "quiver", "prob": 100 }, { "item": "quiver_large", "prob": 50 } ]
   }
 ]

--- a/data/json/itemgroups/main.json
+++ b/data/json/itemgroups/main.json
@@ -197,7 +197,7 @@
       { "item": "bolt_wood_bodkin", "prob": 50 },
       { "item": "bolt_cf", "prob": 100 }
     ]
-  }
+  },
   {
     "type": "item_group",
     "id": "archery_quivers",

--- a/data/json/itemgroups/main.json
+++ b/data/json/itemgroups/main.json
@@ -202,6 +202,10 @@
     "type": "item_group",
     "id": "archery_quivers",
     "subtype": "distribution",
-    "entries": [ { "item": "quiver", "prob": 100 }, { "item": "quiver_large", "prob": 50 } ]
+    "entries": [
+      { "item": "quiver", "prob": 100 },
+      { "item": "quiver_large", "prob": 50 },
+      { "item": "nylon_quiver", "prob": 10 }
+    ]
   }
 ]

--- a/data/json/mapgen/store/s_hunting.json
+++ b/data/json/mapgen/store/s_hunting.json
@@ -41,6 +41,7 @@
         { "group": "lodge_archery_ammo", "x": 2, "y": 16, "chance": 80, "repeat": [ 4, 6 ] },
         { "group": "archery_mods", "x": 2, "y": 17, "chance": 70, "repeat": [ 3, 4 ] },
         { "group": "gun_cases", "x": [ 3, 9 ], "y": 6, "chance": 80, "repeat": [ 6, 7 ] },
+        { "group": "archery_quivers", "x": [ 3, 9 ], "y": 6, "chance": 80, "repeat": [ 6, 7 ] },
         { "group": "clothing_hunting", "x": [ 3, 9 ], "y": [ 8, 9 ], "chance": 80, "repeat": [ 12, 14 ] },
         { "group": "tools_hunting", "x": [ 14, 20 ], "y": 6, "chance": 70, "repeat": [ 6, 7 ] },
         { "group": "tools_hunting", "x": [ 14, 20 ], "y": [ 8, 9 ], "chance": 70, "repeat": [ 12, 14 ] },

--- a/data/json/mapgen/store/s_hunting.json
+++ b/data/json/mapgen/store/s_hunting.json
@@ -41,7 +41,7 @@
         { "group": "lodge_archery_ammo", "x": 2, "y": 16, "chance": 80, "repeat": [ 4, 6 ] },
         { "group": "archery_mods", "x": 2, "y": 17, "chance": 70, "repeat": [ 3, 4 ] },
         { "group": "gun_cases", "x": [ 3, 9 ], "y": 6, "chance": 80, "repeat": [ 6, 7 ] },
-        { "group": "archery_quivers", "x": [ 3, 9 ], "y": 6, "chance": 80, "repeat": [ 6, 7 ] },
+        { "group": "archery_quivers", "x": [ 3, 9 ], "y": 6, "chance": 80 },
         { "group": "clothing_hunting", "x": [ 3, 9 ], "y": [ 8, 9 ], "chance": 80, "repeat": [ 12, 14 ] },
         { "group": "tools_hunting", "x": [ 14, 20 ], "y": 6, "chance": 70, "repeat": [ 6, 7 ] },
         { "group": "tools_hunting", "x": [ 14, 20 ], "y": [ 8, 9 ], "chance": 70, "repeat": [ 12, 14 ] },


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Our hunting supply stores are missing out on a business opportunity: we are selling bows and arrows, but we are not providing our customers with a convenient means of carrying arrows.

#### Describe the solution

Add quivers and large quivers to the store inventory.

#### Describe alternatives you've considered

We could employ a more competent store manager.

#### Testing

1. Game loads w/o errors
2. A hunting supply store has quivers in stock

<!-- 

#### Additional context

Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
