### PR TITLE
Use llvm tools to cut windows build noop critical path by 85% or more

### DIFF
--- a/doc/COMPILING/COMPILING-VS-VCPKG.md
+++ b/doc/COMPILING/COMPILING-VS-VCPKG.md
@@ -120,7 +120,7 @@ It is possible to use ccache with Visual Studio and gain the same benefits as ot
 
     - If you use the LLVM toolchain ("clang-cl.exe") when building, make another copy of `ccache.exe` called `clang-cl.exe`.
 
-4. Create a file called `Directory.Build.props` at the root of the Cataclysm-DDA folder with the following contents. The value of `CDDA_CCACHE_PATH` should be the folder where you put `ccache.exe`. Assuming this path is `C:\dev\ccache\` (note: `\` vs `/` matters, you need to use `\` here):
+4. Create a file called `Directory.Build.props` at the root of the Cataclysm-DDA folder with the following contents. If it already exists, merge it with the contents below. The value of `CDDA_CCACHE_PATH` should be the folder where you put `ccache.exe`. Assuming this path is `C:\dev\ccache\` (note: `\` vs `/` matters, you need to use `\` here):
 
 ```
 <Project>
@@ -132,3 +132,32 @@ It is possible to use ccache with Visual Studio and gain the same benefits as ot
 ```
 
 5. ccache should now just work when building with Release modes in Visual Studio. Debug builds do not work because of the size of CDDA and limitations in the msvc toolchain. However, Debug builds are almost intolerably slow anyway so this limitation is not something we are going to fix right now.
+
+### llvm tools integration
+
+It is possible to use `llvm-lib.exe` and `lld-link.exe` to speed up your local builds by skipping unnecessary copy steps.
+
+1. Install LLVM from Github or through the Visual Studio Installer.
+  - Github: Download a release from https://github.com/llvm/llvm-project/releases. You typically want the installer from the `Assets` section called eg. `LLVM-16.0.6-win64.exe`, or whatever version you are downloading.
+  - Visual Studio Installer: Open the Visual Studio Installer, select 'Modify' next to your install, click the 'Individual Components' section, search for 'C++ Clang Compiler for Windows', and make sure the result is selected.
+
+2. Create a file called `Directory.Build.props` at the root of the Cataclysm-DDA folder with the following contents.
+  - If you installed a release directly from LLVM releases, use these settings. If you installed to a non default location, set the two `_PATH` variables to the path you installed LLVM to.
+```
+<Project>
+  <PropertyGroup>
+    <CDDA_ENABLE_THIN_ARCHIVES>true</CDDA_ENABLE_THIN_ARCHIVES>
+    <CDDA_LLVM_LIB_PATH>C:\Program Files\LLVM\</CDDA_ENABLE_THIN_ARCHIVES>
+    <CDDA_LLD_LINK_PATH>C:\Program Files\LLVM\</CDDA_ENABLE_THIN_ARCHIVES>
+  </PropertyGroup>
+</Project>
+```
+
+  - If you installed LLVM through the Visual Studio Installer, then use these contents. The path to LLVM will be provided by MSBuild/Visual Studio directly and does not need to be set.
+```
+<Project>
+  <PropertyGroup>
+    <CDDA_ENABLE_THIN_ARCHIVES>true</CDDA_ENABLE_THIN_ARCHIVES>
+  </PropertyGroup>
+</Project>
+```

--- a/msvc-full-features/Cataclysm-common.props
+++ b/msvc-full-features/Cataclysm-common.props
@@ -13,12 +13,30 @@
     <_CDDA_BACKTRACE Condition="'$(BACKTRACE)'!=''">true</_CDDA_BACKTRACE>
     <_CDDA_RELEASE_BUILD>false</_CDDA_RELEASE_BUILD>
     <_CDDA_RELEASE_BUILD Condition="'$(CDDA_RELEASE_BUILD)'!=''">true</_CDDA_RELEASE_BUILD>
+    <CDDA_LLVM_LIB_PATH Condition="'$(CDDA_LLVM_LIB_PATH)'==''">$(LLVMInstallDir)</CDDA_LLVM_LIB_PATH>
+    <CDDA_LLD_LINK_PATH Condition="'$(CDDA_LLD_LINK_PATH)'==''">$(LLVMInstallDir)</CDDA_LLD_LINK_PATH>
+    <_CDDA_ENABLE_THIN_ARCHIVES>false</_CDDA_ENABLE_THIN_ARCHIVES>
+    <_CDDA_ENABLE_THIN_ARCHIVES Condition="'$(CDDA_ENABLE_THIN_ARCHIVES)'!=''">true</_CDDA_ENABLE_THIN_ARCHIVES>
+    <_CDDA_USE_LLD_LINK>false</_CDDA_USE_LLD_LINK>
+    <_CDDA_USE_LLD_LINK Condition="'$(CDDA_USE_LLD_LINK)'!='' Or $(_CDDA_ENABLE_THIN_ARCHIVES)">true</_CDDA_USE_LLD_LINK>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgAdditionalInstallOptions>--clean-after-build</VcpkgAdditionalInstallOptions>
   </PropertyGroup>
   <PropertyGroup Condition="$(_CDDA_USE_CCACHE)">
     <ClToolPath>$(CDDA_CCACHE_PATH)</ClToolPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(_CDDA_ENABLE_THIN_ARCHIVES)">
+    <LibToolPath>$(CDDA_LLVM_LIB_PATH)\bin</LibToolPath>
+    <LibToolExe>llvm-lib.exe</LibToolExe>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(_CDDA_USE_LLD_LINK)">
+    <LinkToolPath>$(CDDA_LLD_LINK_PATH)\bin</LinkToolPath>
+    <LinkToolExe>lld-link.exe</LinkToolExe>
+    <!-- vcpkg passes dependecy libs via a glob pattern which lld-link doesn't accept. We have to manually enumerate the deps now. -->
+    <VcpkgAutoLink>false</VcpkgAutoLink>
+    <VcpkgLibSuffix></VcpkgLibSuffix>
+    <VcpkgLibSuffix Condition="$(Configuration.StartsWith(Debug))">d</VcpkgLibSuffix>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -50,6 +68,9 @@
       <ObjectFileName>$(IntDir)%(FileName).obj</ObjectFileName>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
     </ClCompile>
+    <Lib Condition="$(_CDDA_ENABLE_THIN_ARCHIVES)">
+      <AdditionalOptions>/llvmlibthin $(AdditionalOptions)</AdditionalOptions>
+    </Lib>
     <Link>
       <GenerateDebugInformation>DebugFastLink</GenerateDebugInformation>
       <LinkIncremental>true</LinkIncremental>
@@ -66,6 +87,56 @@
       <LinkIncremental>false</LinkIncremental>
       <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <StripPrivateSymbols>$(OutDir)$(TargetName).stripped.pdb</StripPrivateSymbols>
+    </Link>
+    <Link Condition="$(_CDDA_USE_LLD_LINK)">
+      <AdditionalLibraryDirectories Condition="$(Configuration.StartsWith(Debug))">
+        $(ProjectDir)vcpkg_installed\$(VcpkgTripet)\$(VcpkgTriplet)\debug\lib;%(AdditionalLibraryDirectories)
+      </AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="$(Configuration.StartsWith(Release))">
+        $(ProjectDir)vcpkg_installed\$(VcpkgTripet)\$(VcpkgTriplet)\lib;%(AdditionalLibraryDirectories)
+      </AdditionalLibraryDirectories>
+      <AdditionalDependencies>
+        brotlicommon-static.lib;
+        brotlidec-static.lib;
+        brotlienc-static.lib;
+        bz2$(VcpkgLibSuffix).lib;
+        FLAC.lib;
+        FLAC++.lib;
+        freetype$(VcpkgLibSuffix).lib;
+        jpeg.lib;
+        libpng16$(VcpkgLibSuffix).lib;
+        modplug.lib;
+        mpg123.lib;
+        ogg.lib;
+        out123.lib;
+        SDL2_image-static$(VcpkgLibSuffix).lib;
+        SDL2_mixer-static$(VcpkgLibSuffix).lib;
+        SDL2_ttf.lib;
+        SDL2-static$(VcpkgLibSuffix).lib;
+        syn123.lib;
+        turbojpeg.lib;
+        vorbis.lib;
+        vorbisenc.lib;
+        vorbisfile.lib;
+        zlib$(VcpkgLibSuffix).lib;
+        <!-- win32 deps of the vcpkg deps -->
+        Advapi32.lib;
+        Cfgmgr32.lib;
+        Gdi32.lib;
+        Imm32.lib;
+        Ole32.lib;
+        OleAut32.lib;
+        Setupapi.lib;
+        Shell32.lib;
+        Shlwapi.lib;
+        User32.lib;
+        Version.lib;
+        Winmm.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
+      <LinkIncremental />
+      <LinkStatus />
     </Link>
     <ProjectReference>
       <LinkLibraryDependencies>true</LinkLibraryDependencies>

--- a/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
+++ b/msvc-full-features/Cataclysm-lib-vcpkg-static.vcxproj
@@ -181,6 +181,7 @@
   <ItemGroup>
     <ProjectReference Include="flatbuffers.vcxproj">
       <Project>{8a533a64-435d-4d4f-9ff0-1e97aace9374}</Project>
+      <LinkLibraryDependencies>false</LinkLibraryDependencies>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/msvc-object_creator/ObjectCreator-vcpkg-static.vcxproj
+++ b/msvc-object_creator/ObjectCreator-vcpkg-static.vcxproj
@@ -81,6 +81,21 @@
       <AdditionalLibraryDirectories Condition="'$(Configuration)'=='Debug'">.\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\debug\plugins\platforms;.\vcpkg_installed\$(VcpkgTriplet)\debug\plugins\platforms;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(Configuration)'=='Release'">.\vcpkg_installed\$(VcpkgTriplet)\$(VcpkgTriplet)\plugins\platforms;.\vcpkg_installed\$(VcpkgTriplet)\plugins\platforms;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
+    <Link Condition="$(_CDDA_USE_LLD_LINK)">
+      <AdditionalDependencies>
+        double-conversion.lib;
+        harfbuzz.lib;
+        pcre2-16$(VcpkgLibSuffix).lib;
+        Qt5Core$(VcpkgLibSuffix).lib;
+        Qt5EventDispatcherSupport$(VcpkgLibSuffix).lib;
+        Qt5FontDatabaseSupport$(VcpkgLibSuffix).lib;
+        Qt5ThemeSupport$(VcpkgLibSuffix).lib;
+        Qt5Widgets$(VcpkgLibSuffix).lib;
+        Qt5WindowsUIAutomationSupport$(VcpkgLibSuffix).lib;
+        zstd.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
+    </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug'">
     <ClCompile>


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Build "Fast Windows iteration with llvm-lib and lld-link"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
A lot of the time in the windows build is spent re-assembling the cata lib static archive, which is largely i/o bound. llvm tools support creating 'thin' archives which are indexes of objects instead of copies of objects, making this step almost instantaneous. To use this though we have to also use lld-link. lld-link is generally faster than link.exe anyway, although link.exe is more competitive nowadays. Most people are doing 'release' builds locally which are typically not set up for the fastest iteration speeds. We can safely allow people to opt-in to this behavior without sacrificing anything about the usual build process.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a new property people can set in Directory.Build.props `CDDA_ENABLE_THIN_ARCHIVES`, which accepts any nonempty value, to opt into the new behavior. When set, override the lib and link tools to be llvm-lib and lld-link, respectively. Either use the default VS installed llvm tools or read a user provided path from `CDDA_LLVM_LIB_PATH` and `CDDA_LLD_LINK_PATH` (separate for debugging one binary or another).

Naively enabling llvm-lib caused segfaults when used in combination with ccache, because ccache was sharing stdafx.obj between different projects and this tickled llvm-lib the wrong way (it was reading the 'wrong' source file name from the object file which messed up some internal maps). So, gate off the stdafx source from being included at all when ccache is used.

lld-link doesn't work with vcpkg's autolink/integration because vcpkg passes libs via a glob pattern like `vcpkg_installed/triple/triple/*.lib`. So we have to manually list all the libs in the folders, with the right libpath, and also their windows lib dependencies. But it work.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Build locally. See that CI has a much faster lib step and potentially faster link step too.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
