### PR TITLE
[BombPerks] Attack speed perk for chainsaws & other powered blades(& a typo)

### DIFF
--- a/data/mods/BombasticPerks/corefiles/welcomemenu.json
+++ b/data/mods/BombasticPerks/corefiles/welcomemenu.json
@@ -81,7 +81,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_PERK_MENU_WELCOME_PLAYSTYLE",
-    "dynamic_line": "Normal perks are considered lifestyle perks and are small bonuses to help your character progress.  Playstyle perks on the other hand can vary wildly in power, in some cases aren't well balanced, and will define your characters playstyle.  Do you want to enable playstyle perks and if so, how many perk points should they cost?",
+    "dynamic_line": "Normal perks are considered lifestyle perks and are small bonuses to help your character progress.  Playstyle perks on the other hand can vary wildly in power, in some cases aren't well balanced, and will define your character's playstyle.  Do you want to enable playstyle perks and if so, how many perk points should they cost?",
     "responses": [
       {
         "text": "Default (4 perk points)",

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -586,6 +586,21 @@
         "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_chainsaw" } },
+        "text": "Gain [<trait_name:perk_chainsaw>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_chainsaw>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_chainsaw>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_chainsaw", "target_var": { "context_val": "trait_id" } },
+          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT_PLAYSTYLE"
+      },
+      {
         "condition": { "not": { "u_has_trait": "perk_skeleton" } },
         "text": "Gain [<trait_name:perk_skeleton>]",
         "effect": [

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -353,6 +353,17 @@
   },
   {
     "type": "mutation",
+    "id": "perk_chainsaw",
+    "name": { "str": "The Great Communicator" },
+    "points": 0,
+    "description": "You've always had something to say about ripping apart things with chainsaws.  You can swing powered blades faster.",
+    "category": [ "perk" ],
+    "enchantments": [
+      { "condition": { "u_has_wielded_with_flag": "MESSY" }, "values": [ { "value": "ATTACK_SPEED", "multiply": -0.20 } ] }
+    ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_olde_guns",
     "name": { "str": "Olde Reliables" },
     "points": 0,

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -358,9 +358,7 @@
     "points": 0,
     "description": "You've always had something to say about ripping apart things with chainsaws.  You can swing powered blades faster.",
     "category": [ "perk" ],
-    "enchantments": [
-      { "condition": { "u_has_wielded_with_flag": "MESSY" }, "values": [ { "value": "ATTACK_SPEED", "multiply": -0.20 } ] }
-    ]
+    "enchantments": [ { "condition": { "u_has_wielded_with_flag": "MESSY" }, "values": [ { "value": "ATTACK_SPEED", "multiply": -0.2 } ] } ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
Mods "Bombastic Perks: Perk for faster swing speed with powered blades"

#### Purpose of change

Powered blades such as chainsaws are iconic in apocalypse media for being able to cut down hordes(but fail in reality as weapons due to being heavy & having blades gum up on flesh). 

#### Describe the solution

Add +20% attack speed perk for powered blades(which are already flagged with MESSY in vanilla).

#### Describe alternatives you've considered

Different %.

#### Testing
Traitless, 8 stats, 3 in melee skills w/ equipped gear
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/99621099/bb26e1f5-51e0-41ae-abfd-28e686d922ec)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/99621099/1abd4cbf-5066-4451-ae11-8f1bfa41fc29)
Perk vs. no perk attack speed
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/99621099/ca99cda4-b751-43d7-8183-0b8ae48003fe)



#### Additional context