### PR TITLE
Allow free selection of cataclysm and game start dates in new character menu

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -521,8 +521,8 @@
     "start_name": "Outside Town",
     "surround_groups": [ [ "GROUP_BLACK_ROAD", 70.0 ] ],
     "flags": [ "LONE_START" ],
-    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
-    "start_of_game": { "hour": "random", "day": "random", "season": "winter", "year": 1 },
+    "start_of_cataclysm": { "hour": 0, "day": 61, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": 8, "day": 1, "season": "winter", "year": 1 },
     "add_professions": true,
     "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army" ],
     "requirement": "achievement_survive_91_days"
@@ -547,8 +547,8 @@
     ],
     "start_name": "Outside Town",
     "flags": [ "LONE_START" ],
-    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
-    "start_of_game": { "hour": "random", "day": "random", "season": "summer", "year": 2 },
+    "start_of_cataclysm": { "hour": 0, "day": 61, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": 8, "day": 1, "season": "summer", "year": 2 },
     "add_professions": true,
     "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army" ],
     "requirement": "achievement_survive_91_days"
@@ -561,8 +561,8 @@
     "description": "It's been a year since the apocalypse, and winter is fast approaching.  You and your company have managed to gather up enough supplies to finally settle down somewhere, away from the death and destruction.  Life has been hard for you, but in your heart you still hold a vision of a bright future lying ahead.",
     "start_name": "Old Evac Shelter",
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
-    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
-    "start_of_game": { "hour": "random", "day": "random", "season": "autumn", "year": 2 },
+    "start_of_cataclysm": { "hour": 0, "day": 61, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": 8, "day": 1, "season": "autumn", "year": 2 },
     "add_professions": true,
     "professions": [ "sheltered_survivor", "sheltered_militia", "winter_scavenger", "winter_army" ],
     "requirement": "achievement_survive_91_days",
@@ -578,8 +578,8 @@
     "allowed_locs": [ "sloc_lmoe_empty", "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "start_name": "Enclosed Shelter",
     "flags": [ "LONE_START" ],
-    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
-    "start_of_game": { "hour": "random", "day": "random", "season": "winter", "year": 1 },
+    "start_of_cataclysm": { "hour": 0, "day": 61, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": 8, "day": 1, "season": "winter", "year": 1 },
     "professions": [ "sheltered_militia", "sheltered_survivor", "unemployed" ]
   },
   {
@@ -652,8 +652,8 @@
     "requirement": "achievement_reach_mi-Go_encampment",
     "reveal_locale": false,
     "flags": [ "LONE_START", "CHALLENGE" ],
-    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
-    "start_of_game": { "hour": "random", "day": "random", "season": "winter", "year": 1 }
+    "start_of_cataclysm": { "hour": 0, "day": 61, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": 8, "day": 1, "season": "winter", "year": 1 }
   },
   {
     "type": "scenario",
@@ -1102,8 +1102,8 @@
     "description": "You were camping in the wild to let things back home cool off.  One night strange noises closed in on you and you were attacked.  You managed to get away but can feel things moving in the dark.",
     "id": "camp_attack_start",
     "points": 0,
-    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
-    "start_of_game": { "hour": 1, "day": 60, "season": "spring", "year": 1 },
+    "start_of_cataclysm": { "hour": 0, "day": 61, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": 1, "day": 61, "season": "spring", "year": 1 },
     "start_name": "Wilderness",
     "eoc": [ "scenario_surrounded_zombie_heavy" ],
     "allowed_locs": [

--- a/data/mods/Standard_Combat_Tests/modinfo.json
+++ b/data/mods/Standard_Combat_Tests/modinfo.json
@@ -37,7 +37,8 @@
     "professions": [ "sct_mid" ],
     "map_extra": "mx_sct_mid",
     "flags": [ "CITY_START", "LONE_START" ],
-    "start_of_game": { "hour": 8, "day": 45, "season": "summer" }
+    "start_of_cataclysm": { "hour": 0, "day": 61, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": 8, "day": 45, "season": "summer", "year": 1 }
   },
   {
     "type": "scenario",
@@ -50,7 +51,8 @@
     "professions": [ "sct_late" ],
     "map_extra": "mx_sct_late",
     "flags": [ "CITY_START", "LONE_START" ],
-    "start_of_game": { "hour": 8, "day": 45, "season": "autumn" }
+    "start_of_cataclysm": { "hour": 0, "day": 61, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": 8, "day": 45, "season": "autumn", "year": 1 }
   },
   {
     "id": "mx_sct_day1",

--- a/data/mods/TEST_DATA/scenarios.json
+++ b/data/mods/TEST_DATA/scenarios.json
@@ -8,8 +8,7 @@
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "start_name": "Evac Shelter",
     "flags": [ "CITY_START" ],
-    "start_of_cataclysm": { "year": 1, "season": "spring", "day": 60, "hour": 0 },
-    "start_of_game": { "year": 4, "season": "summer", "day": 7, "hour": 18 }
+    "start_of_game": { "hour": 18, "day": 7, "season": "summer", "year": 4 }
   },
   {
     "type": "scenario",
@@ -20,8 +19,7 @@
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "start_name": "Evac Shelter",
     "flags": [ "CITY_START" ],
-    "start_of_cataclysm": { "year": 1, "season": "spring", "day": 60, "hour": 0 },
-    "start_of_game": { "year": -1, "season": "spring", "day": 8, "hour": 3 }
+    "start_of_game": { "hour": 3, "day": 8, "season": "spring", "year": -1 }
   },
   {
     "type": "scenario",
@@ -32,7 +30,7 @@
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "start_name": "Evac Shelter",
     "flags": [ "CITY_START" ],
-    "start_of_cataclysm": { "year": 7, "season": "autumn", "day": 9, "hour": 1 }
+    "start_of_cataclysm": { "hour": 1, "day": 9, "season": "autumn", "year": 7 }
   },
   {
     "type": "scenario",
@@ -43,43 +41,7 @@
     "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
     "start_name": "Evac Shelter",
     "flags": [ "CITY_START" ],
-    "start_of_cataclysm": { "year": 6, "season": "winter", "day": 4, "hour": 6 },
-    "start_of_game": { "year": 9, "season": "autumn", "day": 19, "hour": 13 }
-  },
-  {
-    "type": "scenario",
-    "id": "test_random_hour",
-    "name": "Test random hour",
-    "points": 0,
-    "description": "Test starting on random hour.",
-    "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
-    "start_name": "Evac Shelter",
-    "flags": [ "CITY_START" ],
-    "start_of_cataclysm": { "day": 60, "season": "spring", "year": 1, "hour": 0 },
-    "start_of_game": { "day": 0, "year": 1, "hour": "random", "season": "summer" }
-  },
-  {
-    "type": "scenario",
-    "id": "test_random_day",
-    "name": "Test random day",
-    "points": 0,
-    "description": "Test starting on random day.",
-    "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
-    "start_name": "Evac Shelter",
-    "flags": [ "CITY_START" ],
-    "start_of_cataclysm": { "day": 60, "season": "spring", "year": 1, "hour": 0 },
-    "start_of_game": { "day": "random", "season": "summer", "year": 1, "hour": 8 }
-  },
-  {
-    "type": "scenario",
-    "id": "test_random_year",
-    "name": "Test random year",
-    "points": 0,
-    "description": "Test starting on random year.",
-    "allowed_locs": [ "sloc_shelter_a", "sloc_shelter_b", "sloc_shelter_c" ],
-    "start_name": "Evac Shelter",
-    "flags": [ "CITY_START" ],
-    "start_of_cataclysm": { "day": 60, "season": "spring", "year": 1, "hour": 0 },
-    "start_of_game": { "year": "random", "day": 60, "season": "summer", "hour": 8 }
+    "start_of_cataclysm": { "hour": 6, "day": 4, "season": "winter", "year": 6 },
+    "start_of_game": { "hour": 13, "day": 19, "season": "autumn", "year": 9 }
   }
 ]

--- a/data/mods/innawood/scenarios.json
+++ b/data/mods/innawood/scenarios.json
@@ -261,8 +261,8 @@
     "start_name": "Outside Town",
     "surround_groups": [ [ "GROUP_BLACK_ROAD", 70.0 ] ],
     "flags": [ "LONE_START" ],
-    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
-    "start_of_game": { "day": "random", "hour": "random", "season": "winter", "year": 1 },
+    "start_of_cataclysm": { "hour": 0, "day": 61, "season": "spring", "year": 1 },
+    "start_of_game": { "hour": 8, "day": 1, "season": "winter", "year": 1 },
     "professions": [
       "svictim",
       "naked",
@@ -302,7 +302,7 @@
     "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island", "sloc_river" ],
     "start_name": "Outside Town",
     "flags": [ "LONE_START" ],
-    "start_of_cataclysm": { "hour": 0, "day": 60, "season": "spring", "year": 1 },
+    "start_of_cataclysm": { "hour": 0, "day": 61, "season": "spring", "year": 1 },
     "start_of_game": { "hour": 8, "day": 1, "season": "summer", "year": 2 },
     "professions": [
       "svictim",

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1528,6 +1528,27 @@
   },
   {
     "type": "keybinding",
+    "id": "CHANGE_START_OF_CATACLYSM",
+    "category": "NEW_CHAR_DESCRIPTION",
+    "name": "Change cataclysm start date",
+    "bindings": [ { "input_method": "keyboard_char", "key": "%" }, { "input_method": "keyboard_code", "key": "5", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "CHANGE_START_OF_GAME",
+    "category": "NEW_CHAR_DESCRIPTION",
+    "name": "Change game start date",
+    "bindings": [ { "input_method": "keyboard_char", "key": "^" }, { "input_method": "keyboard_code", "key": "6", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "RESET_CALENDAR",
+    "category": "NEW_CHAR_DESCRIPTION",
+    "name": "Reset scenario calendar",
+    "bindings": [ { "input_method": "keyboard_char", "key": "$" }, { "input_method": "keyboard_code", "key": "4", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
     "id": "CHOOSE_CITY",
     "category": "NEW_CHAR_DESCRIPTION",
     "name": "Choose character starting city",
@@ -1579,38 +1600,31 @@
   },
   {
     "type": "keybinding",
-    "id": "RANDOMIZE_SCENARIO_START_OF_CATACLYSM",
-    "category": "NEW_CHAR_SCENARIOS",
-    "name": "Randomize cataclysm start date (if supported by scenario)",
-    "bindings": [ { "input_method": "keyboard_char", "key": "^" }, { "input_method": "keyboard_code", "key": "6", "mod": [ "shift" ] } ]
-  },
-  {
-    "type": "keybinding",
-    "id": "RANDOMIZE_SCENARIO_START_OF_GAME",
-    "category": "NEW_CHAR_SCENARIOS",
-    "name": "Randomize game start date (if supported by scenario)",
-    "bindings": [ { "input_method": "keyboard_char", "key": "&" }, { "input_method": "keyboard_code", "key": "7", "mod": [ "shift" ] } ]
-  },
-  {
-    "type": "keybinding",
-    "id": "RESET_SCENARIO_START_OF_CATACLYSM",
-    "category": "NEW_CHAR_SCENARIOS",
-    "name": "Reset cataclysm start date",
-    "bindings": [ { "input_method": "keyboard_char", "key": "$" }, { "input_method": "keyboard_code", "key": "4", "mod": [ "shift" ] } ]
-  },
-  {
-    "type": "keybinding",
-    "id": "RESET_SCENARIO_START_OF_GAME",
-    "category": "NEW_CHAR_SCENARIOS",
-    "name": "Reset game start date",
-    "bindings": [ { "input_method": "keyboard_char", "key": "%" }, { "input_method": "keyboard_code", "key": "5", "mod": [ "shift" ] } ]
-  },
-  {
-    "type": "keybinding",
     "id": "SORT",
     "category": "NEW_CHAR_SCENARIOS",
     "name": "Toggle sorting order",
     "bindings": [ { "input_method": "keyboard_any", "key": "s" } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "CHANGE_START_OF_CATACLYSM",
+    "category": "NEW_CHAR_SCENARIOS",
+    "name": "Change cataclysm start date",
+    "bindings": [ { "input_method": "keyboard_char", "key": "%" }, { "input_method": "keyboard_code", "key": "5", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "CHANGE_START_OF_GAME",
+    "category": "NEW_CHAR_SCENARIOS",
+    "name": "Change game start date",
+    "bindings": [ { "input_method": "keyboard_char", "key": "^" }, { "input_method": "keyboard_code", "key": "6", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
+    "id": "RESET_CALENDAR",
+    "category": "NEW_CHAR_SCENARIOS",
+    "name": "Reset scenario calendar",
+    "bindings": [ { "input_method": "keyboard_char", "key": "$" }, { "input_method": "keyboard_code", "key": "4", "mod": [ "shift" ] } ]
   },
   {
     "type": "keybinding",

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -5330,36 +5330,36 @@ A list of mission ids that will be started and assigned to the player at the sta
 ## `start_of_cataclysm`
 (optional, object with optional members "hour", "day", "season" and "year")
 
-Allows customization of cataclysm start date. If `start_of_cataclysm` is not set the corresponding default values are used instead - 0 hour, 60 day (which is day 61), Spring season, 1 year. By default this date be randomized in new character creation screen.
+Allows customization of cataclysm start date. If `start_of_cataclysm` is not set the corresponding default values are used instead - `Year 1, Spring, Day 61, 00:00:00`. Can be changed in new character creation screen.
 
 ```C++
-"start_of_cataclysm": { "hour": "random", "day": 10, "season": "winter", "year": 1 }
+"start_of_cataclysm": { "hour": 7, "day": 10, "season": "winter", "year": 1 }
 ```
 
  Identifier            | Description
 ---                    | ---
-`hour`                 | (optional, integer or `random` string) Hour of the day. Default value is 0. String `random` randomizes 0-23.
-`day`                  | (optional, integer or `random` string) Day of the season. Default value is 60 (which is day 61). String `random` randomizes 0-season length.
-`season`               | (optional, integer or `random` string) Season of the year. Default value is `spring`. String `random` randomizes to one of 4 season.
-`year`                 | (optional, integer or `random` string) Year. Default value is 1. String `random` randomizes 1-11.
+`hour`                 | (optional, integer) Hour of the day. Default value is 0.
+`day`                  | (optional, integer) Day of the season. Default value is 61.
+`season`               | (optional, integer) Season of the year. Default value is `spring`.
+`year`                 | (optional, integer) Year. Default value is 1.
 
 ## `start_of_game`
 (optional, object with optional members "hour", "day", "season" and "year")
 
-Allows customization of game start date. If `start_of_game` is not set the corresponding default values are used instead - random hour (0-23), 60 day (which is day 61), Spring season, 1 year. By default hour part of this date can be randomized in new character creation screen.
+Allows customization of game start date. If `start_of_game` is not set the corresponding default values are used instead - `Year 1, Spring, Day 61, 08:00:00`. Can be changed in new character creation screen.
 
-If the scenario game start date is before the scenario cataclysm start date then the scenario game start would be automatically set to scenario cataclysm start date.
+**Attention**: Game start date is automatically adjusted, so it is not before the cataclysm start date.
 
 ```C++
-"start_of_game": { "hour": "random", "day": "random", "season": "winter", "year": 2 }
+"start_of_game": { "hour": 8, "day": 16, "season": "winter", "year": 2 }
 ```
 
  Identifier            | Description
 ---                    | ---
-`hour`                 | (optional, integer or `random` string) Hour of the day. Default value is 8. String `random` randomizes 0-23.
-`day`                  | (optional, integer or `random` string) Day of the season. Default value is 60 (which is day 61). String `random` randomizes 0-season length.
-`season`               | (optional, integer or `random` string) Season of the year. Default value is `spring`. String `random` randomizes to one of 4 season.
-`year`                 | (optional, integer or `random` string) Year. Default value is 1. String `random` randomizes 1-11.
+`hour`                 | (optional, integer) Hour of the day. Default value is 8.
+`day`                  | (optional, integer) Day of the season. Default value is 61.
+`season`               | (optional, integer) Season of the year. Default value is `spring`.
+`year`                 | (optional, integer) Year. Default value is 1.
 
 # Starting locations
 

--- a/src/calendar_ui.cpp
+++ b/src/calendar_ui.cpp
@@ -1,0 +1,80 @@
+#include "calendar_ui.h"
+
+#include "string_formatter.h"
+#include "string_input_popup.h"
+#include "ui.h"
+#include "ui_manager.h"
+
+time_point calendar_ui::select_time_point( time_point initial_value, std::string_view title )
+{
+    time_point return_value = initial_value;
+    auto set_turn = [&]( const int initial, const time_duration & factor, const char *const msg ) {
+        string_input_popup pop;
+        const int new_value = pop
+                              .title( msg )
+                              .width( 20 )
+                              .text( std::to_string( initial ) )
+                              .only_digits( true )
+                              .query_int();
+        if( pop.canceled() ) {
+            return;
+        }
+        const time_duration offset = ( new_value - initial ) * factor;
+        // Arbitrary maximal value.
+        const time_point max = calendar::turn_zero + time_duration::from_turns(
+                                   std::numeric_limits<int>::max() / 2 );
+        return_value = std::max( std::min( max, return_value + offset ), calendar::turn_zero );
+    };
+
+    uilist smenu;
+    static const auto years = []( const time_point & p ) {
+        return static_cast<int>( ( p - calendar::turn_zero ) / calendar::year_length() );
+    };
+    do {
+        const int iSel = smenu.ret;
+        smenu.reset();
+        smenu.title = title;
+        smenu.text += string_format( "Old date: %1$s\nNew date: %2$s",
+                                     colorize( to_string( initial_value ), c_light_red ),
+                                     colorize( to_string( return_value ), c_light_cyan ) );
+        smenu.desc_enabled = true;
+        smenu.footer_text = string_format( _( "Press <color_light_green>%s</color> when done" ),
+                                           input_context( smenu.input_category ).get_desc( "UILIST.QUIT" ) );
+        smenu.addentry( 0, true, 'y', "%s: %d", _( "year" ), years( return_value ) + 1 );
+        smenu.addentry( 1, !calendar::eternal_season(), 's', "%s: %d",
+                        _( "season" ), static_cast<int>( season_of_year( return_value ) ) );
+        smenu.addentry( 2, true, 'd', "%s: %d", _( "day" ), day_of_season<int>( return_value ) + 1 );
+        smenu.addentry( 3, true, 'h', "%s: %d", _( "hour" ), hour_of_day<int>( return_value ) );
+        smenu.addentry( 4, true, 'm', "%s: %d", _( "minute" ), minute_of_hour<int>( return_value ) );
+        smenu.addentry( 5, true, 't', "%s: %d", _( "turn" ),
+                        to_turns<int>( return_value - calendar::turn_zero ) );
+        smenu.selected = iSel;
+        smenu.query();
+
+        switch( smenu.ret ) {
+            case 0:
+                set_turn( years( return_value ) + 1, calendar::year_length(), _( "Set year to?" ) );
+                break;
+            case 1:
+                set_turn( static_cast<int>( season_of_year( return_value ) ), calendar::season_length(),
+                          _( "Set season to?  (0 = spring)" ) );
+                break;
+            case 2:
+                set_turn( day_of_season<int>( return_value ) + 1, 1_days, _( "Set days to?" ) );
+                break;
+            case 3:
+                set_turn( hour_of_day<int>( return_value ), 1_hours, _( "Set hour to?" ) );
+                break;
+            case 4:
+                set_turn( minute_of_hour<int>( return_value ), 1_minutes, _( "Set minute to?" ) );
+                break;
+            case 5:
+                set_turn( to_turns<int>( return_value - calendar::turn_zero ), 1_turns,
+                          string_format( _( "Set turn to?  (One day is %i turns)" ), to_turns<int>( 1_days ) ).c_str() );
+                break;
+            default:
+                break;
+        }
+    } while( smenu.ret != UILIST_CANCEL );
+    return return_value;
+}

--- a/src/calendar_ui.h
+++ b/src/calendar_ui.h
@@ -1,0 +1,20 @@
+#pragma once
+#ifndef CATA_SRC_CALENDAR_UI_H
+#define CATA_SRC_CALENDAR_UI_H
+
+#include <string>
+
+#include "calendar.h"
+#include "translations.h"
+
+namespace calendar_ui
+{
+
+/**
+ * Displays ui element that allows to select and return time point.
+ */
+time_point select_time_point( time_point initial_value,
+                              std::string_view title = _( "Select time point" ) );
+} // namespace calendar_ui
+
+#endif // CATA_SRC_CALENDAR_UI_H

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -33,6 +33,7 @@
 #include "avatar.h"
 #include "bodypart.h"
 #include "calendar.h"
+#include "calendar_ui.h"
 #include "cata_path.h"
 #include "cata_utility.h"
 #include "catacharset.h"
@@ -2523,71 +2524,6 @@ static void debug_menu_spawn_vehicle()
     }
 }
 
-static void debug_menu_change_time()
-{
-    auto set_turn = [&]( const int initial, const time_duration & factor, const char *const msg ) {
-        string_input_popup pop;
-        const int new_value = pop
-                              .title( msg )
-                              .width( 20 )
-                              .text( std::to_string( initial ) )
-                              .only_digits( true )
-                              .query_int();
-        if( pop.canceled() ) {
-            return;
-        }
-        const time_duration offset = ( new_value - initial ) * factor;
-        // Arbitrary maximal value.
-        const time_point max = calendar::turn_zero + time_duration::from_turns(
-                                   std::numeric_limits<int>::max() / 2 );
-        calendar::turn = std::max( std::min( max, calendar::turn + offset ), calendar::turn_zero );
-    };
-
-    uilist smenu;
-    static const auto years = []( const time_point & p ) {
-        return static_cast<int>( ( p - calendar::turn_zero ) / calendar::year_length() );
-    };
-    do {
-        const int iSel = smenu.ret;
-        smenu.reset();
-        smenu.addentry( 0, true, 'y', "%s: %d", _( "year" ), years( calendar::turn ) + 1 );
-        smenu.addentry( 1, !calendar::eternal_season(), 's', "%s: %d",
-                        _( "season" ), static_cast<int>( season_of_year( calendar::turn ) ) );
-        smenu.addentry( 2, true, 'd', "%s: %d", _( "day" ), day_of_season<int>( calendar::turn ) + 1 );
-        smenu.addentry( 3, true, 'h', "%s: %d", _( "hour" ), hour_of_day<int>( calendar::turn ) );
-        smenu.addentry( 4, true, 'm', "%s: %d", _( "minute" ), minute_of_hour<int>( calendar::turn ) );
-        smenu.addentry( 5, true, 't', "%s: %d", _( "turn" ),
-                        to_turns<int>( calendar::turn - calendar::turn_zero ) );
-        smenu.selected = iSel;
-        smenu.query();
-
-        switch( smenu.ret ) {
-            case 0:
-                set_turn( years( calendar::turn ) + 1, calendar::year_length(), _( "Set year to?" ) );
-                break;
-            case 1:
-                set_turn( static_cast<int>( season_of_year( calendar::turn ) ), calendar::season_length(),
-                          _( "Set season to?  (0 = spring)" ) );
-                break;
-            case 2:
-                set_turn( day_of_season<int>( calendar::turn ) + 1, 1_days, _( "Set days to?" ) );
-                break;
-            case 3:
-                set_turn( hour_of_day<int>( calendar::turn ), 1_hours, _( "Set hour to?" ) );
-                break;
-            case 4:
-                set_turn( minute_of_hour<int>( calendar::turn ), 1_minutes, _( "Set minute to?" ) );
-                break;
-            case 5:
-                set_turn( to_turns<int>( calendar::turn - calendar::turn_zero ), 1_turns,
-                          string_format( _( "Set turn to?  (One day is %i turns)" ), to_turns<int>( 1_days ) ).c_str() );
-                break;
-            default:
-                break;
-        }
-    } while( smenu.ret != UILIST_CANCEL );
-}
-
 static void debug_menu_force_temperature()
 {
     uilist tempmenu;
@@ -3137,7 +3073,7 @@ void debug()
             g->toggle_debug_hour_timer();
             break;
         case debug_menu_index::CHANGE_TIME:
-            debug_menu_change_time();
+            calendar::turn = calendar_ui::select_time_point( calendar::turn );
             break;
         case debug_menu_index::FORCE_TEMP:
             debug_menu_force_temperature();

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -57,25 +57,8 @@ class scenario
 
         bool reveal_locale = true;
 
-        bool _is_random_start_of_cataclysm_hour = true;
-        bool _is_random_start_of_cataclysm_day = true;
-        bool _is_random_start_of_cataclysm_season = true;
-        bool _is_random_start_of_cataclysm_year = true;
-
-        int _start_of_cataclysm_hour = 0;
-        int _start_of_cataclysm_day = 60;
-        season_type _start_of_cataclysm_season = SPRING;
-        int _start_of_cataclysm_year = 1;
-
-        bool _is_random_start_of_game_hour = true;
-        bool _is_random_start_of_game_day = false;
-        bool _is_random_start_of_game_season = false;
-        bool _is_random_start_of_game_year = false;
-
-        int _start_of_game_hour = 8;
-        int _start_of_game_day = 60;
-        season_type _start_of_game_season = SPRING;
-        int _start_of_game_year = 1;
+        time_point _default_start_of_cataclysm;
+        time_point _default_start_of_game;
 
         time_point _start_of_cataclysm;
         time_point _start_of_game;
@@ -118,39 +101,13 @@ class scenario
 
         bool get_reveal_locale() const;
 
-        void rerandomize( bool randomize_start_of_cataclysm = true,
-                          bool randomize_start_of_game = true ) const;
-        void update_start_dates() const;
-
-        void reset_start_of_dates( bool reset_start_of_cataclysm = true,
-                                   bool reset_start_of_game = true ) const;
-
-        bool is_random_start_of_cataclysm_hour() const;
-        bool is_random_start_of_cataclysm_day() const;
-        bool is_random_start_of_cataclysm_season() const;
-        bool is_random_start_of_cataclysm_year() const;
-        bool is_random_start_of_cataclysm() const;
-
-        int start_of_cataclysm_hour() const;
-        // Returns day of the season cataclysm in this scenario starts on
-        int start_of_cataclysm_day() const;
-        season_type start_of_cataclysm_season() const;
-        int start_of_cataclysm_year() const;
-
-        bool is_random_start_of_game_hour() const;
-        bool is_random_start_of_game_day() const;
-        bool is_random_start_of_game_season() const;
-        bool is_random_start_of_game_year() const;
-        bool is_random_start_of_game() const;
-
-        int start_of_game_hour() const;
-        // Returns day of the season game in this scenario starts on
-        int start_of_game_day() const;
-        season_type start_of_game_season() const;
-        int start_of_game_year() const;
+        void normalize_calendar() const;
+        void reset_calendar() const;
 
         time_point start_of_cataclysm() const;
         time_point start_of_game() const;
+        void change_start_of_cataclysm( const time_point &t ) const;
+        void change_start_of_game( const time_point &t ) const;
 
         vproto_id vehicle() const;
 

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -1139,6 +1139,10 @@ TEST_CASE( "npc_test_tags", "[npc_talk]" )
 
 TEST_CASE( "npc_compare_int", "[npc_talk]" )
 {
+    calendar::turn = calendar::turn_zero;
+    calendar::start_of_cataclysm = calendar::turn_zero;
+    calendar::start_of_game = calendar::turn_zero;
+
     dialogue d;
     npc &beta = prep_test( d );
     Character &player_character = get_avatar();
@@ -1324,6 +1328,9 @@ TEST_CASE( "npc_arithmetic_op", "[npc_talk]" )
     gen_response_lines( d, 14 );
 
     calendar::turn = calendar::turn_zero;
+    calendar::start_of_cataclysm = calendar::turn_zero;
+    calendar::start_of_game = calendar::turn_zero;
+
     REQUIRE( calendar::turn == time_point( 0 ) );
     // "Sets time since cataclysm to 2 * 5 turns.  (10)"
     talk_effect_t &effects = d.responses[ 0 ].success;

--- a/tests/start_date_test.cpp
+++ b/tests/start_date_test.cpp
@@ -10,9 +10,6 @@ static const string_id<scenario> scenario_test_custom_both( "test_custom_both" )
 static const string_id<scenario> scenario_test_custom_cataclysm( "test_custom_cataclysm" );
 static const string_id<scenario> scenario_test_custom_game( "test_custom_game" );
 static const string_id<scenario> scenario_test_custom_game_invalid( "test_custom_game_invalid" );
-static const string_id<scenario> scenario_test_random_day( "test_random_day" );
-static const string_id<scenario> scenario_test_random_hour( "test_random_hour" );
-static const string_id<scenario> scenario_test_random_year( "test_random_year" );
 
 TEST_CASE( "Test_start_dates" )
 {
@@ -22,18 +19,17 @@ TEST_CASE( "Test_start_dates" )
     on_out_of_scope guard{ []()
     {
         set_scenario( scenario::generic() );
+        g->start_calendar();
     } };
 
     SECTION( "Scenario with custom game start date" ) {
         scenario scen = scenario_test_custom_game.obj();
-
         set_scenario( &scen );
-        scen.rerandomize();
         g->start_calendar();
 
         CHECK( calendar::start_of_game == calendar::turn_zero +
                1_hours * 18 +
-               1_days * 7 +
+               1_days * 6 +
                1_days * default_season_length * season_type::SUMMER +
                1_days * default_year_length * 3
              );
@@ -41,9 +37,7 @@ TEST_CASE( "Test_start_dates" )
 
     SECTION( "Scenario has game start date before cataclysm start date" ) {
         scenario scen = scenario_test_custom_game_invalid.obj();
-
         set_scenario( &scen );
-        scen.rerandomize();
         g->start_calendar();
 
         CHECK( calendar::start_of_game == calendar::start_of_cataclysm );
@@ -51,14 +45,12 @@ TEST_CASE( "Test_start_dates" )
 
     SECTION( "Scenario with custom cataclysm start date" ) {
         scenario scen = scenario_test_custom_cataclysm.obj();
-
         set_scenario( &scen );
-        scen.rerandomize();
         g->start_calendar();
 
         CHECK( calendar::start_of_cataclysm == calendar::turn_zero +
                1_hours * 1 +
-               1_days * 9 +
+               1_days * 8 +
                1_days * default_season_length * season_type::AUTUMN +
                1_days * default_year_length * 6
              );
@@ -66,137 +58,21 @@ TEST_CASE( "Test_start_dates" )
 
     SECTION( "Scenario with custom cataclysm start date and game start date" ) {
         scenario scen = scenario_test_custom_both.obj();
-
         set_scenario( &scen );
-        scen.rerandomize();
         g->start_calendar();
 
         CHECK( calendar::start_of_cataclysm == calendar::turn_zero +
                1_hours * 6 +
-               1_days * 4 +
+               1_days * 3 +
                1_days * default_season_length * season_type::WINTER +
                1_days * default_year_length * 5
              );
         CHECK( calendar::start_of_game == calendar::turn_zero +
                1_hours * 13 +
-               1_days * 19 +
+               1_days * 18 +
                1_days * default_season_length * season_type::AUTUMN +
                1_days * default_year_length * 8
              );
-    }
-
-    // Reset dates so other tests won't fail
-    calendar::start_of_game = calendar::turn_zero;
-    calendar::start_of_cataclysm = calendar::turn_zero;
-    calendar::turn = calendar::turn_zero;
-}
-
-TEST_CASE( "Random_scenario_dates" )
-{
-    // Days counted from start of year
-    time_duration first_day_of_summer = calendar::season_length();
-    time_duration last_day_of_summer = 2 * calendar::season_length() - 1_days;
-    time_duration default_start_hour = 1_hours * 8;
-
-    on_out_of_scope guard{ []()
-    {
-        set_scenario( scenario::generic() );
-    } };
-
-    SECTION( "Random hour" ) {
-        scenario scen = scenario_test_random_hour.obj();
-
-        set_scenario( &scen );
-        scen.rerandomize();
-        g->start_calendar();
-
-        // Random hour should result in something between day default_first_day_of_summer hour 0 - day first_day_of_summer hour 23
-        INFO( "Game started on turn " << to_turn<int>( calendar::start_of_game ) );
-        CHECK( calendar::start_of_game >= calendar::turn_zero + first_day_of_summer );
-        CHECK( calendar::start_of_game <= calendar::turn_zero + first_day_of_summer + 1_hours * 23 );
-
-        time_point start_of_game_1 = calendar::start_of_game;
-
-        // Generate up to 10 worlds to check that randomness makes different dates.
-        // If even one of them is different everything is fine.
-        bool all_same = true;
-        for( int i = 0; i < 10; i++ ) {
-            set_scenario( &scen );
-            scen.rerandomize();
-            g->start_calendar();
-            all_same = start_of_game_1 == calendar::start_of_game;
-            if( !all_same ) {
-                break;
-            }
-        }
-
-        // There is astronomically low chance for this to fail even if everything is working right.
-        CHECK_FALSE( all_same );
-    }
-
-    SECTION( "Random day" ) {
-        scenario scen = scenario_test_random_day.obj();
-
-        set_scenario( &scen );
-        scen.rerandomize();
-        g->start_calendar();
-
-        // Random day should result in something between day first_day_of_summer hour 8 - day last_day_of_summer hour 8
-        INFO( "Game started on turn " << to_turn<int>( calendar::start_of_game ) );
-        CHECK( calendar::start_of_game >= calendar::turn_zero + first_day_of_summer +
-               default_start_hour );
-        CHECK( calendar::start_of_game <= calendar::turn_zero + last_day_of_summer + default_start_hour );
-
-        time_point start_of_game_1 = calendar::start_of_game;
-
-        // Generate up to 10 worlds to check that randomness makes different dates.
-        // If even one of them is different everything is fine.
-        bool all_same = true;
-        for( int i = 0; i < 10; i++ ) {
-            set_scenario( &scen );
-            scen.rerandomize();
-            g->start_calendar();
-            all_same = start_of_game_1 == calendar::start_of_game;
-            if( !all_same ) {
-                break;
-            }
-        }
-
-        // There is astronomically low chance for this to fail even if everything is working right.
-        CHECK_FALSE( all_same );
-    }
-
-    SECTION( "Random year" ) {
-        scenario scen = scenario_test_random_year.obj();
-
-        set_scenario( &scen );
-        scen.rerandomize();
-        g->start_calendar();
-
-        // Random year should result in something between year 0 day first_day_of_summer hour 8 - year 11 day first_day_of_summer hour 8
-        INFO( "Game started on turn " << to_turn<int>( calendar::start_of_game ) );
-        CHECK( calendar::start_of_game >= calendar::turn_zero + first_day_of_summer +
-               default_start_hour );
-        CHECK( calendar::start_of_game <= calendar::turn_zero + first_day_of_summer +
-               calendar::year_length() * 10 + default_start_hour );
-
-        time_point start_of_game_1 = calendar::start_of_game;
-
-        // Generate up to 10 worlds to check that randomness makes different dates.
-        // If even one of them is different everything is fine.
-        bool all_same = true;
-        for( int i = 0; i < 10; i++ ) {
-            set_scenario( &scen );
-            scen.rerandomize();
-            g->start_calendar();
-            all_same = start_of_game_1 == calendar::start_of_game;
-            if( !all_same ) {
-                break;
-            }
-        }
-
-        // There is astronomically low chance for this to fail even if everything is working right.
-        CHECK_FALSE( all_same );
     }
 
     // Reset dates so other tests won't fail

--- a/tests/stats_tracker_test.cpp
+++ b/tests/stats_tracker_test.cpp
@@ -19,6 +19,7 @@
 #include "event_bus.h"
 #include "event_statistics.h"
 #include "event_subscriber.h"
+#include "game.h"
 #include "game_constants.h"
 #include "json.h"
 #include "json_loader.h"
@@ -565,6 +566,9 @@ TEST_CASE( "stats_tracker_watchers", "[stats]" )
 
 TEST_CASE( "achievements_tracker", "[stats]" )
 {
+
+    g->start_calendar();
+
     override_option opt( "24_HOUR", "military" );
 
     std::map<achievement_id, const achievement *> achievements_completed;
@@ -695,7 +699,7 @@ TEST_CASE( "achievements_tracker", "[stats]" )
         } else {
             CHECK( a.ui_text_for( &*a_kill_in_first_minute ) ==
                    "<color_c_red>Rude awakening</color>\n"
-                   "  <color_c_red>Failed Year 1, Spring, day 1 0010.00</color>\n"
+                   "  <color_c_red>Failed Year 1, Spring, day 61 0810.00</color>\n"
                    "  <color_c_yellow>0/1 monster killed</color>\n" );
         }
 
@@ -719,34 +723,34 @@ TEST_CASE( "achievements_tracker", "[stats]" )
         if( time_since_game_start < 1_minutes ) {
             CHECK( a.ui_text_for( achievements_completed.at( a_kill_zombie ) ) ==
                    "<color_c_light_green>One down, billions to go…</color>\n"
-                   "  <color_c_light_green>Completed Year 1, Spring, day 1 0000.30</color>\n"
+                   "  <color_c_light_green>Completed Year 1, Spring, day 61 0800.30</color>\n"
                    "  <color_c_green>1/1 zombie killed</color>\n" );
             CHECK( a.ui_text_for( achievements_completed.at( a_kill_in_first_minute ) ) ==
                    "<color_c_light_green>Rude awakening</color>\n"
-                   "  <color_c_light_green>Completed Year 1, Spring, day 1 0000.30</color>\n"
+                   "  <color_c_light_green>Completed Year 1, Spring, day 61 0800.30</color>\n"
                    "  <color_c_green>1/1 monster killed</color>\n" );
         } else {
             CHECK( a.ui_text_for( achievements_completed.at( a_kill_zombie ) ) ==
                    "<color_c_light_green>One down, billions to go…</color>\n"
-                   "  <color_c_light_green>Completed Year 1, Spring, day 1 0010.00</color>\n"
+                   "  <color_c_light_green>Completed Year 1, Spring, day 61 0810.00</color>\n"
                    "  <color_c_green>1/1 zombie killed</color>\n" );
             CHECK( !achievements_completed.count( a_kill_in_first_minute ) );
             CHECK( a.ui_text_for( &*a_kill_in_first_minute ) ==
                    "<color_c_red>Rude awakening</color>\n"
-                   "  <color_c_red>Failed Year 1, Spring, day 1 0010.00</color>\n"
+                   "  <color_c_red>Failed Year 1, Spring, day 61 0810.00</color>\n"
                    "  <color_c_yellow>0/1 monster killed</color>\n" );
         }
 
         if( time_since_game_start < 1_minutes ) {
             CHECK( a.ui_text_for( &*c_pacifist ) ==
                    "<color_c_red>Pacifist</color>\n"
-                   "  <color_c_red>Failed Year 1, Spring, day 1 0000.30</color>\n"
+                   "  <color_c_red>Failed Year 1, Spring, day 61 0800.30</color>\n"
                    "  <color_c_yellow>Kill no monsters</color>\n"
                    "  <color_c_green>Kill no characters</color>\n" );
         } else {
             CHECK( a.ui_text_for( &*c_pacifist ) ==
                    "<color_c_red>Pacifist</color>\n"
-                   "  <color_c_red>Failed Year 1, Spring, day 1 0010.00</color>\n"
+                   "  <color_c_red>Failed Year 1, Spring, day 61 0810.00</color>\n"
                    "  <color_c_yellow>Kill no monsters</color>\n"
                    "  <color_c_green>Kill no characters</color>\n" );
         }
@@ -765,21 +769,21 @@ TEST_CASE( "achievements_tracker", "[stats]" )
         if( time_since_game_start < 1_minutes ) {
             CHECK( a.ui_text_for( achievements_completed.at( a_kill_zombie ) ) ==
                    "<color_c_light_green>One down, billions to go…</color>\n"
-                   "  <color_c_light_green>Completed Year 1, Spring, day 1 0000.30</color>\n"
+                   "  <color_c_light_green>Completed Year 1, Spring, day 61 0800.30</color>\n"
                    "  <color_c_green>1/1 zombie killed</color>\n" );
             CHECK( a.ui_text_for( achievements_completed.at( a_kill_in_first_minute ) ) ==
                    "<color_c_light_green>Rude awakening</color>\n"
-                   "  <color_c_light_green>Completed Year 1, Spring, day 1 0000.30</color>\n"
+                   "  <color_c_light_green>Completed Year 1, Spring, day 61 0800.30</color>\n"
                    "  <color_c_green>1/1 monster killed</color>\n" );
         } else {
             CHECK( a.ui_text_for( achievements_completed.at( a_kill_zombie ) ) ==
                    "<color_c_light_green>One down, billions to go…</color>\n"
-                   "  <color_c_light_green>Completed Year 1, Spring, day 1 0010.00</color>\n"
+                   "  <color_c_light_green>Completed Year 1, Spring, day 61 0810.00</color>\n"
                    "  <color_c_green>1/1 zombie killed</color>\n" );
             CHECK( !achievements_completed.count( a_kill_in_first_minute ) );
             CHECK( a.ui_text_for( &*a_kill_in_first_minute ) ==
                    "<color_c_red>Rude awakening</color>\n"
-                   "  <color_c_red>Failed Year 1, Spring, day 1 0010.00</color>\n"
+                   "  <color_c_red>Failed Year 1, Spring, day 61 0810.00</color>\n"
                    "  <color_c_yellow>0/1 monster killed</color>\n" );
         }
     }


### PR DESCRIPTION
#### Summary
Features "Allow free selection of cataclysm and game start dates in new character menu"

#### Purpose of change

Reworked scenario calendar to allow free selection of cataclysm and game start dates.

Fixes #67674
Fixes #67759

#### Describe the solution

See commit messages.

#### Additional context

Same UI element for time point selection is used for debug menu date change. We probably can expand it later with additional actions ("reset to old value", "increase by 1 day", "decrease by 1 day", etc).

__Screenshots:__

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/16213433/c55449e2-f4c9-4f04-8d86-646e9f13656b)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/16213433/c643537b-fe38-4f3c-9aa7-80394da83745)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/16213433/48da6229-d85b-4a47-8401-0ab7411c159b)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/16213433/8a1fd72a-4cbf-429a-b626-24123c4810a6)