### PR TITLE
NPCs actually flee - playtesting requested

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -524,7 +524,7 @@ void npc::assess_danger()
         // Unlike allies, hostile npcs should not see invisible players
         ai_cache.hostile_guys.emplace_back( g->shared_from( player_character ) );
     }
-    
+
     for( const monster &critter : g->all_monsters() ) {
         if( !clairvoyant && !here.has_potential_los( pos(), critter.pos() ) ) {
             continue;
@@ -561,7 +561,7 @@ void npc::assess_danger()
         if( !clear_shot_reach( pos(), critter.pos(), false ) ) {
             continue;
         }
-        
+
         float scaled_distance = std::max( 1.0f, dist / critter.speed_rating() );
         float hp_percent = 1.0f - static_cast<float>( critter.get_hp() ) / critter.get_hp_max();
         float critter_danger = std::max( critter_threat * ( hp_percent * 0.5f + 0.5f ),
@@ -599,16 +599,16 @@ void npc::assess_danger()
             ai_cache.danger = critter_danger;
         }
     }
-    
+
     if( assessment == 0.0 && ai_cache.hostile_guys.empty() ) {
         ai_cache.danger_assessment = assessment;
         return;
     }
     // being outnumbered is serious.  Scale up your assessment if you're outnumbered.
-    if ( hostile_count > friendly_count ) {
+    if( hostile_count > friendly_count ) {
         assessment *= ( hostile_count / friendly_count );
     }
-    
+
     const auto handle_hostile = [&]( const Character & foe, float foe_threat,
     const std::string & bogey, const std::string & warning ) {
         int dist = rl_dist( pos(), foe.pos() );
@@ -636,7 +636,7 @@ void npc::assess_danger()
             }
         }
 
-        
+
         if( !is_player_ally() || is_too_close || ok_by_rules( foe, dist, scaled_distance ) ) {
             float priority = std::max( foe_threat - 2.0f * ( scaled_distance - 1 ),
                                        is_too_close ? std::max( foe_threat, NPC_DANGER_VERY_LOW ) :
@@ -651,7 +651,7 @@ void npc::assess_danger()
         }
         return foe_threat;
     };
-    
+
     for( const weak_ptr_fast<Creature> &guy : ai_cache.hostile_guys ) {
         Character *foe = dynamic_cast<Character *>( guy.lock().get() );
         if( foe && foe->is_npc() ) {
@@ -659,7 +659,7 @@ void npc::assess_danger()
                                           "kill_npc" );
         }
     }
-    
+
     for( const weak_ptr_fast<Creature> &guy : ai_cache.friends ) {
         if( !( guy.lock() && guy.lock()->is_npc() ) ) {
             continue;
@@ -668,7 +668,7 @@ void npc::assess_danger()
         float min_danger = assessment >= NPC_DANGER_VERY_LOW ? NPC_DANGER_VERY_LOW : -10.0f;
         assessment = std::max( min_danger, assessment - guy_threat * 0.5f );
     }
-    
+
     if( sees( player_character.pos() ) ) {
         // Mod for the player
         // cap player difficulty at 150
@@ -682,7 +682,7 @@ void npc::assess_danger()
             ai_cache.friends.emplace_back( g->shared_from( player_character ) );
         }
     }
-    
+
     assessment *= 0.5f;
     if( !has_effect( effect_npc_run_away ) && !has_effect( effect_npc_fire_bad ) ) {
         float my_diff = evaluate_enemy( *this ) * 0.5f + rng( 0, personality.bravery * 2 );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -275,17 +275,11 @@ tripoint npc::good_escape_direction( bool include_pos )
         const zone_manager &mgr = zone_manager::get_manager();
         std::optional<tripoint_abs_ms> retreat_target = mgr.get_nearest( retreat_zone, abs_pos, 60,
                 fac_id );
-        // if there is a retreat zone in range, go there
-        if( !retreat_target ) {
-            //if not, regroup on the player
-            tripoint_bub_ms player_pos = get_player_character().pos_bub();
-            retreat_target = here.getglobal( player_pos );
-        }
         if( retreat_target && *retreat_target != abs_pos ) {
             update_path( here.getlocal( *retreat_target ) );
-        }
-        if( !path.empty() ) {
-            return path[0];
+            if( !path.empty() ) {
+                return path[0];
+            }
         }
     }
 
@@ -683,7 +677,7 @@ void npc::assess_danger()
         float my_diff = evaluate_enemy( *this ) * 0.5f + rng( 0, personality.bravery * 2 );
         if( my_diff < assessment ) {
             add_msg_debug( debugmode::DF_NPC, "assessment: %1f, diff: %2f.", assessment, my_diff );
-            time_duration run_away_for = 5_turns + 1_turns * rng( 0, 5 );
+            time_duration run_away_for = 10_turns + 1_turns * rng( 0, 10 ) - 1_turns * personality.bravery;
             warn_about( "run_away", run_away_for );
             add_effect( effect_npc_run_away, run_away_for );
             path.clear();

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -682,7 +682,7 @@ void npc::assess_danger()
     if( !has_effect( effect_npc_run_away ) && !has_effect( effect_npc_fire_bad ) ) {
         float my_diff = evaluate_enemy( *this ) * 0.5f + rng( 0, personality.bravery * 2 );
         if( my_diff < assessment ) {
-            add_msg_debug( "assessment: %1f, diff: %2f.", assessment, my_diff );
+            add_msg_debug( debugmode::DF_NPC, "assessment: %1f, diff: %2f.", assessment, my_diff );
             time_duration run_away_for = 5_turns + 1_turns * rng( 0, 5 );
             warn_about( "run_away", run_away_for );
             add_effect( effect_npc_run_away, run_away_for );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "NPC fleeing behaviour adjusted and slightly improved"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
in #29867, @mlangsdorf added some NPC retreat zones and associated retreat behaviour. This was a start meant to be expanded but, well, we haven't done so. NPCs seem to never retreat.

#### Describe the solution
Initially I thought this was because we never use retreat zones, so I set up retreat zones to test, but NPCs still didn't retreat to them. I added some debug messages to determine danger assessment and found that NPCs were much too brave.

I have adjusted the bravery calculation and made NPCs noticeably more cowardly. Initially I also added a fallback behaviour, where NPCs would try to flee to your location. However then I realized that there was an implemented threat map that gave them a significantly smarter flee route, it just wasn't triggering because they were so fatally courageous.

So, I spent a while adjusting the calculations for bravery, making the personality trait "bravery" more important and making threats much higher. I also significantly extended the duration they'll flee, so instead of dancing a few tiles back and charging in, they'll actually run a fairly long way away. Honestly they could stand to run further but I think this works pretty well.

Edit: after some playtesting reports from @Maleclypse I found that regular zombies, even hordes of them, were still not triggering a flee response. Specifically, it seems like threats of large groups are not scaled up enough: one zombie presents a threat of 5, six zombies presented a threat of 13. One migo presents a threat of 27, four migo present a threat of 55. I don't understand the code well enough to see why this is, but I added what may be just a simple hack to quickly count the number of hostiles and the number of friendlies in view, and scale up assessed threat if the friendly team is outnumbered. Now, six zombies present a threat of 50, ten fold what a single zombie does, which feels way more appropriate. This did seem to work: NPCs now run if there are more than a couple zombies coming at them. I would like some testing to see if I've made them too chicken, but I am on the way out on a trip tomorrow. I'd love some comments on the balance, but I think if this was merged as it is, it wouldn't be a total flop.

#### Describe alternatives you've considered

- more testing to see if the bravery calculations are appropriate. NPCs should be cowardly compared to the player, but not so cowardly as to be useless
- we could consider some more customization. You could tell your NPCs to run sooner, which would decrease their bravery roll, or tell them to run further when they decide to run. You could also have an override to tell them to regroup on your position instead of running away, and then we could implement the behaviour I had to begin with.
- I think we still should have the ability to give a RUN AWAY command that activates `effect_npc_run_away`, and a REGROUP command that causes the NPC to path to  you, regardless of what they're doing. It would also be nice to have a "HOLD THE LINE" command that decreases their chance to flee, but doesn't remove it entirely.

#### Testing
Loaded game. Spawned NPC ally and zomborg. NPC fought zomborg and was winning. Spawned another zomborg. NPC continued to fight. Spawned a third zomborg. NPC ran like a frightened rabbit.

Spawned a skeletal juggernaut. NPC fired until their gun ran out of ammo, then reassessed the threat, realized they stood no chance, and ran away.

Honestly it worked really well. Mark's AI stuff was pretty well done, it just wasn't triggering.