### PR TITLE
Fix some guns looks_like

### DIFF
--- a/data/json/items/gun/12mm.json
+++ b/data/json/items/gun/12mm.json
@@ -2,7 +2,7 @@
   {
     "id": "hk_g80",
     "copy-from": "gun_base",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "H&K G80 railgun" },
     "description": "A highly advanced infantry weapon that magnetically propels a ferromagnetic projectile using an alternating current.  Markings and serials imply it was manufactured by Heckler & Koch, but the maturity of the implemented technologies makes such a claim suspect.  Powered by UPS.",

--- a/data/json/items/gun/223.json
+++ b/data/json/items/gun/223.json
@@ -200,7 +200,7 @@
   {
     "id": "famas",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str_sp": "MAS .223" },
     "description": "A bullpup assault rifle that was used by French armed forces only until recently.  While the FAMAS was famous for its high fire rate, the MAS .223 is a semi-auto only variation imported to the US in the late eighties.  It retains the integral bipod, though.",
@@ -238,7 +238,7 @@
   {
     "id": "fs2000",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "FS2000" },
     "description": "A sleek bullpup carbine designed by FN Herstal, complete with an integrated sight accessory rail.  The forward ejecting action and ambidextrous controls make firing comfortable for both left and right-handed shooting.  The whole rifle is well sealed from mud and dust for reliability, but this makes it incompatible with many aftermarket magazines.",
@@ -272,7 +272,7 @@
   {
     "//": "Groups all 'H&K416' related rifles together. Used M27 due to it being the most popular of the three in the US.",
     "id": "modular_m27_assault_rifle",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "M27 assault rifle" },
     "description": "Designed to replace the M4 Carbine, the M27 assault rifle features most of the former's strengths, while being considerably more durable.  It is chambered in 5.56x45mm and accepts STANAG magazines.",
@@ -419,7 +419,7 @@
   {
     "id": "hk_g36",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "G36 assault rifle" },
     "description": "An assault rifle chambered in 5.56x45mm and accepting G36 magazines.",
@@ -453,7 +453,7 @@
   {
     "id": "m249",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "M249" },
     "description": "The M249 is a mountable machine gun used by the US military and SWAT teams.  Quite inaccurate and difficult to control, the M249 is designed to fire many rounds very quickly.",
@@ -526,7 +526,7 @@
   },
   {
     "id": "modular_m4_carbine",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "M4 carbine" },
     "description": "A popular carbine, long used by the US military.  Though accurate, small, and lightweight, it is infamous for its unreliability when not properly maintained.  It is chambered in 5.56x45mm and accepts STANAG magazines.",
@@ -600,7 +600,7 @@
   },
   {
     "id": "m4_cqbr",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "special duty carbine" },
     "description": "A rugged military carbine that has been outfitted with various accessories, such as an adjustable buttstock, suppressor, and shortened barrel, to improve its close-quarter battle effectiveness.  Most commonly deployed with special forces units and marines before the Cataclysm, its handy size lends itself well to room clearing and fighting within tight spaces.",
@@ -672,7 +672,7 @@
   },
   {
     "id": "modular_m16a4",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "M16 burst rifle" },
     "description": "The M16 is a common assault rifle descended from the AR-15, used by militaries across the world for over 50 years.  It fires in three round bursts, ensuring the rifle is more accurate, but at the cost of being slower than other assault rifles.  It is chambered in 5.56x45mm rounds, and accepts STANAG magazines.",
@@ -903,7 +903,7 @@
   {
     "id": "ruger_mini",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Ruger Mini-14" },
     "description": "A small, lightweight semi-auto carbine designed for civilian and police use.  Its superb accuracy and low recoil makes it more suitable than full-auto rifles for some situations.",
@@ -948,7 +948,7 @@
     "//": "Name changed to match the non-branded version. Also changed to the SIG 553, as the 552 is discontinued and the 553 is still in production and is identical to the 552.",
     "id": "sig_assault_rifle",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "SIG assault rifle" },
     "description": "A compact selective fire automatic rifle designed for the Swiss military.  It features a three-round burst mode and an integrated folding stock.  It is chambered in 5.56x45mm and accepts STANAG magazines.",
@@ -1005,7 +1005,7 @@
   {
     "id": "steyr_aug",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "AUG assault rifle" },
     "description": "An assault rifle chambered in 5.56x45mm and accepting AUG magazines",
@@ -1055,7 +1055,7 @@
   {
     "id": "ak556",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "5.56x45mm AK" },
     "description": "A civilian AK pattern rifle, chambered in 5.56x45 NATO.",
@@ -1101,7 +1101,7 @@
   {
     "id": "minidraco556",
     "copy-from": "pistol_base",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "5.56x45mm Mini Draco" },
     "description": "A civilian AK pattern rifle, chambered in 5.56x45 NATO.  This one is shorter and without a stock",
@@ -1146,7 +1146,7 @@
   {
     "id": "mdrx",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Desert Tech bullpup carbine" },
     "description": "Produced by the Desert Tech gun company, this is a highly modular, semi-automatic rifle of remarkably modest dimensions.  The weapon is notable for the simplicity of converting it to fire a wide number of different cartridges, with retool kits for .223 Remington, .308 Winchester, and .300 AAC Blackout being available.",
@@ -1221,7 +1221,7 @@
   {
     "id": "bren2_556",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Bren 5.56x45mm carbine" },
     "description": "A semi-automatic clone of the Czech Republic’s standard infantry carbine, sold for civilian sport shooting and recreational use, this modular rifle makes use of the 7.62x39mm Soviet cartridge and uses proprietary magazines.",
@@ -1291,7 +1291,7 @@
   {
     "id": "cz600",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "bolt-action trail carbine" },
     "description": "Compact, svelte, and lightweight, this Leen bolt-action rifle packs the same features of larger sporting weapons into a backpack-sized package.  Possessing an adjustable buttstock, a detachable magazine-based system, and a quick-swap barrel that can be exchanged to accommodate the firing of .223 Remington or 7.62x39mm Soviet ammunition, the weapon is a commendable backpacker or prepper rifle.",
@@ -1363,7 +1363,7 @@
   {
     "id": "rdb_223",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "5.56x45mm bullpup rifle" },
     "description": "This is a semi-automatic bullpup rifle with a lightened body due to the use of polymers and aluminum, using standard magazines of the AR-15 platform and a 5.56x45mm cartridge.",

--- a/data/json/items/gun/270win.json
+++ b/data/json/items/gun/270win.json
@@ -2,7 +2,7 @@
   {
     "id": "remington700_270",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "bolt-action hunting rifle" },
     "description": "Featuring a handsome set of wooden furnishings, a classic design, and a no nonsense .270 caliber chambering, this is a powerful hunting rifle.  With a tried and proven pedigree dating back over 60 years, millions of such rugged arms have been made, exported, and used throughout the United States and the world at large.  Where hunting is concerned, this is a highly capable and well proven weapon in all respects.  Fortunate, given that your prey in these dark days may turn out to be a little bit more feisty than typical White-Tailed deer, moose, and black bears.",

--- a/data/json/items/gun/300.json
+++ b/data/json/items/gun/300.json
@@ -2,7 +2,7 @@
   {
     "id": "m2010",
     "copy-from": "rifle_base",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str_sp": "M2010 ESR" },
     "//": "http://www.guns.com/2012/05/17/remington-xm2010-army-sniper-system-esr-now-in-stores/.",
@@ -26,7 +26,7 @@
   {
     "id": "weatherby_5",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str_sp": "Weatherby Mark V" },
     "//": "MSRP, believe it or not.",
@@ -66,7 +66,7 @@
   {
     "id": "win70",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str_sp": "Winchester Model 70" },
     "description": "The Winchester Model 70 is a bolt-action sporting rifle.  It has an iconic place in American sporting culture and has been held in high regard by shooters since it was introduced in 1936.",
@@ -104,7 +104,7 @@
   },
   {
     "id": "ruger_pr",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "copy-from": "rifle_manual",
     "type": "GUN",
     "name": "Ruger Precision Rifle",

--- a/data/json/items/gun/3006.json
+++ b/data/json/items/gun/3006.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "browning_blr",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str_sp": "Browning BLR" },
@@ -42,7 +42,7 @@
   },
   {
     "id": "garand",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str": "M1 Garand" },
@@ -84,7 +84,7 @@
   {
     "id": "m1903",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "M1903 Springfield" },
     "description": "A powerful military rifle chambered in .30-06, developed to replace the US Army's older Krag rifle.  It served as the main American rifle in World War I, was used alongside the M1 Garand in World War II, and was used as a sniper rifle as late as the Vietnam War.",
@@ -124,7 +124,7 @@
   },
   {
     "id": "m1918",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str": "Browning Automatic Rifle" },
@@ -168,7 +168,7 @@
   {
     "id": "remington_700",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str_sp": "Remington 700 .30-06" },
     "description": "A very popular and durable hunting or sniping rifle.  Popular among SWAT and US Marine snipers.  Highly damaging, but perhaps not as accurate as the competing Browning BLR.",
@@ -194,7 +194,7 @@
   },
   {
     "id": "ruger_m77",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "copy-from": "rifle_manual",
     "type": "GUN",
     "name": { "str": "Ruger Guide rifle" },

--- a/data/json/items/gun/300BLK.json
+++ b/data/json/items/gun/300BLK.json
@@ -2,7 +2,7 @@
   {
     "id": "acr_300blk",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Remington ACR .300BLK" },
     "description": "This carbine was developed for military use in the early 21st century.  It is damaging and accurate, though its rate of fire is a bit slower than competing carbines.  This version is chambered for the .300 AAC Blackout round.",
@@ -52,7 +52,7 @@
   {
     "id": "iwi_tavor_x95_300blk",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "IWI Tavor X95 .300BLK" },
     "description": "The IWI Tavor X95 (also called Micro-Tavor or MTAR) is an Israeli bullpup assault rifle designed and produced by Israel Weapon Industries.  This is the civilian version chambered for .300 AAC Blackout.",
@@ -112,7 +112,7 @@
   {
     "id": "sig_mcx_rattler_sbr",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "SIG MCX Rattler SBR" },
     "description": "A gas-operated rifle, with a short 5.5 inch barrel, built-in thin folding stock, and full rail mount on the upper receiver.  This particular one is a select-fire military version.",

--- a/data/json/items/gun/303.json
+++ b/data/json/items/gun/303.json
@@ -2,7 +2,7 @@
   {
     "id": "smle_mk3",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Enfield battle rifle" },
     "description": "An iconic weapon of both the First and Second World Wars, this bolt-action rifle has seen deployment in the hands of Commonwealth troops across Europe and beyond.  Firing the .303-caliber cartridge and making use of 10-round Enfield magazines, the firearm’s reputation precedes it.",
@@ -49,7 +49,7 @@
   {
     "id": "number4_mki",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "updated Enfield rifle" },
     "description": "An evolution of Britten’s First World War battle rifle, this bolt-action firearm uses the same .303-caliber cartridge as its forerunner.  Much beloved across the globe by collectors, rifles like this served as England’s infantry rifle well into the 1950s, with a specialized sniper variant remaining in service until the early nineties.",

--- a/data/json/items/gun/308.json
+++ b/data/json/items/gun/308.json
@@ -2,7 +2,7 @@
   {
     "id": "fn_fal",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str_sp": "heavy automatic rifle" },
     "description": "Originally designed in the mid 1950s, this gun is probably the most successful battle rifle ever designed.  Even though often labeled as obsolete, its high rate of fire and powerful ammunition make it perfectly capable of holding its ground against modern competitors.",
@@ -37,7 +37,7 @@
   {
     "id": "hk_g3",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str_sp": "H&K G3" },
     "description": "An early battle rifle developed after the end of WWII.  The G3 is designed to unload large amounts of deadly ammunition, but it is less suitable over long ranges.",
@@ -61,7 +61,7 @@
   },
   {
     "id": "m134",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str": "M134D-H Minigun" },
@@ -121,7 +121,7 @@
   {
     "id": "m1a",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str_sp": "M1A" },
     "description": "The child of the M1 Garand World War II rifle, the M1A is a semi-automatic variant of the M14, favored for its accuracy and modular use.",
@@ -159,7 +159,7 @@
   {
     "id": "m240",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "M240" },
     "description": "The M240 is a medium machine gun used by the US military, replacing the older M60.  Quite inaccurate and difficult to control, the M240 is designed to fire many rounds very quickly.",
@@ -200,7 +200,7 @@
   {
     "id": "m60",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "M60" },
     "description": "The M60 is a general-purpose machine gun developed to replace the .30-caliber M1918 and M1919.  Heavy and difficult to handle fired from the shoulder, as most people aren't action-movie heroes.",
@@ -275,7 +275,7 @@
   {
     "id": "scar_h",
     "copy-from": "scar_l",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str_sp": "FN SCAR-H" },
     "description": "A highly accurate and modular battle rifle specially designed for the United States Special Operations Command.  The 'H' in its name stands for heavy, as it uses the powerful .308 round.",
@@ -297,7 +297,7 @@
   {
     "id": "M24",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str_sp": "M24" },
     "description": "The M24 Sniper is the military and police version of the Remington Model 700 rifle, M24 being the model name assigned by the United States Army after adoption as their standard sniper rifle in 1988.  The M24 is referred to as a 'weapon system' because it consists of not only a rifle, but also a detachable telescopic sight and other accessories.",
@@ -338,7 +338,7 @@
   {
     "id": "hk417_13",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "HK417 A2" },
     "description": "A German battle rifle with a 13\" barrel and telescopic stock.  It is a gas-operated, rotating bolt rifle with a short-stroke piston design similar to that of the G36.",
@@ -364,7 +364,7 @@
   {
     "id": "m110a1",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "M110A1" },
     "description": "A derivative of H&K's G28 with an aluminum upper receiver to meet US Army weight requirements.  It is a gas-operated, rotating bolt rifle accurate to 1.5 MOA with standard ammunition.",
@@ -389,7 +389,7 @@
   {
     "id": "ak308",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "7.62x51mm AK" },
     "description": "A civilian AK pattern rifle, chambered in 7.62x51mm NATO.",
@@ -435,7 +435,7 @@
   {
     "id": "ar10",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "AR-10" },
     "description": "Somewhat similar to the later AR-15, the AR-10 is a gas-operated, rotating bolt rifle chambered for 7.62x51mm rounds.",
@@ -464,7 +464,7 @@
   {
     "id": "rfb_308",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "7.62x51mm bullpup rifle" },
     "description": "This is a semi-automatic bullpup rifle with a lightened body due to the use of polymers and aluminum, using standard magazines of the heavy automatic rifle and a 7.62x51mm cartridge.",

--- a/data/json/items/gun/32.json
+++ b/data/json/items/gun/32.json
@@ -144,7 +144,7 @@
   },
   {
     "id": "rifle_32",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str": "pipe rifle: .32", "str_pl": "pipe rifles: .32" },

--- a/data/json/items/gun/338lapua.json
+++ b/data/json/items/gun/338lapua.json
@@ -2,7 +2,7 @@
   {
     "id": "tac338",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": ".338 bolt-action sniper rifle" },
     "description": "A high-precision bolt-action sniper rifle, in service with special operations members of the US Navy prior to the cataclysm.  Firing the powerful .338 Lapua cartridge, the weapon feeds from detachable five round Accuracy International magazines.",
@@ -35,7 +35,7 @@
   {
     "id": "savage112",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "single-shot target rifle" },
     "description": "A bolt-action precision rifle with the potential for impressive accuracy, this particular weapon makes use of the powerful .338 Lapua cartridge and is decked in a handsome set of wooden furniture, providing the rifle with a classical mystique.  Unfortunately, the weapon's single-round magazine and a lack of factory iron sights, which makes target acquisition an exercise in futility unless a gunsight is installed, make the rifle limited in its post-Cataclysm utility.",
@@ -83,7 +83,7 @@
   {
     "id": "mrad_smr",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Barrett precision rifle" },
     "description": "A box magazine-fed bolt-action precision rifle developed by the Barrett Arms Company, firing the .338 Lapua cartridge.  A civilian copy of more versatile military weapons, this rifle is a remarkably well-crafted piece of anti-personnel engineering despite lacking the sheer modularity of its Marshal sister, and is still capable of engaging targets at extreme distances.",
@@ -129,7 +129,7 @@
   {
     "id": "axmc",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "modular sniper rifle" },
     "description": "A weapon platform that prides itself on modularity and customizability, this highly accurate precision rifle may be configured with various caliber conversion kits that can allow it to fire either the .338 Lapua, .300 Win Mag, or .308 Winchester cartridges.  The rifle's size prevents it from being a particularly mobile piece of equipment, but the weapon's folding buttstock aids in portability.",

--- a/data/json/items/gun/38.json
+++ b/data/json/items/gun/38.json
@@ -142,7 +142,7 @@
   {
     "id": "rifle_38",
     "copy-from": "gun_base",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "pipe rifle: .38 Special", "str_pl": "pipe rifles: .38 Special" },
     "description": "A home-made rifle.  It is simply a pipe attached to a stock, with a hammer to strike the single round it holds.",

--- a/data/json/items/gun/380.json
+++ b/data/json/items/gun/380.json
@@ -133,7 +133,7 @@
   },
   {
     "id": "rifle_380",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str": "pipe rifle: .380 ACP", "str_pl": "pipe rifles: .380 ACP" },

--- a/data/json/items/gun/40.json
+++ b/data/json/items/gun/40.json
@@ -92,7 +92,7 @@
   {
     "id": "rifle_40",
     "copy-from": "gun_base",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "pipe rifle: .40 S&W", "str_pl": "pipe rifles: .40 S&W" },
     "description": "A home-made rifle.  It is simply a pipe attached to a stock, with a hammer to strike the single round it holds.",

--- a/data/json/items/gun/44.json
+++ b/data/json/items/gun/44.json
@@ -42,7 +42,7 @@
   {
     "id": "henry_big_boy",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str_sp": "Henry Big Boy .44" },
     "description": "This fine lever-action rifle is chambered in the powerful .44 Magnum cartridge and features a sleek octagonal barrel with a tube fed magazine.  Go get 'em cowboy!",
@@ -80,7 +80,7 @@
   {
     "id": "rifle_44",
     "copy-from": "gun_base",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "pipe rifle: .44 Magnum", "str_pl": "pipe rifles: .44 Magnum" },
     "description": "A home-made rifle.  It is simply a pipe attached to a stock, with a hammer to strike the single round it holds.",

--- a/data/json/items/gun/45.json
+++ b/data/json/items/gun/45.json
@@ -199,7 +199,7 @@
   },
   {
     "id": "rifle_45",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str": "pipe rifle: .45", "str_pl": "pipe rifles: .45" },
@@ -241,7 +241,7 @@
   {
     "id": "hk_usc45",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "H&K USC 45 Carbine" },
     "description": "A compact, lightweight carbine chambering the popular .45 ACP pistol round.  Resembling the popular UMP submachine gun in both its blowback operating system and lightweight polymer frame construction.  This civilian variant is distinguished by its skeletonized stock and 16 inch barrel.",

--- a/data/json/items/gun/450bushmaster.json
+++ b/data/json/items/gun/450bushmaster.json
@@ -2,7 +2,7 @@
   {
     "id": "ruger_arr",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Ruger American Ranch Rifle" },
     "description": "A compact, magazine-fed, bolt-action hunting rifle designed and manufactured with cost-effectiveness at the peak of concerns, the Ruger American Ranch Rifle series caters to shooters on a budget.  Factory chambered for the powerful, though short-range, .450 Bushmaster cartridge, the weapon was able to stand toe-to-toe with all native North American game despite its minimalist design.",

--- a/data/json/items/gun/4570.json
+++ b/data/json/items/gun/4570.json
@@ -2,7 +2,7 @@
   {
     "id": "1895sbl",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Marlin 1895 SBL" },
     "description": "A handy but powerful lever-action rifle chambered for .45-70 Government.  Designed for wilderness guides for defense against large predators such as grizzly bears, moose, and dinosaurs.",
@@ -72,7 +72,7 @@
   {
     "id": "sharps",
     "copy-from": "gun_base",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str_sp": "1874 Sharps" },
     "//": "Specs from Uberti 32in barrel Special",

--- a/data/json/items/gun/45colt.json
+++ b/data/json/items/gun/45colt.json
@@ -38,7 +38,7 @@
   {
     "id": "colt_lightning",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Colt Lightning .45 Carbine" },
     "description": "A modern reproduction of a Colt pump-action rifle.  Originally chambered in .44-40, modern versions most commonly use .45 Colt, complementing the Single Action Army as a Cowboy Action Shooting firearm.",

--- a/data/json/items/gun/50.json
+++ b/data/json/items/gun/50.json
@@ -2,7 +2,7 @@
   {
     "id": "m107a1",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str_sp": "Barrett M107A1" },
     "//": "Price based on unit cost quote for fiscal year 2005 listed at inetres.com, with gunmod modifiers to be added later.",

--- a/data/json/items/gun/50.json
+++ b/data/json/items/gun/50.json
@@ -28,7 +28,7 @@
   {
     "id": "m2browning",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str_sp": "M2HB Browning HMG" },
     "description": "A heavy machine gun used by the US Military from its inception to the Cataclysm, and even rarely by Cataclysm survivors.  Its massive size and design make it impossible to use unless deployed or mounted to a vehicle.",
@@ -100,7 +100,7 @@
   {
     "id": "as50",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "AI AS50" },
     "description": "Developed by the British firearms producer Accuracy International, the AI AS50 is a semi-automatic .50 caliber anti-materiel rifle produced for the British armed forces and the United States Navy SEALs.  With a free-floated barrel, titanium frame, and an accessory rail integrated into the weapon’s machined-steel receiver with two others mounted on each side of the barrel shroud, the rifle features commendable ergonomics and a notable level of modularity.  Providing operators with the capability to engage targets at a maximum estimated range of around 1500 meters, the firearm feeds from detachable 10-round box magazines.",
@@ -127,7 +127,7 @@
   {
     "id": "tac50",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "McMillan TAC-50" },
     "description": "A long-range anti-materiel and anti-personnel sniper rifle made by McMillan Firearms, serving the Canadian Army since 2000 as the C15, and the Navy Seals as the Mk 15 Mod 0.  This .50 caliber bolt-action rifle is capable of defeating light vehicles, radar installations and crew-served weapons at extreme distances.  It notably holds the longest-range confirmed sniper kill, as well as the 4th and 5th longest.",
@@ -154,7 +154,7 @@
   {
     "id": "bfg50",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Serbu BFG-50" },
     "description": "A single-shot, bolt-action rifle made by Serbu Firearms, the BFG-50 is a very affordable firearm for those wishing to shoot .50 BMG.",

--- a/data/json/items/gun/500.json
+++ b/data/json/items/gun/500.json
@@ -2,7 +2,7 @@
   {
     "id": "bh_m89",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": ".500 Magnum lever gun" },
     "description": "A finely put together rifle, constructed in the image of old west lever-guns, this weapon features an impressive chambering of .500 Magnum.  Less unmanageable and impractical than within a handgun platform, the power potential of the huge round is nevertheless preserved within this rifle sized package.  Capable of taking down most forms of game, including deer, boars, and small dinosaurs, this is a respectable weapon for only the most enthusiastic of large-calibre shooters.",

--- a/data/json/items/gun/545x39.json
+++ b/data/json/items/gun/545x39.json
@@ -2,7 +2,7 @@
   {
     "id": "ak74",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "AK-74M" },
     "//": "AKs likewise aren't commercially traded in the US, plus this is newer.",
@@ -42,7 +42,7 @@
   {
     "id": "kord",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Kord 6P67" },
     "//": "An exceptionally new AK style gun found illicitly as part of a quest.",

--- a/data/json/items/gun/700nx.json
+++ b/data/json/items/gun/700nx.json
@@ -2,7 +2,7 @@
   {
     "id": "trex_gun",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Elephant gun" },
     "description": "A ornately engraved, custom-made double rifle specially designed for the hunting of huge game.  You could obviously kill everything with this, EVERYTHING.  If you ever find enough ammo of course.",

--- a/data/json/items/gun/762.json
+++ b/data/json/items/gun/762.json
@@ -2,7 +2,7 @@
   {
     "id": "ak47",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "AKM" },
     "description": "One of the most recognizable assault rifles ever made, the AKM is renowned for its durability even under the worst conditions.",
@@ -39,7 +39,7 @@
   {
     "id": "arx160",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str_sp": "Beretta ARX-160" },
     "//": "Total unloaded weight of gun 3000 grams.  Current weight of folding stock 200 grams.",
@@ -79,7 +79,7 @@
   {
     "id": "sks",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "SKS" },
     "description": "Developed by the Soviets in 1945, this rifle was quickly replaced by the full-auto AK-47.  However, due to its superb accuracy, low recoil, and deployable integrated bayonet, this gun maintains immense popularity.",
@@ -129,7 +129,7 @@
   {
     "id": "aksemi",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "AK-47" },
     "description": "Civilian-legal clones of the iconic Kalashnikov, like this one, were manufactured and imported by many different firms.  Even without full-auto function, their solid firepower and reliability in harsh conditions make them valuable weapons in this new world.",
@@ -165,7 +165,7 @@
   {
     "id": "draco",
     "copy-from": "pistol_base",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Mini Draco" },
     "description": "Essentially a semi-auto AK with a short barrel and no stock, this unwieldy \"pistol\" has seen some popularity with civilian shooters and gangbangers alike.",
@@ -211,7 +211,7 @@
     "price_postapoc": 4000,
     "to_hit": { "balance": "neutral", "grip": "solid", "length": "long", "surface": "point" },
     "material": [ "plastic", "steel" ],
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "ammo": [ "762" ],
     "built_in_mods": [ "pistol_grip" ],
     "dispersion": 150,
@@ -235,7 +235,7 @@
   {
     "id": "vz58_p",
     "copy-from": "rifle_auto",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "vz. 58 combat rifle" },
     "description": "A Cold War-era Czechoslovak assault rifle, likely constructed stateside from a pre-1986 imported parts kit or brought back from a third world war zone.  Externally similar to the AK family of rifles, this weapon nevertheless only shares the former’s 7.62x39mm chambering.  Featuring no interchangeable parts with its Russian doppelganger, this firearm makes use of a completely different internal operating system, is far more svelte than its other Warsaw Pact counterparts, and feeds from proprietary box magazines.",
@@ -287,7 +287,7 @@
   {
     "id": "vz58ts",
     "copy-from": "vz58_p",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "vz. 58 tactical rifle" },
     "description": "Inspired and built primarily from older Czechoslovak military combat rifles, this weapon bears an uncanny resemblance to the Kalashnikov despite sharing no components with it, including magazines.  Chambering the Soviet 7.62x39mm cartridge and featuring an American produced folding buttstock, receiver, and barrel in order to comply with US importation laws, the weapon is equipped with a side mounted rail assembly as well as a detachable muzzle brake.  Despite the firearm’s Cold War design being nearly 80 years old, this modern iteration makes for a relatively portable and serviceable cataclysmic problem solver.",
@@ -307,7 +307,7 @@
   {
     "id": "bren2_762",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Bren 7.62mm carbine" },
     "description": "A semi-automatic clone of the Czech Republic’s standard infantry carbine, sold for civilian sport shooting and recreational use, this modular rifle makes use of the 7.62x39mm Soviet cartridge and uses proprietary magazines.",

--- a/data/json/items/gun/762R.json
+++ b/data/json/items/gun/762R.json
@@ -2,7 +2,7 @@
   {
     "id": "mosin44",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Mosin carbine" },
     "description": "A later produced and substantially shortened version of Imperial Russia’s original service rifle, this variant of the Mosin features a notably more compact barrel and an integral side-folding bayonet.  Produced during the latter days of the Second World War for the Soviet Union, the weapon exhibits less overall stopping power than its full-length older brother thanks to the former’s stubbier barrel.  Despite the arm being somewhat weaker than its forefather, the 7.62x54mm round that it chambers still packs a hefty punch, whilst its smaller size helps to make the weapon wieldier.",
@@ -59,7 +59,7 @@
   {
     "id": "mosin91_30",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Mosin battle rifle" },
     "description": "Developed by the Russian Empire prior to the onset of the First World War, the Mosin is a bolt-action military battle rifle chambered for 7.62x54mm rounds.  Powerful, unwieldy, and prolific across the world as military surplus, this sizable rifle is a Soviet updated version of the venerable Mosin.",
@@ -114,7 +114,7 @@
   {
     "id": "psl",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "//": "Mom can we have a McDragunov? Mom: we have McDragunov at home. The McDragunov at home:",
     "type": "GUN",
     "name": { "str": "PSL" },

--- a/data/json/items/gun/8x40mm.json
+++ b/data/json/items/gun/8x40mm.json
@@ -38,7 +38,7 @@
   },
   {
     "id": "rm11b_sniper_rifle",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str": "RM11B scout rifle" },

--- a/data/json/items/gun/9mm.json
+++ b/data/json/items/gun/9mm.json
@@ -52,7 +52,7 @@
   },
   {
     "id": "cx4",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str": "9x19mm pistol-caliber carbine" },
@@ -672,7 +672,7 @@
   },
   {
     "id": "rifle_9mm",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str": "pipe rifle: 9x19mm", "str_pl": "pipe rifles: 9x19mm" },
@@ -1289,7 +1289,7 @@
   {
     "id": "colt_ro635",
     "copy-from": "smg_base",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Colt Model 635" },
     "description": "A 9x19mm submachine gun based on the M16 rifle design, it is a closed bolt, blowback operated firearm.  There is a large plastic brass deflector mounted by the ejection port, and no forward assist.  It looks very similar to an M4 carbine, except for the magazine well that accepts Uzi-style magazines.",
@@ -1334,7 +1334,7 @@
   {
     "id": "bt_apc9k",
     "copy-from": "smg_base",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "B&T APC9 PRO K" },
     "description": "The Brügger & Thomet APC9 PRO K is a closed bolt blowback submachine gun in 9x19mm Parabellum.  It has a collapsible shoulder stock and a red dot sight.",

--- a/data/json/items/gun/9x18.json
+++ b/data/json/items/gun/9x18.json
@@ -71,7 +71,7 @@
   },
   {
     "id": "rifle_9x18",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str": "pipe rifle: 9x18mm", "str_pl": "pipe rifles: 9x18mm" },

--- a/data/json/items/gun/combination.json
+++ b/data/json/items/gun/combination.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "combination_gun",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "reload_noise_volume": 10,
     "symbol": "(",

--- a/data/json/items/gun/exodii.json
+++ b/data/json/items/gun/exodii.json
@@ -2,7 +2,7 @@
   {
     "id": "pamd68",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Exodii battle rifle" },
     "description": "The most popular gun to use the 12.3ln cartridge was, of course, the PA md. 71.  Its predecessor, the md. 68, was viewed by many as a sort of failure: although it was reliable and powerful, it was too heavy to be used as a good infantry weapon, and not really heavy enough to be a good support gun.  Enough were made, though, that during the zombie apocalypse, it gained a great deal of resurgent popularity as a light emplacement gun that used readily available ammunition.  It perfectly served the purposes of the Exodii, who had far less concern about its unwieldiness.",
@@ -38,7 +38,7 @@
   {
     "id": "pamd71z",
     "copy-from": "rifle_manual",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Exodii zombie hunting rifle" },
     "description": "This extremely popular Romanian rifle, made famous in the third Carpathian War, has been redesigned slightly by the Exodii for precision shots against high-priority targets.  In a pinch this modified design can fire an extremely rapid 2-shot burst, with the goal of shredding the target and preventing revivification.",

--- a/data/json/items/gun/flintlock.json
+++ b/data/json/items/gun/flintlock.json
@@ -2,7 +2,7 @@
   {
     "id": "carbine_flintlock",
     "copy-from": "rifle_flintlock",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "price": 40000,
     "price_postapoc": 2250,
@@ -69,7 +69,7 @@
   },
   {
     "id": "rifle_flintlock",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str": "flintlock musket" },

--- a/data/json/items/gun/nail.json
+++ b/data/json/items/gun/nail.json
@@ -30,7 +30,7 @@
   {
     "id": "coilgun",
     "copy-from": "gun_base",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "coilgun" },
     "//": "Hard to make, plentiful and cheap ammo, and silent - people will want this thing.",

--- a/data/json/items/gun/robofac_gun.json
+++ b/data/json/items/gun/robofac_gun.json
@@ -56,7 +56,7 @@
   {
     "id": "xedra_gun",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "prototype gun" },
     "description": "A weapons platform you don't recognize.  With its combination of black-finished steel, brown polymer furniture, and a number of proprietary bolts and fasteners to hold the pieces in place, this weapon looks like it belongs in a science fiction movie.  The body has \"XE\" inlaid in the steel.",

--- a/data/json/items/gun/robofac_gun.json
+++ b/data/json/items/gun/robofac_gun.json
@@ -2,7 +2,7 @@
   {
     "id": "robofac_gun",
     "copy-from": "rifle_semi",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "name": { "str": "Hub 01 HWP" },
     "description": "The Hub 01 Hybrid Weapons Platform, or just the HWP.  With its combination of black-finished steel, blue polymer furniture, and a number of proprietary bolts and fasteners to hold the pieces in place, this weapon looks like it belongs in a science fiction movie.  The body has \"MULTI CALIBER\" inlaid in the steel, near a quick release used both to exchange the installed barrel and to change the magazine well's adapter.",

--- a/data/json/items/gun/ups.json
+++ b/data/json/items/gun/ups.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "emp_gun",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str": "XM34 EMP projector" },
@@ -105,7 +105,7 @@
   },
   {
     "id": "laser_rifle",
-    "looks_like": "ar15",
+    "looks_like": "modular_ar15",
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str": "A7 laser rifle" },


### PR DESCRIPTION
#### Summary
None


#### Purpose of change

Update the looks_likes on guns using `ar15` so it would refer to the newer ar-15 id `modular_ar15`

#### Describe the solution

`looks_like: "ar15"` to `looks_like:"modular_ar15"`

#### Describe alternatives you've considered

Not doing this.

#### Testing

I applied the 223.json to my build (because im not in the mood to inspect all of the guns in my phone) and spawned in the guns from said json. The ones that did not have a sprite on them (in MSXotto+) fall back to the `modular_ar15` looks_like as expected. If this works for the 223.json guns, it should work for the other guns.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
