### PR TITLE
Consume comestible meds that aren't count_by_charges

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6100,7 +6100,8 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
     if( used_tool->has_flag( flag_SINGLE_USE ) ) {
         it.remove_item();
     } else if( used_tool->is_medication() ) {
-        if( it->use_charges( it->typeId(), charges_consumed, used, it.position() ) ) {
+        if( !it->count_by_charges() ||
+            it->use_charges( it->typeId(), charges_consumed, used, it.position() ) ) {
             it.remove_item();
         }
     } else if( used_tool->is_tool() ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #67519

#### Describe the solution

Remove comestible meds even if they're not count_by_charges.

#### Describe alternatives you've considered

Adding the `SINGLE_USE` flag to all the meds, but if they're comestibles, I think they're supposed to be consumed anyway.

#### Testing

Used hemostatic powder, bandages and liquid bandages to fix bleeding and all were consumed as expected.

#### Additional context

