### PR TITLE
Optimize pocket overflow function

### DIFF
--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1168,7 +1168,9 @@ units::mass outfit::weight_carried_with_tweaks( const std::map<const item *, int
 {
     units::mass ret = 0_gram;
     for( const item &i : worn ) {
-        if( !without.count( &i ) ) {
+        if( without.empty() ) {
+            ret += i.weight();
+        } else if( !without.count( &i ) ) {
             for( const item *j : i.all_items_ptr( item_pocket::pocket_type::CONTAINER ) ) {
                 if( j->count_by_charges() ) {
                     ret -= get_selected_stack_weight( j, without );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1282,11 +1282,13 @@ void item::update_modified_pockets()
     contents.update_modified_pockets( mag_or_mag_well, container_pockets );
 }
 
-int item::charges_per_volume( const units::volume &vol ) const
+int item::charges_per_volume( const units::volume &vol, bool suppress_warning ) const
 {
     if( count_by_charges() ) {
         if( type->volume == 0_ml ) {
-            debugmsg( "Item '%s' with zero volume", tname() );
+            if( !suppress_warning ) {
+                debugmsg( "Item '%s' with zero volume", tname() );
+            }
             return INFINITE_CHARGES;
         }
         // Type cast to prevent integer overflow with large volume containers like the cargo
@@ -1295,25 +1297,31 @@ int item::charges_per_volume( const units::volume &vol ) const
     } else {
         units::volume my_volume = volume();
         if( my_volume == 0_ml ) {
-            debugmsg( "Item '%s' with zero volume", tname() );
+            if( !suppress_warning ) {
+                debugmsg( "Item '%s' with zero volume", tname() );
+            }
             return INFINITE_CHARGES;
         }
         return vol / my_volume;
     }
 }
 
-int item::charges_per_weight( const units::mass &m ) const
+int item::charges_per_weight( const units::mass &m, bool suppress_warning ) const
 {
     if( count_by_charges() ) {
         if( type->weight == 0_gram ) {
-            debugmsg( "Item '%s' with zero weight", tname() );
+            if( !suppress_warning ) {
+                debugmsg( "Item '%s' with zero weight", tname() );
+            }
             return INFINITE_CHARGES;
         }
         return m / type->weight;
     } else {
         units::mass my_weight = weight();
         if( my_weight == 0_gram ) {
-            debugmsg( "Item '%s' with zero weight", tname() );
+            if( !suppress_warning ) {
+                debugmsg( "Item '%s' with zero weight", tname() );
+            }
             return INFINITE_CHARGES;
         }
         return m / my_weight;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -12369,7 +12369,7 @@ bool item::process_temperature_rot( float insulation, const tripoint &pos, map &
             debugmsg( "Temperature flag enum not valid.  Using current temperature." );
     }
 
-    bool carried = carrier != nullptr && carrier->has_item( *this );
+    bool carried = carrier != nullptr;
     // body heat increases inventory temperature by 5 F (2.77 K) and insulation by 50%
     if( carried ) {
         insulation *= 1.5;

--- a/src/item.h
+++ b/src/item.h
@@ -1794,8 +1794,8 @@ class item : public visitable
          *
          * For items not counted by charges, this returns vol / this->volume().
          */
-        int charges_per_volume( const units::volume &vol ) const;
-        int charges_per_weight( const units::mass &m ) const;
+        int charges_per_volume( const units::volume &vol, bool suppress_warning = false ) const;
+        int charges_per_weight( const units::mass &m, bool suppress_warning = false ) const;
 
         /**
          * @name Item variables

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -944,7 +944,7 @@ int item_location::max_charges_by_parent_recursive( const item &it ) const
         current_location = current_location.parent_item();
     }
 
-    int charges = std::min( it.charges_per_weight( max_weight ), it.charges_per_volume( max_volume ) );
+    int charges = std::min( it.charges_per_weight( max_weight, true ), it.charges_per_volume( max_volume, true ) );
     return charges;
 }
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -944,7 +944,8 @@ int item_location::max_charges_by_parent_recursive( const item &it ) const
         current_location = current_location.parent_item();
     }
 
-    int charges = std::min( it.charges_per_weight( max_weight, true ), it.charges_per_volume( max_volume, true ) );
+    int charges = std::min( it.charges_per_weight( max_weight, true ),
+                            it.charges_per_volume( max_volume, true ) );
     return charges;
 }
 

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1448,47 +1448,47 @@ ret_val<item_pocket::contain_code> item_pocket::_can_contain( const item &it,
     if( it.made_of( phase_id::LIQUID ) ) {
         if( size() != 0 && !contents.front().can_combine( it ) && data->watertight ) {
             return ret_val<item_pocket::contain_code>::make_failure(
-                contain_code::ERR_LIQUID, _( "can't mix liquid with contained item" ) );
+                       contain_code::ERR_LIQUID, _( "can't mix liquid with contained item" ) );
         }
     } else if( size() == 1 && !it.is_frozen_liquid() &&
-        contents.front().made_of( phase_id::LIQUID ) && data->watertight ) {
+               contents.front().made_of( phase_id::LIQUID ) && data->watertight ) {
         return ret_val<item_pocket::contain_code>::make_failure(
-            contain_code::ERR_LIQUID, _( "can't put non liquid into pocket with liquid" ) );
+                   contain_code::ERR_LIQUID, _( "can't put non liquid into pocket with liquid" ) );
     }
 
     if( it.is_frozen_liquid() ) {
         if( size() != 0 && !contents.front().can_combine( it ) && data->watertight ) {
             return ret_val<item_pocket::contain_code>::make_failure(
-                contain_code::ERR_LIQUID,
-                _( "can't mix frozen liquid with contained item in the watertight container" ) );
+                       contain_code::ERR_LIQUID,
+                       _( "can't mix frozen liquid with contained item in the watertight container" ) );
         }
     } else if( data->watertight ) {
         if( size() == 1 && contents.front().is_frozen_liquid() && !contents.front().can_combine( it ) ) {
             return ret_val<item_pocket::contain_code>::make_failure(
-                contain_code::ERR_LIQUID,
-                _( "can't mix item with contained frozen liquid in the watertight container" ) );
+                       contain_code::ERR_LIQUID,
+                       _( "can't mix item with contained frozen liquid in the watertight container" ) );
         }
     }
 
     if( it.made_of( phase_id::GAS ) ) {
         if( size() != 0 && !contents.front().can_combine( it ) ) {
             return ret_val<item_pocket::contain_code>::make_failure(
-                contain_code::ERR_GAS, _( "can't mix gas with contained item" ) );
+                       contain_code::ERR_GAS, _( "can't mix gas with contained item" ) );
         }
     } else if( size() == 1 && contents.front().made_of( phase_id::GAS ) ) {
         return ret_val<item_pocket::contain_code>::make_failure(
-            contain_code::ERR_GAS, _( "can't put non gas into pocket with gas" ) );
+                   contain_code::ERR_GAS, _( "can't put non gas into pocket with gas" ) );
     }
 
     if( !check_for_enough_space ) {
         // Skip all the checks that could result in NO_SPACE or CANNOT_SUPPORT errors.
         if( it.weight() > weight_capacity() ) {
             return ret_val<item_pocket::contain_code>::make_failure(
-                contain_code::ERR_TOO_HEAVY, _( "item is too heavy" ) );
+                       contain_code::ERR_TOO_HEAVY, _( "item is too heavy" ) );
         }
         if( it.volume() > volume_capacity() ) {
             return ret_val<item_pocket::contain_code>::make_failure(
-                contain_code::ERR_TOO_BIG, _( "item too big" ) );
+                       contain_code::ERR_TOO_BIG, _( "item too big" ) );
         }
         return ret_val<item_pocket::contain_code>::make_success();
     }

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2275,9 +2275,9 @@ int item_pocket::charges_per_remaining_volume( const item &it ) const
                 non_it_volume -= contained.volume();
             }
         }
-        return it.charges_per_volume( non_it_volume ) - contained_charges;
+        return it.charges_per_volume( non_it_volume, true ) - contained_charges;
     } else {
-        return it.charges_per_volume( remaining_volume() );
+        return it.charges_per_volume( remaining_volume(), true );
     }
 }
 
@@ -2293,9 +2293,9 @@ int item_pocket::charges_per_remaining_weight( const item &it ) const
                 non_it_weight -= contained.weight();
             }
         }
-        return it.charges_per_weight( non_it_weight ) - contained_charges;
+        return it.charges_per_weight( non_it_weight, true ) - contained_charges;
     } else {
-        return it.charges_per_weight( remaining_weight() );
+        return it.charges_per_weight( remaining_weight(), true );
     }
 }
 

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -196,10 +196,15 @@ class item_pocket
 
         /**
          * Can the pocket contain the specified item?
-         * @param it the item being put in
+         * @param it The item being put in
+         * @param copies_remaining An optional integer reference that will be set to the number of item copies that won't fit
          */
-        ret_val<contain_code> can_contain( const item &it ) const;
         ret_val<contain_code> can_contain( const item &it, int &copies_remaining ) const;
+        ret_val<contain_code> can_contain( const item &it ) const;
+        /**
+        * @brief A version of can_contain that skips the weight and volume check.
+        */
+        ret_val<contain_code> can_contain_skip_weight_volume( const item &it ) const;
         bool can_contain_liquid( bool held_or_ground ) const;
         bool contains_phase( phase_id phase ) const;
 
@@ -419,6 +424,9 @@ class item_pocket
         bool _sealed = false;
         // list of sub body parts that can't currently support rigid ablative armor
         std::set<sub_bodypart_id> no_rigid;
+
+        ret_val<contain_code> _can_contain( const item &it, int &copies_remaining,
+                                            bool check_weight_volume ) const;
 };
 
 /**

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -204,7 +204,7 @@ class item_pocket
         /**
         * @brief A version of can_contain that skips the weight and volume check.
         */
-        ret_val<contain_code> can_contain_skip_weight_volume( const item &it ) const;
+        ret_val<contain_code> can_contain_skip_space_checks( const item &it ) const;
         bool can_contain_liquid( bool held_or_ground ) const;
         bool contains_phase( phase_id phase ) const;
 
@@ -426,7 +426,7 @@ class item_pocket
         std::set<sub_bodypart_id> no_rigid;
 
         ret_val<contain_code> _can_contain( const item &it, int &copies_remaining,
-                                            bool check_weight_volume ) const;
+                                            bool check_for_enough_space ) const;
 };
 
 /**


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Optimize pocket overflow function"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
`item_pocket::overflow` is a common sight at the top of my profiler's CPU% results, a function that spends a lot of CPU time checking `can_contain` on every individual item in a pocket whenever the player's inventory validity is checked, which is fairly often. This intensive check is often not even necessary, as it's specifically checking for items that should never have been in the pocket in the first place.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add an unordered map that caches all of the `can_contain` results for every item type, and just use the cached result for all other items of that type.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The consolidation of all contents into a map of types is something that could be useful for other optimizations, so in the future it might be good to have a function for creating that map.

`process_items` is still the elephant in the room, optimization-wise, but I wanted to take on this first as a stepping stone towards that.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested enough to get profiler results. Tested around with frozen liquids, as that's the one case where you can't necessarily treat items the same just because they share a type. Didn't notice anything wrong occur, but I could've missed something, it wasn't the easiest thing to manually test.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
##### Before
Results right after spawning 6000 pills into a pocket universe (keep in mind that Visual Studio is giving the red highlight to the line AFTER a bottleneck):

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/6759778/4884a6ad-c7cb-4559-b2d7-5eb81a51036e)

##### After
Results after the same test - note how `drop_invalid_inventory` isn't even using 1 CPU unit anymore:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/6759778/2d565287-c1ba-4e11-bd8e-332266dbd75a)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
