### PR TITLE
Erase invalid or blacklisted nested categories

### DIFF
--- a/src/recipe_dictionary.cpp
+++ b/src/recipe_dictionary.cpp
@@ -478,6 +478,9 @@ bool recipe_dictionary::is_item_on_loop( const itype_id &i ) const
 void recipe_dictionary::finalize_internal( std::map<recipe_id, recipe> &obj )
 {
     for( auto &elem : obj ) {
+        erase_if( elem.second.nested_category_data, [&]( const recipe_id & nest ) {
+            return !nest.is_valid() || nest->will_be_blacklisted();
+        } );
         elem.second.finalize();
         inp_mngr.pump_events();
     }


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Fixes #66311

#### Describe the solution

Erase invalid or blacklisted nested categories
