### PR TITLE
Cataclysm and game start dates are to be set through scenarios

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -521,7 +521,7 @@
     "start_name": "Outside Town",
     "surround_groups": [ [ "GROUP_BLACK_ROAD", 70.0 ] ],
     "flags": [ "LONE_START" ],
-    "custom_initial_date": { "season": "winter" },
+    "start_of_game": { "season": "winter" },
     "add_professions": true,
     "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army" ],
     "requirement": "achievement_survive_91_days"
@@ -546,7 +546,7 @@
     ],
     "start_name": "Outside Town",
     "flags": [ "LONE_START" ],
-    "custom_initial_date": { "season": "summer", "year": 2 },
+    "start_of_game": { "season": "summer", "year": 2 },
     "add_professions": true,
     "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army" ],
     "requirement": "achievement_survive_91_days"
@@ -559,7 +559,7 @@
     "description": "It's been a year since the apocalypse, and winter is fast approaching.  You and your company have managed to gather up enough supplies to finally settle down somewhere, away from the death and destruction.  Life has been hard for you, but in your heart you still hold a vision of a bright future lying ahead.",
     "start_name": "Old Evac Shelter",
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
-    "custom_initial_date": { "season": "autumn", "year": 2 },
+    "start_of_game": { "season": "autumn", "year": 2 },
     "add_professions": true,
     "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army" ],
     "requirement": "achievement_survive_91_days",
@@ -575,7 +575,7 @@
     "allowed_locs": [ "sloc_lmoe_empty", "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "start_name": "Enclosed Shelter",
     "flags": [ "LONE_START" ],
-    "custom_initial_date": { "season": "winter" },
+    "start_of_game": { "season": "winter" },
     "professions": [ "sheltered_militia", "sheltered_survivor", "unemployed" ]
   },
   {
@@ -648,7 +648,7 @@
     "requirement": "achievement_reach_mi-Go_encampment",
     "reveal_locale": false,
     "flags": [ "LONE_START", "CHALLENGE" ],
-    "custom_initial_date": { "season": "winter" }
+    "start_of_game": { "season": "winter" }
   },
   {
     "type": "scenario",
@@ -1097,7 +1097,7 @@
     "description": "You were camping in the wild to let things back home cool off.  One night strange noises closed in on you and you were attacked.  You managed to get away but can feel things moving in the dark.",
     "id": "camp_attack_start",
     "points": 0,
-    "custom_initial_date": { "hour": 1 },
+    "start_of_game": { "hour": 1 },
     "start_name": "Wilderness",
     "eoc": [ "scenario_surrounded_zombie_heavy" ],
     "allowed_locs": [

--- a/data/mods/Standard_Combat_Tests/modinfo.json
+++ b/data/mods/Standard_Combat_Tests/modinfo.json
@@ -37,7 +37,7 @@
     "professions": [ "sct_mid" ],
     "map_extra": "mx_sct_mid",
     "flags": [ "CITY_START", "LONE_START" ],
-    "custom_initial_date": { "hour": 8, "day": 45, "season": "summer" }
+    "start_of_game": { "hour": 8, "day": 45, "season": "summer" }
   },
   {
     "type": "scenario",
@@ -50,7 +50,7 @@
     "professions": [ "sct_late" ],
     "map_extra": "mx_sct_late",
     "flags": [ "CITY_START", "LONE_START" ],
-    "custom_initial_date": { "hour": 8, "day": 45, "season": "autumn" }
+    "start_of_game": { "hour": 8, "day": 45, "season": "autumn" }
   },
   {
     "id": "mx_sct_day1",

--- a/data/mods/TEST_DATA/scenarios.json
+++ b/data/mods/TEST_DATA/scenarios.json
@@ -1,6 +1,51 @@
 [
   {
     "type": "scenario",
+    "id": "test_custom_game",
+    "name": "Test custom game start date",
+    "points": 0,
+    "description": "Test starting on custom game start date.",
+    "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
+    "start_name": "Evac Shelter",
+    "flags": [ "CITY_START" ],
+    "start_of_game": { "year": 4, "season": "summer", "day": 7, "hour": 18 }
+  },
+  {
+    "type": "scenario",
+    "id": "test_custom_game_invalid",
+    "name": "Test invalid custom game start date",
+    "points": 0,
+    "description": "Test starting on custom start date that is before cataclysm start date.",
+    "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
+    "start_name": "Evac Shelter",
+    "flags": [ "CITY_START" ],
+    "start_of_game": { "year": -1, "season": "spring", "day": 8, "hour": 3 }
+  },
+  {
+    "type": "scenario",
+    "id": "test_custom_cataclysm",
+    "name": "Test custom cataclysm start date",
+    "points": 0,
+    "description": "Test starting with custom cataclysm start date.",
+    "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
+    "start_name": "Evac Shelter",
+    "flags": [ "CITY_START" ],
+    "start_of_cataclysm": { "year": 7, "season": "autumn", "day": 9, "hour": 1 }
+  },
+  {
+    "type": "scenario",
+    "id": "test_custom_both",
+    "name": "Test custom cataclysm start date and game start date",
+    "points": 0,
+    "description": "Test starting with custom cataclysm start date and on custom game start date.",
+    "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
+    "start_name": "Evac Shelter",
+    "flags": [ "CITY_START" ],
+    "start_of_cataclysm": { "year": 6, "season": "winter", "day": 4, "hour": 6 },
+    "start_of_game": { "year": 9, "season": "autumn", "day": 19, "hour": 13 }
+  },
+  {
+    "type": "scenario",
     "id": "test_random_hour",
     "name": "Test random hour",
     "points": 0,
@@ -8,7 +53,7 @@
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "start_name": "Evac Shelter",
     "flags": [ "CITY_START" ],
-    "custom_initial_date": { "hour": -1, "season": "summer" }
+    "start_of_game": { "hour": "random", "season": "summer" }
   },
   {
     "type": "scenario",
@@ -19,7 +64,7 @@
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "start_name": "Evac Shelter",
     "flags": [ "CITY_START" ],
-    "custom_initial_date": { "day": -1, "season": "summer" }
+    "start_of_game": { "day": "random", "season": "summer", "hour": 8 }
   },
   {
     "type": "scenario",
@@ -30,6 +75,6 @@
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "start_name": "Evac Shelter",
     "flags": [ "CITY_START" ],
-    "custom_initial_date": { "year": -1, "season": "summer" }
+    "start_of_game": { "year": "random", "season": "summer", "hour": 8 }
   }
 ]

--- a/data/mods/innawood/scenarios.json
+++ b/data/mods/innawood/scenarios.json
@@ -261,7 +261,7 @@
     "start_name": "Outside Town",
     "surround_groups": [ [ "GROUP_BLACK_ROAD", 70.0 ] ],
     "flags": [ "LONE_START" ],
-    "custom_initial_date": { "season": "winter" },
+    "start_of_game": { "season": "winter" },
     "professions": [
       "svictim",
       "naked",
@@ -301,7 +301,7 @@
     "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island", "sloc_river" ],
     "start_name": "Outside Town",
     "flags": [ "LONE_START" ],
-    "custom_initial_date": { "season": "summer", "year": 2 },
+    "start_of_game": { "season": "summer", "year": 2 },
     "professions": [
       "svictim",
       "naked",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1579,6 +1579,20 @@
   },
   {
     "type": "keybinding",
+    "id": "RANDOMIZE_SCENARIO_START_OF_CATACLYSM",
+    "category": "NEW_CHAR_SCENARIOS",
+    "name": "Randomize cataclysm start date",
+    "bindings": [ { "input_method": "keyboard_char", "key": "^" }, { "input_method": "keyboard_code", "key": "6", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "RANDOMIZE_SCENARIO_START_OF_GAME",
+    "category": "NEW_CHAR_SCENARIOS",
+    "name": "Randomize game start date",
+    "bindings": [ { "input_method": "keyboard_char", "key": "&" }, { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
     "id": "SORT",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Toggle sorting order",

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -249,7 +249,8 @@ Use the `Home` key to return to the top.
   - [`reveal_locale`](#reveal_locale)
   - [`eocs`](#eocs)
   - [`missions`](#missions-1)
-  - [`custom_initial_date`](#custom_initial_date)
+  - [`start_of_cataclysm`](#start_of_cataclysm)
+  - [`start_of_game`](#start_of_game)
 - [Starting locations](#starting-locations)
   - [`name`](#name-3)
   - [`terrain`](#terrain)
@@ -5314,23 +5315,39 @@ A list of eocs that are triggered once for each new character on scenario start.
 
 A list of mission ids that will be started and assigned to the player at the start of the game. Only missions with the ORIGIN_GAME_START origin are allowed. The last mission in the list will be the active mission, if multiple missions are assigned.
 
-## `custom_initial_date`
+## `start_of_cataclysm`
 (optional, object with optional members "hour", "day", "season" and "year")
 
-Allows customizing start date. If `custom_initial_date` is not set the corresponding values from world options are used instead.
-
-If the start date of the scenario is before the date of cataclysm defined by map settings then the scenario date is moved forwards by one year.
+Allows customization of cataclysm start date. If `start_of_cataclysm` is not set the corresponding default values are used instead - 0 hour, 0 day (which is day 1), Spring season, 1 year.
 
 ```C++
-"custom_initial_date": { "hour": 3, "day": 10, "season": "winter", "year": 1 }
+"start_of_cataclysm": { "hour": "random", "day": 10, "season": "winter", "year": 1 }
 ```
 
  Identifier            | Description
 ---                    | ---
-`hour`                 | (optional, integer) Hour of the day for initial date. Default 8. -1 randomizes 0-23.
-`day`                  | (optional, integer) Day of the season for initial date. Default 0. -1 randomizes 0-season length.
-`season`               | (optional, integer) Season for initial date. Default `SPRING`.
-`year`                 | (optional, integer) Year for initial date. Default 1. -1 randomizes 1-11.
+`hour`                 | (optional, integer or `random` string) Hour of the day. Default value is 0. String `random` randomizes 0-23.
+`day`                  | (optional, integer or `random` string) Day of the season. Default value is 0 (which is day 1). String `random` randomizes 0-season length.
+`season`               | (optional, integer or `random` string) Season of the year. Default value is `SPRING`. String `random` randomizes to one of 4 season.
+`year`                 | (optional, integer or `random` string) Year. Default value is 1. String `random` randomizes 1-11.
+
+## `start_of_game`
+(optional, object with optional members "hour", "day", "season" and "year")
+
+Allows customization of game start date. If `start_of_game` is not set the corresponding default values are used instead - random hour (0-23), 0 day (which is day 1), Spring season, 1 year.
+
+If the scenario game start date is before the scenario cataclysm start date then the scenario game start would be automatically set to scenario cataclysm start date.
+
+```C++
+"start_of_game": { "hour": "random", "day": "random", "season": "winter", "year": 2 }
+```
+
+ Identifier            | Description
+---                    | ---
+`hour`                 | (optional, integer or `random` string) Hour of the day. Default value is 0. String `random` randomizes 0-23.
+`day`                  | (optional, integer or `random` string) Day of the season. Default value is 0 (which is day 1). String `random` randomizes 0-season length.
+`season`               | (optional, integer or `random` string) Season of the year. Default value is `SPRING`. String `random` randomizes to one of 4 season.
+`year`                 | (optional, integer or `random` string) Year. Default value is 1. String `random` randomizes 1-11.
 
 # Starting locations
 

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2547,10 +2547,10 @@ static void debug_menu_change_time()
     do {
         const int iSel = smenu.ret;
         smenu.reset();
-        smenu.addentry( 0, true, 'y', "%s: %d", _( "year" ), years( calendar::turn ) );
+        smenu.addentry( 0, true, 'y', "%s: %d", _( "year" ), years( calendar::turn ) + 1 );
         smenu.addentry( 1, !calendar::eternal_season(), 's', "%s: %d",
                         _( "season" ), static_cast<int>( season_of_year( calendar::turn ) ) );
-        smenu.addentry( 2, true, 'd', "%s: %d", _( "day" ), day_of_season<int>( calendar::turn ) );
+        smenu.addentry( 2, true, 'd', "%s: %d", _( "day" ), day_of_season<int>( calendar::turn ) + 1 );
         smenu.addentry( 3, true, 'h', "%s: %d", _( "hour" ), hour_of_day<int>( calendar::turn ) );
         smenu.addentry( 4, true, 'm', "%s: %d", _( "minute" ), minute_of_hour<int>( calendar::turn ) );
         smenu.addentry( 5, true, 't', "%s: %d", _( "turn" ),
@@ -2560,14 +2560,14 @@ static void debug_menu_change_time()
 
         switch( smenu.ret ) {
             case 0:
-                set_turn( years( calendar::turn ), calendar::year_length(), _( "Set year to?" ) );
+                set_turn( years( calendar::turn ) + 1, calendar::year_length(), _( "Set year to?" ) );
                 break;
             case 1:
                 set_turn( static_cast<int>( season_of_year( calendar::turn ) ), calendar::season_length(),
                           _( "Set season to?  (0 = spring)" ) );
                 break;
             case 2:
-                set_turn( day_of_season<int>( calendar::turn ), 1_days, _( "Set days to?" ) );
+                set_turn( day_of_season<int>( calendar::turn ) + 1, 1_days, _( "Set days to?" ) );
                 break;
             case 3:
                 set_turn( hour_of_day<int>( calendar::turn ), 1_hours, _( "Set hour to?" ) );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -767,8 +767,7 @@ void game::setup()
 
     weather.weather_id = WEATHER_CLEAR;
     // Weather shift in 30
-    weather.nextweather = calendar::start_of_cataclysm + time_duration::from_hours(
-                              get_option<int>( "INITIAL_TIME" ) ) + 30_minutes;
+    weather.nextweather = calendar::start_of_game + 30_minutes;
 
     turnssincelastmon = 0_turns; //Auto safe mode init
 
@@ -12799,7 +12798,7 @@ void game::start_calendar()
     calendar::start_of_game = scen->start_of_game();
     calendar::turn = calendar::start_of_game;
     calendar::initial_season = static_cast<season_type>( ( to_days<int>( calendar::start_of_game -
-                               calendar::turn_zero ) / get_option<int>( "SEASON_LENGTH" ) ) % 4 );
+                               calendar::turn_zero ) / get_option<int>( "SEASON_LENGTH" ) ) % season_type::NUM_SEASONS );
 }
 
 overmap &game::get_cur_om() const
@@ -13271,7 +13270,6 @@ const scenario *get_scenario()
 }
 void set_scenario( const scenario *new_scenario )
 {
-    new_scenario->rerandomize();
     g->scen = new_scenario;
 }
 

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3046,6 +3046,16 @@ static std::string assemble_scenario_details( const avatar &u, const input_conte
     std::string assembled;
     assembled += string_format( g_switch_msg( u ), ctxt.get_desc( "CHANGE_GENDER" ),
                                 current_scenario->gender_appropriate_name( !u.male ) ) + "\n";
+    if( current_scenario->is_random_start_of_cataclysm() ) {
+        assembled += string_format(
+                         _( "Press <color_light_green>%1$s</color> to randomize cataclysm start date." ),
+                         ctxt.get_desc( "RANDOMIZE_SCENARIO_START_OF_CATACLYSM" ) ) + "\n";
+    }
+    if( current_scenario->is_random_start_of_game() ) {
+        assembled += string_format(
+                         _( "Press <color_light_green>%1$s</color> to randomize game start date." ),
+                         ctxt.get_desc( "RANDOMIZE_SCENARIO_START_OF_GAME" ) ) + "\n";
+    }
 
     assembled += "\n" + colorize( _( "Scenario Story:" ), COL_HEADER ) + "\n";
     assembled += colorize( current_scenario->description( u.male ), c_green ) + "\n";
@@ -3098,22 +3108,24 @@ static std::string assemble_scenario_details( const avatar &u, const input_conte
         assembled += current_scenario->vehicle()->name + "\n";
     }
 
-    assembled += "\n" + colorize( _( "Scenario calendar:" ), COL_HEADER ) + "\n";
-    if( current_scenario->custom_start_date() ) {
-        assembled += string_format( current_scenario->is_random_year() ?
-                                    _( "Year:   Random" ) : _( "Year:   %s" ),
-                                    current_scenario->start_year() ) + "\n";
-        assembled += string_format( _( "Season: %s" ),
-                                    calendar::name_season( current_scenario->start_season() ) ) + "\n";
-        assembled += string_format( current_scenario->is_random_day() ? _( "Day:    Random" ) :
-                                    _( "Day:    %d" ), current_scenario->start_day() ) + "\n";
-        assembled += string_format( current_scenario->is_random_hour() ? _( "Hour:   Random" ) :
-                                    _( "Hour:   %d" ), current_scenario->start_hour() ) + "\n";
-    } else {
-        assembled += _( "Default" );
-        assembled += "\n";
+    if( current_scenario->start_of_cataclysm() != calendar::turn_zero ||
+        current_scenario->is_random_start_of_cataclysm() ) {
+        assembled += "\n" + colorize( _( "Start of cataclysm:" ), COL_HEADER ) + "\n";
+        assembled += string_format( _( "Hour %1$d of %3$s, day %2$d (year %4$d)" ),
+                                    current_scenario->start_of_cataclysm_hour(),
+                                    current_scenario->start_of_cataclysm_day() + 1,
+                                    calendar::name_season( current_scenario->start_of_cataclysm_season() ),
+                                    current_scenario->start_of_cataclysm_year() ) + "\n";
     }
-
+    if( current_scenario->start_of_game() != current_scenario->start_of_cataclysm() + 8_hours ||
+        current_scenario->is_random_start_of_game() ) {
+        assembled += "\n" + colorize( _( "Start of game:" ), COL_HEADER ) + "\n";
+        assembled += string_format( _( "Hour %1$d of %3$s, day %2$d (year %4$d)" ),
+                                    current_scenario->start_of_game_hour(),
+                                    current_scenario->start_of_game_day() + 1,
+                                    calendar::name_season( current_scenario->start_of_game_season() ),
+                                    current_scenario->start_of_game_year() ) + "\n";
+    }
     if( !current_scenario->missions().empty() ) {
         assembled += "\n" + colorize( _( "Scenario missions:" ), COL_HEADER ) + "\n";
         for( mission_type_id mission_id : current_scenario->missions() ) {
@@ -3182,6 +3194,8 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
     ctxt.register_action( "FILTER" );
     ctxt.register_action( "RESET_FILTER" );
     ctxt.register_action( "RANDOMIZE" );
+    ctxt.register_action( "RANDOMIZE_SCENARIO_START_OF_GAME" );
+    ctxt.register_action( "RANDOMIZE_SCENARIO_START_OF_CATACLYSM" );
 
     bool recalc_scens = true;
     size_t scens_length = 0;
@@ -3326,6 +3340,7 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
                 continue;
             }
             reset_scenario( u, sorted_scens[cur_id] );
+            details_recalc = true;
         } else if( action == "CHANGE_GENDER" ) {
             u.male = !u.male;
             recalc_scens = true;
@@ -3346,6 +3361,20 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
             }
         } else if( action == "RANDOMIZE" ) {
             cur_id = rng( 0, scens_length - 1 );
+        } else if( action == "RANDOMIZE_SCENARIO_START_OF_CATACLYSM" ) {
+            if( cur_id != id_for_curr_description ) {
+                get_scenario()->rerandomize( true, false );
+            } else {
+                sorted_scens[cur_id]->rerandomize( true, false );
+            }
+            details_recalc = true;
+        } else if( action == "RANDOMIZE_SCENARIO_START_OF_GAME" ) {
+            if( cur_id != id_for_curr_description ) {
+                get_scenario()->rerandomize( false, true );
+            } else {
+                sorted_scens[cur_id]->rerandomize( false, true );
+            }
+            details_recalc = true;
         }
 
         if( cur_id != id_for_curr_description || recalc_scens ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2684,21 +2684,6 @@ void options_manager::add_options_world_default()
     add_option_group( "world_default", Group( "spawn_time_opts", to_translation( "Spawn Time Options" ),
                       to_translation( "Options regarding spawn time." ) ),
     [&]( const std::string & page_id ) {
-        add( "INITIAL_TIME", page_id, to_translation( "Initial time" ),
-             to_translation( "Initial starting time of day on character generation.  Value -1 randomizes the starting time and overrides scenario setting." ),
-             -1, 23, 8
-           );
-
-        add( "INITIAL_DAY", page_id, to_translation( "Initial day" ),
-             to_translation( "How many days into the year the Cataclysm ended.  Day 0 is Spring 1.  Day -1 randomizes the start date.  Can be overridden by scenarios.  This does not advance food rot or monster evolution." ),
-             -1, 999, 60
-           );
-
-        add( "SPAWN_DELAY", page_id, to_translation( "Spawn delay" ),
-             to_translation( "How many days after the end of the Cataclysm the player spawns.  Day 0 is immediately after the end of the Cataclysm.  Can be overridden by scenarios.  Increasing this will cause food rot and monster evolution to advance." ),
-             0, 9999, 0
-           );
-
         add( "SEASON_LENGTH", page_id, to_translation( "Season length" ),
              to_translation( "Season length, in days.  Warning: Very little other than the duration of seasons scales with this value, so adjusting it may cause nonsensical results." ),
              14, 127, 91

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -475,8 +475,7 @@ void SkillLevel::deserialize( const JsonObject &data )
     data.read( "istraining", _isTraining );
     data.read( "rustaccumulator", _rustAccumulator );
     if( !data.read( "lastpracticed", _lastPracticed ) ) {
-        _lastPracticed = calendar::start_of_cataclysm + time_duration::from_hours(
-                             get_option<int>( "INITIAL_TIME" ) );
+        _lastPracticed = calendar::start_of_game;
     }
     data.read( "knowledgeLevel", _knowledgeLevel );
     if( _knowledgeLevel < _level ) {

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -105,24 +105,62 @@ void scenario::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "eoc", _eoc, auto_flags_reader<effect_on_condition_id> {} );
 
     if( !was_loaded ) {
-        if( jo.has_member( "custom_initial_date" ) ) {
-            _custom_start_date = true;
-
-            JsonObject jocid = jo.get_member( "custom_initial_date" );
-            if( jocid.has_member( "hour" ) ) {
-                optional( jocid, was_loaded, "hour", _start_hour );
-                _is_random_hour = _start_hour == -1;
+        if( jo.has_member( "start_of_cataclysm" ) ) {
+            JsonObject jocid = jo.get_member( "start_of_cataclysm" );
+            if( jocid.has_string( "hour" ) )  {
+                _is_random_start_of_cataclysm_hour = jocid.get_string( "hour" ) == "random";
+            } else if( jocid.has_int( "hour" ) ) {
+                _is_random_start_of_cataclysm_hour = false;
+                optional( jocid, was_loaded, "hour", _start_of_cataclysm_hour );
             }
-            if( jocid.has_member( "day" ) ) {
-                optional( jocid, was_loaded, "day", _start_day );
-                _is_random_day = _start_day == -1;
+            if( jocid.has_string( "day" ) ) {
+                _is_random_start_of_cataclysm_day = jocid.get_string( "day" ) == "random";
+            } else if( jocid.has_int( "day" ) ) {
+                _is_random_start_of_cataclysm_day = false;
+                optional( jocid, was_loaded, "day", _start_of_cataclysm_day );
             }
-            if( jocid.has_member( "season" ) ) {
-                optional( jocid, was_loaded, "season", _start_season );
+            if( jocid.has_string( "season" ) ) {
+                if( jocid.get_string( "season" ) == "random" ) {
+                    _is_random_start_of_cataclysm_season = true;
+                } else {
+                    _is_random_start_of_cataclysm_season = false;
+                    optional( jocid, was_loaded, "season", _start_of_cataclysm_season );
+                }
             }
-            if( jocid.has_member( "year" ) ) {
-                optional( jocid, was_loaded, "year", _start_year );
-                _is_random_year = _start_year == -1;
+            if( jocid.has_string( "year" ) ) {
+                _is_random_start_of_cataclysm_year = jocid.get_string( "year" ) == "random";
+            } else if( jocid.has_int( "year" ) ) {
+                _is_random_start_of_cataclysm_year = false;
+                optional( jocid, was_loaded, "year", _start_of_cataclysm_year );
+            }
+        }
+        if( jo.has_member( "start_of_game" ) ) {
+            JsonObject jocid = jo.get_member( "start_of_game" );
+            if( jocid.has_string( "hour" ) )  {
+                _is_random_start_of_game_hour = jocid.get_string( "hour" ) == "random";
+            } else if( jocid.has_int( "hour" ) ) {
+                _is_random_start_of_game_hour = false;
+                optional( jocid, was_loaded, "hour", _start_of_game_hour );
+            }
+            if( jocid.has_string( "day" ) ) {
+                _is_random_start_of_game_day = jocid.get_string( "day" ) == "random";
+            } else if( jocid.has_int( "day" ) ) {
+                _is_random_start_of_game_day = false;
+                optional( jocid, was_loaded, "day", _start_of_game_day );
+            }
+            if( jocid.has_string( "season" ) ) {
+                if( jocid.get_string( "season" ) == "random" ) {
+                    _is_random_start_of_game_season = true;
+                } else {
+                    _is_random_start_of_game_season = false;
+                    optional( jocid, was_loaded, "season", _start_of_game_season );
+                }
+            }
+            if( jocid.has_string( "year" ) ) {
+                _is_random_start_of_game_year = jocid.get_string( "year" ) == "random";
+            } else if( jocid.has_int( "year" ) ) {
+                _is_random_start_of_game_year = false;
+                optional( jocid, was_loaded, "year", _start_of_game_year );
             }
         }
     }
@@ -135,6 +173,7 @@ void scenario::load( const JsonObject &jo, const std::string_view )
         _surround_groups.emplace_back( mongroup_id( ja.get_string( 0 ) ),
                                        static_cast<float>( ja.get_float( 1 ) ) );
     }
+    rerandomize();
 }
 
 const scenario *scenario::generic()
@@ -493,73 +532,161 @@ std::optional<achievement_id> scenario::get_requirement() const
     return _requirement;
 }
 
-bool scenario::custom_start_date() const
-{
-    return _custom_start_date;
-}
-
 bool scenario::get_reveal_locale() const
 {
     return reveal_locale;
 }
 
-void scenario::rerandomize() const
+void scenario::rerandomize( bool randomize_start_of_cataclysm, bool randomize_start_of_game ) const
 {
     scenario *hack = const_cast<scenario *>( this );
-
-    if( hack->is_random_hour() ) {
-        hack->_start_hour = rng( 0, 23 );
+    if( randomize_start_of_cataclysm ) {
+        if( hack->is_random_start_of_cataclysm_hour() ) {
+            hack->_start_of_cataclysm_hour = rng( 0, 23 );
+        }
+        if( hack->is_random_start_of_cataclysm_day() ) {
+            hack->_start_of_cataclysm_day = rng( 0, get_option<int>( "SEASON_LENGTH" ) - 1 );
+        }
+        if( hack->is_random_start_of_cataclysm_season() ) {
+            hack->_start_of_cataclysm_season = static_cast<season_type>( rng( 0, 3 ) );
+        }
+        if( hack->is_random_start_of_cataclysm_year() ) {
+            hack->_start_of_cataclysm_year = rng( 1, 11 );
+        }
     }
-    if( hack->is_random_year() ) {
-        hack->_start_year = rng( 1, 11 );
+
+    if( randomize_start_of_game ) {
+        if( hack->is_random_start_of_game_hour() ) {
+            hack->_start_of_game_hour = rng( 0, 23 );
+        }
+        if( hack->is_random_start_of_game_day() ) {
+            hack->_start_of_game_day = rng( 0, get_option<int>( "SEASON_LENGTH" ) - 1 );
+        }
+        if( hack->is_random_start_of_game_season() ) {
+            hack->_start_of_game_season = static_cast<season_type>( rng( 0, 3 ) );
+        }
+        if( hack->is_random_start_of_game_year() ) {
+            hack->_start_of_game_year = rng( 1, 11 );
+        }
     }
-    if( hack->is_random_day() ) {
-        hack->_start_day = rng( 0, get_option<int>( "SEASON_LENGTH" ) - 1 );
+
+    hack->_start_of_cataclysm = calendar::turn_zero +
+                                1_hours * hack->start_of_cataclysm_hour() +
+                                1_days * hack->start_of_cataclysm_day() +
+                                1_days * get_option<int>( "SEASON_LENGTH" ) * hack->start_of_cataclysm_season() +
+                                calendar::year_length() * ( hack->start_of_cataclysm_year() - 1 )
+                                ;
+
+    hack->_start_of_game = calendar::turn_zero +
+                           1_hours * hack->start_of_game_hour() +
+                           1_days * hack->start_of_game_day() +
+                           1_days * get_option<int>( "SEASON_LENGTH" ) * hack->start_of_game_season() +
+                           calendar::year_length() * ( hack->start_of_game_year() - 1 )
+                           ;
+
+    if( hack->start_of_game() < hack->start_of_cataclysm() ) {
+        hack->_start_of_game = hack->start_of_cataclysm();
+        hack->_start_of_game_hour = hack->start_of_cataclysm_hour();
+        hack->_start_of_game_day = hack->start_of_cataclysm_day();
+        hack->_start_of_game_season = hack->start_of_cataclysm_season();
+        hack->_start_of_game_year = hack->start_of_cataclysm_year();
     }
-
-    // Initial day is the time of the Cataclysm. Limit it to occur on the first year.
-    hack->_start_of_cataclysm = calendar::turn_zero;
-    if( get_option<int>( "INITIAL_DAY" )  == -1 ) {
-        hack->_start_of_cataclysm += 1_days * rng( 0, get_option<int>( "SEASON_LENGTH" ) * 4 - 1 );
-    } else {
-        hack->_start_of_cataclysm += 1_days * std::min( get_option<int>( "INITIAL_DAY" ),
-                                     get_option<int>( "SEASON_LENGTH" ) * 4 );
-    }
 }
 
-bool scenario::is_random_hour() const
+bool scenario::is_random_start_of_cataclysm_hour() const
 {
-    return _is_random_hour;
+    return _is_random_start_of_cataclysm_hour;
 }
 
-bool scenario::is_random_day() const
+bool scenario::is_random_start_of_cataclysm_day() const
 {
-    return _is_random_day;
+    return _is_random_start_of_cataclysm_day;
 }
 
-bool scenario::is_random_year() const
+bool scenario::is_random_start_of_cataclysm_season() const
 {
-    return _is_random_year;
+    return _is_random_start_of_cataclysm_season;
 }
 
-int scenario::start_hour() const
+bool scenario::is_random_start_of_cataclysm_year() const
 {
-    return _start_hour;
+    return _is_random_start_of_cataclysm_year;
 }
 
-int scenario::start_day() const
+bool scenario::is_random_start_of_cataclysm() const
 {
-    return _start_day;
+    return is_random_start_of_cataclysm_hour() ||
+           is_random_start_of_cataclysm_day() ||
+           is_random_start_of_cataclysm_season() ||
+           is_random_start_of_cataclysm_year();
 }
 
-season_type scenario::start_season() const
+int scenario::start_of_cataclysm_hour() const
 {
-    return _start_season;
+    return _start_of_cataclysm_hour;
 }
 
-int scenario::start_year() const
+int scenario::start_of_cataclysm_day() const
 {
-    return _start_year;
+    return _start_of_cataclysm_day;
+}
+
+season_type scenario::start_of_cataclysm_season() const
+{
+    return _start_of_cataclysm_season;
+}
+
+int scenario::start_of_cataclysm_year() const
+{
+    return _start_of_cataclysm_year;
+}
+
+bool scenario::is_random_start_of_game_hour() const
+{
+    return _is_random_start_of_game_hour;
+}
+
+bool scenario::is_random_start_of_game_day() const
+{
+    return _is_random_start_of_game_day;
+}
+
+bool scenario::is_random_start_of_game_season() const
+{
+    return _is_random_start_of_game_season;
+}
+
+bool scenario::is_random_start_of_game_year() const
+{
+    return _is_random_start_of_game_year;
+}
+
+bool scenario::is_random_start_of_game() const
+{
+    return is_random_start_of_game_hour() ||
+           is_random_start_of_game_day() ||
+           is_random_start_of_game_season() ||
+           is_random_start_of_game_year();
+}
+
+int scenario::start_of_game_hour() const
+{
+    return _start_of_game_hour;
+}
+
+int scenario::start_of_game_day() const
+{
+    return _start_of_game_day;
+}
+
+season_type scenario::start_of_game_season() const
+{
+    return _start_of_game_season;
+}
+
+int scenario::start_of_game_year() const
+{
+    return _start_of_game_year;
 }
 
 time_point scenario::start_of_cataclysm() const
@@ -569,27 +696,7 @@ time_point scenario::start_of_cataclysm() const
 
 time_point scenario::start_of_game() const
 {
-    time_point ret;
-
-    const int options_start_hour = get_option<int>( "INITIAL_TIME" );
-
-    if( custom_start_date() ) {
-        ret = calendar::turn_zero
-              + 1_hours * ( options_start_hour == -1 ? rng( 0, 23 ) : start_hour() )
-              + 1_days * start_day()
-              + 1_days * get_option<int>( "SEASON_LENGTH" ) * start_season()
-              + calendar::year_length() * ( start_year() - 1 );
-        if( ret < start_of_cataclysm() ) {
-            // If the Cataclysm has been set to happen late or the scenario has random start it may try to start before the Cataclysm happens.
-            // That is unacceptable. So lets just jump to same day on next year.
-            ret += calendar::year_length();
-        }
-    } else {
-        ret = start_of_cataclysm()
-              + 1_hours * ( options_start_hour == -1 ? rng( 0, 23 ) : options_start_hour )
-              + 1_days * get_option<int>( "SPAWN_DELAY" );
-    }
-    return ret;
+    return _start_of_game;
 }
 
 vproto_id scenario::vehicle() const

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -55,16 +55,30 @@ class scenario
         // does this scenario require a specific achiement to unlock
         std::optional<achievement_id> _requirement;
 
-        bool _custom_start_date = false;
         bool reveal_locale = true;
-        bool _is_random_hour = false;
-        int _start_hour = 8;
-        bool _is_random_day = false;
-        int _start_day = 0;
-        season_type _start_season = SPRING;
-        bool _is_random_year = false;
-        int _start_year = 1;
+
+        bool _is_random_start_of_cataclysm_hour = false;
+        bool _is_random_start_of_cataclysm_day = false;
+        bool _is_random_start_of_cataclysm_season = false;
+        bool _is_random_start_of_cataclysm_year = false;
+
+        int _start_of_cataclysm_hour = 0;
+        int _start_of_cataclysm_day = 0;
+        season_type _start_of_cataclysm_season = SPRING;
+        int _start_of_cataclysm_year = 1;
+
+        bool _is_random_start_of_game_hour = true;
+        bool _is_random_start_of_game_day = false;
+        bool _is_random_start_of_game_season = false;
+        bool _is_random_start_of_game_year = false;
+
+        int _start_of_game_hour = 8;
+        int _start_of_game_day = 0;
+        season_type _start_of_game_season = SPRING;
+        int _start_of_game_year = 1;
+
         time_point _start_of_cataclysm;
+        time_point _start_of_game;
 
         vproto_id _starting_vehicle = vproto_id::NULL_ID();
 
@@ -102,17 +116,34 @@ class scenario
 
         std::optional<achievement_id> get_requirement() const;
 
-        bool custom_start_date() const;
         bool get_reveal_locale() const;
-        void rerandomize() const;
-        bool is_random_hour() const;
-        bool is_random_day() const;
-        bool is_random_year() const;
-        int start_hour() const;
-        // Returns day of the season this scenario starts on
-        int start_day() const;
-        season_type start_season() const;
-        int start_year() const;
+
+        void rerandomize( bool randomize_start_of_cataclysm = true,
+                          bool randomize_start_of_game = true ) const;
+
+        bool is_random_start_of_cataclysm_hour() const;
+        bool is_random_start_of_cataclysm_day() const;
+        bool is_random_start_of_cataclysm_season() const;
+        bool is_random_start_of_cataclysm_year() const;
+        bool is_random_start_of_cataclysm() const;
+
+        int start_of_cataclysm_hour() const;
+        // Returns day of the season cataclysm in this scenario starts on
+        int start_of_cataclysm_day() const;
+        season_type start_of_cataclysm_season() const;
+        int start_of_cataclysm_year() const;
+
+        bool is_random_start_of_game_hour() const;
+        bool is_random_start_of_game_day() const;
+        bool is_random_start_of_game_season() const;
+        bool is_random_start_of_game_year() const;
+        bool is_random_start_of_game() const;
+
+        int start_of_game_hour() const;
+        // Returns day of the season game in this scenario starts on
+        int start_of_game_day() const;
+        season_type start_of_game_season() const;
+        int start_of_game_year() const;
 
         time_point start_of_cataclysm() const;
         time_point start_of_game() const;


### PR DESCRIPTION
#### Summary
Features "Cataclysm and game start dates are to be set through scenarios"

#### Purpose of change
Allow cataclysm and game start dates to be customized in scenarios

Also fixes #67450

#### Describe the solution
World options related to cataclysm and game start dates were replaced with appropriate scenario functionality.

#### Testing
Start game using scenario with custom game start date (e.g. `Ambush`, `The Next Summer`, `Brave New World`, `Challenge - Mi-Go Camp`, etc) and verify that game actually starts at expected date.

#### Additional context
If selected/highlighted scenario supports randomization of cataclysm/game start date, these dates can be separately randomized using two new keybindings.

If selected/highlighted scenario supports randomization of cataclysm/game start date or if one of these dates is different from the default ones, respective start date information would be displayed.

__Screenshots:__

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/16213433/33ffc652-4c26-40b6-8bc9-827b2f6c3456)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/16213433/865ffd04-b35f-4df3-b3fe-b6ac06238a5a)

