### PR TITLE
Sidebar: extend/delete support for the "widgets" field

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -467,6 +467,31 @@ void widget::load( const JsonObject &jo, const std::string_view )
         optional( jo, was_loaded, "string", _string );
     }
     optional( jo, was_loaded, "widgets", _widgets, string_id_reader<::widget> {} );
+
+    if( jo.has_object( "extend" ) ) {
+        JsonObject tmp = jo.get_object( "extend" );
+        tmp.allow_omitted_members();
+        if( tmp.has_member( "widgets" ) ) {
+            std::vector<widget_id> tmp_wgts;
+            mandatory( tmp, false, "widgets", tmp_wgts, string_id_reader<::widget> {} );
+            _widgets.insert( _widgets.end(), tmp_wgts.begin(), tmp_wgts.end() );
+        }
+    }
+
+    if( jo.has_object( "delete" ) ) {
+        JsonObject tmp = jo.get_object( "delete" );
+        tmp.allow_omitted_members();
+        if( tmp.has_member( "widgets" ) ) {
+            std::vector<widget_id> tmp_wgts;
+            mandatory( tmp, false, "widgets", tmp_wgts, string_id_reader<::widget> {} );
+            for( const widget_id &tmp_w : tmp_wgts ) {
+                auto iter = std::find( _widgets.begin(), _widgets.end(), tmp_w );
+                if( iter != _widgets.end() ) {
+                    _widgets.erase( iter );
+                }
+            }
+        }
+    }
 }
 
 // Returns the derived label width for this widget/layout


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Some extra minor convenience for modded sidebars.

#### Describe the solution
For sidebars or layouts, the `"widgets"` field defines which elements it contains. This just makes it possible to "extend" or "delete" contained widgets in sidebars or layouts that "copy-from" an existing sidebar or layout.

#### Describe alternatives you've considered


#### Testing
<details>
<summary>Tested with these sidebars:</summary>

```json
{
  "id": "test",
  "type": "widget",
  "style": "sidebar",
  "label": "test",
  "separator": ": ",
  "padding": 2,
  "width": 44,
  "widgets": [ "compass_all_layout", "compass_all_layout_alt" ]
},
{
  "id": "test_del",
  "copy-from": "test",
  "type": "widget",
  "label": "test del",
  "delete": { "widgets": [ "compass_all_layout", "compass_all_layout_alt" ] }
},
{
  "id": "test_ext",
  "copy-from": "test",
  "type": "widget",
  "label": "test ext",
  "extend": { "widgets": [ "vital_numbers_layout", "rad_badge_desc" ] }
}
```

</details>

<details>
<summary>Results:</summary>

![Screenshot from 2023-08-12 01-41-00](https://github.com/CleverRaven/Cataclysm-DDA/assets/12537966/f534896d-e072-4479-81f8-c5fdf3644a0b)
![Screenshot from 2023-08-12 01-41-20](https://github.com/CleverRaven/Cataclysm-DDA/assets/12537966/9d246f46-3e74-47d1-a05c-f5359fd8d181)
![Screenshot from 2023-08-12 01-41-37](https://github.com/CleverRaven/Cataclysm-DDA/assets/12537966/6acab0c2-5142-46b0-95d8-3b70e668a847)

</details>

#### Additional context
