### PR TITLE
Cleanup autogenerated prefix.h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1032,7 +1032,7 @@ clean: clean-tests clean-object_creator clean-pch
 	rm -rf *$(TILES_TARGET_NAME).exe *$(TARGET_NAME).exe *$(TARGET_NAME).a
 	rm -rf *obj *objwin
 	rm -rf *$(BINDIST_DIR) *cataclysmdda-*.tar.gz *cataclysmdda-*.zip
-	rm -f $(SRC_DIR)/version.h
+	rm -f $(SRC_DIR)/version.h $(SRC_DIR)/prefix.h
 	rm -f $(CHKJSON_BIN)
 	rm -f $(TEST_MO)
 


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Running `make clean` after a build left behind the autogenerated file `src/prefix.h`.

#### Describe the solution

Remove file in clean target.