### PR TITLE
Fix scenario start dates

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -521,7 +521,8 @@
     "start_name": "Outside Town",
     "surround_groups": [ [ "GROUP_BLACK_ROAD", 70.0 ] ],
     "flags": [ "LONE_START" ],
-    "start_of_game": { "season": "winter" },
+    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": "random", "day": "random", "season": "winter", "year": 1 },
     "add_professions": true,
     "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army" ],
     "requirement": "achievement_survive_91_days"
@@ -546,7 +547,8 @@
     ],
     "start_name": "Outside Town",
     "flags": [ "LONE_START" ],
-    "start_of_game": { "season": "summer", "year": 2 },
+    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": "random", "day": "random", "season": "summer", "year": 2 },
     "add_professions": true,
     "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army" ],
     "requirement": "achievement_survive_91_days"
@@ -559,7 +561,8 @@
     "description": "It's been a year since the apocalypse, and winter is fast approaching.  You and your company have managed to gather up enough supplies to finally settle down somewhere, away from the death and destruction.  Life has been hard for you, but in your heart you still hold a vision of a bright future lying ahead.",
     "start_name": "Old Evac Shelter",
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
-    "start_of_game": { "season": "autumn", "year": 2 },
+    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": "random", "day": "random", "season": "autumn", "year": 2 },
     "add_professions": true,
     "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army" ],
     "requirement": "achievement_survive_91_days",
@@ -575,7 +578,8 @@
     "allowed_locs": [ "sloc_lmoe_empty", "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "start_name": "Enclosed Shelter",
     "flags": [ "LONE_START" ],
-    "start_of_game": { "season": "winter" },
+    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": "random", "day": "random", "season": "winter", "year": 1 },
     "professions": [ "sheltered_militia", "sheltered_survivor", "unemployed" ]
   },
   {
@@ -648,7 +652,8 @@
     "requirement": "achievement_reach_mi-Go_encampment",
     "reveal_locale": false,
     "flags": [ "LONE_START", "CHALLENGE" ],
-    "start_of_game": { "season": "winter" }
+    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": "random", "day": "random", "season": "winter", "year": 1 }
   },
   {
     "type": "scenario",
@@ -1097,7 +1102,8 @@
     "description": "You were camping in the wild to let things back home cool off.  One night strange noises closed in on you and you were attacked.  You managed to get away but can feel things moving in the dark.",
     "id": "camp_attack_start",
     "points": 0,
-    "start_of_game": { "hour": 1 },
+    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": 1, "day": 60, "season": "spring", "year": 1 },
     "start_name": "Wilderness",
     "eoc": [ "scenario_surrounded_zombie_heavy" ],
     "allowed_locs": [

--- a/data/mods/TEST_DATA/scenarios.json
+++ b/data/mods/TEST_DATA/scenarios.json
@@ -8,6 +8,7 @@
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "start_name": "Evac Shelter",
     "flags": [ "CITY_START" ],
+    "start_of_cataclysm": { "year": 1, "season": "spring", "day": 60, "hour": 0 },
     "start_of_game": { "year": 4, "season": "summer", "day": 7, "hour": 18 }
   },
   {
@@ -19,6 +20,7 @@
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "start_name": "Evac Shelter",
     "flags": [ "CITY_START" ],
+    "start_of_cataclysm": { "year": 1, "season": "spring", "day": 60, "hour": 0 },
     "start_of_game": { "year": -1, "season": "spring", "day": 8, "hour": 3 }
   },
   {
@@ -53,7 +55,8 @@
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "start_name": "Evac Shelter",
     "flags": [ "CITY_START" ],
-    "start_of_game": { "hour": "random", "season": "summer" }
+    "start_of_cataclysm": { "day": 60, "season": "spring", "year": 1, "hour": 0 },
+    "start_of_game": { "day": 0, "year": 1, "hour": "random", "season": "summer" }
   },
   {
     "type": "scenario",
@@ -64,7 +67,8 @@
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "start_name": "Evac Shelter",
     "flags": [ "CITY_START" ],
-    "start_of_game": { "day": "random", "season": "summer", "hour": 8 }
+    "start_of_cataclysm": { "day": 60, "season": "spring", "year": 1, "hour": 0 },
+    "start_of_game": { "day": "random", "season": "summer", "year": 1, "hour": 8 }
   },
   {
     "type": "scenario",
@@ -75,6 +79,7 @@
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "start_name": "Evac Shelter",
     "flags": [ "CITY_START" ],
+    "start_of_cataclysm": { "day": 60, "season": "spring", "year": 1, "hour": 0 },
     "start_of_game": { "year": "random", "season": "summer", "hour": 8 }
   }
 ]

--- a/data/mods/innawood/scenarios.json
+++ b/data/mods/innawood/scenarios.json
@@ -261,7 +261,8 @@
     "start_name": "Outside Town",
     "surround_groups": [ [ "GROUP_BLACK_ROAD", 70.0 ] ],
     "flags": [ "LONE_START" ],
-    "start_of_game": { "season": "winter" },
+    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
+    "start_of_game": { "day": "random", "hour": "random", "season": "winter", "year": 1 },
     "professions": [
       "svictim",
       "naked",
@@ -301,7 +302,8 @@
     "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island", "sloc_river" ],
     "start_name": "Outside Town",
     "flags": [ "LONE_START" ],
-    "start_of_game": { "season": "summer", "year": 2 },
+    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": 8, "day": 1, "season": "summer", "year": 2 },
     "professions": [
       "svictim",
       "naked",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1593,6 +1593,20 @@
   },
   {
     "type": "keybinding",
+    "id": "RESET_SCENARIO_START_OF_CATACLYSM",
+    "category": "NEW_CHAR_SCENARIOS",
+    "name": "Reset cataclysm start date",
+    "bindings": [ { "input_method": "keyboard_char", "key": "$" }, { "input_method": "keyboard_code", "key": "4", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "RESET_SCENARIO_START_OF_GAME",
+    "category": "NEW_CHAR_SCENARIOS",
+    "name": "Reset game start date",
+    "bindings": [ { "input_method": "keyboard_char", "key": "%" }, { "input_method": "keyboard_code", "key": "5", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
     "id": "SORT",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Toggle sorting order",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1581,14 +1581,14 @@
     "type": "keybinding",
     "id": "RANDOMIZE_SCENARIO_START_OF_CATACLYSM",
     "category": "NEW_CHAR_SCENARIOS",
-    "name": "Randomize cataclysm start date",
+    "name": "Randomize cataclysm start date (if supported by scenario)",
     "bindings": [ { "input_method": "keyboard_char", "key": "^" }, { "input_method": "keyboard_code", "key": "6", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",
     "id": "RANDOMIZE_SCENARIO_START_OF_GAME",
     "category": "NEW_CHAR_SCENARIOS",
-    "name": "Randomize game start date",
+    "name": "Randomize game start date (if supported by scenario)",
     "bindings": [ { "input_method": "keyboard_char", "key": "&" }, { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] } ]
   },
   {

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -5316,7 +5316,7 @@ A list of mission ids that will be started and assigned to the player at the sta
 ## `start_of_cataclysm`
 (optional, object with optional members "hour", "day", "season" and "year")
 
-Allows customization of cataclysm start date. If `start_of_cataclysm` is not set the corresponding default values are used instead - 0 hour, 0 day (which is day 1), Spring season, 1 year.
+Allows customization of cataclysm start date. If `start_of_cataclysm` is not set the corresponding default values are used instead - 0 hour, 60 day (which is day 61), Spring season, 1 year. By default this date be randomized in new character creation screen.
 
 ```C++
 "start_of_cataclysm": { "hour": "random", "day": 10, "season": "winter", "year": 1 }
@@ -5325,14 +5325,14 @@ Allows customization of cataclysm start date. If `start_of_cataclysm` is not set
  Identifier            | Description
 ---                    | ---
 `hour`                 | (optional, integer or `random` string) Hour of the day. Default value is 0. String `random` randomizes 0-23.
-`day`                  | (optional, integer or `random` string) Day of the season. Default value is 0 (which is day 1). String `random` randomizes 0-season length.
-`season`               | (optional, integer or `random` string) Season of the year. Default value is `SPRING`. String `random` randomizes to one of 4 season.
+`day`                  | (optional, integer or `random` string) Day of the season. Default value is 60 (which is day 61). String `random` randomizes 0-season length.
+`season`               | (optional, integer or `random` string) Season of the year. Default value is `spring`. String `random` randomizes to one of 4 season.
 `year`                 | (optional, integer or `random` string) Year. Default value is 1. String `random` randomizes 1-11.
 
 ## `start_of_game`
 (optional, object with optional members "hour", "day", "season" and "year")
 
-Allows customization of game start date. If `start_of_game` is not set the corresponding default values are used instead - random hour (0-23), 0 day (which is day 1), Spring season, 1 year.
+Allows customization of game start date. If `start_of_game` is not set the corresponding default values are used instead - random hour (0-23), 60 day (which is day 61), Spring season, 1 year. By default hour part of this date can be randomized in new character creation screen.
 
 If the scenario game start date is before the scenario cataclysm start date then the scenario game start would be automatically set to scenario cataclysm start date.
 
@@ -5342,9 +5342,9 @@ If the scenario game start date is before the scenario cataclysm start date then
 
  Identifier            | Description
 ---                    | ---
-`hour`                 | (optional, integer or `random` string) Hour of the day. Default value is 0. String `random` randomizes 0-23.
-`day`                  | (optional, integer or `random` string) Day of the season. Default value is 0 (which is day 1). String `random` randomizes 0-season length.
-`season`               | (optional, integer or `random` string) Season of the year. Default value is `SPRING`. String `random` randomizes to one of 4 season.
+`hour`                 | (optional, integer or `random` string) Hour of the day. Default value is 8. String `random` randomizes 0-23.
+`day`                  | (optional, integer or `random` string) Day of the season. Default value is 60 (which is day 61). String `random` randomizes 0-season length.
+`season`               | (optional, integer or `random` string) Season of the year. Default value is `spring`. String `random` randomizes to one of 4 season.
 `year`                 | (optional, integer or `random` string) Year. Default value is 1. String `random` randomizes 1-11.
 
 # Starting locations

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3048,13 +3048,15 @@ static std::string assemble_scenario_details( const avatar &u, const input_conte
                                 current_scenario->gender_appropriate_name( !u.male ) ) + "\n";
     if( current_scenario->is_random_start_of_cataclysm() ) {
         assembled += string_format(
-                         _( "Press <color_light_green>%1$s</color> to randomize cataclysm start date." ),
-                         ctxt.get_desc( "RANDOMIZE_SCENARIO_START_OF_CATACLYSM" ) ) + "\n";
+                         _( "Press <color_light_green>%1$s</color> to randomize (or <color_light_green>%2$s</color> to reset) cataclysm start date." ),
+                         ctxt.get_desc( "RANDOMIZE_SCENARIO_START_OF_CATACLYSM" ),
+                         ctxt.get_desc( "RESET_SCENARIO_START_OF_CATACLYSM" ) ) + "\n";
     }
     if( current_scenario->is_random_start_of_game() ) {
         assembled += string_format(
-                         _( "Press <color_light_green>%1$s</color> to randomize game start date." ),
-                         ctxt.get_desc( "RANDOMIZE_SCENARIO_START_OF_GAME" ) ) + "\n";
+                         _( "Press <color_light_green>%1$s</color> to randomize (or <color_light_green>%2$s</color> to reset) game start date." ),
+                         ctxt.get_desc( "RANDOMIZE_SCENARIO_START_OF_GAME" ),
+                         ctxt.get_desc( "RESET_SCENARIO_START_OF_GAME" ) ) + "\n";
     }
 
     assembled += "\n" + colorize( _( "Scenario Story:" ), COL_HEADER ) + "\n";
@@ -3196,6 +3198,8 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
     ctxt.register_action( "RANDOMIZE" );
     ctxt.register_action( "RANDOMIZE_SCENARIO_START_OF_GAME" );
     ctxt.register_action( "RANDOMIZE_SCENARIO_START_OF_CATACLYSM" );
+    ctxt.register_action( "RESET_SCENARIO_START_OF_GAME" );
+    ctxt.register_action( "RESET_SCENARIO_START_OF_CATACLYSM" );
 
     bool recalc_scens = true;
     size_t scens_length = 0;
@@ -3373,6 +3377,20 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
                 get_scenario()->rerandomize( false, true );
             } else {
                 sorted_scens[cur_id]->rerandomize( false, true );
+            }
+            details_recalc = true;
+        } else if( action == "RESET_SCENARIO_START_OF_CATACLYSM" ) {
+            if( cur_id != id_for_curr_description ) {
+                get_scenario()->reset_start_of_dates( true, false );
+            } else {
+                sorted_scens[cur_id]->reset_start_of_dates( true, false );
+            }
+            details_recalc = true;
+        } else if( action == "RESET_SCENARIO_START_OF_GAME" ) {
+            if( cur_id != id_for_curr_description ) {
+                get_scenario()->reset_start_of_dates( false, true );
+            } else {
+                sorted_scens[cur_id]->reset_start_of_dates( false, true );
             }
             details_recalc = true;
         }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -112,6 +112,8 @@ static bool isWide = false;
 #define COL_SKILL_USED      c_green   // A skill with at least one point
 #define COL_HEADER          c_white   // Captions, like "Profession items"
 #define COL_NOTE_MINOR      c_light_gray  // Just regular note
+#define COL_DATE_FIXED      c_light_red  // Fixed part of cataclysm/game start date
+#define COL_DATE_RANDOM     c_light_cyan  // Random part of cataclysm/game start date
 
 static int skill_increment_cost( const Character &u, const skill_id &skill );
 
@@ -3110,24 +3112,43 @@ static std::string assemble_scenario_details( const avatar &u, const input_conte
         assembled += current_scenario->vehicle()->name + "\n";
     }
 
-    if( current_scenario->start_of_cataclysm() != calendar::turn_zero ||
-        current_scenario->is_random_start_of_cataclysm() ) {
-        assembled += "\n" + colorize( _( "Start of cataclysm:" ), COL_HEADER ) + "\n";
-        assembled += string_format( _( "Hour %1$d of %3$s, day %2$d (year %4$d)" ),
-                                    current_scenario->start_of_cataclysm_hour(),
-                                    current_scenario->start_of_cataclysm_day() + 1,
-                                    calendar::name_season( current_scenario->start_of_cataclysm_season() ),
-                                    current_scenario->start_of_cataclysm_year() ) + "\n";
-    }
-    if( current_scenario->start_of_game() != current_scenario->start_of_cataclysm() + 8_hours ||
-        current_scenario->is_random_start_of_game() ) {
-        assembled += "\n" + colorize( _( "Start of game:" ), COL_HEADER ) + "\n";
-        assembled += string_format( _( "Hour %1$d of %3$s, day %2$d (year %4$d)" ),
-                                    current_scenario->start_of_game_hour(),
-                                    current_scenario->start_of_game_day() + 1,
-                                    calendar::name_season( current_scenario->start_of_game_season() ),
-                                    current_scenario->start_of_game_year() ) + "\n";
-    }
+    assembled += "\n" + colorize( string_format( _( "Start of cataclysm (%s):" ),
+                                  current_scenario->is_random_start_of_cataclysm()
+                                  ? colorize( "random", COL_DATE_RANDOM )
+                                  : colorize( "fixed",  COL_DATE_FIXED ) ), COL_HEADER ) + "\n";
+    assembled += string_format( _( "Hour %1$s of %3$s, day %2$s (year %4$s)" ),
+                                colorize( string_format( "%d",
+                                          current_scenario->start_of_cataclysm_hour() ),
+                                          current_scenario->is_random_start_of_cataclysm_hour() ? COL_DATE_RANDOM : COL_DATE_FIXED ),
+                                colorize( string_format( "%d",
+                                          current_scenario->start_of_cataclysm_day() + 1 ),
+                                          current_scenario->is_random_start_of_cataclysm_day() ? COL_DATE_RANDOM : COL_DATE_FIXED ),
+                                colorize( string_format( "%s",
+                                          calendar::name_season( current_scenario->start_of_cataclysm_season() ) ),
+                                          current_scenario->is_random_start_of_cataclysm_season() ? COL_DATE_RANDOM : COL_DATE_FIXED ),
+                                colorize( string_format( "%d",
+                                          current_scenario->start_of_cataclysm_year() + 1 ),
+                                          current_scenario->is_random_start_of_cataclysm_year() ? COL_DATE_RANDOM : COL_DATE_FIXED )
+                              ) + "\n";
+    assembled += "\n" + colorize( string_format( _( "Start of game (%s):" ),
+                                  current_scenario->is_random_start_of_game()
+                                  ? colorize( "random", COL_DATE_RANDOM )
+                                  : colorize( "fixed",  COL_DATE_FIXED ) ), COL_HEADER ) + "\n";
+    assembled += string_format( _( "Hour %1$s of %3$s, day %2$s (year %4$s)" ),
+                                colorize( string_format( "%d",
+                                          current_scenario->start_of_game_hour() ),
+                                          current_scenario->is_random_start_of_game_hour() ? COL_DATE_RANDOM : COL_DATE_FIXED ),
+                                colorize( string_format( "%d",
+                                          current_scenario->start_of_game_day() + 1 ),
+                                          current_scenario->is_random_start_of_game_day() ? COL_DATE_RANDOM : COL_DATE_FIXED ),
+                                colorize( string_format( "%s",
+                                          calendar::name_season( current_scenario->start_of_game_season() ) ),
+                                          current_scenario->is_random_start_of_game_season() ? COL_DATE_RANDOM : COL_DATE_FIXED ),
+                                colorize( string_format( "%d",
+                                          current_scenario->start_of_game_year() + 1 ),
+                                          current_scenario->is_random_start_of_game_year() ? COL_DATE_RANDOM : COL_DATE_FIXED )
+                              ) + "\n";
+
     if( !current_scenario->missions().empty() ) {
         assembled += "\n" + colorize( _( "Scenario missions:" ), COL_HEADER ) + "\n";
         for( mission_type_id mission_id : current_scenario->missions() ) {

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -173,7 +173,14 @@ void scenario::load( const JsonObject &jo, const std::string_view )
         _surround_groups.emplace_back( mongroup_id( ja.get_string( 0 ) ),
                                        static_cast<float>( ja.get_float( 1 ) ) );
     }
-    rerandomize();
+    // Initial cataclysm start date would be always set to Hour 0 of Spring, 1 (year 1).
+    // Initial start game hour would be always set to 8.
+    // Both can be later randomized by player in new character menu if scenario allows it.
+    rerandomize( false, true );
+    if( is_random_start_of_game_hour() ) {
+        _start_of_game_hour = 8;
+    }
+    update_start_dates();
 }
 
 const scenario *scenario::generic()
@@ -570,6 +577,12 @@ void scenario::rerandomize( bool randomize_start_of_cataclysm, bool randomize_st
         }
     }
 
+    update_start_dates();
+}
+
+void scenario::update_start_dates() const
+{
+    scenario *hack = const_cast<scenario *>( this );
     hack->_start_of_cataclysm = calendar::turn_zero +
                                 1_hours * hack->start_of_cataclysm_hour() +
                                 1_days * hack->start_of_cataclysm_day() +
@@ -584,6 +597,7 @@ void scenario::rerandomize( bool randomize_start_of_cataclysm, bool randomize_st
                            calendar::year_length() * ( hack->start_of_game_year() - 1 )
                            ;
 
+    // We don't currently allow to start game before Cataclysm
     if( hack->start_of_game() < hack->start_of_cataclysm() ) {
         hack->_start_of_game = hack->start_of_cataclysm();
         hack->_start_of_game_hour = hack->start_of_cataclysm_hour();

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -607,6 +607,40 @@ void scenario::update_start_dates() const
     }
 }
 
+void scenario::reset_start_of_dates( bool reset_start_of_cataclysm, bool reset_start_of_game ) const
+{
+    scenario *hack = const_cast<scenario *>( this );
+    if( reset_start_of_cataclysm ) {
+        if( is_random_start_of_cataclysm_hour() ) {
+            hack->_start_of_cataclysm_hour = 0;
+        }
+        if( is_random_start_of_cataclysm_day() ) {
+            hack->_start_of_cataclysm_day = 60;
+        }
+        if( is_random_start_of_cataclysm_season() ) {
+            hack->_start_of_cataclysm_season = SPRING;
+        }
+        if( is_random_start_of_cataclysm_year() ) {
+            hack->_start_of_cataclysm_year = 1;
+        }
+    }
+    if( reset_start_of_game ) {
+        if( is_random_start_of_game_hour() ) {
+            hack->_start_of_game_hour = 8;
+        }
+        if( is_random_start_of_game_day() ) {
+            hack->_start_of_game_day = 60;
+        }
+        if( is_random_start_of_game_season() ) {
+            hack->_start_of_game_season = SPRING;
+        }
+        if( is_random_start_of_game_year() ) {
+            hack->_start_of_game_year = 1;
+        }
+    }
+    hack->update_start_dates();
+}
+
 bool scenario::is_random_start_of_cataclysm_hour() const
 {
     return _is_random_start_of_cataclysm_hour;

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -122,6 +122,9 @@ class scenario
                           bool randomize_start_of_game = true ) const;
         void update_start_dates() const;
 
+        void reset_start_of_dates( bool reset_start_of_cataclysm = true,
+                                   bool reset_start_of_game = true ) const;
+
         bool is_random_start_of_cataclysm_hour() const;
         bool is_random_start_of_cataclysm_day() const;
         bool is_random_start_of_cataclysm_season() const;

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -57,13 +57,13 @@ class scenario
 
         bool reveal_locale = true;
 
-        bool _is_random_start_of_cataclysm_hour = false;
-        bool _is_random_start_of_cataclysm_day = false;
-        bool _is_random_start_of_cataclysm_season = false;
-        bool _is_random_start_of_cataclysm_year = false;
+        bool _is_random_start_of_cataclysm_hour = true;
+        bool _is_random_start_of_cataclysm_day = true;
+        bool _is_random_start_of_cataclysm_season = true;
+        bool _is_random_start_of_cataclysm_year = true;
 
         int _start_of_cataclysm_hour = 0;
-        int _start_of_cataclysm_day = 0;
+        int _start_of_cataclysm_day = 60;
         season_type _start_of_cataclysm_season = SPRING;
         int _start_of_cataclysm_year = 1;
 
@@ -73,7 +73,7 @@ class scenario
         bool _is_random_start_of_game_year = false;
 
         int _start_of_game_hour = 8;
-        int _start_of_game_day = 0;
+        int _start_of_game_day = 60;
         season_type _start_of_game_season = SPRING;
         int _start_of_game_year = 1;
 
@@ -120,6 +120,7 @@ class scenario
 
         void rerandomize( bool randomize_start_of_cataclysm = true,
                           bool randomize_start_of_game = true ) const;
+        void update_start_dates() const;
 
         bool is_random_start_of_cataclysm_hour() const;
         bool is_random_start_of_cataclysm_day() const;

--- a/tests/start_date_test.cpp
+++ b/tests/start_date_test.cpp
@@ -16,7 +16,6 @@ static const string_id<scenario> scenario_test_random_year( "test_random_year" )
 
 TEST_CASE( "Test_start_dates" )
 {
-    int default_initial_day = 0;
     int default_season_length = 91;
     int default_year_length = default_season_length * 4;
 
@@ -25,17 +24,6 @@ TEST_CASE( "Test_start_dates" )
         set_scenario( scenario::generic() );
     } };
 
-    SECTION( "Default game start date with no scenario" ) {
-        scenario scen = *scenario::generic();
-
-        set_scenario( &scen );
-        scen.rerandomize();
-        g->start_calendar();
-
-        CHECK( calendar::start_of_game >= calendar::turn_zero + 1_days * default_initial_day + 0_hours );
-        CHECK( calendar::start_of_game <= calendar::turn_zero + 1_days * default_initial_day + 23_hours );
-    }
-
     SECTION( "Scenario with custom game start date" ) {
         scenario scen = scenario_test_custom_game.obj();
 
@@ -43,7 +31,6 @@ TEST_CASE( "Test_start_dates" )
         scen.rerandomize();
         g->start_calendar();
 
-        CHECK( calendar::start_of_cataclysm == calendar::turn_zero );
         CHECK( calendar::start_of_game == calendar::turn_zero +
                1_hours * 18 +
                1_days * 7 +
@@ -59,8 +46,7 @@ TEST_CASE( "Test_start_dates" )
         scen.rerandomize();
         g->start_calendar();
 
-        CHECK( calendar::start_of_cataclysm == calendar::turn_zero );
-        CHECK( calendar::start_of_game == calendar::turn_zero );
+        CHECK( calendar::start_of_game == calendar::start_of_cataclysm );
     }
 
     SECTION( "Scenario with custom cataclysm start date" ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fix scenario start dates"

#### Purpose of change

Fix various issues related to scenario start dates

Fixes #67558

#### Describe the solution

- Clarified descriptions of randomize start date keybindings;
- Fixed default values for scenario start dates to be consistent with previous status quo:
    - Default cataclysm start date is `Hour 0 on Spring, 61 of (Year 1)`. All parts of it can be randomized unless set to a fixed value in a scenario.
    - Default game start date is `Hour 8 on Spring, 61 of (Year 1)`. Game start hour can be randomized unless set to a fixed value in a scenario.
- Added two keybindings to reset start dates to default values in new character menu;
- Start dates are now always displayed in new character menu no matter if they are random or fixed.
- Added color coding of random (`light cyan`) and fixed (`light red`) parts of start dates in new character menu.
- Fixed unit tests.

#### Testing

"Test_start_dates" and "Random_scenario_dates" tests successfully pass.
Start various scenarios with fixed or random cataclysm and game start date.

#### Additional context

**Screenshots:**

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/16213433/023c7005-c695-4b75-94f7-4e05fb34d13b)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/16213433/506e1951-b40c-497b-ad33-a0b3e9224acd)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/16213433/00ef8966-a371-4677-b11e-62d206a24c0c)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/16213433/59d420d0-dda6-4c76-b1b0-02c6af9ed38a)


