### PR TITLE
character: fix fine detail vision

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1581,27 +1581,21 @@ void read_activity_actor::do_turn( player_activity &act, Character &who )
                  book_type::martial_art : book_type::normal;
     }
 
-    if( who.is_avatar() ) {
-        // he following check doesn't work for NPCs
-        // because it is counted for player's submap and z-level only
-        if( who.fine_detail_vision_mod() > 4 ) {
-            // It got too dark during the process of reading, bail out.
-            act.set_to_null();
-            who.add_msg_if_player( m_bad, _( "It's too dark to read!" ) );
-            return;
-        }
+    if( who.fine_detail_vision_mod() > 4 ) {
+        // It got too dark during the process of reading, bail out.
+        act.set_to_null();
+        who.add_msg_if_player( m_bad, _( "It's too dark to read!" ) );
+        return;
+    }
 
-        if( bktype.value() == book_type::martial_art && one_in( 3 ) ) {
-            who.mod_stamina( -1 );
-        }
+    if( bktype.value() == book_type::martial_art && one_in( 3 ) ) {
+        who.mod_stamina( -1 );
+    }
 
-        // do not spam the message log
-        if( calendar::once_every( 5_minutes ) ) {
-            add_msg_debug( debugmode::DF_ACT_READ, "reading time = %s",
-                           to_string_writable( time_duration::from_moves( act.moves_left ) ) );
-        }
-    } else {
-        who.moves = 0;
+    // do not spam the message log
+    if( calendar::once_every( 5_minutes ) ) {
+        add_msg_debug( debugmode::DF_ACT_READ, "%s reading time = %s",
+                       who.name, to_string_writable( time_duration::from_moves( act.moves_left ) ) );
     }
 
     if( using_ereader && !ereader ) {

--- a/src/character.h
+++ b/src/character.h
@@ -3123,7 +3123,7 @@ class Character : public Creature, public visitable
          * above 4.0 means these activities cannot be performed.
          * takes pos as a parameter so that remote spots can be judged
          * if they will potentially have enough light when player gets there */
-        float fine_detail_vision_mod( const tripoint &p = tripoint_zero ) const;
+        float fine_detail_vision_mod( const tripoint &p = tripoint_min ) const;
 
         // ---- CRAFTING ----
         void make_craft_with_command( const recipe_id &id_to_make, int batch_size, bool is_long,
@@ -3542,8 +3542,6 @@ class Character : public Creature, public visitable
 
         // Our weariness level last turn, so we know when we transition
         int old_weary_level = 0;
-        // Z-level on the last turn (used for edge-case "fine_detail_vision_mod" NPCs function override)
-        int last_pc_zlev = 0;
 
         trap_map known_traps;
         mutable std::map<std::string, double> cached_info;

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -134,7 +134,7 @@ static bool crafting_allowed( const Character &p, const recipe &rec )
 float Character::lighting_craft_speed_multiplier( const recipe &rec ) const
 {
     // negative is bright, 0 is just bright enough, positive is dark, +7.0f is pitch black
-    float darkness = fine_detail_vision_mod( this->pos() ) - 4.0f;
+    float darkness = fine_detail_vision_mod() - 4.0f;
     if( darkness <= 0.0f ) {
         return 1.0f; // it's bright, go for it
     }

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -435,8 +435,6 @@ bool do_turn()
     mission::process_all();
     avatar &u = get_avatar();
     map &m = get_map();
-    // Set the last PC z-level position value (used in character.cpp for "fine_detail_vision_mod" NPCs function override) Check will compare last turn and current Z-levels
-    get_player_character().last_pc_zlev = get_player_character().pos().z;
     // If controlling a vehicle that is owned by someone else
     if( u.in_vehicle && u.controlling_vehicle ) {
         vehicle *veh = veh_pointer_or_null( m.veh_at( u.pos() ) );

--- a/tests/char_sight_test.cpp
+++ b/tests/char_sight_test.cpp
@@ -85,6 +85,11 @@ TEST_CASE( "light_and_fine_detail_vision_mod", "[character][sight][light][vision
     // 6.0 is LIGHT_AMBIENT_DIM
 
     SECTION( "midnight with a new moon" ) {
+        // yes, surprisingly, we need to test for this
+        tripoint const z_shift = GENERATE( tripoint_above, tripoint_zero );
+        dummy.setpos( dummy.pos() + z_shift );
+        CAPTURE( z_shift );
+
         calendar::turn = calendar::turn_zero;
         here.build_map_cache( 0, false );
         REQUIRE_FALSE( g->is_in_sunlight( dummy.pos() ) );
@@ -92,6 +97,8 @@ TEST_CASE( "light_and_fine_detail_vision_mod", "[character][sight][light][vision
 
         // 7.3 is LIGHT_AMBIENT_MINIMAL, a dark cloudy night, unlit indoors
         CHECK( dummy.fine_detail_vision_mod() == Approx( 7.3f ) );
+
+        dummy.setpos( dummy.pos() - z_shift );
     }
 
     SECTION( "blindfolded" ) {
@@ -100,6 +107,67 @@ TEST_CASE( "light_and_fine_detail_vision_mod", "[character][sight][light][vision
 
         // 11.0 is zero light or blindness
         CHECK( dummy.fine_detail_vision_mod() == Approx( 11.0f ) );
+    }
+}
+
+TEST_CASE( "npc_light_and_fine_detail_vision_mod", "[character][npc][sight][light][vision]" )
+{
+    Character &u = get_player_character();
+    standard_npc n( "Mr. Testerman" );
+    n.set_body();
+
+    clear_avatar();
+    clear_map();
+    tripoint const u_shift = GENERATE( tripoint_zero, tripoint_above );
+    CAPTURE( u_shift );
+    u.setpos( u.pos() + u_shift );
+    scoped_weather_override weather_clear( WEATHER_CLEAR );
+    restore_on_out_of_scope<bool> restore_fov_3d( fov_3d );
+    restore_on_out_of_scope<int> restore_fov_3d_z_range( fov_3d_z_range );
+
+    time_point time_dst;
+    float expected_vision{};
+    if( GENERATE( true, false ) ) {
+        time_dst = calendar::turn - time_past_midnight( calendar::turn ) + 12_hours;
+        CAPTURE( "daylight" );
+        expected_vision = 1.0;
+    } else {
+        time_dst = calendar::turn - time_past_midnight( calendar::turn );
+        CAPTURE( "darkness" );
+        expected_vision = 7.3;
+    }
+
+    SECTION( "3d fov off" ) {
+        fov_3d = false;
+        set_time( time_dst );
+        REQUIRE( u.fine_detail_vision_mod() == expected_vision );
+        SECTION( "NPC on same z-level" ) {
+            n.setpos( u.pos() + tripoint_east );
+            CHECK( n.fine_detail_vision_mod() == u.fine_detail_vision_mod() );
+        }
+        SECTION( "NPC on a different z-level" ) {
+            n.setpos( u.pos() + tripoint_above );
+            CHECK( n.fine_detail_vision_mod() == Approx( 1.0 ) ); // light not calculated
+        }
+    }
+
+    SECTION( "3d fov on" ) {
+        fov_3d = true;
+        fov_3d_z_range = 2;
+        set_time( time_dst );
+        REQUIRE( u.fine_detail_vision_mod() == expected_vision );
+        SECTION( "NPC on same z-level" ) {
+            n.setpos( u.pos() + tripoint_east );
+            CHECK( n.fine_detail_vision_mod() == u.fine_detail_vision_mod() );
+        }
+        SECTION( "NPC on a different z-level, but in 3d fov range" ) {
+            n.setpos( u.pos() + tripoint_above );
+            CHECK( n.fine_detail_vision_mod() == u.fine_detail_vision_mod() );
+        }
+        SECTION( "NPC on a different z-level, outside of 3d fov range" ) {
+            n.setpos( u.pos() + tripoint{ 0, 0, fov_3d_z_range + 1 } );
+            CHECK( n.fine_detail_vision_mod() == Approx( 1.0 ) ); // light not calculated
+        }
     }
 }
 

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -12,6 +12,7 @@
 #include "character.h"
 #include "item.h"
 #include "itype.h"
+#include "map_helpers.h"
 #include "morale_types.h"
 #include "player_helpers.h"
 #include "skill.h"
@@ -288,9 +289,12 @@ TEST_CASE( "estimated_reading_time_for_a_book", "[reading][book][time]" )
 
 TEST_CASE( "reasons_for_not_being_able_to_read", "[reading][reasons]" )
 {
-    avatar dummy;
+    clear_avatar();
+    clear_map();
+    Character &dummy = get_avatar();
     dummy.set_body();
     dummy.worn.wear_item( dummy, item( "backpack" ), false, false );
+    set_time_to_day();
     std::vector<std::string> reasons;
     std::vector<std::string> expect_reasons;
 
@@ -308,12 +312,19 @@ TEST_CASE( "reasons_for_not_being_able_to_read", "[reading][reasons]" )
     }
 
     SECTION( "you cannot read in darkness" ) {
-        dummy.add_env_effect( effect_darkness, bodypart_id( "eyes" ), 3, 1_hours );
+        if( GENERATE( true, false ) ) {
+            dummy.add_env_effect( effect_darkness, bodypart_id( "eyes" ), 3, 1_hours );
+            CAPTURE( "darkness effect" );
+        } else {
+            set_time( calendar::turn - time_past_midnight( calendar::turn ) );
+            CAPTURE( "actual darkness" );
+        }
         REQUIRE( dummy.fine_detail_vision_mod() > 4 );
 
         CHECK( dummy.get_book_reader( *child, reasons ) == nullptr );
         expect_reasons = { "It's too dark to read!" };
         CHECK( reasons == expect_reasons );
+        set_time_to_day();
     }
 
     GIVEN( "some identified books and plenty of light" ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fine detail vision is broken
* Fixes: #67286
* Fixes: #66279
* Fixes: #65997

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
* Revert #65835 and use a somewhat more sensible check for whether ambient light has been calculated
* Revert #46615 to remove special casing

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
New and updated test unit

Manual testing:
Setup an NPC to disassemble items or read books, then move to another z-level with 3d fov on an off. If 3d fov is on, they should keep doing their job only if there is sufficient light. If 3d fov is off, they should keep working regardless of light.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
N/A

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
