### PR TITLE
Fix bugs that cause eoc duplication

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -325,6 +325,8 @@ struct queued_eocs {
 
     queued_eocs &operator=( const queued_eocs &rhs ) {
         list = rhs.list;
+        // Why doesn't std::priority_queue have a clear() function.
+        queue = {};
         for( auto it = list.begin(), end = list.end(); it != end; ++it ) {
             queue.emplace( it );
         }

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -237,6 +237,8 @@ static void process_eocs( queued_eocs &eoc_queue, std::vector<effect_on_conditio
                     eoc_queue.list.erase( it );
                 }
             }
+        } else {
+            eoc_queue.list.erase( it );
         }
     }
     for( queued_eocs::storage_iter &q_eoc : eocs_to_queue ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
A particular bug would cause certain eocs to multiply exponentially, like the portal storm stuck effect. When the eoc is non-recurring, an `erase` call was missing to remove it from the underlying storage list. When the `queued_eoc` instance with this list is assigned to another `queued_eoc` struct, the 'zombie' eoc in the list is re-added to the priority queue.

There was also a non-relevant bug where the object's existing queue was not cleared on assignment, which would cause segfaults if it was not empty, as the entries would point into the free'd storage.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Add the missing erase.
- Explicitly zero the queue on assignment.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load a problematic save, see the eoc list appropriately shrinks when processing the stuck portal storm effect.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
