### PR TITLE
AIM: Make navigation feel faster by fewer sidebar updates

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1658,7 +1658,9 @@ void advanced_inventory::display()
 
         if( ui ) {
             ui->invalidate_ui();
-            g->invalidate_main_ui_adaptor();
+            if( recalc ) {
+                g->invalidate_main_ui_adaptor();
+            }
             ui_manager::redraw_invalidated();
         }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Make AIM navigation feel faster by updating sidebar less"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Before, when pressing up/down in AIM to select different items, there was a noticeable subsecond delay before the selection changed. This made scrolling feel slow, at least on my machine.

A callgrind trace when pressing "down" 5 times in AIM is pictured below. The callgrind trace shows that about 40% of the work is spent on updating the main ui, with calls like `game::draw`, `draw_mminimap`, `update_visbility_cache` and `build_sunlight_cache`. It seems unncesessary to update these things for each up/down keypress in AIM.

![callgrind out 11194](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/b1754512-f3cf-44bd-90af-07410cf2a296)

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

This suggested change is to only invalidate the main ui when something has actually changed by AIM, such as items being moved or time has passed. With the suggested change applied, the callgrind trace no longer contains calls to for example `game::draw` when pressing "down" in AIM. Navigating the AIM with the arrow buttons feels smoother.

![callgrind out 11757](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/5b53488a-429f-4afc-9bdd-b910f8468967)

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

* It could also be investigated if there are ways to make `draw_mminimap`, `update_visbility_cache` and `build_sunlight_cache` do less work when called often without changes to the underlying data.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

* Pressing up/down in AIM now feels faster
* Did the steps in #63368 . Sidebar is still updated correctly when something is actually changed.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->

