### PR TITLE
Balance nether waves in Defense Mode

### DIFF
--- a/data/mods/Defense_Mode/eocs.json
+++ b/data/mods/Defense_Mode/eocs.json
@@ -258,7 +258,7 @@
     "condition": { "math": [ "subspace_allowed", "==", "1" ] },
     "effect": [
       {
-        "u_spawn_monster": "GROUP_NETHER",
+        "u_spawn_monster": "GROUP_NETHER_DM",
         "real_count": { "global_val": "wave_number", "default": 1 },
         "outdoor_only": true,
         "group": true,
@@ -266,7 +266,7 @@
         "max_radius": 40
       },
       {
-        "u_spawn_monster": "GROUP_NETHER",
+        "u_spawn_monster": "GROUP_NETHER_DM",
         "real_count": { "global_val": "wave_number", "default": 1 },
         "outdoor_only": true,
         "group": true,
@@ -274,7 +274,7 @@
         "max_radius": 40
       },
       {
-        "u_spawn_monster": "GROUP_NETHER",
+        "u_spawn_monster": "GROUP_NETHER_DM",
         "real_count": { "global_val": "wave_number", "default": 1 },
         "outdoor_only": true,
         "group": true,

--- a/data/mods/Defense_Mode/monstergroups.json
+++ b/data/mods/Defense_Mode/monstergroups.json
@@ -18,5 +18,17 @@
       { "monster": "mon_skitterbot", "weight": 220, "cost_multiplier": 0 },
       { "monster": "mon_molebot", "weight": 40, "cost_multiplier": 0 }
     ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_NETHER_DM",
+    "default": "mon_blank",
+    "monsters": [
+      { "monster": "mon_blank", "weight": 135, "cost_multiplier": 0 },
+      { "monster": "mon_flying_polyp", "weight": 5, "cost_multiplier": 0 },
+      { "monster": "mon_yugg", "weight": 10, "cost_multiplier": 0 },
+      { "monster": "mon_kreck", "weight": 210, "cost_multiplier": 0 },
+      { "monster": "mon_gozu", "weight": 5, "cost_multiplier": 0 }
+    ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Make nether waves easier in Defense Mode."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Nether waves could be extremely powerful and easily kill early game players, so this fixes that.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a new monster group based on `NETHER` and remove some ultra-hard and passive monsters from spawn pools.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this, or gating some really hard monsters behind time or boss waves.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Went into the game, and manually activated some waves. Nothing I removed spawned.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
