### PR TITLE
Scrollbar for wish item menu

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4336,7 +4336,7 @@
     "type": "keybinding",
     "category": "WISH_ITEM",
     "id": "SCROLL_DESC_DOWN",
-    "name": "Scroll item description DOWN",
+    "name": "Scroll item description Down",
     "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
   },
   {
@@ -4347,7 +4347,7 @@
     "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
   },
   {
-    "type": "keybinding"
+    "type": "keybinding",
     "id": "SCROLL_ITEM_INFO_DOWN",
     "category": "VENDING_MACHINE",
     "name": "Scroll item info down",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4313,6 +4313,20 @@
   },
   {
     "type": "keybinding",
+    "category": "WISH_ITEM",
+    "id": "SCROLL_DESC_UP",
+    "name": "Scroll item description up",
+    "bindings": [ { "input_method": "keyboard_char", "key": "<" }, { "input_method": "keyboard_code", "key": ",", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
+    "category": "WISH_ITEM",
+    "id": "SCROLL_DESC_DOWN",
+    "name": "Scroll item description DOWN",
+    "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
+   },
+   { 
+    "type": "keybinding",
     "category": "DIALOGUE_CHOOSE_RESPONSE",
     "id": "LOOK_AT",
     "name": "Look at",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4324,8 +4324,8 @@
     "id": "SCROLL_DESC_DOWN",
     "name": "Scroll item description DOWN",
     "bindings": [ { "input_method": "keyboard_char", "key": ">" }, { "input_method": "keyboard_code", "key": ".", "mod": [ "shift" ] } ]
-   },
-   { 
+  },
+  {
     "type": "keybinding",
     "category": "DIALOGUE_CHOOSE_RESPONSE",
     "id": "LOOK_AT",

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -809,7 +809,7 @@ static item wishitem_produce( const itype &type, std::string &flags, bool incont
 class wish_item_callback: public uilist_callback
 {
     public:
-	int examine_pos;
+	    int examine_pos;
         bool incontainer;
         bool spawn_everything;
         bool renew_snippet;
@@ -833,7 +833,7 @@ class wish_item_callback: public uilist_callback
                 return;
             }
 	    
-	    examine_pos=0;
+	        examine_pos=0;
             chosen_snippet_id = { -1, "" };
             renew_snippet = true;
             const itype &selected_itype = *standard_itype_ids[menu->selected];
@@ -918,12 +918,12 @@ class wish_item_callback: public uilist_callback
                 }
                 return true;
             }
-	    if( action == "SCROLL_DESC_UP"  ){
-	        examine_pos=std::max( examine_pos -1, 0 );
-	    }
-	    if( action == "SCROLL_DESC_DOWN"  ){
-	    	examine_pos+=1;
-	    }
+            if( action == "SCROLL_DESC_UP"  ){
+	            examine_pos=std::max( examine_pos -1, 0 );
+	        }
+	        if( action == "SCROLL_DESC_DOWN"  ){
+	    	    examine_pos+=1;
+	        }
             if( cur_key == KEY_LEFT || cur_key == KEY_RIGHT ) {
                 // For Renew snippet_id.
                 renew_snippet = true;
@@ -934,7 +934,7 @@ class wish_item_callback: public uilist_callback
 
         void refresh( uilist *menu ) override {
             const int description_height = menu->w_height - 6;
-	    const int starty = 3;
+	        const int starty = 3;
             const int startx = menu->w_width - menu->pad_right;
             const std::string padding( menu->pad_right, ' ' );
             for( int y = 2; y < menu->w_height - 1; y++ ) {
@@ -974,16 +974,16 @@ class wish_item_callback: public uilist_callback
                 mvwprintz( menu->window, point( startx + ( menu->pad_right - 1 - utf8_width( header ) ) / 2, 1 ),
                            c_cyan, header );
 		
-		std::vector<std::string> desc = foldstring( tmp.info(true), menu->pad_right - 1 );
-		const bool do_scroll = desc.size() > static_cast<unsigned>( description_height );
-		examine_pos = std::min( examine_pos, static_cast<int>( desc.size() - description_height ) );
-		const int first_line = do_scroll ? examine_pos : 0;
-		const int last_line = do_scroll ? ( first_line + description_height ) : desc.size();
-		draw_scrollbar( menu->window, first_line, description_height, desc.size(), point( menu->w_width - 1, starty ),
-			        c_white, true  );
-		for( int i = first_line; i < last_line; i++ ){
-		     fold_and_print( menu->window, point( startx, starty + i - first_line ), menu->pad_right - 1, c_light_gray, desc[i] );
-		}
+		        std::vector<std::string> desc = foldstring( tmp.info(true), menu->pad_right - 1 );
+		        const bool do_scroll = desc.size() > static_cast<unsigned>( description_height );
+		        examine_pos = std::min( examine_pos, static_cast<int>( desc.size() - description_height ) );
+		        const int first_line = do_scroll ? examine_pos : 0;
+		        const int last_line = do_scroll ? ( first_line + description_height ) : desc.size();
+		        draw_scrollbar( menu->window, first_line, description_height, desc.size(), point( menu->w_width - 1, starty ),
+			                    c_white, true  );
+		        for( int i = first_line; i < last_line; i++ ){
+		             fold_and_print( menu->window, point( startx, starty + i - first_line ), menu->pad_right - 1, c_light_gray, desc[i] );
+		        }
             }
 
             mvwprintz( menu->window, point( startx, menu->w_height - 3 ), c_green, msg );
@@ -1047,8 +1047,8 @@ void debug_menu::wishitem( Character *you, const tripoint &pos )
         { "FLAG", translation() },
         { "EVERYTHING", translation() },
         { "SNIPPET", translation() },
-	{ "SCROLL_DESC_UP", translation() },
-	{ "SCROLL_DESC_DOWN", translation() },
+	    { "SCROLL_DESC_UP", translation() },
+	    { "SCROLL_DESC_DOWN", translation() },
     };
     wmenu.w_x_setup = 0;
     wmenu.w_width_setup = []() -> int {

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -809,7 +809,7 @@ static item wishitem_produce( const itype &type, std::string &flags, bool incont
 class wish_item_callback: public uilist_callback
 {
     public:
-	    int examine_pos;
+        int examine_pos;
         bool incontainer;
         bool spawn_everything;
         bool renew_snippet;
@@ -831,8 +831,8 @@ class wish_item_callback: public uilist_callback
         void select( uilist *menu ) override {
             if( menu->selected < 0 ) {
                 return;
-            } 
-	        examine_pos=0;
+            }
+            examine_pos = 0;
             chosen_snippet_id = { -1, "" };
             renew_snippet = true;
             const itype &selected_itype = *standard_itype_ids[menu->selected];
@@ -917,12 +917,12 @@ class wish_item_callback: public uilist_callback
                 }
                 return true;
             }
-            if( action == "SCROLL_DESC_UP"  ){
-	            examine_pos=std::max( examine_pos -1, 0 );
-	        }
-	        if( action == "SCROLL_DESC_DOWN"  ){
-	    	    examine_pos+=1;
-	        }
+            if( action == "SCROLL_DESC_UP" ) {
+                examine_pos = std::max( examine_pos - 1, 0 );
+            }
+            if( action == "SCROLL_DESC_DOWN" ) {
+                examine_pos += 1;
+            }
             if( cur_key == KEY_LEFT || cur_key == KEY_RIGHT ) {
                 // For Renew snippet_id.
                 renew_snippet = true;
@@ -933,7 +933,7 @@ class wish_item_callback: public uilist_callback
 
         void refresh( uilist *menu ) override {
             const int description_height = menu->w_height - 6;
-	        const int starty = 3;
+            const int starty = 3;
             const int startx = menu->w_width - menu->pad_right;
             const std::string padding( menu->pad_right, ' ' );
             for( int y = 2; y < menu->w_height - 1; y++ ) {
@@ -972,17 +972,19 @@ class wish_item_callback: public uilist_callback
                                            flags.empty() ? "" : _( " (flagged)" ) );
                 mvwprintz( menu->window, point( startx + ( menu->pad_right - 1 - utf8_width( header ) ) / 2, 1 ),
                            c_cyan, header );
-		
-		        std::vector<std::string> desc = foldstring( tmp.info(true), menu->pad_right - 1 );
-		        const bool do_scroll = desc.size() > static_cast<unsigned>( description_height );
-		        examine_pos = std::min( examine_pos, static_cast<int>( desc.size() - description_height ) );
-		        const int first_line = do_scroll ? examine_pos : 0;
-		        const int last_line = do_scroll ? ( first_line + description_height ) : desc.size();
-		        draw_scrollbar( menu->window, first_line, description_height, desc.size(), point( menu->w_width - 1, starty ),
-			                    c_white, true  );
-		        for( int i = first_line; i < last_line; i++ ){
-		             fold_and_print( menu->window, point( startx, starty + i - first_line ), menu->pad_right - 1, c_light_gray, desc[i] );
-		        }
+
+                std::vector<std::string> desc = foldstring( tmp.info( true ), menu->pad_right - 1 );
+                const bool do_scroll = desc.size() > static_cast<unsigned>( description_height );
+                examine_pos = std::min( examine_pos, static_cast<int>( desc.size() - description_height ) );
+                const int first_line = do_scroll ? examine_pos : 0;
+                const int last_line = do_scroll ? ( first_line + description_height ) : desc.size();
+                draw_scrollbar( menu->window, first_line, description_height, desc.size(), point( menu->w_width - 1,
+                                starty ),
+                                c_white, true );
+                for( int i = first_line; i < last_line; i++ ) {
+                    fold_and_print( menu->window, point( startx, starty + i - first_line ), menu->pad_right - 1,
+                                    c_light_gray, desc[i] );
+                }
             }
 
             mvwprintz( menu->window, point( startx, menu->w_height - 3 ), c_green, msg );
@@ -1046,8 +1048,8 @@ void debug_menu::wishitem( Character *you, const tripoint &pos )
         { "FLAG", translation() },
         { "EVERYTHING", translation() },
         { "SNIPPET", translation() },
-	    { "SCROLL_DESC_UP", translation() },
-	    { "SCROLL_DESC_DOWN", translation() },
+        { "SCROLL_DESC_UP", translation() },
+        { "SCROLL_DESC_DOWN", translation() },
     };
     wmenu.w_x_setup = 0;
     wmenu.w_width_setup = []() -> int {

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -831,8 +831,7 @@ class wish_item_callback: public uilist_callback
         void select( uilist *menu ) override {
             if( menu->selected < 0 ) {
                 return;
-            }
-	    
+            } 
 	        examine_pos=0;
             chosen_snippet_id = { -1, "" };
             renew_snippet = true;
@@ -994,7 +993,7 @@ class wish_item_callback: public uilist_callback
                        ctxt.get_desc( "FILTER" ), ctxt.get_desc( "CONTAINER" ),
                        ctxt.get_desc( "FLAG" ), ctxt.get_desc( "EVERYTHING" ),
                        ctxt.get_desc( "SNIPPET" ),
-                       ctxt.get_desc( "QUIT" ));
+                       ctxt.get_desc( "QUIT" ) );
             wnoutrefresh( menu->window );
         }
 };

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -809,6 +809,7 @@ static item wishitem_produce( const itype &type, std::string &flags, bool incont
 class wish_item_callback: public uilist_callback
 {
     public:
+	int examine_pos;
         bool incontainer;
         bool spawn_everything;
         bool renew_snippet;
@@ -831,7 +832,8 @@ class wish_item_callback: public uilist_callback
             if( menu->selected < 0 ) {
                 return;
             }
-
+	    
+	    examine_pos=0;
             chosen_snippet_id = { -1, "" };
             renew_snippet = true;
             const itype &selected_itype = *standard_itype_ids[menu->selected];
@@ -916,6 +918,12 @@ class wish_item_callback: public uilist_callback
                 }
                 return true;
             }
+	    if( action == "SCROLL_DESC_UP"  ){
+	        examine_pos=std::max( examine_pos -1, 0 );
+	    }
+	    if( action == "SCROLL_DESC_DOWN"  ){
+	    	examine_pos+=1;
+	    }
             if( cur_key == KEY_LEFT || cur_key == KEY_RIGHT ) {
                 // For Renew snippet_id.
                 renew_snippet = true;
@@ -925,7 +933,8 @@ class wish_item_callback: public uilist_callback
         }
 
         void refresh( uilist *menu ) override {
-            const int starty = 3;
+            const int description_height = menu->w_height - 6;
+	    const int starty = 3;
             const int startx = menu->w_width - menu->pad_right;
             const std::string padding( menu->pad_right, ' ' );
             for( int y = 2; y < menu->w_height - 1; y++ ) {
@@ -964,9 +973,17 @@ class wish_item_callback: public uilist_callback
                                            flags.empty() ? "" : _( " (flagged)" ) );
                 mvwprintz( menu->window, point( startx + ( menu->pad_right - 1 - utf8_width( header ) ) / 2, 1 ),
                            c_cyan, header );
-
-                fold_and_print( menu->window, point( startx, starty ), menu->pad_right - 1, c_light_gray,
-                                tmp.info( true ) );
+		
+		std::vector<std::string> desc = foldstring( tmp.info(true), menu->pad_right - 1 );
+		const bool do_scroll = desc.size() > static_cast<unsigned>( description_height );
+		examine_pos = std::min( examine_pos, static_cast<int>( desc.size() - description_height ) );
+		const int first_line = do_scroll ? examine_pos : 0;
+		const int last_line = do_scroll ? ( first_line + description_height ) : desc.size();
+		draw_scrollbar( menu->window, first_line, description_height, desc.size(), point( menu->w_width - 1, starty ),
+			        c_white, true  );
+		for( int i = first_line; i < last_line; i++ ){
+		     fold_and_print( menu->window, point( startx, starty + i - first_line ), menu->pad_right - 1, c_light_gray, desc[i] );
+		}
             }
 
             mvwprintz( menu->window, point( startx, menu->w_height - 3 ), c_green, msg );
@@ -977,7 +994,7 @@ class wish_item_callback: public uilist_callback
                        ctxt.get_desc( "FILTER" ), ctxt.get_desc( "CONTAINER" ),
                        ctxt.get_desc( "FLAG" ), ctxt.get_desc( "EVERYTHING" ),
                        ctxt.get_desc( "SNIPPET" ),
-                       ctxt.get_desc( "QUIT" ) );
+                       ctxt.get_desc( "QUIT" ));
             wnoutrefresh( menu->window );
         }
 };
@@ -1029,7 +1046,9 @@ void debug_menu::wishitem( Character *you, const tripoint &pos )
         { "CONTAINER", translation() },
         { "FLAG", translation() },
         { "EVERYTHING", translation() },
-        { "SNIPPET", translation() }
+        { "SNIPPET", translation() },
+	{ "SCROLL_DESC_UP", translation() },
+	{ "SCROLL_DESC_DOWN", translation() },
     };
     wmenu.w_x_setup = 0;
     wmenu.w_width_setup = []() -> int {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Added scrollbar for wish item menu"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #65559 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
I added two actions in keybindings for scrolling up and down, registered them for wish item menu and then in `wish_item_callback` I added variable `examine_pos` for keeping scroll position. Then in `refresh` function I turned item description into vector of strings so I can print each line of description separately and added few calculations to determine if we even need to scroll the description, what is the first and last line I'm going to print in description area. 

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Opened the item spawn menu and checked few items with long description. The lowest row is no longer overwritten and I scrolled through their descriptions few times to be sure that it doesn't cause any error/shows entire description
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Item with short description
![ccda_no_scroll](https://github.com/CleverRaven/Cataclysm-DDA/assets/73073559/191de07f-eaae-4450-9f74-259746b22214)

Item with description longer than description window height
![ccda_scroll_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/73073559/723b0f15-e790-4c67-81e3-945821f5bece)
![ccda_scroll_2](https://github.com/CleverRaven/Cataclysm-DDA/assets/73073559/60d4c925-9f82-4020-a932-d6dda139bc29)

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
