### PR TITLE
Nerf phaseimmersion drop from xedra merc

### DIFF
--- a/data/json/npcs/EOC_talkers/xedra_merc.json
+++ b/data/json/npcs/EOC_talkers/xedra_merc.json
@@ -47,9 +47,9 @@
       },
       { "group": "clothing_tactical_leg" },
       { "group": "clothing_watch" },
-      { "item": "phase_immersion_suit", "damage: [ 1, 4 ], "custom-flags": [ "BROKEN" ] },
+      { "item": "phase_immersion_suit", "damage": [ 1, 4 ], "custom-flags": [ "BROKEN" ] },
       { "item": "id_science_security_black" },
-      { "item": "survivor_machete_qt", "variant": "xedra_machete", "container-item": "scabbard", "damage: [ 1, 2 ] },
+      { "item": "survivor_machete_qt", "variant": "xedra_machete", "container-item": "scabbard", "damage": [ 1, 3 ] },
       {
         "collection": [
           { "item": "rm103a_pistol", "prob": 100, "charges": 6, "container-item": "holster" },

--- a/data/json/npcs/EOC_talkers/xedra_merc.json
+++ b/data/json/npcs/EOC_talkers/xedra_merc.json
@@ -47,7 +47,7 @@
       },
       { "group": "clothing_tactical_leg" },
       { "group": "clothing_watch" },
-      { "item": "phase_immersion_suit", "damage": [ 1, 4 ], "custom-flags": [ "BROKEN" ] },
+      { "item": "phase_immersion_suit", "damage": [ 1, 4 ], "custom-flags": [ "ITEM_BROKEN" ] },
       { "item": "id_science_security_black" },
       { "item": "survivor_machete_qt", "variant": "xedra_machete", "container-item": "scabbard", "damage": [ 1, 3 ] },
       {

--- a/data/json/npcs/EOC_talkers/xedra_merc.json
+++ b/data/json/npcs/EOC_talkers/xedra_merc.json
@@ -47,9 +47,9 @@
       },
       { "group": "clothing_tactical_leg" },
       { "group": "clothing_watch" },
-      { "item": "phase_immersion_suit" },
+      { "item": "phase_immersion_suit", "damage: [ 1, 4 ], "custom-flags": [ "BROKEN" ] },
       { "item": "id_science_security_black" },
-      { "item": "survivor_machete_qt", "variant": "xedra_machete", "container-item": "scabbard" },
+      { "item": "survivor_machete_qt", "variant": "xedra_machete", "container-item": "scabbard", "damage: [ 1, 2 ] },
       {
         "collection": [
           { "item": "rm103a_pistol", "prob": 100, "charges": 6, "container-item": "holster" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Phase immersion boss drop needs extra work to be usable"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently the by far most easy and effective way to get good armor is to kill the xedra merc boss, as it drops a fully functional suit of phase immersion armor which handles night vision, defense, temperature, electricity, radiation, acid, gas, etc... I've also never had it even degrade on me once even after being subjected to months of abuse. Balance wise, it's simply too strong and too easy to get - you just need a good rifle and can kill the boss very quickly, the hardest part is getting there since the hallway can be a little chaotic especially if leechplants invade.
Realism wise, is the nether spitting out a perfect "copy" of the merc's gear in mint condition? Or is the merc dying and dropping the suit, which should realistically be riddled with bulletholes from me killing the merc? And they were killed in some sort of dimensional breach so logically there should be a bit more wear and tear on their gear.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The phase immersion suit now spawns with a random amount of damage and the BROKEN flag. Both of these can be fixed by Hub01 and should create a more interesting "mini quest" - I have this cool suit of hypertech armor, but it's trashed, so how do I fix it? Then you get a big reward for doing so (the armor)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Don't give it the "broken" flag. I'm not sure if a nanofabricator will fix it but I know hub will remove it. Alternatively, make nanofabs hardcoded to remove that flag. It just feels weird to have your suit be mangled but still say `"Initiating...Running suit integrity diagnostics…All systems operational."`
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
