### PR TITLE
Bugfix: Do not destroy items when climbing grappling hook

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12204,14 +12204,18 @@ std::optional<tripoint> game::find_or_make_stairs( map &mp, const int z_after, b
     } else if( u.has_amount( itype_grapnel, 1 ) ) {
         if( query_yn( _( "There is a sheer drop halfway down.  Climb your grappling hook down?" ) ) ) {
             rope_ladder = true;
-            u.use_amount( itype_grapnel, 1 );
+            for( item &used_item : u.use_amount( itype_grapnel, 1 ) ) {
+                used_item.spill_contents( u );
+            }
         } else {
             return std::nullopt;
         }
     } else if( u.has_amount( itype_rope_30, 1 ) ) {
         if( query_yn( _( "There is a sheer drop halfway down.  Climb your rope down?" ) ) ) {
             rope_ladder = true;
-            u.use_amount( itype_rope_30, 1 );
+            for( item &used_item : u.use_amount( itype_rope_30, 1 ) ) {
+                used_item.spill_contents( u );
+            }
         } else {
             return std::nullopt;
         }
@@ -13203,7 +13207,9 @@ void game::climb_down( const tripoint &examp )
     } else if( has_grapnel ) {
         you.add_msg_if_player( _( "You tie the rope around your waist and begin to climb down." ) );
         g->vertical_move( -1, true );
-        you.use_amount( itype_grapnel, 1 );
+        for( item &used_item : you.use_amount( itype_grapnel, 1 ) ) {
+            used_item.spill_contents( you );
+        }
         here.furn_set( you.pos(), furn_f_rope_up );
     } else if( !g->slip_down( true ) ) {
         // One tile of falling less (possibly zero)


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Do not destroy items when climbing grappling hook"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

* Do not destroy items in grappling hook when climbing down ledge.
* For example, having a pistol inside the grapplng hook when climbing down a ledge would previously make the pistol disappear after having climbed down using the grappling hook. With this change, it is instead moved to the player's inventory.

Testcase:

* is wearing grappling hook
* grappling hook contains glock

![items-in-grapplinghook-testcase1](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/dd717836-cd0b-475d-b331-02bdd567b956)

* climbs down a ledge using the grappling hook:

![items-in-grapplinghook-testcase2](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/cb7a83e8-d693-460e-a995-ea198bda6d5e)

![items-in-grapplinghook-testcase3](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/cf77c4c7-02f8-43b3-b900-ad23be9bc16b)


Before this change, the glock would disappear completely:

![items-in-grapplinghook-before](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/66820282-ae04-416f-8b23-aeb873f94189)

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
* `you.use_amount` returns the items that were used.
* Reuse existing functions for spilling contents into inventory or floor.

#### Describe alternatives you've considered

* If a grappling hook contains any items, we could disallow it from being used as a climbing tool.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

After:
![items-in-grapplinghook-after](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/9a4710c3-3d1e-46ee-902c-a244885507ae)

* Climbed down a ledge with the testcase listed above.
* The glock is now put into inventory.
* Also tested when not having enough inventory space: then the glock is instead dropped to the ground with this change.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
