### PR TITLE
minor cleanup of item spawning code

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -5229,26 +5229,6 @@ std::vector<item_group_id> Item_factory::get_all_group_names()
     return rval;
 }
 
-bool Item_factory::add_item_to_group( const item_group_id &group_id, const itype_id &item_id,
-                                      int chance )
-{
-    if( m_template_groups.find( group_id ) == m_template_groups.end() ) {
-        return false;
-    }
-    Item_spawn_data &group_to_access = *m_template_groups[group_id];
-    if( group_to_access.has_item( item_id ) ) {
-        group_to_access.remove_item( item_id );
-    }
-
-    Item_group *ig = dynamic_cast<Item_group *>( &group_to_access );
-    if( chance != 0 && ig != nullptr ) {
-        // Only re-add if chance != 0
-        ig->add_item_entry( item_id, chance );
-    }
-
-    return true;
-}
-
 void item_group::debug_spawn()
 {
     std::vector<item_group_id> groups = item_controller->get_all_group_names();

--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -166,16 +166,6 @@ class Item_factory
          * Returns the idents of all item groups that are known.
          */
         std::vector<item_group_id> get_all_group_names();
-        /**
-         * Sets the chance of the specified item in the group.
-         * @param group_id Group to add item to
-         * @param item_id Id of item to add to group
-         * @param chance The relative weight of the item. A value of 0 removes the item from the
-         * group.
-         * @return false if the group doesn't exist.
-         */
-        bool add_item_to_group( const item_group_id &, const itype_id &item_id, int chance );
-        /*@}*/
 
         /**
          * @name Item type loading

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -387,12 +387,10 @@ bool Single_item_creator::remove_item( const itype_id &itemid )
             type = S_NONE;
             return true;
         }
-    } else if( type == S_ITEM_GROUP ) {
-        Item_spawn_data *isd = item_controller->get_group( item_group_id( id ) );
-        if( isd != nullptr ) {
-            isd->remove_item( itemid );
-        }
     }
+    // This part of code is currently only used in Item_factory::finalize_item_blacklist(), not during the game.
+    // Else if type == S_ITEM_GROUP, the group must have been indexed in m_template_groups,
+    // and finalize_item_blacklist() will deal with it, so no need to find it and call its remove_item().
     return type == S_NONE;
 }
 
@@ -407,12 +405,10 @@ void Single_item_creator::replace_items( const std::unordered_map<itype_id, ityp
         if( it != replacements.end() ) {
             id = it->second.str();
         }
-    } else if( type == S_ITEM_GROUP ) {
-        Item_spawn_data *isd = item_controller->get_group( item_group_id( id ) );
-        if( isd != nullptr ) {
-            isd->replace_items( replacements );
-        }
     }
+    // This part of code is currently only used in Item_factory::finalize_item_blacklist(), not during the game.
+    // Else if type == S_ITEM_GROUP, the group must have been indexed in m_template_groups,
+    // and finalize_item_blacklist() will deal with it, so no need to find it and call its replace_items().
 }
 
 bool Single_item_creator::has_item( const itype_id &itemid ) const


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
1. Remove some dead code.
2. Speed up basic build and test by reducing duplicate calls to remove_item() and replace_items(). 

It takes around 3 minutes to run `./tests/cata_test '~*' --mods=dda,mindovermatter,Mythos-Creatures,ruralbiome,MA,Tamable_Wildlife,no_hope,generic_guns,no_fungal_growth,deadly_bites,sees_player_retro,blazeindustries,megafauna,personal_portal_storms,speedydex,alt_map_key,DinoMod,no_npc_food,my_sweet_cataclysm,No_Rail_Stations,stats_through_kills,MMA,xedra_evolved,translate_dialogue,StatsThroughSkills,crazy_cataclysm,cbm_slots,magiclysm,sees_player_hitbutton,bombastic_perks,standard_combat_test,tropicata,package_bionic_professions,extra_mut_scens,Only_Wildlife` locally. It turns out that blacklisting items takes up the most of time.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
For single_item_creator whose type is S_ITEM_GROUP, do not lookup the corresponding itemgroup and call remove. No need to do so because all itemgroups that can be looked up are also processed by finalize_item_blacklist().
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tests passed.

Created a world with generic guns, confirmed that the mod is still taking effect.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
