### PR TITLE
Arcade machine emits dim light

### DIFF
--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -165,9 +165,9 @@
     "damage_modifier": 10,
     "damage_reduction": { "all": 10 },
     "durability": 80,
-    "flags": [ "OBSTACLE", "COVERED", "APPLIANCE", "ENABLED_DRAINS_EPOWER", "ARCADE", "CTRL_ELECTRONIC" ],
+    "flags": [ "OBSTACLE", "COVERED", "HALF_CIRCLE_LIGHT", "APPLIANCE", "ENABLED_DRAINS_EPOWER", "ARCADE", "CTRL_ELECTRONIC" ],
     "epower": "-150 W",
-    "light_emitted": 10,
+    "bonus": 10,
     "item": "arcade_machine",
     "looks_like": "f_arcade_machine",
     "breaks_into": [

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -167,7 +167,7 @@
     "durability": 80,
     "flags": [ "OBSTACLE", "COVERED", "APPLIANCE", "ENABLED_DRAINS_EPOWER", "ARCADE", "CTRL_ELECTRONIC" ],
     "epower": "-150 W",
-    "light_emitted": 4,
+    "light_emitted": 10,
     "item": "arcade_machine",
     "looks_like": "f_arcade_machine",
     "breaks_into": [

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -167,6 +167,7 @@
     "durability": 80,
     "flags": [ "OBSTACLE", "COVERED", "APPLIANCE", "ENABLED_DRAINS_EPOWER", "ARCADE", "CTRL_ELECTRONIC" ],
     "epower": "-150 W",
+    "light_emitted": 4,
     "item": "arcade_machine",
     "looks_like": "f_arcade_machine",
     "breaks_into": [


### PR DESCRIPTION
#### Summary
Balance "Arcade machine appliance provides cloudy light"

#### Purpose of change
Powered arcade machine does not output any light despite mostly being a display screen. Only cloudy light provided for adjacent squares in half-circle as IRL arcade machine monitors don't put out much light.

#### Describe the solution
'bonus' from floodlight code used to provide light, based on value of 'light_emitted' copied from f_console. HALF_CIRCLE_LIGHT flag used so light is directional based on appliance placement.

#### Describe alternatives you've considered

None.

#### Testing

Tested changes on older experimental, appears to work fine.

#### Additional context

https://old.reddit.com/r/cataclysmdda/comments/15q8ijl/arcade_machine_does_not_provide_light/
