### PR TITLE
Fix radio modded explosives

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7258,7 +7258,15 @@ static void sendRadioSignal( Character &p, const flag_id &signal )
                 sounds::sound( p.pos(), 6, sounds::sound_t::alarm, _( "beep" ), true, "misc", "beep" );
                 if( it.has_flag( flag_RADIO_INVOKE_PROC ) ) {
                     // Invoke to transform a radio-modded explosive into its active form
-                    it.type->invoke( &p, it, loc );
+                    // The item activation may have all kinds of requirements. Like requiring item to be wielded.
+                    // We do not care. Call item action directly without checking can_use.
+                    // Items where this can be a problem should not be radio moddable
+                    std::map<std::string, use_function> use_methods = it.type->use_methods;
+                    if( use_methods.find( "transform" ) != use_methods.end() ) {
+                        it.type->get_use( "transform" )->call( &p, it, loc );
+                    } else {
+                        it.type->get_use( it.type->use_methods.begin()->first )->call( &p, it, loc );
+                    }
                 }
             } else if( !it.empty_container() ) {
                 item *itm = it.get_item_with( [&signal]( const item & c ) {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -231,43 +231,11 @@ std::optional<int> iuse_transform::use( Character *p, item &it, const tripoint &
     if( !p ) {
         debugmsg( "%s called action transform that requires character but no character is present",
                   it.typeId().str() );
-        return std::nullopt; // invoked from active item processing, do nothing.
+        return std::nullopt;
     }
 
     int result = 0;
 
-    if( need_worn && !p->is_worn( it ) ) {
-        p->add_msg_if_player( m_info, _( "You need to wear the %1$s before activating it." ), it.tname() );
-        return std::nullopt;
-    }
-    if( need_wielding && !p->is_wielding( it ) ) {
-        p->add_msg_if_player( m_info, _( "You need to wield the %1$s before activating it." ), it.tname() );
-        return std::nullopt;
-    }
-    if( need_empty && !it.empty() ) {
-        p->add_msg_if_player( m_info, _( "You need to empty the %1$s before activating it." ), it.tname() );
-        return std::nullopt;
-    }
-
-    if( p->is_worn( it ) ) {
-        item tmp = item( target );
-        if( !tmp.has_flag( flag_OVERSIZE ) && !tmp.has_flag( flag_SEMITANGIBLE ) ) {
-            for( const trait_id &mut : p->get_mutations() ) {
-                const mutation_branch &branch = mut.obj();
-                if( branch.conflicts_with_item( tmp ) ) {
-                    p->add_msg_if_player( m_info, _( "Your %1$s mutation prevents you from doing that." ),
-                                          p->mutation_name( mut ) );
-                    return std::nullopt;
-                }
-            }
-        }
-    }
-
-    if( need_charges && it.ammo_remaining( p, true ) < need_charges ) {
-
-        p->add_msg_if_player( m_info, need_charges_msg, it.tname() );
-        return std::nullopt;
-    }
 
     if( need_fire ) {
         if( !p->use_charges_if_avail( itype_fire, need_fire ) ) {
@@ -278,6 +246,7 @@ std::optional<int> iuse_transform::use( Character *p, item &it, const tripoint &
             return std::nullopt;
         }
     }
+
 
     if( !msg_transform.empty() ) {
         p->add_msg_if_player( m_neutral, msg_transform, it.tname() );
@@ -374,9 +343,41 @@ void iuse_transform::do_transform( Character *p, item &it ) const
     }
 }
 
-ret_val<void> iuse_transform::can_use( const Character &p, const item &,
+ret_val<void> iuse_transform::can_use( const Character &p, const item &it,
                                        const tripoint & ) const
 {
+    if( need_worn && !p.is_worn( it ) ) {
+        return ret_val<void>::make_failure( _( "You need to wear the %1$s before activating it." ),
+                                            it.tname() );
+    }
+    if( need_wielding && !p.is_wielding( it ) ) {
+        return ret_val<void>::make_failure( _( "You need to wield the %1$s before activating it." ),
+                                            it.tname() );
+    }
+    if( need_empty && !it.empty() ) {
+        return ret_val<void>::make_failure( _( "You need to empty the %1$s before activating it." ),
+                                            it.tname() );
+    }
+
+
+    if( p.is_worn( it ) ) {
+        item tmp = item( target );
+        if( !tmp.has_flag( flag_OVERSIZE ) && !tmp.has_flag( flag_SEMITANGIBLE ) ) {
+            for( const trait_id &mut : p.get_mutations() ) {
+                const mutation_branch &branch = mut.obj();
+                if( branch.conflicts_with_item( tmp ) ) {
+                    return ret_val<void>::make_failure( _( "Your %1$s mutation prevents you from doing that." ),
+                                                        p.mutation_name( mut ) );
+                }
+            }
+        }
+    }
+
+    if( need_charges && it.ammo_remaining( &p, true ) < need_charges ) {
+        //return ret_val<void>::make_failure( need_charges_msg, it.tname() );
+        return ret_val<void>::make_failure( string_format( need_charges_msg, it.tname() ) );
+    }
+
     if( qualities_needed.empty() ) {
         return ret_val<void>::make_success();
     }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -247,7 +247,6 @@ std::optional<int> iuse_transform::use( Character *p, item &it, const tripoint &
         }
     }
 
-
     if( !msg_transform.empty() ) {
         p->add_msg_if_player( m_neutral, msg_transform, it.tname() );
     }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -374,7 +374,6 @@ ret_val<void> iuse_transform::can_use( const Character &p, const item &it,
     }
 
     if( need_charges && it.ammo_remaining( &p, true ) < need_charges ) {
-        //return ret_val<void>::make_failure( need_charges_msg, it.tname() );
         return ret_val<void>::make_failure( string_format( need_charges_msg, it.tname() ) );
     }
 


### PR DESCRIPTION

#### Summary
Bugfixes "Fix radio modded explosives"

#### Purpose of change

Fix #67524

#### Describe the solution

Move checks from `iuse_transform::use` to `iuse_transform::can_use`.
The "can't do" messages from those checks now display in inventory and block item activation. Before they allowed item activation and then showed up in sidebar as the action failed. The messages could probably be made a bit shorter to better fit the inventory view.
For bombs the checks are unnecessary. For things that require ammo all the currently radiomoddable items turn back off before they do anything so activating them without ammo is not a problem.

Using remote calls `use` directly without checking for `can_use`. This skipps checks like "must be wielded".

#### Describe alternatives you've considered


#### Testing

Radio modded explosive activates and blows up when RC control is used.

#### Additional context


