### PR TITLE
Cache nutrient results for recipes while calculating nutrient range for food info

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -3075,10 +3075,13 @@ class Character : public Creature, public visitable
          * depending on choice of ingredients */
         std::pair<nutrients, nutrients> compute_nutrient_range(
             const item &, const recipe_id &,
+            std::map<recipe_id, std::pair<nutrients, nutrients>> &rec_cache,
             const cata::flat_set<flag_id> &extra_flags = {} ) const;
         /** Same, but across arbitrary recipes */
         std::pair<nutrients, nutrients> compute_nutrient_range(
-            const itype_id &, const cata::flat_set<flag_id> &extra_flags = {} ) const;
+            const itype_id &,
+            std::map<recipe_id, std::pair<nutrients, nutrients>> &rec_cache,
+            const cata::flat_set<flag_id> &extra_flags = {} ) const;
         /** Returns allergy type or MORALE_NULL if not allergic for this character */
         morale_type allergy_type( const item &food ) const;
         nutrients compute_effective_nutrients( const item & ) const;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2447,8 +2447,9 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
     if( recipe_exemplar.empty() ) {
         min_nutr = max_nutr = player_character.compute_effective_nutrients( *food_item );
     } else {
+        std::map<recipe_id, std::pair<nutrients, nutrients>> rec_cache;
         std::tie( min_nutr, max_nutr ) =
-            player_character.compute_nutrient_range( *food_item, recipe_id( recipe_exemplar ) );
+            player_character.compute_nutrient_range( *food_item, recipe_id( recipe_exemplar ), rec_cache );
     }
 
     bool show_nutr = parts->test( iteminfo_parts::FOOD_NUTRITION ) ||

--- a/tests/comestible_test.cpp
+++ b/tests/comestible_test.cpp
@@ -250,8 +250,9 @@ TEST_CASE( "cooked_veggies_get_correct_calorie_prediction", "[recipe]" )
     const Character &u = get_player_character();
 
     nutrients default_nutrition = u.compute_effective_nutrients( veggy_wild_cooked );
+    std::map<recipe_id, std::pair<nutrients, nutrients>> rec_cache;
     std::pair<nutrients, nutrients> predicted_nutrition =
-        u.compute_nutrient_range( veggy_wild_cooked, recipe_veggy_wild_cooked );
+        u.compute_nutrient_range( veggy_wild_cooked, recipe_veggy_wild_cooked, rec_cache );
 
     CHECK( default_nutrition.kcal() == predicted_nutrition.first.kcal() );
     CHECK( default_nutrition.kcal() == predicted_nutrition.second.kcal() );


### PR DESCRIPTION
#### Summary
Performance "Cache nutrient results for recipes while calculating nutrient range for food info"

#### Purpose of change

Fixes #67344 (not perfectly, but I'd say it's good enough)

#### Describe the solution

Calculating nutrients could become excessively repetitive for very long chains of components with recipes with components with recipes etc. Cache the results to cut those chains short.
The cache is currently just local to the one call to `item::food_info`, so there's definitely room for improvement if performance gets worse again or if someone thinks this is not enough. The upside is not having to think about invalidating the cache.

#### Describe alternatives you've considered

Putting in more effort for better results.

#### Testing

Scrolled through recipes fairly smoothly. Some recipes are still slower than others, but depending on your system, you might not even notice. I didn't even test combined results with #67466, but that probably doesn't make that much of a difference.

#### Additional context

