### PR TITLE
adjust spawns of sulfur powder and red phosphorous powder

### DIFF
--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -222,7 +222,7 @@
       { "prob": 16, "group": "chem_citric_acid_bottle_glass_100_inf" },
       { "item": "denat_alcohol", "prob": 6, "charges-min": 250 },
       { "item": "methed_alcohol", "prob": 4, "charges-min": 250 },
-      { "item": "red_phosphorous", "prob": 10 },
+      { "item": "red_phosphorous", "prob": 10, "charges": [ 100, 1200 ] },
       { "item": "acetic_anhydride", "prob": 8 },
       { "item": "iodine_crystal", "prob": 12 }
     ]
@@ -571,7 +571,7 @@
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",
     "container-item": "bottle_plastic_small",
-    "entries": [ { "item": "chem_sulphur", "container-item": "null", "charges-min": 100 } ]
+    "entries": [ { "item": "chem_sulphur", "container-item": "null", "charges": [ 100, 1500 ] } ]
   },
   {
     "type": "item_group",

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -1943,12 +1943,12 @@
     "weight": "100 mg",
     "volume": "5 ml",
     "//": "Density around 2.2g/cm3, but since it's a powder, it's a bit lower, around 1.8-2.0 g/cm3",
-    "container": "bag_plastic",
+    "container": "bottle_plastic_small",
     "symbol": "=",
     "color": "red",
     "price": 50,
     "price_postapoc": 2,
-    "count": 10000,
+    "count": 1000,
     "stack_size": 25
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "correct two spawns of lab chemicals"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Red phosphorous was spawning in too great of quantities and sulfur powder too few. Red phosphorous spawned in 2-3kg bags, and while commercially it is potentially sold in high quantities in the kg it was spawning in too high values due to the size limit of a plastic bag. This is more of a balance thing but I felt the # of pipebombs you could make per bag was a little high (maybe those need to use more though). Sulfur also had a charges-min of 100 but only ever spawned as 100 even though I've seen other examples of charges-min meaning it spawns anywhere from the min to the max available container space.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make red phosphorous use a small plastic bottle. It spawns up to the maximum size of that bottle. Sulfur powder likewise, though it already used a small bottle.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
different bottle sizes.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
