### PR TITLE
Add pinecone to tinder recipes requiring cutting tools

### DIFF
--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -895,6 +895,7 @@
         [ "stick", 1 ],
         [ "2x4", 1 ],
         [ "splinter", 2 ],
+        [ "pinecone", 2 ],
         [ "pine_bough", 1 ],
         [ "cotton_patchwork", 1 ],
         [ "paper", 5 ],
@@ -921,7 +922,7 @@
     "time": "1 m",
     "autolearn": true,
     "qualities": [ { "id": "CUT", "level": 1 } ],
-    "components": [ [ [ "splinter", 2 ], [ "withered", 2 ], [ "cattail_stalk", 1 ] ] ]
+    "components": [ [ [ "splinter", 2 ], [ "pinecone", 2 ], [ "withered", 2 ], [ "cattail_stalk", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

You can cut pinecones into splintered wood and splintered wood into tinder. That's annoying so skip one step.

#### Describe the solution

Add pinecones to the recipes in the same quantity as splinters.

#### Describe alternatives you've considered



#### Testing

Shows up as a component.

#### Additional context

Dunno why tinder recipes are set up the way they are with different quality levels still allowing the same components. But I'm not gonna change that.