### PR TITLE
Conditional nest predecessor check for subway and trail map unhardcoding

### DIFF
--- a/doc/MAPGEN.md
+++ b/doc/MAPGEN.md
@@ -1141,7 +1141,7 @@ an `update_mapgen`, as normal mapgen can just specify the terrain directly.
 
 ### Spawn nested chunks based on overmap neighbors with "place_nested"
 
-Place_nested allows for limited conditional spawning of chunks based on the `"id"`s of their overmap neighbors and the joins that were used in placing a mutable overmap special.  This is useful for creating smoother transitions between biome types or to dynamically create walls at the edges of a mutable structure.
+Place_nested allows for conditional spawning of chunks based on the `"id"`s and/or flags of their overmap neighbors, the joins that were used in placing a mutable overmap special or the maps' predecessors.  This is useful for creating smoother transitions between biome types or to dynamically create walls at the edges of a mutable structure.
 
 | Field              | Description
 | ---                | ---
@@ -1151,6 +1151,7 @@ Place_nested allows for limited conditional spawning of chunks based on the `"id
 | joins              | (optional) Any mutable overmap special joins that should be checked before placing the chunk.  Each direction is associated with a list of join `"id"` strings.
 | flags              | (optional) Any overmap terrain flags that should be checked before placing the chunk.  Each direction is associated with a list of `oter_flags` flags.
 | flags_any          | (optional) Identical to flags except only requires a single direction to pass.  Useful to check if there's at least one of a flag in cardinal or orthoganal directions etc.
+| predecessors       | (optional) Any of the maps' predecessors that should be checked before placing the chunk. Only useful if using fallback_predecessor_mapgen.
 
 
 The adjacent overmaps which can be checked in this manner are:
@@ -1168,7 +1169,8 @@ Example:
     { "chunks": [ "nest2" ], "x": 0, "y": 0, "neighbors": { "north": [ { "om_terrain": "fort", "om_terrain_match_type": "PREFIX" }, "mansion" ] } },
     { "chunks": [ "nest3" ], "x": 0, "y": 0, "joins": { "north": [ "interior_to_exterior" ] } },
     { "chunks": [ "nest4" ], "x": 0, "y": 0, "flags": { "north": [ "RIVER" ] }, "flags_any": { "north_east": [ "RIVER" ], "north_west": [ "RIVER" ] } },
-    { "else_chunks": [ "nest5" ], "x": 0, "y": 0, "flags": { "north_west": [ "RIVER", "LAKE", "LAKE_SHORE" ] } }
+    { "else_chunks": [ "nest5" ], "x": 0, "y": 0, "flags": { "north_west": [ "RIVER", "LAKE", "LAKE_SHORE" ] } },
+    { "chunks": [ "nest6" ], "x": 0, "y": 0, "predecessors": [ "field", { "om_terrain": "river", "om_terrain_match_type": "PREFIX" } ] }
   ],
 ```
 The code excerpt above will place chunks as follows:
@@ -1177,6 +1179,7 @@ The code excerpt above will place chunks as follows:
 * `"nest3"` if the join `"interior_to_exterior"` was used to the north during mutable overmap placement.
 * `"nest4"` if the north neighboring overmap terrain has a flag `"RIVER"` and either of the north east or north west neighboring overmap terrains have a `"RIVER"` flag.
 * `"nest5"` if the north west neighboring overmap terrain has neither the `"RIVER"`, `"LAKE"` nor `"LAKE_SHORE"` flags.
+* `"nest6"` if the there's a predecessor present of either `"field"` or any overmap with the prefix `"river"`.
 
 
 ### Place monster corpse from a monster group with "place_corpses"

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3599,6 +3599,40 @@ class jmapgen_nested : public jmapgen_piece
                     return neighbors.empty();
                 }
         };
+        
+        class predecessor_oter_check
+        {
+            private:
+                cata::flat_set<std::pair<std::string, ot_match_type>> allowed_predecessors;
+            public:
+                explicit predecessor_oter_check( const JsonArray &jarr ) {
+                    for( const JsonValue entry : jarr ) {
+                        std::pair<std::string, ot_match_type> allowed_predecessor;
+                        if( entry.test_string() ) {
+                            allowed_predecessor.first = entry.get_string();
+                            allowed_predecessor.second = ot_match_type::contains;
+                        } else {
+                            JsonObject jo = entry.get_object();
+                            allowed_predecessor.first = jo.get_string( "om_terrain" );
+                            allowed_predecessor.second = jo.get_enum_value<ot_match_type>( "om_terrain_match_type",
+                                                  ot_match_type::contains );
+                        }
+                        allowed_predecessors.insert( allowed_predecessor );
+                    }
+                }
+
+                bool test( const mapgendata &dat ) const {
+                    const std::vector<oter_id> predecessors = dat.get_predecessors();
+                    for( const std::pair<std::string, ot_match_type> &allowed_predecessor : allowed_predecessors ) {
+                        for( const oter_id &predecessor : predecessors ) {
+                            if ( is_ot_match( allowed_predecessor.first, predecessor, allowed_predecessor.second ) ) {
+                                return true;
+                            }
+                        }
+                    }
+                    return allowed_predecessors.empty();
+                }
+        };
 
     public:
         weighted_int_list<mapgen_value<nested_mapgen_id>> entries;
@@ -3607,11 +3641,13 @@ class jmapgen_nested : public jmapgen_piece
         neighbor_join_check neighbor_joins;
         neighbor_flag_check neighbor_flags;
         neighbor_flag_any_check neighbor_flags_any;
+        predecessor_oter_check predecessors;
         jmapgen_nested( const JsonObject &jsi, const std::string_view/*context*/ )
             : neighbor_oters( jsi.get_object( "neighbors" ) )
             , neighbor_joins( jsi.get_object( "joins" ) )
             , neighbor_flags( jsi.get_object( "flags" ) )
-            , neighbor_flags_any( jsi.get_object( "flags_any" ) ) {
+            , neighbor_flags_any( jsi.get_object( "flags_any" ) )
+            , predecessors( jsi.get_array( "predecessors" ) ) {
             if( jsi.has_member( "chunks" ) ) {
                 load_weighted_list( jsi.get_member( "chunks" ), entries, 100 );
             }
@@ -3652,7 +3688,7 @@ class jmapgen_nested : public jmapgen_piece
         const weighted_int_list<mapgen_value<nested_mapgen_id>> &get_entries(
         const mapgendata &dat ) const {
             if( neighbor_oters.test( dat ) && neighbor_joins.test( dat ) && neighbor_flags.test( dat ) &&
-                neighbor_flags_any.test( dat ) ) {
+                neighbor_flags_any.test( dat ) && predecessors.test( dat ) ) {
                 return entries;
             } else {
                 return else_entries;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -3599,7 +3599,6 @@ class jmapgen_nested : public jmapgen_piece
                     return neighbors.empty();
                 }
         };
-        
         class predecessor_oter_check
         {
             private:
@@ -3615,7 +3614,7 @@ class jmapgen_nested : public jmapgen_piece
                             JsonObject jo = entry.get_object();
                             allowed_predecessor.first = jo.get_string( "om_terrain" );
                             allowed_predecessor.second = jo.get_enum_value<ot_match_type>( "om_terrain_match_type",
-                                                  ot_match_type::contains );
+                                                         ot_match_type::contains );
                         }
                         allowed_predecessors.insert( allowed_predecessor );
                     }
@@ -3625,7 +3624,7 @@ class jmapgen_nested : public jmapgen_piece
                     const std::vector<oter_id> predecessors = dat.get_predecessors();
                     for( const std::pair<std::string, ot_match_type> &allowed_predecessor : allowed_predecessors ) {
                         for( const oter_id &predecessor : predecessors ) {
-                            if ( is_ot_match( allowed_predecessor.first, predecessor, allowed_predecessor.second ) ) {
+                            if( is_ot_match( allowed_predecessor.first, predecessor, allowed_predecessor.second ) ) {
                                 return true;
                             }
                         }

--- a/src/mapgendata.h
+++ b/src/mapgendata.h
@@ -185,6 +185,9 @@ class mapgendata
             // TODO: should be able to determine this from the map itself
             return zlevel_;
         }
+        std::vector<oter_id> get_predecessors() const {
+            return predecessors_;
+        }
 
         void set_dir( int dir_in, int val );
         void fill( int val );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Being able to test for underlying predecessors will allow me to select appropriate nests/foliage for trails in #67470 depending on whether they're in swamp/forest/forest_thick and also help with the way I want to do sub stations with a partial subway unhardcoding I'm doing

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds a check in the same vain as the others but that only checks the map itself rather than it's neighbors
Adds documentation

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked it worked using some simple nests like this one on road_straight `
"place_nested": [ { "chunks": [ "24x24_fence1" ], "x": 0, "y": 0, "predecessors": [ "field" ] } ]`
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/f06e0892-4941-48f9-ab0d-2ce25c399a49)
Also tested match type ( and that nests still spawn elsewhere >-< )

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
