### PR TITLE
Improve turn performance when having many solar panels

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4811,7 +4811,7 @@ std::optional<int> link_up_actor::link_to_veh_app( Character *p, item &it,
                     ( it.link->t_abs_pos + prev_veh->coord_translate( it.link->t_mount ) ).raw(),
                     it.link->t_abs_pos.raw() );
 
-        for( const vpart_reference &vpr : prev_veh->get_any_parts( "POWER_TRANSFER" ) ) {
+        for( const vpart_reference &vpr : prev_veh->get_any_parts( VPFLAG_POWER_TRANSFER ) ) {
             if( vpr.part().target.first == prev_part_target.first &&
                 vpr.part().target.second == prev_part_target.second ) {
                 p->add_msg_if_player( m_warning, _( "The %1$s and %2$s are already connected." ),

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -635,6 +635,7 @@ void map::vehmove()
     }
     dirty_vehicle_list.clear();
     std::map<vehicle *, bool> vehs; // value true means in on map
+    std::unordered_set<vehicle *> connected_vehs;
     for( int zlev = minz; zlev <= maxz; ++zlev ) {
         const level_cache *cache = get_cache_lazy( zlev );
         if( !cache ) {
@@ -642,10 +643,11 @@ void map::vehmove()
         }
         for( vehicle *veh : cache->vehicle_list ) {
             vehs[veh] = true; // force on map vehicles to true
-            for( const std::pair<vehicle *const, float> &pair : veh->search_connected_vehicles() ) {
-                vehs.emplace( pair.first, false ); // add with 'false' if does not exist (off map)
-            }
+            veh->get_connected_vehicles( connected_vehs );
         }
+    }
+    for( vehicle *connected_veh : connected_vehs ) {
+        vehs.emplace( connected_veh, false ); // add with 'false' if does not exist (off map)
     }
     for( const std::pair<vehicle *const, bool> &veh_pair : vehs ) {
         veh_pair.first->idle( /* on_map = */ veh_pair.second );

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -3323,7 +3323,7 @@ void veh_interact::complete_vehicle( Character &you )
             }
 
             // Power cables must remove parts from the target vehicle, too.
-            if( vpi.has_flag( "POWER_TRANSFER" ) ) {
+            if( vpi.has_flag( VPFLAG_POWER_TRANSFER ) ) {
                 veh.remove_remote_part( vp );
             }
 

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -132,7 +132,8 @@ static const std::unordered_map<std::string, vpart_bitflags> vpart_bitflag_map =
     { "TURRET_CONTROLS", VPFLAG_TURRET_CONTROLS },
     { "ROOF", VPFLAG_ROOF },
     { "CABLE_PORTS", VPFLAG_CABLE_PORTS },
-    { "BATTERY", VPFLAG_BATTERY }
+    { "BATTERY", VPFLAG_BATTERY },
+    { "POWER_TRANSFER", VPFLAG_POWER_TRANSFER }
 };
 
 static std::map<vpart_id, vpart_migration> vpart_migrations;

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -108,6 +108,7 @@ enum vpart_bitflags : int {
     VPFLAG_ROOF,
     VPFLAG_CABLE_PORTS,
     VPFLAG_BATTERY,
+    VPFLAG_POWER_TRANSFER,
 
     NUM_VPFLAGS
 };

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -854,6 +854,8 @@ class vehicle
         std::map<vehicle *, float> search_connected_vehicles();
         //! @copydoc vehicle::search_connected_vehicles( Vehicle *start )
         std::map<const vehicle *, float> search_connected_vehicles() const;
+        //! @copydoc vehicle::search_connected_vehicles( Vehicle *start )
+        void get_connected_vehicles( std::unordered_set<vehicle *> &dest );
 
         /// Returns a map of connected battery references to power loss factor
         /// Keys are batteries in vehicles (includes self) connected by POWER_TRANSFER parts

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1864,7 +1864,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
     bool power_linked = false;
     bool cable_linked = false;
     for( vehicle_part *vp_part : vp_parts ) {
-        power_linked = power_linked ? true : vp_part->info().has_flag( "POWER_TRANSFER" );
+        power_linked = power_linked ? true : vp_part->info().has_flag( VPFLAG_POWER_TRANSFER );
         cable_linked = cable_linked ? true : vp_part->has_flag( vp_flag::linked_flag ) ||
                        vp_part->info().has_flag( "TOW_CABLE" );
     }
@@ -2088,7 +2088,7 @@ void vehicle::build_interact_menu( veh_menu &menu, const tripoint &p, bool with_
         .on_submit( [this, vp_parts] {
             for( vehicle_part *vp_part : vp_parts )
             {
-                if( vp_part->info().has_flag( "POWER_TRANSFER" ) ) {
+                if( vp_part->info().has_flag( VPFLAG_POWER_TRANSFER ) ) {
                     item drop = part_to_item( *vp_part );
                     if( !magic && !drop.has_flag( STATIC( flag_id( "NO_DROP" ) ) ) ) {
                         get_player_character().i_add_or_drop( drop );


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Improve turn performance when having many solar panels"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

When having many solar panels, each turn can take a long time, most noticeable when sleeping or waiting. This change attempts to reduce the number of calls during each turn without changing any behaviour.

This was verified using a setup of 20 adjacent solar panels in a x3 grid, as pictured below.

![rumney-layout](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/0a7ec928-bf8d-4223-9fa7-f2815f0a7861)

A callgrind trace was done to measure which parts of `do_turn()` take up work, pictured below. The callgrind trace shows that **31%** of the work in `do_turn()` comes from `map::vehmove()`, which in turn calls `vehicle::search_connected_vehicles`. In effect, `search_connected_vehicles` takes up 27% of the work in `do_turn()`. The callgrind trace measured 177 calls to `vehmove`, which in turn resulted in 531693 calls to `find_vehicle` - which gives approximately **3004** calls to `find_vehicle` for each turn.

![callgrind out rumney-master](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/94054f53-b625-403d-bf73-7dc046347928)

This issue relates to #57152 , which was resolved in #60776 , but the issue seems to have reappeared since then.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

The existing method `vehicle::search_connected_vehicles` uses a variant of Dijkstra's algorithm to find the shortest path to each vehicle. When doing this, it traverses many of the vehicles multiple times, comparing the found path lengths each time and choosing the shorter one. But the calls from `vehmove` shown in the callgrind trace above, do not in fact require us to find the shortest path - it only needs the list of unique vehicles. This makes it possible to simplify the vehicle traversal done in `map::vehmove` to only step through each vehicle once.

The simpler algorithm that only finds unique connected vehicles is implemented in a new function `get_connected_vehicles`, which populates the supplied set.

With this change applied, a callgrind trace was done using the same map as above. The new callgrind trace now shows that **9%** of the work in `do_turn()` now comes from `map::vehmove()` (was 31% before). The callgrind trace measured 277 calls to `vehmove`, which in turn resulted in 172026 calls to `find_vehicle` - which gives approximately **621** calls to `find_vehicle` for each turn (was 3004 before, as shown above).

![callgrind out rumney-get_connected_vehicles](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/bcdbf185-4c20-433c-b3d0-bee435411332)

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

* Merging adjacent solarpanels into a single but larger vehicle, as done in #60681
* The current implementation of Dijkstra's algorithm in `vehicle::search_connected_vehicles` might be incorrect. Other implementations usually start each step of the loop by finding the first unvisited node with the lowest weight. The current implementation seems to pick any that was put on the queue. This might make it traverse each node multiple times, which is not needed if implemented correctly.
* It is unclear whether the calls to `search_connected_vehicles`/`get_connected_vehicles` done by `vehicle::gain_moves` each 5 turns are actually needed. It might be possible to just remove those calls.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

* Verified that batteries are still being charged/discharged, appliances still work etc

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Hour debug timer before:

![rumney-hourtimer-before](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/3f21afbf-6ab0-4886-8143-b14ebad34f78)

After:

![rumney-hourtimer-after](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/d8e5976f-c50b-44ba-a322-838b42e52989)

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
