### PR TITLE
Fix compilation error on GCC 7 and 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -505,6 +505,15 @@ ifeq ($(PCH), 1)
   endif
 endif
 
+# Workaround for GCC 7 and 8.
+FS_TEST_FILE := $(shell printf "\#include <filesystem>\\\n int main() { std::filesystem::path p; p.parent_path(); }")
+ifeq   ($(shell echo "$(FS_TEST_FILE)" | $(CXX) -o /dev/null -x c++ -std=c++17 -            >/dev/null 2>&1 || echo fail),fail)
+  ifeq ($(shell echo "$(FS_TEST_FILE)" | $(CXX) -o /dev/null -x c++ -std=c++17 - -lstdc++fs >/dev/null 2>&1 || echo fail),fail)
+    $(error "Unable to compile test filesystem program")
+  endif
+  LDFLAGS += -lstdc++fs
+endif
+
 CPPFLAGS += -Isrc -isystem ${SRC_DIR}/third-party
 CXXFLAGS += $(WARNINGS) $(DEBUG) $(DEBUGSYMS) $(PROFILE) $(OTHERS)
 TOOL_CXXFLAGS = -DCATA_IN_TOOL

--- a/Makefile
+++ b/Makefile
@@ -507,8 +507,11 @@ endif
 
 # Workaround for GCC 7 and 8.
 FS_TEST_FILE := $(shell printf "\#include <filesystem>\\\n int main() { std::filesystem::path p; p.parent_path(); }")
-ifeq   ($(shell echo "$(FS_TEST_FILE)" | $(CXX) -o /dev/null -x c++ -std=c++17 -            >/dev/null 2>&1 || echo fail),fail)
-  ifeq ($(shell echo "$(FS_TEST_FILE)" | $(CXX) -o /dev/null -x c++ -std=c++17 - -lstdc++fs >/dev/null 2>&1 || echo fail),fail)
+$(shell echo "Debug: CXX='$(CXX)'" 1>&2)
+#ifeq   ($(shell echo "$(FS_TEST_FILE)" | $(CXX) -o /dev/null -x c++ -std=c++17 -            >/dev/null 2>&1 || echo fail),fail)
+  #ifeq ($(shell echo "$(FS_TEST_FILE)" | $(CXX) -o /dev/null -x c++ -std=c++17 - -lstdc++fs >/dev/null 2>&1 || echo fail),fail)
+ifeq   ($(shell echo "$(FS_TEST_FILE)" | $(CXX) -o /dev/null -x c++ -std=c++17 -            || echo fail),fail)
+  ifeq ($(shell echo "$(FS_TEST_FILE)" | $(CXX) -o /dev/null -x c++ -std=c++17 - -lstdc++fs || echo fail),fail)
     $(error "Unable to compile test filesystem program")
   endif
   LDFLAGS += -lstdc++fs

--- a/Makefile
+++ b/Makefile
@@ -506,8 +506,9 @@ ifeq ($(PCH), 1)
 endif
 
 # Workaround for GCC 7 and 8.
-FS_TEST_FILE := $(shell printf "\#include <filesystem>\\\n int main() { std::filesystem::path p; p.parent_path(); }")
+FS_TEST_FILE := $$(printf "\#include <filesystem>\\\n int main() { std::filesystem::path p; p.parent_path(); }")
 $(shell echo "Debug: CXX='$(CXX)'" 1>&2)
+$(shell echo "Debug: FS_TEST_FILE='$(FS_TEST_FILE)'" 1>&2)
 #ifeq   ($(shell echo "$(FS_TEST_FILE)" | $(CXX) -o /dev/null -x c++ -std=c++17 -            >/dev/null 2>&1 || echo fail),fail)
   #ifeq ($(shell echo "$(FS_TEST_FILE)" | $(CXX) -o /dev/null -x c++ -std=c++17 - -lstdc++fs >/dev/null 2>&1 || echo fail),fail)
 ifeq   ($(shell echo "$(FS_TEST_FILE)" | $(CXX) -o /dev/null -x c++ -std=c++17 -            || echo fail),fail)


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Build "Fix compilation error on GCC 7 and 8"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

It's been quite awhile since I've compiled Cataclysm, and the other day I received a bunch of compilation errors with g++ 8.3.0 running under Debian GNU/Linux (64 bit). The errors are due to fancy <filesystem> stuff in src/third-party/ghc, and I got it to compile by adding `-lstdc++fs`. You might want to reference this [interesting discussion](https://github.com/avast/retdec/issues/842) involving the same issue. Below is the tail end of the compilation errors; the entire thing is 235 lines.

```
/usr/bin/ld: obj/tgz_archiver.o: in function `tgz_archiver::_gen_tar_header(std::filesystem::__cxx11::path const&, std::filesystem::__cxx11::path const&, std::filesystem::__cxx11::path const&, long)':
tgz_archiver.cpp:(.text+0xda): undefined reference to `std::filesystem::status(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: tgz_archiver.cpp:(.text+0xe8): undefined reference to `std::filesystem::status(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: tgz_archiver.cpp:(.text+0x108): undefined reference to `std::filesystem::symlink_status(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: tgz_archiver.cpp:(.text+0x114): undefined reference to `std::filesystem::last_write_time(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: tgz_archiver.cpp:(.text+0x134): undefined reference to `std::filesystem::status(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: obj/tgz_archiver.o: in function `tgz_archiver::add_file(std::filesystem::__cxx11::path const&, std::filesystem::__cxx11::path const&)':
tgz_archiver.cpp:(.text+0x6a2): undefined reference to `std::filesystem::__cxx11::path::has_root_directory() const'
/usr/bin/ld: tgz_archiver.cpp:(.text+0x6d9): undefined reference to `std::filesystem::__cxx11::path::has_filename() const'
/usr/bin/ld: tgz_archiver.cpp:(.text+0x711): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
/usr/bin/ld: tgz_archiver.cpp:(.text+0x76a): undefined reference to `std::filesystem::__cxx11::path::lexically_relative(std::filesystem::__cxx11::path const&) const'
/usr/bin/ld: tgz_archiver.cpp:(.text+0x832): undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'
/usr/bin/ld: tgz_archiver.cpp:(.text+0x887): undefined reference to `std::filesystem::status(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: tgz_archiver.cpp:(.text+0x94e): undefined reference to `std::filesystem::status(std::filesystem::__cxx11::path const&)'
/usr/bin/ld: obj/translation_document.o: in function `TranslationDocument::TranslationDocument(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
translation_document.cpp:(.text+0x6d1): undefined reference to `std::filesystem::file_size(std::filesystem::__cxx11::path const&)'
collect2: error: ld returned 1 exit status
make: *** [Makefile:956: cataclysm] Error 1
```

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

I've modified the makefile to do a couple of minimal test compiles that use a `<filesystem>` function; if the one without the `-lstdc++fs` flag works (which I suppose would be the case for everyone but me), then all is well. If it fails, but adding the flag fixes it, then `LDFLAGS` is modified accordingly. On the other hand, if both of them fail, it will err. 

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Abandoning support for GCC 7 and 8 is an option. Another option would be to check for g++ version 7 or 8 instead of checking via a test compile, but I think this way is cleaner.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

It took some experimentation to get `FS_TEST_FILE` right; I can't say I've ever had to escape an `#` before since quotes usually do the job. I also examined the stdout and stderr of the test compilation programs to make sure that the first compilation was failing for the right reasons. And, of course, I compiled the game to make sure I didn't get any other errors or anything. I **haven't** tested under any other operating systems or with any other compilers.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
