### PR TITLE
Better description for diary keybinding

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3025,7 +3025,7 @@
   {
     "type": "keybinding",
     "id": "diary",
-    "name": "Open diary",
+    "name": "Open diary / achievements / scores",
     "category": "DEFAULTMODE",
     "bindings": [ { "input_method": "keyboard_char", "key": ")" }, { "input_method": "keyboard_code", "key": "0", "mod": [ "shift" ] } ]
   },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
At some point the achievements / scores / kills window was moved behind the diary window.  But the keybinding is just called "open diary".  This makes it essentially impossible to figure out how to get to the achievements and scores unless you already know.

#### Describe the solution

Rename the keybinding to mention achievements and scores too, so that it can be found more easily.

#### Describe alternatives you've considered

Also mentioning 'kills'.

#### Testing
Searched in the keybindings screen in-game (see screenshot below).

#### Additional context
I've been confused by this, and I've seen at least one YouTuber be confused by it too.

![achievements-in-keybindings](https://github.com/CleverRaven/Cataclysm-DDA/assets/52664/70ed0b12-ce5f-4e1c-a80c-3ec39a8ba3fe)
