### PR TITLE
Make waiting in npc heavy areas up to 2x faster

### DIFF
--- a/src/cata_lazy.h
+++ b/src/cata_lazy.h
@@ -1,0 +1,81 @@
+#pragma once
+#ifndef CATA_SRC_CATA_LAZY_H
+#define CATA_SRC_CATA_LAZY_H
+
+#include <optional>
+#include <type_traits>
+
+/**
+ * A wrapper for a type that lazily initializes the underlying type as needed. Use to
+ * save unnecessary allocation costs for eg. std containers in transiently allocated types.
+ *
+ * T must be default initializable.
+ */
+template<typename T, typename = std::enable_if_t<std::is_default_constructible_v<T>>>
+struct lazy {
+    lazy() = default;
+
+    // std::optional-like api for testing without allocating
+
+    bool has_value() const {
+        return actual.has_value();
+    }
+
+    // Transparent value operators that proxy to the actual value.
+
+    template<typename Arg, typename ...Args>
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    lazy( Arg &&arg, Args &&...args ) : actual{std::in_place, std::forward<Arg>( arg ), std::forward<Args>( args )...} {}
+
+    template<typename U>
+    // NOLINTNEXTLINE(misc-unconventional-assign-operator)
+    T &operator=( U &&u ) {
+        get() = std::forward<U>( u );
+        return get();
+    }
+
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    operator T &() {
+        return get();
+    }
+
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    operator T const &() const {
+        return get();
+    }
+
+    T &operator*() {
+        return get();
+    }
+
+    const T &operator*() const {
+        return get();
+    }
+
+    T *operator->() {
+        return &get();
+    }
+
+    const T *operator->() const {
+        return &get();
+    }
+
+
+    template<typename Arg>
+    auto &&operator[]( Arg &&arg ) {
+        return get()[std::forward<Arg>( arg )];
+    }
+
+private:
+    // The constness is a lie because actual is mutable, but that's why it's private.
+    T &get() const {
+        if( !actual.has_value() ) {
+            actual.emplace();
+        }
+        return actual.value();
+    }
+
+    mutable std::optional<T> actual;
+};
+
+#endif // CATA_SRC_CATA_LAZY_H

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -425,6 +425,7 @@ static const trait_id trait_FAT( "FAT" );
 static const trait_id trait_FEL_NV( "FEL_NV" );
 static const trait_id trait_GILLS( "GILLS" );
 static const trait_id trait_GILLS_CEPH( "GILLS_CEPH" );
+static const trait_id trait_GLASSJAW( "GLASSJAW" );
 static const trait_id trait_HATES_BOOKS( "HATES_BOOKS" );
 static const trait_id trait_HEAVYSLEEPER( "HEAVYSLEEPER" );
 static const trait_id trait_HEAVYSLEEPER2( "HEAVYSLEEPER2" );
@@ -1811,20 +1812,34 @@ float Character::stability_roll() const
 
 bool Character::is_dead_state() const
 {
+    if( cached_dead_state.has_value() ) {
+        return cached_dead_state.value();
+    }
+
+    cached_dead_state = false;
     // we want to warn the player with a debug message if they are invincible. this should be unimportant once wounds exist and bleeding is how you die.
     bool has_vitals = false;
-    for( const bodypart_id &part : get_all_body_parts( get_body_part_flags::only_main ) ) {
-        if( part->is_vital ) {
-            if( get_part_hp_cur( part ) <= 0 ) {
-                return true;
-            }
+    for( const bodypart_id &bp : get_all_body_parts( get_body_part_flags::only_main ) ) {
+        if( bp->is_vital ) {
             has_vitals = true;
+            if( get_part_hp_cur( bp ) <= 0 ) {
+                cached_dead_state = true;
+                return cached_dead_state.value();
+            }
         }
     }
     if( !has_vitals ) {
         debugmsg( _( "WARNING!  Player has no vital part and is invincible." ) );
     }
     return false;
+}
+
+void Character::set_part_hp_cur( const bodypart_id &id, int set )
+{
+    if( set <= 0 ) {
+        cached_dead_state.reset();
+    }
+    Creature::set_part_hp_cur( id, set );
 }
 
 void Character::on_try_dodge()
@@ -2390,6 +2405,30 @@ void Character::recalc_hp()
                           enchantment_cache->get_value_add( enchant_vals::mod::MAX_HP );
     calc_all_parts_hp( hp_mod, hp_adjustment, get_str_base(), get_dex_base(), get_per_base(),
                        get_int_base(), get_lifestyle(), get_fat_to_hp() );
+    cached_dead_state.reset();
+}
+
+void Character::calc_all_parts_hp( float hp_mod, float hp_adjustment, int str_max, int dex_max,
+                                   int per_max, int int_max, int healthy_mod, int fat_to_max_hp )
+{
+    for( std::pair<const bodypart_str_id, bodypart> &part : body ) {
+        int new_max = ( part.first->base_hp + str_max * part.first->hp_mods.str_mod + dex_max *
+                        part.first->hp_mods.dex_mod + int_max * part.first->hp_mods.int_mod + per_max *
+                        part.first->hp_mods.per_mod + part.first->hp_mods.health_mod * healthy_mod + fat_to_max_hp +
+                        hp_adjustment ) * hp_mod;
+
+        if( has_trait( trait_GLASSJAW ) && part.first == body_part_head ) {
+            new_max *= 0.8;
+        }
+
+        float max_hp_ratio = static_cast<float>( new_max ) /
+                             static_cast<float>( part.second.get_hp_max() );
+
+        int new_cur = std::ceil( static_cast<float>( part.second.get_hp_cur() ) * max_hp_ratio );
+
+        part.second.set_hp_max( std::max( new_max, 1 ) );
+        part.second.set_hp_cur( std::max( std::min( new_cur, new_max ), 0 ) );
+    }
 }
 
 // This must be called when any of the following change:

--- a/src/character.h
+++ b/src/character.h
@@ -1100,6 +1100,16 @@ class Character : public Creature, public visitable
 
         /** Returns true if the player should be dead */
         bool is_dead_state() const override;
+
+    private:
+        mutable std::optional<bool> cached_dead_state;
+    public:
+        void set_part_hp_cur( const bodypart_id &id, int set ) override;
+
+        void calc_all_parts_hp( float hp_mod = 0.0, float hp_adjust = 0.0, int str_max = 0,
+                                int dex_max = 0, int per_max = 0, int int_max = 0, int healthy_mod = 0,
+                                int fat_to_max_hp = 0 );
+
         /** Returns true if the player has stealthy movement */
         bool is_stealthy() const;
         /** Returns true if the current martial art works with the player's current weapon */

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1700,7 +1700,7 @@ std::function<double( dialogue & )> conditional_t::get_get_dbl( J const &jo )
             }
         }
         return [eoc_id, given_unit]( dialogue const & ) {
-            std::priority_queue<queued_eoc, std::vector<queued_eoc>, eoc_compare> copy_queue =
+            queued_eocs copy_queue =
                 g->queued_global_effect_on_conditions;
             time_point turn;
             bool found = false;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -124,7 +124,6 @@ static const mon_flag_str_id mon_flag_WATER_CAMOUFLAGE( "WATER_CAMOUFLAGE" );
 
 static const species_id species_ROBOT( "ROBOT" );
 
-static const trait_id trait_GLASSJAW( "GLASSJAW" );
 static const trait_id trait_PYROMANIA( "PYROMANIA" );
 
 const std::map<std::string, creature_size> Creature::size_map = {
@@ -2106,29 +2105,6 @@ void Creature::set_body()
     body.clear();
     for( const bodypart_id &bp : get_anatomy()->get_bodyparts() ) {
         body.emplace( bp.id(), bodypart( bp.id() ) );
-    }
-}
-
-void Creature::calc_all_parts_hp( float hp_mod, float hp_adjustment, int str_max, int dex_max,
-                                  int per_max,  int int_max, int healthy_mod,  int fat_to_max_hp )
-{
-    for( std::pair<const bodypart_str_id, bodypart> &part : body ) {
-        int new_max = ( part.first->base_hp + str_max * part.first->hp_mods.str_mod + dex_max *
-                        part.first->hp_mods.dex_mod + int_max * part.first->hp_mods.int_mod + per_max *
-                        part.first->hp_mods.per_mod + part.first->hp_mods.health_mod * healthy_mod + fat_to_max_hp +
-                        hp_adjustment ) * hp_mod;
-
-        if( has_trait( trait_GLASSJAW ) && part.first == body_part_head ) {
-            new_max *= 0.8;
-        }
-
-        float max_hp_ratio = static_cast<float>( new_max ) /
-                             static_cast<float>( part.second.get_hp_max() );
-
-        int new_cur = std::ceil( static_cast<float>( part.second.get_hp_cur() ) * max_hp_ratio );
-
-        part.second.set_hp_max( std::max( new_max, 1 ) );
-        part.second.set_hp_cur( std::max( std::min( new_cur, new_max ), 0 ) );
     }
 }
 

--- a/src/creature.h
+++ b/src/creature.h
@@ -785,9 +785,6 @@ class Creature : public viewer
 
         const std::map<bodypart_str_id, bodypart> &get_body() const;
         void set_body();
-        void calc_all_parts_hp( float hp_mod = 0.0,  float hp_adjust = 0.0, int str_max = 0,
-                                int dex_max = 0,  int per_max = 0,  int int_max = 0, int healthy_mod = 0,
-                                int fat_to_max_hp = 0 );
         // Does not fire debug message if part does not exist
         bool has_part( const bodypart_id &id, body_part_filter filter = body_part_filter::strict ) const;
         // A debug message will be fired if part does not exist.
@@ -817,7 +814,7 @@ class Creature : public viewer
 
         const encumbrance_data &get_part_encumbrance_data( const bodypart_id &id )const;
 
-        void set_part_hp_cur( const bodypart_id &id, int set );
+        virtual void set_part_hp_cur( const bodypart_id &id, int set );
         void set_part_hp_max( const bodypart_id &id, int set );
         void set_part_healed_total( const bodypart_id &id, int set );
         void set_part_damage_disinfected( const bodypart_id &id, int set );

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -194,11 +194,14 @@ struct dialogue {
         dialogue() = default;
         dialogue( const dialogue &d );
         dialogue( dialogue && ) = default;
-        dialogue &operator=( const dialogue & ) = delete;
+        dialogue &operator=( const dialogue & );
         dialogue &operator=( dialogue && ) = default;
+        dialogue( std::unique_ptr<talker> alpha_in, std::unique_ptr<talker> beta_in );
         dialogue( std::unique_ptr<talker> alpha_in, std::unique_ptr<talker> beta_in,
-                  const std::unordered_map<std::string, std::function<bool( dialogue & )>> &cond = {},
-                  const std::unordered_map<std::string, std::string> &ctx = {} );
+                  const std::unordered_map<std::string, std::function<bool( dialogue & )>> &cond );
+        dialogue( std::unique_ptr<talker> alpha_in, std::unique_ptr<talker> beta_in,
+                  const std::unordered_map<std::string, std::function<bool( dialogue & )>> &cond,
+                  const std::unordered_map<std::string, std::string> &ctx );
         talker *actor( bool is_beta ) const;
 
         mutable itype_id cur_item;

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "cata_lazy.h"
 #include "dialogue_win.h"
 #include "global_vars.h"
 #include "npc.h"
@@ -246,10 +247,12 @@ struct dialogue {
         std::unique_ptr<talker> beta;
 
         // dialogue specific variables that can be passed down to additional EOCs but are one way
-        std::unordered_map<std::string, std::string> context;
+        lazy<std::unordered_map<std::string, std::string>> context;
+        // Weirdly unnecessarily in context.
+        std::string callstack;
 
         // conditionals that were set at the upper level
-        std::unordered_map<std::string, std::function<bool( dialogue & )>> conditionals;
+        lazy<std::unordered_map<std::string, std::function<bool( dialogue & )>>> conditionals;
 
         /**
          * Add a simple response that switches the topic to the new one. If first == true, force

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -289,7 +289,7 @@ void effect_on_conditions::process_reactivate()
 bool effect_on_condition::activate( dialogue &d ) const
 {
     bool retval = false;
-    d.amend_callstack( string_format( "EOC: %s", id.c_str() ) );
+    d.amend_callstack( "EOC: " + id.str() );
     // each version needs a copy of the dialogue to pass down
     dialogue d_eoc( d );
     if( !has_condition || condition( d_eoc ) ) {

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -210,7 +210,9 @@ void effect_on_conditions::queue_effect_on_condition( time_duration duration,
 static void process_eocs( std::priority_queue<queued_eoc, std::vector<queued_eoc>, eoc_compare>
                           &eoc_queue, std::vector<effect_on_condition_id> &eoc_vector, dialogue &d )
 {
-    std::vector<queued_eoc> eocs_to_queue;
+    static std::vector<queued_eoc> eocs_to_queue;
+    eocs_to_queue.clear();
+
     while( !eoc_queue.empty() &&
            eoc_queue.top().time <= calendar::turn ) {
         queued_eoc top = eoc_queue.top();

--- a/src/game.h
+++ b/src/game.h
@@ -1082,8 +1082,7 @@ class game
         bool unique_npc_exists( const std::string &id );
         void unique_npc_despawn( const std::string &id );
         std::vector<effect_on_condition_id> inactive_global_effect_on_condition_vector;
-        std::priority_queue<queued_eoc, std::vector<queued_eoc>, eoc_compare>
-        queued_global_effect_on_conditions;
+        queued_eocs queued_global_effect_on_conditions;
 
         // setting that specifies which reachability zone cache to display
         struct debug_reachability_zones_display {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1991,13 +1991,13 @@ void dialogue::set_value( const std::string &key, const std::string &value )
 
 void dialogue::remove_value( const std::string &key )
 {
-    context.erase( key );
+    context->erase( key );
 }
 
 std::string dialogue::get_value( const std::string &key ) const
 {
-    auto it = context.find( key );
-    return ( it == context.end() ) ? "" : it->second;
+    auto it = context->find( key );
+    return ( it == context->end() ) ? "" : it->second;
 }
 
 void dialogue::set_conditional( const std::string &key,
@@ -2008,8 +2008,8 @@ void dialogue::set_conditional( const std::string &key,
 
 bool dialogue::evaluate_conditional( const std::string &key, dialogue &d )
 {
-    auto it = conditionals.find( key );
-    return ( it == conditionals.end() ) ? false : it->second( d );
+    auto it = conditionals->find( key );
+    return ( it == conditionals->end() ) ? false : it->second( d );
 }
 
 const std::unordered_map<std::string, std::string> &dialogue::get_context() const
@@ -2025,17 +2025,17 @@ const std::unordered_map<std::string, std::function<bool( dialogue & )>>
 
 void dialogue::amend_callstack( const std::string &value )
 {
-    if( !context["callstack"].empty() ) {
-        context["callstack"] += " \\ " + value;
+    if( !callstack.empty() ) {
+        callstack += " \\ " + value;
     } else {
-        context["callstack"] = value;
+        callstack = value;
     }
 }
 
 std::string dialogue::get_callstack() const
 {
-    if( context.count( "callstack" ) != 0 ) {
-        return "Callstack: " + context.find( "callstack" )->second;
+    if( !callstack.empty() ) {
+        return "Callstack: " + callstack;
     }
     return "";
 }
@@ -2073,8 +2073,13 @@ dialogue::dialogue( const dialogue &d ) : has_beta( d.has_beta ), has_alpha( d.h
     if( !has_alpha && !has_beta ) {
         debugmsg( "Constructed a dialogue with no actors!  %s", get_callstack() );
     }
-    context = d.get_context();
-    conditionals = d.get_conditionals();
+    if( d.context.has_value() ) {
+        context = *d.context;
+    }
+    if( d.conditionals.has_value() ) {
+        conditionals = *d.conditionals;
+    }
+    callstack = d.callstack;
 }
 
 dialogue::dialogue( std::unique_ptr<talker> alpha_in,

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2078,24 +2078,39 @@ dialogue::dialogue( const dialogue &d ) : has_beta( d.has_beta ), has_alpha( d.h
 }
 
 dialogue::dialogue( std::unique_ptr<talker> alpha_in,
-                    std::unique_ptr<talker> beta_in,
-                    const std::unordered_map<std::string, std::function<bool( dialogue & )>> &cond,
-                    const std::unordered_map<std::string, std::string> &ctx )
+                    std::unique_ptr<talker> beta_in ) : alpha( std::move( alpha_in ) ), beta( std::move( beta_in ) )
 {
-    has_alpha = alpha_in != nullptr;
-    has_beta = beta_in != nullptr;
-    if( has_alpha ) {
-        alpha = std::move( alpha_in );
-    }
-    if( has_beta ) {
-        beta = std::move( beta_in );
-    }
+    has_alpha = alpha != nullptr;
+    has_beta = beta != nullptr;
     if( !has_alpha && !has_beta ) {
         debugmsg( "Constructed a dialogue with no actors!  %s", get_callstack() );
     }
+}
 
-    context = ctx;
-    conditionals = cond;
+dialogue::dialogue( std::unique_ptr<talker> alpha_in,
+                    std::unique_ptr<talker> beta_in,
+                    const std::unordered_map<std::string, std::function<bool( dialogue & )>> &cond ) : alpha( std::move(
+                                    alpha_in ) ), beta( std::move( beta_in ) ), conditionals( cond )
+{
+    has_alpha = alpha != nullptr;
+    has_beta = beta != nullptr;
+    if( !has_alpha && !has_beta ) {
+        debugmsg( "Constructed a dialogue with no actors!  %s", get_callstack() );
+    }
+}
+
+dialogue::dialogue( std::unique_ptr<talker> alpha_in,
+                    std::unique_ptr<talker> beta_in,
+                    const std::unordered_map<std::string, std::function<bool( dialogue & )>> &cond,
+                    const std::unordered_map<std::string, std::string> &ctx ) : alpha( std::move( alpha_in ) ),
+    beta( std::move( beta_in ) ), context( ctx ), conditionals( cond )
+{
+    has_alpha = alpha != nullptr;
+    has_beta = beta != nullptr;
+
+    if( !has_alpha && !has_beta ) {
+        debugmsg( "Constructed a dialogue with no actors!  %s", get_callstack() );
+    }
 }
 
 talk_data talk_response::create_option_line( dialogue &d, const input_event &hotkey,

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -132,8 +132,7 @@ void game::serialize( std::ostream &fout )
                  inactive_global_effect_on_condition_vector );
 
     //save queued effect_on_conditions
-    std::priority_queue<queued_eoc, std::vector<queued_eoc>, eoc_compare> temp_queued(
-        queued_global_effect_on_conditions );
+    queued_eocs temp_queued( queued_global_effect_on_conditions );
     json.member( "queued_global_effect_on_conditions" );
     json.start_array();
     while( !temp_queued.empty() ) {

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1489,8 +1489,7 @@ void Character::store( JsonOut &json ) const
     json.end_array();
 
     //save queued effect_on_conditions
-    std::priority_queue<queued_eoc, std::vector<queued_eoc>, eoc_compare> temp_queued(
-        queued_effect_on_conditions );
+    queued_eocs temp_queued( queued_effect_on_conditions );
     json.member( "queued_effect_on_conditions" );
     json.start_array();
     while( !temp_queued.empty() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Optimize eoc processing and other fixes to speed up waiting near many npcs"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Waiting in npc heavy areas is slow. Very slow. Excruciatingly slow. The hot spots that stood out could be optimized to make things better. Better things are better.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- `npc::is_dead` took up 25% of all cpu time just recalculating if an npc was dead every turn for ai planning purposes. This 'dead state' be cached and invalidated only when the relevant conditions to kill a character occur. This cost is essentially eliminated.
- `effect_on_conditions::process_effect_on_conditions` took up ~46% of all cpu time. Approximately 3% was an unnecessary `string_format` call just parsing for a single string printf formatter which could be replaced with a direct string concatenate. Of the remaining 43%, ~18.5% was effectively allocator overhead and eliminated through a variety of caching and lazy initialization techniques.
  - `process_eocs` was allocating (and reallocating) and deallocating a heavyweight vector every call. Caching this as a function static amortizes the cost to zero. This memory management of a transient vector cost 2.75% of cpu time.
  - A certain `dialogue::dialogue` constructor was creating temporary empty maps as arguments, default initializing member temporary empty maps, then copy-assigning from the temporary arguments to the member variables, resulting in net two wasted map allocations out of three. Likewise a map was being copied instead of moved-from during eoc queue processing. Optimizing the above to avoid the unnecessary allocations saved approximately .75% of cpu time.
  - The eoc queue structure was a `std::priority_queue` which uses a `std::vector` as storage. A contiguous storage data structure is essentially required by `std::priority_queue` (technically, it requires a random access data structure). `priority_queue` operations result in moving and swapping values around, which requires constructing a temporary value to swap into, resulting in more wasted allocations from temporary maps, every time a value is pushed and popped. Reimplementing the queue as a pair of a `std::list<queued_eoc>` and a `std::priority_queue<std::list<queued_eoc>::iterator>` made the expensive queue operations allocation-free, as the iterators are trivial. The list is only pushed and popped when an eoc actually is processed and dequeued, and if it is re-scheduled then the timestamp is updated in place instead of making (another) copy. This saves 3.5% of cpu time.
  - Despite optimizing how many copies happen during eoc processing, there are temporary `dialogue` objects created during eoc processing as copies of existing dialogues. This seems to be to provide a 'scratch' space for eoc logic to write and read context vars, among other things. Most of the time this resulted in just copying empty maps. Instead, introduce a `lazy<>` wrapper which allows transparently deferring initialization of a type until it is actually needed. Optimize the dialogue constructor to avoid unnecessarily instantiating or copying empty context or conditional maps. Move the callstack debug variable out of the context map and into a string member in dialog, to avoid instantiating a map for a single entry. Doing the above optimized out the remaining overhead, approximately 9.5% of total cpu time.
  
Between both fixes, time spent waiting eg. in the refugee center start was reduced by almost half, ~46.5%. This value is bigger the more npcs are in the bubble.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- :elmofire:
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Wait 1 hour at the refugee center start, with a couple wasps in a glass door cage for extra npc ai pain just to help find hot spots.
Quick wait in MSVC debug mode to verify STL debug iterators don't immediately fire exceptions (care was taken to use apis that preserve iterators).

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/2e2cfc75-e532-48c5-abe9-7ea64dd9db60)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/db236c9c-465e-4bf9-a446-287e9a1a410d)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/5503d5a8-065e-4fe6-940c-ed04b0e69f97)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/36f8d85e-475c-4f84-8147-9495e115facf)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
TODO:
- [x] Need to ask implementors if the callstack *must* be in the context eg. when being written out to a debug file, or if its acceptable to stash as a side variable as it is.
- [x] Need to fix tests.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
