### PR TITLE
Allow installing and removing bionics through debug menu

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -8671,26 +8671,6 @@
   },
   {
     "type": "mutation",
-    "id": "DEBUG_BIONIC_POWER",
-    "name": { "str": "Debug Bionic Power" },
-    "points": 99,
-    "valid": false,
-    "description": "For fueling your inner cybug.  Activate to increase power capacity by 100 (can be repeated).",
-    "debug": true,
-    "active": true
-  },
-  {
-    "type": "mutation",
-    "id": "DEBUG_BIONIC_POWERGEN",
-    "name": { "str": "Debug Bionic Powergen" },
-    "points": 99,
-    "valid": false,
-    "description": "Activate to increase power by an amount you specify (can be repeated).",
-    "debug": true,
-    "active": true
-  },
-  {
-    "type": "mutation",
     "id": "DEBUG_SPEED",
     "name": { "str": "Debug Speed" },
     "points": 99,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -408,7 +408,6 @@ static const trait_id trait_CF_HAIR( "CF_HAIR" );
 static const trait_id trait_CHEMIMBALANCE( "CHEMIMBALANCE" );
 static const trait_id trait_CHLOROMORPH( "CHLOROMORPH" );
 static const trait_id trait_CLUMSY( "CLUMSY" );
-static const trait_id trait_DEBUG_BIONIC_POWER( "DEBUG_BIONIC_POWER" );
 static const trait_id trait_DEBUG_CLOAK( "DEBUG_CLOAK" );
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
 static const trait_id trait_DEBUG_LS( "DEBUG_LS" );
@@ -2240,10 +2239,6 @@ void Character::process_turn()
     leak_items();
     // Didn't just pick something up
     last_item = itype_null;
-
-    if( !is_npc() && has_trait( trait_DEBUG_BIONIC_POWER ) ) {
-        mod_power_level( get_max_power_level() );
-    }
 
     visit_items( [this]( item * e, item * ) {
         e->process_relic( this, pos() );

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1854,7 +1854,7 @@ static void character_edit_menu()
     enum {
         D_DESC, D_SKILLS, D_THEORY, D_PROF, D_STATS, D_SPELLS, D_ITEMS, D_DELETE_ITEMS, D_DROP_ITEMS, D_ITEM_WORN,
         D_HP, D_STAMINA, D_MORALE, D_PAIN, D_NEEDS, D_HEALTHY, D_STATUS, D_MISSION_ADD, D_MISSION_EDIT,
-        D_TELE, D_MUTATE, D_CLASS, D_ATTITUDE, D_OPINION, D_ADD_EFFECT, D_ASTHMA, D_PRINT_VARS,
+        D_TELE, D_MUTATE, D_BIONICS, D_CLASS, D_ATTITUDE, D_OPINION, D_ADD_EFFECT, D_ASTHMA, D_PRINT_VARS,
         D_WRITE_EOCS, D_KILL_XP, D_CHECK_TEMP, D_EDIT_VARS
     };
     nmenu.addentry( D_DESC, true, 'D', "%s",
@@ -1878,6 +1878,7 @@ static void character_edit_menu()
         nmenu.addentry( D_KILL_XP, true, 'X', "%s", _( "Set kill XP" ) );
     }
     nmenu.addentry( D_MUTATE, true, 'u', "%s", _( "Mutate" ) );
+    nmenu.addentry( D_BIONICS, true, 'b', "%s", _( "Edit [b]ionics" ) );
     nmenu.addentry( D_STATUS, true,
                     hotkey_for_action( ACTION_PL_INFO, /*maximum_modifier_count=*/1 ),
                     "%s", _( "Status window" ) );
@@ -2034,6 +2035,9 @@ static void character_edit_menu()
             }
             break;
         }
+        case D_BIONICS:
+            wishbionics( &you );
+            break;
         case D_HEALTHY: {
             uilist smenu;
             smenu.addentry( 0, true, 'h', "%s: %d", _( "Health" ), you.get_lifestyle() );

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -110,6 +110,7 @@ void wishitem( Character *you = nullptr );
 void wishitem( Character *you, const tripoint & );
 void wishmonster( const std::optional<tripoint> &p );
 void wishmutate( Character *you );
+void wishbionics( Character *you );
 void wishskill( Character *you, bool change_theory = false );
 void wishproficiency( Character *you );
 

--- a/src/mutation.cpp
+++ b/src/mutation.cpp
@@ -64,8 +64,6 @@ static const mutation_category_id mutation_category_ANY( "ANY" );
 static const trait_id trait_BURROW( "BURROW" );
 static const trait_id trait_BURROWLARGE( "BURROWLARGE" );
 static const trait_id trait_CHAOTIC_BAD( "CHAOTIC_BAD" );
-static const trait_id trait_DEBUG_BIONIC_POWER( "DEBUG_BIONIC_POWER" );
-static const trait_id trait_DEBUG_BIONIC_POWERGEN( "DEBUG_BIONIC_POWERGEN" );
 static const trait_id trait_DEX_ALPHA( "DEX_ALPHA" );
 static const trait_id trait_GASTROPOD_EXTREMITY2( "GASTROPOD_EXTREMITY2" );
 static const trait_id trait_GASTROPOD_EXTREMITY3( "GASTROPOD_EXTREMITY3" );
@@ -913,19 +911,6 @@ void Character::activate_mutation( const trait_id &mut )
             activity.values.push_back( to_turns<int>( startup_time ) );
             return;
         }
-    } else if( mut == trait_DEBUG_BIONIC_POWER ) {
-        mod_max_power_level_modifier( 100_kJ );
-        add_msg_if_player( m_good, _( "Bionic power storage increased by 100." ) );
-        tdata.powered = false;
-        return;
-    } else if( mut == trait_DEBUG_BIONIC_POWERGEN ) {
-        int npower;
-        if( query_int( npower, "Modify bionic power by how much?  (Values are in millijoules)" ) ) {
-            mod_power_level( units::from_millijoule( npower ) );
-            add_msg_if_player( m_good, _( "Bionic power increased by %dmJ." ), npower );
-            tdata.powered = false;
-        }
-        return;
     } else if( !mdata.spawn_item.is_empty() ) {
         item tmpitem( mdata.spawn_item );
         i_add_or_drop( tmpitem );

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "bionics.h"
 #include "calendar.h"
 #include "catacharset.h"
 #include "character.h"
@@ -42,7 +43,9 @@
 #include "translations.h"
 #include "type_id.h"
 #include "ui.h"
+#include "ui_manager.h"
 #include "uistate.h"
+#include "units.h"
 
 static const efftype_id effect_pet( "pet" );
 
@@ -340,6 +343,129 @@ void debug_menu::wishmutate( Character *you )
             wmenu.filterlist();
         }
     } while( wmenu.ret >= 0 );
+}
+
+void debug_menu::wishbionics( Character *you )
+{
+    std::vector<const itype *> cbm_items = item_controller->find( []( const itype & itm ) -> bool {
+        return itm.can_use( "install_bionic" );
+    } );
+    std::sort( cbm_items.begin(), cbm_items.end(), []( const itype * a, const itype * b ) {
+        return localized_compare( a->nname( 1 ), b->nname( 1 ) );
+    } );
+
+    while( true ) {
+        units::energy power_level = you->get_power_level();
+        units::energy power_max = you->get_max_power_level();
+        size_t num_installed = you->get_bionics().size();
+
+        bool can_uninstall = num_installed > 0;
+        bool can_uninstall_all = can_uninstall || power_max > 0_J;
+
+        uilist smenu;
+        smenu.text += string_format(
+                          _( "Current power level: %s\nMax power: %s\nBionics installed: %d" ),
+                          units::display( power_level ),
+                          units::display( power_max ),
+                          num_installed
+                      );
+        smenu.addentry( 0, true, 'i', _( "Install from CBM…" ) );
+        smenu.addentry( 1, can_uninstall, 'u', _( "Uninstall…" ) );
+        smenu.addentry( 2, can_uninstall_all, 'U', _( "Uninstall all" ) );
+        smenu.addentry( 3, true, 'c', _( "Edit power capacity (kJ)" ) );
+        smenu.addentry( 4, true, 'C', _( "Edit power capacity (J)" ) );
+        smenu.addentry( 5, true, 'p', _( "Edit power level (kJ)" ) );
+        smenu.addentry( 6, true, 'P', _( "Edit power level (J)" ) );
+        smenu.query();
+        switch( smenu.ret ) {
+            case 0: {
+                uilist scbms;
+                for( size_t i = 0; i < cbm_items.size(); i++ ) {
+                    bool enabled = !you->has_bionic( cbm_items[i]->bionic->id );
+                    scbms.addentry( i, enabled, MENU_AUTOASSIGN, "%s", cbm_items[i]->nname( 1 ) );
+                }
+                scbms.query();
+                if( scbms.ret >= 0 ) {
+                    const itype &cbm = *cbm_items[scbms.ret];
+                    const bionic_id &bio = cbm.bionic->id;
+                    constexpr int difficulty = 0;
+                    constexpr int success = 1;
+                    constexpr int level = 99;
+
+                    bionic_uid upbio_uid = 0;
+                    if( std::optional<bionic *> upbio = you->find_bionic_by_type( bio->upgraded_bionic ) ) {
+                        upbio_uid = ( *upbio )->get_uid();
+                    }
+
+                    you->perform_install( bio, upbio_uid, difficulty, success, level, "NOT_MED",
+                                          bio->canceled_mutations,
+                                          you->pos() );
+                }
+                break;
+            }
+            case 1: {
+                const bionic_collection &installed_bionics = *you->my_bionics;
+                std::vector<std::string> bionic_names;
+                std::vector<const bionic *> bionics;
+                for( const bionic &bio : installed_bionics ) {
+                    if( item::type_is_defined( bio.info().itype() ) ) {
+                        bionic_names.emplace_back( bio.info().name.translated() );
+                        bionics.push_back( &bio );
+                    }
+                }
+                int bionic_index = uilist( _( "Choose bionic to uninstall" ), bionic_names );
+                if( bionic_index < 0 ) {
+                    return;
+                }
+
+                you->remove_bionic( *bionics[bionic_index] );
+                break;
+            }
+            case 2: {
+                you->clear_bionics();
+                you->set_power_level( units::from_kilojoule( 0 ) );
+                you->set_max_power_level( units::from_kilojoule( 0 ) );
+                break;
+            }
+            case 3: {
+                int new_value = 0;
+                if( query_int( new_value, _( "Set the value to (in kJ)?  Currently: %s" ),
+                               units::display( power_max ) ) ) {
+                    you->set_max_power_level( units::from_kilojoule( new_value ) );
+                    you->set_power_level( you->get_power_level() );
+                }
+                break;
+            }
+            case 4: {
+                int new_value = 0;
+                if( query_int( new_value, _( "Set the value to (in J)?  Currently: %s" ),
+                               units::display( power_max ) ) ) {
+                    you->set_max_power_level( units::from_joule( new_value ) );
+                    you->set_power_level( you->get_power_level() );
+                }
+                break;
+            }
+            case 5: {
+                int new_value = 0;
+                if( query_int( new_value, _( "Set the value to (in kJ)?  Currently: %s" ),
+                               units::display( power_level ) ) ) {
+                    you->set_power_level( units::from_kilojoule( new_value ) );
+                }
+                break;
+            }
+            case 6: {
+                int new_value = 0;
+                if( query_int( new_value, _( "Set the value to (in J)?  Currently: %s" ),
+                               units::display( power_level ) ) ) {
+                    you->set_power_level( units::from_joule( new_value ) );
+                }
+                break;
+            }
+            default: {
+                return;
+            }
+        }
+    }
 }
 
 void debug_menu::wisheffect( Character &p )


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Add a much more convenient way to debug bionics-related stuff.

#### Describe the solution
Ported https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/pull/33, which itself is a port of https://github.com/cataclysmbnteam/Cataclysm-BN/pull/2507 by @olanti-p.

#### Describe alternatives you've considered
None.

#### Testing
Installed and uninstalled bionics through new menu without any issues.

#### Additional context
![изображение](https://github.com/CleverRaven/Cataclysm-DDA/assets/11132525/ed3e9164-508e-4725-ae50-2fc5726f7f42)