### PR TITLE
Add transparency to some pockets

### DIFF
--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -1335,7 +1335,8 @@
         "max_item_length": "30 cm",
         "moves": 50,
         "flag_restriction": [ "BELT_CLIP" ],
-        "volume_encumber_modifier": 0.3
+        "volume_encumber_modifier": 0.3,
+        "transparent": true
       }
     ],
     "flags": [ "CANT_WEAR", "WATER_FRIENDLY", "PALS_SMALL" ],
@@ -1365,7 +1366,8 @@
         "max_item_length": "60 cm",
         "moves": 50,
         "flag_restriction": [ "BELT_CLIP" ],
-        "volume_encumber_modifier": 0.3
+        "volume_encumber_modifier": 0.3,
+        "transparent": true
       }
     ],
     "flags": [ "CANT_WEAR", "WATER_FRIENDLY", "PALS_MEDIUM" ],
@@ -1395,7 +1397,8 @@
         "max_item_length": "100 cm",
         "moves": 50,
         "flag_restriction": [ "BELT_CLIP" ],
-        "volume_encumber_modifier": 0.3
+        "volume_encumber_modifier": 0.3,
+        "transparent": true
       }
     ],
     "flags": [ "CANT_WEAR", "WATER_FRIENDLY", "PALS_LARGE" ],

--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -22,7 +22,8 @@
         "max_item_length": "90 cm",
         "moves": 50,
         "flag_restriction": [ "BELT_CLIP" ],
-        "holster": true
+        "holster": true,
+        "transparent": true
       },
       {
         "holster": true,
@@ -32,7 +33,8 @@
         "max_item_length": "70 cm",
         "moves": 60,
         "description": "Clipped directly to side of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -42,7 +44,8 @@
         "max_item_length": "70 cm",
         "moves": 60,
         "description": "Clipped directly to side of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Attach what to belt loop?", "holster_msg": "You clip your %s to your %s" },
@@ -156,7 +159,8 @@
         "max_item_length": "70 cm",
         "moves": 60,
         "description": "Clipped directly to side of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -165,7 +169,8 @@
         "max_item_length": "70 cm",
         "moves": 60,
         "description": "Clipped directly to side of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -174,7 +179,8 @@
         "max_item_length": "70 cm",
         "moves": 60,
         "description": "Clipped directly to side of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -183,7 +189,8 @@
         "max_item_length": "70 cm",
         "moves": 60,
         "description": "Clipped directly to side of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -192,7 +199,8 @@
         "max_item_length": "70 cm",
         "moves": 110,
         "description": "Clipped directly to back of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -201,7 +209,8 @@
         "max_item_length": "70 cm",
         "moves": 110,
         "description": "Clipped directly to back of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stick what into your belt", "holster_msg": "You tuck your %s into your %s" },
@@ -271,7 +280,8 @@
         "max_contains_weight": "3600 g",
         "max_item_length": "70 cm",
         "moves": 50,
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -280,7 +290,8 @@
         "max_contains_weight": "1750 g",
         "max_item_length": "70 cm",
         "moves": 60,
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -289,7 +300,8 @@
         "max_contains_weight": "1750 g",
         "max_item_length": "70 cm",
         "moves": 60,
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Attach what to holder?", "holster_msg": "You attach your %s to your %s." },
@@ -329,7 +341,8 @@
         "max_contains_weight": "800 g",
         "max_item_length": "90 cm",
         "moves": 60,
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stick what into your belt", "holster_msg": "You tuck your %s into your %s" },
@@ -375,7 +388,8 @@
         "max_item_length": "70 cm",
         "moves": 60,
         "description": "Clipped directly to the belt.",
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -386,7 +400,8 @@
         "max_item_length": "70 cm",
         "moves": 60,
         "description": "Clipped directly to the belt.",
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -397,7 +412,8 @@
         "max_item_length": "70 cm",
         "moves": 50,
         "description": "In a sheath.",
-        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -408,7 +424,8 @@
         "max_item_length": "70 cm",
         "moves": 50,
         "description": "In a sheath.",
-        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -419,7 +436,8 @@
         "max_item_length": "70 cm",
         "moves": 50,
         "description": "In a sheath.",
-        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
+        "transparent": true
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Store tool or blade", "holster_msg": "You put your %1$s in your %2$s" },
@@ -451,7 +469,8 @@
         "max_item_length": "70 cm",
         "moves": 60,
         "description": "Clipped directly to belt.",
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -461,7 +480,8 @@
         "max_item_length": "70 cm",
         "moves": 60,
         "description": "Clipped directly to belt.",
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -471,7 +491,8 @@
         "max_item_length": "70 cm",
         "moves": 110,
         "description": "Clipped directly to the back of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -481,7 +502,8 @@
         "max_item_length": "70 cm",
         "moves": 110,
         "description": "Clipped directly to the back of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       }
     ],
     "use_action": [

--- a/data/json/items/armor/bespoke_armor/custom_storage.json
+++ b/data/json/items/armor/bespoke_armor/custom_storage.json
@@ -32,7 +32,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       },
       {
         "//": "dedicated tool loops. either a daisy chain, hooking to compression straps, or ice axe loop",
@@ -45,7 +46,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       },
       {
         "//": "items slipped under the top of a duffelbag not well secured",
@@ -58,7 +60,8 @@
         "moves": 80,
         "extra_encumbrance": 5,
         "description": "Tucked under the carry handles.",
-        "ripoff": 1
+        "ripoff": 1,
+        "transparent": true
       }
     ],
     "warmth": 10,
@@ -100,7 +103,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       },
       {
         "//": "dedicated tool loops. either a daisy chain, hooking to compression straps, or ice axe loop",
@@ -113,7 +117,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       },
       {
         "//": "items slipped under the top of a duffelbag not well secured",
@@ -126,7 +131,8 @@
         "moves": 80,
         "extra_encumbrance": 5,
         "description": "Tucked under the carry handles.",
-        "ripoff": 1
+        "ripoff": 1,
+        "transparent": true
       }
     ],
     "warmth": 10,
@@ -187,7 +193,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -201,7 +208,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 60 }
+        "activity_noise": { "volume": 8, "chance": 60 },
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -215,7 +223,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 60 }
+        "activity_noise": { "volume": 8, "chance": 60 },
+        "transparent": true
       }
     ],
     "warmth": 6,
@@ -257,7 +266,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 60 }
+        "activity_noise": { "volume": 8, "chance": 60 },
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -271,7 +281,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 60 }
+        "activity_noise": { "volume": 8, "chance": 60 },
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -285,7 +296,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 60 }
+        "activity_noise": { "volume": 8, "chance": 60 },
+        "transparent": true
       },
       {
         "//": "dedicated tool loops. either a daisy chain, hooking to compression straps, or ice axe loop",
@@ -298,7 +310,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       },
       {
         "//": "dedicated tool loops. either a daisy chain, hooking to compression straps, or ice axe loop",
@@ -311,7 +324,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       }
     ],
     "warmth": 8,
@@ -405,7 +419,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       },
       {
         "//": "dedicated tool loops. either a daisy chain, hooking to compression straps, or ice axe loop",
@@ -418,7 +433,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       },
       {
         "pocket_type": "CONTAINER",

--- a/data/json/items/armor/bespoke_armor/utility.json
+++ b/data/json/items/armor/bespoke_armor/utility.json
@@ -80,7 +80,8 @@
         "max_contains_weight": "6 kg",
         "max_item_length": "90 cm",
         "moves": 50,
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Store item", "holster_msg": "You put your %1$s in your %2$s" },

--- a/data/json/items/armor/hats.json
+++ b/data/json/items/armor/hats.json
@@ -574,7 +574,8 @@
         "max_item_length": "14 cm",
         "moves": 100,
         "description": "Pocket for a flashlight attachment.",
-        "flag_restriction": [ "HELMET_HEAD_ATTACHMENT" ]
+        "flag_restriction": [ "HELMET_HEAD_ATTACHMENT" ],
+        "transparent": true
       }
     ],
     "variant_type": "generic",
@@ -758,7 +759,8 @@
         "max_item_length": "14 cm",
         "moves": 100,
         "description": "Pocket for a flashlight attachment.",
-        "flag_restriction": [ "HELMET_HEAD_ATTACHMENT" ]
+        "flag_restriction": [ "HELMET_HEAD_ATTACHMENT" ],
+        "transparent": true
       }
     ],
     "variant_type": "generic",

--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -248,7 +248,8 @@
         "max_item_length": "14 cm",
         "moves": 100,
         "description": "Pocket for a flashlight attachment.",
-        "flag_restriction": [ "HELMET_HEAD_ATTACHMENT" ]
+        "flag_restriction": [ "HELMET_HEAD_ATTACHMENT" ],
+        "transparent": true
       }
     ],
     "melee_damage": { "bash": 2 }
@@ -424,7 +425,8 @@
         "max_item_length": "14 cm",
         "moves": 100,
         "description": "Pocket for a flashlight attachment.",
-        "flag_restriction": [ "HELMET_HEAD_ATTACHMENT" ]
+        "flag_restriction": [ "HELMET_HEAD_ATTACHMENT" ],
+        "transparent": true
       }
     ],
     "melee_damage": { "bash": 2 }

--- a/data/json/items/armor/robofac_armor.json
+++ b/data/json/items/armor/robofac_armor.json
@@ -489,7 +489,8 @@
         "max_contains_weight": "1500 g",
         "max_item_length": "70 cm",
         "moves": 50,
-        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -499,7 +500,8 @@
         "max_contains_weight": "1500 g",
         "max_item_length": "70 cm",
         "moves": 50,
-        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
+        "transparent": true
       }
     ],
     "flags": [ "WATER_FRIENDLY", "BELTED" ],

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -43,7 +43,8 @@
         "moves": 200,
         "extra_encumbrance": 10,
         "description": "Tucked between your back and the backpack.",
-        "ripoff": 3
+        "ripoff": 3,
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -57,7 +58,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       }
     ],
     "warmth": 6,
@@ -150,7 +152,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -164,7 +167,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "dedicated tool loops. either a daisy chain, hooking to compression straps, or ice axe loop",
@@ -177,7 +181,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       },
       {
         "//": "dedicated tool loops. either a daisy chain, hooking to compression straps, or ice axe loop",
@@ -190,7 +195,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Sheath blade", "holster_msg": "You sheath your %s" },
@@ -274,7 +280,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -288,7 +295,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "dedicated tool loops. either a daisy chain, hooking to compression straps, or ice axe loop",
@@ -301,7 +309,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       },
       {
         "//": "dedicated tool loops. either a daisy chain, hooking to compression straps, or ice axe loop",
@@ -314,7 +323,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       },
       {
         "//": "has the ability to loosen the pack, causing a lot of encumbrance but allowing for storage of very large items between the pack and the frame",
@@ -475,7 +485,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -489,7 +500,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -503,7 +515,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       }
     ],
     "warmth": 10,
@@ -602,7 +615,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       },
       {
         "//": "dedicated tool loops. either a daisy chain, hooking to compression straps, or ice axe loop",
@@ -615,7 +629,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       }
     ],
     "warmth": 10,
@@ -682,7 +697,8 @@
         "moves": 200,
         "extra_encumbrance": 10,
         "description": "Tucked between your back and the backpack.",
-        "ripoff": 3
+        "ripoff": 3,
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -696,7 +712,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       }
     ],
     "warmth": 5,
@@ -800,7 +817,8 @@
         "moves": 200,
         "extra_encumbrance": 10,
         "description": "Tucked between your back and the backpack.",
-        "ripoff": 3
+        "ripoff": 3,
+        "transparent": true
       },
       {
         "//": "water bottle pocket",
@@ -826,7 +844,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       }
     ],
     "warmth": 5,
@@ -999,7 +1018,8 @@
         "moves": 80,
         "extra_encumbrance": 5,
         "description": "Tucked under the carry handles.",
-        "ripoff": 1
+        "ripoff": 1,
+        "transparent": true
       }
     ],
     "warmth": 10,
@@ -1050,7 +1070,8 @@
         "moves": 80,
         "extra_encumbrance": 5,
         "description": "Tucked under the carry handles.",
-        "ripoff": 1
+        "ripoff": 1,
+        "transparent": true
       }
     ],
     "warmth": 10,
@@ -1601,7 +1622,8 @@
         "moves": 200,
         "extra_encumbrance": 10,
         "description": "Tucked between your back and the backpack.",
-        "ripoff": 3
+        "ripoff": 3,
+        "transparent": true
       }
     ],
     "warmth": 5,
@@ -1728,7 +1750,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -1742,7 +1765,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "tucked against back",
@@ -1755,7 +1779,8 @@
         "moves": 200,
         "extra_encumbrance": 10,
         "description": "Tucked between your back and the backpack.",
-        "ripoff": 3
+        "ripoff": 3,
+        "transparent": true
       }
     ],
     "warmth": 10,
@@ -1816,7 +1841,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -1830,7 +1856,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "tucked against back",
@@ -1843,7 +1870,8 @@
         "moves": 200,
         "extra_encumbrance": 10,
         "description": "Tucked between your back and the backpack.",
-        "ripoff": 3
+        "ripoff": 3,
+        "transparent": true
       }
     ],
     "warmth": 10,
@@ -1904,7 +1932,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -1918,7 +1947,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "tucked against back",
@@ -1931,7 +1961,8 @@
         "moves": 200,
         "extra_encumbrance": 10,
         "description": "Tucked between your back and the backpack.",
-        "ripoff": 3
+        "ripoff": 3,
+        "transparent": true
       }
     ],
     "warmth": 12,
@@ -2171,7 +2202,8 @@
         "moves": 200,
         "extra_encumbrance": 10,
         "description": "Tucked between your back and the backpack.",
-        "ripoff": 3
+        "ripoff": 3,
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -2185,7 +2217,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -2199,7 +2232,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -2213,7 +2247,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       }
     ],
     "warmth": 8,
@@ -2485,7 +2520,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       },
       {
         "//": "dedicated tool loops. either a daisy chain, hooking to compression straps, or ice axe loop",
@@ -2498,7 +2534,8 @@
         "moves": 300,
         "extra_encumbrance": 1,
         "description": "Secured under compression straps or with a tool loop.",
-        "ripoff": 5
+        "ripoff": 5,
+        "transparent": true
       }
     ],
     "warmth": 8,
@@ -2952,7 +2989,8 @@
         "moves": 1000,
         "ripoff": 5,
         "activity_noise": { "volume": 9, "chance": 15 },
-        "extra_encumbrance": 20
+        "extra_encumbrance": 20,
+        "transparent": true
       }
     ],
     "material_thickness": 2,

--- a/data/mods/Aftershock/items/armor.json
+++ b/data/mods/Aftershock/items/armor.json
@@ -392,7 +392,8 @@
         "moves": 40,
         "flag_restriction": [ "BELT_CLIP" ],
         "rigid": true,
-        "holster": true
+        "holster": true,
+        "transparent": true
       },
       {
         "pocket_type": "CONTAINER",

--- a/data/mods/Aftershock/items/armor/civilian_blue_collar.json
+++ b/data/mods/Aftershock/items/armor/civilian_blue_collar.json
@@ -124,7 +124,8 @@
         "moves": 40,
         "flag_restriction": [ "BELT_CLIP" ],
         "rigid": true,
-        "holster": true
+        "holster": true,
+        "transparent": true
       },
       {
         "max_contains_volume": "2 L",
@@ -133,7 +134,8 @@
         "moves": 40,
         "flag_restriction": [ "BELT_CLIP" ],
         "rigid": true,
-        "holster": true
+        "holster": true,
+        "transparent": true
       },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 60 },
       { "pocket_type": "CONTAINER", "max_contains_volume": "1 L", "max_contains_weight": "2 kg", "moves": 60 },

--- a/data/mods/Magiclysm/items/enchanted_belts.json
+++ b/data/mods/Magiclysm/items/enchanted_belts.json
@@ -18,7 +18,8 @@
         "max_contains_weight": "750 g",
         "max_item_length": "70 cm",
         "moves": 60,
-        "flag_restriction": [ "BELT_CLIP" ]
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Stick what into your belt", "holster_msg": "You tuck your %s into your %s" },

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -398,7 +398,8 @@
         "max_contains_volume": "1500 ml",
         "max_contains_weight": "1200 g",
         "moves": 50,
-        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -407,7 +408,8 @@
         "max_contains_volume": "1500 ml",
         "max_contains_weight": "1200 g",
         "moves": 50,
-        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -416,7 +418,8 @@
         "max_contains_volume": "1500 ml",
         "max_contains_weight": "1200 g",
         "moves": 50,
-        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
+        "transparent": true
       },
       {
         "holster": true,
@@ -425,7 +428,8 @@
         "max_contains_volume": "1500 ml",
         "max_contains_weight": "1200 g",
         "moves": 50,
-        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
+        "transparent": true
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Store tool or blade", "holster_msg": "You put your %1$s in your %2$s" },
@@ -463,7 +467,8 @@
         "max_item_length": "70 cm",
         "moves": 50,
         "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
-        "name": "P2"
+        "name": "P2",
+        "transparent": true
       },
       {
         "holster": true,
@@ -473,7 +478,8 @@
         "max_item_length": "70 cm",
         "moves": 50,
         "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
-        "name": "P3"
+        "name": "P3",
+        "transparent": true
       },
       {
         "holster": true,
@@ -483,7 +489,8 @@
         "max_item_length": "70 cm",
         "moves": 50,
         "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
-        "name": "P4"
+        "name": "P4",
+        "transparent": true
       },
       {
         "holster": true,
@@ -493,7 +500,8 @@
         "max_item_length": "70 cm",
         "moves": 50,
         "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
-        "name": "P5"
+        "name": "P5",
+        "transparent": true
       },
       {
         "holster": true,
@@ -503,7 +511,8 @@
         "max_item_length": "70 cm",
         "moves": 50,
         "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
-        "name": "P6"
+        "name": "P6",
+        "transparent": true
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Store tool or blade", "holster_msg": "You put your %1$s in your %2$s" },
@@ -611,7 +620,8 @@
         "max_contains_weight": "1000 g",
         "max_item_length": "15 cm",
         "moves": 50,
-        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
+        "transparent": true
       },
       {
         "//": "Large holster for an axe or Halligan bar",
@@ -622,7 +632,8 @@
         "max_contains_weight": "4000 g",
         "max_item_length": "80 cm",
         "moves": 200,
-        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ]
+        "flag_restriction": [ "BELT_CLIP", "SHEATH_KNIFE" ],
+        "transparent": true
       },
       {
         "//": "Flexible water pouch for drinks or other liquid.  Integrated straw for fast access.",

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -106,7 +106,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "carabiner pocket",
@@ -120,7 +121,8 @@
         "extra_encumbrance": 3,
         "ripoff": 2,
         "description": "Attached with a carabiner or strap.",
-        "activity_noise": { "volume": 8, "chance": 10 }
+        "activity_noise": { "volume": 8, "chance": 10 },
+        "transparent": true
       },
       {
         "//": "tucked against back",
@@ -133,7 +135,8 @@
         "moves": 200,
         "extra_encumbrance": 10,
         "description": "Tucked between your back and the backpack.",
-        "ripoff": 3
+        "ripoff": 3,
+        "transparent": true
       }
     ],
     "warmth": 10,

--- a/tools/json_tools/pocket_transparency.py
+++ b/tools/json_tools/pocket_transparency.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+
+args = argparse.ArgumentParser()
+args.add_argument("dir", action="store", help="specify data directory")
+args_dict = vars(args.parse_args())
+
+types = [
+    "AMMO",
+    "ARMOR",
+    "BATTERY",
+    "BIONIC_ITEM",
+    "BOOK",
+    "COMESTIBLE",
+    "CONTAINER",
+    "ENGINE",
+    "GENERIC",
+    "GUN",
+    "GUNMOD",
+    "MAGAZINE",
+    "PET_ARMOR",
+    "TOOL",
+    "TOOLMOD",
+    "TOOL_ARMOR",
+]
+
+
+def adjust_pockets(jo):
+    if "pocket_data" not in jo:
+        return None
+
+    changed = False
+    for pocket in jo["pocket_data"]:
+        if "flag_restriction" in pocket:
+            if ("BELT_CLIP" in pocket["flag_restriction"] or
+                    "HELMET_HEAD_ATTACHMENT" in pocket["flag_restriction"]):
+                pocket["transparent"] = True
+                changed = True
+                continue
+        ripoff = 0
+        encumb = 0
+        if "ripoff" in pocket:
+            ripoff = pocket["ripoff"]
+        if "extra_encumbrance" in pocket:
+            encumb = pocket["extra_encumbrance"]
+
+        if ripoff > 0 and encumb > 0:
+            pocket["transparent"] = True
+            changed = True
+
+    return jo if changed else None
+
+
+def gen_new(path):
+    change = False
+    new_datas = list()
+    # Having troubles with this script halting?
+    # Uncomment below to find the file it's halting on
+    #print(path)
+    with open(path, "r", encoding="utf-8") as json_file:
+        try:
+            json_data = json.load(json_file)
+        except json.JSONDecodeError:
+            print(f"Json Decode Error at {path}")
+            print("Ensure that the file is a JSON file consisting of"
+                  " an array of objects!")
+            return None
+
+        for jo in json_data:
+            if type(jo) is not dict:
+                print(f"Incorrectly formatted JSON data at {path}")
+                print("Ensure that the file is a JSON file consisting"
+                      " of an array of objects!")
+                break
+
+            if "type" not in jo:
+                continue
+
+            if jo["type"] not in types:
+                continue
+
+            new_data = adjust_pockets(jo)
+
+            if new_data is not None:
+                jo = new_data
+                change = True
+
+    if len(new_datas) > 0:
+        json_data.extend(new_datas)
+    return json_data if change else None
+
+
+def format_json(path):
+    file_path = os.path.dirname(__file__)
+    format_path_linux = os.path.join(file_path, "../format/json_formatter.cgi")
+    path_win = "../format/JsonFormatter-vcpkg-static-Release-x64.exe"
+    format_path_win = os.path.join(file_path, path_win)
+    if os.path.exists(format_path_linux):
+        os.system(f"{format_path_linux} {path}")
+    elif os.path.exists(format_path_win):
+        os.system(f"{format_path_win} {path}")
+    else:
+        print("No json formatter found")
+
+
+# adjust items
+json_path = os.path.join(args_dict["dir"], "json")
+for root, directories, filenames in os.walk(json_path):
+    for filename in filenames:
+        if not filename.endswith(".json"):
+            continue
+
+        path = os.path.join(root, filename)
+        new = gen_new(path)
+        if new is not None:
+            with open(path, "w", encoding="utf-8") as jf:
+                json.dump(new, jf, ensure_ascii=False)
+            format_json(path)
+
+for f in os.scandir(os.path.join(args_dict["dir"], "mods")):
+    if f.is_dir():
+        for root, directories, filenames in os.walk(f.path):
+            for filename in filenames:
+                if not filename.endswith(".json"):
+                    continue
+
+                path = os.path.join(root, filename)
+                new = gen_new(path)
+                if new is not None:
+                    with open(path, "w", encoding="utf-8") as jf:
+                        json.dump(new, jf, ensure_ascii=False)
+                    format_json(path)


### PR DESCRIPTION
#### Summary
Bugfixes "Add transparency to some pockets"

#### Purpose of change

Pocket transparency is a somewhat new concept that will get more use in #67595. It allows seeing the contents of the pocket from a distance (`V` menu), and will be expanded to allow light sources inside them to illuminate the surroundings. But there aren't any pockets actually using it, yet, apart from corpses.

#### Describe the solution

Made a script to determine a baseline of pockets that could or should be transparent.
That currently includes
- pockets restricted to the flags `BELT_CLIP` or `HELMET_HEAD_ATTACHMENT` (flags of the flashlight item)
- pockets with `ripoff` and `extra_encumberance` values > 0

#### Describe alternatives you've considered

Identify more conditions that justify inclusion.

#### Testing



#### Additional context

