### PR TITLE
Rebalance some larger food loot groups to commercial kitchens

### DIFF
--- a/data/json/itemgroups/Food/food.json
+++ b/data/json/itemgroups/Food/food.json
@@ -280,20 +280,20 @@
       { "prob": 40, "group": "dry_lentils_bag_plastic_2" },
       { "prob": 40, "group": "dry_rice_bag_plastic_3" },
       { "prob": 6, "group": "meat_pickled_jar_glass_sealed_2" },
-      { "prob": 4, "group": "meat_canned_jar_3l_glass_sealed_12" },
-      { "prob": 4, "group": "veggy_canned_jar_3l_glass_sealed_12" },
-      { "prob": 4, "group": "apple_canned_jar_3l_glass_sealed_12" },
-      { "prob": 1, "group": "offal_canned_jar_3l_glass_sealed_12" },
-      { "prob": 4, "group": "can_tomato_jar_3l_glass_sealed_12" },
-      { "prob": 4, "group": "fish_pickled_jar_3l_glass_sealed_12" },
-      { "prob": 4, "group": "meat_pickled_jar_3l_glass_sealed_12" },
-      { "prob": 4, "group": "veggy_pickled_jar_3l_glass_sealed_12" },
-      { "prob": 4, "group": "fish_pickled_jar_3l_glass_sealed_12" },
-      { "item": "sauce_red", "prob": 4, "charges": 12, "container-item": "jar_3l_glass_sealed" },
-      { "item": "kompot", "prob": 4, "charges": 12, "container-item": "jar_3l_glass_sealed" },
-      { "group": "big_canned_food", "prob": 4 },
+      { "prob": 2, "group": "kitchen_sealed_3L_jar" },
+      { "group": "big_canned_food", "prob": 1 },
       { "group": "teabag_box", "prob": 20 },
       { "group": "soup_box", "prob": 20 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "cannedfood_commercial",
+    "subtype": "distribution",
+    "entries": [
+      { "prob": 1, "group": "kitchen_sealed_3L_jar", "count": [ 1, 4 ] },
+      { "prob": 1, "group": "kitchen_plastic_bag", "count": [ 1, 4 ] },
+      { "prob": 1, "group": "kitchen_sack", "count": [ 1, 2 ] }
     ]
   },
   {

--- a/data/json/itemgroups/food_service.json
+++ b/data/json/itemgroups/food_service.json
@@ -1528,6 +1528,50 @@
   },
   {
     "type": "item_group",
+    "id": "kitchen_sealed_3L_jar",
+    "subtype": "distribution",
+    "container-item": "jar_3l_glass_sealed",
+    "entries": [
+      { "item": "meat_canned", "prob": 4, "container-item": "null", "count": 12 },
+      { "item": "veggy_canned", "prob": 4, "container-item": "null", "count": 12 },
+      { "item": "apple_canned", "prob": 4, "container-item": "null", "count": 24 },
+      { "item": "offal_canned", "prob": 1, "container-item": "null", "count": 12 },
+      { "item": "can_tomato", "prob": 8, "container-item": "null", "count": 24 },
+      { "item": "fish_pickled", "prob": 2, "container-item": "null", "count": 12 },
+      { "item": "meat_pickled", "prob": 2, "container-item": "null", "count": 12 },
+      { "item": "fish_pickled", "prob": 2, "container-item": "null", "count": 12 },
+      { "item": "sauce_red", "prob": 8, "container-item": "null", "count": 6 },
+      { "item": "kompot", "prob": 4, "container-item": "null", "count": 12 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "kitchen_plastic_bag",
+    "subtype": "distribution",
+    "container-item": "bag_plastic",
+    "entries": [
+      { "item": "dry_beans", "prob": 4, "container-item": "null", "count": [ 1, 96 ] },
+      { "item": "dry_rice", "prob": 4, "container-item": "null", "count": [ 1, 48 ] },
+      { "item": "dry_lentils", "prob": 4, "container-item": "null", "count": [ 1, 32 ] },
+      { "item": "tortilla_flour", "prob": 4, "container-item": "null", "count": [ 1, 50 ] },
+      { "item": "tortilla_corn", "prob": 4, "container-item": "null", "count": [ 1, 50 ] },
+      { "item": "oats", "prob": 4, "container-item": "null", "count": [ 1, 8 ] },
+      { "item": "flour", "prob": 4, "container-item": "null", "count": [ 1, 100 ] }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "kitchen_sack",
+    "subtype": "distribution",
+    "container-item": "bag_canvas",
+    "entries": [
+      { "item": "potato", "prob": 6, "container-item": "null", "count": [ 1, 40 ] },
+      { "item": "carrot", "prob": 4, "container-item": "null", "count": [ 1, 116 ] },
+      { "item": "onion", "prob": 4, "container-item": "null", "count": [ 1, 60 ] }
+    ]
+  },
+  {
+    "type": "item_group",
     "id": "cookies_box_snack_4",
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",

--- a/data/json/mapgen/restaurant.json
+++ b/data/json/mapgen/restaurant.json
@@ -155,8 +155,8 @@
         { "group": "alcohol_bottled_canned", "x": 8, "y": 18, "chance": 80 },
         { "group": "baked_goods", "x": [ 9, 11 ], "y": 20, "chance": 50, "repeat": [ 2, 3 ] },
         { "group": "groce_bread", "x": [ 9, 11 ], "y": 20, "chance": 50, "repeat": [ 2, 3 ] },
-        { "group": "cannedfood", "x": [ 12, 13 ], "y": 18, "chance": 50, "repeat": [ 2, 3 ] },
-        { "group": "cannedfood", "x": [ 16, 18 ], "y": 18, "chance": 50, "repeat": [ 2, 3 ] }
+        { "group": "cannedfood_commercial", "x": [ 12, 13 ], "y": 18, "chance": 50, "repeat": [ 2, 4 ] },
+        { "group": "cannedfood_commercial", "x": [ 16, 18 ], "y": 18, "chance": 50, "repeat": [ 2, 4 ] }
       ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }

--- a/data/json/mapgen/school_1.json
+++ b/data/json/mapgen/school_1.json
@@ -506,7 +506,7 @@
       "k": { "item": "chem_school", "chance": 80, "repeat": [ 1, 4 ] },
       "l": { "item": "school", "chance": 60 },
       "o": { "item": "book_school", "chance": 100 },
-      "r": [ { "item": "snacks", "chance": 10, "repeat": [ 1, 2 ] }, { "item": "cannedfood", "chance": 60, "repeat": [ 1, 3 ] } ],
+      "r": [ { "item": "snacks", "chance": 10, "repeat": [ 1, 2 ] }, { "item": "cannedfood_commercial", "chance": 60, "repeat": [ 1, 3 ] } ],
       "p": { "item": "gym_school", "chance": 70, "repeat": [ 1, 5 ] },
       "R": { "item": "tools_plumbing", "chance": 55, "repeat": [ 1, 2 ] },
       "t": { "item": "dining", "chance": 33, "repeat": [ 1, 2 ] },
@@ -514,7 +514,7 @@
       "F": { "item": "file_room", "chance": 85, "repeat": [ 1, 4 ] },
       "U": [
         { "item": "snacks", "chance": 10, "repeat": [ 1, 2 ] },
-        { "item": "cannedfood", "chance": 70, "repeat": [ 1, 3 ] },
+        { "item": "cannedfood_commercial", "chance": 70, "repeat": [ 1, 3 ] },
         { "item": "dining", "chance": 5, "repeat": [ 1, 3 ] }
       ]
     },

--- a/data/json/mapgen/school_1.json
+++ b/data/json/mapgen/school_1.json
@@ -506,7 +506,10 @@
       "k": { "item": "chem_school", "chance": 80, "repeat": [ 1, 4 ] },
       "l": { "item": "school", "chance": 60 },
       "o": { "item": "book_school", "chance": 100 },
-      "r": [ { "item": "snacks", "chance": 10, "repeat": [ 1, 2 ] }, { "item": "cannedfood_commercial", "chance": 60, "repeat": [ 1, 3 ] } ],
+      "r": [
+        { "item": "snacks", "chance": 10, "repeat": [ 1, 2 ] },
+        { "item": "cannedfood_commercial", "chance": 60, "repeat": [ 1, 3 ] }
+      ],
       "p": { "item": "gym_school", "chance": 70, "repeat": [ 1, 5 ] },
       "R": { "item": "tools_plumbing", "chance": 55, "repeat": [ 1, 2 ] },
       "t": { "item": "dining", "chance": 33, "repeat": [ 1, 2 ] },

--- a/data/json/mapgen_palettes/restaurant_palette.json
+++ b/data/json/mapgen_palettes/restaurant_palette.json
@@ -110,7 +110,7 @@
       "5": { "item": "SUS_kitchen_sink", "chance": 100 },
       "6": [
         { "item": "SUS_pantry", "chance": 25 },
-        { "item": "cannedfood", "chance": 20, "repeat": [ 1, 2 ] },
+        { "item": "cannedfood_commercial", "chance": 20, "repeat": [ 1, 2 ] },
         { "item": "SUS_spice_collection", "chance": 100, "repeat": [ 1, 2 ] }
       ],
       "7": [ { "item": "coffee_display_2", "chance": 30 }, { "item": "SUS_coffee_cupboard", "chance": 50 } ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Less frequent large sealed food items in residential locations, more in commercial kitchens"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
It is uncommon for a house to store sealed 3L containers of food, while this size is far more likely to be used in a commercial kitchen, such as a restaurant kitchen. 

This also somewhat relates to #54917 

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
These drops have been moved to be more frequent in restaurant and school kitchens. They are still possible in the regular cannedfood loot table that occurs in residential locations, but at a reduced frequency.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
New item group cannedfood_commercial takes the place of cannedfood in school and restaurant locations. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Example loot pool
![loot](https://github.com/CleverRaven/Cataclysm-DDA/assets/52116377/502a5d0e-f365-43f6-822c-ca6d7a6bc687)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
