### PR TITLE
Mods Over Matter: Defense Mode Compatibility for MOM

### DIFF
--- a/data/mods/Defense_Mode/eocs.json
+++ b/data/mods/Defense_Mode/eocs.json
@@ -70,7 +70,8 @@
           [ "DEFENSE_MODE_WAVE_SPAWN_GOLEMS", { "const": 1 } ],
           [ "DEFENSE_MODE_WAVE_SPAWN_GOBLINS", { "const": 1 } ],
           [ "DEFENSE_MODE_WAVE_SPAWN_ORCS", { "const": 1 } ],
-          [ "DEFENSE_MODE_WAVE_SPAWN_MEGAFAUNA", { "const": 1 } ]
+          [ "DEFENSE_MODE_WAVE_SPAWN_MEGAFAUNA", { "const": 1 } ],
+          [ "DEFENSE_MODE_WAVE_SPAWN_PSYCHICS", { "const": 1 } ]
         ]
       }
     ]
@@ -93,7 +94,8 @@
           [ "DEFENSE_MODE_WAVE_SPAWN_GOLEMS", { "const": 1 } ],
           [ "DEFENSE_MODE_WAVE_SPAWN_GOBLINS", { "const": 1 } ],
           [ "DEFENSE_MODE_WAVE_SPAWN_ORCS", { "const": 1 } ],
-          [ "DEFENSE_MODE_WAVE_SPAWN_MEGAFAUNA", { "const": 1 } ]
+          [ "DEFENSE_MODE_WAVE_SPAWN_MEGAFAUNA", { "const": 1 } ],
+          [ "DEFENSE_MODE_WAVE_SPAWN_PSYCHICS", { "const": 1 } ]
         ]
       }
     ]

--- a/data/mods/Defense_Mode/menu_screen.json
+++ b/data/mods/Defense_Mode/menu_screen.json
@@ -21,7 +21,8 @@
             { "math": [ "lizardfolk_allowed", "==", "1" ] },
             { "math": [ "goblins_allowed", "==", "1" ] },
             { "math": [ "golems_allowed", "==", "1" ] },
-            { "math": [ "orcs_allowed", "==", "1" ] }
+            { "math": [ "orcs_allowed", "==", "1" ] },
+            { "math": [ "mindovermatter_allowed", "==", "1" ] }
           ]
         },
         "topic": "TALK_DONE"
@@ -178,6 +179,18 @@
         "topic": "TALK_DEFENSE_MODE_ENEMY_SELECTION"
       },
       {
+        "text": "Allow psychics.",
+        "condition": { "and": [ { "mod_is_loaded": "mindovermatter" }, { "math": [ "mindovermatter_allowed", "==", "0" ] } ] },
+        "effect": { "math": [ "mindovermatter_allowed", "=", "1" ] },
+        "topic": "TALK_DEFENSE_MODE_ENEMY_SELECTION"
+      },
+      {
+        "text": "Disable psychics.",
+        "condition": { "and": [ { "mod_is_loaded": "mindovermatter" }, { "math": [ "mindovermatter_allowed", "==", "1" ] } ] },
+        "effect": { "math": [ "mindovermatter_allowed", "=", "0" ] },
+        "topic": "TALK_DEFENSE_MODE_ENEMY_SELECTION"
+      },
+      {
         "text": "Play!",
         "condition": {
           "or": [
@@ -192,7 +205,8 @@
             { "math": [ "lizardfolk_allowed", "==", "1" ] },
             { "math": [ "goblins_allowed", "==", "1" ] },
             { "math": [ "golems_allowed", "==", "1" ] },
-            { "math": [ "orcs_allowed", "==", "1" ] }
+            { "math": [ "orcs_allowed", "==", "1" ] },
+            { "math": [ "mindovermatter_allowed", "==", "1" ] }
           ]
         },
         "topic": "TALK_DONE"

--- a/data/mods/Defense_Mode/mod_interactions/MindOverMatter/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/MindOverMatter/eocs.json
@@ -5,7 +5,7 @@
     "condition": { "math": [ "mindovermatter_allowed", "==", "1" ] },
     "effect": [
       {
-        "u_spawn_monster": "GROUP_FERAL_PSYCHIC",
+        "u_spawn_monster": "GROUP_FERAL_PSYCHIC_DM",
         "real_count": { "global_val": "wave_number", "default": 1 },
         "outdoor_only": true,
         "group": true,
@@ -13,7 +13,7 @@
         "max_radius": 40
       },
       {
-        "u_spawn_monster": "GROUP_FERAL_PSYCHIC",
+        "u_spawn_monster": "GROUP_FERAL_PSYCHIC_DM",
         "real_count": { "global_val": "wave_number", "default": 1 },
         "outdoor_only": true,
         "group": true,
@@ -21,7 +21,7 @@
         "max_radius": 40
       },
       {
-        "u_spawn_monster": "GROUP_FERAL_PSYCHIC",
+        "u_spawn_monster": "GROUP_FERAL_PSYCHIC_DM",
         "real_count": { "global_val": "wave_number", "default": 1 },
         "outdoor_only": true,
         "group": true,

--- a/data/mods/Defense_Mode/mod_interactions/MindOverMatter/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/MindOverMatter/eocs.json
@@ -1,0 +1,34 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "DEFENSE_MODE_WAVE_SPAWN_PSYCHICS",
+    "condition": { "math": [ "mindovermatter_allowed", "==", "1" ] },
+    "effect": [
+      {
+        "u_spawn_monster": "GROUP_FERAL_PSYCHIC",
+        "real_count": { "global_val": "wave_number", "default": 1 },
+        "outdoor_only": true,
+        "group": true,
+        "min_radius": 20,
+        "max_radius": 40
+      },
+      {
+        "u_spawn_monster": "GROUP_FERAL_PSYCHIC",
+        "real_count": { "global_val": "wave_number", "default": 1 },
+        "outdoor_only": true,
+        "group": true,
+        "min_radius": 20,
+        "max_radius": 40
+      },
+      {
+        "u_spawn_monster": "GROUP_FERAL_PSYCHIC",
+        "real_count": { "global_val": "wave_number", "default": 1 },
+        "outdoor_only": true,
+        "group": true,
+        "min_radius": 20,
+        "max_radius": 40
+      }
+    ],
+    "false_effect": { "run_eocs": "DEFENSE_MODE_WAVE_SPAWN_FALLBACK" }
+  }
+]

--- a/data/mods/Defense_Mode/mod_interactions/MindOverMatter/species.json
+++ b/data/mods/Defense_Mode/mod_interactions/MindOverMatter/species.json
@@ -1,0 +1,7 @@
+[
+  {
+    "type": "SPECIES",
+    "id": "HUMAN",
+    "flags": [ "ALL_SEEING", "NEMESIS" ]
+  }
+]

--- a/data/mods/MindOverMatter/modinteractions/Defense_Mode/monstergroups.json
+++ b/data/mods/MindOverMatter/modinteractions/Defense_Mode/monstergroups.json
@@ -1,5 +1,5 @@
 [
- {
+  {
     "name": "GROUP_FERAL_PSYCHIC_DM",
     "type": "monstergroup",
     "monsters": [

--- a/data/mods/MindOverMatter/modinteractions/Defense_Mode/monstergroups.json
+++ b/data/mods/MindOverMatter/modinteractions/Defense_Mode/monstergroups.json
@@ -1,0 +1,15 @@
+[
+ {
+    "name": "GROUP_FERAL_PSYCHIC_DM",
+    "type": "monstergroup",
+    "monsters": [
+      { "monster": "mon_feral_human_bio_dm", "weight": 1, "cost_multiplier": 2 },
+      { "monster": "mon_feral_human_clair_dm", "weight": 1 },
+      { "monster": "mon_feral_human_pyrokin_dm", "weight": 1, "cost_multiplier": 3 },
+      { "monster": "mon_feral_human_telekin_dm", "weight": 1, "cost_multiplier": 2 },
+      { "monster": "mon_feral_human_teep_dm", "weight": 1 },
+      { "monster": "mon_feral_human_porter_dm", "weight": 1 },
+      { "monster": "mon_feral_human_vita_dm", "weight": 1 }
+    ]
+  }
+]

--- a/data/mods/MindOverMatter/modinteractions/Defense_Mode/monsters.json
+++ b/data/mods/MindOverMatter/modinteractions/Defense_Mode/monsters.json
@@ -1,0 +1,72 @@
+[
+ {
+    "id": "mon_feral_human_bio_dm",
+    "copy-from": "mon_feral_human_bio",
+    "type": "MONSTER",
+    "species": [ "HUMAN" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_feral_human_clair_dm",
+    "copy-from": "mon_feral_human_clair",
+    "type": "MONSTER",
+    "species": [ "HUMAN" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_feral_human_pyrokin_dm",
+    "copy-from": "mon_feral_human_pyrokin",
+    "type": "MONSTER",
+    "species": [ "HUMAN" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_feral_human_telekin_dm",
+    "copy-from": "mon_feral_human_telekin",
+    "type": "MONSTER",
+    "species": [ "HUMAN" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_feral_human_teep_dm",
+    "copy-from": "mon_feral_human_teep",
+    "type": "MONSTER",
+    "species": [ "HUMAN" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_feral_human_porter_dm",
+    "copy-from": "mon_feral_human_porter",
+    "type": "MONSTER",
+    "species": [ "HUMAN" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_feral_human_vita_dm",
+    "copy-from": "mon_feral_human_vita",
+    "type": "MONSTER",
+    "species": [ "HUMAN" ],
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  }
+]

--- a/data/mods/MindOverMatter/modinteractions/Defense_Mode/monsters.json
+++ b/data/mods/MindOverMatter/modinteractions/Defense_Mode/monsters.json
@@ -1,5 +1,5 @@
 [
- {
+  {
     "id": "mon_feral_human_bio_dm",
     "copy-from": "mon_feral_human_bio",
     "type": "MONSTER",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Add MOM compatibility for Defense Mode."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Add some Mind Over Matter compatibility to Defense Mode, continuing on the work of bringing more mods into the fold of the game mode.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds the new EOCs, monsters and groups, and dialogue options to enable Mind Over Matter enemies to appear in Defense Mode.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned in and fought some ferals casting spells at me. It was pretty fun.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I don't know if the waves are overturned due to the exclusive spawns of psychic ferals. If so, I can change it to include a lot of regular zombies to thin the hordes out. Based on what I know about how Mind Over Matter's powers work, this should provide a big opportunity to gain great psychic powers.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
