### PR TITLE
Make Yrax Trifacet untameable

### DIFF
--- a/data/json/effect_on_condition.json
+++ b/data/json/effect_on_condition.json
@@ -1333,5 +1333,13 @@
       { "u_add_trait": "CHITIN2" },
       { "u_add_trait": "CRUSTACEAN_CARAPACE" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "yrax_trifacet_activation",
+    "effect": [
+      { "u_spawn_monster": "mon_yrax_trifacet", "real_count": 1, "min_radius": 1, "max_radius": 2 },
+      { "u_message": "The hostile trifacet violently unfolds just clear of your hand!", "type": "bad" }
+    ]
   }
 ]

--- a/data/json/items/corpses/inactive_bots.json
+++ b/data/json/items/corpses/inactive_bots.json
@@ -751,16 +751,7 @@
     "material": [ "steel", "ceramic" ],
     "symbol": ",",
     "color": "cyan",
-    "use_action": {
-      "type": "place_monster",
-      "monster_id": "mon_yrax_trifacet",
-      "friendly_msg": "Your attempt at reprogramming the trifacet is somehow successful!",
-      "hostile_msg": "The hostile trifacet violently unfolds just clear of your hand!",
-      "difficulty": 20,
-      "moves": 60,
-      "place_randomly": true,
-      "skills": [ "electronics", "computer" ]
-    },
+    "use_action": { "type": "effect_on_conditions", "menu_text": "Activate", "effect_on_conditions": [ "yrax_trifacet_activation" ] },
     "flags": [ "SINGLE_USE" ],
     "melee_damage": { "bash": 6, "cut": 6 }
   },

--- a/data/json/items/corpses/inactive_bots.json
+++ b/data/json/items/corpses/inactive_bots.json
@@ -742,7 +742,7 @@
     "id": "bot_yrax_trifacet",
     "type": "TOOL",
     "name": { "str": "inactive trifacet" },
-    "description": "A featureless quartz pyramid that, although obviously artificial, shows no real indication of ever having been an advanced robot.  Although this trifacet could probably be reactivated, trying to do is way beyond your capabilities.",
+    "description": "A featureless quartz pyramid that, although obviously artificial, shows no real indication of ever having been an advanced robot.  Perhaps you could try reactivating it?",
     "weight": "30 kg",
     "volume": "50 L",
     "price": 64500,
@@ -751,6 +751,17 @@
     "material": [ "steel", "ceramic" ],
     "symbol": ",",
     "color": "cyan",
+    "use_action": {
+      "type": "place_monster",
+      "monster_id": "mon_yrax_trifacet",
+      "friendly_msg": "Your attempt at reprogramming the trifacet is somehow successful!",
+      "hostile_msg": "The hostile trifacet violently unfolds just clear of your hand!",
+      "difficulty": 20,
+      "moves": 60,
+      "place_randomly": true,
+      "skills": [ "electronics", "computer" ]
+    },
+    "flags": [ "SINGLE_USE" ],
     "melee_damage": { "bash": 6, "cut": 6 }
   },
   {

--- a/data/json/items/corpses/inactive_bots.json
+++ b/data/json/items/corpses/inactive_bots.json
@@ -742,7 +742,7 @@
     "id": "bot_yrax_trifacet",
     "type": "TOOL",
     "name": { "str": "inactive trifacet" },
-    "description": "A featureless quartz pyramid that, although obviously artificial, shows no real indication of ever having been an advanced robot.  Although this trifacet could probably be reactivated, it's unlikely to recognize you as an ally.",
+    "description": "A featureless quartz pyramid that, although obviously artificial, shows no real indication of ever having been an advanced robot.  Although this trifacet could probably be reactivated, trying to do is way beyond your capabilities.",
     "weight": "30 kg",
     "volume": "50 L",
     "price": 64500,
@@ -751,17 +751,6 @@
     "material": [ "steel", "ceramic" ],
     "symbol": ",",
     "color": "cyan",
-    "use_action": {
-      "type": "place_monster",
-      "monster_id": "mon_yrax_trifacet",
-      "friendly_msg": "Your attempt at reprogramming the trifacet is somehow successful!",
-      "hostile_msg": "The hostile trifacet violently unfolds just clear of your hand!",
-      "difficulty": 12,
-      "moves": 60,
-      "place_randomly": true,
-      "skills": [ "electronics", "computer" ]
-    },
-    "flags": [ "SINGLE_USE" ],
     "melee_damage": { "bash": 6, "cut": 6 }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
~~We had a person come to the discord with a screenshot of a trifacet they somehow reactivated and got a friendly one. Why is that even possible, in the first place? Reactivating a robot you cannot fully comprehend is bullshit as is, reprogramming it is entirely impossible.~~
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
~~Remove the use action of the inactive trifacet. The player should not be able to handle technology of this level.~~ Check comments
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
~~Keeping it activable but always spawning a hostile, but really the player should not have a set of controls or a guide on how to work with an Yrax. Deactivating it in the first place is already iffy but removing that would break Hub quests.~~
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I imagine the Hub with enough figuring out would likely find a way to reactivate it, but this does not in any way mean the player should be capable of doing so. And the question of whether the Hub could reprogram it is a different one entirely
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
