### PR TITLE
Fixes to select timepoint menu

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2753,6 +2753,17 @@
   },
   {
     "type": "keybinding",
+    "id": "RESET",
+    "category": "CALENDAR_UI",
+    "name": "Reset time point to initial value",
+    "bindings": [
+      { "input_method": "keyboard_any", "key": "r" },
+      { "input_method": "keyboard_char", "key": "R" },
+      { "input_method": "keyboard_code", "key": "r", "mod": [ "shift" ] }
+    ]
+  },
+  {
+    "type": "keybinding",
     "name": "View scent map",
     "category": "DEFAULTMODE",
     "id": "debug_scent"

--- a/src/calendar_ui.cpp
+++ b/src/calendar_ui.cpp
@@ -5,19 +5,24 @@
 #include "ui.h"
 #include "ui_manager.h"
 
-time_point calendar_ui::select_time_point( time_point initial_value, std::string_view title )
+time_point calendar_ui::select_time_point( time_point initial_value, std::string_view title,
+        calendar_ui::granularity granularity_level )
 {
     time_point return_value = initial_value;
-    auto set_turn = [&]( const int initial, const time_duration & factor, const char *const msg ) {
-        string_input_popup pop;
-        const int new_value = pop
-                              .title( msg )
-                              .width( 20 )
-                              .text( std::to_string( initial ) )
-                              .only_digits( true )
-                              .query_int();
-        if( pop.canceled() ) {
-            return;
+    auto set_turn = [&]( const int initial, const time_duration & factor, const char *const msg,
+    int auto_value = 0 ) {
+        int new_value = initial + auto_value;
+        if( new_value == initial ) {
+            string_input_popup pop;
+            new_value = pop
+                        .title( msg )
+                        .width( 20 )
+                        .text( std::to_string( initial ) )
+                        .only_digits( true )
+                        .query_int();
+            if( pop.canceled() ) {
+                return;
+            }
         }
         const time_duration offset = ( new_value - initial ) * factor;
         // Arbitrary maximal value.
@@ -30,51 +35,113 @@ time_point calendar_ui::select_time_point( time_point initial_value, std::string
     static const auto years = []( const time_point & p ) {
         return static_cast<int>( ( p - calendar::turn_zero ) / calendar::year_length() );
     };
+    int iSel = smenu.ret;
     do {
-        const int iSel = smenu.ret;
         smenu.reset();
         smenu.title = title;
         smenu.text += string_format( "Old date: %1$s\nNew date: %2$s",
                                      colorize( to_string( initial_value ), c_light_red ),
                                      colorize( to_string( return_value ), c_light_cyan ) );
         smenu.desc_enabled = true;
-        smenu.footer_text = string_format( _( "Press <color_light_green>%s</color> when done" ),
-                                           input_context( smenu.input_category ).get_desc( "UILIST.QUIT" ) );
-        smenu.addentry( 0, true, 'y', "%s: %d", _( "year" ), years( return_value ) + 1 );
-        smenu.addentry( 1, !calendar::eternal_season(), 's', "%s: %d",
-                        _( "season" ), static_cast<int>( season_of_year( return_value ) ) );
-        smenu.addentry( 2, true, 'd', "%s: %d", _( "day" ), day_of_season<int>( return_value ) + 1 );
-        smenu.addentry( 3, true, 'h', "%s: %d", _( "hour" ), hour_of_day<int>( return_value ) );
-        smenu.addentry( 4, true, 'm', "%s: %d", _( "minute" ), minute_of_hour<int>( return_value ) );
-        smenu.addentry( 5, true, 't', "%s: %d", _( "turn" ),
-                        to_turns<int>( return_value - calendar::turn_zero ) );
+        smenu.allow_additional = true;
+        smenu.input_category = "CALENDAR_UI";
+        smenu.additional_actions = {
+            { "LEFT", to_translation( "Decrease value" ) },
+            { "RIGHT", to_translation( "Increase value" ) },
+            { "RESET", to_translation( "Reset value" ) }
+        };
+        smenu.footer_text += string_format( _( "Press <color_light_green>%s</color> to decrease value.\n" ),
+                                            input_context( smenu.input_category ).get_desc( "LEFT" ) );
+        smenu.footer_text += string_format( _( "Press <color_light_green>%s</color> to increase value.\n" ),
+                                            input_context( smenu.input_category ).get_desc( "RIGHT" ) );
+        smenu.footer_text += string_format( _( "Press <color_light_green>%s</color> to reset value.\n" ),
+                                            input_context( smenu.input_category ).get_desc( "RESET" ) );
+        smenu.footer_text += string_format(
+                                 _( "Press <color_light_green>%s</color> when done selecting time point." ),
+                                 input_context( smenu.input_category ).get_desc( "UILIST.QUIT" ) );
+
+        smenu.addentry( static_cast<int>( calendar_ui::granularity::year ), true,
+                        'y', "%s: %d", _( "year" ), years( return_value ) + 1 );
+        smenu.addentry( static_cast<int>( calendar_ui::granularity::season ), true,
+                        's', "%s: %s", _( "season" ), calendar::name_season( season_of_year( return_value ) ) );
+        smenu.addentry( static_cast<int>( calendar_ui::granularity::day ), true,
+                        'd', "%s: %d", _( "day" ), day_of_season<int>( return_value ) + 1 );
+        smenu.addentry( static_cast<int>( calendar_ui::granularity::hour ), true,
+                        'h', "%s: %d", _( "hour" ), hour_of_day<int>( return_value ) );
+        smenu.addentry( static_cast<int>( calendar_ui::granularity::minute ), true,
+                        'm', "%s: %d", _( "minute" ), minute_of_hour<int>( return_value ) );
+        smenu.addentry( static_cast<int>( calendar_ui::granularity::turn ), true,
+                        't', "%s: %d", _( "turn" ), to_turns<int>( return_value - calendar::turn_zero ) );
+
+        for( uilist_entry &entry : smenu.entries ) {
+            if( entry.retval > static_cast<int>( granularity_level ) ) {
+                entry.enabled = false;
+            }
+        }
         smenu.selected = iSel;
         smenu.query();
 
+        int auto_value = 0;
         switch( smenu.ret ) {
-            case 0:
+            case static_cast<int>( calendar_ui::granularity::year ):
                 set_turn( years( return_value ) + 1, calendar::year_length(), _( "Set year to?" ) );
                 break;
-            case 1:
+            case static_cast<int>( calendar_ui::granularity::season ):
                 set_turn( static_cast<int>( season_of_year( return_value ) ), calendar::season_length(),
                           _( "Set season to?  (0 = spring)" ) );
                 break;
-            case 2:
+            case static_cast<int>( calendar_ui::granularity::day ):
                 set_turn( day_of_season<int>( return_value ) + 1, 1_days, _( "Set days to?" ) );
                 break;
-            case 3:
+            case static_cast<int>( calendar_ui::granularity::hour ):
                 set_turn( hour_of_day<int>( return_value ), 1_hours, _( "Set hour to?" ) );
                 break;
-            case 4:
+            case static_cast<int>( calendar_ui::granularity::minute ):
                 set_turn( minute_of_hour<int>( return_value ), 1_minutes, _( "Set minute to?" ) );
                 break;
-            case 5:
+            case static_cast<int>( calendar_ui::granularity::turn ):
                 set_turn( to_turns<int>( return_value - calendar::turn_zero ), 1_turns,
                           string_format( _( "Set turn to?  (One day is %i turns)" ), to_turns<int>( 1_days ) ).c_str() );
+                break;
+            case UILIST_ADDITIONAL:
+                if( smenu.ret_act == "LEFT" ) {
+                    auto_value = -1;
+                } else if( smenu.ret_act == "RIGHT" ) {
+                    auto_value = 1;
+                } else if( smenu.ret_act == "RESET" ) {
+                    auto_value = 0;
+                    return_value = initial_value;
+                }
+                if( auto_value != 0 ) {
+                    switch( smenu.selected ) {
+                        case static_cast<int>( calendar_ui::granularity::year ):
+                            set_turn( years( return_value ) + 1, calendar::year_length(), "", auto_value );
+                            break;
+                        case static_cast<int>( calendar_ui::granularity::season ):
+                            set_turn( static_cast<int>( season_of_year( return_value ) ), calendar::season_length(), "",
+                                      auto_value );
+                            break;
+                        case static_cast<int>( calendar_ui::granularity::day ):
+                            set_turn( day_of_season<int>( return_value ) + 1, 1_days, "", auto_value );
+                            break;
+                        case static_cast<int>( calendar_ui::granularity::hour ):
+                            set_turn( hour_of_day<int>( return_value ), 1_hours, "", auto_value );
+                            break;
+                        case static_cast<int>( calendar_ui::granularity::minute ):
+                            set_turn( minute_of_hour<int>( return_value ), 1_minutes, "", auto_value );
+                            break;
+                        case static_cast<int>( calendar_ui::granularity::turn ):
+                            set_turn( to_turns<int>( return_value - calendar::turn_zero ), 1_turns, "", auto_value );
+                            break;
+                        default:
+                            break;
+                    }
+                }
                 break;
             default:
                 break;
         }
+        iSel = smenu.selected;
     } while( smenu.ret != UILIST_CANCEL );
     return return_value;
 }

--- a/src/calendar_ui.h
+++ b/src/calendar_ui.h
@@ -10,11 +10,22 @@
 namespace calendar_ui
 {
 
+enum class granularity : int {
+    year,
+    season,
+    day,
+    hour,
+    minute,
+    turn,
+    last,
+};
+
 /**
  * Displays ui element that allows to select and return time point.
  */
 time_point select_time_point( time_point initial_value,
-                              std::string_view title = _( "Select time point" ) );
+                              std::string_view title = _( "Select time point" ),
+                              calendar_ui::granularity granularity_level = calendar_ui::granularity::turn );
 } // namespace calendar_ui
 
 #endif // CATA_SRC_CALENDAR_UI_H

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3354,7 +3354,7 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
                 scen = get_scenario();
             }
             scen->change_start_of_cataclysm( calendar_ui::select_time_point( scen->start_of_cataclysm(),
-                                             "Select cataclysm start date" ) );
+                                             "Select cataclysm start date", calendar_ui::granularity::hour ) );
             details_recalc = true;
         } else if( action == "CHANGE_START_OF_GAME" ) {
             const scenario *scen = sorted_scens[cur_id];
@@ -3362,7 +3362,7 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
                 scen = get_scenario();
             }
             scen->change_start_of_game( calendar_ui::select_time_point( scen->start_of_game(),
-                                        "Select game start date" ) );
+                                        "Select game start date", calendar_ui::granularity::hour ) );
             details_recalc = true;
         } else if( action == "RESET_CALENDAR" ) {
             const scenario *scen = sorted_scens[cur_id];
@@ -4205,11 +4205,11 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
         } else if( action == "CHANGE_START_OF_CATACLYSM" ) {
             const scenario *scen = get_scenario();
             scen->change_start_of_cataclysm( calendar_ui::select_time_point( scen->start_of_cataclysm(),
-                                             "Select cataclysm start date" ) );
+                                             "Select cataclysm start date", calendar_ui::granularity::hour ) );
         } else if( action == "CHANGE_START_OF_GAME" ) {
             const scenario *scen = get_scenario();
             scen->change_start_of_game( calendar_ui::select_time_point( scen->start_of_game(),
-                                        "Select game start date" ) );
+                                        "Select game start date", calendar_ui::granularity::hour ) );
         } else if( action == "RESET_CALENDAR" ) {
             get_scenario()->reset_calendar();
         } else if( action == "CHOOSE_CITY" ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Fixes to select timepoint menu"

#### Purpose of change

Fixes #67811

#### Describe the solution

Added more hotkeys to select timepoint menu (reset time point to initial value, increase and decrease value of selected time point part).
Allowed to change season even with eternal seasons enabled.
Locked cataclysm and game start selection to years, seasons, days and hours (i.e. you cannot* change minutes and turns in UI).

#### Additional context

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/16213433/4b258136-4f5d-405f-8002-b30b7e80e440)