### PR TITLE
Colourize confirm message in compare item screen

### DIFF
--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -2187,9 +2187,12 @@ bool game_menus::inv::compare_items( const item &first, const item &second,
             ui.on_redraw( [&]( const ui_adaptor & ) {
                 if( !confirm_message.empty() ) {
                     draw_border( wnd_message );
-                    mvwputch( wnd_message, point( 3, 1 ), c_white, confirm_message
-                              + " " + ctxt.describe_key_and_name( "CONFIRM" )
-                              + " " + ctxt.describe_key_and_name( "QUIT" ) );
+                    nc_color col = c_white;
+                    print_colored_text(
+                        wnd_message, point( 3, 1 ), col, col,
+                        confirm_message + " " +
+                        ctxt.describe_key_and_name( "CONFIRM" ) + " " +
+                        ctxt.describe_key_and_name( "QUIT" ) );
                     wnoutrefresh( wnd_message );
                 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #67581.

After #67309, this text had colour tags in but those were not being correctly interpreted.

#### Describe the solution
Change the printing function so that they are.

#### Describe alternatives you've considered
None

#### Testing
Checked in-game.

#### Additional context
![attach-modification-after](https://github.com/CleverRaven/Cataclysm-DDA/assets/52664/5c313442-ebeb-4b55-89d0-d94bbdafcacd)