### PR TITLE
Update simple string condition keys in string extractor and fix some string extraction warnings

### DIFF
--- a/lang/string_extractor/parsers/talk_topic.py
+++ b/lang/string_extractor/parsers/talk_topic.py
@@ -20,11 +20,12 @@ dynamic_line_string_keys = [
     "has_available_mission", "has_many_available_missions",
     "mission_complete", "mission_incomplete", "mission_has_generic_rewards",
     "npc_available", "npc_following", "npc_friend", "npc_hostile",
-    "npc_train_skills", "npc_train_styles",
-    "at_safe_space", "is_day", "npc_has_activity", "is_outside", "u_has_camp",
-    "u_can_stow_weapon", "npc_can_stow_weapon", "u_has_weapon",
-    "npc_has_weapon", "u_driving", "npc_driving",
-    "has_pickup_list", "is_by_radio", "has_reason",
+    "npc_train_skills", "npc_train_styles", "npc_train_spells",
+    "at_safe_space", "is_day", "npc_has_activity",
+    "is_outside", "u_is_outside", "npc_is_outside", "u_has_camp",
+    "u_can_stow_weapon", "npc_can_stow_weapon", "u_can_drop_weapon",
+    "npc_can_drop_weapon", "u_has_weapon", "npc_has_weapon",
+    "u_driving", "npc_driving", "has_pickup_list", "is_by_radio", "has_reason"
     # yes/no strings for complex conditions, 'and' list
     "yes", "no", "concatenate"
 ]

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -150,7 +150,7 @@ advanced_inventory::advanced_inventory()
         { AIM_DRAGGED,   point( 22, 3 ), tripoint_zero,       _( "Grabbed Vehicle" ),    _( "GR" ),  "D", "ITEMS_DRAGGED_CONTAINER", AIM_DRAGGED},
         { AIM_ALL,       point( 25, 3 ), tripoint_zero,       _( "Surrounding area" ),   _( "AL" ),  "A", "ITEMS_AROUND",    AIM_ALL},
         { AIM_CONTAINER, point( 25, 1 ), tripoint_zero,       _( "Container" ),          _( "CN" ),  "C", "ITEMS_CONTAINER", AIM_CONTAINER},
-        { AIM_PARENT,    point( 22, 1 ), tripoint_zero,       _( "" ),                   _( "" ),    "X", "ITEMS_PARENT",    AIM_PARENT},
+        { AIM_PARENT,    point( 22, 1 ), tripoint_zero,       "",                        "",         "X", "ITEMS_PARENT",    AIM_PARENT},
         { AIM_WORN,      point( 22, 2 ), tripoint_zero,       _( "Worn Items" ),         _( "WR" ),  "W", "ITEMS_WORN",      AIM_WORN}
     }
 } )

--- a/src/condition.h
+++ b/src/condition.h
@@ -15,19 +15,22 @@
 class JsonObject;
 namespace dialogue_data
 {
-// when updating this, please also update `dynamic_line_string_keys` in
-// `lang/extract_json_string.py` so the lines are properly extracted for translation
+// When updating this, please also update `dynamic_line_string_keys` in
+// `lang/string_extractor/parsers/talk_topic.py` so the lines are properly
+// extracted for translation
 const std::unordered_set<std::string> simple_string_conds = { {
         "u_male", "u_female", "npc_male", "npc_female",
-        "has_no_assigned_mission", "has_assigned_mission", "has_many_assigned_missions",
-        "has_no_available_mission", "has_available_mission", "has_many_available_missions",
+        "has_no_assigned_mission", "has_assigned_mission",
+        "has_many_assigned_missions", "has_no_available_mission",
+        "has_available_mission", "has_many_available_missions",
         "mission_complete", "mission_incomplete", "mission_has_generic_rewards",
         "npc_available", "npc_following", "npc_friend", "npc_hostile",
         "npc_train_skills", "npc_train_styles", "npc_train_spells",
-        "at_safe_space", "is_day", "npc_has_activity", "is_outside", "u_is_outside", "npc_is_outside", "u_has_camp",
-        "u_can_stow_weapon", "npc_can_stow_weapon", "u_can_drop_weapon", "npc_can_drop_weapon", "u_has_weapon", "npc_has_weapon",
-        "u_driving", "npc_driving",
-        "has_pickup_list", "is_by_radio", "has_reason"
+        "at_safe_space", "is_day", "npc_has_activity",
+        "is_outside", "u_is_outside", "npc_is_outside", "u_has_camp",
+        "u_can_stow_weapon", "npc_can_stow_weapon", "u_can_drop_weapon",
+        "npc_can_drop_weapon", "u_has_weapon", "npc_has_weapon",
+        "u_driving", "npc_driving", "has_pickup_list", "is_by_radio", "has_reason"
     }
 };
 const std::unordered_set<std::string> complex_conds = { {

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -710,8 +710,8 @@ std::string ma_requirements::get_description( bool buff ) const
     if( std::any_of( min_skill.begin(), min_skill.end(), []( const std::pair<skill_id, int> &pr ) {
     return pr.second > 0;
 } ) ) {
-        dump += string_format( _( "<bold>%s required: </bold>" ),
-                               n_gettext( "Skill", "Skills", min_skill.size() ) );
+        dump += n_gettext( "<bold>Skill required: </bold>",
+                           "<bold>Skills required: </bold>", min_skill.size() );
 
         dump += enumerate_as_string( min_skill.begin(),
         min_skill.end(), []( const std::pair<skill_id, int>  &pr ) {
@@ -966,8 +966,8 @@ std::string ma_buff::get_description( bool passive ) const
 
     std::string temp = bonuses.get_description();
     if( !temp.empty() ) {
-        dump += string_format( _( "<bold>%s:</bold> " ),
-                               n_gettext( "Bonus", "Bonus/stack", max_stacks ) ) + "\n" + temp;
+        dump += std::string( npgettext( "martial arts buff desc", "<bold>Bonus:</bold> ",
+                                        "<bold>Bonus/stack:</bold> ", max_stacks ) ) + "\n" + temp;
     }
 
     dump += reqs.get_description( true );
@@ -979,24 +979,38 @@ std::string ma_buff::get_description( bool passive ) const
 
     const int turns = to_turns<int>( buff_duration );
     if( !passive && turns ) {
-        dump += string_format( _( "* Will <info>last</info> for <stat>%d %s</stat>" ),
-                               turns, n_gettext( "turn", "turns", turns ) ) + "\n";
+        dump += string_format( n_gettext( "* Will <info>last</info> for <stat>%d turn</stat>",
+                                          "* Will <info>last</info> for <stat>%d turns</stat>",
+                                          turns ),
+                               turns ) + "\n";
     }
 
     if( dodges_bonus > 0 ) {
-        dump += string_format( _( "* Will give a <good>+%s</good> bonus to <info>dodge</info>%s" ),
-                               dodges_bonus, n_gettext( " for the stack", " per stack", max_stacks ) ) + "\n";
+        dump += string_format(
+                    n_gettext( "* Will give a <good>+%s</good> bonus to <info>dodge</info> for the stack",
+                               "* Will give a <good>+%s</good> bonus to <info>dodge</info> per stack",
+                               max_stacks ),
+                    dodges_bonus ) + "\n";
     } else if( dodges_bonus < 0 ) {
-        dump += string_format( _( "* Will give a <bad>%s</bad> penalty to <info>dodge</info>%s" ),
-                               dodges_bonus, n_gettext( " for the stack", " per stack", max_stacks ) ) + "\n";
+        dump += string_format(
+                    n_gettext( "* Will give a <bad>%s</bad> penalty to <info>dodge</info> for the stack",
+                               "* Will give a <bad>%s</bad> penalty to <info>dodge</info> per stack",
+                               max_stacks ),
+                    dodges_bonus ) + "\n";
     }
 
     if( blocks_bonus > 0 ) {
-        dump += string_format( _( "* Will give a <good>+%s</good> bonus to <info>block</info>%s" ),
-                               blocks_bonus, n_gettext( " for the stack", " per stack", max_stacks ) ) + "\n";
+        dump += string_format(
+                    n_gettext( "* Will give a <good>+%s</good> bonus to <info>block</info> for the stack",
+                               "* Will give a <good>+%s</good> bonus to <info>block</info> per stack",
+                               max_stacks ),
+                    blocks_bonus ) + "\n";
     } else if( blocks_bonus < 0 ) {
-        dump += string_format( _( "* Will give a <bad>%s</bad> penalty to <info>block</info>%s" ),
-                               blocks_bonus, n_gettext( " for the stack", " per stack", max_stacks ) ) + "\n";
+        dump += string_format(
+                    n_gettext( "* Will give a <bad>%s</bad> penalty to <info>block</info> for the stack",
+                               "* Will give a <bad>%s</bad> penalty to <info>block</info> per stack",
+                               max_stacks ),
+                    blocks_bonus ) + "\n";
     }
 
     if( quiet ) {
@@ -1895,8 +1909,10 @@ std::string ma_technique::get_description() const
     }
 
     if( knockback_dist ) {
-        dump += string_format( _( "* Will <info>knock back</info> enemies <stat>%d %s</stat>" ),
-                               knockback_dist, n_gettext( "tile", "tiles", knockback_dist ) ) + "\n";
+        dump += string_format( n_gettext( "* Will <info>knock back</info> enemies <stat>%d tile</stat>",
+                                          "* Will <info>knock back</info> enemies <stat>%d tiles</stat>",
+                                          knockback_dist ),
+                               knockback_dist ) + "\n";
     }
 
     if( knockback_follow ) {
@@ -1904,13 +1920,17 @@ std::string ma_technique::get_description() const
     }
 
     if( down_dur ) {
-        dump += string_format( _( "* Will <info>down</info> enemies for <stat>%d %s</stat>" ),
-                               down_dur, n_gettext( "turn", "turns", down_dur ) ) + "\n";
+        dump += string_format( n_gettext( "* Will <info>down</info> enemies for <stat>%d turn</stat>",
+                                          "* Will <info>down</info> enemies for <stat>%d turns</stat>",
+                                          down_dur ),
+                               down_dur ) + "\n";
     }
 
     if( stun_dur ) {
-        dump += string_format( _( "* Will <info>stun</info> target for <stat>%d %s</stat>" ),
-                               stun_dur, n_gettext( "turn", "turns", stun_dur ) ) + "\n";
+        dump += string_format( n_gettext( "* Will <info>stun</info> target for <stat>%d turn</stat>",
+                                          "* Will <info>stun</info> target for <stat>%d turns</stat>",
+                                          stun_dur ),
+                               stun_dur ) + "\n";
     }
 
     if( disarms ) {

--- a/src/units.h
+++ b/src/units.h
@@ -681,7 +681,7 @@ template<typename value_type>
 inline constexpr quantity<value_type, length_in_millimeter_tag> from_kilometer(
     const value_type v )
 {
-    return from_millimeter<value_type>( v * 1'000'000 );
+    return from_millimeter<value_type>( v * 1000000 );
 }
 
 template<typename value_type>
@@ -699,13 +699,13 @@ inline constexpr value_type to_centimeter( const quantity<value_type, length_in_
 template<typename value_type>
 inline constexpr value_type to_meter( const quantity<value_type, length_in_millimeter_tag> &v )
 {
-    return to_millimeter( v ) / 1'000.0;
+    return to_millimeter( v ) / 1000.0;
 }
 
 template<typename value_type>
 inline constexpr value_type to_kilometer( const quantity<value_type, length_in_millimeter_tag> &v )
 {
-    return to_millimeter( v ) / 1'000'000.0;
+    return to_millimeter( v ) / 1000000.0;
 }
 
 template<typename value_type>


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Make sure the simple string conditions keys are the same in c++ and python files.

Fix some string extraction warnings reported by xgettext.

#### Describe the solution
1. Update the keys in `talk_topic.py` with the keys in `conditions.h` and update comments in `conditions.h`.
2. Remove calls to `_()` with empty strings.
3. Change `n_gettext` calls with words to `n_gettext` calls with sentences, to fix the warning about these words being called with both `_()` and `n_gettext`, and so that other languages can change other parts of the sentences to match the number.
4. Remove thousands separators from `units.h` which xgettext treats incorrectly as quotes.

#### Describe alternatives you've considered

#### Testing
The game compiles and the string extraction script completed successfully and reported less warnings.

#### Additional context

