### PR TITLE
Correct inaccurate Kickboxing moves, let you start with it.

### DIFF
--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -630,7 +630,12 @@
     "name": "Cardio Kickboxing",
     "description": "You've trained in non-combat kickboxing at a gym as a way to exercise.  While you were taught the moves, you've never sparred or fought anything more dangerous than a falling punching bag.  Whether you can remember your training when push kick comes to jab is up to you.",
     "points": 5,
-    "skills": [ { "level": 2, "name": "melee" }, { "level": 2, "name": "unarmed" }, { "level": 2, "name": "swimming" }, { "level": 1, "name": "dodge" } ],
+    "skills": [
+      { "level": 2, "name": "melee" },
+      { "level": 2, "name": "unarmed" },
+      { "level": 2, "name": "swimming" },
+      { "level": 1, "name": "dodge" }
+    ],
     "traits": [ "PROF_KICKBOXER" ]
   },
   {

--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -629,8 +629,8 @@
     "id": "kickboxing_beginner",
     "name": "Cardio Kickboxing",
     "description": "You've trained in non-combat kickboxing at a gym as a way to exercise.  While you were taught the moves, you've never sparred or fought anything more dangerous than a falling punching bag.  Whether you can remember your training when push kick comes to jab is up to you.",
-    "points": 3,
-    "skills": [ { "level": 1, "name": "melee" }, { "level": 1, "name": "unarmed" }, { "level": 1, "name": "dodge" } ],
+    "points": 5,
+    "skills": [ { "level": 2, "name": "melee" }, { "level": 2, "name": "unarmed" }, { "level": 2, "name": "swimming" }, { "level": 1, "name": "dodge" } ],
     "traits": [ "PROF_KICKBOXER" ]
   },
   {

--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -626,6 +626,16 @@
   {
     "type": "profession",
     "subtype": "hobby",
+    "id": "kickboxing_beginner",
+    "name": "Cardio Kickboxing",
+    "description": "You've trained in non-combat kickboxing at a gym as a way to exercise.  While you were taught the moves, you've never sparred or fought anything more dangerous than a falling punching bag.  Whether you can remember your training when push kick comes to jab is up to you.",
+    "points": 3,
+    "skills": [ { "level": 1, "name": "melee" }, { "level": 1, "name": "unarmed" }, { "level": 1, "name": "dodge" } ],
+    "traits": [ "PROF_KICKBOXER" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
     "id": "martial_training",
     "name": "Martial Arts",
     "description": "You have received some martial arts training at a local dojo.  You start with your choice of Karate, Judo, Aikido, Tai Chi, Taekwondo, or Pankration.",
@@ -638,7 +648,7 @@
     "subtype": "hobby",
     "id": "self_defense",
     "name": "Self-Defense",
-    "description": "You have taken some self-defense classes at a local gym.  You start with your choice of Boxing, Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
+    "description": "You have taken some self-defense classes at a local gym.  You start with your choice of Boxing, Kickboxing, Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
     "points": 5,
     "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 3, "name": "dodge" } ],
     "traits": [ "MARTIAL_ARTS2" ]

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -720,7 +720,7 @@
     "id": "style_kickboxing",
     "name": { "str": "Kickboxing" },
     "description": "A martial art that combines western boxing with elements of Karate, Taekwondo, Muay Thai, and Savate, particularly in the use of kicks.",
-    "initiate": [ "You bring your fists up and stay light on your feet.", "%s assumes a kickboxing stance." ],
+    "initiate": [ "You bring your fists up and stay light on your feet.", "%s brings their fists up and stays light on their feet." ],
     "learn_difficulty": 4,
     "arm_block": 2,
     "leg_block": 4,

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -720,7 +720,7 @@
     "id": "style_kickboxing",
     "name": { "str": "Kickboxing" },
     "description": "A martial art that combines western boxing with elements of Karate, Taekwondo, Muay Thai, and Savate, particularly in the use of kicks.",
-    "initiate": [ "You assume a kickboxing stance and focus power into your limbs.", "%s assumes a kickboxing stance." ],
+    "initiate": [ "You bring your fists up and stay light on your feet.", "%s assumes a kickboxing stance." ],
     "learn_difficulty": 4,
     "arm_block": 2,
     "leg_block": 4,
@@ -735,11 +735,10 @@
     ],
     "techniques": [
       "tec_kickboxing_rapid",
+      "tec_kickboxing_cross",
+      "tec_kickboxing_push",
       "tec_kickboxing_upper",
-      "tec_kickboxing_roundhouse",
-      "tec_kickboxing_sidekick",
-      "tec_kickboxing_straight_knee",
-      "tec_kickboxing_flying_knee"
+      "tec_kickboxing_roundhouse"
     ]
   },
   {

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -719,7 +719,7 @@
     "type": "martial_art",
     "id": "style_kickboxing",
     "name": { "str": "Kickboxing" },
-    "description": "A martial art that combines western boxing with elements of Karate, Taekwondo, Muay Thai, and Savate, particularly in the use of kicks.",
+    "description": "A martial art that combines western boxing with elements of Karate, Taekwondo, Muay Thai, and Savate, particularly in the use of kicks.  American Kickboxing in particular focuses on high kicks without knee or elbow strikes.",
     "initiate": [ "You bring your fists up and stay light on your feet.", "%s brings their fists up and stays light on their feet." ],
     "learn_difficulty": 4,
     "arm_block": 2,

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1181,7 +1181,7 @@
     "id": "MARTIAL_ARTS2",
     "name": { "str": "Self-Defense Classes" },
     "points": 2,
-    "description": "You have taken some self-defense classes at a nearby gym.  You start with your choice of Boxing, Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
+    "description": "You have taken some self-defense classes at a nearby gym.  You start with your choice of Boxing, Kickboxing, Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
     "player_display": false,
     "initial_ma_styles": [
       "style_krav_maga",
@@ -1190,6 +1190,7 @@
       "style_capoeira",
       "style_zui_quan",
       "style_wingchun",
+      "style_kickboxing",
       "style_boxing"
     ],
     "valid": false
@@ -8315,6 +8316,17 @@
     "description": "You are experienced in the Sweet Science of boxing.  You could've had a shot at a local boxing tournament, if the Cataclysm hadn't screwed that up.",
     "valid": false,
     "initial_ma_styles": [ "style_boxing" ],
+    "purifiable": false,
+    "profession": true
+  },
+  {
+    "type": "mutation",
+    "id": "PROF_KICKBOXER",
+    "name": { "str": "Kickboxer" },
+    "points": 0,
+    "description": "You have some training in the art of kickboxing.  It's just boxing with kicks, right?",
+    "valid": false,
+    "initial_ma_styles": [ "style_kickboxing" ],
     "purifiable": false,
     "profession": true
   },

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -1559,6 +1559,51 @@
   },
   {
     "type": "technique",
+    "id": "tec_kickboxing_cross",
+    "name": "Cross",
+    "messages": [ "You throw a heavy cross at %s", "<npcname> throws a cross at %s" ],
+    "unarmed_allowed": true,
+    "mult_bonuses": [
+      { "stat": "damage", "type": "bash", "scale": 1.2 },
+      { "stat": "damage", "type": "cut", "scale": 1.2 },
+      { "stat": "damage", "type": "stab", "scale": 1.2 }
+    ],
+    "attack_vectors": [ "HAND" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_kickboxing_push",
+    "name": "Push Kick",
+    "messages": [ "You shove %s back with a front kick", "<npcname> shoves %s back with a front kick" ],
+    "skill_requirements": [ { "name": "unarmed", "level": 1 } ],
+    "unarmed_allowed": true,
+    "condition": {
+      "and": [
+        { "math": [ "u_val('size')", ">=", "n_val('size')" ] },
+        {
+          "or": [
+            {
+              "and": [
+                { "npc_has_flag": "GRAB_FILTER" },
+                { "u_has_flag": "GRAB" },
+                {
+                  "roll_contested": { "math": [ "u_val('strength')" ] },
+                  "die_size": 20,
+                  "difficulty": { "math": [ "n_val('grab_strength')" ] }
+                }
+              ]
+            },
+            { "not": { "and": [ { "npc_has_flag": "GRAB_FILTER" }, { "u_has_flag": "GRAB" } ] } }
+          ]
+        }
+      ]
+    },
+    "condition_desc": "* Only works on a target of <info>similar or smaller</info> size, may fail on enemies grabbing you",
+    "knockback_dist": 1,
+    "attack_vectors": [ "FOOT" ]
+  },
+  {
+    "type": "technique",
     "id": "tec_kickboxing_upper",
     "name": "Uppercut",
     "messages": [ "You uppercut %s", "<npcname> uppercuts %s" ],
@@ -1611,103 +1656,16 @@
     "id": "tec_kickboxing_roundhouse",
     "name": "Roundhouse Kick",
     "messages": [ "You roundhouse kick %s", "<npcname> roundhouse kicks %s" ],
-    "unarmed_allowed": true,
-    "melee_allowed": true,
-    "mult_bonuses": [
-      { "stat": "damage", "type": "bash", "scale": 1.2 },
-      { "stat": "damage", "type": "cut", "scale": 1.2 },
-      { "stat": "damage", "type": "stab", "scale": 1.2 }
-    ],
-    "attack_vectors": [ "FOOT" ]
-  },
-  {
-    "type": "technique",
-    "id": "tec_kickboxing_sidekick",
-    "name": "Side Kick",
-    "messages": [ "You side kick %s", "<npcname> side kicks %s" ],
     "skill_requirements": [ { "name": "unarmed", "level": 2 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,
+    "crit_ok": true,
     "mult_bonuses": [
-      { "stat": "damage", "type": "bash", "scale": 1.2 },
-      { "stat": "damage", "type": "cut", "scale": 1.2 },
-      { "stat": "damage", "type": "stab", "scale": 1.2 }
+      { "stat": "damage", "type": "bash", "scale": 1.4 },
+      { "stat": "damage", "type": "cut", "scale": 1.4 },
+      { "stat": "damage", "type": "stab", "scale": 1.4 }
     ],
     "attack_vectors": [ "FOOT" ]
-  },
-  {
-    "type": "technique",
-    "id": "tec_kickboxing_straight_knee",
-    "name": "Straight Knee",
-    "messages": [ "You deliver a straight knee to %s", "<npcname> delivers a straight knee to %s" ],
-    "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
-    "unarmed_allowed": true,
-    "crit_tec": true,
-    "stun_dur": 1,
-    "condition": {
-      "and": [
-        { "math": [ "u_val('size') + 1", ">=", "n_val('size')" ] },
-        { "not": { "npc_has_effect": "stunned" } },
-        {
-          "and": [
-            { "not": { "npc_has_species": "ZOMBIE" } },
-            { "not": { "npc_has_species": "NETHER" } },
-            { "not": { "npc_has_species": "NETHER_EMENATION" } },
-            { "not": { "npc_has_species": "LEECH_PLANT" } },
-            { "not": { "npc_has_species": "MIGO" } },
-            { "not": { "npc_has_species": "SLIME" } },
-            { "not": { "npc_has_species": "FUNGUS" } },
-            { "not": { "npc_has_species": "PLANT" } },
-            { "not": { "npc_has_species": "ROBOT" } },
-            { "not": { "npc_has_species": "CYBORG" } },
-            { "not": { "npc_has_species": "HALLUCINATION" } },
-            { "not": { "npc_has_species": "HORROR" } },
-            { "not": { "npc_has_species": "ABERRATION" } },
-            { "not": { "npc_has_species": "KRAKEN" } }
-          ]
-        }
-      ]
-    },
-    "condition_desc": "* Only works on a <info>non-stunned mundane</info> target of <info>similar or smaller</info> size",
-    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.4 } ],
-    "attack_vectors": [ "KNEE" ]
-  },
-  {
-    "type": "technique",
-    "id": "tec_kickboxing_flying_knee",
-    "name": "Flying Knee",
-    "messages": [ "You leap and deliver a flying knee to %s", "<npcname> leaps and delivers a flying knees to %s" ],
-    "skill_requirements": [ { "name": "unarmed", "level": 5 } ],
-    "unarmed_allowed": true,
-    "crit_tec": true,
-    "condition": {
-      "and": [
-        { "math": [ "u_val('size') + 1", ">=", "n_val('size')" ] },
-        { "not": { "npc_has_effect": "stunned" } },
-        {
-          "and": [
-            { "not": { "npc_has_species": "ZOMBIE" } },
-            { "not": { "npc_has_species": "NETHER" } },
-            { "not": { "npc_has_species": "NETHER_EMENATION" } },
-            { "not": { "npc_has_species": "LEECH_PLANT" } },
-            { "not": { "npc_has_species": "MIGO" } },
-            { "not": { "npc_has_species": "SLIME" } },
-            { "not": { "npc_has_species": "FUNGUS" } },
-            { "not": { "npc_has_species": "PLANT" } },
-            { "not": { "npc_has_species": "ROBOT" } },
-            { "not": { "npc_has_species": "CYBORG" } },
-            { "not": { "npc_has_species": "HALLUCINATION" } },
-            { "not": { "npc_has_species": "HORROR" } },
-            { "not": { "npc_has_species": "ABERRATION" } },
-            { "not": { "npc_has_species": "KRAKEN" } }
-          ]
-        }
-      ]
-    },
-    "condition_desc": "* Only works on a <info>non-stunned mundane</info> target of <info>similar or smaller</info> size",
-    "stun_dur": 1,
-    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.4 } ],
-    "attack_vectors": [ "KNEE" ]
   },
   {
     "type": "technique",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Adjust Kickboxing and let you start with it"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Far as I could tell, there wasn't a way to start with kickboxing at all. As for the art itself, it included two knee strikes despite kickboxing not using knee or elbow strikes _(Muay Thai Kickboxing_ does, but we already have Muay Thai), while missing some foundational moves.

Obsoletes #60649

#### Describe the solution

Added Kickboxing as a possible choice for the "Self Defense" background, and another lower-tier "Cardio Kickboxing" background as it is a popular fitness thing.

Removed the two knee strikes. Also removed the side kick, as it was redundant with the roundhouse kick and while it _is_ a technique in kickboxing it's not as foundational. Added the "Cross" technique (basically a copy of Pankration's cross) and "Push Kick" technique (basically a copy of Taekwondo's side kick).

Slightly buffed the roundhouse kick from 1.2x to 1.4x damage to separate it from Cross (higher base damage but there's not really any good foot weapons compared to fist weapons) and made it crit_ok so there was a usable crit technique on enemies that can't be uppercut.

#### Describe alternatives you've considered

Leaving the side kick in mostly for flavor, or trying to figure out how to differentiate it from the roundhouse/push kick.
Increased the skills in Cardio Kickboxing; maybe getting actual instruction should be 2 melee/unarmed even if all you're doing is punching a bag and 1 is undershooting it.

#### Testing

Checked to make sure the backgrounds spawned, kickboxing was chooseable, and the techniques were reflected in game.

#### Additional context

I made this PR after coming home from my own cardio kickboxing class. It was leg day. orz