### PR TITLE
More consistent key highlighting

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1148,20 +1148,10 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
         const unsigned int header_info_width = std::max( width / 4, width - FULL_SCREEN_WIDTH - 1 );
         const int wStart = ( TERMX - width ) / 2;
 
-        // Keybinding tips
-        static const translation inline_fmt = to_translation(
-                //~ %1$s: action description text before key,
-                //~ %2$s: key description,
-                //~ %3$s: action description text after key.
-                "keybinding", "%1$s[<color_yellow>%2$s</color>]%3$s" );
-        static const translation separate_fmt = to_translation(
-                //~ %1$s: key description,
-                //~ %2$s: action description.
-                "keybinding", "[<color_yellow>%1$s</color>]%2$s" );
         std::vector<std::string> act_descs;
         const auto add_action_desc = [&]( const std::string & act, const std::string & txt ) {
-            act_descs.emplace_back( ctxt.get_desc( act, txt, input_context::allow_all_keys,
-                                                   inline_fmt, separate_fmt ) );
+            act_descs.emplace_back(
+                ctxt.get_desc( act, txt, input_context::allow_all_keys ) );
         };
         add_action_desc( "CONFIRM", pgettext( "crafting gui", "Craft" ) );
         add_action_desc( "HELP_RECIPE", pgettext( "crafting gui", "Describe" ) );

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1164,17 +1164,21 @@ std::string input_context::get_desc(
     const std::string &text,
     const input_event_filter &evt_filter ) const
 {
-    return get_desc( action_descriptor, text, evt_filter,
-                     to_translation(
-                         //~ %1$s: action description text before key,
-                         //~ %2$s: key description,
-                         //~ %3$s: action description text after key.
-                         "keybinding", "%1$s(%2$s)%3$s" ),
-                     to_translation(
-                         // \u00A0 is the non-breaking space
-                         //~ %1$s: key description,
-                         //~ %2$s: action description.
-                         "keybinding", "[%1$s]\u00A0%2$s" ) );
+
+    // Keybinding tips
+    static const translation inline_fmt = to_translation(
+            //~ %1$s: action description text before key,
+            //~ %2$s: key description,
+            //~ %3$s: action description text after key.
+            "keybinding", "%1$s[<color_light_green>%2$s</color>]%3$s" );
+    static const translation separate_fmt = to_translation(
+            // \u00A0 is the non-breaking space
+            //~ %1$s: key description,
+            //~ %2$s: action description.
+            "keybinding", "[<color_light_green>%1$s</color>]\u00A0%2$s" );
+
+    return get_desc( action_descriptor, text, evt_filter, inline_fmt,
+                     separate_fmt );
 }
 
 std::string input_context::describe_key_and_name( const std::string &action_descriptor,

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -237,10 +237,14 @@ void query_popup::show() const
     }
 
     for( size_t ind = 0; ind < buttons.size(); ++ind ) {
-        nc_color col = ind == cur ? hilite( c_white ) : c_white;
         const query_popup::button &btn = buttons[ind];
+        nc_color col = c_white;
+        std::string text = colorize( btn.text, col );
+        if( ind == cur ) {
+            text = hilite_string( text );
+        }
         print_colored_text( win, btn.pos + point( border_width, border_width ),
-                            col, col, btn.text );
+                            col, col, text );
     }
 
     wnoutrefresh( win );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Input contexts have a get_desc option intended to get a description of a particular command with the key for that command highlighted in it.

There is an option to pass in formatting information to control exactly how these strings are formatted.

The default formatting is somewhat boring (no colour).  Two places I found override this default formatting: the crafting menu highlights the relevant letter in yellow, and the vehicle interaction menu highlights it in green.  The vehicle menu doesn't use any brackets around the relevant letter like the other uses do.

This seems unnecessarily inconsistent.

#### Describe the solution
I changed the default to use colour, but green instead of yellow.  I think green is the more common colour used for keys the player can press across the CDDA UI (and I prefer it personally).

I then stopped the crafting menu from overriding the default.

I did not change the vehicle menu, because what it's doing is a bit more complex, and changing to the default might make the options not fit on smaller screens.

#### Describe alternatives you've considered
I could have changed the vehicle menu too, or more.  There are still other places in the UI using yellow (like the main menu) which I have not changed.  I believe they don't use `get_desc`.  Perhaps they should, but I'm treating that as out of scope for this change.

#### Testing
Looked at stuff in-game.  See screenshots below.

#### Additional context
Here are four examples from before the change:
![get_desc-vehicle-before](https://github.com/CleverRaven/Cataclysm-DDA/assets/52664/2a252767-a44e-4a32-b08c-c4f6d427f1df)
![get_desc-crafting-before](https://github.com/CleverRaven/Cataclysm-DDA/assets/52664/be6b50c0-603c-4398-8e25-7ec14b428dd5)
![get_desc-diary-before](https://github.com/CleverRaven/Cataclysm-DDA/assets/52664/fe25c0bf-cf70-44d0-b982-83472271c28e)
![get_desc-dialog-before](https://github.com/CleverRaven/Cataclysm-DDA/assets/52664/3736a2f3-a7c9-496a-a9d3-e99129b23faa)

The vehicle UI is unchanged; here are the other three after the change:
![get_desc-crafting-after](https://github.com/CleverRaven/Cataclysm-DDA/assets/52664/b78396b6-92cc-4404-92a1-29becbfa9c56)
![get_desc-diary-after](https://github.com/CleverRaven/Cataclysm-DDA/assets/52664/20de3948-c2f4-4c15-b547-7f16bb691be6)
![get_desc-dialog-after](https://github.com/CleverRaven/Cataclysm-DDA/assets/52664/63dcb0dd-3578-45ba-aabd-ac26d0c1128b)

You can see that there's one small issue where the blue highlighting on the selected option in the dialog box is dropped for the one green letter.  ~That might be an issue with the code that interprets colour tags; I could look into that but it seemed mostly orthogonal to this PR.~  That's now fixed (see below).