### PR TITLE
Fix crash in object creator spell window

### DIFF
--- a/object_creator/spell_window.cpp
+++ b/object_creator/spell_window.cpp
@@ -25,6 +25,45 @@ static spell_type default_spell_type()
     ret.spell_class = trait_id( "NONE" );
     ret.effect_name = "area_pull";
     ret.spell_area = spell_shape::blast;
+    ret.min_damage.min.dbl_val = 0;
+    ret.max_damage.min.dbl_val = 0;
+    ret.damage_increment.min.dbl_val = 0.0f;
+    ret.min_accuracy.min.dbl_val = 20;
+    ret.accuracy_increment.min.dbl_val = 0.0f;
+    ret.max_accuracy.min.dbl_val = 20;
+    ret.min_range.min.dbl_val = 0;
+    ret.max_range.min.dbl_val = 0;
+    ret.range_increment.min.dbl_val = 0.0f;
+    ret.min_aoe.min.dbl_val = 0;
+    ret.max_aoe.min.dbl_val = 0;
+    ret.aoe_increment.min.dbl_val = 0.0f;
+    ret.min_dot.min.dbl_val = 0;
+    ret.max_dot.min.dbl_val = 0;
+    ret.dot_increment.min.dbl_val = 0.0f;
+    ret.min_duration.min.dbl_val = 0;
+    ret.max_duration.min.dbl_val = 0;
+    ret.duration_increment.min.dbl_val = 0.0f;
+    ret.min_pierce.min.dbl_val = 0;
+    ret.max_pierce.min.dbl_val = 0;
+    ret.pierce_increment.min.dbl_val = 0.0f;
+    ret.base_energy_cost.min.dbl_val = 0;
+    ret.final_energy_cost.min.dbl_val = 0;
+    ret.base_energy_cost.min.dbl_val = 0;
+    ret.energy_increment.min.dbl_val = 0.0f;
+    ret.difficulty.min.dbl_val = 0;
+    ret.max_level.min.dbl_val = 0;
+    ret.base_casting_time.min.dbl_val = 0;
+    ret.final_casting_time.min.dbl_val = 0;
+    ret.base_casting_time.min.dbl_val = 0;
+    ret.casting_time_increment.min.dbl_val = 0.0f;
+    ret.field_chance.min.dbl_val = 1;
+    ret.max_field_intensity.min.dbl_val = 0;
+    ret.min_field_intensity.min.dbl_val = 0;
+    ret.field_intensity_increment.min.dbl_val = 0.0f;
+    ret.field_intensity_variance.min.dbl_val = 0.0f;
+
+
+
     return ret;
 }
 

--- a/object_creator/spell_window.cpp
+++ b/object_creator/spell_window.cpp
@@ -481,18 +481,7 @@ creator::spell_window::spell_window( QWidget *parent, Qt::WindowFlags flags )
     base_energy_cost_box.show();
     QObject::connect( &base_energy_cost_box, &QSpinBox::textChanged,
     [&]() {
-        editable_spell.base_energy_cost.min.dbl_val = base_energy_cost_box.value();
-        if( editable_spell.energy_increment.min.dbl_val.value() > 0.0f ) {
-            final_energy_cost_box.setValue( std::max( final_energy_cost_box.value(),
-                                            static_cast<int>( editable_spell.base_energy_cost.min.dbl_val.value() ) ) );
-        } else if( editable_spell.energy_increment.min.dbl_val.value() < 0.0f ) {
-            final_energy_cost_box.setValue( std::min( final_energy_cost_box.value(),
-                                            static_cast<int>( editable_spell.base_energy_cost.min.dbl_val.value() ) ) );
-        } else {
-            final_energy_cost_box.setValue( editable_spell.base_energy_cost.min.dbl_val.value() );
-        }
-        editable_spell.final_energy_cost.min.dbl_val = final_energy_cost_box.value();
-        write_json();
+        void base_energy_cost_box_textchanged();
     } );
 
     min_damage_box.setParent( this );
@@ -504,16 +493,7 @@ creator::spell_window::spell_window( QWidget *parent, Qt::WindowFlags flags )
     min_damage_box.show();
     QObject::connect( &min_damage_box, &QSpinBox::textChanged,
     [&]() {
-        editable_spell.min_damage.min.dbl_val = min_damage_box.value();
-        if( editable_spell.damage_increment.min.dbl_val.value() > 0.0f ) {
-            max_damage_box.setValue( std::max( max_damage_box.value(), static_cast<int>( editable_spell.min_damage.min.dbl_val.value() ) ) );
-        } else if( editable_spell.damage_increment.min.dbl_val.value() < 0.0f ) {
-            max_damage_box.setValue( std::min( max_damage_box.value(), static_cast<int>( editable_spell.min_damage.min.dbl_val.value() ) ) );
-        } else {
-            max_damage_box.setValue( editable_spell.min_damage.min.dbl_val.value() );
-        }
-        editable_spell.max_damage.min.dbl_val = max_damage_box.value();
-        write_json();
+        min_damage_box_textchanged();
     } );
 
     min_range_box.setParent( this );
@@ -586,18 +566,7 @@ creator::spell_window::spell_window( QWidget *parent, Qt::WindowFlags flags )
     base_casting_time_box.show();
     QObject::connect( &base_casting_time_box, &QSpinBox::textChanged,
     [&]() {
-        editable_spell.base_casting_time.min.dbl_val = base_casting_time_box.value();
-        if( editable_spell.casting_time_increment.min.dbl_val.value() > 0.0f ) {
-            final_casting_time_box.setValue( std::max( final_casting_time_box.value(),
-                                             static_cast<int>( editable_spell.base_casting_time.min.dbl_val.value() ) ) );
-        } else if( editable_spell.energy_increment.min.dbl_val.value() < 0.0f ) {
-            final_casting_time_box.setValue( std::min( final_casting_time_box.value(),
-                                             static_cast<int>( editable_spell.base_casting_time.min.dbl_val.value() ) ) );
-        } else {
-            final_casting_time_box.setValue( editable_spell.base_casting_time.min.dbl_val.value() );
-        }
-        editable_spell.final_casting_time.min.dbl_val = final_casting_time_box.value();
-        write_json();
+        base_casting_time_box_textchanged();
     } );
 
 
@@ -1043,18 +1012,7 @@ creator::spell_window::spell_window( QWidget *parent, Qt::WindowFlags flags )
     final_energy_cost_box.show();
     QObject::connect( &final_energy_cost_box, &QSpinBox::textChanged,
     [&]() {
-        editable_spell.final_energy_cost.min.dbl_val = final_energy_cost_box.value();
-        if( editable_spell.energy_increment.min.dbl_val.value() > 0.0f) {
-            base_energy_cost_box.setValue( std::min( base_energy_cost_box.value(),
-                                           static_cast<int>( editable_spell.final_energy_cost.min.dbl_val.value() ) ) );
-        } else if( editable_spell.energy_increment.min.dbl_val.value() < 0.0f ) {
-            base_energy_cost_box.setValue( std::max( base_energy_cost_box.value(),
-                                           static_cast<int>( editable_spell.final_energy_cost.min.dbl_val.value() ) ) );
-        } else {
-            base_energy_cost_box.setValue( editable_spell.final_energy_cost.min.dbl_val.value() );
-        }
-        editable_spell.base_energy_cost.min.dbl_val = base_energy_cost_box.value();
-        write_json();
+        final_energy_cost_box_textchanged();
     } );
 
     max_damage_box.setParent( this );
@@ -1143,22 +1101,8 @@ creator::spell_window::spell_window( QWidget *parent, Qt::WindowFlags flags )
     final_casting_time_box.show();
     QObject::connect( &final_casting_time_box, &QSpinBox::textChanged,
     [&]() {
-        editable_spell.final_casting_time.min.dbl_val = final_casting_time_box.value();
-        if( editable_spell.energy_increment.min.dbl_val.value() > 0.0f) {
-            base_casting_time_box.setValue( std::min( base_casting_time_box.value(),
-                                            static_cast<int>( editable_spell.final_casting_time.min.dbl_val.value() ) ) );
-        } else if( editable_spell.energy_increment.min.dbl_val.value() < 0.0f ) {
-            base_casting_time_box.setValue( std::max( base_casting_time_box.value(),
-                                            static_cast<int>( editable_spell.final_casting_time.min.dbl_val.value() ) ) );
-        } else {
-            base_casting_time_box.setValue( editable_spell.final_casting_time.min.dbl_val.value() );
-        }
-        editable_spell.base_casting_time.min.dbl_val = base_casting_time_box.value();
-        write_json();
+        final_casting_time_box_textchanged();
     } );
-
-
-
 
     max_duration_box.setParent( this );
     max_duration_box.resize( default_text_box_size );
@@ -1266,6 +1210,101 @@ creator::spell_window::spell_window( QWidget *parent, Qt::WindowFlags flags )
     max_col = std::max( max_col, col );
     this->resize( QSize( ( max_col + 1 ) * default_text_box_width,
                          ( max_row ) * default_text_box_height ) );
+}
+
+//When the final_casting_time_box text changes, update the base casting time box
+//First check if the energy increment has a value
+//if the energy increment is positive, the base casting time should be the minimum of the two
+//if the energy increment is negative, the base casting time should be the maximum of the two
+void creator::spell_window::final_casting_time_box_textchanged()
+{
+    editable_spell.final_casting_time.min.dbl_val = final_casting_time_box.value();
+    //check if the casting time increment has a value
+    if(editable_spell.casting_time_increment.min.dbl_val.has_value()) {
+        if( editable_spell.casting_time_increment.min.dbl_val.value() > 0.0f) {
+            base_casting_time_box.setValue( std::min( base_casting_time_box.value(),
+                                            static_cast<int>( editable_spell.final_casting_time.min.dbl_val.value() ) ) );
+        } else if( editable_spell.casting_time_increment.min.dbl_val.value() < 0.0f ) {
+            base_casting_time_box.setValue( std::max( base_casting_time_box.value(),
+                                            static_cast<int>( editable_spell.final_casting_time.min.dbl_val.value() ) ) );
+        } else {
+            base_casting_time_box.setValue( editable_spell.final_casting_time.min.dbl_val.value() );
+        }
+    }
+    editable_spell.base_casting_time.min.dbl_val = base_casting_time_box.value();
+    write_json();
+}
+
+
+void creator::spell_window::base_energy_cost_box_textchanged()
+{
+    editable_spell.base_energy_cost.min.dbl_val = base_energy_cost_box.value();
+    if(editable_spell.energy_increment.min.dbl_val.has_value()) {
+        if( editable_spell.energy_increment.min.dbl_val.value() > 0.0f ) {
+            final_energy_cost_box.setValue( std::max( final_energy_cost_box.value(),
+                                            static_cast<int>( editable_spell.base_energy_cost.min.dbl_val.value() ) ) );
+        } else if( editable_spell.energy_increment.min.dbl_val.value() < 0.0f ) {
+            final_energy_cost_box.setValue( std::min( final_energy_cost_box.value(),
+                                            static_cast<int>( editable_spell.base_energy_cost.min.dbl_val.value() ) ) );
+        } else {
+            final_energy_cost_box.setValue( editable_spell.base_energy_cost.min.dbl_val.value() );
+        }
+    }
+    editable_spell.final_energy_cost.min.dbl_val = final_energy_cost_box.value();
+    write_json();
+}
+
+void creator::spell_window::base_casting_time_box_textchanged()
+{
+    editable_spell.base_casting_time.min.dbl_val = base_casting_time_box.value();
+    if(editable_spell.casting_time_increment.min.dbl_val.has_value()) {
+        if( editable_spell.casting_time_increment.min.dbl_val.value() > 0.0f ) {
+            final_casting_time_box.setValue( std::max( final_casting_time_box.value(),
+                                             static_cast<int>( editable_spell.base_casting_time.min.dbl_val.value() ) ) );
+        } else if( editable_spell.energy_increment.min.dbl_val.value() < 0.0f ) {
+            final_casting_time_box.setValue( std::min( final_casting_time_box.value(),
+                                             static_cast<int>( editable_spell.base_casting_time.min.dbl_val.value() ) ) );
+        } else {
+            final_casting_time_box.setValue( editable_spell.base_casting_time.min.dbl_val.value() );
+        }
+        editable_spell.final_casting_time.min.dbl_val = final_casting_time_box.value();
+    }
+    write_json();
+}
+
+
+void creator::spell_window::min_damage_box_textchanged()
+{
+    editable_spell.min_damage.min.dbl_val = min_damage_box.value();
+    if(editable_spell.damage_increment.min.dbl_val.has_value()) {
+        if( editable_spell.damage_increment.min.dbl_val.value() > 0.0f ) {
+            max_damage_box.setValue( std::max( max_damage_box.value(), static_cast<int>( editable_spell.min_damage.min.dbl_val.value() ) ) );
+        } else if( editable_spell.damage_increment.min.dbl_val.value() < 0.0f ) {
+            max_damage_box.setValue( std::min( max_damage_box.value(), static_cast<int>( editable_spell.min_damage.min.dbl_val.value() ) ) );
+        } else {
+            max_damage_box.setValue( editable_spell.min_damage.min.dbl_val.value() );
+        }
+    }
+    editable_spell.max_damage.min.dbl_val = max_damage_box.value();
+    write_json();
+}
+
+void creator::spell_window::final_energy_cost_box_textchanged()
+{
+    editable_spell.final_energy_cost.min.dbl_val = final_energy_cost_box.value();
+    if(editable_spell.energy_increment.min.dbl_val.has_value()) {
+        if( editable_spell.energy_increment.min.dbl_val.value() > 0.0f) {
+            base_energy_cost_box.setValue( std::min( base_energy_cost_box.value(),
+                                        static_cast<int>( editable_spell.final_energy_cost.min.dbl_val.value() ) ) );
+        } else if( editable_spell.energy_increment.min.dbl_val.value() < 0.0f ) {
+            base_energy_cost_box.setValue( std::max( base_energy_cost_box.value(),
+                                        static_cast<int>( editable_spell.final_energy_cost.min.dbl_val.value() ) ) );
+        } else {
+            base_energy_cost_box.setValue( editable_spell.final_energy_cost.min.dbl_val.value() );
+        }
+    }
+    editable_spell.base_energy_cost.min.dbl_val = base_energy_cost_box.value();
+    write_json();
 }
 
 static std::string check_errors( const spell_type &sp )

--- a/object_creator/spell_window.cpp
+++ b/object_creator/spell_window.cpp
@@ -1479,15 +1479,27 @@ void creator::spell_window::populate_fields()
             min_damage_box.setValue( sp_t.min_damage.min.dbl_val.value() );
             damage_increment_box.setValue( sp_t.damage_increment.min.dbl_val.value() );
             max_damage_box.setValue( sp_t.max_damage.min.dbl_val.value() );
-            min_aoe_box.setValue( sp_t.min_aoe.min.dbl_val.value() );
+            if(sp_t.min_aoe.min.dbl_val.has_value()) {
+                min_aoe_box.setValue( sp_t.min_aoe.min.dbl_val.value() );
+            } else {
+                min_aoe_box.setValue( 0 );
+            }
             aoe_increment_box.setValue( sp_t.aoe_increment.min.dbl_val.value() );
             max_aoe_box.setValue( sp_t.max_aoe.min.dbl_val.value() );
             min_dot_box.setValue( sp_t.min_dot.min.dbl_val.value() );
             dot_increment_box.setValue( sp_t.dot_increment.min.dbl_val.value() );
             max_dot_box.setValue( sp_t.max_dot.min.dbl_val.value() );
-            min_duration_box.setValue( sp_t.min_duration.min.dbl_val.value() );
+            if(sp_t.min_duration.min.dbl_val.has_value()) {
+                min_duration_box.setValue( sp_t.min_duration.min.dbl_val.value() );
+            } else {
+                min_duration_box.setValue( 0 );
+            }
             duration_increment_box.setValue( sp_t.duration_increment.min.dbl_val.value() );
-            max_duration_box.setValue( sp_t.max_duration.min.dbl_val.value() );
+            if( sp_t.max_duration.min.dbl_val.has_value() ) {
+                max_duration_box.setValue( sp_t.max_duration.min.dbl_val.value() );
+            } else {
+                max_duration_box.setValue( 0 );
+            }
             base_casting_time_box.setValue( sp_t.base_casting_time.min.dbl_val.value() );
             casting_time_increment_box.setValue( sp_t.casting_time_increment.min.dbl_val.value() );
             final_casting_time_box.setValue( sp_t.final_casting_time.min.dbl_val.value() );

--- a/object_creator/spell_window.cpp
+++ b/object_creator/spell_window.cpp
@@ -61,9 +61,6 @@ static spell_type default_spell_type()
     ret.min_field_intensity.min.dbl_val = 0;
     ret.field_intensity_increment.min.dbl_val = 0.0f;
     ret.field_intensity_variance.min.dbl_val = 0.0f;
-
-
-
     return ret;
 }
 

--- a/object_creator/spell_window.h
+++ b/object_creator/spell_window.h
@@ -52,11 +52,14 @@ class spell_window : public QMainWindow
 
         QLabel energy_cost_label;
         QSpinBox base_energy_cost_box;
+        void base_energy_cost_box_textchanged();
         QDoubleSpinBox energy_increment_box;
         QSpinBox final_energy_cost_box;
+        void final_energy_cost_box_textchanged();
 
         QLabel damage_label;
         QSpinBox min_damage_box;
+        void min_damage_box_textchanged();
         QDoubleSpinBox damage_increment_box;
         QSpinBox max_damage_box;
 
@@ -82,8 +85,10 @@ class spell_window : public QMainWindow
 
         QLabel casting_time_label;
         QSpinBox base_casting_time_box;
+        void base_casting_time_box_textchanged();
         QDoubleSpinBox casting_time_increment_box;
         QSpinBox final_casting_time_box;
+        void final_casting_time_box_textchanged();
 
         QLabel duration_label;
         QSpinBox min_duration_box;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix crash in object creator spell window"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The spell window crashed when selecting a spell from the window. Probably due to #64416. The error that showed up was 'bad optional access' and occurred when `dbl_val.value()` was called when it had no value.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- moved some text_changed events to their own functions which helps with debugging
- Assigned default values to most spell properties. I tried using the min_damage_default property but it's private so instead I copied the values to the spell_window file. 
- Added some checks in `populate_fields` to prevent the `bad optional access` error
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Adjusting the `serialize` function in magic.cpp so it doesn't throw `bad optional access` when a property it tries to write has no value.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
On both linux and windows:
- included the magiclysm mod when opening the object creator
- Open the spell window
- Select the first spell in the spell list
- Hold the down-arrow button until the last spell in the list is selected
- Observe no crash occurs

[Screencast from 22.08.2023 13:39:16.webm](https://github.com/CleverRaven/Cataclysm-DDA/assets/50166150/496e00d7-af88-4f14-a40e-3c6b2cc6acc1)



<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
There's still some logic that's not quite sound in the spell window. For example the `max energy cost` does not increase when the `base energy cost` exceeds it. This should be fixed in another PR. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
