### PR TITLE
Improve performance of recipe::create_results

### DIFF
--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -781,15 +781,20 @@ std::vector<item> recipe::create_results( int batch, item_components *used ) con
             item_components mult_comps = batch_comps.split( result_mult, j, is_cooked );
             std::vector<item> newits = create_result( set_components, temp.is_food(), &mult_comps );
 
-            for( const item &it : newits ) {
-                // try to combine batch results for liquid handling
-                auto found = std::find_if( items.begin(), items.end(), [it]( const item & rhs ) {
-                    return it.can_combine( rhs );
-                } );
-                if( found != items.end() ) {
-                    found->combine( it );
-                } else {
-                    items.emplace_back( it );
+            if( !result_->count_by_charges() ) {
+                items.reserve( items.size() + newits.size() );
+                items.insert( items.end(), newits.begin(), newits.end() );
+            } else {
+                for( const item &it : newits ) {
+                    // try to combine batch results for liquid handling
+                    auto found = std::find_if( items.begin(), items.end(), [it]( const item & rhs ) {
+                        return it.can_combine( rhs );
+                    } );
+                    if( found != items.end() ) {
+                        found->combine( it );
+                    } else {
+                        items.emplace_back( it );
+                    }
                 }
             }
         }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Helps a bit with #67344, but by no means fixes it.

#### Describe the solution

Don't try to combine items when they're not even count_by_charges.
Most of the CPU time is still spent creating results, but there's probably not too much more to gain there (for a non C++ person like me at least). I think more improvents would have to reduce the calls to `recipe::create_results` or make some reduced version for nutrient calculations.

#### Describe alternatives you've considered



#### Testing

Scroll through food recipes, it's a little better, but the more extreme cases are still bad.

#### Additional context

Learn all recipes > filter for `c:brown bread` > hold down

Before: (actually already slightly tweaked, only found the brown bread reproduction filter while fiddling around with stuff and didn't go back to pure master)

![grafik](https://github.com/CleverRaven/Cataclysm-DDA/assets/38702195/62f3383d-adb9-4026-a7d3-a562202c3668)

After:

![grafik](https://github.com/CleverRaven/Cataclysm-DDA/assets/38702195/5024f78d-4f7c-4ca6-aca0-26d830405d5b)

Because they're all so bad, it kinda feels the same as before honestly, but the data says it helps.