### PR TITLE
[MoM] Add more feral psion attacks and fix current bugged attacks

### DIFF
--- a/data/mods/MindOverMatter/monsters/death_effects.json
+++ b/data/mods/MindOverMatter/monsters/death_effects.json
@@ -95,6 +95,7 @@
     "shape": "blast",
     "effect": "attack",
     "damage_type": "psi_telepathic_damage",
+    "max_level": 30,
     "min_damage": 5,
     "max_damage": 15,
     "damage_increment": 0.5,

--- a/data/mods/MindOverMatter/monsters/death_effects.json
+++ b/data/mods/MindOverMatter/monsters/death_effects.json
@@ -102,5 +102,32 @@
     "min_aoe": 1,
     "max_aoe": 30,
     "aoe_increment": 1
+  },
+  {
+    "id": "teleport_summon_monster",
+    "type": "SPELL",
+    "name": "[Ψ]Breach Monster",
+    "description": "Summons Nether creatures when the target dies.  It's a bug if you have it.",
+    "message": "The air nearby fractures and something comes through!",
+    "valid_targets": [ "self", "ally", "hostile", "ground" ],
+    "flags": [
+      "RANDOM_DAMAGE",
+      "RANDOM_AOE",
+      "SPAWN_GROUP",
+      "PERMANENT",
+      "HOSTILE_SUMMON",
+      "SPAWN_WITH_DEATH_DROPS",
+      "NO_EXPLOSION_SFX"
+    ],
+    "effect": "summon",
+    "effect_str": "GROUP_NETHER_BREACH",
+    "shape": "blast",
+    "max_level": 10,
+    "min_damage": 1,
+    "max_damage": 3,
+    "min_range": 3,
+    "min_aoe": 2,
+    "max_aoe": 6,
+    "min_duration": 9999999999999999999
   }
 ]

--- a/data/mods/MindOverMatter/monsters/death_effects.json
+++ b/data/mods/MindOverMatter/monsters/death_effects.json
@@ -90,14 +90,16 @@
     "type": "SPELL",
     "name": { "str": "Psychic Scream" },
     "valid_targets": [ "ally", "ground", "hostile" ],
-    "description": "Stuns and blinds if the player is near the telepath when they die.",
-    "flags": [ "NO_EXPLOSION_SFX", "SILENT", "RANDOM_DURATION" ],
+    "description": "Possibly stuns and blinds if the player is near the telepath when they die.",
+    "flags": [ "NO_EXPLOSION_SFX", "SILENT", "IGNORE_WALLS", "PERCENTAGE_DAMAGE" ],
     "shape": "blast",
     "effect": "attack",
-    "effect_str": "stunned",
-    "extra_effects": [ { "id": "pyrokinetic_flash_monster", "hit_self": false, "max_level": 4 } ],
-    "min_aoe": 6,
-    "min_duration": 100,
-    "max_duration": 500
+    "damage_type": "psi_telepathic_damage",
+    "min_damage": 5,
+    "max_damage": 15,
+    "damage_increment": 0.5,
+    "min_aoe": 1,
+    "max_aoe": 30,
+    "aoe_increment": 1
   }
 ]

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -969,7 +969,20 @@
         "cooldown": 10,
         "monster_message": "%1$s glances at %3$s and the world lurches."
       },
-      { "id": "teleport_touch", "cooldown": 15 },
+      {
+        "type": "monster_attack",
+        "attack_type": "melee",
+        "id": "teleport_touch",
+        "move_cost": 80,
+        "cooldown": 15,
+        "accuracy": 5,
+        "damage_max_instance": [ { "damage_type": "psi_teleporter_teleporting_damage", "amount": 2, "armor_penetration": 10 } ],
+        "blockable": false,
+        "hit_dmg_u": "%1$s touches you and the world shifts around you!",
+        "hit_dmg_npc": "%1$s touches <npcname> and the world shifts around them!",
+        "miss_msg_u": "%s reaches for you but you avoid their touch!",
+        "miss_msg_npc": "%s reaches for <npcname> but they dodge!"
+      },
       {
         "type": "leap",
         "cooldown": 2,
@@ -1027,16 +1040,26 @@
     "vision_night": 3,
     "path_settings": { "max_dist": 40, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_porter",
-    "death_function": {
-      "effect": { "id": "teleport_summon", "hit_self": true },
-      "message": "As the %1$s dies, the air warps around them!"
-    },
+    "death_function": { "effect": { "id": "teleport_summon_monster" }, "message": "As the %1$s dies, the air warps around them!" },
     "zombify_into": "mon_zombie_survivor",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "luminance": 25,
     "special_attacks": [
       [ "PARROT_AT_DANGER", 10 ],
-      { "id": "teleport_touch" },
+      {
+        "type": "monster_attack",
+        "attack_type": "melee",
+        "id": "teleport_touch",
+        "move_cost": 65,
+        "cooldown": 10,
+        "accuracy": 6,
+        "damage_max_instance": [ { "damage_type": "psi_teleporter_teleporting_damage", "amount": 2, "armor_penetration": 10 } ],
+        "blockable": false,
+        "hit_dmg_u": "%1$s touches you and the world warps around you!",
+        "hit_dmg_npc": "%1$s touches <npcname> and the world warps around them!",
+        "miss_msg_u": "%s reaches for you but you avoid their touch!",
+        "miss_msg_npc": "%s reaches for <npcname> but they dodge!"
+      },
       {
         "id": "psi_teleport3_slow",
         "type": "spell",

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -765,7 +765,7 @@
     "zombify_into": "mon_zombie_survivor",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": {
-      "effect": { "id": "death_psychic_scream", "hit_self": false },
+      "effect": { "id": "death_psychic_scream", "hit_self": false, "min_level": 5 },
       "message": "As the %1$s dies, a scream fills your mind!"
     },
     "upgrades": { "half_life": 45, "into": "mon_feral_human_teep2" },
@@ -826,7 +826,7 @@
     "zombify_into": "mon_zombie_survivor",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": {
-      "effect": { "id": "death_psychic_scream", "hit_self": false },
+      "effect": { "id": "death_psychic_scream", "hit_self": false, "min_level": 10 },
       "message": "As the %1$s dies, a scream fills your mind!"
     },
     "special_attacks": [

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -969,6 +969,7 @@
         "cooldown": 10,
         "monster_message": "%1$s glances at %3$s and the world lurches."
       },
+      { "id": "teleport_touch", "cooldown": 15 },
       {
         "type": "leap",
         "cooldown": 2,
@@ -1026,11 +1027,16 @@
     "vision_night": 3,
     "path_settings": { "max_dist": 40, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_porter",
+    "death_function": {
+      "effect": { "id": "teleport_summon", "hit_self": true },
+      "message": "As the %1$s dies, the air warps around them!"
+    },
     "zombify_into": "mon_zombie_survivor",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "luminance": 25,
     "special_attacks": [
       [ "PARROT_AT_DANGER", 10 ],
+      { "id": "teleport_touch" },
       {
         "id": "psi_teleport3_slow",
         "type": "spell",

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -589,7 +589,10 @@
     "death_drops": "feral_humans_death_drops_telekin",
     "zombify_into": "mon_zombie_survivor",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "death_function": { "effect": { "id": "death_telekeinetic_hit_oneinfive", "hit_self": true } },
+    "death_function": {
+      "effect": { "id": "death_telekeinetic_hit_oneinfive", "hit_self": true },
+      "message": "As the %1$s dies, a wave of force explodes outward!"
+    },
     "upgrades": { "half_life": 45, "into": "mon_feral_human_telekin2" },
     "starting_ammo": { "rock": 6 },
     "special_attacks": [
@@ -680,7 +683,10 @@
     "death_drops": "feral_humans_death_drops_telekin",
     "zombify_into": "mon_zombie_survivor",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "death_function": { "effect": { "id": "death_telekeinetic_hit_oneinthree", "hit_self": true } },
+    "death_function": {
+      "effect": { "id": "death_telekeinetic_hit_oneinthree", "hit_self": true },
+      "message": "As the %1$s dies, a wave of force explodes outward!"
+    },
     "special_attacks": [
       {
         "id": "psi_telekin2_telegrab",

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -589,7 +589,7 @@
     "death_drops": "feral_humans_death_drops_telekin",
     "zombify_into": "mon_zombie_survivor",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "death_function": { "effect": { "id": "death_telekeinetic_hit_oneinfive", "hit_self": false } },
+    "death_function": { "effect": { "id": "death_telekeinetic_hit_oneinfive", "hit_self": true } },
     "upgrades": { "half_life": 45, "into": "mon_feral_human_telekin2" },
     "starting_ammo": { "rock": 6 },
     "special_attacks": [
@@ -680,7 +680,7 @@
     "death_drops": "feral_humans_death_drops_telekin",
     "zombify_into": "mon_zombie_survivor",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
-    "death_function": { "effect": { "id": "death_telekeinetic_hit_oneinthree", "hit_self": false } },
+    "death_function": { "effect": { "id": "death_telekeinetic_hit_oneinthree", "hit_self": true } },
     "special_attacks": [
       {
         "id": "psi_telekin2_telegrab",

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -765,7 +765,7 @@
     "zombify_into": "mon_zombie_survivor",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": {
-      "effect": { "id": "death_psychic_scream", "hit_self": false, "min_level": 5 },
+      "effect": { "id": "death_psychic_scream", "hit_self": true, "min_level": 5 },
       "message": "As the %1$s dies, a scream fills your mind!"
     },
     "upgrades": { "half_life": 45, "into": "mon_feral_human_teep2" },
@@ -826,7 +826,7 @@
     "zombify_into": "mon_zombie_survivor",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "death_function": {
-      "effect": { "id": "death_psychic_scream", "hit_self": false, "min_level": 10 },
+      "effect": { "id": "death_psychic_scream", "hit_self": true, "min_level": 10 },
       "message": "As the %1$s dies, a scream fills your mind!"
     },
     "special_attacks": [
@@ -1040,7 +1040,10 @@
     "vision_night": 3,
     "path_settings": { "max_dist": 40, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true },
     "death_drops": "feral_humans_death_drops_porter",
-    "death_function": { "effect": { "id": "teleport_summon_monster" }, "message": "As the %1$s dies, the air warps around them!" },
+    "death_function": {
+      "effect": { "id": "teleport_summon_monster", "hit_self": true },
+      "message": "As the %1$s dies, the air warps around them!"
+    },
     "zombify_into": "mon_zombie_survivor",
     "anger_triggers": [ "FRIEND_DIED", "FRIEND_ATTACKED", "HURT" ],
     "luminance": 25,

--- a/data/mods/MindOverMatter/monsters/monster_special_attacks.json
+++ b/data/mods/MindOverMatter/monsters/monster_special_attacks.json
@@ -8,7 +8,6 @@
     "accuracy": 5,
     "damage_max_instance": [ { "damage_type": "psi_teleporter_teleporting_damage", "amount": 2, "armor_penetration": 10 } ],
     "blockable": false,
-    "effects_require_dmg": false,
     "hit_dmg_u": "%1$s touches you and the world warps around you!",
     "hit_dmg_npc": "%1$s touches <npcname> and the world warps around them!",
     "miss_msg_u": "%s reaches for you but you avoid their touch!",

--- a/data/mods/MindOverMatter/monsters/monster_special_attacks.json
+++ b/data/mods/MindOverMatter/monsters/monster_special_attacks.json
@@ -2,18 +2,16 @@
   {
     "type": "monster_attack",
     "attack_type": "melee",
-    "id": "tk_smash",
+    "id": "teleport_touch",
     "move_cost": 80,
-    "cooldown": 10,
-    "damage_max_instance": [ { "damage_type": "bash", "amount": 25, "armor_penetration": 10 } ],
-    "hitsize_min": 12,
-    "range": 6,
-    "throw_strength": 60,
+    "cooldown": 15,
+    "accuracy": 5,
+    "damage_max_instance": [ { "damage_type": "psi_teleporter_teleporting_damage", "amount": 2, "armor_penetration": 10 } ],
     "blockable": false,
     "effects_require_dmg": false,
-    "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
-    "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",
-    "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
-    "miss_msg_npc": "%s stares at <npcname> but nothing happens!"
+    "hit_dmg_u": "%1$s touches you and the world warps around you!",
+    "hit_dmg_npc": "%1$s touches <npcname> and the world warps around them!",
+    "miss_msg_u": "%s reaches for you but you avoid their touch!",
+    "miss_msg_npc": "%s reaches for <npcname> but they dodge!"
   }
 ]

--- a/data/mods/MindOverMatter/monsters/monsters_spells.json
+++ b/data/mods/MindOverMatter/monsters/monsters_spells.json
@@ -287,34 +287,6 @@
     "casting_time_increment": -4
   },
   {
-    "id": "teleport_summon_monster",
-    "type": "SPELL",
-    "name": "[Ψ]Breach Monster",
-    "description": "Summons Nether creatures when the target dies.  It's a bug if you have it.",
-    "message": "The air nearby fractures and something comes through!",
-    "valid_targets": [ "self", "ally", "hostile", "ground" ],
-    "flags": [
-      "RANDOM_DAMAGE",
-      "RANDOM_AOE",
-      "SPAWN_GROUP",
-      "PERMANENT",
-      "RANDOM_TARGET",
-      "HOSTILE_SUMMON",
-      "SPAWN_WITH_DEATH_DROPS",
-      "NO_EXPLOSION_SFX"
-    ],
-    "effect": "summon",
-    "effect_str": "GROUP_NETHER_BREACH",
-    "shape": "blast",
-    "max_level": 10,
-    "min_damage": 1,
-    "max_damage": 3,
-    "min_range": 3,
-    "min_aoe": 2,
-    "max_aoe": 6,
-    "min_duration": 9999999999999999999
-  },
-  {
     "id": "vitakinetic_health_down",
     "type": "SPELL",
     "name": "[Ψ]Draining Touch Monster",

--- a/data/mods/MindOverMatter/monsters/monsters_spells.json
+++ b/data/mods/MindOverMatter/monsters/monsters_spells.json
@@ -287,6 +287,34 @@
     "casting_time_increment": -4
   },
   {
+    "id": "teleport_summon_monster",
+    "type": "SPELL",
+    "name": "[Ψ]Breach Monster",
+    "description": "Summons Nether creatures when the target dies.  It's a bug if you have it.",
+    "message": "The air nearby fractures and something comes through!",
+    "valid_targets": [ "self", "ally", "hostile", "ground" ],
+    "flags": [
+      "RANDOM_DAMAGE",
+      "RANDOM_AOE",
+      "SPAWN_GROUP",
+      "PERMANENT",
+      "RANDOM_TARGET",
+      "HOSTILE_SUMMON",
+      "SPAWN_WITH_DEATH_DROPS",
+      "NO_EXPLOSION_SFX"
+    ],
+    "effect": "summon",
+    "effect_str": "GROUP_NETHER_BREACH",
+    "shape": "blast",
+    "max_level": 10,
+    "min_damage": 1,
+    "max_damage": 3,
+    "min_range": 3,
+    "min_aoe": 2,
+    "max_aoe": 6,
+    "min_duration": 9999999999999999999
+  },
+  {
     "id": "vitakinetic_health_down",
     "type": "SPELL",
     "name": "[Ψ]Draining Touch Monster",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Add more feral psion attacks and fix current bugged attacks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Now that there's a damage type that teleports you, feral teleporters should be able to use it. Also, feral telepaths' death spell was broken.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add an attack to feral sliders and ephemeral riftwalkers that lets them teleport the player on hit.  Also add Breach as a death spell for ephemeral riftwalkers. 

Fix feral telepaths' death spell.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Everything works!  Feral telepaths' death spell hits the torso and not the head, but that's a hardcoded spell limitation.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
