### PR TITLE
Adds priority flags for special placement

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -16,7 +16,7 @@
     "locations": [ "land" ],
     "city_distance": [ 8, 30 ],
     "occurrences": [ 0, 2 ],
-    "flags": [ "CLASSIC", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "MAN_MADE", "PRIORITY_LOW" ]
   },
   {
     "type": "overmap_special",
@@ -35,7 +35,7 @@
     "locations": [ "land" ],
     "city_distance": [ 8, 30 ],
     "occurrences": [ 1, 2 ],
-    "flags": [ "CLASSIC", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "MAN_MADE", "PRIORITY_LOW" ]
   },
   {
     "type": "overmap_special",
@@ -57,7 +57,7 @@
     "locations": [ "land" ],
     "city_distance": [ 8, 40 ],
     "occurrences": [ 0, 2 ],
-    "flags": [ "CLASSIC", "URBAN", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "URBAN", "MAN_MADE", "PRIORITY_LOW" ]
   },
   {
     "type": "overmap_special",
@@ -414,7 +414,7 @@
     "city_distance": [ 5, 25 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 0, 4 ],
-    "flags": [ "CLASSIC", "URBAN", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "URBAN", "MAN_MADE", "PRIORITY_HIGH" ]
   },
   {
     "type": "overmap_special",
@@ -469,7 +469,7 @@
     "locations": [ "land" ],
     "city_distance": [ 20, -1 ],
     "occurrences": [ 0, 2 ],
-    "flags": [ "CLASSIC", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "MAN_MADE", "PRIORITY_LOW" ]
   },
   {
     "type": "overmap_special",
@@ -539,7 +539,7 @@
     "locations": [ "land" ],
     "city_distance": [ 5, -1 ],
     "occurrences": [ 0, 2 ],
-    "flags": [ "CLASSIC", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "MAN_MADE", "PRIORITY_LOW" ]
   },
   {
     "type": "overmap_special",
@@ -765,7 +765,7 @@
     "city_distance": [ 15, -1 ],
     "occurrences": [ 40, 100 ],
     "//": "Inflated chance, effective rate ~25%",
-    "flags": [ "UNIQUE", "LAB", "WILDERNESS", "MAN_MADE" ],
+    "flags": [ "UNIQUE", "LAB", "WILDERNESS", "MAN_MADE", "PRIORITY_HIGH" ],
     "rotate": false
   },
   {
@@ -953,7 +953,7 @@
     "locations": [ "field" ],
     "city_distance": [ 10, 40 ],
     "occurrences": [ 0, 6 ],
-    "flags": [ "CLASSIC", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "MAN_MADE", "PRIORITY_LOW" ]
   },
   {
     "type": "overmap_special",
@@ -3458,7 +3458,7 @@
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 3, 20 ],
     "occurrences": [ 35, 100 ],
-    "flags": [ "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE" ]
+    "flags": [ "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE", "PRIORITY_HIGH" ]
   },
   {
     "type": "overmap_special",
@@ -3739,7 +3739,7 @@
     "locations": [ "land" ],
     "city_distance": [ 10, 200 ],
     "occurrences": [ 0, 4 ],
-    "flags": [ "CLASSIC", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "MAN_MADE", "PRIORITY_LOW" ]
   },
   {
     "type": "overmap_special",
@@ -3752,7 +3752,7 @@
     "locations": [ "land" ],
     "city_distance": [ 10, 200 ],
     "occurrences": [ 0, 4 ],
-    "flags": [ "CLASSIC", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "MAN_MADE", "PRIORITY_LOW" ]
   },
   {
     "type": "overmap_special",
@@ -3765,7 +3765,7 @@
     "locations": [ "land" ],
     "city_distance": [ 10, 200 ],
     "occurrences": [ 0, 4 ],
-    "flags": [ "CLASSIC", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "MAN_MADE", "PRIORITY_LOW" ]
   },
   {
     "type": "overmap_special",
@@ -3809,7 +3809,7 @@
     "locations": [ "land" ],
     "city_distance": [ -1, 100 ],
     "occurrences": [ 0, 4 ],
-    "flags": [ "CLASSIC", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "MAN_MADE", "PRIORITY_LOW" ]
   },
   {
     "type": "overmap_special",
@@ -4349,7 +4349,7 @@
     "locations": [ "wilderness" ],
     "city_distance": [ 15, 150 ],
     "occurrences": [ 0, 4 ],
-    "flags": [ "CLASSIC", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "MAN_MADE", "PRIORITY_LOW" ]
   },
   {
     "type": "overmap_special",
@@ -4518,7 +4518,7 @@
     "city_distance": [ -1, 20 ],
     "city_sizes": [ 3, 12 ],
     "occurrences": [ 50, 100 ],
-    "flags": [ "CLASSIC", "UNIQUE", "URBAN", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "UNIQUE", "URBAN", "MAN_MADE", "PRIORITY_HIGH" ]
   },
   {
     "type": "overmap_special",
@@ -4664,7 +4664,7 @@
     "city_distance": [ 3, -1 ],
     "city_sizes": [ 1, 16 ],
     "occurrences": [ 33, 100 ],
-    "flags": [ "UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE" ]
+    "flags": [ "UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE", "PRIORITY_LOW" ]
   },
   {
     "type": "overmap_special",
@@ -7202,11 +7202,11 @@
       { "point": [ 28, 29, 0 ], "overmap": "special_forest" },
       { "point": [ 29, 29, 0 ], "overmap": "special_forest_thick" }
     ],
-    "locations": [ "land", "road" ],
+    "locations": [ "land" ],
     "occurrences": [ 35, 100 ],
     "//": "Inflated chance, effective rate ~19% (n=726)",
     "connections": [ { "point": [ -1, 15, 0 ], "terrain": "road" } ],
-    "flags": [ "FARM", "UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE" ]
+    "flags": [ "FARM", "UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE", "PRIORITY_HIGH" ]
   },
   {
     "id": "airliner_crashed",
@@ -7921,7 +7921,7 @@
     "locations": [ "potential_basement_lab_entrance" ],
     "//": "Low chance to find a matching location, so always try to place it",
     "occurrences": [ 99, 100 ],
-    "flags": [ "LAB", "UNIQUE", "MAN_MADE" ]
+    "flags": [ "LAB", "UNIQUE", "MAN_MADE", "PRIORITY_LOW" ]
   },
   {
     "type": "overmap_special",
@@ -7957,7 +7957,7 @@
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 1, 12 ],
     "occurrences": [ 5, 100 ],
-    "flags": [ "CLASSIC", "UNIQUE", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "UNIQUE", "MAN_MADE", "PRIORITY_LOW" ]
   },
   {
     "type": "overmap_special",
@@ -7975,7 +7975,7 @@
     "locations": [ "wilderness" ],
     "city_sizes": [ 1, 12 ],
     "occurrences": [ 5, 100 ],
-    "flags": [ "CLASSIC", "UNIQUE", "MAN_MADE" ]
+    "flags": [ "CLASSIC", "UNIQUE", "MAN_MADE", "PRIORITY_LOW" ]
   },
   {
     "type": "overmap_special",

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6177,9 +6177,7 @@ bool overmap::place_special_attempt(
     const tripoint_om_omt p( rng( p2.x(), p2.x() + sector_width - 1 ),
                              rng( p2.y(), p2.y() + sector_width - 1 ), 0 );
     const city &nearest_city = get_nearest_city( p );
-    
     enabled_specials.prioritise_and_shuffle();
-    
     for( auto iter = enabled_specials.begin(); iter != enabled_specials.end(); ++iter ) {
         const overmap_special &special = *iter->special_details;
         const overmap_special_placement_constraints &constraints = special.get_constraints();

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6659,6 +6659,33 @@ overmap_special_id overmap_specials::create_building_from( const string_id<oter_
     return specials.insert( new_special ).id;
 }
 
+void prioritise_and_shuffle() {
+    std::vector<overmap_special_placement> placements_priority_high;
+    std::vector<overmap_special_placement> placements_priority_normal;
+    std::vector<overmap_special_placement> placements_priority_low;
+    
+    for( auto & placement : placements ) {
+        if( iter->special_details->has_flag( "PRIORITY_HIGH" ) ) {
+            placements_priority_high.push_back( *iter );
+        } else if( iter->special_details->has_flag( "PRIORITY_LOW" ) ) {
+            placements_priority_low.push_back( *iter );
+        } else {
+            placements_priority_normal.push_back( *iter );
+        }
+    }
+    
+    std::shuffle( placements_priority_high.begin(), placements_priority_high.end(), rng_get_engine() );
+    std::shuffle( placements_priority_normal.begin(), placements_priority_normal.end(),
+                  rng_get_engine() );
+    std::shuffle( placements_priority_low.begin(), placements_priority_low.end(), rng_get_engine() );
+    
+    placements = placements_priority_high;
+    placements.insert( placements.end(), placements_priority_normal.begin(),
+                       placements_priority_normal.end() );
+    placements.insert( placements.end(), placements_priority_low.begin(),
+                       placements_priority_low.end() );
+}
+
 namespace io
 {
 template<>

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6665,7 +6665,7 @@ void overmap_special_batch::prioritise_and_shuffle()
     std::vector<overmap_special_placement> placements_priority_normal;
     std::vector<overmap_special_placement> placements_priority_low;
 
-    for( auto &placement : placements ) {
+    for( overmap_special_placement &placement : placements ) {
         if( placement->special_details->has_flag( "PRIORITY_HIGH" ) ) {
             placements_priority_high.push_back( placement );
         } else if( placement->special_details->has_flag( "PRIORITY_LOW" ) ) {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6177,8 +6177,9 @@ bool overmap::place_special_attempt(
     const tripoint_om_omt p( rng( p2.x(), p2.x() + sector_width - 1 ),
                              rng( p2.y(), p2.y() + sector_width - 1 ), 0 );
     const city &nearest_city = get_nearest_city( p );
-
-    std::shuffle( enabled_specials.begin(), enabled_specials.end(), rng_get_engine() );
+    
+    enabled_specials.prioritise_and_shuffle();
+    
     for( auto iter = enabled_specials.begin(); iter != enabled_specials.end(); ++iter ) {
         const overmap_special &special = *iter->special_details;
         const overmap_special_placement_constraints &constraints = special.get_constraints();

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6659,7 +6659,7 @@ overmap_special_id overmap_specials::create_building_from( const string_id<oter_
     return specials.insert( new_special ).id;
 }
 
-void prioritise_and_shuffle()
+void overmap_special_batch::prioritise_and_shuffle()
 {
     std::vector<overmap_special_placement> placements_priority_high;
     std::vector<overmap_special_placement> placements_priority_normal;

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6659,12 +6659,13 @@ overmap_special_id overmap_specials::create_building_from( const string_id<oter_
     return specials.insert( new_special ).id;
 }
 
-void prioritise_and_shuffle() {
+void prioritise_and_shuffle()
+{
     std::vector<overmap_special_placement> placements_priority_high;
     std::vector<overmap_special_placement> placements_priority_normal;
     std::vector<overmap_special_placement> placements_priority_low;
-    
-    for( auto & placement : placements ) {
+
+    for( auto &placement : placements ) {
         if( iter->special_details->has_flag( "PRIORITY_HIGH" ) ) {
             placements_priority_high.push_back( *iter );
         } else if( iter->special_details->has_flag( "PRIORITY_LOW" ) ) {
@@ -6673,12 +6674,10 @@ void prioritise_and_shuffle() {
             placements_priority_normal.push_back( *iter );
         }
     }
-    
     std::shuffle( placements_priority_high.begin(), placements_priority_high.end(), rng_get_engine() );
     std::shuffle( placements_priority_normal.begin(), placements_priority_normal.end(),
                   rng_get_engine() );
     std::shuffle( placements_priority_low.begin(), placements_priority_low.end(), rng_get_engine() );
-    
     placements = placements_priority_high;
     placements.insert( placements.end(), placements_priority_normal.begin(),
                        placements_priority_normal.end() );

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6666,12 +6666,12 @@ void prioritise_and_shuffle()
     std::vector<overmap_special_placement> placements_priority_low;
 
     for( auto &placement : placements ) {
-        if( iter->special_details->has_flag( "PRIORITY_HIGH" ) ) {
-            placements_priority_high.push_back( *iter );
-        } else if( iter->special_details->has_flag( "PRIORITY_LOW" ) ) {
-            placements_priority_low.push_back( *iter );
+        if( placement->special_details->has_flag( "PRIORITY_HIGH" ) ) {
+            placements_priority_high.push_back( placement );
+        } else if( placement->special_details->has_flag( "PRIORITY_LOW" ) ) {
+            placements_priority_low.push_back( placement );
         } else {
-            placements_priority_normal.push_back( *iter );
+            placements_priority_normal.push_back( placement );
         }
     }
     std::shuffle( placements_priority_high.begin(), placements_priority_high.end(), rng_get_engine() );

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -157,12 +157,15 @@ class overmap_special_batch
             }
 
             std::shuffle( placements_priority_high.begin(), placements_priority_high.end(), rng_get_engine() );
-            std::shuffle( placements_priority_normal.begin(), placements_priority_normal.end(), rng_get_engine() );
+            std::shuffle( placements_priority_normal.begin(), placements_priority_normal.end(),
+                          rng_get_engine() );
             std::shuffle( placements_priority_low.begin(), placements_priority_low.end(), rng_get_engine() );
 
             placements = placements_priority_high;
-            placements.insert( placements.end(), placements_priority_normal.begin(), placements_priority_normal.end() );
-            placements.insert( placements.end(), placements_priority_low.begin(), placements_priority_low.end() );
+            placements.insert( placements.end(), placements_priority_normal.begin(),
+                               placements_priority_normal.end() );
+            placements.insert( placements.end(), placements_priority_low.begin(),
+                               placements_priority_low.end() );
         }
         point_abs_om get_origin() const {
             return origin_overmap;

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -141,7 +141,29 @@ class overmap_special_batch
         bool empty() {
             return placements.empty();
         }
+        void prioritise_and_shuffle() {
+            std::vector<overmap_special_placement> placements_priority_high;
+            std::vector<overmap_special_placement> placements_priority_normal;
+            std::vector<overmap_special_placement> placements_priority_low;
 
+            for( auto iter = placements.begin(); iter != placements.end(); iter++ ) {
+                if( iter->special_details->has_flag( "PRIORITY_HIGH" ) ) {
+                    placements_priority_high.push_back( *iter );
+                } else if( iter->special_details->has_flag( "PRIORITY_LOW" ) ) {
+                    placements_priority_low.push_back( *iter );
+                } else {
+                    placements_priority_normal.push_back( *iter );
+                }
+            }
+
+            std::shuffle( placements_priority_high.begin(), placements_priority_high.end(), rng_get_engine() );
+            std::shuffle( placements_priority_normal.begin(), placements_priority_normal.end(), rng_get_engine() );
+            std::shuffle( placements_priority_low.begin(), placements_priority_low.end(), rng_get_engine() );
+
+            placements = placements_priority_high;
+            placements.insert( placements.end(), placements_priority_normal.begin(), placements_priority_normal.end() );
+            placements.insert( placements.end(), placements_priority_low.begin(), placements_priority_low.end() );
+        }
         point_abs_om get_origin() const {
             return origin_overmap;
         }

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -141,35 +141,11 @@ class overmap_special_batch
         bool empty() {
             return placements.empty();
         }
-        void prioritise_and_shuffle() {
-            std::vector<overmap_special_placement> placements_priority_high;
-            std::vector<overmap_special_placement> placements_priority_normal;
-            std::vector<overmap_special_placement> placements_priority_low;
-
-            for( auto iter = placements.begin(); iter != placements.end(); iter++ ) {
-                if( iter->special_details->has_flag( "PRIORITY_HIGH" ) ) {
-                    placements_priority_high.push_back( *iter );
-                } else if( iter->special_details->has_flag( "PRIORITY_LOW" ) ) {
-                    placements_priority_low.push_back( *iter );
-                } else {
-                    placements_priority_normal.push_back( *iter );
-                }
-            }
-
-            std::shuffle( placements_priority_high.begin(), placements_priority_high.end(), rng_get_engine() );
-            std::shuffle( placements_priority_normal.begin(), placements_priority_normal.end(),
-                          rng_get_engine() );
-            std::shuffle( placements_priority_low.begin(), placements_priority_low.end(), rng_get_engine() );
-
-            placements = placements_priority_high;
-            placements.insert( placements.end(), placements_priority_normal.begin(),
-                               placements_priority_normal.end() );
-            placements.insert( placements.end(), placements_priority_low.begin(),
-                               placements_priority_low.end() );
-        }
         point_abs_om get_origin() const {
             return origin_overmap;
         }
+
+        void prioritise_and_shuffle();
 
     private:
         std::vector<overmap_special_placement> placements;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Not having priorities is limiting

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds 2 new special flags PRIORITY_HIGH and PRIORITY_LOW which result in attempting to place the special before/after other specials
Isn't really ideal because it still checks all mandatory special occurrences first which I think means UNIQUE and GLOBALLY_UNIQUE only try after all of the mandatory occurrences
Applies the flags to some maps that probably benefit from it including most `"existing": true` road connections (which should hopefully help with clumping when they get shuffled to the front when there aren't many roads), removes the ability for isherwood farm to spawn over roads in exchange for giving it high priority

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Making priority a numerical field

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Idk how to test this if someone could suggest a proper test or a way to test locally that'd be great

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
