### PR TITLE
pressurized tanks type to GENERIC

### DIFF
--- a/data/mods/Aftershock/items/containers.json
+++ b/data/mods/Aftershock/items/containers.json
@@ -27,7 +27,7 @@
   },
   {
     "id": "pressure_tank",
-    "type": "TOOL",
+    "type": "GENERIC",
     "copy-from": "pressure_tank",
     "name": { "str": "pressurized tank" },
     "flags": [ "NO_UNLOAD", "MAG_BULKY" ]


### PR DESCRIPTION
#### Summary
Bugfixes "Aftershock pressurized tanks type to GENERIC"

#### Purpose of change

Allows items in pressurized tanks to be used for crafting in After shock world.
Issue #67306 

#### Describe the solution
change type of pressurized tanks type to GENERIC from TOOL.

#### Describe alternatives you've considered

#### Testing

Rewrite  the line of my 0.G file cdda-windows-tiles-sounds-x64-2023-03-01-0054\data\mods\Aftershock\items\containers.json.

#### Additional context
