### PR TITLE
Show inventory selector for tinder when starting fires with tools that require tinder

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1834,9 +1834,32 @@ void activity_handlers::start_fire_do_turn( player_activity *act, Character *you
     item &firestarter = *act->targets.front();
     if( firestarter.has_flag( flag_REQUIRES_TINDER ) ) {
         if( !here.tinder_at( where ) ) {
-            you->add_msg_if_player( m_info, _( "This item requires tinder to light." ) );
-            you->cancel_activity();
-            return;
+            inventory_filter_preset preset( []( const item_location & loc ) {
+                return loc->has_flag( flag_TINDER );
+            } );
+            inventory_pick_selector inv_s( *you, preset );
+            inv_s.add_nearby_items( PICKUP_RANGE );
+            inv_s.add_character_items( *you );
+
+            inv_s.set_title( _( "Select tinder to use for lighting a fire" ) );
+
+            item_location tinder;
+            if( inv_s.empty() || !( tinder = inv_s.execute() ) ) {
+                you->add_msg_if_player( m_info, _( "This item requires tinder to light." ) );
+                you->cancel_activity();
+                return;
+            }
+
+            item copy = *tinder;
+            bool count_by_charges = tinder->count_by_charges();
+            if( count_by_charges ) {
+                tinder->charges--;
+                copy.charges = 1;
+            }
+            here.add_item_or_charges( where, copy );
+            if( !count_by_charges || tinder->charges <= 0 ) {
+                tinder.remove_item();
+            }
         }
     }
 


### PR DESCRIPTION
#### Summary
Features "Show inventory selector for tinder when starting fires with tools that require tinder"

#### Purpose of change

It's annoying to have to put tinder on a fireplace manually.

#### Describe the solution

Show inventory selector to select tinder from when available and no tinder is on the fireplace yet.

#### Describe alternatives you've considered

Automatically pick one from a crafting inventory for even less key presses, but there's no easy way to prefer one item over the other.

#### Testing

Examined a fire ring with a firewood zone, a loaded pump fire drill, and some tinder, straw, and withered plants nearby. Selecting one moves one charge/item to the fire ring and starts the fire.

#### Additional context

