### PR TITLE
Fix use menu denial message and invoking items for comestibles without charges

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10559,6 +10559,10 @@ bool item::ammo_sufficient( const Character *carrier, int qty ) const
         return ammo_remaining( carrier, true ) >= qty;
     }
 
+    if( is_comestible() ) {
+        return true;
+    }
+
     return shots_remaining( carrier ) >= qty;
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #67330

#### Describe the solution

Exit early when checking `item::ammo_sufficient` for comestibles, so the menu and invoking items accepts comestibles as having the required charge.

#### Describe alternatives you've considered

This whole chain of `item::ammo_sufficient` > `item::shots_remaining` > `item::ammo_required` > `item::ammo_remaining` is really ugly, because it shouldn't even have anything to do with comestibles. But it's still checking them, expects comestibles to use 1 charge, but now obviously fails for uncharged comestibles. This really should get a rework to properly split things up, but that requires quite a bit more work.

#### Testing

Activated a caffein pill from the use menu.

#### Additional context

