### PR TITLE
[MoM] Fix zombie telepathic stuns

### DIFF
--- a/data/mods/MindOverMatter/damage_types.json
+++ b/data/mods/MindOverMatter/damage_types.json
@@ -56,7 +56,8 @@
         { "x_in_y_chance": { "x": 1, "y": 20 } },
         { "math": [ "_damage_taken", ">", "0" ] },
         { "not": { "npc_has_flag": "HIVE_MIND" } },
-        { "not": { "npc_has_flag": "TEEP_IMMUNE" } }
+        { "not": { "npc_has_flag": "TEEP_IMMUNE" } },
+        { "not": { "npc_has_flag": "TEEPSHIELD" } }
       ]
     },
     "effect": [ { "npc_add_effect": "downed", "duration": "1 s" } ]
@@ -69,7 +70,8 @@
         { "x_in_y_chance": { "x": 1, "y": 3 } },
         { "math": [ "_damage_taken", ">", "0" ] },
         { "not": { "npc_has_flag": "HIVE_MIND" } },
-        { "not": { "npc_has_flag": "TEEP_IMMUNE" } }
+        { "not": { "npc_has_flag": "TEEP_IMMUNE" } },
+        { "not": { "npc_has_flag": "TEEPSHIELD" } }
       ]
     },
     "effect": [ { "npc_add_effect": "stunned", "duration": "1 s" } ]
@@ -82,7 +84,8 @@
         { "x_in_y_chance": { "x": 2, "y": 3 } },
         { "math": [ "_damage_taken", ">", "0" ] },
         { "not": { "npc_has_flag": "HIVE_MIND" } },
-        { "not": { "npc_has_flag": "TEEP_IMMUNE" } }
+        { "not": { "npc_has_flag": "TEEP_IMMUNE" } },
+        { "not": { "npc_has_flag": "TEEPSHIELD" } }
       ]
     },
     "effect": [ { "npc_add_effect": "psi_dazed", "duration": "2 s" } ]

--- a/data/mods/MindOverMatter/damage_types.json
+++ b/data/mods/MindOverMatter/damage_types.json
@@ -55,7 +55,8 @@
       "and": [
         { "x_in_y_chance": { "x": 1, "y": 20 } },
         { "math": [ "_damage_taken", ">", "0" ] },
-        { "not": { "npc_has_flag": "HIVE_MIND" } }
+        { "not": { "npc_has_flag": "HIVE_MIND" } },
+        { "not": { "npc_has_flag": "TEEP_IMMUNE" } }
       ]
     },
     "effect": [ { "npc_add_effect": "downed", "duration": "1 s" } ]
@@ -67,7 +68,8 @@
       "and": [
         { "x_in_y_chance": { "x": 1, "y": 3 } },
         { "math": [ "_damage_taken", ">", "0" ] },
-        { "not": { "npc_has_flag": "HIVE_MIND" } }
+        { "not": { "npc_has_flag": "HIVE_MIND" } },
+        { "not": { "npc_has_flag": "TEEP_IMMUNE" } }
       ]
     },
     "effect": [ { "npc_add_effect": "stunned", "duration": "1 s" } ]
@@ -79,7 +81,8 @@
       "and": [
         { "x_in_y_chance": { "x": 2, "y": 3 } },
         { "math": [ "_damage_taken", ">", "0" ] },
-        { "not": { "npc_has_flag": "HIVE_MIND" } }
+        { "not": { "npc_has_flag": "HIVE_MIND" } },
+        { "not": { "npc_has_flag": "TEEP_IMMUNE" } }
       ]
     },
     "effect": [ { "npc_add_effect": "psi_dazed", "duration": "2 s" } ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix zombie telepathic stuns"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Despite being immune to telepathic damage, zombies (and robots etc) could still be dazed and stunned by telepathic assaults. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add an explicit check to the ondamage_eocs looking for the TEEP_IMMUNE flag, as well as the TEEPSHIELD flag so the PC will also be immune if using Telepathic Shield. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works! No stunned zombies found. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This will fix the specific problem reported in https://github.com/CleverRaven/Cataclysm-DDA/issues/67394 but not the underlying issue. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
