### PR TITLE
[MoM] Intensify center of Quell Fire mist

### DIFF
--- a/data/mods/MindOverMatter/powers/pyrokinesis.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis.json
@@ -159,7 +159,7 @@
     "skill": "metaphysics",
     "flags": [ "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "IGNORE_WALLS", "NO_EXPLOSION_SFX" ],
     "effect": "attack",
-    "extra_effects": [ { "id": "psionic_drained_difficulty_three", "hit_self": true } ],
+    "extra_effects": [ { "id": "pyro_quell_flames_1" }, { "id": "psionic_drained_difficulty_three", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 3,
     "max_level": { "math": [ "int_to_level(1)" ] },
@@ -168,7 +168,7 @@
     },
     "max_range": 70,
     "min_aoe": {
-      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_quell_flames') * 0.5) + 0) * (scaling_factor(u_val('intelligence') ) )" ]
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_quell_flames') * 0.5) + 1) * (scaling_factor(u_val('intelligence') ) )" ]
     },
     "max_aoe": 50,
     "field_id": "fd_extinguisher",
@@ -188,15 +188,26 @@
     "id": "pyro_quell_flames_1",
     "type": "SPELL",
     "name": "[Ψ]Quell Heat 1",
-    "description": "The part of Quell Fire that removes heat.  If you have it, you debugged it in.",
+    "description": "The second part of Quell Fire that has a higher intensity in the center.  If you have it, you debugged it in.",
     "valid_targets": [ "ground" ],
     "spell_class": "PYROKINETIC",
     "flags": [ "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "IGNORE_WALLS", "NO_EXPLOSION_SFX" ],
-    "effect": "remove_field",
-    "effect_str": "fd_hot_air2",
+    "effect": "attack",
     "shape": "blast",
-    "max_level": { "math": [ "int_to_level(1)" ] },
-    "min_aoe": 0
+    "min_range": {
+      "math": [ "( (u_val('spell_level', 'spell: pyrokinetic_quell_flames') * 0.8) + 5) * (scaling_factor(u_val('intelligence') ) )" ]
+    },
+    "max_range": 70,
+    "min_aoe": {
+      "math": [
+        "( (u_val('spell_level', 'spell: pyrokinetic_quell_flames') * 0.25) + 0) * (scaling_factor(u_val('intelligence') ) )"
+      ]
+    },
+    "max_aoe": 50,
+    "field_id": "fd_extinguisher",
+    "min_field_intensity": 2,
+    "max_field_intensity": 3,
+    "field_chance": 1
   },
   {
     "id": "pyro_quell_flames_2",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Intensify center of Quell Fire mist"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Due to the way "field_chance" works, it was possible to have Quell Fire completely miss a single-tile fire on multiple channel attempts. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a guaranteed thicker center to the Quell Fire power so the mist always goes at least on the targeted square.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
