### PR TITLE
Canceling "save zone" query returns you to zone manager instead of discarding changes

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3950,7 +3950,7 @@
     "type": "keybinding",
     "id": "QUIT",
     "category": "YESNOQUIT",
-    "name": "Quit",
+    "name": "Cancel",
     "bindings": [
       { "input_method": "keyboard_char", "key": "Q" },
       { "input_method": "keyboard_code", "key": "q", "mod": [ "shift" ] },

--- a/src/diary_ui.cpp
+++ b/src/diary_ui.cpp
@@ -397,21 +397,10 @@ void diary::edit_page_ui( const std::function<catacurses::window()> &create_wind
             break;
         }
 
-        const bool force_uc = get_option<bool>( "FORCE_CAPITAL_YN" );
-        const auto &allow_key = force_uc ? input_context::disallow_lower_case_or_non_modified_letters
-                                : input_context::allow_all_keys;
-        const std::string action = query_popup()
-                                   .context( "YESNOQUIT" )
-                                   .message( "%s", _( "Save entry?" ) )
-                                   .option( "YES", allow_key )
-                                   .option( "NO", allow_key )
-                                   .allow_cancel( true )
-                                   .default_color( c_light_red )
-                                   .query()
-                                   .action;
-        if( action == "YES" ) {
+        const query_ynq_result res = query_ynq( _( "Save entry?" ) );
+        if( res == query_ynq_result::yes ) {
             break;
-        } else if( action == "NO" ) {
+        } else if( res == query_ynq_result::no ) {
             new_text = old_text;
             break;
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -6859,7 +6859,6 @@ void game::zones_manager()
     } );
     ui.mark_resize();
 
-    std::string action;
     input_context ctxt( "ZONES_MANAGER" );
     ctxt.register_navigate_ui_list();
     ctxt.register_action( "CONFIRM" );
@@ -7089,9 +7088,34 @@ void game::zones_manager()
     } );
 
     const int scroll_rate = zone_cnt > 20 ? 10 : 3;
+    bool quit = false;
+    bool save = false;
     zones_manager_open = true;
     zone_manager::get_manager().save_zones( "zmgr-temp" );
-    do {
+    while( !quit ) {
+        if( zone_cnt > 0 ) {
+            blink = !blink;
+            const zone_data &zone = zones[active_index].get();
+            zone_start = m.getlocal( zone.get_start_point() );
+            zone_end = m.getlocal( zone.get_end_point() );
+            ctxt.set_timeout( get_option<int>( "BLINK_SPEED" ) );
+        } else {
+            blink = false;
+            zone_start = zone_end = std::nullopt;
+            ctxt.reset_timeout();
+        }
+
+        // Actually accessed from the terrain overlay callback `zone_cb` in the
+        // call to `ui_manager::redraw`.
+        //NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
+        zone_blink = blink;
+        invalidate_main_ui_adaptor();
+
+        ui_manager::redraw();
+
+        //Wait for input
+        const std::string action = ctxt.handle_input();
+
         if( action == "ADD_ZONE" ) {
             do { // not a loop, just for quick bailing out if canceled
                 const auto maybe_id = mgr.query_type();
@@ -7186,6 +7210,25 @@ void game::zones_manager()
             .edit( facname );
             zones_faction = faction_id( facname );
             zones = get_zones();
+        } else if( action == "QUIT" ) {
+            if( stuff_changed ) {
+                const query_ynq_result res = query_ynq( _( "Save changes?" ) );
+                switch( res ) {
+                    case query_ynq_result::cancel:
+                        break;
+                    case query_ynq_result::no:
+                        save = false;
+                        quit = true;
+                        break;
+                    case query_ynq_result::yes:
+                        save = true;
+                        quit = true;
+                        break;
+                }
+            } else {
+                save = false;
+                quit = true;
+            }
         } else if( zone_cnt > 0 ) {
             if( navigate_ui_list( action, active_index, scroll_rate, zone_cnt, true ) ) {
                 blink = false;
@@ -7354,37 +7397,14 @@ void game::zones_manager()
                 stuff_changed = zones_changed;
             }
         }
-
-        if( zone_cnt > 0 ) {
-            blink = !blink;
-            const zone_data &zone = zones[active_index].get();
-            zone_start = m.getlocal( zone.get_start_point() );
-            zone_end = m.getlocal( zone.get_end_point() );
-            ctxt.set_timeout( get_option<int>( "BLINK_SPEED" ) );
-        } else {
-            blink = false;
-            zone_start = zone_end = std::nullopt;
-            ctxt.reset_timeout();
-        }
-
-        // Actually accessed from the terrain overlay callback `zone_cb` in the
-        // call to `ui_manager::redraw`.
-        //NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
-        zone_blink = blink;
-        invalidate_main_ui_adaptor();
-
-        ui_manager::redraw();
-
-        //Wait for input
-        action = ctxt.handle_input();
-    } while( action != "QUIT" );
+    }
     zones_manager_open = false;
     ctxt.reset_timeout();
     zone_cb = nullptr;
 
     if( stuff_changed ) {
         zone_manager &zones = zone_manager::get_manager();
-        if( !query_yn( _( "Save changes?" ) ) ) {
+        if( !save ) {
             zones.load_zones( "zmgr-temp" );
         }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7214,7 +7214,7 @@ void game::zones_manager()
             if( stuff_changed ) {
                 const query_ynq_result res = query_ynq( _( "Save changes?" ) );
                 switch( res ) {
-                    case query_ynq_result::cancel:
+                    case query_ynq_result::quit:
                         break;
                     case query_ynq_result::no:
                         save = false;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -849,6 +849,35 @@ bool query_yn( const std::string &text )
            .action == "YES";
 }
 
+query_ynq_result query_ynq( const std::string &text )
+{
+    // TODO: android native UI
+    const bool force_uc = get_option<bool>( "FORCE_CAPITAL_YN" );
+    const auto &allow_key = force_uc ? input_context::disallow_lower_case_or_non_modified_letters
+                            : input_context::allow_all_keys;
+
+    const std::string action =
+        query_popup()
+        .context( "YESNOQUIT" )
+        .message( force_uc && !is_keycode_mode_supported()
+                  ? pgettext( "query_yn", "%s (Case Sensitive)" )
+                  : pgettext( "query_yn", "%s" ), text )
+        .option( "YES", allow_key )
+        .option( "NO", allow_key )
+        .option( "QUIT", allow_key )
+        .allow_cancel( true )
+        .cursor( 2 )
+        .default_color( c_light_red )
+        .query()
+        .action;
+    if( action == "NO" ) {
+        return query_ynq_result::no;
+    } else if( action == "YES" ) {
+        return query_ynq_result::yes;
+    }
+    return query_ynq_result::cancel;
+}
+
 bool query_int( int &result, const std::string &text )
 {
     string_input_popup popup;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -875,7 +875,7 @@ query_ynq_result query_ynq( const std::string &text )
     } else if( action == "YES" ) {
         return query_ynq_result::yes;
     }
-    return query_ynq_result::cancel;
+    return query_ynq_result::quit;
 }
 
 bool query_int( int &result, const std::string &text )

--- a/src/output.h
+++ b/src/output.h
@@ -429,7 +429,7 @@ inline bool query_yn( const char *const msg, Args &&... args )
 }
 
 enum class query_ynq_result {
-    cancel, no, yes
+    quit, no, yes
 };
 query_ynq_result query_ynq( const std::string &text );
 template<typename ...Args>

--- a/src/output.h
+++ b/src/output.h
@@ -428,6 +428,16 @@ inline bool query_yn( const char *const msg, Args &&... args )
     return query_yn( string_format( msg, std::forward<Args>( args )... ) );
 }
 
+enum class query_ynq_result {
+    cancel, no, yes
+};
+query_ynq_result query_ynq( const std::string &text );
+template<typename ...Args>
+inline query_ynq_result query_ynq( const char *const msg, Args &&... args )
+{
+    return query_ynq( string_format( msg, std::forward<Args>( args )... ) );
+}
+
 bool query_int( int &result, const std::string &text );
 template<typename ...Args>
 inline bool query_int( int &result, const char *const msg, Args &&... args )


### PR DESCRIPTION
#### Summary
Bugfixes "Canceling 'save zone' query returns you to zone manager instead of discarding changes"

#### Purpose of change
Give you one last chance when you misclick.

#### Describe the solution
1. Create a function `query_ynq` similar to `query_yn` that allows and defaults to canceling.
2. Change the zone manager code to support canceling the save zone query and use `query_ynq` for the save zone query.
3. Use `query_ynq` in the diary UI for the save diary query.
4. Change description of "QUIT" of the "YESNOQUIT" action to "Cancel" to reduce confusion.

#### Describe alternatives you've considered

#### Testing
Zone manager was displayed correctly and pressing ESC showed the save zone query, and selecting yes, no, and cancel saved changes, discarded changes, and returned to the zone manager respectively.

Selecting yes, not, and cancel in the save diary query saved changes, discarded changes, and returned to the string editor window respectively.

#### Additional context

