### PR TITLE
No more sealed half-full cans

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9436,7 +9436,8 @@ bool item::is_map() const
 
 bool item::seal()
 {
-    if( is_container_full() ) {
+    // Check the actual fullness of all kinds of containers.
+    if( is_container_full( /*allow_bucket = */ true ) ) {
         return contents.seal_all_pockets();
     } else {
         return false;

--- a/tests/unseal_and_spill_test.cpp
+++ b/tests/unseal_and_spill_test.cpp
@@ -339,6 +339,12 @@ void test_scenario::run()
                                     {}
                                 }
                             }
+                        },
+                        initialization {
+                            itype_test_solid_1ml,
+                            true,
+                            false,
+                            {}
                         }
                     }
                 }
@@ -591,6 +597,12 @@ void test_scenario::run()
                             false,
                             false,
                             {}
+                        },
+                        final_result {
+                            itype_test_solid_1ml,
+                            false,
+                            false,
+                            {}
                         }
                     }
                 };
@@ -600,6 +612,41 @@ void test_scenario::run()
                         false,
                         false,
                         {}
+                    }
+                };
+            } else if( !will_spill_outer && !do_spill ) {
+                original_location = final_result{
+                    itype_test_watertight_open_sealed_container_1L,
+                    false,
+                    false,
+                    {
+                        final_result {
+                            itype_test_solid_1ml,
+                            false,
+                            false,
+                            {}
+                        }
+                    }
+                };
+                ground = {
+                    final_result {
+                        itype_test_watertight_open_sealed_multipocket_container_2x250ml,
+                        false,
+                        false,
+                        {
+                            final_result {
+                                itype_test_liquid_1ml,
+                                false,
+                                false,
+                                {}
+                            },
+                            final_result {
+                                itype_test_liquid_1ml,
+                                false,
+                                false,
+                                {}
+                            }
+                        }
                     }
                 };
             } else if( !do_spill ) {
@@ -628,6 +675,12 @@ void test_scenario::run()
                                 {}
                             }
                         }
+                    },
+                    final_result {
+                        itype_test_solid_1ml,
+                        false,
+                        false,
+                        {}
                     }
                 };
             } else {
@@ -646,6 +699,12 @@ void test_scenario::run()
                     },
                     final_result {
                         itype_test_watertight_open_sealed_multipocket_container_2x250ml,
+                        false,
+                        false,
+                        {}
+                    },
+                    final_result {
+                        itype_test_solid_1ml,
                         false,
                         false,
                         {}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
none
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
~~#67634~~
Just to make sure no container is sealed when it's not full.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
When checking container fullness in item::seal(), allow checking buckets, so spillable containers are not always considered full.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Actually there are no more sealed half-full cans. They are now unsealed.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

There are two problems that relate to this PR but remain unaddressed :

1. There are many cans that seems to be full, but actually cannot be sealed due to volume rounding issues with the contents, including player crafted ones ( see #71878 ).

2. There are containers that should be sealed but currently have insufficient content, needing itemgroup audits.

Problem 1 is making problem 2 harder to be distinguished and fixed, but problem 2 technically is more easy to fix.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
