### PR TITLE
Properly mark few strings for translation in vehicle_use.cpp

### DIFF
--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -526,13 +526,13 @@ void vehicle::toggle_autopilot()
         stop_engines();
     } );
 
-    menu.add( string_format( _( precollision_on ? ( "Disable %s" ) : ( "Enable %s" ) ),
-                             "pre-collision system" ) )
+    menu.add( precollision_on ? _( "Disable pre-collision system" ) :
+              _( "Enable pre-collision system" ) )
     .hotkey( "CONTROL_AUTOPILOT_CAS" )
     .desc( _( "Toggle pre-collision system" ) )
     .on_submit( [this] {
         precollision_on = !precollision_on;
-        add_msg( string_format( _( "You turn %s pre-collision system." ), precollision_on ? "on" : "off" ) );
+        add_msg( precollision_on ? _( "You turn on pre-collision system." ) : _( "You turn off pre-collision system." ) );
     } );
 
     menu.query();


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

I noticed strings in the code that were not marked for translation.

#### Describe the solution

Marked them for translation. Also skipзув string formatting here to translate a full sentence.

#### Describe alternatives you've considered

None

#### Testing

New strings are extracted by helper tools.

#### Additional context

None