### PR TITLE
Micro dialogue update 2: Uyen

### DIFF
--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
@@ -189,6 +189,11 @@
           ]
         }
       },
+      {
+        "text": "So, did anyone tell you there are actual no-kidding talking cyborg-robot people out there now?",
+        "condition": { "u_has_var": "u_met_Rubik", "type": "general", "context": "meeting", "value": "yes" },
+        "topic": "TALK_REFUGEE_JENNY_Exodii"
+      },
       { "text": "Sorry about your luck.  What were you saying before?", "topic": "TALK_NONE" },
       { "text": "I'd better get going.", "topic": "TALK_DONE" }
     ]
@@ -216,6 +221,44 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_JENNY_World",
     "dynamic_line": "Ha!  I wonder how long that's going to be one of our go-to small talk questions.  It's perfect, isn't it?  Doesn't make you talk about the worst stuff but stays on theme for what's on everyone's mind.  Okay, I'll bite.  Have you heard any of the really wild stories?  Giant monsters the size of skyscrapers kicking over tanks and stuff, during the worst days?  I think somehow our planet got moved into another dimension, probably some kind of experimental process gone wrong.  During transit, some of those things came across, but they left when we arrived wherever we are now.  The rules are different here, and maybe we're superimposed with whatever version of Earth was here to start with, and that's why we hear about aliens and other unbelievable stuff out there along with the zombies.\"  She grins.  \"And before you say that's implausible, bear in mind that *the dead walk now*, so plausibility is off the table.",
+    "responses": [
+      { "text": "What were you saying before?", "topic": "TALK_NONE" },
+      { "text": "I'd better get going.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_REFUGEE_JENNY_Exodii",
+    "dynamic_line": "*lets out a low whistle.  \"No, not as such.  I've heard some rumors, I guess, but nothing credible.\"  She pauses, looking thoughtful.  \"I think, unless you can offer me some detailed answers about who and what they are and how they work, you'd better not tell me anything else.  I don't know if I could handle the stress.\"  With a gulp, she pulls listlessly at her earlobe.  \"If you do really know some juicy tidbits though, spill.\"",
+    "responses": [
+      {
+        "text": "Well, I know they're cyborgs, from some other dimension.  I think they're humans underneath the machines though.  Some of them kinda speak English.",
+        "condition": { "u_has_var": "u_knows_exodiilore", "type": "knowledge", "context": "exodization", "value": "yes" },
+        "topic": "TALK_REFUGEE_JENNY_Exodii2"
+      },
+      { "text": "What were you saying before?", "topic": "TALK_NONE" },
+      { "text": "I'd better get going.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_REFUGEE_JENNY_Exodii2",
+    "dynamic_line": "*puts her hands on her hips and glares at you.  \"I thought I made it clear I wasn't willing to accept enticing tidbits of information.  What the actual fuck?  Interdimensional cyborgs?  I don't want to believe you, but also, I already kinda thought there might be some multidimensional hijinx going on here, so I kinda do want to believe you.  They speak English though?  Are you sure this isn't some kind of scam?  Are you just fucking with me?  Honestly this would be a great way to fuck with me.\"",
+    "responses": [
+      {
+        "text": "(show her your bionic interface)",
+        "condition": { "u_has_trait": "CBM_Interface" },
+        "topic": "TALK_REFUGEE_JENNY_Exodii_Proof"
+      },
+      { "text": "What were you saying before?", "topic": "TALK_NONE" },
+      { "text": "I'd better get going.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_REFUGEE_JENNY_Exodii_Proof",
+    "dynamic_line": "*breathes a long, sighing curse as she examines your CBM interface.  \"Holeeeeeeshiiiiiiit.  This is amazing!  Like seriously, it's not even high tech.  At least not this part.  Can I see the schematics?  Can we dissect you?  I'm kidding.  Unless?  No, really kidding though.  Holy shit.\"  She pauses and studies you with a furrowed brow.  \"Wait, you let a strange interdimensional cyborg do brain surgery on you?  Never mind, I'd totally do that too.  Can you get me one of these?  No, I'd wind up taking it out and dismantling it.\"  She looks you up and down.  \"Thanks.  That's incredible.  It sucks that the world ended but I'm glad to know at least it ended with *cyborgs*.\"",
+    "//": "TK: Bring her a CBM to check out. Nothing useful results, it just makes her happy.",
     "responses": [
       { "text": "What were you saying before?", "topic": "TALK_NONE" },
       { "text": "I'd better get going.", "topic": "TALK_DONE" }

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
@@ -127,7 +127,9 @@
           ]
         }
       },
-      { "text": "Can you tell me anything about the other refugees here?", "topic": "TALK_REFUGEE_JENNY_Refugees1" }
+      { "text": "Can you tell me anything about the other refugees here?", "topic": "TALK_REFUGEE_JENNY_Refugees1" },
+      { "text": "How did you make it here during the chaos?", "topic": "TALK_REFUGEE_JENNY_Survival" },
+      { "text": "What do you think happened to the world?", "topic": "TALK_REFUGEE_JENNY_World" }
     ]
   },
   {
@@ -197,6 +199,24 @@
     "dynamic_line": "*grins and tugs at her shirt, an uncharacteristically crisp white T-shirt sporting a brightly colored penguin holding a slide rule, and a rainbow slogan reading 'sudo build it the way I told you to'.  \"Ha!  You must not know many engineers, hey?  I guess there's more to me than engineering, but most of my hobbies come back to it one way or the other.  It's not that I live for my work, doing engineering for a heating company wasn't some great dream, but when I got home I'd putter with the projects I wanted to do instead of the ones they made me do.  You know?  And of course, I had my friends and things, we'd go out or hang out and play board games and stuff.  Maybe some day I'll get a board game group started up here, although there's nothing wrong with the card games we've got now.  Plus I don't think Zombicide would hold the same interest for me as it used to.\"",
     "responses": [
       { "text": "What kind of board games do you play?", "topic": "TALK_REFUGEE_JENNY_Games1" },
+      { "text": "What were you saying before?", "topic": "TALK_NONE" },
+      { "text": "I'd better get going.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_REFUGEE_JENNY_Survival",
+    "dynamic_line": "*shrugs, looking distant.  \"I don't really like to talk about that time much.  None of us do.  Short story is that I made it to one of the evacuation shelters and got loaded onto a bus.  It was supposed to go to some sort of FEMA support camp, but there was a roadblock on the way there.  A few people just jumped out and ran for the military for protection.  They… it… it was bad.  The driver managed to get us turned around and booked it, and I guess they didn't chase us.  She took us back to one of the shelters and we found the address for this place.  Only a few of us decided to risk it, the rest stayed at the shelter to try their luck a different way.  I still wonder how they did.\"",
+    "responses": [
+      { "text": "What were you saying before?", "topic": "TALK_NONE" },
+      { "text": "I'd better get going.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_REFUGEE_JENNY_World",
+    "dynamic_line": "Ha!  I wonder how long that's going to be one of our go-to small talk questions.  It's perfect, isn't it?  Doesn't make you talk about the worst stuff but stays on theme for what's on everyone's mind.  Okay, I'll bite.  Have you heard any of the really wild stories?  Giant monsters the size of skyscrapers kicking over tanks and stuff, during the worst days?  I think somehow our planet got moved into another dimension, probably some kind of experimental process gone wrong.  During transit, some of those things came across, but they left when we arrived wherever we are now.  The rules are different here, and maybe we're superimposed with whatever version of Earth was here to start with, and that's why we hear about aliens and other unbelievable stuff out there along with the zombies.\"  She grins.  \"And before you say that's implausible, bear in mind that *the dead walk now*, so plausibility is off the table.",
+    "responses": [
       { "text": "What were you saying before?", "topic": "TALK_NONE" },
       { "text": "I'd better get going.", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Uyen_Tran.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Uyen_Tran.json
@@ -69,7 +69,13 @@
   {
     "type": "talk_topic",
     "//": "common talk responses",
-    "id": [ "TALK_REFUGEE_Uyen_2", "TALK_REFUGEE_Uyen_Background", "TALK_REFUGEE_Uyen_Situation" ],
+    "id": [
+      "TALK_REFUGEE_Uyen_2",
+      "TALK_REFUGEE_Uyen_Background",
+      "TALK_REFUGEE_Uyen_Situation",
+      "TALK_REFUGEE_UYEN_World",
+      "TALK_REFUGEE_Uyen_Kaiju"
+    ],
     "responses": [
       {
         "text": "I'm trying to put a cleanup crew together to tidy up the back room.  Can you help?",
@@ -92,6 +98,7 @@
         "condition": { "u_has_var": "Uyen_teach", "type": "knowledge", "context": "flag", "value": "yes" },
         "topic": "TALK_REFUGEE_Uyen_Teach"
       },
+      { "text": "What do you think happened to the world?", "topic": "TALK_REFUGEE_UYEN_World" },
       { "text": "Is there anything I can do to help you out?", "topic": "TALK_MISSION_LIST" },
       { "text": "What were you saying before?", "topic": "TALK_NONE" },
       { "text": "Actually I'm just heading out.", "topic": "TALK_DONE" }
@@ -148,8 +155,45 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Uyen_Background",
-    "dynamic_line": "\"I was a paramedic.\"  She idly touches her forehead to brush aside a bit of hair, then notices it's already tucked back.  \"I was there through some of the absolute worst of it, to this day I can't tell you how I made it out.  One thing led to another and I got pushed onto a bus to help take care of a couple people who needed assistance for travel.  Broken arms, that kinda stuff.  I got here early, I was one of the first to arrive.  Then, this woman in processing 'lost' my paperwork while I was busy helping a guy with a bad gash on his head.  If I hadn't made a stink about it, I'd probably be out in the lobby with those poor souls that couldn't get in at all.\"",
+    "dynamic_line": "I was a paramedic.\"  She idly touches her forehead to brush aside a bit of hair, then notices it's already tucked back.  \"I was there through some of the absolute worst of it, to this day I can't tell you how I made it out.  One thing led to another and I got pushed onto a bus to help take care of a couple people who needed assistance for travel.  Broken arms, that kinda stuff.  I got here early, I was one of the first to arrive.  Then, this woman in processing 'lost' my paperwork while I was busy helping a guy with a bad gash on his head.  If I hadn't made a stink about it, I'd probably be out in the lobby with those poor souls that couldn't get in at all.",
     "responses": [ { "text": "Could you teach me a bit about first aid?", "topic": "TALK_REFUGEE_Uyen_Teach" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_REFUGEE_Uyen_World",
+    "dynamic_line": "*smiles slightly.  \"Everyone's got some idea, hey?  I really don't know.  It seems crazy to even try to guess.  Can you believe we live in a world where corpses come back to life?  There's weirder stuff out there too.  In the hospital, people had all kinds of injuries and talked about seeing monsters.  On the way here, I saw huge creatures in the distance, the sort of thing that belongs in a kaiju movie, not stomping through suburban Worcester.\"  She shrugs.  \"I guess today I'll go with simulation theory.  None of this is real, we're all in a hyper-detailed computer simulation, and the creator is cruel and messing with us.\"  She briefly stares into space, as though looking directly into some imaginary camera.  \"Honestly I don't think any scientific explanation is ever going to get close to the sheer amount of mind-shattering madness around here.\"",
+    "responses": [ { "text": "Hey wait, are you a fan of kaiju stuff?", "topic": "TALK_REFUGEE_Uyen_Kaiju" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_REFUGEE_Uyen_Kaiju",
+    "dynamic_line": "*grins more broadly.  \"Busted!  Okay, I'm not like, a superfan.  My sister was huge into it, and I kinda picked it up through her, but yeah.  I'd do anything for a night on the couch with her, a copy of Pacific Rim, and a big bowl of popcorn.\"",
+    "responses": [
+      {
+        "text": "Maybe I could help.  There are lots of movie discs out there just collecting dust, and you've got electricity.",
+        "topic": "TALK_REFUGEE_Uyen_Kaiju2"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_REFUGEE_Uyen_Kaiju2",
+    "dynamic_line": "Right.\"  Her grin fades slowly.  \"There's one ingredient you can't replace, and without her, I don't…\" her voice catches.  \"Sorry.  That's a sweet offer though, I really appreciate it.",
+    "responses": [
+      { "text": "What were you saying before?", "topic": "TALK_NONE" },
+      { "text": "I'd better get going.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_REFUGEE_Uyen_Kaiju2",
+    "dynamic_line": "*grins more broadly.  \"Busted!  Okay, I'm not like, a superfan.  My sister was huge into it, and I kinda picked it up through her, but yeah.  I'd do anything for a night on the couch with her, a copy of Pacific Rim, and a big bowl of popcorn.",
+    "responses": [
+      {
+        "text": "Maybe I could help.  There are lots of movie discs out there just collecting dust, and you've got electricity.",
+        "topic": "TALK_REFUGEE_Uyen_Kaiju2"
+      }
+    ]
   },
   {
     "type": "talk_topic",


### PR DESCRIPTION
#### Summary
Content "Micro dialogue update 1: Small talk with Uyen Tran"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I've been unable to get back into my contributing hobby because I just can't maintain big things... so I decided to do some micro updates to dialogue, one PR at a time, rather than trying to overhaul a whole faction. I already did Jenny, and Uyen seemed like a fun one to get a bit of expansion

#### Describe the solution
Depends on #67413, though in hindsight I guess it didn't need to.

Added a few small talk options for Uyen: You can ask her what she thinks happened to the world, and that can lead to a brief conversation about kaiju.

#### Describe alternatives you've considered
I might add a little more  dialogue here bit by bit but never anything complex enough that it couldn't be done in a single commit.

#### Testing
TK but should need minimal tests.

#### Additional context
I don't know a ton about kaiju movies, if anyone wants to suggest some on-topic questions to add then I'll give her a little more to say on the topic.