### PR TITLE
Restored light industry expansion

### DIFF
--- a/data/json/mapgen/basecamps/base/fbmc_lightindustry/fbmc_lightindustry_workshop.json
+++ b/data/json/mapgen/basecamps/base/fbmc_lightindustry/fbmc_lightindustry_workshop.json
@@ -1,9 +1,38 @@
 [
   {
     "type": "mapgen",
+    "om_terrain": [ "faction_base_lightindustry_workshop_0" ],
+    "method": "json",
+    "object": { "fill_ter": "t_dirt" }
+  },
+  {
+    "type": "palette",
+    "id": "fbmc_lightindustry_workshop_palette",
+    "terrain": { "x": "t_null" },
+    "furniture": { "x": "f_clear" }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "faction_base_lightindustry_workshop_0",
+    "object": {
+      "mapgensize": [ 6, 6 ],
+      "rows": [
+        "x     ",
+        "      ",
+        "      ",
+        "      ",
+        "      ",
+        "      "
+      ],
+      "palettes": [ "fbmc_lightindustry_workshop_palette" ]
+    }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "faction_base_lightindustry_workshop_0",
     "method": "json",
-    "object": { "set": [ { "point": "furniture", "id": "f_clear", "x": 0, "y": 0 } ] }
+    "object": { "place_nested": [ { "chunks": [ "faction_base_lightindustry_workshop_0" ], "x": 0, "y": 0 } ] }
   },
   {
     "type": "mapgen",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_faction_base.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_faction_base.json
@@ -248,6 +248,13 @@
   },
   {
     "type": "overmap_terrain",
+    "id": "faction_base_lightindustry_workshop_0",
+    "copy-from": "faction_base_camp_0",
+    "name": "light industries workshop survey",
+    "color": "cyan"
+  },
+  {
+    "type": "overmap_terrain",
     "id": "faction_base_mansion_e1",
     "name": "mansion base entrance",
     "sym": "M",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #67226

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the missing pieces (two different kinds of om_terrain entries)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Leave it to someone who understands what they're doing.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Created a light industry glass office base, built the walls required to allow for an expansion, expanded into the industrial area, built the drop hammer there, and verified that it appeared, as well as verified that the drop hammer recipes appeared.
Repeated the process on the other wing to verify that a base there would likewise get its drop hammer and recipes.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I don't know why or how this expansion that presumably worked when constructed got destroyed. Based on how other expansions are constructed, you need an entry in overmap_terrain_faction_base, so I added one, and you also seem to need an om_terrain entry for the expansion (fbmc_lightindustry_workshop), although its "fill_ter" entry doesn't seem to do anything (thus not destroying the workshop). Attempting to use "t_null" as a filler didn't work.

It's probable there is a better way to implement a restoration.

As an aside, it can be noted that the set of recipes provided by the expansion is limited to the companion exclusive drop hammer ones. I would have wanted a reasonable set of other useful recipes as well (but without the excessive bloat crammed into the other workshops). That, however, is outside of the scope of this PR.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
