### PR TITLE
Mutation selector mod

### DIFF
--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -355,5 +355,12 @@
     "info": "Sets eternal weather.  Possible values are 'normal', 'clear', 'cloudy', 'light_drizzle', 'drizzle', 'rain', 'rainstorm', 'thunder', 'lightning', 'flurries', 'snowing', 'snowstorm', 'early_portal_storm', 'portal_storm'.  'normal' clears all eternal weather overrides and sets normal weather pattern.  Requires restart of the game after changing value to take effect.",
     "stype": "string_input",
     "value": "normal"
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "SHOW_MUTATION_SELECTOR",
+    "info": "When mutating, displays a menu which allows players to pick from a list of possible mutations.",
+    "stype": "bool",
+    "value": false
   }
 ]

--- a/data/mods/Mutation_Selector/modinfo.json
+++ b/data/mods/Mutation_Selector/modinfo.json
@@ -4,7 +4,7 @@
     "id": "mutation_selector",
     "name": "Mutation Selector",
     "authors": [ "Rewryte" ],
-    "description": "When mutating, displays a menu which allows you to pick from a list of possible mutations.",
+    "description": "When mutating, allows you to pick from a list of possible mutations instead of getting one at random.",
     "category": "rebalance",
     "dependencies": [ "dda" ]
   },

--- a/data/mods/Mutation_Selector/modinfo.json
+++ b/data/mods/Mutation_Selector/modinfo.json
@@ -1,0 +1,17 @@
+[
+  {
+    "type": "MOD_INFO",
+    "id": "mutation_selector",
+    "name": "Mutation Selector",
+    "authors": [ "Rewryte" ],
+    "description": "When mutating, displays a menu which allows you to pick from a list of possible mutations.",
+    "category": "rebalance",
+    "dependencies": [ "dda" ]
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "SHOW_MUTATION_SELECTOR",
+    "stype": "bool",
+    "value": true
+  }
+]

--- a/src/character.h
+++ b/src/character.h
@@ -1468,6 +1468,9 @@ class Character : public Creature, public visitable
                           bool allow_neutral ) const;
         /** Roll, based on instability, whether next mutation should be good or bad */
         bool roll_bad_mutation() const;
+        /** Opens a menu which allows players to choose from a list of mutations */
+        bool mutation_selector( const std::vector<trait_id> &prospective_traits,
+                                const mutation_category_id &cat, const bool &use_vitamins );
         /** Picks a random valid mutation in a category and mutate_towards() it */
         void mutate_category( const mutation_category_id &mut_cat, bool use_vitamins,
                               bool true_random = false );

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1196,7 +1196,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
         }
 
         // Mutation selector
-        if( get_option<bool>( "SHOW_MUTATION_SELECTOR" ) ) {
+        if( is_avatar() && get_option<bool>( "SHOW_MUTATION_SELECTOR" ) ) {
 
             // Setup menu
             uilist mmenu;

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1085,13 +1085,23 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
     mutation_category_id cat;
     weighted_int_list<mutation_category_id> cat_list = get_vitamin_weighted_categories();
 
-    //If we picked bad, mutation can be bad or neutral
-    //Otherwise, can be good or neutral
-    bool picked_bad = roll_bad_mutation();
+    bool select_mutation = is_avatar() && get_option<bool>( "SHOW_MUTATION_SELECTOR" );
 
-    bool allow_good = !picked_bad;
-    bool allow_bad = picked_bad;
+    bool allow_good = false;
+    bool allow_bad = false;
     bool allow_neutral = true;
+
+    if( select_mutation ) {
+        // Mutation selector overrrides good / bad mutation rolls
+        allow_good = true;
+        allow_bad = true;
+    } else if( roll_bad_mutation() ) {
+        // If we picked bad, mutation can be bad or neutral
+        allow_bad = true;
+    } else {
+        // Otherwise, can be good or neutral
+        allow_good = true;
+    }
 
     add_msg_debug( debugmode::DF_MUTATION, "mutate: true_random_chance %d",
                    true_random_chance );
@@ -1196,7 +1206,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
         }
 
         // Mutation selector
-        if( is_avatar() && get_option<bool>( "SHOW_MUTATION_SELECTOR" ) ) {
+        if( select_mutation ) {
 
             // Setup menu
             uilist mmenu;

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1207,29 +1207,46 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
             }
         };
 
+
+        std::vector<trait_id> prospective_traits;
+        prospective_traits.insert(prospective_traits.end(), upgrades.begin(), upgrades.end());
+        prospective_traits.insert(prospective_traits.end(), valid.begin(), valid.end());
+        prospective_traits.insert(prospective_traits.end(), dummies.begin(), dummies.end());
         std::vector<trait_id> traits;
-        //traits.insert(traits.end(), upgrades.begin(), upgrades.end());
-        //traits.insert(traits.end(), valid.begin(), valid.end());
-        //traits.insert(traits.end(), dummies.begin(), dummies.end());
-        for( trait_id trait : upgrades ) {
-        	traits.push_back( trait );
-        	add_msg("upgrades: " + mutation_name( trait ));
+        for( trait_id trait : prospective_traits ) {
+        	const mutation_branch &mdata = trait.obj();
+            std::vector<trait_id> prereqs1 = mdata.prereqs;
+            std::vector<trait_id> prereqs2 = mdata.prereqs2;
+        	bool c_has_prereq1 = false;
+            bool c_has_prereq2 = false;
+            if( prereqs1.empty() ) {
+            	c_has_prereq1 = true;
+            } else {
+                for( size_t i = 0; ( !c_has_prereq1 ) && i < prereqs1.size(); i++ ) {
+                    if( has_trait( prereqs1[i] ) ) {
+                        c_has_prereq1 = true;
+                    }
+                }
+            }
+            if( prereqs2.empty() ) {
+            	c_has_prereq2 = true;
+            } else {
+                for( size_t i = 0; ( !c_has_prereq2 ) && i < prereqs2.size(); i++ ) {
+                    if( has_trait( prereqs2[i] ) ) {
+                        c_has_prereq2 = true;
+                    }
+                }
+            }
+            if ( c_has_prereq1 && c_has_prereq2 && std::find(traits.begin(), traits.end(), trait) == traits.end() ) {
+            	traits.push_back( trait );
+            }
         }
-        for( trait_id trait : valid ) {
-        	traits.push_back( trait );
-        	add_msg("valid: " + mutation_name( trait ));
-        }
-        for( trait_id trait : dummies ) {
-        	traits.push_back( trait );
-        	add_msg("dummies: " + mutation_name( trait ));
-        }
+        
         mmenu.text = _( "Choose a mutation" );
-
         make_entries( traits );
-
         mmenu.query();
         if( mmenu.ret >= 0 ) {
-            if( mutate_towards( valid[mmenu.ret], cat, nullptr, use_vitamins ) ) {
+            if( mutate_towards( traits[mmenu.ret], cat, nullptr, use_vitamins ) ) {
                 add_msg_if_player( m_mixed, mutation_category_trait::get_category( cat ).mutagen_message() );
             }
         }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -33,6 +33,7 @@
 #include "messages.h"
 #include "monster.h"
 #include "omdata.h"
+#include "options.h"
 #include "output.h"
 #include "overmapbuffer.h"
 #include "pimpl.h"
@@ -1194,70 +1195,68 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
             }
         }
 
-        // Setup menu
-        uilist mmenu;
-        mmenu.text = _( "Choose a mutation" );
-        auto make_entries = [this, &mmenu]( const std::vector<trait_id> &traits ) {
-            const size_t iterations = traits.size();
-            for( int i = 0; i < static_cast<int>( iterations ); ++i ) {
-                const trait_id &trait = traits[i];
-                const std::string &entry_name = mutation_name( trait );
-                mmenu.addentry( i, true, MENU_AUTOASSIGN, entry_name );
-            }
-        };
+        // Mutation selector
+        if( get_option<bool>("SHOW_MUTATION_SELECTOR") ) {
+            // Setup menu
+            uilist mmenu;
+            mmenu.text = _( "Choose a mutation" );
+            auto make_entries = [this, &mmenu]( const std::vector<trait_id> &traits ) {
+                const size_t iterations = traits.size();
+                for( int i = 0; i < static_cast<int>( iterations ); ++i ) {
+                    const trait_id &trait = traits[i];
+                    const std::string &entry_name = mutation_name( trait );
+                    mmenu.addentry( i, true, MENU_AUTOASSIGN, entry_name );
+                }
+            };
 
-        // Aggregate all prospective traits
-        std::vector<trait_id> prospective_traits;
-        prospective_traits.insert(prospective_traits.end(), upgrades.begin(), upgrades.end());
-        prospective_traits.insert(prospective_traits.end(), valid.begin(), valid.end());
-        prospective_traits.insert(prospective_traits.end(), dummies.begin(), dummies.end());
-        
-        // Only allow traits with fulfilled prerequisites
-        std::vector<trait_id> traits;
-        for( trait_id trait : prospective_traits ) {
-        	const mutation_branch &mdata = trait.obj();
-            std::vector<trait_id> prereqs1 = mdata.prereqs;
-            std::vector<trait_id> prereqs2 = mdata.prereqs2;
-        	bool c_has_prereq1 = false;
-            bool c_has_prereq2 = false;
-            if( prereqs1.empty() ) {
-            	c_has_prereq1 = true;
-            } else {
-                for( size_t i = 0; ( !c_has_prereq1 ) && i < prereqs1.size(); i++ ) {
-                    if( has_trait( prereqs1[i] ) ) {
-                        c_has_prereq1 = true;
+            // Aggregate all prospective traits
+            std::vector<trait_id> prospective_traits;
+            prospective_traits.insert(prospective_traits.end(), upgrades.begin(), upgrades.end());
+            prospective_traits.insert(prospective_traits.end(), valid.begin(), valid.end());
+            prospective_traits.insert(prospective_traits.end(), dummies.begin(), dummies.end());
+
+            // Only allow traits with fulfilled prerequisites
+            std::vector<trait_id> traits;
+            for( trait_id trait : prospective_traits ) {
+            	const mutation_branch &mdata = trait.obj();
+                std::vector<trait_id> prereqs1 = mdata.prereqs;
+                std::vector<trait_id> prereqs2 = mdata.prereqs2;
+            	bool c_has_prereq1 = false;
+                bool c_has_prereq2 = false;
+                if( prereqs1.empty() ) {
+                	c_has_prereq1 = true;
+                } else {
+                    for( size_t i = 0; ( !c_has_prereq1 ) && i < prereqs1.size(); i++ ) {
+                        if( has_trait( prereqs1[i] ) ) {
+                            c_has_prereq1 = true;
+                        }
                     }
                 }
-            }
-            if( prereqs2.empty() ) {
-            	c_has_prereq2 = true;
-            } else {
-                for( size_t i = 0; ( !c_has_prereq2 ) && i < prereqs2.size(); i++ ) {
-                    if( has_trait( prereqs2[i] ) ) {
-                        c_has_prereq2 = true;
+                if( prereqs2.empty() ) {
+                	c_has_prereq2 = true;
+                } else {
+                    for( size_t i = 0; ( !c_has_prereq2 ) && i < prereqs2.size(); i++ ) {
+                        if( has_trait( prereqs2[i] ) ) {
+                            c_has_prereq2 = true;
+                        }
                     }
                 }
+                // std::find function returns false on duplicate entry
+                if ( c_has_prereq1 && c_has_prereq2 && std::find(traits.begin(), traits.end(), trait) == traits.end() ) {
+                	traits.push_back( trait );
+                }
             }
-            // std::find function returns false on duplicate entry
-            if ( c_has_prereq1 && c_has_prereq2 && std::find(traits.begin(), traits.end(), trait) == traits.end() ) {
-            	traits.push_back( trait );
+            make_entries( traits );
+
+            // Display menu and handle selection
+            mmenu.query();
+            if( mmenu.ret >= 0 ) {
+                if( mutate_towards( traits[mmenu.ret], cat, nullptr, use_vitamins ) ) {
+                    add_msg_if_player( m_mixed, mutation_category_trait::get_category( cat ).mutagen_message() );
+                }
+                return;
             }
         }
-        make_entries( traits );
-        
-        // Display menu and handle selection
-        mmenu.query();
-        if( mmenu.ret >= 0 ) {
-            if( mutate_towards( traits[mmenu.ret], cat, nullptr, use_vitamins ) ) {
-                add_msg_if_player( m_mixed, mutation_category_trait::get_category( cat ).mutagen_message() );
-            }
-            return;
-        }
-
-
-
-
-
 
         // Prioritize upgrading existing mutations
         if( one_in( 2 ) ) {

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1197,8 +1197,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
         // Setup menu
         uilist mmenu;
         mmenu.text = _( "Choose a mutation" );
-        trait_id current_trait;
-        auto make_entries = [this, &mmenu, &current_trait]( const std::vector<trait_id> &traits ) {
+        auto make_entries = [this, &mmenu]( const std::vector<trait_id> &traits ) {
             const size_t iterations = traits.size();
             for( int i = 0; i < static_cast<int>( iterations ); ++i ) {
                 const trait_id &trait = traits[i];

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1216,10 +1216,10 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
             prospective_traits.insert( prospective_traits.end(), upgrades.begin(), upgrades.end() );
             prospective_traits.insert( prospective_traits.end(), valid.begin(), valid.end() );
             for( trait_id dummy_trait : dummies ) {
-            	// Only dummy traits with conflicts are considered
-            	if( has_conflicting_trait( dummy_trait ) ) {
-            		prospective_traits.push_back( dummy_trait );
-            	}
+                // Only dummy traits with conflicts are considered
+                if( has_conflicting_trait( dummy_trait ) ) {
+                    prospective_traits.push_back( dummy_trait );
+                }
             }
 
             // Only allow traits with fulfilled prerequisites
@@ -1236,7 +1236,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                     }
                 }
                 if( !c_has_prereq1 ) {
-                	continue;
+                    continue;
                 }
 
                 // Check prereq 2
@@ -1248,7 +1248,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                     }
                 }
                 if( !c_has_prereq2 ) {
-                	continue;
+                    continue;
                 }
 
                 // Check threshold requirement
@@ -1260,7 +1260,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                     }
                 }
                 if( !c_has_threshreq ) {
-                	continue;
+                    continue;
                 }
 
                 // Check bionic conflicts

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1197,6 +1197,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
 
         // Mutation selector
         if( get_option<bool>("SHOW_MUTATION_SELECTOR") ) {
+        	
             // Setup menu
             uilist mmenu;
             mmenu.text = _( "As your body transforms, you realize that by asserting your willpower, you can guide these changes to an extent." );
@@ -1219,41 +1220,41 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
             std::vector<trait_id> traits;
             for( trait_id trait : prospective_traits ) {
             	const mutation_branch &mdata = trait.obj();
+
+                // Check prereq 1
                 std::vector<trait_id> prereqs1 = mdata.prereqs;
+            	bool c_has_prereq1 = prereqs1.empty() ? true : false;
+                for( size_t i = 0; ( !c_has_prereq1 ) && i < prereqs1.size(); i++ ) {
+                    if( has_trait( prereqs1[i] ) ) {
+                        c_has_prereq1 = true;
+                    }
+                }
+
+                // Check prereq 2
                 std::vector<trait_id> prereqs2 = mdata.prereqs2;
-            	bool c_has_prereq1 = false;
-                bool c_has_prereq2 = false;
-                if( prereqs1.empty() ) {
-                	c_has_prereq1 = true;
-                } else {
-                    for( size_t i = 0; ( !c_has_prereq1 ) && i < prereqs1.size(); i++ ) {
-                        if( has_trait( prereqs1[i] ) ) {
-                            c_has_prereq1 = true;
-                        }
+                bool c_has_prereq2 = prereqs2.empty() ? true : false;
+                for( size_t i = 0; ( !c_has_prereq2 ) && i < prereqs2.size(); i++ ) {
+                    if( has_trait( prereqs2[i] ) ) {
+                        c_has_prereq2 = true;
                     }
                 }
-                if( prereqs2.empty() ) {
-                	c_has_prereq2 = true;
-                } else {
-                    for( size_t i = 0; ( !c_has_prereq2 ) && i < prereqs2.size(); i++ ) {
-                        if( has_trait( prereqs2[i] ) ) {
-                            c_has_prereq2 = true;
-                        }
-                    }
-                }
-                
-                bool c_has_threshreq = false;
+
+                // Check threshold requirement
                 std::vector<trait_id> threshreq = mdata.threshreq;
-                if( threshreq.empty() ) {
-                	c_has_threshreq = true;
-                } else {
-                    for( size_t i = 0; !c_has_threshreq && i < threshreq.size(); i++ ) {
-                        if( has_trait( threshreq[i] ) ) {
-                            c_has_threshreq = true;
-                        }
+                bool c_has_threshreq = threshreq.empty() ? true : false;
+                for( size_t i = 0; !c_has_threshreq && i < threshreq.size(); i++ ) {
+                    if( has_trait( threshreq[i] ) ) {
+                        c_has_threshreq = true;
                     }
                 }
-    
+
+                // Check bionic conflicts
+                for( const bionic_id &bid : get_bionics() ) {
+                    if( bid->mutation_conflicts.count( trait ) != 0 ) {
+                        continue;
+                    }
+                }
+
                 // std::find function returns false on duplicate entry
                 if ( c_has_prereq1 && c_has_prereq2 && c_has_threshreq && std::find(traits.begin(), traits.end(), trait) == traits.end() ) {
                 	traits.push_back( trait );

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1199,7 +1199,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
         if( get_option<bool>("SHOW_MUTATION_SELECTOR") ) {
             // Setup menu
             uilist mmenu;
-            mmenu.text = _( "Choose a mutation" );
+            mmenu.text = _( "As your body transforms, you realize that by asserting your willpower, you can guide these changes to an extent." );
             auto make_entries = [this, &mmenu]( const std::vector<trait_id> &traits ) {
                 const size_t iterations = traits.size();
                 for( int i = 0; i < static_cast<int>( iterations ); ++i ) {

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1217,8 +1217,10 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                     prospective_traits.push_back( dummy_trait );
                 }
             }
-
-            mutation_selector( prospective_traits, cat, use_vitamins );
+            if( mutation_selector( prospective_traits, cat, use_vitamins ) ) {
+                // Stop if mutation properly handled by mutation selector
+                return;
+            }
         }
 
         // Prioritize upgrading existing mutations

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1196,11 +1196,12 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
         }
 
         // Mutation selector
-        if( get_option<bool>("SHOW_MUTATION_SELECTOR") ) {
-        	
+        if( get_option<bool>( "SHOW_MUTATION_SELECTOR" ) ) {
+
             // Setup menu
             uilist mmenu;
-            mmenu.text = _( "As your body transforms, you realize that by asserting your willpower, you can guide these changes to an extent." );
+            mmenu.text =
+                _( "As your body transforms, you realize that by asserting your willpower, you can guide these changes to an extent." );
             auto make_entries = [this, &mmenu]( const std::vector<trait_id> &traits ) {
                 const size_t iterations = traits.size();
                 for( int i = 0; i < static_cast<int>( iterations ); ++i ) {
@@ -1212,18 +1213,18 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
 
             // Aggregate all prospective traits
             std::vector<trait_id> prospective_traits;
-            prospective_traits.insert(prospective_traits.end(), upgrades.begin(), upgrades.end());
-            prospective_traits.insert(prospective_traits.end(), valid.begin(), valid.end());
-            prospective_traits.insert(prospective_traits.end(), dummies.begin(), dummies.end());
+            prospective_traits.insert( prospective_traits.end(), upgrades.begin(), upgrades.end() );
+            prospective_traits.insert( prospective_traits.end(), valid.begin(), valid.end() );
+            prospective_traits.insert( prospective_traits.end(), dummies.begin(), dummies.end() );
 
             // Only allow traits with fulfilled prerequisites
             std::vector<trait_id> traits;
             for( trait_id trait : prospective_traits ) {
-            	const mutation_branch &mdata = trait.obj();
+                const mutation_branch &mdata = trait.obj();
 
                 // Check prereq 1
                 std::vector<trait_id> prereqs1 = mdata.prereqs;
-            	bool c_has_prereq1 = prereqs1.empty() ? true : false;
+                bool c_has_prereq1 = prereqs1.empty() ? true : false;
                 for( size_t i = 0; ( !c_has_prereq1 ) && i < prereqs1.size(); i++ ) {
                     if( has_trait( prereqs1[i] ) ) {
                         c_has_prereq1 = true;
@@ -1256,8 +1257,9 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                 }
 
                 // std::find function returns false on duplicate entry
-                if ( c_has_prereq1 && c_has_prereq2 && c_has_threshreq && std::find(traits.begin(), traits.end(), trait) == traits.end() ) {
-                	traits.push_back( trait );
+                if( c_has_prereq1 && c_has_prereq2 && c_has_threshreq &&
+                    std::find( traits.begin(), traits.end(), trait ) == traits.end() ) {
+                    traits.push_back( trait );
                 }
             }
             make_entries( traits );

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1241,8 +1241,21 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                         }
                     }
                 }
+                
+                bool c_has_threshreq = false;
+                std::vector<trait_id> threshreq = mdata.threshreq;
+                if( threshreq.empty() ) {
+                	c_has_threshreq = true;
+                } else {
+                    for( size_t i = 0; !c_has_threshreq && i < threshreq.size(); i++ ) {
+                        if( has_trait( threshreq[i] ) ) {
+                            c_has_threshreq = true;
+                        }
+                    }
+                }
+    
                 // std::find function returns false on duplicate entry
-                if ( c_has_prereq1 && c_has_prereq2 && std::find(traits.begin(), traits.end(), trait) == traits.end() ) {
+                if ( c_has_prereq1 && c_has_prereq2 && c_has_threshreq && std::find(traits.begin(), traits.end(), trait) == traits.end() ) {
                 	traits.push_back( trait );
                 }
             }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1225,19 +1225,25 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                 // Check prereq 1
                 std::vector<trait_id> prereqs1 = mdata.prereqs;
                 bool c_has_prereq1 = prereqs1.empty() ? true : false;
-                for( size_t i = 0; ( !c_has_prereq1 ) && i < prereqs1.size(); i++ ) {
+                for( size_t i = 0; !c_has_prereq1 && i < prereqs1.size(); i++ ) {
                     if( has_trait( prereqs1[i] ) ) {
                         c_has_prereq1 = true;
                     }
+                }
+                if( !c_has_prereq1 ) {
+                	continue;
                 }
 
                 // Check prereq 2
                 std::vector<trait_id> prereqs2 = mdata.prereqs2;
                 bool c_has_prereq2 = prereqs2.empty() ? true : false;
-                for( size_t i = 0; ( !c_has_prereq2 ) && i < prereqs2.size(); i++ ) {
+                for( size_t i = 0; !c_has_prereq2 && i < prereqs2.size(); i++ ) {
                     if( has_trait( prereqs2[i] ) ) {
                         c_has_prereq2 = true;
                     }
+                }
+                if( !c_has_prereq2 ) {
+                	continue;
                 }
 
                 // Check threshold requirement
@@ -1248,6 +1254,9 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                         c_has_threshreq = true;
                     }
                 }
+                if( !c_has_threshreq ) {
+                	continue;
+                }
 
                 // Check bionic conflicts
                 for( const bionic_id &bid : get_bionics() ) {
@@ -1257,8 +1266,7 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                 }
 
                 // std::find function returns false on duplicate entry
-                if( c_has_prereq1 && c_has_prereq2 && c_has_threshreq &&
-                    std::find( traits.begin(), traits.end(), trait ) == traits.end() ) {
+                if( std::find( traits.begin(), traits.end(), trait ) == traits.end() ) {
                     traits.push_back( trait );
                 }
             }

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1251,8 +1251,8 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
             if( mutate_towards( traits[mmenu.ret], cat, nullptr, use_vitamins ) ) {
                 add_msg_if_player( m_mixed, mutation_category_trait::get_category( cat ).mutagen_message() );
             }
+            return;
         }
-        return;
 
 
 

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1215,7 +1215,12 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
             std::vector<trait_id> prospective_traits;
             prospective_traits.insert( prospective_traits.end(), upgrades.begin(), upgrades.end() );
             prospective_traits.insert( prospective_traits.end(), valid.begin(), valid.end() );
-            prospective_traits.insert( prospective_traits.end(), dummies.begin(), dummies.end() );
+            for( trait_id dummy_trait : dummies ) {
+            	// Only dummy traits with conflicts are considered
+            	if( has_conflicting_trait( dummy_trait ) ) {
+            		prospective_traits.push_back( dummy_trait );
+            	}
+            }
 
             // Only allow traits with fulfilled prerequisites
             std::vector<trait_id> traits;

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -1194,10 +1194,10 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
             }
         }
 
-        //menu
+        // Setup menu
         uilist mmenu;
+        mmenu.text = _( "Choose a mutation" );
         trait_id current_trait;
-
         auto make_entries = [this, &mmenu, &current_trait]( const std::vector<trait_id> &traits ) {
             const size_t iterations = traits.size();
             for( int i = 0; i < static_cast<int>( iterations ); ++i ) {
@@ -1207,11 +1207,13 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
             }
         };
 
-
+        // Aggregate all prospective traits
         std::vector<trait_id> prospective_traits;
         prospective_traits.insert(prospective_traits.end(), upgrades.begin(), upgrades.end());
         prospective_traits.insert(prospective_traits.end(), valid.begin(), valid.end());
         prospective_traits.insert(prospective_traits.end(), dummies.begin(), dummies.end());
+        
+        // Only allow traits with fulfilled prerequisites
         std::vector<trait_id> traits;
         for( trait_id trait : prospective_traits ) {
         	const mutation_branch &mdata = trait.obj();
@@ -1237,13 +1239,14 @@ void Character::mutate( const int &true_random_chance, bool use_vitamins )
                     }
                 }
             }
+            // std::find function returns false on duplicate entry
             if ( c_has_prereq1 && c_has_prereq2 && std::find(traits.begin(), traits.end(), trait) == traits.end() ) {
             	traits.push_back( trait );
             }
         }
-        
-        mmenu.text = _( "Choose a mutation" );
         make_entries( traits );
+        
+        // Display menu and handle selection
         mmenu.query();
         if( mmenu.ret >= 0 ) {
             if( mutate_towards( traits[mmenu.ret], cat, nullptr, use_vitamins ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Mutation selector mod"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The mutation system leaves plenty of decisions to RNG.  I think some players would appreciate being offered mutation choices for story and roleplay purposes, or to better suit their playstyle.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
When the player character acquires a mutation, a selector menu appears which allows players to choose from a list of possible mutations.  Only mutations which the player is eligible for is shown on the list, and mutation category restrictions still apply.  It works with "true random" mutations which can result in a bigger list of mutations to choose from.  As in the base game, certain mutations, such as purifier mutations, may have to be mutated more than once to achieve the desired outcome as conflicting mutations are gradually removed.

![Capture](https://github.com/CleverRaven/Cataclysm-DDA/assets/129854247/70285e07-aa0a-4903-81e6-d68d9b991344)

This feature is a balance mod which has to be added into a world before it is enabled.  It is safe to add to an existing save.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Make an option instead of a mod.
Remove flavor text to make the menu much smaller.
Allow mutations to be selected for NPCs.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Builds successfully.
A fresh character was given mutagen and primer.
Waited in game until mutation happens.
Mutation selection menu appears correctly when mod is activated.
Mutations with missing prerequisites do not appear on list.
Mutations with threshold requirements only appear when threshold unlocked.
Mutations with bionic conflicts do not appear on list.
Purifier mutations only appear when applicable and correctly downgrades a conflicting mutation by one level.
Only mutations with the correct primer category is shown on list.
List does not show duplicate entries or existing mutations.
Mutations are applied correctly upon selection.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
