### PR TITLE
Overflow crafting components before consuming them

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1978,6 +1978,8 @@ std::list<item> Character::consume_items( map &m, const comp_selection<item_comp
     }
     for( item &it : ret ) {
         it.spill_contents( *this );
+        // todo: make a proper solution that overflows with the proper item_location
+        it.overflow( pos() );
     }
     empty_buckets( *this );
     return ret;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Crafting with a migrated item with things in its migration pocket would also remove all the contents of the pocket. That's not a new issue but very apparent with #60885 merged.

#### Describe the solution

Overflow the items at the crafters feet.

#### Describe alternatives you've considered

I wanted to overflow the item_location as established in #65518, but turns out item_locations are hardly available in the crafting process.

#### Testing

Crafted something from migrated popcorn kernels and the migrated kernels were dropped at my feet.

#### Additional context

Guess I'll have to add using item_locations for crafting to my todo someday list.