### PR TITLE
Fix smoking racks delete calories

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5927,7 +5927,7 @@ static void smoker_finalize( Character &, const tripoint &examp, const time_poin
             } else {
                 it.calc_rot_while_processing( 6_hours );
 
-                item result( it.get_comestible()->smoking_result, start_time + 6_hours, it.charges );
+                item result( it.get_comestible()->smoking_result, start_time + 6_hours, it.count() );
 
                 // Set flag to tell set_relative_rot() to calc from bday not now
                 result.set_flag( flag_PROCESSING_RESULT );
@@ -5944,7 +5944,7 @@ static void smoker_finalize( Character &, const tripoint &examp, const time_poin
                     }
                     result.components.add( it );
                     // Smoking is always 1:1, so these must be equal for correct kcal/vitamin calculation.
-                    result.recipe_charges = it.charges;
+                    result.recipe_charges = it.count();
                     result.set_flag_recursive( flag_COOKED );
                 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Fix smoking racks delete calories of fishes and fruits

#### Purpose of change
Fixes #67411 
Fixes #67627 

#### Describe the solution

As [mqrause](https://github.com/mqrause) said
> Pretty sure that'd break when you save and load during smoking, because stuff can't have charges anymore. The issue is in `smoker_finalize`, which still assumes charges exist.


If the problem is in `finalize` still assumes charges exist, so I try another method for finalize result, 
https://github.com/CleverRaven/Cataclysm-DDA/blob/3a3d124fce4699c680175298a29c8c4c2600f0c3/src/iexamine.cpp#L5930
to ` item result( it.get_comestible()->smoking_result, start_time + 6_hours, it.count() ); `
https://github.com/CleverRaven/Cataclysm-DDA/blob/3a3d124fce4699c680175298a29c8c4c2600f0c3/src/iexamine.cpp#L5947
to ` result.recipe_charges = it.count(); `

#### Describe alternatives you've considered

N/A

#### Testing

Testing with dehydrated fruits, and dehydrated fishes, both test from loading the save during smoking.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/65117312/539ee128-1482-4829-a6d0-61f69309b67a)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/65117312/0698811e-6b29-43fd-8b1b-fd913be0ae5f)

#### Additional context

N/A
