### PR TITLE
Fix component distribution error false positives for a bunch of recipes

### DIFF
--- a/data/json/recipes/food/brewing.json
+++ b/data/json/recipes/food/brewing.json
@@ -39,7 +39,6 @@
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_milk_curdled",
-    "result_mult": 18,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -50,13 +49,13 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_cheesemaking_1" } ],
     "book_learn": [ [ "survival_book", 3 ], [ "textbook_survival", 3 ], [ "manual_survival", 3 ], [ "dairy_book", 3 ] ],
     "using": [ [ "milk_standard_raw_fresh", 15 ] ],
-    "components": [ [ [ "vinegar", 3 ] ], [ [ "wild_herbs", 40 ], [ "meat_stomach", 1, "LIST" ] ] ]
+    "components": [ [ [ "vinegar", 3 ] ], [ [ "wild_herbs", 40 ], [ "meat_stomach", 1, "LIST" ] ] ],
+    "charges": 18
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_whiskey",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -68,13 +67,13 @@
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 58, "LIST" ] ] ],
     "//": "assuming grains are roasted, that's 52u flour by weight, plus 6u to heat water and activate yeast",
-    "components": [ [ [ "water_clean", 3 ] ], [ [ "malted_grain", 2 ] ], [ [ "sugar", 50 ] ], [ [ "yeast", 1 ] ] ]
+    "components": [ [ [ "water_clean", 3 ] ], [ [ "malted_grain", 2 ] ], [ [ "sugar", 50 ] ], [ [ "yeast", 1 ] ] ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_gin",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -90,7 +89,8 @@
       [ [ "water_clean", 2 ] ],
       [ [ "corn", 3 ], [ "cornmeal", 5 ], [ "barley", 1 ], [ "buckwheat", 1 ], [ "oats", 3 ] ],
       [ [ "juniper", 10 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",
@@ -111,7 +111,6 @@
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_sake",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -121,7 +120,8 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_fermenting" }, { "proficiency": "prof_brewing" } ],
     "book_learn": [ [ "brewing_cookbook", 6 ] ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "components": [ [ [ "sake_koji_rice", 1 ] ], [ [ "rice_cooked", 1 ] ], [ [ "water_clean", 3 ] ], [ [ "yeast", 1 ] ] ]
+    "components": [ [ [ "sake_koji_rice", 1 ] ], [ [ "rice_cooked", 1 ] ], [ [ "water_clean", 3 ] ], [ [ "yeast", 1 ] ] ],
+    "charges": 3
   },
   {
     "type": "recipe",
@@ -143,7 +143,6 @@
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_soy_sauce",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -153,13 +152,13 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_fermenting" } ],
     "book_learn": [ [ "cookbook_sushi", 6 ] ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "components": [ [ [ "soy_wheat_dough_done", 1 ] ], [ [ "water_clean", 3 ] ], [ [ "salt", 30 ] ] ]
+    "components": [ [ [ "soy_wheat_dough_done", 1 ] ], [ [ "water_clean", 3 ] ], [ [ "salt", 30 ] ] ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_vodka",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -184,13 +183,13 @@
         [ "sugar_beet", 1 ]
       ],
       [ [ "yeast", 1 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_rum",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -201,13 +200,13 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_fermenting" } ],
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
-    "components": [ [ [ "water_clean", 3 ] ], [ [ "molasses", 2 ], [ "sugar_beet", 5 ] ], [ [ "yeast", 1 ] ] ]
+    "components": [ [ [ "water_clean", 3 ] ], [ [ "molasses", 2 ], [ "sugar_beet", 5 ] ], [ [ "yeast", 1 ] ] ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_moonshine",
-    "result_mult": 15,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -219,13 +218,13 @@
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 60, "LIST" ] ] ],
     "//": "30u for corn and 30u to heat water & activate the yeast",
-    "components": [ [ [ "water_clean", 15 ] ], [ [ "cornmeal", 12 ], [ "corn", 2 ] ], [ [ "sugar", 100 ] ], [ [ "yeast", 2 ] ] ]
+    "components": [ [ [ "water_clean", 15 ] ], [ [ "cornmeal", 12 ], [ "corn", 2 ] ], [ [ "sugar", 100 ] ], [ [ "yeast", 2 ] ] ],
+    "charges": 15
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_hb_seltzer",
-    "result_mult": 10,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -242,14 +241,14 @@
       [ [ "sugar", 2 ] ],
       [ [ "yeast", 1 ] ],
       [ [ "juice", 2 ], [ "apple_cider", 4 ], [ "sweet_fruit", 1, "LIST" ] ]
-    ]
+    ],
+    "charges": 10
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_moonshine",
     "id_suffix": "pumpkin",
-    "result_mult": 15,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -261,13 +260,13 @@
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 54, "LIST" ] ] ],
     "//": "24u for pumpkin and 30u to heat water & activate the yeast",
-    "components": [ [ [ "water_clean", 15 ] ], [ [ "pumpkin_cut", 12 ] ], [ [ "sugar", 50 ] ], [ [ "yeast", 2 ] ] ]
+    "components": [ [ [ "water_clean", 15 ] ], [ [ "pumpkin_cut", 12 ] ], [ [ "sugar", 50 ] ], [ [ "yeast", 2 ] ] ],
+    "charges": 15
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_fruit_wine",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -277,13 +276,13 @@
     "book_learn": [ [ "brewing_cookbook", 2 ], [ "winemaking_beginner", 2 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_fermenting" }, { "proficiency": "prof_winemaking" } ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "components": [ [ [ "juice", 2 ] ], [ [ "yeast", 1 ] ], [ [ "water_clean", 2 ] ] ]
+    "components": [ [ [ "juice", 2 ] ], [ [ "yeast", 1 ] ], [ [ "water_clean", 2 ] ] ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_hb_beer",
-    "result_mult": 10,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -295,13 +294,13 @@
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 74, "LIST" ] ] ],
     "//": "assuming grains are roasted, that's 52u flour by weight, 2u for hops, plus 20u to heat water and activate yeast",
-    "components": [ [ [ "water_clean", 10 ] ], [ [ "malted_grain", 2 ] ], [ [ "hops", 1 ] ], [ [ "yeast", 1 ] ] ]
+    "components": [ [ [ "water_clean", 10 ] ], [ [ "malted_grain", 2 ] ], [ [ "hops", 1 ] ], [ [ "yeast", 1 ] ] ],
+    "charges": 10
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_mead",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -315,13 +314,13 @@
       [ [ "water_clean", 3 ] ],
       [ [ "honey_bottled", 12 ], [ "honeycomb", 2 ], [ "honey_glassed", 4 ] ],
       [ [ "yeast", 1 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "result": "brew_hopped_mead",
     "activity_level": "NO_EXERCISE",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -338,13 +337,13 @@
       [ [ "honey_bottled", 12 ], [ "honeycomb", 2 ], [ "honey_glassed", 4 ] ],
       [ [ "hops", 1 ] ],
       [ [ "yeast", 1 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "result": "brew_spiced_mead",
     "activity_level": "NO_EXERCISE",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -361,13 +360,13 @@
       [ [ "honey_bottled", 12 ], [ "honeycomb", 2 ], [ "honey_glassed", 4 ] ],
       [ [ "chilly-p", 50 ], [ "chili_pepper", 1 ], [ "cinnamon", 25 ], [ "pepper", 50 ], [ "wild_herbs", 10 ] ],
       [ [ "yeast", 1 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_dandelion_wine",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -390,13 +389,13 @@
       [ [ "soaked_dandelion", 10 ] ],
       [ [ "sugar_standard", 2, "LIST" ], [ "honeycomb", 1 ] ],
       [ [ "yeast", 1 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_burdock_wine",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -424,13 +423,13 @@
       [ [ "raw_burdock", 10 ] ],
       [ [ "sugar_standard", 2, "LIST" ], [ "honeycomb", 1 ] ],
       [ [ "yeast", 1 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_pine_wine",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -447,13 +446,13 @@
       [ [ "pine_bough", 5 ] ],
       [ [ "sugar_standard", 2, "LIST" ], [ "honeycomb", 1 ] ],
       [ [ "yeast", 1 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "malting_grain",
-    "result_mult": 1,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -463,13 +462,13 @@
     "book_learn": [ [ "brewing_cookbook", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" } ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "components": [ [ [ "water_clean", 1 ] ], [ [ "corn", 1 ], [ "barley", 1 ], [ "buckwheat", 1 ], [ "oats", 1 ], [ "wheat", 1 ] ] ]
+    "components": [ [ [ "water_clean", 1 ] ], [ [ "corn", 1 ], [ "barley", 1 ], [ "buckwheat", 1 ], [ "oats", 1 ], [ "wheat", 1 ] ] ],
+    "charges": 1
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "soaking_dandelion",
-    "result_mult": 1,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -486,13 +485,13 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" } ],
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 6, "LIST" ] ] ],
-    "components": [ [ [ "water_clean", 1 ] ], [ [ "raw_dandelion", 1 ] ] ]
+    "components": [ [ [ "water_clean", 1 ] ], [ [ "raw_dandelion", 1 ] ] ],
+    "charges": 1
   },
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "brew_vinegar",
-    "result_mult": 1,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -511,13 +510,13 @@
         [ "sweet_fruit", 1, "LIST" ],
         [ "wild_herbs", 40 ]
       ]
-    ]
+    ],
+    "charges": 1
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "fermenting_yogurt",
-    "result_mult": 10,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -532,13 +531,13 @@
     "components": [
       [ [ "milk_standard_raw", 9, "LIST" ] ],
       [ [ "cabbage", 1 ], [ "chili_pepper", 1 ], [ "yoghurt", 1 ], [ "yogurt_starter_culture", 1 ] ]
-    ]
+    ],
+    "charges": 10
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_rootbeer",
-    "result_mult": 1,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -554,6 +553,7 @@
       [ [ "molasses", 1 ] ],
       [ [ "yeast", 1 ] ],
       [ [ "sassafras_root", 1 ] ]
-    ]
+    ],
+    "charges": 1
   }
 ]

--- a/data/json/recipes/food/casseroles.json
+++ b/data/json/recipes/food/casseroles.json
@@ -130,7 +130,6 @@
     "subcategory": "CSC_FOOD_VEGGI",
     "skill_used": "cooking",
     "difficulty": 2,
-    "result_mult": 4,
     "time": "40 m",
     "batch_time_factors": [ 50, 2 ],
     "book_learn": [ [ "cookbook_italian", 2 ] ],
@@ -143,6 +142,7 @@
       [ [ "any_butter_or_oil", 4, "LIST" ] ],
       [ [ "cheese", 4 ], [ "can_cheese", 4 ], [ "mozzarella_cheese", 4 ] ],
       [ [ "sauce_red", 4 ] ]
-    ]
+    ],
+    "charges": 4
   }
 ]

--- a/data/json/recipes/food/dairy_products.json
+++ b/data/json/recipes/food/dairy_products.json
@@ -3,7 +3,6 @@
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "raw_butter",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
@@ -14,7 +13,7 @@
     "book_learn": [ [ "dairy_book", 3 ] ],
     "//": "Book Things to do with milk.  Add curdled milk and cheese recipes to the book.  Also consider adding to brewing json Airag from this book.",
     "components": [ [ [ "milk_cream", 5 ] ] ],
-    "charges": 33
+    "charges": 99
   },
   {
     "type": "recipe",
@@ -22,7 +21,6 @@
     "result": "raw_butter",
     "id_suffix": "shake",
     "byproducts": [ [ "buttermilk", 3 ] ],
-    "result_mult": 1,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
@@ -64,7 +62,6 @@
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "milk_cream",
-    "result_mult": 5,
     "byproducts": [ [ "jar_3l_glass_sealed", 1 ], [ "buttermilk", 7 ] ],
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_OTHER",
@@ -73,7 +70,8 @@
     "time": "30 m",
     "autolearn": true,
     "qualities": [ { "id": "COOK", "level": 1 } ],
-    "components": [ [ [ "milk_cream_jar", 1 ] ] ]
+    "components": [ [ [ "milk_cream_jar", 1 ] ] ],
+    "charges": 5
   },
   {
     "type": "recipe",
@@ -84,7 +82,6 @@
     "skill_used": "cooking",
     "difficulty": 1,
     "time": "5 m",
-    "result_mult": 8,
     "book_learn": [ [ "dairy_book", 1 ] ],
     "qualities": [ { "id": "COOK", "level": 1 } ],
     "proficiencies": [
@@ -96,7 +93,8 @@
       [ [ "water_boiling_heat", 2, "LIST" ] ],
       [ [ "colander_steel", -1 ], [ "sieve_steel", -1 ], [ "sieve_primitive", -1 ], [ "cotton_patchwork", -1 ] ]
     ],
-    "components": [ [ [ "milk", 16 ], [ "milk_raw", 16 ] ], [ [ "vinegar", 1 ] ], [ [ "salt", 1 ] ] ]
+    "components": [ [ [ "milk", 16 ], [ "milk_raw", 16 ] ], [ [ "vinegar", 1 ] ], [ [ "salt", 1 ] ] ],
+    "charges": 8
   },
   {
     "type": "recipe",
@@ -210,7 +208,6 @@
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
     "difficulty": 2,
-    "result_mult": 4,
     "time": "40 m",
     "batch_time_factors": [ 50, 2 ],
     "book_learn": [ [ "cookbook_italian", 2 ] ],
@@ -223,7 +220,8 @@
       [ [ "eggs_any_shape", 3, "LIST" ] ],
       [ [ "sugar", 4 ], [ "artificial_sweetener", 4 ] ],
       [ [ "coffee", 3 ] ]
-    ]
+    ],
+    "charges": 4
   },
   {
     "type": "recipe",
@@ -233,11 +231,11 @@
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
     "difficulty": 3,
-    "result_mult": 6,
     "book_learn": [ [ "cookbook_italian", 3 ] ],
     "time": "30 m",
     "batch_time_factors": [ 70, 2 ],
     "qualities": [ { "id": "CHURN", "level": 1 } ],
-    "components": [ [ [ "milk_cream", 8 ] ], [ [ "lemon", 2 ] ] ]
+    "components": [ [ [ "milk_cream", 8 ] ], [ [ "lemon", 2 ] ] ],
+    "charges": 6
   }
 ]

--- a/data/json/recipes/food/offal_dishes.json
+++ b/data/json/recipes/food/offal_dishes.json
@@ -131,7 +131,6 @@
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "liver_onion",
-    "result_mult": 2,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_MEAT",
     "skill_used": "cooking",
@@ -146,7 +145,8 @@
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 36, "LIST" ] ] ],
     "//": "liver is 32u total and onions are 2u, adding 2u on top since the onions are cooked more thoroughly than usual.",
-    "components": [ [ [ "meat_liver", 8, "LIST" ] ], [ [ "onion", 1 ], [ "irradiated_onion", 1 ] ] ]
+    "components": [ [ [ "meat_liver", 8, "LIST" ] ], [ [ "onion", 1 ], [ "irradiated_onion", 1 ] ] ],
+    "charges": 2
   },
   {
     "type": "recipe",

--- a/data/json/recipes/food/other.json
+++ b/data/json/recipes/food/other.json
@@ -112,7 +112,6 @@
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "acid_soaked_hide",
-    "result_mult": 1,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
@@ -125,21 +124,21 @@
       [ [ "formic_acid", 10 ] ],
       [ [ "water", 10 ], [ "water_clean", 10 ] ],
       [ [ "raw_leather", 1 ], [ "raw_hleather", 1 ], [ "raw_demihumanleather", 1 ] ]
-    ]
+    ],
+    "charges": 1
   },
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "gelatin_fresh",
     "byproducts": [ [ "formic_acid" ], [ "ruined_chunks" ] ],
-    "result_mult": 12,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
     "difficulty": 2,
     "time": "120 m",
     "batch_time_factors": [ 90, 1 ],
-    "charges": 1,
+    "charges": 12,
     "autolearn": true,
     "tools": [ [ "colander_steel" ] ],
     "components": [ [ [ "gelatin_extracted", 1 ] ] ]

--- a/data/json/recipes/food/pasta.json
+++ b/data/json/recipes/food/pasta.json
@@ -238,7 +238,6 @@
     "skill_used": "cooking",
     "difficulty": 4,
     "time": "25 m",
-    "result_mult": 4,
     "book_learn": [ [ "cookbook_italian", 3 ] ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
     "tools": [ [ [ "surface_heat", 13, "LIST" ] ] ],
@@ -250,7 +249,8 @@
       [ [ "eggs_any_shape", 3, "LIST" ] ],
       [ [ "cheese_standard", 1, "LIST" ], [ "pecorino_cheese", 1 ] ],
       [ [ "meat_cooked", 1, "LIST" ], [ "dry_meat", 1 ], [ "bacon", 1 ] ]
-    ]
+    ],
+    "charges": 4
   },
   {
     "result": "amatriciana_pasta",
@@ -261,7 +261,6 @@
     "skill_used": "cooking",
     "difficulty": 3,
     "time": "25 m",
-    "result_mult": 4,
     "book_learn": [ [ "cookbook_italian", 3 ] ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
     "tools": [ [ [ "surface_heat", 13, "LIST" ] ] ],
@@ -273,6 +272,7 @@
       [ [ "sauce_red", 3 ] ],
       [ [ "cheese_standard", 1, "LIST" ], [ "pecorino_cheese", 1 ] ],
       [ [ "meat_cooked", 1, "LIST" ], [ "dry_meat", 1 ], [ "bacon", 1 ] ]
-    ]
+    ],
+    "charges": 4
   }
 ]

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -2871,7 +2871,6 @@
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "almond_milk",
-    "result_mult": 3,
     "byproducts": [ [ "almond_pulp" ] ],
     "id_suffix": "mortar",
     "category": "CC_FOOD",
@@ -2884,13 +2883,13 @@
     "autolearn": true,
     "batch_time_factors": [ 30, 1 ],
     "proficiencies": [ { "proficiency": "prof_food_prep" } ],
-    "components": [ [ [ "almond_shelled", 2 ] ], [ [ "water_clean", 3 ] ] ]
+    "components": [ [ [ "almond_shelled", 2 ] ], [ [ "water_clean", 3 ] ] ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "almond_milk",
-    "result_mult": 3,
     "byproducts": [ [ "almond_pulp" ] ],
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_DRINKS",
@@ -2902,7 +2901,8 @@
     "autolearn": true,
     "batch_time_factors": [ 80, 1 ],
     "proficiencies": [ { "proficiency": "prof_food_prep" } ],
-    "components": [ [ [ "almond_shelled", 2 ] ], [ [ "water_clean", 3 ] ] ]
+    "components": [ [ [ "almond_shelled", 2 ] ], [ [ "water_clean", 3 ] ] ],
+    "charges": 3
   },
   {
     "type": "recipe",
@@ -2967,13 +2967,13 @@
     "activity_level": "NO_EXERCISE",
     "result": "milk_reconstituted",
     "id_suffix": "from_condensed",
-    "result_mult": 4,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_DRINKS",
     "skill_used": "cooking",
     "time": "1 m",
     "autolearn": true,
-    "components": [ [ [ "con_milk", 5 ] ], [ [ "water_clean", 3 ] ] ]
+    "components": [ [ [ "con_milk", 5 ] ], [ [ "water_clean", 3 ] ] ],
+    "charges": 4
   },
   {
     "type": "recipe",
@@ -3106,7 +3106,6 @@
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "lemonade",
-    "result_mult": 2,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_DRINKS",
     "skill_used": "cooking",
@@ -3114,7 +3113,8 @@
     "time": "2 m",
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "CONTAIN", "level": 1 } ],
-    "components": [ [ [ "irradiated_lemon", 1 ], [ "lemon", 1 ] ], [ [ "sugar_powdered", 10, "LIST" ] ], [ [ "water_clean", 1 ] ] ]
+    "components": [ [ [ "irradiated_lemon", 1 ], [ "lemon", 1 ] ], [ [ "sugar_powdered", 10, "LIST" ] ], [ [ "water_clean", 1 ] ] ],
+    "charges": 2
   },
   {
     "type": "recipe",
@@ -3132,7 +3132,6 @@
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "spezi",
-    "result_mult": 2,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_DRINKS",
     "skill_used": "cooking",
@@ -3140,13 +3139,13 @@
     "time": "30 s",
     "autolearn": true,
     "flags": [ "BLIND_HARD" ],
-    "components": [ [ [ "orangesoda", 1 ] ], [ [ "cola", 1 ] ] ]
+    "components": [ [ [ "orangesoda", 1 ] ], [ [ "cola", 1 ] ] ],
+    "charges": 2
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "crispycran",
-    "result_mult": 2,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_DRINKS",
     "skill_used": "cooking",
@@ -3154,7 +3153,8 @@
     "time": "30 s",
     "autolearn": true,
     "flags": [ "BLIND_HARD" ],
-    "components": [ [ [ "lemonlime", 1 ] ], [ [ "cranberry_juice", 1 ] ] ]
+    "components": [ [ [ "lemonlime", 1 ] ], [ [ "cranberry_juice", 1 ] ] ],
+    "charges": 2
   },
   {
     "type": "recipe",
@@ -7750,9 +7750,9 @@
     "skill_used": "cooking",
     "time": "5 m",
     "autolearn": true,
-    "result_mult": 2,
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "components": [ [ [ "sweet_fruit", 1, "LIST" ] ], [ [ "hard_liquor", 1, "LIST" ] ] ]
+    "components": [ [ [ "sweet_fruit", 1, "LIST" ] ], [ [ "hard_liquor", 1, "LIST" ] ] ],
+    "charges": 2
   },
   {
     "type": "recipe",
@@ -8879,7 +8879,6 @@
     "skills_required": [ "tailor", 1 ],
     "time": "45 m",
     "book_learn": [ [ "survival_book", 6 ], [ "scots_cookbook", 3 ] ],
-    "result_mult": 2,
     "batch_time_factors": [ 50, 4 ],
     "using": [ [ "sewing_standard", 4 ] ],
     "qualities": [ { "id": "BOIL", "level": 1 }, { "id": "COOK", "level": 3 }, { "id": "CUT", "level": 2 } ],
@@ -8890,7 +8889,8 @@
       [ [ "meat_stomach_large", 1, "LIST" ] ],
       [ [ "meat_offal", 2, "LIST" ] ],
       [ [ "oatmeal", 8 ], [ "buckwheat", 2 ] ]
-    ]
+    ],
+    "charges": 2
   },
   {
     "type": "recipe",
@@ -9022,7 +9022,6 @@
     "time": "5 m",
     "batch_time_factors": [ 20, 1 ],
     "autolearn": true,
-    "result_mult": 2,
     "qualities": [ { "id": "COOK", "level": 3 } ],
     "tools": [ [ [ "surface_heat", 5, "LIST" ] ] ],
     "components": [
@@ -9035,7 +9034,8 @@
       ],
       [ [ "water_clean", 1 ] ],
       [ [ "sugar", 5 ], [ "artificial_sweetener", 5 ] ]
-    ]
+    ],
+    "charges": 2
   },
   {
     "result": "mex_chocolate",
@@ -9711,10 +9711,10 @@
     "skill_used": "cooking",
     "difficulty": 1,
     "time": "5 m",
-    "result_mult": 2,
     "autolearn": true,
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "components": [ [ [ "water_clean", 1 ] ], [ [ "flour_any", 4, "LIST" ] ], [ [ "sourdough_starter_uncovered", 1 ] ] ]
+    "components": [ [ [ "water_clean", 1 ] ], [ [ "flour_any", 4, "LIST" ] ], [ [ "sourdough_starter_uncovered", 1 ] ] ],
+    "charges": 2
   },
   {
     "type": "recipe",
@@ -10153,7 +10153,6 @@
     "subcategory": "CSC_FOOD_DRINKS",
     "skill_used": "cooking",
     "difficulty": 1,
-    "result_mult": 2,
     "time": "30 s",
     "autolearn": true,
     "flags": [ "BLIND_HARD" ],
@@ -10163,7 +10162,8 @@
       [ [ "salt", 1 ], [ "seasoning_salt", 1 ] ],
       [ [ "pepper", 1 ], [ "curry_powder", 1 ], [ "chilly-p", 1 ], [ "hot_sauce", 1 ] ],
       [ [ "salt", 1 ], [ "irradiated_lemon", 1 ], [ "lemon", 1 ] ]
-    ]
+    ],
+    "charges": 2
   },
   {
     "type": "recipe",
@@ -10173,7 +10173,6 @@
     "subcategory": "CSC_*_NESTED",
     "skill_used": "cooking",
     "difficulty": 1,
-    "result_mult": 2,
     "time": "30 s",
     "book_learn": [ [ "cookbook_bloodforgood", 2 ] ],
     "flags": [ "BLIND_HARD" ],
@@ -10183,7 +10182,8 @@
       [ [ "salt", 1 ], [ "seasoning_salt", 1 ] ],
       [ [ "pepper", 1 ], [ "curry_powder", 1 ], [ "chilly-p", 1 ], [ "hot_sauce", 1 ] ],
       [ [ "salt", 1 ], [ "irradiated_lemon", 1 ], [ "lemon", 1 ] ]
-    ]
+    ],
+    "charges": 2
   },
   {
     "type": "recipe",
@@ -10193,7 +10193,6 @@
     "subcategory": "CSC_FOOD_DRINKS",
     "skill_used": "cooking",
     "difficulty": 3,
-    "result_mult": 6,
     "time": "45 m",
     "autolearn": true,
     "batch_time_factors": [ 80, 4 ],
@@ -10204,7 +10203,8 @@
       [ [ "water", 1 ], [ "water_clean", 1 ] ],
       [ [ "sugar", 1 ], [ "artificial_sweetener", 1 ] ],
       [ [ "salt", 1 ], [ "seasoning_salt", 1 ] ]
-    ]
+    ],
+    "charges": 6
   },
   {
     "type": "recipe",

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -1037,7 +1037,6 @@
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "chem_hydrogen_peroxide",
-    "result_mult": 5,
     "category": "CC_*",
     "subcategory": "CSC_*_NESTED",
     "skill_used": "chemistry",
@@ -1049,7 +1048,8 @@
     "book_learn": [ [ "recipe_labchem", 3 ], [ "textbook_chemistry", 3 ] ],
     "qualities": [ { "id": "BOIL", "level": 2 }, { "id": "CHEM", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 10, "LIST" ] ] ],
-    "components": [ [ [ "chem_hydrogen_peroxide_conc", 1 ] ], [ [ "water", 4 ], [ "water_clean", 4 ] ] ]
+    "components": [ [ [ "chem_hydrogen_peroxide_conc", 1 ] ], [ [ "water", 4 ], [ "water_clean", 4 ] ] ],
+    "charges": 5
   },
   {
     "type": "recipe",

--- a/data/mods/Aftershock/recipes/comestible_recipes.json
+++ b/data/mods/Aftershock/recipes/comestible_recipes.json
@@ -3,7 +3,6 @@
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "atomic_butter",
-    "result_mult": 1,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",

--- a/data/mods/DinoMod/recipes/food_egg.json
+++ b/data/mods/DinoMod/recipes/food_egg.json
@@ -11,11 +11,10 @@
     "time": "28 m",
     "autolearn": true,
     "batch_time_factors": [ 80, 2 ],
-    "result_mult": 20,
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 40, "LIST" ] ] ],
     "components": [ [ [ "eggs_dino", 1, "LIST" ] ] ],
-    "charges": 2
+    "charges": 40
   },
   {
     "type": "recipe",
@@ -29,11 +28,10 @@
     "time": "52 m",
     "autolearn": true,
     "batch_time_factors": [ 80, 2 ],
-    "result_mult": 40,
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 80, "LIST" ] ] ],
     "components": [ [ [ "eggs_dino_large", 1, "LIST" ] ] ],
-    "charges": 2
+    "charges": 80
   },
   {
     "type": "recipe",
@@ -47,10 +45,10 @@
     "time": "21 m",
     "autolearn": true,
     "batch_time_factors": [ 80, 2 ],
-    "result_mult": 20,
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 40, "LIST" ] ] ],
-    "components": [ [ [ "eggs_dino", 1, "LIST" ] ], [ [ "any_butter_or_oil", 40, "LIST" ] ] ]
+    "components": [ [ [ "eggs_dino", 1, "LIST" ] ], [ [ "any_butter_or_oil", 40, "LIST" ] ] ],
+    "charges": 20
   },
   {
     "type": "recipe",
@@ -64,10 +62,10 @@
     "time": "37 m",
     "autolearn": true,
     "batch_time_factors": [ 80, 2 ],
-    "result_mult": 40,
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 80, "LIST" ] ] ],
-    "components": [ [ [ "eggs_dino_large", 1, "LIST" ] ], [ [ "any_butter_or_oil", 80, "LIST" ] ] ]
+    "components": [ [ [ "eggs_dino_large", 1, "LIST" ] ], [ [ "any_butter_or_oil", 80, "LIST" ] ] ],
+    "charges": 40
   },
   {
     "type": "recipe",
@@ -81,7 +79,6 @@
     "time": "28 m",
     "autolearn": true,
     "batch_time_factors": [ 80, 2 ],
-    "result_mult": 20,
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 40, "LIST" ] ] ],
     "components": [
@@ -89,7 +86,8 @@
       [ [ "any_butter_or_oil", 40, "LIST" ] ],
       [ [ "bread_sandwich", 40, "LIST" ] ],
       [ [ "condiment", 40, "LIST" ] ]
-    ]
+    ],
+    "charges": 20
   },
   {
     "type": "recipe",
@@ -103,7 +101,6 @@
     "time": "28 m",
     "autolearn": true,
     "batch_time_factors": [ 80, 2 ],
-    "result_mult": 20,
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 40, "LIST" ] ] ],
     "components": [
@@ -111,7 +108,8 @@
       [ [ "any_butter_or_oil", 40, "LIST" ] ],
       [ [ "bread_sandwich_wheat_free", 40, "LIST" ] ],
       [ [ "condiment", 40, "LIST" ] ]
-    ]
+    ],
+    "charges": 20
   },
   {
     "type": "recipe",
@@ -125,7 +123,6 @@
     "time": "38 m",
     "autolearn": true,
     "batch_time_factors": [ 80, 2 ],
-    "result_mult": 20,
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 40, "LIST" ] ] ],
     "components": [
@@ -136,7 +133,8 @@
       [ [ "salt", 40 ], [ "soysauce", 40 ], [ "seasoning_salt", 40 ], [ "pepper", 80 ] ],
       [ [ "condiment", 40, "LIST" ] ],
       [ [ "bread_sandwich", 40, "LIST" ] ]
-    ]
+    ],
+    "charges": 20
   },
   {
     "type": "recipe",
@@ -150,7 +148,6 @@
     "time": "38 m",
     "autolearn": true,
     "batch_time_factors": [ 80, 2 ],
-    "result_mult": 20,
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 40, "LIST" ] ] ],
     "components": [
@@ -161,7 +158,8 @@
       [ [ "salt", 40 ], [ "soysauce", 40 ], [ "seasoning_salt", 40 ], [ "pepper", 80 ] ],
       [ [ "condiment", 40, "LIST" ] ],
       [ [ "bread_sandwich_wheat_free", 40, "LIST" ] ]
-    ]
+    ],
+    "charges": 20
   },
   {
     "type": "recipe",
@@ -218,12 +216,11 @@
     "skill_used": "cooking",
     "difficulty": 1,
     "time": "60 m",
-    "result_mult": 20,
     "autolearn": true,
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 40, "LIST" ] ] ],
     "components": [ [ [ "eggs_dino", 1, "LIST" ] ], [ [ "meat_cooked", 20, "LIST" ] ] ],
-    "charges": 3
+    "charges": 60
   },
   {
     "type": "recipe",
@@ -235,7 +232,6 @@
     "skill_used": "cooking",
     "difficulty": 3,
     "time": "240 m",
-    "result_mult": 40,
     "autolearn": true,
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 320, "LIST" ] ] ],
@@ -247,7 +243,7 @@
       [ [ "any_butter_or_oil", 40, "LIST" ] ],
       [ [ "water", 40 ], [ "water_clean", 40 ] ]
     ],
-    "charges": 4
+    "charges": 160
   },
   {
     "type": "recipe",
@@ -259,7 +255,6 @@
     "skill_used": "cooking",
     "difficulty": 3,
     "time": "240 m",
-    "result_mult": 40,
     "autolearn": true,
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 320, "LIST" ] ] ],
@@ -271,7 +266,8 @@
       [ [ "any_butter_or_oil", 40, "LIST" ] ],
       [ [ "water", 40 ], [ "water_clean", 40 ] ],
       [ [ "sweet_fruit_like", 40, "LIST" ], [ "jam_fruit", 40 ] ]
-    ]
+    ],
+    "charges": 40
   },
   {
     "type": "recipe",
@@ -283,7 +279,6 @@
     "skill_used": "cooking",
     "difficulty": 3,
     "time": "240 m",
-    "result_mult": 40,
     "autolearn": true,
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 320, "LIST" ] ] ],
@@ -295,7 +290,8 @@
       [ [ "any_butter_or_oil", 40, "LIST" ] ],
       [ [ "water", 40 ], [ "water_clean", 40 ] ],
       [ [ "chocolate", 40 ], [ "choc_drink", 80 ] ]
-    ]
+    ],
+    "charges": 40
   },
   {
     "type": "recipe",
@@ -307,8 +303,7 @@
     "skill_used": "cooking",
     "difficulty": 3,
     "time": "240 m",
-    "result_mult": 40,
-    "charges": 3,
+    "charges": 120,
     "autolearn": true,
     "qualities": [ { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 320, "LIST" ] ] ],
@@ -329,7 +324,6 @@
     "skill_used": "cooking",
     "difficulty": 3,
     "time": "240 m",
-    "result_mult": 40,
     "autolearn": true,
     "tools": [ [ [ "surface_heat", 320, "LIST" ] ], [ [ "waffleiron", -1 ] ] ],
     "components": [
@@ -340,7 +334,8 @@
       [ [ "sugar", 80 ], [ "artificial_sweetener", 80 ] ],
       [ [ "any_butter_or_oil", 40, "LIST" ] ],
       [ [ "water", 40 ], [ "water_clean", 40 ] ]
-    ]
+    ],
+    "charges": 40
   },
   {
     "type": "recipe",
@@ -352,7 +347,6 @@
     "skill_used": "cooking",
     "difficulty": 3,
     "time": "240 m",
-    "result_mult": 40,
     "autolearn": true,
     "tools": [ [ [ "surface_heat", 320, "LIST" ] ], [ [ "waffleiron", -1 ] ] ],
     "components": [
@@ -364,7 +358,8 @@
       [ [ "any_butter_or_oil", 40, "LIST" ] ],
       [ [ "water", 40 ], [ "water_clean", 40 ] ],
       [ [ "sweet_fruit_like", 40, "LIST" ], [ "jam_fruit", 40 ] ]
-    ]
+    ],
+    "charges": 40
   },
   {
     "type": "recipe",
@@ -376,7 +371,6 @@
     "skill_used": "cooking",
     "difficulty": 3,
     "time": "240 m",
-    "result_mult": 40,
     "autolearn": true,
     "tools": [ [ [ "surface_heat", 320, "LIST" ] ], [ [ "waffleiron", -1 ] ] ],
     "components": [
@@ -388,7 +382,8 @@
       [ [ "any_butter_or_oil", 40, "LIST" ] ],
       [ [ "water", 40 ], [ "water_clean", 40 ] ],
       [ [ "chocolate", 40 ], [ "choc_drink", 80 ] ]
-    ]
+    ],
+    "charges": 40
   },
   {
     "type": "recipe",
@@ -399,9 +394,8 @@
     "subcategory": "CSC_FOOD_DRY",
     "skill_used": "cooking",
     "difficulty": 2,
-    "charges": 30,
+    "charges": 90,
     "time": "30 m",
-    "result_mult": 3,
     "autolearn": true,
     "batch_time_factors": [ 67, 5 ],
     "tools": [ [ [ "dehydrator", 60 ], [ "char_smoker", 60 ] ] ],
@@ -416,9 +410,8 @@
     "subcategory": "CSC_FOOD_DRY",
     "skill_used": "cooking",
     "difficulty": 2,
-    "charges": 30,
+    "charges": 90,
     "time": "34 m",
-    "result_mult": 3,
     "autolearn": true,
     "batch_time_factors": [ 67, 5 ],
     "tools": [ [ [ "dehydrator", 60 ], [ "char_smoker", 60 ] ], [ [ "surface_heat", 15, "LIST" ] ] ],
@@ -433,9 +426,8 @@
     "subcategory": "CSC_FOOD_DRY",
     "skill_used": "cooking",
     "difficulty": 2,
-    "charges": 70,
+    "charges": 490,
     "time": "40 m",
-    "result_mult": 7,
     "autolearn": true,
     "batch_time_factors": [ 67, 5 ],
     "tools": [ [ [ "dehydrator", 140 ], [ "char_smoker", 140 ] ] ],
@@ -450,9 +442,8 @@
     "subcategory": "CSC_FOOD_DRY",
     "skill_used": "cooking",
     "difficulty": 2,
-    "charges": 70,
+    "charges": 490,
     "time": "60 m",
-    "result_mult": 7,
     "autolearn": true,
     "batch_time_factors": [ 67, 5 ],
     "tools": [ [ [ "dehydrator", 140 ], [ "char_smoker", 140 ] ], [ [ "surface_heat", 35, "LIST" ] ] ],

--- a/data/mods/DinoMod/recipes/offal_dishes.json
+++ b/data/mods/DinoMod/recipes/offal_dishes.json
@@ -10,9 +10,8 @@
     "skill_used": "cooking",
     "skills_required": [ "survival", 2 ],
     "time": "220 m",
-    "charges": 8,
+    "charges": 32,
     "book_learn": [ [ "cookbook", 1 ], [ "scots_cookbook", 2 ] ],
-    "result_mult": 4,
     "difficulty": 3,
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
     "tools": [ [ [ "surface_heat", 100, "LIST" ] ] ],
@@ -52,10 +51,9 @@
     "difficulty": 5,
     "time": "180 m",
     "batch_time_factors": [ 83, 5 ],
-    "charges": 240,
+    "charges": 960,
     "byproducts": [ [ "ruined_chunks", 8 ] ],
     "book_learn": [ [ "offalcooking", 3 ] ],
-    "result_mult": 4,
     "qualities": [ { "id": "COOK", "level": 2 }, { "id": "CUT_FINE", "level": 1 } ],
     "components": [ [ [ "stomach_sauropod", 1 ] ], [ [ "salt", 80 ] ], [ [ "water", 8 ], [ "water_clean", 8 ] ] ]
   }

--- a/data/mods/DinoMod/recipes/recipe_food.json
+++ b/data/mods/DinoMod/recipes/recipe_food.json
@@ -26,7 +26,6 @@
     "skills_required": [ "tailor", 1 ],
     "time": "110 m",
     "book_learn": [ [ "survival_book", 6 ], [ "scots_cookbook", 3 ] ],
-    "result_mult": 4,
     "batch_time_factors": [ 50, 4 ],
     "using": [ [ "sewing_standard", 4 ] ],
     "qualities": [ { "id": "BOIL", "level": 1 }, { "id": "COOK", "level": 3 }, { "id": "CUT", "level": 2 } ],
@@ -36,6 +35,7 @@
       [ [ "stomach_sauropod", 1 ] ],
       [ [ "meat_offal", 4, "LIST" ] ],
       [ [ "oatmeal", 16 ], [ "buckwheat", 4 ] ]
-    ]
+    ],
+    "charges": 4
   }
 ]

--- a/data/mods/Magiclysm/recipes.json
+++ b/data/mods/Magiclysm/recipes.json
@@ -8,10 +8,10 @@
     "skill_used": "cooking",
     "time": "2 m",
     "autolearn": true,
-    "result_mult": 40,
     "byproducts": [ [ "stone_shell", 3 ] ],
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "egg_owlbear_rock", 1 ] ] ]
+    "components": [ [ [ "egg_owlbear_rock", 1 ] ] ],
+    "charges": 40
   },
   {
     "type": "recipe",

--- a/data/mods/Magiclysm/recipes/alchemy.json
+++ b/data/mods/Magiclysm/recipes/alchemy.json
@@ -156,6 +156,6 @@
     "category": "CC_ENCHANTED",
     "subcategory": "CSC_ENCHANTED_OTHER",
     "autolearn": true,
-    "result_mult": 10
+    "charges": 10
   }
 ]

--- a/data/mods/Magiclysm/recipes/recipe_potions.json
+++ b/data/mods/Magiclysm/recipes/recipe_potions.json
@@ -203,7 +203,6 @@
     "type": "recipe",
     "copy-from": "cats_grace_potion",
     "result": "twisted_restore_potion",
-    "result_mult": 5,
     "book_learn": [ [ "necro_basic", 3 ] ],
     "tools": [
       [ [ "surface_heat", 20, "LIST" ] ],
@@ -214,7 +213,8 @@
         [ "rune_animist_weapon_adept", -1 ]
       ]
     ],
-    "components": [ [ [ "potion_starter", 5 ] ], [ [ "edible_blood", 3, "LIST" ] ], [ [ "meat_tainted", 12 ] ] ]
+    "components": [ [ [ "potion_starter", 5 ] ], [ [ "edible_blood", 3, "LIST" ] ], [ [ "meat_tainted", 12 ] ] ],
+    "charges": 5
   },
   {
     "type": "recipe",
@@ -359,7 +359,6 @@
     "copy-from": "flask_healing",
     "result": "twisted_restore_potion_improved",
     "proficiencies": [ { "proficiency": "prof_alchemy" } ],
-    "result_mult": 5,
     "book_learn": [ [ "necro_basic", 5 ] ],
     "qualities": [ { "id": "CHEM", "level": 2 }, { "id": "CONCENTRATE", "level": 1 }, { "id": "MANA_FOCUS", "level": 1 } ],
     "tools": [
@@ -371,7 +370,8 @@
       [ [ "edible_blood", 5, "LIST" ] ],
       [ [ "meat_tainted", 15 ] ],
       [ [ "horn_moss_capsule", 5 ] ]
-    ]
+    ],
+    "charges": 5
   },
   {
     "type": "recipe",

--- a/data/mods/Magiclysm/recipes/weapons.json
+++ b/data/mods/Magiclysm/recipes/weapons.json
@@ -358,7 +358,6 @@
     "skills_required": [ [ "spellcraft", 4 ] ],
     "difficulty": 4,
     "time": "120 m",
-    "result_mult": 3,
     "book_learn": [ [ "necro_basic", 3 ] ],
     "qualities": [ { "id": "SEW", "level": 1 }, { "id": "CUT_FINE", "level": 1 }, { "id": "MANA_INFUSE", "level": 1 } ],
     "tools": [
@@ -375,7 +374,8 @@
       [ [ "sinew", 60 ] ],
       [ [ "bone", 1 ], [ "bone_human", 1 ], [ "bone_tainted", 2 ] ],
       [ [ "needle_bone", 1 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",
@@ -387,7 +387,6 @@
     "skills_required": [ [ "spellcraft", 5 ] ],
     "difficulty": 5,
     "time": "180 m",
-    "result_mult": 3,
     "book_learn": [ [ "necro_basic", 4 ] ],
     "qualities": [
       { "id": "SEW", "level": 1 },
@@ -409,7 +408,8 @@
       [ [ "sinew", 60 ] ],
       [ [ "bone", 4 ], [ "bone_human", 4 ], [ "bone_tainted", 8 ] ],
       [ [ "needle_bone", 1 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",
@@ -421,7 +421,6 @@
     "skills_required": [ [ "spellcraft", 7 ] ],
     "difficulty": 7,
     "time": "210 m",
-    "result_mult": 3,
     "book_learn": [ [ "necro_basic", 6 ] ],
     "qualities": [ { "id": "SEW", "level": 1 }, { "id": "CUT_FINE", "level": 1 }, { "id": "MANA_INFUSE", "level": 1 } ],
     "tools": [ [ [ "rune_animist", -1 ], [ "rune_animist_weapon", -1 ], [ "rune_animist_weapon_adept", -1 ] ] ],
@@ -437,7 +436,8 @@
       [ [ "sinew", 60 ] ],
       [ [ "bone", 1 ], [ "bone_human", 1 ], [ "bone_tainted", 2 ] ],
       [ [ "needle_bone", 1 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",

--- a/data/mods/Xedra_Evolved/recipes/alchemy.json
+++ b/data/mods/Xedra_Evolved/recipes/alchemy.json
@@ -32,7 +32,6 @@
     "flags": [ "SECRET" ],
     "difficulty": 2,
     "time": "160 m",
-    "result_mult": 3,
     "proficiencies": [
       { "proficiency": "prof_intro_chemistry" },
       { "proficiency": "prof_inorganic_chemistry" },
@@ -41,7 +40,8 @@
     ],
     "qualities": [ { "id": "CHEM", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 25, "LIST" ] ] ],
-    "components": [ [ [ "water_clean", 1 ] ], [ [ "corpse_ash", 1 ] ], [ [ "poppy_bud", 1 ] ], [ [ "royal_jelly", 1 ] ] ]
+    "components": [ [ [ "water_clean", 1 ] ], [ [ "corpse_ash", 1 ] ], [ [ "poppy_bud", 1 ] ], [ [ "royal_jelly", 1 ] ] ],
+    "charges": 3
   },
   {
     "type": "recipe",
@@ -53,9 +53,9 @@
     "difficulty": 3,
     "time": "1 m",
     "batch_time_factors": [ 50, 4 ],
-    "result_mult": 6,
     "flags": [ "SECRET" ],
-    "components": [ [ [ "energy_drink", 3 ] ], [ [ "vodka", 3 ], [ "tequila", 3 ] ], [ [ "lotus_blossom", 1 ] ] ]
+    "components": [ [ [ "energy_drink", 3 ] ], [ [ "vodka", 3 ], [ "tequila", 3 ] ], [ [ "lotus_blossom", 1 ] ] ],
+    "charges": 6
   },
   {
     "type": "recipe",
@@ -104,7 +104,6 @@
     "skill_used": "deduction",
     "difficulty": 6,
     "time": "1 h",
-    "result_mult": 20,
     "batch_time_factors": [ 80, 1 ],
     "flags": [ "SECRET" ],
     "proficiencies": [
@@ -133,7 +132,7 @@
       [ [ "scrap_dreamdross", 5 ] ],
       [ [ "lotus_blossom", 2 ] ]
     ],
-    "charges": 5
+    "charges": 100
   },
   {
     "type": "recipe",

--- a/data/mods/innawood/recipes/brewing.json
+++ b/data/mods/innawood/recipes/brewing.json
@@ -3,7 +3,6 @@
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_milk_curdled",
-    "result_mult": 18,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -13,13 +12,13 @@
     "batch_time_factors": [ 50, 4 ],
     "autolearn": true,
     "using": [ [ "milk_standard_raw_fresh", 15 ] ],
-    "components": [ [ [ "vinegar", 3 ] ], [ [ "wild_herbs", 40 ], [ "meat_stomach", 1, "LIST" ] ] ]
+    "components": [ [ [ "vinegar", 3 ] ], [ [ "wild_herbs", 40 ], [ "meat_stomach", 1, "LIST" ] ] ],
+    "charges": 18
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_whiskey",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -29,13 +28,13 @@
     "autolearn": true,
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 6, "LIST" ] ] ],
-    "components": [ [ [ "water", 3 ], [ "water_clean", 3 ] ], [ [ "malted_grain", 2 ] ], [ [ "sugar", 50 ] ], [ [ "yeast", 1 ] ] ]
+    "components": [ [ [ "water", 3 ], [ "water_clean", 3 ] ], [ [ "malted_grain", 2 ] ], [ [ "sugar", 50 ] ], [ [ "yeast", 1 ] ] ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_gin",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -49,13 +48,13 @@
       [ [ "water", 2 ], [ "water_clean", 2 ] ],
       [ [ "corn", 3 ], [ "cornmeal", 3 ], [ "barley", 3 ], [ "buckwheat", 3 ], [ "oats", 3 ] ],
       [ [ "juniper", 10 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_rum",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -65,13 +64,13 @@
     "autolearn": true,
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 6, "LIST" ] ] ],
-    "components": [ [ [ "water", 3 ], [ "water_clean", 3 ] ], [ [ "molasses", 2 ], [ "sugar_beet", 5 ] ], [ [ "yeast", 1 ] ] ]
+    "components": [ [ [ "water", 3 ], [ "water_clean", 3 ] ], [ [ "molasses", 2 ], [ "sugar_beet", 5 ] ], [ [ "yeast", 1 ] ] ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_moonshine",
-    "result_mult": 15,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -86,13 +85,13 @@
       [ [ "cornmeal", 12 ], [ "corn", 2 ] ],
       [ [ "sugar", 100 ] ],
       [ [ "yeast", 2 ] ]
-    ]
+    ],
+    "charges": 15
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_hb_seltzer",
-    "result_mult": 10,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -113,14 +112,14 @@
         [ "worthy_wine", 1, "LIST" ],
         [ "sweet_fruit", 1, "LIST" ]
       ]
-    ]
+    ],
+    "charges": 10
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_moonshine",
     "id_suffix": "pumpkin",
-    "result_mult": 15,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -130,14 +129,14 @@
     "autolearn": true,
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 30, "LIST" ] ] ],
-    "components": [ [ [ "water", 15 ], [ "water_clean", 15 ] ], [ [ "pumpkin", 12 ] ], [ [ "sugar", 50 ] ], [ [ "yeast", 2 ] ] ]
+    "components": [ [ [ "water", 15 ], [ "water_clean", 15 ] ], [ [ "pumpkin", 12 ] ], [ [ "sugar", 50 ] ], [ [ "yeast", 2 ] ] ],
+    "charges": 15
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_moonshine",
     "id_suffix": "forage",
-    "result_mult": 15,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -152,13 +151,13 @@
       [ [ "cattail_rhizome", 12 ], [ "buckwheat", 15 ] ],
       [ [ "sugar", 100 ] ],
       [ [ "yeast", 2 ] ]
-    ]
+    ],
+    "charges": 15
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_fruit_wine",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -167,13 +166,13 @@
     "batch_time_factors": [ 95, 4 ],
     "autolearn": true,
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
-    "components": [ [ [ "juice", 2 ] ], [ [ "yeast", 1 ] ], [ [ "water", 2 ], [ "water_clean", 2 ] ] ]
+    "components": [ [ [ "juice", 2 ] ], [ [ "yeast", 1 ] ], [ [ "water", 2 ], [ "water_clean", 2 ] ] ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_hb_beer",
-    "result_mult": 10,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -183,13 +182,13 @@
     "autolearn": true,
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 6, "LIST" ] ] ],
-    "components": [ [ [ "water", 10 ], [ "water_clean", 10 ] ], [ [ "malted_grain", 2 ] ], [ [ "hops", 1 ] ], [ [ "yeast", 1 ] ] ]
+    "components": [ [ [ "water", 10 ], [ "water_clean", 10 ] ], [ [ "malted_grain", 2 ] ], [ [ "hops", 1 ] ], [ [ "yeast", 1 ] ] ],
+    "charges": 10
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_mead",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -202,13 +201,13 @@
       [ [ "water_clean", 3 ] ],
       [ [ "honey_bottled", 12 ], [ "honeycomb", 2 ], [ "honey_glassed", 4 ] ],
       [ [ "yeast", 1 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_dandelion_wine",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -222,13 +221,13 @@
       [ [ "soaked_dandelion", 10 ] ],
       [ [ "sugar_standard", 2, "LIST" ], [ "honeycomb", 1 ] ],
       [ [ "yeast", 1 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_burdock_wine",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -243,13 +242,13 @@
       [ [ "raw_burdock", 10 ] ],
       [ [ "sugar_standard", 2, "LIST" ], [ "honeycomb", 1 ] ],
       [ [ "yeast", 1 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "brew_pine_wine",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -264,13 +263,13 @@
       [ [ "pine_bough", 5 ] ],
       [ [ "sugar_standard", 2, "LIST" ], [ "honeycomb", 1 ] ],
       [ [ "yeast", 1 ] ]
-    ]
+    ],
+    "charges": 3
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "malting_grain",
-    "result_mult": 1,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -282,13 +281,13 @@
     "components": [
       [ [ "water", 1 ], [ "water_clean", 1 ] ],
       [ [ "corn", 1 ], [ "barley", 1 ], [ "buckwheat", 1 ], [ "oats", 1 ], [ "wheat", 1 ] ]
-    ]
+    ],
+    "charges": 1
   },
   {
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "result": "soaking_dandelion",
-    "result_mult": 1,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -298,13 +297,13 @@
     "autolearn": true,
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 6, "LIST" ] ] ],
-    "components": [ [ [ "water", 1 ], [ "water_clean", 1 ] ], [ [ "raw_dandelion", 1 ] ] ]
+    "components": [ [ [ "water", 1 ], [ "water_clean", 1 ] ], [ [ "raw_dandelion", 1 ] ] ],
+    "charges": 1
   },
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "brew_vinegar",
-    "result_mult": 1,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_BREW",
     "skill_used": "cooking",
@@ -322,6 +321,7 @@
         [ "sweet_fruit", 1, "LIST" ],
         [ "wild_herbs", 40 ]
       ]
-    ]
+    ],
+    "charges": 1
   }
 ]

--- a/data/mods/innawood/recipes/recipe_food.json
+++ b/data/mods/innawood/recipes/recipe_food.json
@@ -508,7 +508,6 @@
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "raw_butter",
-    "result_mult": 3,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
@@ -520,7 +519,7 @@
     "book_learn": [ [ "dairy_book", 3 ] ],
     "//": "Book Things to do with milk.  Add curdled milk and cheese recipes to the book.  Also consider adding to brewing json Airag from this book.",
     "components": [ [ [ "milk_cream", 5 ] ] ],
-    "charges": 33
+    "charges": 99
   },
   {
     "type": "recipe",
@@ -528,7 +527,6 @@
     "result": "raw_butter",
     "id_suffix": "shake",
     "byproducts": [ [ "buttermilk", 3 ] ],
-    "result_mult": 1,
     "category": "CC_FOOD",
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
@@ -663,13 +661,13 @@
     "subcategory": "CSC_FOOD_OTHER",
     "skill_used": "cooking",
     "difficulty": 4,
-    "result_mult": 2,
     "time": "8 m",
     "autolearn": true,
     "book_learn": [ [ "cookbook_italian", 2 ] ],
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
-    "components": [ [ [ "salt", 20 ] ], [ [ "garlic_clove", 6 ] ], [ [ "thyme", 2 ] ], [ [ "wild_herbs", 200 ] ] ]
+    "components": [ [ [ "salt", 20 ] ], [ [ "garlic_clove", 6 ] ], [ [ "thyme", 2 ] ], [ [ "wild_herbs", 200 ] ] ],
+    "charges": 2
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
Bugfixes "Fix component distribution error false positives for a bunch of recipes"

#### Purpose of change

Some recipes complain about not being able to distribute components evenly, when they shouldn't care about that. As a result components are ignored and a default version of the item is produced.

#### Describe the solution

Component amounts are required to be divisible by `result_mult` value. Most recipes don't require `result_mult` functionality (multiply containers), so change them to `charges`.

#### Describe alternatives you've considered



#### Testing

I did this with a small script and checked the numbers on a few samples. The concept of changing result_mult to charges was tested in #67530.

#### Additional context

