### PR TITLE
[Aftershock] Pad Aftershock items

### DIFF
--- a/data/mods/Aftershock/items/armor_helmets.json
+++ b/data/mods/Aftershock/items/armor_helmets.json
@@ -22,7 +22,7 @@
     "material_thickness": 5,
     "environmental_protection": 1,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "STURDY" ],
+    "flags": [ "VARSIZE", "STURDY", "PADDED" ],
     "melee_damage": { "bash": 10 }
   },
   {
@@ -50,7 +50,7 @@
     "material_thickness": 5,
     "environmental_protection": 2,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "VARSIZE", "STURDY", "SUN_GLASSES" ],
+    "flags": [ "VARSIZE", "STURDY", "PADDED", "SUN_GLASSES" ],
     "environmental_protection_with_filter": 16,
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "gasfilter_m": 100 } } ],
     "ammo": "gasfilter_m",
@@ -77,7 +77,7 @@
     "warmth": 10,
     "material_thickness": 4,
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "WATER_FRIENDLY", "STURDY" ],
+    "flags": [ "WATER_FRIENDLY", "STURDY", "PADDED" ],
     "melee_damage": { "bash": 10 }
   }
 ]

--- a/data/mods/Aftershock/items/tool_armor.json
+++ b/data/mods/Aftershock/items/tool_armor.json
@@ -35,7 +35,7 @@
     "warmth": 20,
     "environmental_protection": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "RAINPROOF", "STURDY", "WATERPROOF", "HYGROMETER" ],
+    "flags": [ "VARSIZE", "SKINTIGHT", "RAINPROOF", "STURDY", "WATERPROOF",  "PADDED" ],
     "armor": [
       {
         "encumbrance": 5,
@@ -51,10 +51,10 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "cryopod bodyglove (on)", "str_pl": "cryopod bodygloves (on)" },
     "looks_like": "afs_cryopod_bodyglove",
-    "description": "The temperature control units of this high-tech garment are currently active, and continuously draining battery power.  Use it to turn them off.",
+    "description": "A dark orange bodyglove, hundreds of tubes curl over its surface, tracing the contours of human musculature.  Meant to control body temperature during prolonged cryopreservation, it could easily keep you comfortable in any earthly climate. The temperature control units of this high-tech garment are currently active, and continuously draining battery power.  Use it to turn them off.",
     "power_draw": "90 W",
     "revert_to": "afs_cryopod_bodyglove",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "Your %s deactivates.", "target": "afs_cryopod_bodyglove" },
-    "flags": [ "STURDY", "WATERPROOF", "THERMOMETER", "RAINPROOF" ]
+    "flags": [ "VARSIZE", "SKINTIGHT", "RAINPROOF", "STURDY", "WATERPROOF", "PADDED", "THERMOMETER", "HYGROMETER" ]
   }
 ]

--- a/data/mods/Aftershock/items/tool_armor.json
+++ b/data/mods/Aftershock/items/tool_armor.json
@@ -35,7 +35,7 @@
     "warmth": 20,
     "environmental_protection": 10,
     "material_thickness": 1,
-    "flags": [ "VARSIZE", "SKINTIGHT", "RAINPROOF", "STURDY", "WATERPROOF",  "PADDED" ],
+    "flags": [ "VARSIZE", "SKINTIGHT", "RAINPROOF", "STURDY", "WATERPROOF", "PADDED" ],
     "armor": [
       {
         "encumbrance": 5,

--- a/data/mods/Aftershock/items/tool_armor.json
+++ b/data/mods/Aftershock/items/tool_armor.json
@@ -51,7 +51,7 @@
     "type": "TOOL_ARMOR",
     "name": { "str": "cryopod bodyglove (on)", "str_pl": "cryopod bodygloves (on)" },
     "looks_like": "afs_cryopod_bodyglove",
-    "description": "A dark orange bodyglove, hundreds of tubes curl over its surface, tracing the contours of human musculature.  Meant to control body temperature during prolonged cryopreservation, it could easily keep you comfortable in any earthly climate. The temperature control units of this high-tech garment are currently active, and continuously draining battery power.  Use it to turn them off.",
+    "description": "A dark orange bodyglove, hundreds of tubes curl over its surface, tracing the contours of human musculature.  Meant to control body temperature during prolonged cryopreservation, it could easily keep you comfortable in any earthly climate.  The temperature control units of this high-tech garment are currently active, and continuously draining battery power.  Use it to turn them off.",
     "power_draw": "90 W",
     "revert_to": "afs_cryopod_bodyglove",
     "use_action": { "type": "transform", "menu_text": "Turn off", "msg": "Your %s deactivates.", "target": "afs_cryopod_bodyglove" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Pad various Aftershock armor and clothing items"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
AFS helmets and the cryopod bodyglove were unpadded when the description implied they could be worn without padding. The bodyglove also had some inconsistencies between its active and inactive states.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added `padded` flag to helmets, bodyglove. Adjusted bodyglove flags: the activated bodyglove now has `thermometer` and `hygrometer` - figured it's a simple AR overlay or something.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
New UICA underlayer items
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
None.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
