### PR TITLE
Fix start date tests corrupting global state

### DIFF
--- a/tests/start_date_test.cpp
+++ b/tests/start_date_test.cpp
@@ -1,5 +1,6 @@
 #include "catch/catch.hpp"
 
+#include "cata_scope_helpers.h"
 #include "game.h"
 #include "scenario.h"
 #include "options.h"
@@ -18,6 +19,11 @@ TEST_CASE( "Test_start_dates" )
     int default_initial_day = 0;
     int default_season_length = 91;
     int default_year_length = default_season_length * 4;
+
+    on_out_of_scope guard{ []()
+    {
+        set_scenario( scenario::generic() );
+    } };
 
     SECTION( "Default game start date with no scenario" ) {
         scenario scen = *scenario::generic();
@@ -105,6 +111,11 @@ TEST_CASE( "Random_scenario_dates" )
     time_duration first_day_of_summer = calendar::season_length();
     time_duration last_day_of_summer = 2 * calendar::season_length() - 1_days;
     time_duration default_start_hour = 1_hours * 8;
+
+    on_out_of_scope guard{ []()
+    {
+        set_scenario( scenario::generic() );
+    } };
 
     SECTION( "Random hour" ) {
         scenario scen = scenario_test_random_hour.obj();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #67567.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Reset the global scenario to generic in any situation that leaves the test case scope.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Repro'd the error with @andrei8l's instructions `./build/cata_test "Test_start_dates,npc-movement" --order lex`. Applied the fix. Did not get the error anymore.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
