### PR TITLE
[Aftershock] Adjust bionic toolkit qualities

### DIFF
--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -397,7 +397,7 @@
     "type": "TOOL",
     "name": { "str": "bionic maintenance toolkit" },
     "description": "A set of very small tools and encrypted digital keys normally used to repair bionic modules in clinical settings.  They will allow you to disassemble simple bionics, but anything more complex would require even more specialized tools.",
-    "qualities": [ [ "BIONIC_ASSEMBLY", 1 ], ["SCREW_FINE", 1] [ "WRENCH_FINE", 1 ] ]
+    "qualities": [ [ "BIONIC_ASSEMBLY", 1 ], ["SCREW_FINE", 1], [ "WRENCH_FINE", 1 ] ]
   },
   {
     "id": "afs_complete_bionic_toolkit",

--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -397,7 +397,7 @@
     "type": "TOOL",
     "name": { "str": "bionic maintenance toolkit" },
     "description": "A set of very small tools and encrypted digital keys normally used to repair bionic modules in clinical settings.  They will allow you to disassemble simple bionics, but anything more complex would require even more specialized tools.",
-    "qualities": [ [ "BIONIC_ASSEMBLY", 1 ], ["SCREW_FINE", 1], [ "WRENCH_FINE", 1 ] ]
+    "qualities": [ [ "BIONIC_ASSEMBLY", 1 ], [ "SCREW_FINE", 1 ], [ "WRENCH_FINE", 1 ] ]
   },
   {
     "id": "afs_complete_bionic_toolkit",
@@ -405,7 +405,7 @@
     "type": "TOOL",
     "name": { "str": "complete bionic toolkit" },
     "description": "A set of very small robotic tools and encrypted digital keys originally designed to disassemble and test the quality of industrially produced bionics.  A highly skilled and patient engineer could use them to manually assemble new cybernetics.",
-    "qualities": [ [ "BIONIC_ASSEMBLY", 2 ], ["SCREW_FINE", 1], [ "WRENCH_FINE", 1 ] ]
+    "qualities": [ [ "BIONIC_ASSEMBLY", 2 ], [ "SCREW_FINE", 1 ], [ "WRENCH_FINE", 1 ] ]
   },
   {
     "id": "afs_bionic_power_mod",

--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -397,7 +397,7 @@
     "type": "TOOL",
     "name": { "str": "bionic maintenance toolkit" },
     "description": "A set of very small tools and encrypted digital keys normally used to repair bionic modules in clinical settings.  They will allow you to disassemble simple bionics, but anything more complex would require even more specialized tools.",
-    "qualities": [ [ "BIONIC_ASSEMBLY", 1 ], [ "SAW_M_FINE", 1 ] ]
+    "qualities": [ [ "BIONIC_ASSEMBLY", 1 ], ["SCREW_FINE", 1] [ "WRENCH_FINE", 1 ] ]
   },
   {
     "id": "afs_complete_bionic_toolkit",
@@ -405,7 +405,7 @@
     "type": "TOOL",
     "name": { "str": "complete bionic toolkit" },
     "description": "A set of very small robotic tools and encrypted digital keys originally designed to disassemble and test the quality of industrially produced bionics.  A highly skilled and patient engineer could use them to manually assemble new cybernetics.",
-    "qualities": [ [ "BIONIC_ASSEMBLY", 2 ], [ "SAW_M_FINE", 1 ] ]
+    "qualities": [ [ "BIONIC_ASSEMBLY", 2 ], ["SCREW_FINE", 1], [ "WRENCH_FINE", 1 ] ]
   },
   {
     "id": "afs_bionic_power_mod",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "[Aftershock] Adjust bionic toolkit qualities"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Bionic toolkits couldn't be used to mend bionics. Now they can.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Removed fine metal sawing from both toolkit items. Added fine bolt turning, fine screwdriving
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
New `BIONIC_MENDING` flag, restricting mending bionics to only specialised toolkits. IMO, best to reconsider if and when AFS: Exoplanet is playable, if restrictions on salvaged bionics are desirable. I'm unsure how to implement this in the vanilla context.
Adding soldering iron qualities to the complete toolkit to allow for bionics to be assembled with only that tool. Doesn't make lore sense to me though - QA tools probably wouldn't have an integrated soldering iron when soldering irons are common (powered) tools and reassembly can be done by sending the faulty bionic back to production (or binning it, depending on what sort of factory is producing these bionics)
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned new char, toolkit, faulty bionic. Can mend bionic with only bionic maintenance kit.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
