### PR TITLE
Allow the NECC NPCs to say your name in dialogue.

### DIFF
--- a/data/json/npcs/godco/members/NPC_Aunt_Theresa.json
+++ b/data/json/npcs/godco/members/NPC_Aunt_Theresa.json
@@ -43,7 +43,7 @@
     },
     "responses": [
       {
-        "text": "Nice to meet you, Theresa.",
+        "text": "Nice to meet you, Theresa.  I'm <u_name>.",
         "effect": { "npc_add_var": "u_met_godco_theresa", "type": "general", "context": "meeting", "value": "yes" },
         "condition": {
           "and": [

--- a/data/json/npcs/godco/members/NPC_Chloe_Taylor_King.json
+++ b/data/json/npcs/godco/members/NPC_Chloe_Taylor_King.json
@@ -7,12 +7,12 @@
       "type": "general",
       "context": "meeting",
       "value": "yes",
-      "yes": "Aw hey, it's you again.",
+      "yes": "Aw hey, it's you again, <u_name>.",
       "no": "Oh… hi.  I don't know you.  My name's Chloe."
     },
     "responses": [
       {
-        "text": "Nice to meet you, kid.  What's up?",
+        "text": "Nice to meet you, Chloe.  What's up?",
         "topic": "TALK_GODCO_chloe_2",
         "condition": { "not": { "npc_has_var": "u_met_chloe", "type": "general", "context": "meeting", "value": "yes" } },
         "effect": { "npc_add_var": "u_met_chloe", "type": "general", "context": "meeting", "value": "yes" }

--- a/data/json/npcs/godco/members/NPC_Father_Greenwood.json
+++ b/data/json/npcs/godco/members/NPC_Father_Greenwood.json
@@ -41,8 +41,8 @@
         "value": "yes",
         "yes": {
           "u_male": true,
-          "yes": [ "The Lord be with you, brother.", "Good to see you're still around, brother." ],
-          "no": [ "The Lord be with you, sister.", "Good to see you're still around, sister." ]
+          "yes": [ "The Lord be with you, brother.", "Good to see you're still around, <u_name>." ],
+          "no": [ "The Lord be with you, sister.", "Good to see you're still around, <u_name>." ]
         },
         "no": {
           "u_male": true,

--- a/data/json/npcs/godco/members/NPC_Felicity_Powell.json
+++ b/data/json/npcs/godco/members/NPC_Felicity_Powell.json
@@ -39,7 +39,7 @@
       "type": "general",
       "context": "meeting",
       "value": "yes",
-      "yes": [ "Oh, hi.", "Hey, good to see you're still around." ],
+      "yes": [ "Oh, hi.", "Hey, good to see you're still around.", "Hey <u_name>, nice to see you." ],
       "no": "Oh, hi there.  My name's Felicity, nice to see a new face."
     },
     "responses": [

--- a/data/json/npcs/godco/members/NPC_Gemma_Johnstone.json
+++ b/data/json/npcs/godco/members/NPC_Gemma_Johnstone.json
@@ -46,7 +46,7 @@
         "type": "general",
         "context": "meeting",
         "value": "yes",
-        "yes": [ "Praise the Lord.", "Good to see you're still around, <granny_name_g>." ],
+        "yes": [ "Praise the Lord.", "Good to see you're still around, <granny_name_g>.", "Hey <u_name>.  How can I help you?" ],
         "no": "Great to see a new face.  I'm Gemma.  Will you be staying here with us?"
       }
     },

--- a/data/json/npcs/godco/members/NPC_Helena_Misinter.json
+++ b/data/json/npcs/godco/members/NPC_Helena_Misinter.json
@@ -43,7 +43,7 @@
         "type": "general",
         "context": "meeting",
         "value": "yes",
-        "yes": [ "Praise the Lord.", "Blessings to you." ],
+        "yes": [ "Praise the Lord.", "Blessings to you.", "Bless you, <u_name>." ],
         "no": "Stranger, what brings you to our holy home?"
       }
     },

--- a/data/json/npcs/godco/members/NPC_Jane_Schulz.json
+++ b/data/json/npcs/godco/members/NPC_Jane_Schulz.json
@@ -42,7 +42,7 @@
       "type": "general",
       "context": "meeting",
       "value": "yes",
-      "yes": "How can I help you?",
+      "yes": [ "How can I help you?", "<u_name>, what can I do for you?" ],
       "no": "Oh, I don't think we've met before.  My name's Jane, I'm the local doctor."
     },
     "responses": [

--- a/data/json/npcs/godco/members/NPC_Jeremiah_Weaver.json
+++ b/data/json/npcs/godco/members/NPC_Jeremiah_Weaver.json
@@ -24,7 +24,7 @@
       "type": "general",
       "context": "meeting",
       "value": "yes",
-      "yes": [ "Hey, look who's back.", "Hey again.", "Oh, hey, it's you again." ],
+      "yes": [ "Hey, look who's back.", "Hey again.", "Hey again <u_name>.", "Oh, hey, it's you again." ],
       "no": "Oh, uh… you look new.  Didn't think we'd see new people here.  Hey."
     },
     "responses": [

--- a/data/json/npcs/godco/members/NPC_Julian_Ray.json
+++ b/data/json/npcs/godco/members/NPC_Julian_Ray.json
@@ -51,7 +51,7 @@
         "type": "general",
         "context": "meeting",
         "value": "yes",
-        "yes": [ "Praise the Lord.", "Hey, <name_g>.", "Good to see you again." ],
+        "yes": [ "Praise the Lord.", "Hey, <name_g>.", "Good to see you again <u_name>." ],
         "no": "Hey, a new face.  I'm Julian, the guy in charge of this room.  You're planning on sticking around or somethin'?"
       }
     },

--- a/data/json/npcs/godco/members/NPC_Katherine_Weaver.json
+++ b/data/json/npcs/godco/members/NPC_Katherine_Weaver.json
@@ -63,7 +63,7 @@
         "type": "general",
         "context": "meeting",
         "value": "yes",
-        "yes": "Praise the Lord.",
+        "yes": [ "Praise the Lord.", "<u_name>, bless you." ],
         "no": "Oh well, yet another survivor.  Welcome to our group, I'm Katherine."
       }
     },

--- a/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
+++ b/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
@@ -53,7 +53,7 @@
         "type": "general",
         "context": "meeting",
         "value": "yes",
-        "yes": "Praise the Lord.",
+        "yes": [ "Praise the Lord.", "<u_name>, how can I help you?" ],
         "no": "You must be new here, nice to meet you.  They call me Kostas, I'm the local herbalist."
       }
     },

--- a/data/json/npcs/godco/members/NPC_Maria_Serrano.json
+++ b/data/json/npcs/godco/members/NPC_Maria_Serrano.json
@@ -30,7 +30,7 @@
         "type": "general",
         "context": "meeting",
         "value": "yes",
-        "yes": "Hey <name_g>!  Nice to see you again!",
+        "yes": [ "Hey <name_g>!  Nice to see you again!", "Hey <u_name>!  Nice to see you again!" ],
         "no": "I don't think I've met you before, have I?  I'm Maria Serrano, it's nice to see an new face."
       }
     },

--- a/data/json/npcs/godco/members/NPC_Olwen_Powell.json
+++ b/data/json/npcs/godco/members/NPC_Olwen_Powell.json
@@ -17,7 +17,7 @@
       "type": "general",
       "context": "meeting",
       "value": "yes",
-      "yes": [ "Hey, <name_g>.", "Good to see you again.", "What can I do for you?", "You don't look too shabby." ],
+      "yes": [ "Hey, <name_g>.", "Good to see you again.", "What can I do for you?", "You don't look too shabby, <u_name>." ],
       "no": "I definitely haven't met you yet.  Nice to meet you, I'm Olwen."
     },
     "responses": [

--- a/data/json/npcs/godco/members/NPC_Russell_Connelly.json
+++ b/data/json/npcs/godco/members/NPC_Russell_Connelly.json
@@ -53,7 +53,7 @@
         "type": "general",
         "context": "meeting",
         "value": "yes",
-        "yes": [ "Praise the Lord, <name_g>.", "Greetings, <name_g><punc>  You okay?" ],
+        "yes": [ "Praise the Lord, <name_g>.", "Praise the Lord, <u_name>.", "Greetings, <name_g><punc>  You okay?" ],
         "no": "Huh, so it was you over there.  It's always great to see a new face.  Name's Russell, Russell Connelly."
       }
     },

--- a/data/json/npcs/godco/members/NPC_Sonia_Greene.json
+++ b/data/json/npcs/godco/members/NPC_Sonia_Greene.json
@@ -35,12 +35,12 @@
       "type": "general",
       "context": "meeting",
       "value": "yes",
-      "yes": "Well now, good to see you again, friend.",
+      "yes": [ "Well now, good to see you again, friend.", "Nice of you to come around <u_name>." ],
       "no": "Good to see people like you in the world.  I'm Sonia, Sonia Greene.  I entertain the people."
     },
     "responses": [
       {
-        "text": "Sonia?  Nice to meet you.  How are things here?",
+        "text": "Sonia?  Nice to meet you, I'm <u_name>.  How are things here?",
         "effect": { "npc_add_var": "u_met_godco_sonia", "type": "general", "context": "meeting", "value": "yes" },
         "condition": { "not": { "npc_has_var": "u_met_godco_sonia", "type": "general", "context": "meeting", "value": "yes" } },
         "topic": "TALK_GODCO_Sonia_Feeling"

--- a/data/json/npcs/godco/members/NPC_Tom_Powell.json
+++ b/data/json/npcs/godco/members/NPC_Tom_Powell.json
@@ -38,7 +38,7 @@
         "type": "general",
         "context": "meeting",
         "value": "yes",
-        "yes": "Hey, it's you again!  Any news from the outside world?",
+        "yes": "Hey, it's you again <u_name>!  Any news from the outside world?",
         "no": "Ah, another survivor!  I hope you come in peace.  I'm Tom, nice to meet you."
       }
     },

--- a/data/json/npcs/godco/members/cook.json
+++ b/data/json/npcs/godco/members/cook.json
@@ -17,7 +17,7 @@
         "type": "general",
         "context": "meeting",
         "value": "yes",
-        "yes": [ "Welcome back.", "Hello again.  What do you need?", "*waves you over.  \"Hey <name_g>.  How's it going for you?\"" ],
+        "yes": [ "Welcome back.", "Hello again.  What do you need?", "*waves you over.  \"Hey <u_name>.  How's it going for you?\"" ],
         "no": "Hello stranger, I don't think we've met before.  Its nice to meet you, name's Simon."
       }
     },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "The NECC NPCs can say your name sometimes."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Allow the NECC NPCs to say your name when addressing you, as a way to create immersion and make the dialogue seem more natural.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Use the (I think previously unused) `<u_name>` snippet to let the NPCs say your name.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this or changing around the supporting C++ to designate first and last names, and adding snippets that use those.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Went into the game and talked to everyone, it all works as I desire.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The snippet will output all text you enter on character creation, so you could get funny results if you called your character "P.S Taker" or "Biggus Dickus". I guess character naming could be changed to support first, middle, and last name entries with respective snippets and a character limit per each, but this would be a problem created entirely by the user themselves.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/58958654/4054b3b0-71d5-443e-94df-b209245635cd)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
