### PR TITLE
Balance steel flak helmets

### DIFF
--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -267,13 +267,12 @@
     "//": "assuming this is an antique and not a cheap replica",
     "price_postapoc": 1200,
     "to_hit": -1,
-    "material": [ "hc_steel", "cotton" ],
+    "material": [ "hc_steel", "plastic", "leather" ],
     "repairs_with": [ "hc_steel" ],
     "symbol": "[",
     "looks_like": "helmet_army",
     "color": "dark_gray",
     "warmth": 10,
-    "material_thickness": 1.12,
     "flags": [ "VARSIZE", "STURDY", "PADDED" ],
     "armor": [
       {

--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -277,6 +277,11 @@
     "flags": [ "VARSIZE", "STURDY", "PADDED" ],
     "armor": [
       {
+        "material": [
+          { "type": "hc_steel", "covered_by_mat": 100, "thickness": 1.12 },
+          { "type": "plastic", "covered_by_mat": 100, "thickness": 3 },
+          { "type": "leather", "covered_by_mat": 10, "thickness": 1.0 }
+        ],
         "encumbrance_modifiers": [ "NONE" ],
         "coverage": 100,
         "covers": [ "head" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Balance steel flak helmets"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

As it is currently, the M1 and SSh-68 helmets provide very poor protection (~5 in all categories) that is outmoded by many other pieces of headgear, even ones that are not combat-oriented and/or have no steel in their construction.  Yes, these helmets are outdated but they were not so thoroughly useless when they were issued.

Part of the issue is how the material thickness was considered.  The original PR got the correct steel shell thickness of 1.12 millimeters, but this was divided between both leather and high carbon steel, leading to a thickness in-game of 0.56mm.

Another issue is that the M1 helmet, from my reading, actually consists of two pieces: the outer steel shell, and an inner liner-helmet, similar in construction to a contemporary hard hat.  The construction used in this liner changed over the years, but it generally comes down to a now-obsolete resin or plastic, pressure-formed into helmet shape.  This helps with the concussive force that might be applied to a military helmet and adds somewhat to the protection it can provide.


#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Removed the original material thickness value.

Added new material/thickness values based on the new coverage system:

- High carbon steel, 1.12mm, 100% (Steel shell)
- Plastic, 3mm, 100% (Liner helmet)
- Leather, 1mm, 10% (Sweatband, suspension webbing, chinstrap, etc.  Might give a small edge if the helmet happened to be struck directly over these pieces.)

Additionally, the item materials were updated.  It can still only be repaired with high carbon steel.

These changes put this helmet group where it probably aught to be: Better than a lot of improvised or low-mid handcrafted options, especially for cut and bash, but not as good as modern army helmets or endgame crafts.  The ballistic protection may stop a low caliber round like a .22LR or .32 ACP, but that's about it.

#### Describe alternatives you've considered

Making the helmet and liner separable into two distinct items.  Probably a non-useful contrivance.
Making the liner material cotton or canvas.  Probably more accurate, but the material was already leather, so I kept it.

The SSh-68 in real life does not have a "liner helmet" like the M1 helmet does.  Just the steel pot and the suspending straps.  But since it is a "variant" the only way to address that is to make it its own item with its own stats.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Game loads without errors with the changes, stats are changed accordingly.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/49455167/cd53a2a9-3e13-46e1-bd50-d61de2868bab)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/49455167/773eaed3-51a7-4cf2-9025-ec692929c921)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
