### PR TITLE
Add ETERNAL_TIME_OF_DAY to the list of external options

### DIFF
--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -372,6 +372,13 @@
   },
   {
     "type": "EXTERNAL_OPTION",
+    "name": "ETERNAL_TIME_OF_DAY",
+    "info": "Sets eternal day or night.  Possible values are 'normal', 'day', or 'night'.",
+    "stype": "string_input",
+    "value": "normal"
+  },
+  {
+    "type": "EXTERNAL_OPTION",
     "name": "SHOW_MUTATION_SELECTOR",
     "info": "When mutating, displays a menu which allows players to pick from a list of possible mutations.",
     "stype": "bool",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

#### Purpose of change

Add ETERNAL_TIME_OF_DAY to the list of external options, to document it.
Maybe it's normal that it's not there because it's actual an option that can be tweaked from within the game and putting it there will mess that up
#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
