### PR TITLE
Fix and improve NPC randomizer

### DIFF
--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -150,22 +150,39 @@ Format:
   "mission": 7,
   "chat": "TALK_EXAMPLE",
   "faction": "no_faction",
-  "death_eocs": [ "EOC_DEATH_NPC_TEST" ]
+  "death_eocs": [ "EOC_DEATH_NPC_TEST" ],
+  "age": 30,
+  "height": 180,
+  "str": 7,
+  "dex": 8,
+  "int": 9,
+  "per": 10,
+  "personality": {
+    "aggression": -1,
+    "bravery":  2,
+    "collector":  -3,
+    "altruism":  4
+  }
 }
 ```
-This is the JSON that creates the NPC ID that is used to spawn an NPC in "mapgen" (map generation).
+This is the JSON that creates the NPC ID that is used to spawn an NPC in "mapgen" (map generation). If optional fields are omitted, values are defined randomly.
 
-Attitude is based on the enum in `npc.h`. The important ones are `0=NPCATT_NULL`, `1=NPCATT_TALK`, `3=NPCATT_FOLLOW`, `10=NPCATT_KILL`, and `11=NPCATT_FLEE`.
-
-Mission is based on the enum in `npc.h`.  The important ones are `0=NPC_MISSION_NULL`, `3=NPC_MISSION_SHOPKEEP`, `7=NPC_MISSION_GUARD`, and `8=NPC_MISSION_GUARD_PATROL`.
-
-Chat is covered in the dialogue examples below.
-
-Faction determines what faction, if any, the NPC belongs to.  Some examples are the Free Traders, Old Guard, Marloss Evangelists, and Hell's raiders but could include a brand new faction you create!
-
-`death_eocs` are string `effect_on_condition` ids and/or inline `effect_on_condition`s (see [EFFECT_ON_CONDITION.md](EFFECT_ON_CONDITION.md)).  When the npc dies all of these `eoc`s are run with the victim as u and the killer as npc.
-
-`age` and `height` are optional fields that can be used to define the age and height (in cm) of the NPC respectively.
+| field | Description
+|---    | ---
+| `name_unique` | Set name of NPC.
+| `name_suffix` | Set name suffix of NPC.
+| `attitude`    | _(mandatory)_ Based on the enum in `npc.h`. The important ones are `0=NPCATT_NULL`, `1=NPCATT_TALK`, `3=NPCATT_FOLLOW`, `10=NPCATT_KILL`, and `11=NPCATT_FLEE`.
+| `mission`     | _(mandatory)_ Based on the enum in `npc.h`. The important ones are `0=NPC_MISSION_NULL`, `3=NPC_MISSION_SHOPKEEP`, `7=NPC_MISSION_GUARD`, and `8=NPC_MISSION_GUARD_PATROL`.
+| `chat`        | _(mandatory)_ Covered in the dialogue examples below.
+| `faction`     | Set faction NPC belongs to (see [FACTIONS.md](FACTIONS.md)).
+| `death_eocs`  | String `effect_on_condition` ids and/or inline `effect_on_condition`s (see [EFFECT_ON_CONDITION.md](EFFECT_ON_CONDITION.md)). When the npc dies all of these `eoc`s are run with the victim as u and the killer as npc.
+| `age`         | Set age of NPC.
+| `height`      | Set height of NPC. (in cm)
+| `str`         | Set strength of NPC.
+| `dex`         | Set dexterity of NPC.
+| `int`         | Set intelligence of NPC.
+| `per`         | Set perception of NPC.
+| `personality` | Set personality of NPC. For example, positive value of `aggression` means NPC is aggressive, negative value means NPC is defensive.
 
 ---
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -578,10 +578,11 @@ void npc_template::load( const JsonObject &jsobj )
     jsobj.read( "per", tem.per );
     if( jsobj.has_object( "personality" ) ) {
         const JsonObject personality = jsobj.get_object( "personality" );
-        personality.read( "aggression", tem.personality.aggression );
-        personality.read( "bravery", tem.personality.bravery );
-        personality.read( "collector", tem.personality.collector );
-        personality.read( "altruism", tem.personality.altruism );
+        tem.personality = npc_personality();
+        tem.personality->aggression = personality.get_int( "aggression" );
+        tem.personality->bravery = personality.get_int( "bravery" );
+        tem.personality->collector = personality.get_int( "collector" );
+        tem.personality->altruism = personality.get_int( "altruism" );
     }
     for( JsonValue jv : jsobj.get_array( "death_eocs" ) ) {
         guy.death_eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, "" ) );
@@ -781,35 +782,29 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
 
     if( tem_id.is_valid() ) {
         const npc_template &tem = tem_id.obj();
-        if( tem.personality.aggression != npc_template::random ) {
-            personality.aggression = tem.personality.aggression;
+        if( tem.personality.has_value() ) {
+            personality.aggression = tem.personality->aggression;
+            personality.bravery = tem.personality->bravery;
+            personality.collector = tem.personality->collector;
+            personality.altruism = tem.personality->altruism;
         }
-        if( tem.personality.bravery != npc_template::random ) {
-            personality.bravery = tem.personality.bravery;
+        if( tem.str.has_value() ) {
+            str_max = tem.str.value();
         }
-        if( tem.personality.collector != npc_template::random ) {
-            personality.collector = tem.personality.collector;
+        if( tem.dex.has_value() ) {
+            dex_max = tem.dex.value();
         }
-        if( tem.personality.altruism != npc_template::random ) {
-            personality.altruism = tem.personality.altruism;
+        if( tem.intl.has_value() ) {
+            int_max = tem.intl.value();
         }
-        if( tem.str != npc_template::random ) {
-            str_max = tem.str;
+        if( tem.per.has_value() ) {
+            per_max = tem.per.value();
         }
-        if( tem.dex != npc_template::random ) {
-            dex_max = tem.dex;
+        if( tem.height.has_value() ) {
+            set_base_height( tem.height.value() );
         }
-        if( tem.intl != npc_template::random ) {
-            int_max = tem.intl;
-        }
-        if( tem.per != npc_template::random ) {
-            per_max = tem.per;
-        }
-        if( tem.height != npc_template::random ) {
-            set_base_height( tem.height );
-        }
-        if( tem.age != npc_template::random ) {
-            set_base_age( tem.age );
+        if( tem.age.has_value() ) {
+            set_base_age( tem.age.value() );
         }
     }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -570,11 +570,18 @@ void npc_template::load( const JsonObject &jsobj )
     if( jsobj.has_string( "snip_wear" ) ) {
         guy.chatbin.snip_wear = jsobj.get_string( "snip_wear" );
     }
-    if( jsobj.has_int( "age" ) ) {
-        guy.set_base_age( jsobj.get_int( "age" ) );
-    }
-    if( jsobj.has_int( "height" ) ) {
-        guy.set_base_height( jsobj.get_int( "height" ) );
+    jsobj.read( "age", tem.age );
+    jsobj.read( "height", tem.height );
+    jsobj.read( "str", tem.str );
+    jsobj.read( "dex", tem.dex );
+    jsobj.read( "int", tem.intl );
+    jsobj.read( "per", tem.per );
+    if( jsobj.has_object( "personality" ) ) {
+        const JsonObject personality = jsobj.get_object( "personality" );
+        personality.read( "aggression", tem.personality.aggression );
+        personality.read( "bravery", tem.personality.bravery );
+        personality.read( "collector", tem.personality.collector );
+        personality.read( "altruism", tem.personality.altruism );
     }
     for( JsonValue jv : jsobj.get_array( "death_eocs" ) ) {
         guy.death_eocs.emplace_back( effect_on_conditions::load_inline_eoc( jv, "" ) );
@@ -640,7 +647,7 @@ void npc::load_npc_template( const string_id<npc_template> &ident )
 
     idz = tguy.idz;
     myclass = npc_class_id( tguy.myclass );
-    randomize( myclass );
+    randomize( myclass, ident );
     if( tem.gender_override != npc_template::gender::random ) {
         male = tem.gender_override == npc_template::gender::male;
     }
@@ -749,7 +756,7 @@ void npc::load_npc_template( const string_id<npc_template> &ident )
 
 npc::~npc() = default;
 
-void npc::randomize( const npc_class_id &type )
+void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
 {
     if( !getID().is_valid() ) {
         setID( g->assign_npc_id() );
@@ -765,6 +772,46 @@ void npc::randomize( const npc_class_id &type )
     mission = NPC_MISSION_NULL;
     male = one_in( 2 );
     pick_name();
+    randomize_height();
+    set_base_age( rng( 18, 55 ) );
+    str_max = dice( 4, 3 );
+    dex_max = dice( 4, 3 );
+    int_max = dice( 4, 3 );
+    per_max = dice( 4, 3 );
+
+    if( tem_id.is_valid() ) {
+        const npc_template &tem = tem_id.obj();
+        if( tem.personality.aggression != npc_template::random ) {
+            personality.aggression = tem.personality.aggression;
+        }
+        if( tem.personality.bravery != npc_template::random ) {
+            personality.bravery = tem.personality.bravery;
+        }
+        if( tem.personality.collector != npc_template::random ) {
+            personality.collector = tem.personality.collector;
+        }
+        if( tem.personality.altruism != npc_template::random ) {
+            personality.altruism = tem.personality.altruism;
+        }
+        if( tem.str != npc_template::random ) {
+            str_max = tem.str;
+        }
+        if( tem.dex != npc_template::random ) {
+            dex_max = tem.dex;
+        }
+        if( tem.intl != npc_template::random ) {
+            int_max = tem.intl;
+        }
+        if( tem.per != npc_template::random ) {
+            per_max = tem.per;
+        }
+        if( tem.height != npc_template::random ) {
+            set_base_height( tem.height );
+        }
+        if( tem.age != npc_template::random ) {
+            set_base_age( tem.age );
+        }
+    }
 
     if( !type.is_valid() ) {
         debugmsg( "Invalid NPC class %s", type.c_str() );
@@ -776,10 +823,10 @@ void npc::randomize( const npc_class_id &type )
     }
 
     const npc_class &the_class = myclass.obj();
-    str_max = the_class.roll_strength();
-    dex_max = the_class.roll_dexterity();
-    int_max = the_class.roll_intelligence();
-    per_max = the_class.roll_perception();
+    str_max += the_class.roll_strength();
+    dex_max += the_class.roll_dexterity();
+    int_max += the_class.roll_intelligence();
+    per_max += the_class.roll_perception();
 
     for( Skill &skill : Skill::skills ) {
         int level = myclass->roll_skill( skill.ident() );
@@ -841,7 +888,6 @@ void npc::randomize( const npc_class_id &type )
 
     set_body();
     recalc_hp();
-    randomize_height();
     int days_since_cata = to_days<int>( calendar::turn - calendar::start_of_cataclysm );
     double time_influence = days_since_cata >= 180 ? 3.0 : 6.0 - 3.0 * days_since_cata / 180.0;
     double weight_percent = std::clamp<double>( chi_squared_roll( time_influence ) / 5.0,
@@ -888,8 +934,6 @@ void npc::randomize( const npc_class_id &type )
             sp.gain_level( *this );
         }
     }
-
-    set_base_age( rng( 18, 55 ) );
 
     // Add eocs
     effect_on_conditions::load_new_character( *this );

--- a/src/npc.h
+++ b/src/npc.h
@@ -781,7 +781,8 @@ class npc : public Character
         void npc_dismount();
         weak_ptr_fast<monster> chosen_mount;
         // Generating our stats, etc.
-        void randomize( const npc_class_id &type = npc_class_id::NULL_ID() );
+        void randomize( const npc_class_id &type = npc_class_id::NULL_ID(),
+                        const npc_template_id &tem_id = npc_template_id::NULL_ID() );
         void randomize_from_faction( faction *fac );
         void apply_ownership_to_inv();
         void learn_ma_styles_from_traits();
@@ -1438,7 +1439,12 @@ class standard_npc : public npc
 class npc_template
 {
     public:
-        npc_template() = default;
+        npc_template() {
+            personality.aggression = random;
+            personality.bravery = random;
+            personality.collector = random;
+            personality.altruism = random;
+        }
 
         npc guy;
         translation name_unique;
@@ -1449,6 +1455,14 @@ class npc_template
             female
         };
         gender gender_override = gender::random;
+        static constexpr int random = INT_MIN;
+        int age = random;
+        int height = random;
+        int str = random;
+        int dex = random;
+        int intl = random;
+        int per = random;
+        npc_personality personality;
 
         static void load( const JsonObject &jsobj );
         static void reset();

--- a/src/npc.h
+++ b/src/npc.h
@@ -1455,7 +1455,7 @@ class npc_template
             female
         };
         gender gender_override = gender::random;
-        static constexpr int random = INT_MIN;
+        static constexpr int8_t random = _I8_MIN;
         int age = random;
         int height = random;
         int str = random;

--- a/src/npc.h
+++ b/src/npc.h
@@ -1439,12 +1439,7 @@ class standard_npc : public npc
 class npc_template
 {
     public:
-        npc_template() {
-            personality.aggression = random;
-            personality.bravery = random;
-            personality.collector = random;
-            personality.altruism = random;
-        }
+        npc_template() = default;
 
         npc guy;
         translation name_unique;
@@ -1455,14 +1450,13 @@ class npc_template
             female
         };
         gender gender_override = gender::random;
-        static constexpr int8_t random = _I8_MIN;
-        int age = random;
-        int height = random;
-        int str = random;
-        int dex = random;
-        int intl = random;
-        int per = random;
-        npc_personality personality;
+        std::optional<int> age;
+        std::optional<int> height;
+        std::optional<int> str;
+        std::optional<int> dex;
+        std::optional<int> intl;
+        std::optional<int> per;
+        std::optional<npc_personality> personality;
 
         static void load( const JsonObject &jsobj );
         static void reset();

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -450,22 +450,22 @@ const time_duration &npc_class::get_shop_restock_interval() const
 
 int npc_class::roll_strength() const
 {
-    return dice( 4, 3 ) + bonus_str.roll();
+    return bonus_str.roll();
 }
 
 int npc_class::roll_dexterity() const
 {
-    return dice( 4, 3 ) + bonus_dex.roll();
+    return bonus_dex.roll();
 }
 
 int npc_class::roll_intelligence() const
 {
-    return dice( 4, 3 ) + bonus_int.roll();
+    return bonus_int.roll();
 }
 
 int npc_class::roll_perception() const
 {
-    return dice( 4, 3 ) + bonus_per.roll();
+    return bonus_per.roll();
 }
 
 int npc_class::roll_skill( const skill_id &sid ) const


### PR DESCRIPTION
#### Summary
Bugfixes "Fix and improve NPC randomizer"

#### Purpose of change
`age` and `height` fields in `npc_template` is not working. NPC hight and age is now randomized.

#### Describe the solution
Value set in `npc_template` overrides randomized value. Additionally, add some fields to override more value.

#### Describe alternatives you've considered

#### Testing
NPC these fields set is spawned with expected value. NPC do not has these fields  spawned with random value as is.

#### Additional context
