### PR TITLE
Overconfident officers drop their guns 100% of the time

### DIFF
--- a/data/json/monsters/civilians.json
+++ b/data/json/monsters/civilians.json
@@ -68,10 +68,7 @@
     "melee_damage": [ { "damage_type": "bash", "amount": 5 } ],
     "death_drops": {
       "subtype": "collection",
-      "items": [
-        { "group": "mon_zombie_cop_death_drops", "prob": 100 }, 
-        { "item": "glock_22", "prob": 100, "charges": [ 0, 6 ] }
-      ]
+      "items": [ { "group": "mon_zombie_cop_death_drops", "prob": 100 }, { "item": "glock_22", "prob": 100, "charges": [ 0, 6 ] } ]
     },
     "zombify_into": "mon_zombie_cop",
     "extend": { "flags": [ "DROPS_AMMO" ] },

--- a/data/json/monsters/civilians.json
+++ b/data/json/monsters/civilians.json
@@ -70,7 +70,7 @@
       "subtype": "collection",
       "items": [
         { "group": "mon_zombie_cop_death_drops", "prob": 100 }, 
-        { "item": "glock_22", "prob": 100 }
+        { "item": "glock_22", "prob": 100, "charges": [ 0, 6 ] }
       ]
     },
     "zombify_into": "mon_zombie_cop",

--- a/data/json/monsters/civilians.json
+++ b/data/json/monsters/civilians.json
@@ -66,7 +66,13 @@
     "melee_dice_sides": 4,
     "//2": "Uses a baton for melee attacks",
     "melee_damage": [ { "damage_type": "bash", "amount": 5 } ],
-    "death_drops": "mon_zombie_cop_death_drops",
+    "death_drops": {
+      "subtype": "collection",
+      "items": [
+        { "group": "mon_zombie_cop_death_drops", "prob": 100 }, 
+        { "item": "glock_22", "prob": 100 }
+      ]
+    },
     "zombify_into": "mon_zombie_cop",
     "extend": { "flags": [ "DROPS_AMMO" ] },
     "starting_ammo": { "40fmj": 10 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Make sure overconfident officers reliably drop their guns"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This issue was brought up in the [discourse page](https://discourse.cataclysmdda.org/t/overconfident-officer-does-not-drop-a-gun/28949) when I found it, and turn out overconfident officers have a mystery Glock that they don't drop all that often, leaving players to wonder where it went. This fixes that.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changed the death drops entry to have the officer drop their gun 100% of the time, which may or may not still have ammo in it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this, or always having the gun be empty
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I spawned in and killed a bunch of police officers, everything works fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
