### PR TITLE
fix: correct data fetching in ci workflow

### DIFF
--- a/.github/workflows/label-first-time-contributor.yml
+++ b/.github/workflows/label-first-time-contributor.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  ISSUE_NUMBER: ${{ github.event.issue.number }}
+  PR_NUMBER: ${{ github.event.pull_request.number }}
 
 jobs:
   triage:
@@ -18,7 +18,7 @@ jobs:
       - name: Check if user has any merged PRs in this reposiory
         id: pr-check
         run: |
-          author=$(jq -r '.pull_request.user.login' $GITHUB_EVENT_PATH)
+          author="${{ github.event.pull_request.user.login }}"
           pr_count=$(gh pr list --state merged --author $author --json number | jq 'length')
 
           echo "Debug: $author with $pr_count merged PRs."
@@ -27,4 +27,4 @@ jobs:
       - name: Label contributors with no merged PRs
         if: steps.pr-check.outputs.pr_count == 0
         run: |
-          gh issue edit "$ISSUE_NUMBER" --add-label "new contributor"
+          gh pr edit "$PR_NUMBER" --add-label "new contributor"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
right, after the live test of the new contributor sorter workflow I could see that my logic was correct but my data and commands were wrong

tl;dr I referenced 'issue' where is should have referenced 'pull_request' or 'pr' -- these are used for data fetching, if you mix them up github would just tell you it does not know what you are talking about

also **please** whoever merges this, this needs an existing `new contributor` label to work correctly, please and thank you


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
a test pr for you
https://github.com/casswedson/issue-labeling/pull/39
the workflow run
https://github.com/casswedson/issue-labeling/actions/runs/5848169031/job/15855173545?pr=39
and the workflow file responsible for the run
https://github.com/casswedson/issue-labeling/actions/runs/5848169031/workflow?pr=39
there is one difference, but it is there so I am able to test, for debug reasons
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
