### PR TITLE
Fix windows.h casing for mingw

### DIFF
--- a/tools/format/format_main.cpp
+++ b/tools/format/format_main.cpp
@@ -15,7 +15,7 @@
 #include <string>
 
 #if defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 
 static void erase_char( std::string &s, const char &c )
 {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Make formatter buildable in mingw

#### Describe the solution

Apparently mingw and msdn disagree on the casing of Windows.h and it can't handle it on case sensitive filesystems

https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5699094220/job/15448004845#step:16:422

#### Describe alternatives you've considered

#### Testing

Next release should build the cross-built executable

#### Additional context
