### PR TITLE
[MoM] Add VERDANT HAND Combat Protocol

### DIFF
--- a/data/mods/MindOverMatter/effects/effects_penalty.json
+++ b/data/mods/MindOverMatter/effects/effects_penalty.json
@@ -288,7 +288,7 @@
     "limb_score_mods": [ { "limb_score": "breathing", "modifier": 0.8 }, { "limb_score": "manip", "modifier": 0.8 } ],
     "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   },
-   {
+  {
     "type": "effect_type",
     "id": "effect_asthma_disease_absorbed",
     "name": [ "Difficulty Breathing" ],

--- a/data/mods/MindOverMatter/effects/effects_penalty.json
+++ b/data/mods/MindOverMatter/effects/effects_penalty.json
@@ -277,7 +277,7 @@
   {
     "type": "effect_type",
     "id": "effect_vitakin_overload",
-    "name": [ "Enervated" ],
+    "name": [ "Muscle Weakness" ],
     "desc": [ "Your muscles and coordination are impaired." ],
     "apply_message": "You feel awful!",
     "remove_message": "You don't feel as bad anymore!",
@@ -286,6 +286,18 @@
     "base_mods": { "fatigue_tick": [ 300 ], "fatigue_min": [ 1 ], "health_min": [ -1 ], "health_tick": [ 400 ] },
     "scaling_mods": { "fatigue_min": [ 1 ], "health_min": [ -1 ] },
     "limb_score_mods": [ { "limb_score": "breathing", "modifier": 0.8 }, { "limb_score": "manip", "modifier": 0.8 } ],
+    "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
+  },
+   {
+    "type": "effect_type",
+    "id": "effect_asthma_disease_absorbed",
+    "name": [ "Difficulty Breathing" ],
+    "desc": [ "You're having a very hard time taking in enough air." ],
+    "apply_message": "",
+    "remove_message": "You can finally breathe freely.",
+    "rating": "bad",
+    "base_mods": { "stamina_amount": [ -1000 ] },
+    "limb_score_mods": [ { "limb_score": "breathing", "modifier": 0.8 } ],
     "flags": [ "EFFECT_LIMB_SCORE_MOD" ]
   }
 ]

--- a/data/mods/MindOverMatter/itemgroups/feral_deathdrops.json
+++ b/data/mods/MindOverMatter/itemgroups/feral_deathdrops.json
@@ -212,7 +212,7 @@
       { "group": "feral_humans_crystal_drops_bio", "prob": 40 },
       { "group": "feral_humans_crystal_drops_clair", "prob": 40 },
       { "group": "feral_humans_crystal_drops_vita", "prob": 25 },
-      { "item": "phavian_psionic_martial_power_book", "prob": 15 },
+      { "item": "phavian_psionic_martial_power_book", "prob": 8 },
       { "group": "dist_psionic_shield_belts", "prob": 60, "damage": [ 1, 4 ] },
       { "item": "id_science_visitor_phavian", "prob": 33 }
     ]

--- a/data/mods/MindOverMatter/itemgroups/feral_deathdrops.json
+++ b/data/mods/MindOverMatter/itemgroups/feral_deathdrops.json
@@ -212,6 +212,7 @@
       { "group": "feral_humans_crystal_drops_bio", "prob": 40 },
       { "group": "feral_humans_crystal_drops_clair", "prob": 40 },
       { "group": "feral_humans_crystal_drops_vita", "prob": 25 },
+      { "item": "phavian_psionic_martial_power_book", "prob": 15 },
       { "group": "dist_psionic_shield_belts", "prob": 60, "damage": [ 1, 4 ] },
       { "item": "id_science_visitor_phavian", "prob": 33 }
     ]

--- a/data/mods/MindOverMatter/itemgroups/itemgroups.json
+++ b/data/mods/MindOverMatter/itemgroups/itemgroups.json
@@ -187,6 +187,7 @@
       { "group": "psionic_recipes_beginner", "prob": 5 },
       { "group": "psionic_recipes_tools", "prob": 5 },
       { "group": "psionic_recipes_medicine", "prob": 2 },
+      { "group": "psionic_recipes_powers", "prob": 2 },
       { "group": "psionic_recipes_advanced", "prob": 1 },
       { "group": "dist_matrix_crystals", "prob": 1 }
     ]
@@ -212,6 +213,12 @@
       [ "schematics_instability_remover", 5 ],
       [ "schematics_psionic_purifier", 1 ]
     ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
+    "id": "psionic_recipes_powers",
+    "items": [ [ "phavian_psionic_martial_power_book", 1 ] ]
   },
   {
     "type": "item_group",

--- a/data/mods/MindOverMatter/items/books.json
+++ b/data/mods/MindOverMatter/items/books.json
@@ -126,5 +126,22 @@
     "intelligence": 12,
     "time": "35 m",
     "fun": -2
+  },
+  {
+    "id": "phavian_psionic_martial_power_book",
+    "type": "BOOK",
+    "category": "manuals",
+    "name": {
+      "str": "Training Manual: VERDANT HAND Combat Protocol",
+      "str_pl": "copies of Training Manual: VERDANT HAND Combat Protocol"
+    },
+    "description": "A formal report with a mostly-blank cover page, stamped with the Project PHAVIAN logo at the top and a red \"VERDANT HAND - EYES ONLY\" centered underneath.  Contrary to your initial assumption, it is not a martial arts training manual.  Instead, it describes a series of meditations and visualization exercises designed to \"increase the subject's unarmed combat prowess fivefold\".  There are several charts showing the results of a VERDANT HAND combatant against training opponents armed with weapons or firearms at various engagement distances.  It's clearly still not as good as just having a rifle, but the data look pretty promising if you can get these exercises down.",
+    "copy-from": "recipe_lab_elec",
+    "skill": "unarmed",
+    "required_level": 2,
+    "max_level": 3,
+    "intelligence": 8,
+    "time": "12 m",
+    "fun": 1
   }
 ]

--- a/data/mods/MindOverMatter/mutations/traits.json
+++ b/data/mods/MindOverMatter/mutations/traits.json
@@ -80,5 +80,14 @@
     "purifiable": false,
     "valid": false,
     "spells_learned": [ [ "vita_stop_bleeding", 2 ], [ "vita_health_power", 2 ], [ "vita_hurt_touch", 2 ] ]
+  },
+  {
+    "type": "mutation",
+    "id": "KI_STRIKE",
+    "name": { "str": "VERDANT HAND Combat Protocols" },
+    "points": 2,
+    "description": "Who needs weapons?  Thanks to your biokinesis, you deal more melee damage while fighting barehanded and without gloves.  This damage improves as your unarmed skill increases.",
+    "starting_trait": false,
+    "valid": false
   }
 ]

--- a/data/mods/MindOverMatter/npcs/dialogue/follower_dialogue.json
+++ b/data/mods/MindOverMatter/npcs/dialogue/follower_dialogue.json
@@ -139,7 +139,7 @@
         "condition": { "and": [ { "npc_has_trait": "ASTHMA" }, { "not": { "u_has_trait": "ASTHMA" } }, { "u_has_bionics": "bio_synlungs" } ] },
         "effect": [
           { "npc_lose_trait": "ASTHMA" },
-          { "u_add_effect": "effect_asthma_disease_absorbed" },
+          { "u_add_effect": "effect_asthma_disease_absorbed", "duration": "60 days" },
           {
             "u_message": "You touch <npc_name> and reach out with your powers, looking for the illness within them.  You soon find it, a shadow over their lungs, and draw it into yourself.  It tries to find purchase in your lungs, but it can't; plastic and steel are immune to the weaknesses of the flesh.  Denied purchase there, it settles into the surrounding tissue.",
             "popup": true

--- a/data/mods/MindOverMatter/npcs/dialogue/follower_dialogue.json
+++ b/data/mods/MindOverMatter/npcs/dialogue/follower_dialogue.json
@@ -122,12 +122,26 @@
       {
         "text": "Hold still.  *Remove <npc_name>'s asthma*",
         "topic": "TALK_DONE",
-        "condition": { "and": [ { "npc_has_trait": "ASTHMA" }, { "not": { "u_has_trait": "ASTHMA" } } ] },
+        "condition": { "and": [ { "npc_has_trait": "ASTHMA" }, { "not": { "u_has_trait": "ASTHMA" } }, { "not": { "u_has_bionics": "bio_synlungs" } } ] },
         "effect": [
           { "npc_lose_trait": "ASTHMA" },
           { "u_add_trait": "ASTHMA" },
           {
             "u_message": "You touch <npc_name> and reach out with your powers, looking for the illness within them.  You soon find it, a shadow over their lungs, and draw it into yourself.",
+            "popup": true
+          },
+          { "u_assign_activity": "ACT_VITAKIN_BANISH_FOLLOWER_ILLNESS", "duration": "10 minutes" }
+        ]
+      },
+      {
+        "text": "Hold still.  *Remove <npc_name>'s asthma*",
+        "topic": "TALK_DONE",
+        "condition": { "and": [ { "npc_has_trait": "ASTHMA" }, { "not": { "u_has_trait": "ASTHMA" } }, { "u_has_bionics": "bio_synlungs" } ] },
+        "effect": [
+          { "npc_lose_trait": "ASTHMA" },
+          { "u_add_effect": "effect_asthma_disease_absorbed" },
+          {
+            "u_message": "You touch <npc_name> and reach out with your powers, looking for the illness within them.  You soon find it, a shadow over their lungs, and draw it into yourself.  It tries to find purchase in your lungs, but it can't; plastic and steel are immune to the weaknesses of the flesh.  Denied purchase there, it settles into the surrounding tissue.",
             "popup": true
           },
           { "u_assign_activity": "ACT_VITAKIN_BANISH_FOLLOWER_ILLNESS", "duration": "10 minutes" }

--- a/data/mods/MindOverMatter/npcs/dialogue/follower_dialogue.json
+++ b/data/mods/MindOverMatter/npcs/dialogue/follower_dialogue.json
@@ -122,7 +122,13 @@
       {
         "text": "Hold still.  *Remove <npc_name>'s asthma*",
         "topic": "TALK_DONE",
-        "condition": { "and": [ { "npc_has_trait": "ASTHMA" }, { "not": { "u_has_trait": "ASTHMA" } }, { "not": { "u_has_bionics": "bio_synlungs" } } ] },
+        "condition": {
+          "and": [
+            { "npc_has_trait": "ASTHMA" },
+            { "not": { "u_has_trait": "ASTHMA" } },
+            { "not": { "u_has_bionics": "bio_synlungs" } }
+          ]
+        },
         "effect": [
           { "npc_lose_trait": "ASTHMA" },
           { "u_add_trait": "ASTHMA" },
@@ -136,7 +142,13 @@
       {
         "text": "Hold still.  *Remove <npc_name>'s asthma*",
         "topic": "TALK_DONE",
-        "condition": { "and": [ { "npc_has_trait": "ASTHMA" }, { "not": { "u_has_trait": "ASTHMA" } }, { "u_has_bionics": "bio_synlungs" } ] },
+        "condition": {
+          "and": [
+            { "npc_has_trait": "ASTHMA" },
+            { "not": { "u_has_effect": "effect_asthma_disease_absorbed" } },
+            { "u_has_bionics": "bio_synlungs" }
+          ]
+        },
         "effect": [
           { "npc_lose_trait": "ASTHMA" },
           { "u_add_effect": "effect_asthma_disease_absorbed", "duration": "60 days" },

--- a/data/mods/MindOverMatter/obsolete/obsolete.json
+++ b/data/mods/MindOverMatter/obsolete/obsolete.json
@@ -87,5 +87,10 @@
     "flags": [ "NO_INGEST", "EDIBLE_FROZEN", "ONLY_ONE", "ZERO_WEIGHT", "TRADER_AVOID", "SINGLE_USE" ],
     "use_action": { "type": "heal", "bandages_power": 3, "bleed": 20, "move_cost": 0 },
     "relic_data": { "passive_effects": [ { "has": "HELD", "condition": "ALWAYS", "values": [ { "value": "MAX_MANA", "add": 0 } ] } ] }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CLAIR_SPEED_READING_REMOvE",
+    "effect": [ { "u_lose_trait": "CLAIR_SPEED_READ" } ]
   }
 ]

--- a/data/mods/MindOverMatter/powers/clairsentience_eoc.json
+++ b/data/mods/MindOverMatter/powers/clairsentience_eoc.json
@@ -15,12 +15,12 @@
     "id": "EOC_CLAIR_SPEED_READING",
     "effect": [
       { "u_add_trait": "CLAIR_SPEED_READ" },
-      { "queue_eocs": "EOC_CLAIR_SPEED_READING_REMOvE", "time_in_future": [ "60 minutes", "180 minutes" ] }
+      { "queue_eocs": "EOC_CLAIR_SPEED_READING_REMOVE", "time_in_future": [ "60 minutes", "180 minutes" ] }
     ]
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_CLAIR_SPEED_READING_REMOvE",
+    "id": "EOC_CLAIR_SPEED_READING_REMOVE",
     "effect": [ { "u_lose_trait": "CLAIR_SPEED_READ" } ]
   },
   {

--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -107,7 +107,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VITAKIN_BANISH_ILLNESS_ASTHMA",
-    "condition": { "u_has_trait": "ASTHMA" },
+    "condition": { "or": [ { "u_has_trait": "ASTHMA" }, { "u_has_effect": "effect_asthma_disease_absorbed" } ] },
     "effect": [ { "u_assign_activity": "ACT_VITAKIN_BANISH_ILLNESS_ASTHMA", "duration": "360 minutes" } ],
     "false_effect": [ { "u_message": "You don't have asthma.  There is no need to attempt to cure it.", "type": "mixed" } ]
   },
@@ -126,6 +126,7 @@
     "effect": [
       { "u_message": "You breath easily once again.", "type": "good" },
       { "u_lose_trait": "ASTHMA" },
+      { "u_lose_effect": "effect_asthma_disease_absorbed" },
       { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 20,45 )" ] }
     ],
     "false_effect": [

--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -124,7 +124,7 @@
     "id": "EOC_VITAKIN_BANISH_ILLNESS_ASTHMA_RESULT",
     "condition": { "roll_contested": { "math": [ "rand( u_val('spell_level', 'spell: vita_banish_illness'))" ] }, "difficulty": 12 },
     "effect": [
-      { "u_message": "You breath easily once again.", "type": "good" },
+      { "u_message": "You breathe easily once again.", "type": "good" },
       { "u_lose_trait": "ASTHMA" },
       { "u_lose_effect": "effect_asthma_disease_absorbed" },
       { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 20,45 )" ] }

--- a/data/mods/MindOverMatter/recipes/rituals.json
+++ b/data/mods/MindOverMatter/recipes/rituals.json
@@ -10,7 +10,7 @@
     "skill_used": "unarmed",
     "difficulty": 5,
     "time": "5 h",
-    "autolearn": false,
+    "book_learn": [ [ "phavian_psionic_martial_power_book", 5 ] ],
     "flags": [ "SECRET", "BLIND_HARD" ],
     "result_eocs": [
       {

--- a/data/mods/MindOverMatter/recipes/rituals.json
+++ b/data/mods/MindOverMatter/recipes/rituals.json
@@ -1,0 +1,65 @@
+[
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "study VERDANT HAND combat protocol",
+    "id": "learn_psionic_combat",
+    "description": "Study and attempt to internalize the practices in the VERDANT HAND Combat Protocol training manual.  There's a lot in there; it may take you more than one attempt to understand it.",
+    "category": "CC_PSIONIC",
+    "subcategory": "CSC_PSIONIC_RITUALS",
+    "skill_used": "unarmed",
+    "difficulty": 5,
+    "time": "5 h",
+    "autolearn": false,
+    "flags": [ "SECRET", "BLIND_HARD" ],
+    "result_eocs": [
+      {
+        "id": "EOC_UNLOCK_PSIONIC_COMBAT",
+        "condition": {
+          "and": [
+            { "math": [ "u_val('spell_level', 'spell: biokin_physical_enhance')", ">=", "8" ] },
+            { "math": [ "u_val('spell_level', 'spell: biokin_reflex_enhance')", ">=", "6" ] },
+            { "math": [ "u_val('spell_level', 'spell: biokin_flexibility')", ">=", "8" ] },
+            { "math": [ "u_val('spell_level', 'spell: biokin_overcome_pain')", ">=", "5" ] },
+            { "math": [ "u_val('spell_level', 'spell: biokin_armor_skin')", ">=", "4" ] }
+          ]
+        },
+        "effect": {
+          "run_eocs": {
+            "id": "EOC_UNLOCK_PSIONIC_COMBAT_2",
+            "condition": {
+              "and": [
+                { "roll_contested": { "math": [ "u_skill('unarmed')" ] }, "difficulty": 13 },
+                { "roll_contested": { "math": [ "u_skill('metaphysics')" ] }, "difficulty": 10 }
+              ]
+            },
+            "effect": [
+              {
+                "u_message": "You've done it.  After long effort, you've mastered the VERDANT HAND protocols.  Bring on the zombies; you'll smash them to pieces with your fists.",
+                "type": "good"
+              },
+              { "u_add_trait": "KI_STRIKE" },
+              { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 10,30 )" ] },
+              { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+            ],
+            "false_effect": [
+              {
+                "u_message": "You just couldn't master the forms and the meditations eluded you.  You'll need to try again.",
+                "type": "bad"
+              },
+              { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 10,30 )" ] },
+              { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+            ]
+          }
+        },
+        "false_effect": [
+          {
+            "u_message": "Your mastery of biokinesis isn't deep enough to succeed.  You'll need to develop your powers and try again."
+          },
+          { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 10,30 )" ] },
+          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+        ]
+      }
+    ]
+  }
+]

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -290,6 +290,8 @@ biofuel
 biofuels
 biographic
 biohacker
+biokinesis
+biokinetic
 biollante
 biomachine
 biomancer
@@ -2344,6 +2346,8 @@ pushmower
 pussywillows
 putrescent
 pwn
+pyrokinesis
+pyrokinetic
 pyrolusite
 pyrolysis
 pyrometer


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Add VERDANT HAND Combat Protocol"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Biokinetic ferals can kick the crap out of you with nothing but their bare hands.  It only makes sense that PC biokinetics can do the same.  Plus, finding neat loot is fun. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds a recipe that allows players to gain the hardcoded Ki Strike mutation (renamed "VERDANT HAND Combat Protocols" for the purposes of Mind Over Matter). At the moment, since it's a constant effect the requirements are very high--high proficiency in several biokinetic powers and passing two checks while performing the recipe. Should the Ki Strike mutation ever become an effect, these requirements will be relaxed (and the VERDANT HAND Combat Protocols will be re-implemented as a power you learn from studying the recipe instead). 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

The book exists, shows up in loot tables, and the recipe is learnable. It is possible to succeed at it and gain the VERDANT HAND Combat Protocols.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
