### PR TITLE
"om_terrain_match_type": "SUBTYPE"

### DIFF
--- a/data/json/mapgen/road.json
+++ b/data/json/mapgen/road.json
@@ -99,27 +99,13 @@
           "chunks": [ "3x3_road_corner_se" ],
           "x": 1,
           "y": 21,
-          "neighbors": {
-            "south_west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
-          }
+          "neighbors": { "south_west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ] }
         },
         {
           "chunks": [ "3x3_road_corner_sw" ],
           "x": 20,
           "y": 21,
-          "neighbors": {
-            "south_east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
-          }
+          "neighbors": { "south_east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ] }
         },
         { "chunks": [ "24x24_road_trash" ], "x": 0, "y": 0 },
         { "chunks": [ "24x24_street_lights_end_straight" ], "x": 0, "y": 0 },
@@ -220,18 +206,8 @@
           "x": 1,
           "y": 0,
           "neighbors": {
-            "north_west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "north": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "north_west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "north": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -239,18 +215,8 @@
           "x": 20,
           "y": 0,
           "neighbors": {
-            "north_east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "north": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "north_east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "north": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -258,18 +224,8 @@
           "x": 1,
           "y": 21,
           "neighbors": {
-            "south_west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "south": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "south_west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "south": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -277,18 +233,8 @@
           "x": 20,
           "y": 21,
           "neighbors": {
-            "south_east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "south": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "south_east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "south": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         { "chunks": [ "24x24_road_trash" ], "x": 0, "y": 0 },
@@ -320,24 +266,15 @@
           "neighbors": {
             "east": [
               { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "south_east": [
               { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "south": [
               { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         },
@@ -348,24 +285,15 @@
           "neighbors": {
             "east": [
               { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "south_east": [
               { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "south": [
               { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         }
@@ -385,27 +313,13 @@
           "chunks": [ "24x24_road_curved_diagonal" ],
           "x": 0,
           "y": 0,
-          "neighbors": {
-            "east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
-          }
+          "neighbors": { "east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ] }
         },
         {
           "else_chunks": [ "road_curved_bend_not_connected_bend_east" ],
           "x": 0,
           "y": 0,
-          "neighbors": {
-            "east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
-          }
+          "neighbors": { "east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ] }
         }
       ]
     }
@@ -422,27 +336,13 @@
           "chunks": [ "24x24_road_curved_diagonal" ],
           "x": 0,
           "y": 0,
-          "neighbors": {
-            "south": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
-          }
+          "neighbors": { "south": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ] }
         },
         {
           "else_chunks": [ "24x24_road_curved_curvy" ],
           "x": 0,
           "y": 0,
-          "neighbors": {
-            "south": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
-          }
+          "neighbors": { "south": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ] }
         }
       ]
     }
@@ -558,27 +458,13 @@
           "chunks": [ "3x3_road_corner_se" ],
           "x": 21,
           "y": 1,
-          "neighbors": {
-            "east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
-          }
+          "neighbors": { "east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ] }
         },
         {
           "chunks": [ "3x3_road_corner_se" ],
           "x": 1,
           "y": 21,
-          "neighbors": {
-            "south": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
-          }
+          "neighbors": { "south": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ] }
         },
         { "chunks": [ "24x24_road_trash" ], "x": 0, "y": 0 },
         { "chunks": [ "24x24_road_zombies" ], "x": 0, "y": 0 },
@@ -696,18 +582,8 @@
           "x": 1,
           "y": 21,
           "neighbors": {
-            "south_west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "south": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "south_west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "south": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -715,18 +591,8 @@
           "x": 20,
           "y": 21,
           "neighbors": {
-            "south_east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "south": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "south_east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "south": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -734,18 +600,8 @@
           "x": 21,
           "y": 20,
           "neighbors": {
-            "south_east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "south_east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -753,18 +609,8 @@
           "x": 0,
           "y": 20,
           "neighbors": {
-            "south_west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "south_west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -772,18 +618,8 @@
           "x": 21,
           "y": 1,
           "neighbors": {
-            "north_east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "north_east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -791,18 +627,8 @@
           "x": 0,
           "y": 1,
           "neighbors": {
-            "north_west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "north_west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -968,36 +794,20 @@
           "y": 0,
           "neighbors": {
             "north": [
-              { "om_terrain": "road_ns", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_ew", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_straight", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "east": [
-              { "om_terrain": "road_ns", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_ew", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_straight", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "south": [
-              { "om_terrain": "road_ns", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_ew", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_straight", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "west": [
-              { "om_terrain": "road_ns", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_ew", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_straight", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         },
@@ -1007,36 +817,20 @@
           "y": 0,
           "neighbors": {
             "north": [
-              { "om_terrain": "road_ns", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_ew", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_straight", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "east": [
-              { "om_terrain": "road_ns", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_ew", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_straight", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "south": [
-              { "om_terrain": "road_ns", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_ew", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_straight", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "west": [
-              { "om_terrain": "road_ns", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_ew", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_straight", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         }
@@ -1092,18 +886,8 @@
           "x": 1,
           "y": 0,
           "neighbors": {
-            "north_west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "north": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "north_west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "north": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -1111,18 +895,8 @@
           "x": 20,
           "y": 0,
           "neighbors": {
-            "north_east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "north": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "north_east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "north": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -1130,18 +904,8 @@
           "x": 1,
           "y": 21,
           "neighbors": {
-            "south_west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "south": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "south_west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "south": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -1149,18 +913,8 @@
           "x": 20,
           "y": 21,
           "neighbors": {
-            "south_east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "south": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "south_east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "south": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -1168,18 +922,8 @@
           "x": 21,
           "y": 20,
           "neighbors": {
-            "south_east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "south_east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -1187,18 +931,8 @@
           "x": 0,
           "y": 20,
           "neighbors": {
-            "south_west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "south_west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -1206,18 +940,8 @@
           "x": 21,
           "y": 1,
           "neighbors": {
-            "north_east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "north_east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {
@@ -1225,18 +949,8 @@
           "x": 0,
           "y": 1,
           "neighbors": {
-            "north_west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
-            "west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ]
+            "north_west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
+            "west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ]
           }
         },
         {

--- a/data/json/mapgen/road.json
+++ b/data/json/mapgen/road.json
@@ -265,15 +265,15 @@
           "y": 0,
           "neighbors": {
             "east": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
               { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "south_east": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
               { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "south": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
               { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
@@ -284,15 +284,15 @@
           "y": 0,
           "neighbors": {
             "east": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
               { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "south_east": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
               { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "south": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
               { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
@@ -636,25 +636,14 @@
           "x": 0,
           "y": 0,
           "neighbors": {
-            "east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
+            "east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
             "south_east": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "south": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         },
@@ -663,25 +652,14 @@
           "x": 0,
           "y": 0,
           "neighbors": {
-            "south": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
+            "south": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
             "south_east": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "east": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         },
@@ -690,25 +668,14 @@
           "x": 0,
           "y": 0,
           "neighbors": {
-            "south": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
+            "south": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
             "south_west": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "west": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         },
@@ -717,25 +684,14 @@
           "x": 0,
           "y": 0,
           "neighbors": {
-            "west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
+            "west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
             "south_west": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "south": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         },
@@ -958,25 +914,14 @@
           "x": 0,
           "y": 0,
           "neighbors": {
-            "north": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
+            "north": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
             "north_east": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "east": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         },
@@ -985,25 +930,14 @@
           "x": 0,
           "y": 0,
           "neighbors": {
-            "north": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
+            "north": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
             "north_west": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "west": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         },
@@ -1012,25 +946,14 @@
           "x": 0,
           "y": 0,
           "neighbors": {
-            "east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
+            "east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
             "north_east": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "north": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         },
@@ -1039,25 +962,14 @@
           "x": 0,
           "y": 0,
           "neighbors": {
-            "east": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
+            "east": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
             "south_east": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "south": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         },
@@ -1066,25 +978,14 @@
           "x": 0,
           "y": 0,
           "neighbors": {
-            "south": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
+            "south": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
             "south_east": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "east": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         },
@@ -1093,25 +994,14 @@
           "x": 0,
           "y": 0,
           "neighbors": {
-            "south": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
+            "south": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
             "south_west": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "west": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         },
@@ -1120,25 +1010,14 @@
           "x": 0,
           "y": 0,
           "neighbors": {
-            "west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
+            "west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
             "north_west": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "north": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         },
@@ -1147,25 +1026,14 @@
           "x": 0,
           "y": 0,
           "neighbors": {
-            "west": [
-              { "om_terrain": "road_ne", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_es", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_sw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_wn", "om_terrain_match_type": "EXACT" }
-            ],
+            "west": [ { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ],
             "south_west": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ],
             "south": [
-              { "om_terrain": "road_nesw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_new", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nes", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_nsw", "om_terrain_match_type": "EXACT" },
-              { "om_terrain": "road_esw", "om_terrain_match_type": "EXACT" }
+              { "om_terrain": "road_four_way", "om_terrain_match_type": "SUBTYPE" },
+              { "om_terrain": "road_tee", "om_terrain_match_type": "SUBTYPE" }
             ]
           }
         },

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -5394,6 +5394,10 @@ If it is an object - it has following attributes:
 * `TYPE` - The provided string must completely match the base type id of the
   overmap terrain id, which means that suffixes for rotation and linear terrain
   types are ignored.
+ 
+* `SUBTYPE` - The provided string must completely match the base type id of the
+  overmap terrain id as well as the linear terrain type ie "road_curved" will match
+  "road_ne", "road_es", "road_sw" and "road_wn".
 
 * `PREFIX` - The provided string must be a complete prefix (with additional
   parts delimited by an underscore) of the overmap terrain id. For example,

--- a/doc/MAPGEN.md
+++ b/doc/MAPGEN.md
@@ -1147,7 +1147,7 @@ Place_nested allows for conditional spawning of chunks based on the `"id"`s and/
 | ---                | ---
 | chunks/else_chunks | (required, string) the nested_mapgen_id of the chunk that will be conditionally placed. Chunks are placed if the specified neighbor matches, and "else_chunks" otherwise.
 | x and y            | (required, int) the cardinal position in which the chunk will be placed.
-| neighbors          | (optional) Any of the neighboring overmaps that should be checked before placing the chunk.  Each direction is associated with a list of overmap `"id"` substrings.  See [JSON_INFO.md](JSON_INFO.md#Starting-locations) "terrain" section to do more advanced searches.
+| neighbors          | (optional) Any of the neighboring overmaps that should be checked before placing the chunk.  Each direction is associated with a list of overmap `"id"` substrings.  See [JSON_INFO.md](JSON_INFO.md#Starting-locations) "terrain" section to do more advanced searches, note this field defaults to CONTAINS not TYPE.
 | joins              | (optional) Any mutable overmap special joins that should be checked before placing the chunk.  Each direction is associated with a list of join `"id"` strings.
 | flags              | (optional) Any overmap terrain flags that should be checked before placing the chunk.  Each direction is associated with a list of `oter_flags` flags.
 | flags_any          | (optional) Identical to flags except only requires a single direction to pass.  Useful to check if there's at least one of a flag in cardinal or orthoganal directions etc.
@@ -1170,7 +1170,8 @@ Example:
     { "chunks": [ "nest3" ], "x": 0, "y": 0, "joins": { "north": [ "interior_to_exterior" ] } },
     { "chunks": [ "nest4" ], "x": 0, "y": 0, "flags": { "north": [ "RIVER" ] }, "flags_any": { "north_east": [ "RIVER" ], "north_west": [ "RIVER" ] } },
     { "else_chunks": [ "nest5" ], "x": 0, "y": 0, "flags": { "north_west": [ "RIVER", "LAKE", "LAKE_SHORE" ] } },
-    { "chunks": [ "nest6" ], "x": 0, "y": 0, "predecessors": [ "field", { "om_terrain": "river", "om_terrain_match_type": "PREFIX" } ] }
+    { "chunks": [ "nest6" ], "x": 0, "y": 0, "predecessors": [ "field", { "om_terrain": "river", "om_terrain_match_type": "PREFIX" } ] },
+    { "chunks": [ "nest7" ], "x": 0, "y": 0, "neighbors": { "north": [  { "om_terrain": "road_curved", "om_terrain_match_type": "SUBTYPE" } ] } }
   ],
 ```
 The code excerpt above will place chunks as follows:
@@ -1180,6 +1181,7 @@ The code excerpt above will place chunks as follows:
 * `"nest4"` if the north neighboring overmap terrain has a flag `"RIVER"` and either of the north east or north west neighboring overmap terrains have a `"RIVER"` flag.
 * `"nest5"` if the north west neighboring overmap terrain has neither the `"RIVER"`, `"LAKE"` nor `"LAKE_SHORE"` flags.
 * `"nest6"` if the there's a predecessor present of either `"field"` or any overmap with the prefix `"river"`.
+* `"nest7"` if the north neighbor's om terrain is one of `"road_ne"`, `"road_es"`, `"road_sw"` and `"road_wn"`.
 
 
 ### Place monster corpse from a monster group with "place_corpses"

--- a/src/enums.h
+++ b/src/enums.h
@@ -131,6 +131,9 @@ enum class ot_match_type : int {
     // terrain id, which means that suffixes for rotation and linear terrain types
     // are ignored.
     type,
+    // The provided string must completely match the base type id of the overmap
+    // terrain id as well as the linear subtype.
+    subtype,
     // The provided string must be a complete prefix (with additional parts delimited
     // by an underscore) of the overmap terrain id. For example, "forest" will match
     // "forest" or "forest_thick" but not "forestcabin".

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -595,6 +595,12 @@ bool is_ot_match( const std::string &name, const oter_id &oter,
         // but won't incorrectly match other locations that happen to contain the substring.
         return otype == oter->get_type_id().str();
     };
+    
+    static const auto is_ot_subtype = []( const std::string & otype, const oter_id & oter ) {
+        // Is a match if the base type and linear subtype (end/straight/curved/tee/four_way) are the same which will allow for handling rotations of linear features
+        // but won't incorrectly match other locations that happen to contain the substring.
+        return otype == oter->get_mapgen_id();
+    };
 
     static const auto is_ot_prefix = []( const std::string & otype, const oter_id & oter ) {
         const size_t oter_size = oter.id().str().size();
@@ -617,7 +623,7 @@ bool is_ot_match( const std::string &name, const oter_id &oter,
         return oter_str.str()[compare_size] == '_';
     };
 
-    static const auto is_ot_subtype = []( const std::string & otype, const oter_id & oter ) {
+    static const auto is_ot_contains = []( const std::string & otype, const oter_id & oter ) {
         // Checks for any partial match.
         return strstr( oter.id().c_str(), otype.c_str() );
     };
@@ -627,10 +633,12 @@ bool is_ot_match( const std::string &name, const oter_id &oter,
             return is_ot( name, oter );
         case ot_match_type::type:
             return is_ot_type( name, oter );
+        case ot_match_type::subtype:
+            return is_ot_subtype( name, oter );
         case ot_match_type::prefix:
             return is_ot_prefix( name, oter );
         case ot_match_type::contains:
-            return is_ot_subtype( name, oter );
+            return is_ot_contains( name, oter );
         default:
             return false;
     }
@@ -6669,6 +6677,7 @@ std::string enum_to_string<ot_match_type>( ot_match_type data )
         // *INDENT-OFF*
         case ot_match_type::exact: return "EXACT";
         case ot_match_type::type: return "TYPE";
+        case ot_match_type::subtype: return "SUBTYPE";
         case ot_match_type::prefix: return "PREFIX";
         case ot_match_type::contains: return "CONTAINS";
         // *INDENT-ON*

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -595,7 +595,7 @@ bool is_ot_match( const std::string &name, const oter_id &oter,
         // but won't incorrectly match other locations that happen to contain the substring.
         return otype == oter->get_type_id().str();
     };
-    
+
     static const auto is_ot_subtype = []( const std::string & otype, const oter_id & oter ) {
         // Is a match if the base type and linear subtype (end/straight/curved/tee/four_way) are the same which will allow for handling rotations of linear features
         // but won't incorrectly match other locations that happen to contain the substring.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Not having a way to search for linear maps pieces is limiting in some cases and annoying and bloated in others

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds a new match type SUBTYPE that matches with linear maps of the same piece
Applied it to my road unhardcoding as an example and to cut the bloat
Adds docs

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

A different name that's more on the nose like LINEAR_SUBTYPE or LINEAR_SUFFIX, happy to change if that's less confusing. I've stolen a function name in the C++ atm if that's not ok (I checked it isn't used anywhere else like)

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Seems good in game but a sanity check would be appreciated

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
