### PR TITLE
[Doesn't work, pls help] Json connection origins

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1399,17 +1399,18 @@ struct fixed_overmap_special_data : overmap_special_data {
                 }
 
                 const overmap_connection &connection = *elem.connection;
-                cata::flat_set<std::pair<std::pair<std::string, ot_match_type>, int>> origin_terrains = connection.origin_terrains;
+                cata::flat_set<std::pair<std::pair<std::string, ot_match_type>, int>> origin_terrains =
+                            connection.origin_terrains;
                 point_om_omt connection_point;
                 point_om_omt origin_connection_point;
                 point_om_omt city_connection_point;
                 int distance_to_origin = INT_MAX;
                 int distance_to_city = INT_MAX;
-                
-                auto find_city = [&] () {
+
+                auto find_city = [&]() {
                     if( connection.has_city_origin && cit ) {
                         distance_to_city = cit.get_distance_from( rp );
-                        if ( distance_to_city <= connection.city_origin_max_distance ) {
+                        if( distance_to_city <= connection.city_origin_max_distance ) {
                             city_connection_point = cit.pos;
                             return true;
                         }
@@ -1418,18 +1419,20 @@ struct fixed_overmap_special_data : overmap_special_data {
                 };
 
                 //Using this rather than a generic distance so it matches city's get_distance_from
-                auto get_distance_between = [&] ( tripoint_om_omt a, tripoint_om_omt b ) {
+                auto get_distance_between = [&]( tripoint_om_omt a, tripoint_om_omt b ) {
                     return std::max( static_cast<int>( trig_dist( a, b ) ), 0 );
                 };
-                
-                auto find_origin = [&] () {
+
+                auto find_origin = [&]() {
                     int max_range = 0;
-                    for ( const std::pair<std::pair<std::string, ot_match_type>, int> &origin_terrain : origin_terrains ) {
+                    for( const std::pair<std::pair<std::string, ot_match_type>, int> &origin_terrain :
+                         origin_terrains ) {
                         max_range = std::max( max_range, origin_terrain.second );
                     }
                     for( const tripoint_om_omt &nearby_point : closest_points_first( rp, max_range ) ) {
                         while( !origin_terrains.empty() ) {
-                            for( const std::pair<std::pair<std::string, ot_match_type>, int> &origin_terrain : origin_terrains ) {
+                            for( const std::pair<std::pair<std::string, ot_match_type>, int> &origin_terrain :
+                                 origin_terrains ) {
                                 const int distance = get_distance_between( rp, nearby_point );
                                 if( origin_terrain.second < distance ) {
                                     //Ideally remove it from origin_terrains
@@ -1445,8 +1448,8 @@ struct fixed_overmap_special_data : overmap_special_data {
                     }
                     return false;
                 };
-                
-                auto find_connection = [&] () {
+
+                auto find_connection = [&]() {
                     for( const tripoint_om_omt &nearby_point : closest_points_first( rp, 50 ) ) {
                         if( connection.has( om.ter( nearby_point ) ) ) {
                             connection_point = nearby_point.xy();
@@ -1455,16 +1458,15 @@ struct fixed_overmap_special_data : overmap_special_data {
                     }
                     return false;
                 };
-                
                 if( find_origin() || find_city() ) {
                     if( distance_to_origin < distance_to_city ) {
                         connection_point = origin_connection_point;
                     } else {
                         connection_point = city_connection_point;
                     }
-                } else if ( find_connection() ) {
+                } else if( find_connection() ) {
                     om.build_connection( connection_point, rp.xy(), elem.p.z, connection,
-                                    must_be_unexplored, initial_dir );
+                                         must_be_unexplored, initial_dir );
                 }
             }
         }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1155,50 +1155,6 @@ struct overmap_special_data {
         const city &cit, bool must_be_unexplored ) const = 0;
 };
 
-bool find_city( const city &cit, const tripoint_om_omt &rp ) {
-    if( connection.has_city_origin && cit ) {
-        distance_to_city = cit.get_distance_from( rp );
-        if ( distance_to_city <= city_origin_max_distance ) {
-            city_connection_point = cit.pos;
-            return true;
-        }
-    }
-    return false;
-}
-
-bool find_origin() {
-    int max_range = 0;
-    for ( const std::pair<std::pair<std::string, ot_match_type>, unsigned int> &origin_terrain : origin_terrains ) {
-        max_range = std::max( max_range, origin_terrain.second;
-    }
-    for( const tripoint_om_omt &nearby_point : closest_points_first( rp, max_range ) ) {
-        while( !origin_terrains.empty() ) {
-            for( const std::pair<std::pair<std::string, ot_match_type>, unsigned int> &origin_terrain : origin_terrains ) {
-                if( origin_terrain.second < range ) {
-                    //ideally remove it from from origin_terrains
-                    continue;
-                }
-                if( om.check_ot( origin_terrain.first.first, origin_terrain.first.second, nearby_point ) ) {
-                    origin_connection_point = nearby_point.xy();
-                    distance_to_origin = rp.get_distance_from( nearby_point );
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
-}
-
-bool find_connection() {
-    for( const tripoint_om_omt &nearby_point : closest_points_first( rp, 50 ) ) {
-        if( connection.has( nearby_point.ter() ) ) {
-            connection_point = nearest_point.xy;
-            return true;
-        }
-    }
-    return false;
-}
-
 struct fixed_overmap_special_data : overmap_special_data {
     fixed_overmap_special_data() = default;
     explicit fixed_overmap_special_data( const overmap_special_terrain &ter )
@@ -1443,14 +1399,64 @@ struct fixed_overmap_special_data : overmap_special_data {
                 }
 
                 const overmap_connection &connection = *elem.connection;
-                cata::flat_set<std::pair<std::pair<std::string, ot_match_type>, unsigned int>> origin_terrains = connection.origin_terrains;
+                cata::flat_set<std::pair<std::pair<std::string, ot_match_type>, int>> origin_terrains = connection.origin_terrains;
                 point_om_omt connection_point;
                 point_om_omt origin_connection_point;
                 point_om_omt city_connection_point;
-                int distance_to_origin;
-                int distance_to_city;
+                int distance_to_origin = INT_MAX;
+                int distance_to_city = INT_MAX;
                 
-                if( find_origin() || find_city( cit, rp ) ) {
+                auto find_city = [&] () {
+                    if( connection.has_city_origin && cit ) {
+                        distance_to_city = cit.get_distance_from( rp );
+                        if ( distance_to_city <= connection.city_origin_max_distance ) {
+                            city_connection_point = cit.pos;
+                            return true;
+                        }
+                    }
+                    return false;
+                };
+
+                //Using this rather than a generic distance so it matches city's get_distance_from
+                auto get_distance_between = [&] ( tripoint_om_omt a, tripoint_om_omt b ) {
+                    return std::max( static_cast<int>( trig_dist( a, b ) ), 0 );
+                };
+                
+                auto find_origin = [&] () {
+                    int max_range = 0;
+                    for ( const std::pair<std::pair<std::string, ot_match_type>, int> &origin_terrain : origin_terrains ) {
+                        max_range = std::max( max_range, origin_terrain.second );
+                    }
+                    for( const tripoint_om_omt &nearby_point : closest_points_first( rp, max_range ) ) {
+                        while( !origin_terrains.empty() ) {
+                            for( const std::pair<std::pair<std::string, ot_match_type>, int> &origin_terrain : origin_terrains ) {
+                                const int distance = get_distance_between( rp, nearby_point );
+                                if( origin_terrain.second < distance ) {
+                                    //Ideally remove it from origin_terrains
+                                    continue;
+                                }
+                                if( om.check_ot( origin_terrain.first.first, origin_terrain.first.second, nearby_point ) ) {
+                                    origin_connection_point = nearby_point.xy();
+                                    distance_to_origin = distance;
+                                    return true;
+                                }
+                            }
+                        }
+                    }
+                    return false;
+                };
+                
+                auto find_connection = [&] () {
+                    for( const tripoint_om_omt &nearby_point : closest_points_first( rp, 50 ) ) {
+                        if( connection.has( om.ter( nearby_point ) ) ) {
+                            connection_point = nearby_point.xy();
+                            return true;
+                        }
+                    }
+                    return false;
+                };
+                
+                if( find_origin() || find_city() ) {
                     if( distance_to_origin < distance_to_city ) {
                         connection_point = origin_connection_point;
                     } else {
@@ -1458,9 +1464,7 @@ struct fixed_overmap_special_data : overmap_special_data {
                     }
                 } else if ( find_connection() ) {
                     om.build_connection( connection_point, rp.xy(), elem.p.z, connection,
-                                    must_be_unexplored, initial_dir ) );
-                } else {
-                    debugmsg( "Failed to form any \"%s\" connection to special.", connection.id.c_str() ); //Find the specials id to name
+                                    must_be_unexplored, initial_dir );
                 }
             }
         }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1155,6 +1155,50 @@ struct overmap_special_data {
         const city &cit, bool must_be_unexplored ) const = 0;
 };
 
+bool find_city( const city &cit, const tripoint_om_omt &rp ) {
+    if( connection.has_city_origin && cit ) {
+        distance_to_city = cit.get_distance_from( rp );
+        if ( distance_to_city <= city_origin_max_distance ) {
+            city_connection_point = cit.pos;
+            return true;
+        }
+    }
+    return false;
+}
+
+bool find_origin() {
+    int max_range = 0;
+    for ( const std::pair<std::pair<std::string, ot_match_type>, unsigned int> &origin_terrain : origin_terrains ) {
+        max_range = std::max( max_range, origin_terrain.second;
+    }
+    for( const tripoint_om_omt &nearby_point : closest_points_first( rp, max_range ) ) {
+        while( !origin_terrains.empty() ) {
+            for( const std::pair<std::pair<std::string, ot_match_type>, unsigned int> &origin_terrain : origin_terrains ) {
+                if( origin_terrain.second < range ) {
+                    //ideally remove it from from origin_terrains
+                    continue;
+                }
+                if( om.check_ot( origin_terrain.first.first, origin_terrain.first.second, nearby_point ) ) {
+                    origin_connection_point = nearby_point.xy();
+                    distance_to_origin = rp.get_distance_from( nearby_point );
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+bool find_connection() {
+    for( const tripoint_om_omt &nearby_point : closest_points_first( rp, 50 ) ) {
+        if( connection.has( nearby_point.ter() ) ) {
+            connection_point = nearest_point.xy;
+            return true;
+        }
+    }
+    return false;
+}
+
 struct fixed_overmap_special_data : overmap_special_data {
     fixed_overmap_special_data() = default;
     explicit fixed_overmap_special_data( const overmap_special_terrain &ter )
@@ -1405,50 +1449,8 @@ struct fixed_overmap_special_data : overmap_special_data {
                 point_om_omt city_connection_point;
                 int distance_to_origin;
                 int distance_to_city;
-
-                bool find_city() {
-                    if( connection.has_city_origin && cit ) {
-                        distance_to_city = cit.get_distance_from( rp );
-                        city_connection_point = cit.pos;
-                        return true;
-                    }
-                    return false;
-                }
-
-                bool find_origin() {
-                    int max_range = 0;
-                    for ( const std::pair<std::pair<std::string, ot_match_type>, unsigned int> &origin_terrain : origin_terrains ) {
-                        max_range = std::max( max_range, origin_terrain.second;
-                    }
-                    for( const tripoint_om_omt &nearby_point : closest_points_first( rp, max_range ) ) {
-                        while( !origin_terrains.empty() ) {
-                            for( const std::pair<std::pair<std::string, ot_match_type>, unsigned int> &origin_terrain : origin_terrains ) {
-                                if( origin_terrain.second < range ) {
-                                    //ideally remove it from from origin_terrains
-                                    continue;
-                                }
-                                if( om.check_ot( origin_terrain.first.first, origin_terrain.first.second, nearby_point ) ) {
-                                    origin_connection_point = nearby_point.xy();
-                                    distance_to_origin = rp.get_distance_from( nearby_point );
-                                    return true;
-                                }
-                            }
-                        }
-                    }
-                    return false;
-                }
                 
-                bool find_connection() {
-                    for( const tripoint_om_omt &nearby_point : closest_points_first( rp, 200 ) ) {
-                        if( connection.has( nearby_point.ter() ) ) {
-                            connection_point = nearest_point.xy;
-                            return true;
-                        }
-                    }
-                    return false;
-                }
-                
-                if( find_origin() || find_city() ) {
+                if( find_origin() || find_city( cit, rp ) ) {
                     if( distance_to_origin < distance_to_city ) {
                         connection_point = origin_connection_point;
                     } else {

--- a/src/overmap_connection.cpp
+++ b/src/overmap_connection.cpp
@@ -106,13 +106,13 @@ void overmap_connection::load( const JsonObject &jo, const std::string_view )
 
         std::pair<std::string, ot_match_type> origin_terrain_partial;
         std::pair<std::pair<std::string, ot_match_type>, int> origin_terrain;
-        
         if( entry.has_member( "city" ) ) {
             mandatory( entry, false, "city", has_city_origin );
             optional( entry, false, "max_distance", city_origin_max_distance, 50 );
         } else {
             mandatory( entry, false, "om_terrain", origin_terrain_partial.first );
-            optional( entry, false, "om_terrain_match_type", origin_terrain_partial.second, ot_match_type::type );
+            optional( entry, false, "om_terrain_match_type", origin_terrain_partial.second,
+                      ot_match_type::type );
             origin_terrain.first = origin_terrain_partial;
             optional( entry, false, "max_distance", origin_terrain.second, 50 );
             origin_terrains.insert( origin_terrain );

--- a/src/overmap_connection.cpp
+++ b/src/overmap_connection.cpp
@@ -105,29 +105,16 @@ void overmap_connection::load( const JsonObject &jo, const std::string_view )
     for( const JsonObject entry : jo.get_array( "origin" ) ) {
 
         std::pair<std::string, ot_match_type> origin_terrain_partial;
-        std::pair<std::pair<std::string, ot_match_type>, unsigned int> origin_terrain;
+        std::pair<std::pair<std::string, ot_match_type>, int> origin_terrain;
         
-        if( entry.has_bool( "city" ) ) {
-            has_city_origin = entry.get_bool( "city" );
-            if ( entry.has_string( "max_distance" ) ) {
-                city_origin_max_distance = static_cast<unsigned int>( entry.get_string( "max_distance" ) );
-            } else {
-                city_origin_max_distance = 50;
-            }
+        if( entry.has_member( "city" ) ) {
+            mandatory( entry, false, "city", has_city_origin );
+            optional( entry, false, "max_distance", city_origin_max_distance, 50 );
         } else {
-            origin_terrain_partial.first = ( entry.get_string( "om_terrain" ) );
-            if( entry.has_string( "om_terrain_match_type" ) ) {
-            origin_terrain_partial.second = entry.get_enum_value<ot_match_type>( "om_terrain_match_type",
-                                    ot_match_type::type );
-            } else {
-                origin_terrain_partial.second = ot_match_type::type;
-            }
+            mandatory( entry, false, "om_terrain", origin_terrain_partial.first );
+            optional( entry, false, "om_terrain_match_type", origin_terrain_partial.second, ot_match_type::type );
             origin_terrain.first = origin_terrain_partial;
-            if ( entry.has_string( "max_distance" ) ) {
-                origin_terrain.second = static_cast<unsigned int>( entry.get_string( "max_distance" ) );
-            } else {
-                origin_terrain.second = 50;
-            }
+            optional( entry, false, "max_distance", origin_terrain.second, 50 );
             origin_terrains.insert( origin_terrain );
         }
     }

--- a/src/overmap_connection.cpp
+++ b/src/overmap_connection.cpp
@@ -51,8 +51,24 @@ void overmap_connection::subtype::load( const JsonObject &jo )
 {
     const auto flag_reader =
         make_flag_reader( connection_subtype_flag_map, "connection subtype flag" );
-
-    mandatory( jo, false, "terrain", terrain );
+        
+    if( !jo.has_string( "terrain" ) ) {
+        JsonObject jio = jo.get_object( "terrain" ) ) {
+            if( jio.test_string() ) {
+                terrain.first = ( jio.get_string() );
+                terrain.second = ot_match_type::type;
+            } else {
+                JsonObject pairobj = jio.get_object();
+                terrain.first = ( pairobj.get_string( "om_terrain" ) );
+                terrain.second = pairobj.get_enum_value<ot_match_type>( "om_terrain_match_type",
+                                      ot_match_type::contains );
+            }
+        }
+    } else {
+        terrain.first = jo.get_string( "terrain" );
+        terrain.second = ot_match_type::type;
+    }
+    
     mandatory( jo, false, "locations", locations );
 
     optional( jo, false, "basic_cost", basic_cost, 0 );
@@ -101,6 +117,27 @@ bool overmap_connection::has( const int_id<oter_t> &oter ) const
 void overmap_connection::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, false, "subtypes", subtypes );
+
+    for( const JsonObject entry : jo.get_array( "origin" ) ) {
+
+        std::pair<std::string, ot_match_type> origin_terrain_partial;
+        std::pair<std::pair<std::string, ot_match_type>, unsigned int> origin_terrain;
+
+        origin_terrain_partial.first = ( entry.get_string( "om_terrain" ) );
+        if( entry.has_string( "om_terrain_match_type" ) ) {
+        origin_terrain_partial.second = entry.get_enum_value<ot_match_type>( "om_terrain_match_type",
+                                ot_match_type::type );
+        } else {
+            origin_terrain_partial.second = ot_match_type::type;
+        }
+        origin_terrain.first = origin_terrain_partial;
+        if ( entry.has_string( "max_distance" ) ) {
+            origin_terrain.second = static_cast<unsigned int>( entry.get_string( "max_distance" ) );
+        } else {
+            origin_terrain.second = 100;
+        }
+        origin_terrains.insert( origin_terrain );
+    }
 }
 
 void overmap_connection::check() const

--- a/src/overmap_connection.cpp
+++ b/src/overmap_connection.cpp
@@ -118,25 +118,33 @@ void overmap_connection::load( const JsonObject &jo, const std::string_view )
 {
     mandatory( jo, false, "subtypes", subtypes );
 
-    for( const JsonObject entry : jo.get_array( "origin" ) ) {
+    for( const JsonValue entry : jo.get_array( "origin" ) ) {
 
         std::pair<std::string, ot_match_type> origin_terrain_partial;
         std::pair<std::pair<std::string, ot_match_type>, unsigned int> origin_terrain;
-
-        origin_terrain_partial.first = ( entry.get_string( "om_terrain" ) );
-        if( entry.has_string( "om_terrain_match_type" ) ) {
-        origin_terrain_partial.second = entry.get_enum_value<ot_match_type>( "om_terrain_match_type",
-                                ot_match_type::type );
+        
+        if( entry.test_string() ) {
+            if ( entry == "city" ) {
+                has_city_origin = true;
+            } else {
+                entry.throw_error( "Terrains should be in an object" );
+            }
         } else {
-            origin_terrain_partial.second = ot_match_type::type;
+            origin_terrain_partial.first = ( entry.get_string( "om_terrain" ) );
+            if( entry.has_string( "om_terrain_match_type" ) ) {
+            origin_terrain_partial.second = entry.get_enum_value<ot_match_type>( "om_terrain_match_type",
+                                    ot_match_type::type );
+            } else {
+                origin_terrain_partial.second = ot_match_type::type;
+            }
+            origin_terrain.first = origin_terrain_partial;
+            if ( entry.has_string( "max_distance" ) ) {
+                origin_terrain.second = static_cast<unsigned int>( entry.get_string( "max_distance" ) );
+            } else {
+                origin_terrain.second = 100;
+            }
+            origin_terrains.insert( origin_terrain );
         }
-        origin_terrain.first = origin_terrain_partial;
-        if ( entry.has_string( "max_distance" ) ) {
-            origin_terrain.second = static_cast<unsigned int>( entry.get_string( "max_distance" ) );
-        } else {
-            origin_terrain.second = 100;
-        }
-        origin_terrains.insert( origin_terrain );
     }
 }
 

--- a/src/overmap_connection.h
+++ b/src/overmap_connection.h
@@ -24,7 +24,7 @@ class overmap_connection
             public:
                 enum class flag : int { orthogonal };
 
-                std::pair<std::string, ot_match_type> terrain;
+                string_id<oter_type_t> terrain; //TODO: Make this std::pair<std::string, ot_match_type>
 
                 int basic_cost = 0;
 
@@ -53,6 +53,7 @@ class overmap_connection
         void finalize();
 
         const cata::flat_set<std::pair<std::pair<std::string, ot_match_type>, unsigned int>> origin_terrains;
+        bool has_city_origin = false;
 
         string_id<overmap_connection> id;
         std::vector<std::pair<string_id<overmap_connection>, mod_id>> src;

--- a/src/overmap_connection.h
+++ b/src/overmap_connection.h
@@ -52,7 +52,7 @@ class overmap_connection
         void check() const;
         void finalize();
 
-        const cata::flat_set<std::pair<std::pair<std::string, ot_match_type>, unsigned int>> origin_terrains;
+        cata::flat_set<std::pair<std::pair<std::string, ot_match_type>, int>> origin_terrains;
         bool has_city_origin = false;
         int city_origin_max_distance;
 

--- a/src/overmap_connection.h
+++ b/src/overmap_connection.h
@@ -24,7 +24,7 @@ class overmap_connection
             public:
                 enum class flag : int { orthogonal };
 
-                string_id<oter_type_t> terrain;
+                std::pair<std::string, ot_match_type> terrain;
 
                 int basic_cost = 0;
 
@@ -51,6 +51,8 @@ class overmap_connection
         void load( const JsonObject &jo, std::string_view src );
         void check() const;
         void finalize();
+
+        const cata::flat_set<std::pair<std::pair<std::string, ot_match_type>, unsigned int>> origin_terrains;
 
         string_id<overmap_connection> id;
         std::vector<std::pair<string_id<overmap_connection>, mod_id>> src;

--- a/src/overmap_connection.h
+++ b/src/overmap_connection.h
@@ -54,6 +54,7 @@ class overmap_connection
 
         const cata::flat_set<std::pair<std::pair<std::string, ot_match_type>, unsigned int>> origin_terrains;
         bool has_city_origin = false;
+        int city_origin_max_distance;
 
         string_id<overmap_connection> id;
         std::vector<std::pair<string_id<overmap_connection>, mod_id>> src;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Unhardcoding good
~~The hardcoded function needs changing for sub_connector unhardcoding~~ Makes #68496 alot less wonky
Allows for adding custom connections like a new `rural_road` connection that paths to the nearest road.
Allows separating z-2 and z-4 subway into different connections, with the z-4 pathing to ramps and z-2 pathing to surface subway stations, with fallbacks to join to the closest subway if none found.
Potentially could allow streams to path to rivers if reworked into a connection.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Connection targets can be defined in JSON in their respective `overmap_connection` object under a new "origin" field
Accepts `om_terrain`s optionally with accompanying match types (defaults to type), city true/false (defaults to false) and a max distance that specifies how far it should look for each origin point. Atm it just picks the closest one it finds.
If it fails to find any of the specified origins or there aren't any it tries to find the nearest connection subtype terrain within 50 tiles and joins to that.
(I presume I need to make it select an appropriate adjacent tile to the target but I just want it to work first, it'll need #67723 to work reliably with specials anyway)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Ideally boundary joins would be selectable too (and jsonified themselves)
Ideally you'd be able to join all of one type together to ensure full connectivity where desired (like cities join rn)
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Currently doesn't work, adding `"origin": [ { "city": true } ]` to `local_road` loads but doesn't function properly and anything else (eg `{ "om_terrain": "forest_thick" }`) hangs the game when building a world.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
