### PR TITLE
fix smoking racks delete calories

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5927,7 +5927,7 @@ static void smoker_finalize( Character &, const tripoint &examp, const time_poin
             } else {
                 it.calc_rot_while_processing( 6_hours );
 
-                item result( it.get_comestible()->smoking_result, start_time + 6_hours, it.charges );
+                item result( it.get_comestible()->smoking_result, start_time + 6_hours, it.count() );
 
                 // Set flag to tell set_relative_rot() to calc from bday not now
                 result.set_flag( flag_PROCESSING_RESULT );
@@ -5944,7 +5944,7 @@ static void smoker_finalize( Character &, const tripoint &examp, const time_poin
                     }
                     result.components.add( it );
                     // Smoking is always 1:1, so these must be equal for correct kcal/vitamin calculation.
-                    result.recipe_charges = it.charges;
+                    result.recipe_charges = it.count();
                     result.set_flag_recursive( flag_COOKED );
                 }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -5927,7 +5927,10 @@ static void smoker_finalize( Character &, const tripoint &examp, const time_poin
             } else {
                 it.calc_rot_while_processing( 6_hours );
 
-                item result( it.get_comestible()->smoking_result, start_time + 6_hours, it.count() );
+                item result( it.get_comestible()->smoking_result, start_time + 6_hours );
+                if( it.count_by_charges() ) {
+                    result.charges = it.charges;
+                }
 
                 // Set flag to tell set_relative_rot() to calc from bday not now
                 result.set_flag( flag_PROCESSING_RESULT );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Smoking racks delete calories of fishes and fruits"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #67411 
Fixes #67627 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
As [mqrause](https://github.com/mqrause) said
> Pretty sure that'd break when you save and load during smoking, because stuff can't have charges anymore. The issue is in `smoker_finalize`, which still assumes charges exist.


If the problem is in `finalize` still assumes charges exist, so I try another method for finalize result, 
https://github.com/CleverRaven/Cataclysm-DDA/blob/3a3d124fce4699c680175298a29c8c4c2600f0c3/src/iexamine.cpp#L5930
to ` item result( it.get_comestible()->smoking_result, start_time + 6_hours, it.count() ); `
https://github.com/CleverRaven/Cataclysm-DDA/blob/3a3d124fce4699c680175298a29c8c4c2600f0c3/src/iexamine.cpp#L5947
to ` result.recipe_charges = it.count(); `
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Testing with dehydrated fruits, and dehydrated fishes, both test from loading the save during smoking.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/65117312/539ee128-1482-4829-a6d0-61f69309b67a)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/65117312/0698811e-6b29-43fd-8b1b-fd913be0ae5f)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I see the bot's comment, so I make a new pull request for standards, This is the first time for me, hope for forgiveness.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->