### PR TITLE
increase arpen of 556

### DIFF
--- a/data/json/items/ammo/223.json
+++ b/data/json/items/ammo/223.json
@@ -74,7 +74,7 @@
     "description": "5.56x45mm ammunition, loaded for precision from the Mk 12 SPR rifles, and later used by other SF units looking for more effective loadings for their M4A1 and Mk 18 carbines.  The Mk 262 Mod 1 is loaded with a 77 grain Open Tip Match bullet, enhancing lethality even at longer ranges when compared to older M855 loadings.",
     "price": 600,
     "price_postapoc": 2000,
-    "relative": { "damage": { "damage_type": "bullet", "amount": 1 } },
+    "relative": { "damage": { "damage_type": "bullet", "amount": 8 } },
     "proportional": { "recoil": 1.1 }
   },
   {
@@ -85,7 +85,7 @@
     "description": "5.56x45mm ammunition, developed due to SOF dissatisfaction with the M855 cartridge.  The Mk318 Mod 1 is loaded with a 62 grain Open Tip Match Rear Penetrator bullet, a copper slug enclosed inside an open-tipped brass projectile, providing for consistent loading, enhanced lethality and increased penetration.  When compared to M855, the Mk318 fragments consistently, even out of short-barreled carbines.",
     "price": 700,
     "price_postapoc": 2300,
-    "relative": { "damage": { "damage_type": "bullet", "amount": 1, "armor_penetration": 2 } },
+    "relative": { "damage": { "damage_type": "bullet", "amount": 1, "armor_penetration": 8 } },
     "proportional": { "recoil": 1.1 }
   },
   {
@@ -98,7 +98,7 @@
     "price": 290,
     "price_postapoc": 900,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
-    "relative": { "damage": { "damage_type": "bullet", "amount": -3, "armor_penetration": 4 }, "dispersion": 140 },
+    "relative": { "damage": { "damage_type": "bullet", "amount": -3, "armor_penetration": 10 }, "dispersion": 140 },
     "proportional": { "recoil": 1.1 },
     "extend": { "effects": [ "NEVER_MISFIRES" ] }
   },
@@ -111,7 +111,7 @@
     "price": 300,
     "price_postapoc": 1000,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
-    "relative": { "damage": { "damage_type": "bullet", "amount": -2, "armor_penetration": 5 }, "dispersion": 10 },
+    "relative": { "damage": { "damage_type": "bullet", "amount": -2, "armor_penetration": 11 }, "dispersion": 10 },
     "proportional": { "recoil": 1.1 },
     "extend": { "effects": [ "NEVER_MISFIRES" ] }
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "5.56x45mm ammo has greater armor penetration"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #67245
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Increase arpen of M855 from 6 to 12. Increases M855A1 from 7 to 13. Increases Mk 316 from 4 to 10. Increases Mk 262 from 4 to 10.
By comparison 5,45x39mm 7N22 has 14 arpen and 5.7x28mm has 20 arpen.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Give Mk 316 and Mk 262 a bit less armor penetration since they tend to fragment more. Numbers chosen are a little arbitrary.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
