### PR TITLE
Meds show portions in crafting menu

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2414,7 +2414,7 @@ void item::med_info( const item *med_item, std::vector<iteminfo> &info, const it
 
     if( parts->test( iteminfo_parts::MED_PORTIONS ) ) {
         info.emplace_back( "MED", _( "Portions: " ),
-                           std::abs( static_cast<int>( med_item->charges ) * batch ) );
+                           std::abs( static_cast<int>( med_item->count() ) * batch ) );
     }
 
     if( parts->test( iteminfo_parts::MED_CONSUME_TIME ) ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #67386
In #60885 I did this for food, but missed it for meds.

#### Describe the solution

Use `count` instead of `charges`.

#### Describe alternatives you've considered



#### Testing

Checked aspirin recipe and portions are in line with everything else.

#### Additional context

