### PR TITLE
fix bp fouling rusting (again)

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13437,11 +13437,11 @@ bool item::process_blackpowder_fouling( Character *carrier )
     // this speeds up by the amount the gun is dirty, 2-6x as fast depending on dirt level.
     set_var( "rust_timer", get_var( "rust_timer", 0 ) + 1 + static_cast<int>( get_var( "dirt",
              0 ) / 2000 ) );
-    if( damage() < max_damage() && get_var( "rust_timer", 0 ) > 43200.0 / ( damage() + 1 ) ) {
+    if( damage() < max_damage() && get_var( "rust_timer", 0 ) > 43200.0 * ( damage() + 1 ) ) {
         inc_damage();
         set_var( "rust_timer", 0 );
         if( carrier ) {
-            carrier->add_msg_if_player( m_bad, _( "Your %s rusts due to blackpowder fouling." ), tname() );
+            carrier->add_msg_if_player( m_bad, _( "Your %s rusts due to corrosive powder fouling." ), tname() );
         }
     }
     return false;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13436,7 +13436,8 @@ bool item::process_blackpowder_fouling( Character *carrier )
     // rust is deterministic. 12 hours for first rust, then 24 (36 total), then 36 (72 total) and finally 48 (120 hours to go to XX)
     // this speeds up by the amount the gun is dirty, 2-6x as fast depending on dirt level.
     set_var( "rust_timer", get_var( "rust_timer", 0 ) + 1 + get_var( "dirt", 0 ) / 2000 );
-	double time_mult = 1.0 + ( 4.0 * static_cast<double>( damage() ) ) / static_cast<double>( max_damage() );
+    double time_mult = 1.0 + ( 4.0 * static_cast<double>( damage() ) ) / static_cast<double>
+                       ( max_damage() );
     if( damage() < max_damage() && get_var( "rust_timer", 0 ) > 43200.0 * time_mult ) {
         inc_damage();
         set_var( "rust_timer", 0 );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13435,9 +13435,9 @@ bool item::process_blackpowder_fouling( Character *carrier )
 {
     // rust is deterministic. 12 hours for first rust, then 24 (36 total), then 36 (72 total) and finally 48 (120 hours to go to XX)
     // this speeds up by the amount the gun is dirty, 2-6x as fast depending on dirt level.
-    set_var( "rust_timer", get_var( "rust_timer", 0 ) + 1 + static_cast<int>( get_var( "dirt",
-             0 ) / 2000 ) );
-    if( damage() < max_damage() && get_var( "rust_timer", 0 ) > 43200.0 * ( damage() + 1 ) ) {
+    set_var( "rust_timer", get_var( "rust_timer", 0 ) + 1 + get_var( "dirt", 0 ) / 2000 );
+	double time_mult = 1.0 + ( 4.0 * static_cast<double>( damage() ) ) / static_cast<double>( max_damage() );
+    if( damage() < max_damage() && get_var( "rust_timer", 0 ) > 43200.0 * time_mult ) {
         inc_damage();
         set_var( "rust_timer", 0 );
         if( carrier ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "more fixes for blackpowder rusting"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Blackpowder rusting was normal until the first tick of damage then it did the rest of the damage over the next few turns.
So in other words it was bugged. I think when I made my initial fixes damage was still [0, 4] and my method assumed that but broke when it became a much larger range of numbers.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make damage scaling agnostic of what numbers damage uses. Fixes fouling rust getting faster the more damaged it was.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I changed the message to say "corrosive powder fouling" instead of "blackpowder fouling" in order to support my matchhead PR but I don't have to do that. It would be helpful it we ever had corrosive primers or something though.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested the following:
Shot a gun 6 times. Had about 500 `dirt` on it. Waited 12 hrs, first tick of damage at the end of the wait. Then waited 24hrs for the next, 36 for the next, 48 for the final.
Shot a gun 25 times. Had _ level fouling (about 2200 `dirt`). Waited 6 hours. Gun rusted due to fouling.
Shot a gun 50 times. Had the next step of fouling (4500 `dirt`) Waited 4 hours. Gun rusted due to fouling.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
