### PR TITLE
Added profession age bounds for randomly generated characters

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -878,7 +878,8 @@
       },
       "male": [ "boxer_briefs" ],
       "female": [ "sports_bra", "boxer_shorts" ]
-    }
+    },
+    "age_lower": 18
   },
   {
     "type": "profession",
@@ -929,7 +930,8 @@
       },
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "panties" ]
-    }
+    },
+    "age_lower": 16
   },
   {
     "type": "profession",
@@ -945,7 +947,8 @@
       },
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "panties" ]
-    }
+    },
+    "age_lower": 16
   },
   {
     "type": "profession",
@@ -977,7 +980,8 @@
       },
       "male": [ "under_armor_shorts" ],
       "female": [ "sports_bra", "panties" ]
-    }
+    },
+    "age_lower": 16
   },
   {
     "type": "profession",
@@ -1082,7 +1086,8 @@
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boxer_shorts" ]
     },
-    "missions": [ "MISSION_SOCIAL_BUTTERFLY" ]
+    "missions": [ "MISSION_SOCIAL_BUTTERFLY" ],
+    "age_lower": 45
   },
   {
     "type": "profession",
@@ -2005,7 +2010,8 @@
       },
       "male": [ "undershirt" ],
       "female": [ "camisole" ]
-    }
+    },
+    "age_lower": 18
   },
   {
     "type": "profession",
@@ -2974,7 +2980,8 @@
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "boy_shorts" ]
-    }
+    },
+    "age_lower": 18
   },
   {
     "type": "profession",
@@ -3071,7 +3078,8 @@
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
-    }
+    },
+    "age_lower": 16
   },
   {
     "type": "profession",
@@ -3145,7 +3153,9 @@
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "boy_shorts" ]
-    }
+    },
+    "age_lower": 16,
+    "age_upper": 25
   },
   {
     "type": "profession",
@@ -3197,7 +3207,8 @@
       "both": { "items": [ "socks", "knit_scarf", "dance_shoes" ], "entries": [ { "group": "charged_smart_phone" } ] },
       "male": [ "briefs", "tux", "tourmaline_silver_cufflinks" ],
       "female": [ "bra", "panties", "dress", "purse", "tourmaline_silver_bracelet" ]
-    }
+    },
+    "age_lower": 16
   },
   {
     "type": "profession",
@@ -3214,7 +3225,8 @@
       "female": [ "bra", "panties" ]
     },
     "flags": [ "SCEN_ONLY" ],
-    "missions": [ "MISSION_PATIENT" ]
+    "missions": [ "MISSION_PATIENT" ],
+    "age_lower": 16
   },
   {
     "type": "profession",
@@ -3223,7 +3235,8 @@
     "description": "You were a human guinea pig, used by laboratory technicians to understand the immense power of mutation.  You are determined to live on, if only to spite them for what they did to you.",
     "points": -1,
     "items": { "both": [ "subsuit_xl" ], "male": [ "briefs" ], "female": [ "bra", "panties" ] },
-    "flags": [ "SCEN_ONLY" ]
+    "flags": [ "SCEN_ONLY" ],
+    "age_lower": 16
   },
   {
     "type": "profession",
@@ -3349,7 +3362,8 @@
       },
       "male": [ "briefs", "dress_shirt", "pants_checkered", "pocketwatch" ],
       "female": [ "panties", "bra", "dress", "fanny", "gold_watch" ]
-    }
+    },
+    "age_lower": 50
   },
   {
     "type": "profession",
@@ -4381,7 +4395,9 @@
       },
       "male": [ "briefs" ],
       "female": [ "boy_shorts" ]
-    }
+    },
+    "age_lower": 16,
+    "age_upper": 21
   },
   {
     "type": "profession",
@@ -4410,7 +4426,9 @@
       },
       "male": [ "briefs" ],
       "female": [ "boy_shorts" ]
-    }
+    },
+    "age_lower": 16,
+    "age_upper": 21
   },
   {
     "type": "profession",
@@ -4450,7 +4468,9 @@
       },
       "male": [ "briefs" ],
       "female": [ "boy_shorts" ]
-    }
+    },
+    "age_lower": 16,
+    "age_upper": 18
   },
   {
     "type": "profession",
@@ -4491,7 +4511,9 @@
       },
       "male": [ "briefs" ],
       "female": [ "boy_shorts" ]
-    }
+    },
+    "age_lower": 16,
+    "age_upper": 18
   },
   {
     "type": "profession",
@@ -4507,7 +4529,9 @@
       },
       "male": [ "briefs" ],
       "female": [ "boy_shorts" ]
-    }
+    },
+    "age_lower": 16,
+    "age_upper": 18
   },
   {
     "type": "profession",
@@ -4523,7 +4547,9 @@
       },
       "male": [ "briefs" ],
       "female": [ "panties" ]
-    }
+    },
+    "age_lower": 16,
+    "age_upper": 18
   },
   {
     "type": "profession",
@@ -4549,7 +4575,9 @@
       },
       "male": [ "briefs" ],
       "female": [ "panties" ]
-    }
+    },
+    "age_lower": 16,
+    "age_upper": 18
   },
   {
     "type": "profession",
@@ -4681,7 +4709,8 @@
       },
       "male": [ "briefs" ],
       "female": [ "sports_bra", "boy_shorts" ]
-    }
+    },
+    "age_lower": 18
   },
   {
     "type": "profession",
@@ -4986,7 +5015,8 @@
         "opal_gold_ring",
         "opal_gold_earring"
       ]
-    }
+    },
+    "age_upper": 25
   },
   {
     "type": "profession",
@@ -5711,7 +5741,8 @@
       "female": [ "bra", "panties", "diamond_gold_earring" ]
     },
     "traits": [ "LIAR" ],
-    "missions": [ "MISSION_MAFIA_BOSS", "MISSION_SOCIAL_BUTTERFLY" ]
+    "missions": [ "MISSION_MAFIA_BOSS", "MISSION_SOCIAL_BUTTERFLY" ],
+    "age_lower": 30
   },
   {
     "type": "profession",
@@ -5831,7 +5862,9 @@
       "male": [ "briefs", "shorts", "tank_top" ],
       "female": [ "sports_bra", "panties", "cheerleader_skirt" ]
     },
-    "missions": [ "MISSION_SOCIAL_BUTTERFLY" ]
+    "missions": [ "MISSION_SOCIAL_BUTTERFLY" ],
+    "age_lower": 16,
+    "age_upper": 23
   },
   {
     "type": "profession",
@@ -6200,7 +6233,8 @@
       },
       "male": [ "briefs" ],
       "female": [ "boy_shorts", "bra" ]
-    }
+    },
+    "age_lower": 50
   },
   {
     "type": "profession",
@@ -6238,7 +6272,8 @@
       },
       "male": [ "briefs" ],
       "female": [ "boy_shorts", "sports_bra" ]
-    }
+    },
+    "age_lower": 16
   },
   {
     "type": "profession",

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -1781,6 +1781,18 @@ Example:
 
 This gives the player pants, two rocks, a t-shirt with the snippet id "allyourbase" (giving it a special description), socks and (depending on the gender) briefs or panties.
 
+#### `age_lower`
+
+(optional, int)
+The lowest age that a character with this profession can generate with. 
+This places no limits on manual input, only on random generation (i.e. Play Now!). Defaults to 21.
+
+#### `age_upper`
+
+(optional, int)
+The highest age that a character with this profession can generate with.
+This places no limits on manual input, only on random generation (i.e. Play Now!). Defaults to 55.
+
 #### `pets`
 
 (optional, array of string mtype_ids )

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -424,8 +424,6 @@ void avatar::randomize( const bool random_scenario, bool play_now )
     } else {
         name = MAP_SHARING::getUsername();
     }
-    // if adjusting min and max age from 16 and 55, make sure to see set_description()
-    init_age = rng( 16, 55 );
     randomize_height();
     randomize_blood();
     randomize_heartrate();
@@ -447,6 +445,7 @@ void avatar::randomize( const bool random_scenario, bool play_now )
     }
 
     prof = get_scenario()->weighted_random_profession();
+    init_age = rng( this->prof->age_lower, this->prof->age_upper );
     randomize_hobbies();
     starting_city = std::nullopt;
     world_origin = std::nullopt;

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -195,16 +195,8 @@ void profession::load( const JsonObject &jo, const std::string_view )
         _description_male = to_translation( "prof_desc_male", desc_male );
         _description_female = to_translation( "prof_desc_female", desc_female );
     }
-    if( jo.has_int( "age_lower" ) ) {
-        age_lower = jo.get_int( "age_lower" );
-    } else {
-        age_lower = 21;
-    }
-    if( jo.has_int( "age_upper" ) ) {
-        age_upper = jo.get_int( "age_upper" );
-    } else {
-        age_upper = 55;
-    }
+    age_lower = jo.get_int( "age_lower", 21 );
+    age_upper = jo.get_int( "age_upper", 55 );
 
     if( jo.has_string( "vehicle" ) ) {
         _starting_vehicle = vproto_id( jo.get_string( "vehicle" ) );

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -195,6 +195,12 @@ void profession::load( const JsonObject &jo, const std::string_view )
         _description_male = to_translation( "prof_desc_male", desc_male );
         _description_female = to_translation( "prof_desc_female", desc_female );
     }
+    if(jo.has_int("age_lower")){
+        age_lower = jo.get_int("age_lower");
+    }else{age_lower = 21;}
+    if(jo.has_int("age_upper")){
+        age_upper = jo.get_int("age_upper");
+    }else {age_upper = 55;}
 
     if( jo.has_string( "vehicle" ) ) {
         _starting_vehicle = vproto_id( jo.get_string( "vehicle" ) );

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -195,12 +195,16 @@ void profession::load( const JsonObject &jo, const std::string_view )
         _description_male = to_translation( "prof_desc_male", desc_male );
         _description_female = to_translation( "prof_desc_female", desc_female );
     }
-    if(jo.has_int("age_lower")){
-        age_lower = jo.get_int("age_lower");
-    }else{age_lower = 21;}
-    if(jo.has_int("age_upper")){
-        age_upper = jo.get_int("age_upper");
-    }else {age_upper = 55;}
+    if( jo.has_int( "age_lower" ) ) {
+        age_lower = jo.get_int( "age_lower" );
+    } else {
+        age_lower = 21;
+    }
+    if( jo.has_int( "age_upper" ) ) {
+        age_upper = jo.get_int( "age_upper" );
+    } else {
+        age_upper = 55;
+    }
 
     if( jo.has_string( "vehicle" ) ) {
         _starting_vehicle = vproto_id( jo.get_string( "vehicle" ) );

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -195,8 +195,8 @@ void profession::load( const JsonObject &jo, const std::string_view )
         _description_male = to_translation( "prof_desc_male", desc_male );
         _description_female = to_translation( "prof_desc_female", desc_female );
     }
-    age_lower = jo.get_int( "age_lower", 21 );
-    age_upper = jo.get_int( "age_upper", 55 );
+    optional( jo, was_loaded, "age_lower", age_lower );
+    optional( jo, was_loaded, "age_upper", age_upper );
 
     if( jo.has_string( "vehicle" ) ) {
         _starting_vehicle = vproto_id( jo.get_string( "vehicle" ) );

--- a/src/profession.h
+++ b/src/profession.h
@@ -119,6 +119,8 @@ class profession
         std::vector<proficiency_id> proficiencies() const;
         StartingSkillList skills() const;
         const std::vector<mission_type_id> &missions() const;
+        int age_lower; 
+        int age_upper;
 
         std::optional<achievement_id> get_requirement() const;
 

--- a/src/profession.h
+++ b/src/profession.h
@@ -119,7 +119,7 @@ class profession
         std::vector<proficiency_id> proficiencies() const;
         StartingSkillList skills() const;
         const std::vector<mission_type_id> &missions() const;
-        int age_lower; 
+        int age_lower;
         int age_upper;
 
         std::optional<achievement_id> get_requirement() const;

--- a/src/profession.h
+++ b/src/profession.h
@@ -119,8 +119,8 @@ class profession
         std::vector<proficiency_id> proficiencies() const;
         StartingSkillList skills() const;
         const std::vector<mission_type_id> &missions() const;
-        int age_lower;
-        int age_upper;
+        int age_lower = 21;
+        int age_upper = 55;
 
         std::optional<achievement_id> get_requirement() const;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Randomly generated characters are now aged appropriately to their profession"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When starting a game through Play Now, I've noticed that in the some scenarios, characters have nonsensical age, such as Senior Citizens that are 30 years old.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Profession JSON can now have lower and upper age bounds defined. These do not limit player choice (if you want to play a 16-year-old Major General, you still can), they only affect random generation. For most professions (where bounds aren't defined explicitly), the default lower bound is 21, and the upper bound is 55 (max age).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Tie this into profession groups, but this would probably bloat groups.
Restrict not just random gen, but also manual age input. I don't really want to limit player options with my first PR.
Raise maximum character age so that Senior Citizens could be older than 55. Out of scope of this PR.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Pressed Play Now a few times. Schoolkids generated with ages that are below 18, as they should. An Old Veteran generated with age 52, as she should have.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I don't know much about US military forces, so age brackets could be defined for them in another PR by someone else.
Fixes #66521
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
