### PR TITLE
More granularity and higher levels in backgrounds

### DIFF
--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -201,7 +201,7 @@
     "subtype": "hobby",
     "id": "archery_master",
     "name": "Archery (Master)",
-    "description": "You're a modern day Robin Hood and probably have hella back muscles.  Perhaps you're an olympic archer in training or maybe you're descended from the longbowmen of old.  In either case, sniping zombie heads should be as easy as pinning apples to trees for you.",
+    "description": "You're a modern day Robin Hood and probably have hella back muscles.  Perhaps you're an Olympic archer in training or maybe you're descended from the longbowmen of old.  In either case, sniping zombie heads should be as easy as pinning apples to trees for you.",
     "points": 8,
     "skills": [ { "level": 8, "name": "archery" }, { "level": 5, "name": "gun" } ],
     "proficiencies": [ "prof_bow_basic", "prof_bow_expert", "prof_bow_master" ]

--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -100,11 +100,21 @@
     "type": "profession",
     "subtype": "hobby",
     "id": "lockpicking",
-    "name": "Lockpicking",
+    "name": "Lockpicking (Beginner)",
     "description": "Whether it was for fun, innocent utility, or criminal intent, you learned the basics of how to silently pick locks.  Now, being able to get into secured places just got a lot more useful.",
     "points": 1,
     "proficiencies": [ "prof_lockpicking" ],
     "skills": [ { "level": 1, "name": "traps" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "lockpicking_expert",
+    "name": "Lockpicking (Expert)",
+    "description": "Maybe you're a certified locksmith, a career burglar, or an intense hobbyist.  Regardless, you've spent so long picking locks you could pop most open in under a minute easy, with the right tools.",
+    "points": 3,
+    "proficiencies": [ "prof_lockpicking", "prof_lockpicking_expert" ],
+    "skills": [ { "level": 4, "name": "traps" } ]
   },
   {
     "type": "profession",
@@ -170,17 +180,46 @@
     "type": "profession",
     "subtype": "hobby",
     "id": "archery",
-    "name": "Archery",
-    "description": "You enjoy nocking back an arrow and hearing it whistle through the air.  If you can get the proper gear together and stay on-target, you'll have a good, quiet alternative to using guns.",
-    "points": 3,
-    "skills": [ { "level": 3, "name": "archery" }, { "level": 2, "name": "gun" } ],
+    "name": "Archery (Beginner)",
+    "description": "You've used a bow before and maybe taken a class or two.  You won't be pulling off any trick shots but at least you can usually get an arrow to fly forward instead of spinning off to the side.",
+    "points": 2,
+    "skills": [ { "level": 2, "name": "archery" }, { "level": 2, "name": "gun" } ],
     "proficiencies": [ "prof_bow_basic" ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
+    "id": "archery_expert",
+    "name": "Archery (Intermediate)",
+    "description": "You enjoy nocking back an arrow and hearing it whistle through the air.  If you can get the proper gear together and stay on-target, you'll have a good, quiet alternative to using guns.",
+    "points": 4,
+    "skills": [ { "level": 4, "name": "archery" }, { "level": 3, "name": "gun" } ],
+    "proficiencies": [ "prof_bow_basic", "prof_bow_expert" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "archery_master",
+    "name": "Archery (Master)",
+    "description": "You're a modern day Robin Hood and probably have hella back muscles.  Perhaps you're an olympic archer in training or maybe you're descended from the longbowmen of old.  In either case, sniping zombie heads should be as easy as pinning apples to trees for you.",
+    "points": 8,
+    "skills": [ { "level": 8, "name": "archery" }, { "level": 5, "name": "gun" } ],
+    "proficiencies": [ "prof_bow_basic", "prof_bow_expert", "prof_bow_master" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "swimming_beginner",
+    "name": "Swimming (Beginner)",
+    "description": "You can swim.  Probably not very well, and you won't break any speed records, but, you CAN swim.",
+    "points": 1,
+    "skills": [ { "level": 2, "name": "swimming" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
     "id": "swimming",
-    "name": "Swimming",
+    "name": "Swimming (Intermediate)",
     "description": "You're a strong swimmer, and you're pretty sure zombies aren't.  You can't swim forever, but it's certainly an advantage over the undead.",
     "points": 2,
     "skills": [ { "level": 4, "name": "swimming" } ],
@@ -189,22 +228,78 @@
   {
     "type": "profession",
     "subtype": "hobby",
+    "id": "swimming_expert",
+    "name": "Swimming (Expert)",
+    "description": "You're an excellent swimmer and may be part fish.  Plus, all that swimming has left you in great shape.  There aren't any zombie sharks in the water, right?",
+    "points": 5,
+    "skills": [ { "level": 6, "name": "swimming" } ],
+    "traits": [ "OUTDOORSMAN", "GOODCARDIO" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "baseball_beginner",
+    "name": "Baseball (Beginner)",
+    "description": "You used to play baseball, occasionally.  Maybe you were on your school team growing up, but it was never a focus of yours.  Hopefully you can still remember how to use a bat when your life depends on it.",
+    "points": 2,
+    "skills": [ { "level": 2, "name": "bashing" }, { "level": 2, "name": "throw" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
     "id": "baseball",
-    "name": "Baseball",
+    "name": "Baseball (Intermediate)",
     "description": "You got the stance, you got the grip, you got the game.  Swinging at a zombie's head is close enough to swinging at a baseball… right?",
-    "points": 3,
-    "skills": [ { "level": 3, "name": "bashing" }, { "level": 2, "name": "throw" }, { "level": 1, "name": "swimming" } ]
+    "points": 4,
+    "skills": [ { "level": 4, "name": "bashing" }, { "level": 4, "name": "throw" }, { "level": 1, "name": "swimming" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "baseball_pitcher",
+    "name": "Baseball Pitcher (Expert)",
+    "description": "You're accustomed to striking out poor batters at the plate and can probably throw a mean knuckleball.  Now you get to practice your fastball, but perhaps with rocks or grenades this time.",
+    "points": 6,
+    "skills": [ { "level": 4, "name": "bashing" }, { "level": 7, "name": "throw" }, { "level": 3, "name": "swimming" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "baseball_expert",
+    "name": "Baseball (Expert)",
+    "description": "You didn't quite make it into the big leagues, but you were close.  Now it's time to clutch up and grand slam or you'll be dealing with worse than a strike out.",
+    "points": 6,
+    "skills": [ { "level": 6, "name": "bashing" }, { "level": 5, "name": "throw" }, { "level": 3, "name": "swimming" } ],
+    "traits": [ "GOODCARDIO" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "wrestling_beginner",
+    "name": "Wrestling (Beginner)",
+    "description": "Maybe you've taken a few classes at a gym somewhere, or used to be on the youth team, or maybe you just liked to rough-house with your friends or family growing up.  You're not entirely unused to grappling, but you're hardly an expert.",
+    "points": 2,
+    "skills": [ { "level": 1, "name": "melee" }, { "level": 2, "name": "unarmed" }, { "level": 2, "name": "dodge" } ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
     "id": "wrestling",
-    "name": "Wrestling",
+    "name": "Wrestling (Intermediate)",
     "description": "While not the type of wrestler to use folding chairs as weapons, you have experience wrasslin' and tusslin' with others out on the mat.  There's no referees around to see, but hopefully your skills will help you avoid getting pinned by the undead.",
-    "points": 4,
-    "//": "If Grab Break ever becomes a proficiency instead of tied to martial arts, it should absolutely be added here and replace Fast Reflexes.",
-    "skills": [ { "level": 1, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 3, "name": "dodge" } ],
+    "points": 5,
+    "skills": [ { "level": 3, "name": "melee" }, { "level": 4, "name": "unarmed" }, { "level": 4, "name": "dodge" } ],
     "traits": [ "FAST_REFLEXES" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "wrestling_expert",
+    "name": "Wrestling (Expert)",
+    "description": "You were likely on the 100+ wins list back in school and maybe you're a collegiate wrestler or you're using it as part of something like MMA.  Considering how grabby those zombies are, you should get plenty of use out of your skills.",
+    "points": 8,
+    "skills": [ { "level": 5, "name": "melee" }, { "level": 6, "name": "unarmed" }, { "level": 6, "name": "dodge" } ],
+    "traits": [ "FAST_REFLEXES", "GOODCARDIO" ]
   },
   {
     "type": "profession",
@@ -249,7 +344,7 @@
     "type": "profession",
     "subtype": "hobby",
     "id": "diy_crafts",
-    "name": "DIY Crafting",
+    "name": "DIY Crafting (Intermediate)",
     "description": "You spent much of your time making useful things out of bits and bobbles.",
     "points": 3,
     "proficiencies": [
@@ -265,12 +360,53 @@
   {
     "type": "profession",
     "subtype": "hobby",
+    "id": "diy_crafts_expert",
+    "name": "DIY Crafting (Expert)",
+    "description": "Whether due to circumstances forcing ingenuity or just an unhealthy fascination with tinkering you're a certified MacGyver with a very wide range of fabrication knowledge.  You could probably make a functioning cannon out of a paper clip and some bubble gum.",
+    "points": 8,
+    "proficiencies": [
+      "prof_pottery",
+      "prof_carving",
+      "prof_basketweaving",
+      "prof_elastics",
+      "prof_leatherworking_basic",
+      "prof_plasticworking",
+      "prof_elec_soldering",
+      "prof_metalworking",
+      "prof_welding_basic",
+      "prof_carpentry_basic"
+    ],
+    "skills": [ { "level": 6, "name": "fabrication" }, { "level": 2, "name": "tailor" }, { "level": 2, "name": "electronics" }, { "level": 2, "name": "mechanics" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "cooking_beginner",
+    "name": "Cooking (Beginner)",
+    "description": "You can cook well enough that you didn't have to live on instant noodles and takeout, but you've only really learned the bare minimum.",
+    "points": 1,
+    "proficiencies": [ "prof_food_prep" ],
+    "skills": [ { "level": 2, "name": "cooking" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
     "id": "cooking",
-    "name": "Cooking",
+    "name": "Cooking (Intermediate)",
     "description": "You enjoyed cooking for yourself and others.  The grocery stores are closed for good, so you might need to start getting creative with your recipes.",
     "points": 2,
     "proficiencies": [ "prof_baking", "prof_baking_bread", "prof_baking_desserts_1", "prof_food_prep", "prof_knife_skills" ],
-    "skills": [ { "level": 3, "name": "cooking" } ]
+    "skills": [ { "level": 4, "name": "cooking" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "cooking_expert",
+    "name": "Cooking (Expert)",
+    "description": "You're an excellent chef capable of making delicious meals out of almost anything and have a wide array of culinary knowledge.  Sadly, the undead would rather eat you than your meals.",
+    "points": 6,
+    "proficiencies": [ "prof_baking", "prof_baking_bread", "prof_baking_desserts_1", "prof_food_prep", "prof_knife_skills",  "prof_frying_dessert",  "prof_frying",  "prof_preservation",  "prof_scav_cooking" ],
+    "skills": [ { "level": 7, "name": "cooking" } ]
   },
   {
     "type": "profession",
@@ -288,8 +424,8 @@
     "id": "paintball",
     "name": "Paintball",
     "description": "Pretending to shoot at your friends has always been fun.  Now you can do it for real.",
-    "points": 2,
-    "skills": [ { "level": 3, "name": "rifle" }, { "level": 1, "name": "gun" } ]
+    "points": 3,
+    "skills": [ { "level": 3, "name": "rifle" }, { "level": 2, "name": "gun" } ]
   },
   {
     "type": "profession",
@@ -297,8 +433,8 @@
     "id": "plinking",
     "name": "Plinking",
     "description": "You enjoyed target plinking with your airsoft pistol.  You're a good shot, but you'll need a real gun for it to matter.",
-    "points": 2,
-    "skills": [ { "level": 3, "name": "pistol" }, { "level": 1, "name": "gun" } ]
+    "points": 3,
+    "skills": [ { "level": 3, "name": "pistol" }, { "level": 2, "name": "gun" } ]
   },
   {
     "type": "profession",
@@ -306,8 +442,8 @@
     "id": "skeet_shooting",
     "name": "Skeet Shooting",
     "description": "Where the skeet go, your shot follows.  Throw enough pellets downrange, and you'll at least hit something.",
-    "points": 2,
-    "skills": [ { "level": 3, "name": "shotgun" }, { "level": 1, "name": "gun" } ]
+    "points": 3,
+    "skills": [ { "level": 3, "name": "shotgun" }, { "level": 2, "name": "gun" } ]
   },
   {
     "type": "profession",
@@ -324,10 +460,20 @@
     "type": "profession",
     "subtype": "hobby",
     "id": "street_fighting",
-    "name": "Street Fighting",
-    "description": "You were constantly instigating fights in the street.  You can throw and dodge a punch better than most.",
-    "points": 2,
-    "skills": [ { "level": 1, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 2, "name": "dodge" } ]
+    "name": "Street Fighting (Intermediate)",
+    "description": "You've been in quite a few fights in the street.  You can throw and dodge a punch better than most.",
+    "points": 3,
+    "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 2, "name": "dodge" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "street_fighting_expert",
+    "name": "Street Fighting (Expert)",
+    "description": "Maybe you're the muscle of some criminal gang, maybe you're a bouncer at a club, or maybe you're just a huge asshole.  You've constantly been getting into fights with strangers on the streets for most of your life, and somehow you ain't dead yet, so you must be doing something right.",
+    "points": 6,
+    "skills": [ { "level": 5, "name": "melee" }, { "level": 6, "name": "unarmed" }, { "level": 4, "name": "dodge" } ],
+    "traits": [ "PAINRESIST" ]
   },
   {
     "type": "profession",
@@ -342,7 +488,7 @@
     "type": "profession",
     "subtype": "hobby",
     "id": "sewing",
-    "name": "Sewing",
+    "name": "Sewing (Intermediate)",
     "description": "You are quite good at sewing torn clothes back together, and have even made your own clothes a few times.",
     "points": 3,
     "proficiencies": [ "prof_closures", "prof_elastics", "prof_knitting" ],
@@ -351,11 +497,31 @@
   {
     "type": "profession",
     "subtype": "hobby",
+    "id": "sewing_expert",
+    "name": "Sewing (Expert)",
+    "description": "Despite modern technology making career tailors obsolete you've spent much of your life hand-making clothing of all sorts, whether for historical purposes or to sell as artisinal goods.  Too bad you can't stitch the holes in reality closed.",
+    "points": 8,
+    "proficiencies": [ "prof_closures", "prof_elastics", "prof_knitting", "prof_knitting_speed", "prof_quilting", "prof_closures_waterproofing", "prof_leatherworking_basic", "prof_furriery", "prof_spinning", "prof_weaving" ],
+    "skills": [ { "level": 7, "name": "tailor" }, { "level": 2, "name": "fabrication" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
     "id": "fencing",
-    "name": "Fencing",
+    "name": "Fencing (Intermediate)",
     "description": "You were in a fencing club, and you weren't too shabby with a saber.  If you can get your hands on a real sword, you'll be a formidable fighter.",
-    "points": 5,
-    "skills": [ { "level": 3, "name": "stabbing" }, { "level": 1, "name": "melee" } ],
+    "points": 6,
+    "skills": [ { "level": 3, "name": "stabbing" }, { "level": 3, "name": "melee" }, { "level": 3, "name": "dodge" } ],
+    "traits": [ "MARTIAL_FENCING" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "fencing_expert",
+    "name": "Fencing (Expert)",
+    "description": "You've spent so long practicing your fencing you wouldn't look out of place in the Renaissance dueling with ne'er-do-wells and rapscallions.  En Garde!",
+    "points": 10,
+    "skills": [ { "level": 6, "name": "stabbing" }, { "level": 5, "name": "melee" }, { "level": 5, "name": "dodge" } ],
     "traits": [ "MARTIAL_FENCING" ]
   },
   {
@@ -370,11 +536,20 @@
   {
     "type": "profession",
     "subtype": "hobby",
+    "id": "racing",
+    "name": "Racing",
+    "description": "You're a real speed demon in anything with an engine!  Pulling off hairpin turns at high speeds is a difficult skill to master but you can drift with the best of them.",
+    "points": 5,
+    "skills": [ { "level": 8, "name": "driving" }, { "level": 2, "name": "mechanics" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
     "id": "martial_training",
     "name": "Martial Arts",
     "description": "You have received some martial arts training at a local dojo.  You start with your choice of Karate, Judo, Aikido, Tai Chi, Taekwondo, or Pankration.",
-    "points": 4,
-    "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" } ],
+    "points": 5,
+    "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 3, "name": "dodge" } ],
     "traits": [ "MARTIAL_ARTS" ]
   },
   {
@@ -383,8 +558,8 @@
     "id": "self_defense",
     "name": "Self-Defense",
     "description": "You have taken some self-defense classes at a local gym.  You start with your choice of Boxing, Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
-    "points": 4,
-    "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" } ],
+    "points": 5,
+    "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 3, "name": "dodge" } ],
     "traits": [ "MARTIAL_ARTS2" ]
   },
   {
@@ -400,15 +575,40 @@
   {
     "type": "profession",
     "subtype": "hobby",
+    "id": "blackbelt_hobby",
+    "name": "Black Belt",
+    "description": "You've been doing martial arts for years and have earned the coveted black belt in a martial art of your choice.",
+    "points": 10,
+    "skills": [ { "level": 5, "name": "melee" }, { "level": 5, "name": "unarmed" }, { "level": 5, "name": "dodge" }, { "level": 3, "name": "swimming" } ],
+    "traits": [ "PROF_MA_BLACK" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
     "id": "melee_training",
-    "name": "Melee Training",
+    "name": "Melee Training (Intermediate)",
     "description": "You have practiced fighting with weapons.  You start with your choice of Barbaran Montante, Bōjutsu, Eskrima, Fencing, Fior Di Battaglia, Medieval Swordsmanship, Niten Ichi-Ryu, Pencak Silat, or Sōjutsu.",
-    "points": 6,
+    "points": 7,
     "skills": [
-      { "level": 2, "name": "melee" },
+      { "level": 3, "name": "melee" },
       { "level": 3, "name": "bashing" },
       { "level": 3, "name": "stabbing" },
       { "level": 3, "name": "cutting" }
+    ],
+    "traits": [ "MARTIAL_ARTS5" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "melee_training",
+    "name": "Melee Training (Expert)",
+    "description": "Despite firearms making traditional melee weapons largely obsolete, you have extensive experience fighting in hand-to-hand combat with tools of war.  Maybe it was full-contact HEMA or SCA sparring, or maybe you're just a badass commando with a machete.  You start with your choice of Barbaran Montante, Bōjutsu, Eskrima, Fencing, Fior Di Battaglia, Medieval Swordsmanship, Niten Ichi-Ryu, Pencak Silat, or Sōjutsu.",
+    "points": 14,
+    "skills": [
+      { "level": 6, "name": "melee" },
+      { "level": 5, "name": "bashing" },
+      { "level": 5, "name": "stabbing" },
+      { "level": 5, "name": "cutting" }
     ],
     "traits": [ "MARTIAL_ARTS5" ]
   },
@@ -573,9 +773,37 @@
   {
     "type": "profession",
     "subtype": "hobby",
+    "id": "basketball_beginner",
+    "name": "Basketball (Beginner)",
+    "description": "You'd shoot some b-ball outside of the school, until a couple of corpses up to no good started making trouble in the neighborhood.",
+    "points": 2,
+    "skills": [ { "level": 2, "name": "throw" }, { "level": 2, "name": "dodge" }, { "level": 1, "name": "swimming" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
     "id": "basketball",
-    "name": "Basketball",
+    "name": "Basketball (Intermediate)",
     "description": "Your ability to play point or post will beat the undead in overtime.",
+    "points": 4,
+    "skills": [ { "level": 4, "name": "throw" }, { "level": 3, "name": "dodge" }, { "level": 2, "name": "swimming" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "basketball_expert",
+    "name": "Basketball (Expert)",
+    "description": "You can sink 3-pointers all day and dribble around the most determined defenders.",
+    "points": 7,
+    "skills": [ { "level": 6, "name": "throw" }, { "level": 4, "name": "dodge" }, { "level": 3, "name": "swimming" } ],
+    "traits": [ "GOODCARDIO", "FAST_REFLEXES" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "football_beginner",
+    "name": "Football (Beginner)",
+    "description": "You'd occasionally play touch or flag football at the park, but never got too serious about it.",
     "points": 2,
     "skills": [ { "level": 2, "name": "throw" }, { "level": 2, "name": "dodge" }, { "level": 1, "name": "swimming" } ]
   },
@@ -583,20 +811,40 @@
     "type": "profession",
     "subtype": "hobby",
     "id": "football",
-    "name": "Football",
-    "description": "You could have gone pro if the world hadn't ended, but at least you've gone longer than most.",
+    "name": "Football (Intermediate)",
+    "description": "You're no stranger to throwing the ol' pigskin and taking a few tackles.  Hopefully your skills in dodging defenders will help you charge through the hordes of undead.",
+    "points": 5,
+    "skills": [ { "level": 3, "name": "throw" }, { "level": 3, "name": "dodge" }, { "level": 1, "name": "swimming" } ],
+    "traits": [ "TOUGH", "FLEET" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "football_expert",
+    "name": "Football (Expert)",
+    "description": "You played college ball, ya know.  You could have gone pro if the world hadn't ended.",
+    "points": 8,
+    "skills": [ { "level": 4, "name": "throw" }, { "level": 5, "name": "dodge" }, { "level": 3, "name": "swimming" } ],
+    "traits": [ "TOUGH", "FLEET", "PAINRESIST" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "shooter_beginner",
+    "name": "Shooting (Beginner)",
+    "description": "You've been to a gun range once or twice and maybe took a firearm safety class.  At the very least, you're confident you can point the gun in the correct direction.",
     "points": 2,
-    "skills": [ { "level": 1, "name": "throw" }, { "level": 1, "name": "dodge" }, { "level": 2, "name": "swimming" } ]
+    "skills": [ { "level": 1, "name": "shotgun" }, { "level": 1, "name": "pistol" }, { "level": 1, "name": "rifle" }, { "level": 2, "name": "gun" } ]
   },
   {
     "type": "profession",
     "subtype": "hobby",
     "id": "shooter",
-    "name": "Target Shooting",
-    "description": "You liked going to the local gun range and shooting at some targets or blasting cans off of fence posts.  Maybe if you just imagine targets on those undead, this could help.",
+    "name": "Shooting (Intermediate)",
+    "description": "You liked going to the local gun range and shooting at some targets or blasting cans off of fence posts with a variety of firearms.  Maybe if you just imagine targets on those undead, this could help.",
     "points": 2,
     "proficiencies": [ "prof_gun_cleaning" ],
-    "skills": [ { "level": 3, "name": "gun" } ]
+    "skills": [ { "level": 1, "name": "smg" }, { "level": 2, "name": "shotgun" }, { "level": 2, "name": "pistol" }, { "level": 2, "name": "rifle" }, { "level": 4, "name": "gun" } ]
   },
   {
     "type": "profession",
@@ -643,9 +891,9 @@
     "subtype": "hobby",
     "id": "home_improvement",
     "name": "Home Improvement",
-    "points": 2,
+    "points": 4,
     "description": "You'd fix up any holes and appliances in your own home with nothing but your two hands and some elbow grease.  You did it to save money on repairmen, but now it seems you'll do it to save your life.",
-    "skills": [ { "level": 2, "name": "fabrication" }, { "level": 1, "name": "mechanics" }, { "level": 1, "name": "electronics" } ],
+    "skills": [ { "level": 4, "name": "fabrication" }, { "level": 2, "name": "mechanics" }, { "level": 1, "name": "electronics" } ],
     "proficiencies": [ "prof_carpentry_basic", "prof_appliance_repair" ]
   },
   {

--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -376,7 +376,12 @@
       "prof_welding_basic",
       "prof_carpentry_basic"
     ],
-    "skills": [ { "level": 6, "name": "fabrication" }, { "level": 2, "name": "tailor" }, { "level": 2, "name": "electronics" }, { "level": 2, "name": "mechanics" } ]
+    "skills": [
+      { "level": 6, "name": "fabrication" },
+      { "level": 2, "name": "tailor" },
+      { "level": 2, "name": "electronics" },
+      { "level": 2, "name": "mechanics" }
+    ]
   },
   {
     "type": "profession",
@@ -405,7 +410,17 @@
     "name": "Cooking (Expert)",
     "description": "You're an excellent chef capable of making delicious meals out of almost anything and have a wide array of culinary knowledge.  Sadly, the undead would rather eat you than your meals.",
     "points": 6,
-    "proficiencies": [ "prof_baking", "prof_baking_bread", "prof_baking_desserts_1", "prof_food_prep", "prof_knife_skills",  "prof_frying_dessert",  "prof_frying",  "prof_preservation",  "prof_scav_cooking" ],
+    "proficiencies": [
+      "prof_baking",
+      "prof_baking_bread",
+      "prof_baking_desserts_1",
+      "prof_food_prep",
+      "prof_knife_skills",
+      "prof_frying_dessert",
+      "prof_frying",
+      "prof_preservation",
+      "prof_scav_cooking"
+    ],
     "skills": [ { "level": 7, "name": "cooking" } ]
   },
   {
@@ -501,7 +516,18 @@
     "name": "Sewing (Expert)",
     "description": "Despite modern technology making career tailors obsolete you've spent much of your life hand-making clothing of all sorts, whether for historical purposes or to sell as artisinal goods.  Too bad you can't stitch the holes in reality closed.",
     "points": 8,
-    "proficiencies": [ "prof_closures", "prof_elastics", "prof_knitting", "prof_knitting_speed", "prof_quilting", "prof_closures_waterproofing", "prof_leatherworking_basic", "prof_furriery", "prof_spinning", "prof_weaving" ],
+    "proficiencies": [
+      "prof_closures",
+      "prof_elastics",
+      "prof_knitting",
+      "prof_knitting_speed",
+      "prof_quilting",
+      "prof_closures_waterproofing",
+      "prof_leatherworking_basic",
+      "prof_furriery",
+      "prof_spinning",
+      "prof_weaving"
+    ],
     "skills": [ { "level": 7, "name": "tailor" }, { "level": 2, "name": "fabrication" } ]
   },
   {
@@ -579,7 +605,12 @@
     "name": "Black Belt",
     "description": "You've been doing martial arts for years and have earned the coveted black belt in a martial art of your choice.",
     "points": 10,
-    "skills": [ { "level": 5, "name": "melee" }, { "level": 5, "name": "unarmed" }, { "level": 5, "name": "dodge" }, { "level": 3, "name": "swimming" } ],
+    "skills": [
+      { "level": 5, "name": "melee" },
+      { "level": 5, "name": "unarmed" },
+      { "level": 5, "name": "dodge" },
+      { "level": 3, "name": "swimming" }
+    ],
     "traits": [ "PROF_MA_BLACK" ]
   },
   {
@@ -834,7 +865,12 @@
     "name": "Shooting (Beginner)",
     "description": "You've been to a gun range once or twice and maybe took a firearm safety class.  At the very least, you're confident you can point the gun in the correct direction.",
     "points": 2,
-    "skills": [ { "level": 1, "name": "shotgun" }, { "level": 1, "name": "pistol" }, { "level": 1, "name": "rifle" }, { "level": 2, "name": "gun" } ]
+    "skills": [
+      { "level": 1, "name": "shotgun" },
+      { "level": 1, "name": "pistol" },
+      { "level": 1, "name": "rifle" },
+      { "level": 2, "name": "gun" }
+    ]
   },
   {
     "type": "profession",
@@ -844,7 +880,13 @@
     "description": "You liked going to the local gun range and shooting at some targets or blasting cans off of fence posts with a variety of firearms.  Maybe if you just imagine targets on those undead, this could help.",
     "points": 2,
     "proficiencies": [ "prof_gun_cleaning" ],
-    "skills": [ { "level": 1, "name": "smg" }, { "level": 2, "name": "shotgun" }, { "level": 2, "name": "pistol" }, { "level": 2, "name": "rifle" }, { "level": 4, "name": "gun" } ]
+    "skills": [
+      { "level": 1, "name": "smg" },
+      { "level": 2, "name": "shotgun" },
+      { "level": 2, "name": "pistol" },
+      { "level": 2, "name": "rifle" },
+      { "level": 4, "name": "gun" }
+    ]
   },
   {
     "type": "profession",

--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -600,7 +600,7 @@
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "melee_training",
+    "id": "melee_training_expert",
     "name": "Melee Training (Expert)",
     "description": "Despite firearms making traditional melee weapons largely obsolete, you have extensive experience fighting in hand-to-hand combat with tools of war.  Maybe it was full-contact HEMA or SCA sparring, or maybe you're just a badass commando with a machete.  You start with your choice of Barbaran Montante, Bōjutsu, Eskrima, Fencing, Fior Di Battaglia, Medieval Swordsmanship, Niten Ichi-Ryu, Pencak Silat, or Sōjutsu.",
     "points": 14,

--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -267,7 +267,7 @@
     "subtype": "hobby",
     "id": "baseball_expert",
     "name": "Baseball (Expert)",
-    "description": "You didn't quite make it into the big leagues, but you were close.  Now it's time to clutch up and grand slam or you'll be dealing with worse than a strike out.",
+    "description": "You didn't quite make it into the big leagues, but you were close.  Now it's time to go for the grand slam or you'll be dealing with worse than a strike out.",
     "points": 6,
     "skills": [ { "level": 6, "name": "bashing" }, { "level": 5, "name": "throw" }, { "level": 3, "name": "swimming" } ],
     "traits": [ "GOODCARDIO" ]


### PR DESCRIPTION
#### Summary
Content "Add a bunch of new backgrounds that are tiers of existing ones."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The primary reason is more granularity in character creation for the roleplayers out there. If there's only one option for each background, then both "dad who played football with his kids" and "Peyton Manning" are sharing the same "Football" background. 

Fittingly, many of the new backgrounds are higher tiers of old ones (with a few lower tiers as well), since another thing I wanted to address was a lack of options for people wanting to play "experts" instead of the usual kinda-bad-at-everything survivors most players default to.

The last reason is tutorializing; as a new player it can be hard to parse what exactly "4 throwing" or etc. can entail, so hopefully by adding more concrete examples that are more specific than vaguely "you played basketball, here's 2 throwing" new players can see "Oh, a beginner archer would have 2 archery, an intermediate archer would have 4, and a master archer would have 8."

#### Describe the solution

A shitload of new background options, denoted generally with (Beginner) for <3, (Intermediate) for 3-5, (Expert) for 6-7, and (Master) for 8-10. I believe this adds up to about 25 new backgrounds in total. In particular, the backgrounds I've added grades to were Lockpicking, Swimming, Cooking, DIY Crafting, Sewing, Baseball, Basketball, Football, Wrestling, Street Fighting, Fencing, Shooting (previously Target Shooting) and Melee Weapon Training. I've also added upgraded versions of other traits that use proprietary names instead of just (Expert) or the like. These ones are Racing (upgrade of Motorsports) and Black Belt (an upgraded version of Self Defense and/or Martial Arts, based on the profession of the same name).

#### Describe alternatives you've considered

So much number fiddling...

#### Testing

Checked and made sure the game loaded without errors and the new backgrounds were functioning.

#### Additional context

This isn't an exhaustive list by any stretch, but I'm hoping others will follow suit for any backgrounds they might have an interest in.

It seems skills are labelled as "advanced" in the backgrounds menu for any skill 4 or higher, but that's not really something I can fix.

Lastly, I'd make the traits of the same type (i.e. Archery (Beginner) and Archery (Intermediate)) conflict and be unable to be taken together, but there doesn't seem to be that functionality that I could tell.