### PR TITLE
Rearranged main menu to show Tutorial on top level

### DIFF
--- a/src/enums.h
+++ b/src/enums.h
@@ -150,7 +150,6 @@ struct enum_traits<ot_match_type> {
 enum class special_game_type : int {
     NONE = 0,
     TUTORIAL,
-    DEFENSE,
     NUM_SPECIAL_GAME_TYPES
 };
 

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -54,7 +54,7 @@ enum class main_menu_opts : int {
     NEWCHAR,
     LOADCHAR,
     WORLD,
-    SPECIAL,
+    TUTORIAL,
     SETTINGS,
     HELP,
     CREDITS,
@@ -171,17 +171,6 @@ void main_menu::display_sub_menu( int sel, const point &bottom_left, int sel_lin
             //~ Message Of The Day
             display_text( mmenu_motd, _( "MOTD" ), sel_line );
             return;
-        case main_menu_opts::SPECIAL:
-            for( int i = 1; i < static_cast<int>( special_game_type::NUM_SPECIAL_GAME_TYPES ); i++ ) {
-                std::string spec_name = special_game_name( static_cast<special_game_type>( i ) );
-                nc_color clr = i == sel2 ? hilite( c_yellow ) : c_yellow;
-                sub_opts.push_back( shortcut_text( clr, spec_name ) );
-                int len = utf8_width( shortcut_text( clr, spec_name ), true );
-                if( len > xlen ) {
-                    xlen = len;
-                }
-            }
-            break;
         case main_menu_opts::SETTINGS:
             for( int i = 0; static_cast<size_t>( i ) < vSettingsSubItems.size(); ++i ) {
                 nc_color clr = i == sel2 ? hilite( c_yellow ) : c_yellow;
@@ -457,7 +446,7 @@ void main_menu::init_strings()
     vMenuItems.emplace_back( pgettext( "Main Menu", "<N|n>ew Game" ) );
     vMenuItems.emplace_back( pgettext( "Main Menu", "Lo<a|A>d" ) );
     vMenuItems.emplace_back( pgettext( "Main Menu", "<W|w>orld" ) );
-    vMenuItems.emplace_back( pgettext( "Main Menu", "<S|s>pecial" ) );
+    vMenuItems.emplace_back( pgettext( "Main Menu", "T<u|U>torial Game" ) );
     vMenuItems.emplace_back( pgettext( "Main Menu", "Se<t|T>tings" ) );
     vMenuItems.emplace_back( pgettext( "Main Menu", "H<e|E|?>lp" ) );
     vMenuItems.emplace_back( pgettext( "Main Menu", "<C|c>redits" ) );
@@ -776,9 +765,7 @@ bool main_menu::opening_screen()
                 case main_menu_opts::SETTINGS:
                     max_item_count = vSettingsSubItems.size();
                     break;
-                case main_menu_opts::SPECIAL:
-                    max_item_count = static_cast<int>( special_game_type::NUM_SPECIAL_GAME_TYPES ) - 1;
-                    break;
+                case main_menu_opts::TUTORIAL:
                 case main_menu_opts::HELP:
                 case main_menu_opts::QUIT:
                 default:
@@ -805,19 +792,19 @@ bool main_menu::opening_screen()
                     break;
                 case main_menu_opts::QUIT:
                     return false;
-                case main_menu_opts::SPECIAL:
+                case main_menu_opts::TUTORIAL:
                     if( MAP_SHARING::isSharing() ) {
                         on_error();
-                        popup( _( "Special games don't work with shared maps." ) );
-                    } else if( sel2 >= 0 && sel2 < static_cast<int>( special_game_type::NUM_SPECIAL_GAME_TYPES ) - 1 ) {
+                        popup( _( "Tutorial doesn't work with shared maps." ) );
+                    } else {
                         on_out_of_scope cleanup( [&player_character]() {
                             g->gamemode.reset();
                             player_character = avatar();
                             world_generator->set_active_world( nullptr );
                         } );
-                        g->gamemode = get_special_game( static_cast<special_game_type>( sel2 + 1 ) );
+                        g->gamemode = get_special_game( special_game_type::TUTORIAL );
                         // check world
-                        WORLD *world = world_generator->make_new_world( static_cast<special_game_type>( sel2 + 1 ) );
+                        WORLD *world = world_generator->make_new_world( special_game_type::TUTORIAL );
                         if( world == nullptr ) {
                             break;
                         }

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -808,6 +808,8 @@ bool main_menu::opening_screen()
                         if( world == nullptr ) {
                             break;
                         }
+                        world->active_mod_order.clear();
+                        world->active_mod_order.emplace_back( mod_id( "dda" ) );
                         world_generator->set_active_world( world );
                         try {
                             g->setup();

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -3278,11 +3278,6 @@ void overmap::generate( const overmap *north, const overmap *east,
                         const overmap *south, const overmap *west,
                         overmap_special_batch &enabled_specials )
 {
-    if( g->gametype() == special_game_type::DEFENSE ) {
-        dbg( D_INFO ) << "overmap::generate skipped in Defense special game mode!";
-        return;
-    }
-
     dbg( D_INFO ) << "overmap::generate start…";
 
     const std::string overmap_pregenerated_path =

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -259,9 +259,6 @@ WORLD *worldfactory::make_new_world( special_game_type special_type )
         case special_game_type::TUTORIAL:
             worldname = "TUTORIAL";
             break;
-        case special_game_type::DEFENSE:
-            worldname = "DEFENSE";
-            break;
         default:
             return nullptr;
     }


### PR DESCRIPTION
#### Summary
Interface "Show Tutorial on top level in main menu"

#### Purpose of change
More visibility for tutorial.
Also fixes #51413

#### Describe the solution

Removed remaining code references to DEFENSE game mode and moved TUTORIAL game mode to top level.
Use only `dda` mod in tutorial.

#### Describe alternatives you've considered

We should eventually get rid of hardcoded special game modes and move tutorial to EOC driven mod, that can be updated more easily.

#### Testing
Run tutorial from main menu.

#### Additional context

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/16213433/9e2bafb9-19b4-4d8d-99b9-542971848ab2)
