### PR TITLE
Added detailed info on stats on character creation menu

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1093,7 +1093,7 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
     catacurses::window w_description;
     const auto init_windows = [&]( ui_adaptor & ui ) {
         w = catacurses::newwin( TERMY, TERMX, point_zero );
-        w_description = catacurses::newwin( 8, TERMX - iSecondColumn - 1,
+        w_description = catacurses::newwin( 30, TERMX - iSecondColumn - 1,
                                             point( iSecondColumn, 6 ) );
         ui.position_from_window( w );
     };
@@ -1161,7 +1161,7 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
         }
 
         switch( sel ) {
-            case 0:
+            case 0: {
                 u.recalc_hp();
                 u.set_stored_kcal( u.get_healthy_kcal() );
                 mvwprintz( w_description, point_zero, COL_STAT_NEUTRAL, _( "Base HP: %d" ),
@@ -1169,13 +1169,58 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
                 // NOLINTNEXTLINE(cata-use-named-point-constants)
                 mvwprintz( w_description, point( 0, 1 ), COL_STAT_NEUTRAL, _( "Carry weight: %.1f %s" ),
                            convert_weight( u.weight_capacity() ), weight_units() );
-                mvwprintz( w_description, point( 0, 2 ), COL_STAT_BONUS, _( "Bash damage bonus: %.1f" ),
+                mvwprintz( w_description, point( 0, 2 ), COL_STAT_NEUTRAL,
+                           _( "Resistance to knock down effect when hit: %.1f" ), u.stability_roll() );
+                mvwprintz( w_description, point( 0, 3 ), COL_STAT_NEUTRAL, _( "Intimidation skill: %i" ),
+                           u.intimidation() );
+                mvwprintz( w_description, point( 0, 4 ), COL_STAT_NEUTRAL, _( "Maximum oxygen: %i" ),
+                           u.get_oxygen_max() );
+                mvwprintz( w_description, point( 0, 5 ), COL_STAT_NEUTRAL, _( "Shout volume: %i" ),
+                           u.get_shout_volume() );
+                mvwprintz( w_description, point( 0, 6 ), COL_STAT_NEUTRAL, _( "Lifting strength: %i" ),
+                           u.get_lift_str() );
+                mvwprintz( w_description, point( 0, 7 ), COL_STAT_NEUTRAL, _( "Move cost while swimming: %i" ),
+                           u.swim_speed() );
+                mvwprintz( w_description, point( 0, 8 ), COL_STAT_BONUS, _( "Bash damage bonus: %.1f" ),
                            u.bonus_damage( false ) );
-                fold_and_print( w_description, point( 0, 4 ), getmaxx( w_description ) - 1, c_green,
-                                _( "Strength also makes you more resistant to many diseases and poisons, and makes actions which require brute force more effective." ) );
-                break;
+                mvwprintz( w_description, point( 0, 10 ), COL_STAT_NEUTRAL, _( "Affects:" ) );
 
-            case 1:
+                int y = 11;
+
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Throwing range, accuracy, and damage" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Reload speed for weapons using muscle power to reload: -20 moves per point of strength" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Pull strength of some mutations" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Resistance for being pulled or grabbed by some monsters" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Speed of corpses pulping" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Speed and effectiveness of prying things open, chopping wood, and mining" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of escaping grabs and traps" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Power produced by muscle-powered vehicles" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Most aspects of melee combat" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of smashing furniture or terrain" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Resistance to many diseases and poisons" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Ability to drag heavy objects and grants bonus to speed when dragging them" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Ability to wield heavy weapons with one hand" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Ability to manage gun recoil" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Duration of action of various drugs and alcohol" ) );
+            }
+            break;
+
+            case 1: {
                 mvwprintz( w_description, point_zero, COL_STAT_BONUS, _( "Melee to-hit bonus: +%.2f" ),
                            u.get_melee_hit_base() );
                 // NOLINTNEXTLINE(cata-use-named-point-constants)
@@ -1186,9 +1231,50 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
                     mvwprintz( w_description, point( 0, 2 ), COL_STAT_PENALTY, _( "Ranged penalty: -%d" ),
                                std::abs( u.ranged_dex_mod() ) );
                 }
-                fold_and_print( w_description, point( 0, 4 ), getmaxx( w_description ) - 1, c_green,
-                                _( "Dexterity also enhances many actions which require finesse." ) );
-                break;
+                mvwprintz( w_description, point( 0, 3 ), COL_STAT_NEUTRAL, _( "Dodge skill: %.f" ),
+                           u.get_dodge() );
+                mvwprintz( w_description, point( 0, 4 ), COL_STAT_NEUTRAL, _( "Move cost while swimming: %i" ),
+                           u.swim_speed() );
+                mvwprintz( w_description, point( 0, 6 ), COL_STAT_NEUTRAL, _( "Affects:" ) );
+
+                int y = 7;
+
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of lockpicking" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Resistance for being grabbed by some monsters" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of escaping grabs and traps" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of disarming traps" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of success when manipulating with gun modifications" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of repairing and modifying clothes and armor" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Attack speed and chance of critical hits in melee combat" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of stealing" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Throwing speed" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Aiming speed" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Speed and effectiveness of chopping wood with powered tools" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance to avoid traps" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance to get better results when butchering corpses or cutting items" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of avoiding cuts on sharp terrain" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of losing control of vehicle when driving" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of damaging melee weapon on attack" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Damage from falling" ) );
+            }
+            break;
 
             case 2: {
                 const int read_spd = u.read_speed();
@@ -1196,21 +1282,83 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
                                                         ( read_spd < 100 ? COL_STAT_BONUS : COL_STAT_PENALTY ) ),
                            _( "Read times: %d%%" ), read_spd );
                 // NOLINTNEXTLINE(cata-use-named-point-constants)
+                mvwprintz( w_description, point( 0, 1 ), COL_STAT_NEUTRAL, _( "Persuade/lie skill: %i" ),
+                           u.persuade_skill() );
                 mvwprintz( w_description, point( 0, 2 ), COL_STAT_BONUS, _( "Crafting bonus: %2d%%" ),
                            u.get_int() );
-                fold_and_print( w_description, point( 0, 4 ), getmaxx( w_description ) - 1, c_green,
-                                _( "Intelligence is also used when crafting, installing bionics, and interacting with NPCs." ) );
+                mvwprintz( w_description, point( 0, 4 ), COL_STAT_NEUTRAL, _( "Affects:" ) );
+
+                int y = 5;
+
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Speed of 'catching up' practical experience to theoretical knowledge" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Detection and disarming traps" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of success when installing bionics" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of success when manipulating with gun modifications" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance to learn a recipe when crafting from a book" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance to learn martial arts techniques when using CQB bionic" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of hacking computers and card readers" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of successful robot reprogramming" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of successful decrypting memory cards" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of of bypassing vehicle security system" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance to get better results when disassembling items" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of being paralyzed by fear attack" ) );
             }
             break;
 
-            case 3:
+            case 3: {
                 if( u.ranged_per_mod() > 0 ) {
                     mvwprintz( w_description, point_zero, COL_STAT_PENALTY, _( "Aiming penalty: -%d" ),
                                u.ranged_per_mod() );
                 }
-                fold_and_print( w_description, point( 0, 2 ), getmaxx( w_description ) - 1, c_green,
-                                _( "Perception is also used for detecting traps and other things of interest." ) );
-                break;
+                // NOLINTNEXTLINE(cata-use-named-point-constants)
+                mvwprintz( w_description, point( 0, 1 ), COL_STAT_NEUTRAL, _( "Persuade/lie skill: %i" ),
+                           u.persuade_skill() );
+                mvwprintz( w_description, point( 0, 3 ), COL_STAT_NEUTRAL, _( "Affects:" ) );
+
+                int y = 4;
+
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Speed of 'catching up' practical experience to theoretical knowledge" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Time needed for safe cracking" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Sight distance on game map and overmap" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of stealing" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Throwing accuracy" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of losing control of vehicle when driving" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of spotting camouflaged creatures" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of lockpicking" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of foraging" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Precision when examining wounds and using first aid skill" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Detection and disarming traps" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Morale bonus when playing a musical instrument" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Effectiveness of repairing and modifying clothes and armor" ) );
+                y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
+                                     _( "- Chance of critical hits in melee combat" ) );
+            }
+            break;
         }
 
         wnoutrefresh( w );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1190,7 +1190,7 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
                 y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
                                      _( "- Throwing range, accuracy, and damage" ) );
                 y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
-                                     _( "- Reload speed for weapons using muscle power to reload: -20 moves per point of strength" ) );
+                                     _( "- Reload speed for weapons using muscle power to reload" ) );
                 y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
                                      _( "- Pull strength of some mutations" ) );
                 y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1309,7 +1309,7 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
                 y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
                                      _( "- Chance of successful decrypting memory cards" ) );
                 y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
-                                     _( "- Chance of of bypassing vehicle security system" ) );
+                                     _( "- Chance of bypassing vehicle security system" ) );
                 y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,
                                      _( "- Chance to get better results when disassembling items" ) );
                 y += fold_and_print( w_description, point( 0, y ), getmaxx( w_description ) - 1, c_green,


### PR DESCRIPTION
#### Summary
Interface "Detailed information for stats on character creation menu"

#### Purpose of change
More info allows less experienced players to meaningfully choose stats when creating their characters.
* Closes #67237.

#### Describe the solution
Ported https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/pull/70.

#### Describe alternatives you've considered
None.

#### Testing
Started creating character, switched to STATS tab, looked on the screen.

#### Additional context
![изображение](https://github.com/CleverRaven/Cataclysm-DDA/assets/11132525/c4f4ab7c-7f69-49b5-bfd8-46ab13854836)

![изображение](https://github.com/CleverRaven/Cataclysm-DDA/assets/11132525/17676ad2-a753-480d-996c-a1e3c33b3c7f)

![изображение](https://github.com/CleverRaven/Cataclysm-DDA/assets/11132525/35e6587b-5185-493a-9a38-f1ef520aebfe)

![изображение](https://github.com/CleverRaven/Cataclysm-DDA/assets/11132525/b0cb3711-f52e-48d3-ae00-c1d74ad03c8a)
