### PR TITLE
Cache results of item search functions

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3033,7 +3033,7 @@ void safecracking_activity_actor::do_turn( player_activity &act, Character &who 
 {
     bool can_crack = who.has_flag( json_flag_SUPER_HEARING );
     // short-circuit to avoid the more expensive iteration over items
-    can_crack = can_crack || who.has_item_with_flag( flag_SAFECRACK );
+    can_crack = can_crack || who.has_any_item_with( flag_SAFECRACK );
 
     if( !can_crack ) {
         // We lost our cracking tool somehow, bail out.

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3033,7 +3033,7 @@ void safecracking_activity_actor::do_turn( player_activity &act, Character &who 
 {
     bool can_crack = who.has_flag( json_flag_SUPER_HEARING );
     // short-circuit to avoid the more expensive iteration over items
-    can_crack = can_crack || who.has_any_item_with( flag_SAFECRACK );
+    can_crack = can_crack || who.cache_has_item_with( flag_SAFECRACK );
 
     if( !can_crack ) {
         // We lost our cracking tool somehow, bail out.

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1326,9 +1326,8 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                     if( seed.is_empty() ) {
                         return activity_reason_info::fail( do_activity_reason::ALREADY_DONE );
                     }
-                    std::set<item *> &seed_inv = you.all_items_with( "is_seed", &item::is_seed );
-                    for( const item *elem : seed_inv ) {
-                        if( elem->typeId() == itype_id( seed ) ) {
+                    for( item *seed_it : you.all_items_with( "is_seed", &item::is_seed ) ) {
+                        if( seed_it->typeId() == itype_id( seed ) ) {
                             return activity_reason_info::ok( do_activity_reason::NEEDS_PLANTING );
                         }
                     }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2908,12 +2908,11 @@ static bool generic_multi_activity_do(
         for( const zone_data &zone : zones ) {
             const itype_id seed =
                 dynamic_cast<const plot_options &>( zone.get_options() ).get_seed();
-            std::vector<item *> seed_inv = you.items_with( [seed]( const item & itm ) {
-                return itm.typeId() == itype_id( seed );
-            } );
-            // we don't have the required seed, even though we should at this point.
-            // move onto the next tile, and if need be that will prompt a fetch seeds activity.
+            std::vector<item *> seed_inv = you.all_items_with( "is_seed", itype_id( seed ), {},
+                                           &item::is_seed );
             if( seed_inv.empty() ) {
+                // we don't have the required seed, even though we should at this point.
+                // move onto the next tile, and if need be that will prompt a fetch seeds activity.
                 continue;
             }
             // TODO: fix point types

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1143,7 +1143,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             return activity_reason_info::fail( do_activity_reason::NO_ZONE );
         }
 
-        if( you.has_any_item_with( json_flag_MOP ) ) {
+        if( you.cache_has_item_with( json_flag_MOP ) ) {
             return activity_reason_info::ok( do_activity_reason::NEEDS_MOP );
         } else {
             return activity_reason_info::fail( do_activity_reason::NEEDS_MOP );
@@ -1324,7 +1324,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                     if( seed.is_empty() ) {
                         return activity_reason_info::fail( do_activity_reason::ALREADY_DONE );
                     }
-                    if( you.has_any_item_with( "is_seed", &item::is_seed, [&seed]( const item & it ) {
+                    if( you.cache_has_item_with( "is_seed", &item::is_seed, [&seed]( const item & it ) {
                     return it.typeId() == itype_id( seed );
                     } ) ) {
                         return activity_reason_info::ok( do_activity_reason::NEEDS_PLANTING );
@@ -2908,7 +2908,7 @@ static bool generic_multi_activity_do(
         for( const zone_data &zone : zones ) {
             const itype_id seed =
                 dynamic_cast<const plot_options &>( zone.get_options() ).get_seed();
-            std::vector<item *> seed_inv = you.all_items_with( "is_seed", itype_id( seed ), {},
+            std::vector<item *> seed_inv = you.cache_get_items_with( "is_seed", itype_id( seed ), {},
                                            &item::is_seed );
             if( seed_inv.empty() ) {
                 // we don't have the required seed, even though we should at this point.

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1143,9 +1143,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
             return activity_reason_info::fail( do_activity_reason::NO_ZONE );
         }
 
-        if( you.has_item_with( []( const item & itm ) {
-        return itm.has_flag( json_flag_MOP );
-        } ) ) {
+        if( you.has_any_item_with( json_flag_MOP ) ) {
             return activity_reason_info::ok( do_activity_reason::NEEDS_MOP );
         } else {
             return activity_reason_info::fail( do_activity_reason::NEEDS_MOP );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1324,7 +1324,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                     if( seed.is_empty() ) {
                         return activity_reason_info::fail( do_activity_reason::ALREADY_DONE );
                     }
-                    if( you.do_to_items_with_until( "is_seed", &item::is_seed, [&seed]( const item & it ) {
+                    if( you.has_any_item_with( "is_seed", &item::is_seed, [&seed]( const item & it ) {
                     return it.typeId() == itype_id( seed );
                     } ) ) {
                         return activity_reason_info::ok( do_activity_reason::NEEDS_PLANTING );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1326,9 +1326,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                     if( seed.is_empty() ) {
                         return activity_reason_info::fail( do_activity_reason::ALREADY_DONE );
                     }
-                    std::vector<item *> seed_inv = you.items_with( []( const item & itm ) {
-                        return itm.is_seed();
-                    } );
+                    std::set<item *> &seed_inv = you.all_items_with( "IS SEED", &item::is_seed );
                     for( const item *elem : seed_inv ) {
                         if( elem->typeId() == itype_id( seed ) ) {
                             return activity_reason_info::ok( do_activity_reason::NEEDS_PLANTING );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1326,7 +1326,7 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                     if( seed.is_empty() ) {
                         return activity_reason_info::fail( do_activity_reason::ALREADY_DONE );
                     }
-                    std::set<item *> &seed_inv = you.all_items_with( "IS SEED", &item::is_seed );
+                    std::set<item *> &seed_inv = you.all_items_with( "is_seed", &item::is_seed );
                     for( const item *elem : seed_inv ) {
                         if( elem->typeId() == itype_id( seed ) ) {
                             return activity_reason_info::ok( do_activity_reason::NEEDS_PLANTING );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1326,14 +1326,14 @@ static activity_reason_info can_do_activity_there( const activity_id &act, Chara
                     if( seed.is_empty() ) {
                         return activity_reason_info::fail( do_activity_reason::ALREADY_DONE );
                     }
-                    for( item *seed_it : you.all_items_with( "is_seed", &item::is_seed ) ) {
-                        if( seed_it->typeId() == itype_id( seed ) ) {
-                            return activity_reason_info::ok( do_activity_reason::NEEDS_PLANTING );
-                        }
+                    if( you.do_to_items_with_until( "is_seed", &item::is_seed, [&seed]( const item & it ) {
+                    return it.typeId() == itype_id( seed );
+                    } ) ) {
+                        return activity_reason_info::ok( do_activity_reason::NEEDS_PLANTING );
                     }
                     // didn't find the seed, but maybe there are overlapping farm zones
                     // and another of the zones is for a seed that we have
-                    // so loop again, and return false once all zones done.
+                    // so loop again, and return false once all zones are done.
                 }
 
             } else {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -3366,9 +3366,12 @@ std::vector<item *> Character::get_cable_ups()
 {
     std::vector<item *> stored_fuels;
 
-    const std::vector<item *> cables = items_with( []( const item & it ) {
-        return it.link && it.link->has_states( link_state::ups, link_state::bio_cable );
-    } );
+    std::set<item *> cables = all_items_with( flag_CABLE_SPOOL );
+    for( item *it : cables ) {
+        if( !it->link || !it->link->has_states( link_state::ups, link_state::bio_cable ) ) {
+            cables.erase( it );
+        }
+    }
     int n = cables.size();
     if( n == 0 ) {
         return stored_fuels;
@@ -3399,9 +3402,12 @@ std::vector<item *> Character::get_cable_solar()
 {
     std::vector<item *> solar_sources;
 
-    const std::vector<item *> cables = items_with( []( const item & it ) {
-        return it.link && it.link->has_states( link_state::solarpack, link_state::bio_cable );
-    } );
+    std::set<item *> cables = all_items_with( flag_CABLE_SPOOL );
+    for( item *it : cables ) {
+        if( !it->link || !it->link->has_states( link_state::solarpack, link_state::bio_cable ) ) {
+            cables.erase( it );
+        }
+    }
     int n = cables.size();
     if( n == 0 ) {
         return solar_sources;
@@ -3430,11 +3436,14 @@ std::vector<vehicle *> Character::get_cable_vehicle()
 {
     std::vector<vehicle *> remote_vehicles;
 
-    const std::vector<item *> cables = items_with( []( const item & it ) {
-        return it.link && it.link->has_state( link_state::bio_cable ) &&
-               ( it.link->has_state( link_state::vehicle_battery ) ||
-                 it.link->has_state( link_state::vehicle_port ) );
-    } );
+    std::set<item *> cables = all_items_with( flag_CABLE_SPOOL );
+    for( item *it : cables ) {
+        if( !it->link || !it->link->has_state( link_state::bio_cable ) ||
+            ( !it->link->has_state( link_state::vehicle_battery ) &&
+              !it->link->has_state( link_state::vehicle_port ) ) ) {
+            cables.erase( it );
+        }
+    }
     int n = cables.size();
     if( n == 0 ) {
         return remote_vehicles;

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1140,7 +1140,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             bio.powered = g->remoteveh() != nullptr || !get_value( "remote_controlling" ).empty();
         }
     } else if( bio.info().is_remote_fueled ) {
-        std::set<item *> &cables = all_items_with( flag_CABLE_SPOOL );
+        std::vector<item *> &cables = all_items_with( flag_CABLE_SPOOL );
         bool has_cable = !cables.empty();
         bool free_cable = false;
         bool success = false;
@@ -3366,13 +3366,12 @@ std::vector<item *> Character::get_cable_ups()
 {
     std::vector<item *> stored_fuels;
 
-    std::set<item *> cables = all_items_with( flag_CABLE_SPOOL );
-    for( item *it : cables ) {
-        if( !it->link || !it->link->has_states( link_state::ups, link_state::bio_cable ) ) {
-            cables.erase( it );
+    int n = 0;
+    for( item *it : all_items_with( flag_CABLE_SPOOL ) ) {
+        if( it->link && it->link->has_states( link_state::ups, link_state::bio_cable ) ) {
+            n++;
         }
     }
-    int n = cables.size();
     if( n == 0 ) {
         return stored_fuels;
     }
@@ -3402,13 +3401,12 @@ std::vector<item *> Character::get_cable_solar()
 {
     std::vector<item *> solar_sources;
 
-    std::set<item *> cables = all_items_with( flag_CABLE_SPOOL );
-    for( item *it : cables ) {
-        if( !it->link || !it->link->has_states( link_state::solarpack, link_state::bio_cable ) ) {
-            cables.erase( it );
+    int n = 0;
+    for( item *it : all_items_with( flag_CABLE_SPOOL ) ) {
+        if( it->link && it->link->has_states( link_state::solarpack, link_state::bio_cable ) ) {
+            n++;
         }
     }
-    int n = cables.size();
     if( n == 0 ) {
         return solar_sources;
     }
@@ -3436,12 +3434,12 @@ std::vector<vehicle *> Character::get_cable_vehicle() const
 {
     std::vector<vehicle *> remote_vehicles;
 
-    std::set<item *> cables = all_items_with( flag_CABLE_SPOOL );
-    for( item *it : cables ) {
-        if( !it->link || !it->link->has_state( link_state::bio_cable ) ||
-            ( !it->link->has_state( link_state::vehicle_battery ) &&
-              !it->link->has_state( link_state::vehicle_port ) ) ) {
-            cables.erase( it );
+    std::vector<item *> cables;
+    for( item *it : all_items_with( flag_CABLE_SPOOL ) ) {
+        if( it->link && it->link->has_state( link_state::bio_cable ) &&
+            ( it->link->has_state( link_state::vehicle_battery ) ||
+              it->link->has_state( link_state::vehicle_port ) ) ) {
+            cables.push_back( it );
         }
     }
     int n = cables.size();

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1140,7 +1140,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             bio.powered = g->remoteveh() != nullptr || !get_value( "remote_controlling" ).empty();
         }
     } else if( bio.info().is_remote_fueled ) {
-        std::set<item *> cables = all_items_with_flag( flag_CABLE_SPOOL );
+        std::set<item *> cables = all_items_with( flag_CABLE_SPOOL );
         bool has_cable = !cables.empty();
         bool free_cable = false;
         bool success = false;

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1140,7 +1140,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             bio.powered = g->remoteveh() != nullptr || !get_value( "remote_controlling" ).empty();
         }
     } else if( bio.info().is_remote_fueled ) {
-        std::vector<item *> cables = all_items_with( flag_CABLE_SPOOL );
+        std::vector<item *> cables = cache_get_items_with( flag_CABLE_SPOOL );
         bool has_cable = !cables.empty();
         bool free_cable = false;
         bool success = false;
@@ -3366,7 +3366,7 @@ std::vector<item *> Character::get_cable_ups()
 {
     std::vector<item *> stored_fuels;
 
-    int n = all_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
+    int n = cache_get_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
         return it.link && it.link->has_states( link_state::ups, link_state::bio_cable );
     } ).size();
     if( n == 0 ) {
@@ -3398,7 +3398,7 @@ std::vector<item *> Character::get_cable_solar()
 {
     std::vector<item *> solar_sources;
 
-    int n = all_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
+    int n = cache_get_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
         return it.link && it.link->has_states( link_state::solarpack, link_state::bio_cable );
     } ).size();
     if( n == 0 ) {
@@ -3428,7 +3428,8 @@ std::vector<vehicle *> Character::get_cable_vehicle() const
 {
     std::vector<vehicle *> remote_vehicles;
 
-    std::vector<const item *> cables = all_items_with( flag_CABLE_SPOOL, [&cables]( const item & it ) {
+    std::vector<const item *> cables = cache_get_items_with( flag_CABLE_SPOOL,
+    [&cables]( const item & it ) {
         return it.link && it.link->has_state( link_state::bio_cable ) &&
                ( it.link->has_state( link_state::vehicle_battery ) ||
                  it.link->has_state( link_state::vehicle_port ) );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1140,7 +1140,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             bio.powered = g->remoteveh() != nullptr || !get_value( "remote_controlling" ).empty();
         }
     } else if( bio.info().is_remote_fueled ) {
-        std::vector<item *> cables = get_items_with( flag_CABLE_SPOOL );
+        std::vector<item *> cables = all_items_with( flag_CABLE_SPOOL );
         bool has_cable = !cables.empty();
         bool free_cable = false;
         bool success = false;
@@ -3366,7 +3366,7 @@ std::vector<item *> Character::get_cable_ups()
 {
     std::vector<item *> stored_fuels;
 
-    int n = get_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
+    int n = all_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
         return it.link && it.link->has_states( link_state::ups, link_state::bio_cable );
     } ).size();
     if( n == 0 ) {
@@ -3398,7 +3398,7 @@ std::vector<item *> Character::get_cable_solar()
 {
     std::vector<item *> solar_sources;
 
-    int n = get_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
+    int n = all_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
         return it.link && it.link->has_states( link_state::solarpack, link_state::bio_cable );
     } ).size();
     if( n == 0 ) {
@@ -3428,7 +3428,7 @@ std::vector<vehicle *> Character::get_cable_vehicle() const
 {
     std::vector<vehicle *> remote_vehicles;
 
-    std::vector<const item *> cables = get_items_with( flag_CABLE_SPOOL, [&cables]( const item & it ) {
+    std::vector<const item *> cables = all_items_with( flag_CABLE_SPOOL, [&cables]( const item & it ) {
         return it.link && it.link->has_state( link_state::bio_cable ) &&
                ( it.link->has_state( link_state::vehicle_battery ) ||
                  it.link->has_state( link_state::vehicle_port ) );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1140,9 +1140,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             bio.powered = g->remoteveh() != nullptr || !get_value( "remote_controlling" ).empty();
         }
     } else if( bio.info().is_remote_fueled ) {
-        std::vector<item *> cables = items_with( []( const item & it ) {
-            return it.has_flag( flag_CABLE_SPOOL );
-        } );
+        std::set<item *> cables = all_items_with_flag( flag_CABLE_SPOOL );
         bool has_cable = !cables.empty();
         bool free_cable = false;
         bool success = false;

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -3366,12 +3366,9 @@ std::vector<item *> Character::get_cable_ups()
 {
     std::vector<item *> stored_fuels;
 
-    int n = 0;
-    do_to_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
-        if( it.link && it.link->has_states( link_state::ups, link_state::bio_cable ) ) {
-            n++;
-        }
-    } );
+    int n = get_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
+        return it.link && it.link->has_states( link_state::ups, link_state::bio_cable );
+    } ).size();
     if( n == 0 ) {
         return stored_fuels;
     }
@@ -3401,12 +3398,9 @@ std::vector<item *> Character::get_cable_solar()
 {
     std::vector<item *> solar_sources;
 
-    int n = 0;
-    do_to_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
-        if( it.link && it.link->has_states( link_state::solarpack, link_state::bio_cable ) ) {
-            n++;
-        }
-    } );
+    int n = get_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
+        return it.link && it.link->has_states( link_state::solarpack, link_state::bio_cable );
+    } ).size();
     if( n == 0 ) {
         return solar_sources;
     }
@@ -3434,13 +3428,10 @@ std::vector<vehicle *> Character::get_cable_vehicle() const
 {
     std::vector<vehicle *> remote_vehicles;
 
-    std::vector<const item *> cables;
-    do_to_items_with( flag_CABLE_SPOOL, [&cables]( const item & it ) {
-        if( it.link && it.link->has_state( link_state::bio_cable ) &&
-            ( it.link->has_state( link_state::vehicle_battery ) ||
-              it.link->has_state( link_state::vehicle_port ) ) ) {
-            cables.push_back( &it );
-        }
+    std::vector<const item *> cables = get_items_with( flag_CABLE_SPOOL, [&cables]( const item & it ) {
+        return it.link && it.link->has_state( link_state::bio_cable ) &&
+               ( it.link->has_state( link_state::vehicle_battery ) ||
+                 it.link->has_state( link_state::vehicle_port ) );
     } );
     int n = cables.size();
     if( n == 0 ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1140,7 +1140,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             bio.powered = g->remoteveh() != nullptr || !get_value( "remote_controlling" ).empty();
         }
     } else if( bio.info().is_remote_fueled ) {
-        std::vector<item *> &cables = all_items_with( flag_CABLE_SPOOL );
+        std::vector<item *> cables = get_items_with( flag_CABLE_SPOOL );
         bool has_cable = !cables.empty();
         bool free_cable = false;
         bool success = false;
@@ -1148,7 +1148,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             add_msg_if_player( m_info,
                                _( "You need a jumper cable connected to a power source to drain power from it." ) );
         } else {
-            for( item *cable : cables ) {
+            for( const item *cable : cables ) {
                 if( !cable->link || cable->link->has_no_links() ) {
                     free_cable = true;
                 } else if( cable->link->has_states( link_state::no_link, link_state::bio_cable ) ) {
@@ -3367,11 +3367,11 @@ std::vector<item *> Character::get_cable_ups()
     std::vector<item *> stored_fuels;
 
     int n = 0;
-    for( item *it : all_items_with( flag_CABLE_SPOOL ) ) {
-        if( it->link && it->link->has_states( link_state::ups, link_state::bio_cable ) ) {
+    do_to_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
+        if( it.link && it.link->has_states( link_state::ups, link_state::bio_cable ) ) {
             n++;
         }
-    }
+    } );
     if( n == 0 ) {
         return stored_fuels;
     }
@@ -3402,11 +3402,11 @@ std::vector<item *> Character::get_cable_solar()
     std::vector<item *> solar_sources;
 
     int n = 0;
-    for( item *it : all_items_with( flag_CABLE_SPOOL ) ) {
-        if( it->link && it->link->has_states( link_state::solarpack, link_state::bio_cable ) ) {
+    do_to_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
+        if( it.link && it.link->has_states( link_state::solarpack, link_state::bio_cable ) ) {
             n++;
         }
-    }
+    } );
     if( n == 0 ) {
         return solar_sources;
     }
@@ -3434,14 +3434,14 @@ std::vector<vehicle *> Character::get_cable_vehicle() const
 {
     std::vector<vehicle *> remote_vehicles;
 
-    std::vector<item *> cables;
-    for( item *it : all_items_with( flag_CABLE_SPOOL ) ) {
-        if( it->link && it->link->has_state( link_state::bio_cable ) &&
-            ( it->link->has_state( link_state::vehicle_battery ) ||
-              it->link->has_state( link_state::vehicle_port ) ) ) {
-            cables.push_back( it );
+    std::vector<const item *> cables;
+    do_to_items_with( flag_CABLE_SPOOL, [&cables]( const item & it ) {
+        if( it.link && it.link->has_state( link_state::bio_cable ) &&
+            ( it.link->has_state( link_state::vehicle_battery ) ||
+              it.link->has_state( link_state::vehicle_port ) ) ) {
+            cables.push_back( &it );
         }
-    }
+    } );
     int n = cables.size();
     if( n == 0 ) {
         return remote_vehicles;

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -3366,7 +3366,7 @@ std::vector<item *> Character::get_cable_ups()
 {
     std::vector<item *> stored_fuels;
 
-    int n = cache_get_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
+    int n = cache_get_items_with( flag_CABLE_SPOOL, []( const item & it ) {
         return it.link && it.link->has_states( link_state::ups, link_state::bio_cable );
     } ).size();
     if( n == 0 ) {
@@ -3398,7 +3398,7 @@ std::vector<item *> Character::get_cable_solar()
 {
     std::vector<item *> solar_sources;
 
-    int n = cache_get_items_with( flag_CABLE_SPOOL, [&n]( const item & it ) {
+    int n = cache_get_items_with( flag_CABLE_SPOOL, []( const item & it ) {
         return it.link && it.link->has_states( link_state::solarpack, link_state::bio_cable );
     } ).size();
     if( n == 0 ) {
@@ -3429,7 +3429,7 @@ std::vector<vehicle *> Character::get_cable_vehicle() const
     std::vector<vehicle *> remote_vehicles;
 
     std::vector<const item *> cables = cache_get_items_with( flag_CABLE_SPOOL,
-    [&cables]( const item & it ) {
+    []( const item & it ) {
         return it.link && it.link->has_state( link_state::bio_cable ) &&
                ( it.link->has_state( link_state::vehicle_battery ) ||
                  it.link->has_state( link_state::vehicle_port ) );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -3432,7 +3432,7 @@ std::vector<item *> Character::get_cable_solar()
     return solar_sources;
 }
 
-std::vector<vehicle *> Character::get_cable_vehicle()
+std::vector<vehicle *> Character::get_cable_vehicle() const
 {
     std::vector<vehicle *> remote_vehicles;
 

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1140,7 +1140,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             bio.powered = g->remoteveh() != nullptr || !get_value( "remote_controlling" ).empty();
         }
     } else if( bio.info().is_remote_fueled ) {
-        std::set<item *> cables = all_items_with( flag_CABLE_SPOOL );
+        std::set<item *> &cables = all_items_with( flag_CABLE_SPOOL );
         bool has_cable = !cables.empty();
         bool free_cable = false;
         bool success = false;

--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -491,7 +491,7 @@ void bodygraph_display::prepare_infotext( bool reset_pos )
     info_txt.emplace_back( string_format( "%s: %d%%", colorize( _( "Wetness" ), c_magenta ),
                                           static_cast<int>( info.wetness * 100.0f ) ) );
     // part temperature
-    const bool temp_precise = u->has_any_item_with( STATIC( flag_id( "THERMOMETER" ) ) ) ||
+    const bool temp_precise = u->cache_has_item_with( STATIC( flag_id( "THERMOMETER" ) ) ) ||
                               u->has_flag( STATIC( json_character_flag( "THERMOMETER" ) ) );
     const units::temperature temp = units::from_fahrenheit( info.temperature.first / 50.0 );
     info_txt.emplace_back( string_format( "%s: %s", colorize( _( "Body temp" ), c_magenta ),

--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -491,7 +491,7 @@ void bodygraph_display::prepare_infotext( bool reset_pos )
     info_txt.emplace_back( string_format( "%s: %d%%", colorize( _( "Wetness" ), c_magenta ),
                                           static_cast<int>( info.wetness * 100.0f ) ) );
     // part temperature
-    const bool temp_precise = u->has_item_with_flag( STATIC( flag_id( "THERMOMETER" ) ) ) ||
+    const bool temp_precise = u->has_any_item_with( STATIC( flag_id( "THERMOMETER" ) ) ) ||
                               u->has_flag( STATIC( json_character_flag( "THERMOMETER" ) ) );
     const units::temperature temp = units::from_fahrenheit( info.temperature.first / 50.0 );
     info_txt.emplace_back( string_format( "%s: %s", colorize( _( "Body temp" ), c_magenta ),

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8946,14 +8946,13 @@ void Character::add_to_inv_search_caches( item &it ) const
 void Character::remove_from_inv_search_caches( item &it ) const
 {
     it.visit_items( [this]( item * i, item * ) {
-        for( auto &cache : inv_search_caches ) {
-            if( cache.second.flag.is_valid() && !i->has_flag( cache.second.flag ) ) {
-                continue;
+        for( auto iter = inv_search_caches.begin(); iter != inv_search_caches.end(); ) {
+            if( ( !iter->second.flag.is_valid() || i->has_flag( iter->second.flag ) ) &&
+                ( iter->second.filter_func == nullptr || ( i->*iter->second.filter_func )() ) ) {
+                iter = inv_search_caches.erase( iter );
+            } else {
+                ++iter;
             }
-            if( cache.second.filter_func && !( i->*cache.second.filter_func )() ) {
-                continue;
-            }
-            inv_search_caches.erase( cache.first );
         }
         return VisitResponse::NEXT;
     } );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8989,20 +8989,20 @@ bool Character::has_any_item_with_flag_and_charges( const flag_id &flag ) const
     } );
 }
 
-std::vector<item *> Character::get_items_with( const flag_id &flag,
+std::vector<item *> Character::all_items_with( const flag_id &flag,
         const std::function<bool( item & )> &do_and_check_func )
 {
-    get_items_with( "HAS FLAG " + flag.str(), flag, nullptr, do_and_check_func );
+    all_items_with( "HAS FLAG " + flag.str(), flag, nullptr, do_and_check_func );
 }
 
-std::vector<item *> Character::get_items_with( const std::string &key,
+std::vector<item *> Character::all_items_with( const std::string &key,
         bool( item::*filter_func )() const,
         const std::function<bool( item & )> &do_and_check_func )
 {
-    get_items_with( key, {}, filter_func, do_and_check_func );
+    all_items_with( key, {}, filter_func, do_and_check_func );
 }
 
-std::vector<item *> Character::get_items_with( const std::string &key, const flag_id &flag,
+std::vector<item *> Character::all_items_with( const std::string &key, const flag_id &flag,
         bool( item::*filter_func )() const,
         const std::function<bool( item & )> &do_and_check_func )
 {
@@ -9015,20 +9015,20 @@ std::vector<item *> Character::get_items_with( const std::string &key, const fla
     return ret;
 }
 
-std::vector<const item *> Character::get_items_with( const flag_id &flag,
+std::vector<const item *> Character::all_items_with( const flag_id &flag,
         const std::function<bool( const item & )> &do_and_check_func ) const
 {
-    get_items_with( "HAS FLAG " + flag.str(), flag, nullptr, do_and_check_func );
+    all_items_with( "HAS FLAG " + flag.str(), flag, nullptr, do_and_check_func );
 }
 
-std::vector<const item *> Character::get_items_with( const std::string &key,
+std::vector<const item *> Character::all_items_with( const std::string &key,
         bool( item::*filter_func )() const,
         const std::function<bool( const item & )> &do_and_check_func ) const
 {
-    get_items_with( key, {}, filter_func, do_and_check_func );
+    all_items_with( key, {}, filter_func, do_and_check_func );
 }
 
-std::vector<const item *> Character::get_items_with( const std::string &key, const flag_id &flag,
+std::vector<const item *> Character::all_items_with( const std::string &key, const flag_id &flag,
         bool( item::*filter_func )() const,
         const std::function<bool( const item & )> &do_and_check_func ) const
 {
@@ -12022,7 +12022,7 @@ void Character::process_items()
 
     // Load all items that use the UPS and have their own battery to their minimal functional charge,
     // The tool is not really useful if its charges are below charges_to_use
-    std::vector<item *> inv_use_ups = get_items_with( flag_USE_UPS, [&inv_use_ups]( item & it ) {
+    std::vector<item *> inv_use_ups = all_items_with( flag_USE_UPS, [&inv_use_ups]( item & it ) {
         return !!it.ammo_data();
     } );
     if( !inv_use_ups.empty() ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8891,10 +8891,10 @@ void Character::do_to_items_with( const itype_id &type,
     do_to_items_with( "HAS TYPE " + type.str(), type, {}, nullptr, do_func );
 }
 
-void Character::do_to_items_with( const flag_id &flag,
+void Character::do_to_items_with( const flag_id &type_flag,
                                   const std::function<void( item & )> &do_func ) const
 {
-    do_to_items_with( "HAS FLAG " + flag.str(), {}, flag, nullptr, do_func );
+    do_to_items_with( "HAS FLAG " + type_flag.str(), {}, type_flag, nullptr, do_func );
 }
 
 void Character::do_to_items_with( const std::string &key, bool( item::*filter_func )() const,
@@ -8903,7 +8903,7 @@ void Character::do_to_items_with( const std::string &key, bool( item::*filter_fu
     do_to_items_with( key, {}, {}, filter_func, do_func );
 }
 
-void Character::do_to_items_with( const std::string &key, const itype_id &type, const flag_id &flag,
+void Character::do_to_items_with( const std::string &key, const itype_id &type, const flag_id &type_flag,
                                   bool( item::*filter_func )() const,
                                   const std::function<void( item & )> &do_func ) const
 {
@@ -8922,11 +8922,11 @@ void Character::do_to_items_with( const std::string &key, const itype_id &type, 
     } else {
         // Otherwise, add a new cache and populate with all appropriate items in the inventory. Empty lists are still created.
         inv_search_caches[key].type = type;
-        inv_search_caches[key].flag = flag;
+        inv_search_caches[key].type_flag = type_flag;
         inv_search_caches[key].filter_func = filter_func;
         visit_items( [&]( item * it, item * ) {
-            if( ( !flag.is_valid() || it->has_flag( flag ) ) &&
-                ( !type.is_valid() || it->typeId() == type ) &&
+            if( ( !type.is_valid() || it->typeId() == type ) &&
+                ( !type_flag.is_valid() || it->type->has_flag( type_flag ) ) &&
                 ( filter_func == nullptr || ( it->*filter_func )() ) ) {
 
                 inv_search_caches[key].items.push_back( it->get_safe_reference() );
@@ -8943,10 +8943,10 @@ bool Character::has_any_item_with( const itype_id &type,
     return has_any_item_with( "HAS TYPE " + type.str(), type, {}, nullptr, check_func );
 }
 
-bool Character::has_any_item_with( const flag_id &flag,
+bool Character::has_any_item_with( const flag_id &type_flag,
                                    const std::function<bool( const item & )> &check_func ) const
 {
-    return has_any_item_with( "HAS FLAG " + flag.str(), {}, flag, nullptr, check_func );
+    return has_any_item_with( "HAS FLAG " + type_flag.str(), {}, type_flag, nullptr, check_func );
 }
 
 bool Character::has_any_item_with( const std::string &key, bool( item::*filter_func )() const,
@@ -8956,7 +8956,7 @@ bool Character::has_any_item_with( const std::string &key, bool( item::*filter_f
 }
 
 bool Character::has_any_item_with( const std::string &key, const itype_id &type,
-                                   const flag_id &flag, bool( item::*filter_func )() const,
+                                   const flag_id &type_flag, bool( item::*filter_func )() const,
                                    const std::function<bool( const item & )> &check_func ) const
 {
     bool aborted = false;
@@ -8979,11 +8979,11 @@ bool Character::has_any_item_with( const std::string &key, const itype_id &type,
     } else {
         // Otherwise, add a new cache and populate with all appropriate items in the inventory. Empty lists are still created.
         inv_search_caches[key].type = type;
-        inv_search_caches[key].flag = flag;
+        inv_search_caches[key].type_flag = type_flag;
         inv_search_caches[key].filter_func = filter_func;
         visit_items( [&]( item * it, item * ) {
-            if( ( !flag.is_valid() || it->has_flag( flag ) ) &&
-                ( !type.is_valid() || it->typeId() == type ) &&
+            if( ( !type.is_valid() || it->typeId() == type ) &&
+                ( !type_flag.is_valid() || it->type->has_flag( type_flag ) ) &&
                 ( filter_func == nullptr || ( it->*filter_func )() ) ) {
 
                 inv_search_caches[key].items.push_back( it->get_safe_reference() );
@@ -8998,9 +8998,9 @@ bool Character::has_any_item_with( const std::string &key, const itype_id &type,
     return aborted;
 }
 
-bool Character::has_any_item_with_flag_and_charges( const flag_id &flag ) const
+bool Character::has_any_item_with_flag_and_charges( const flag_id &type_flag ) const
 {
-    return has_any_item_with( "HAS FLAG " + flag.str(), {}, flag, nullptr, [this]( const item & it ) {
+    return has_any_item_with( "HAS FLAG " + type_flag.str(), {}, type_flag, nullptr, [this]( const item & it ) {
         return !it.is_tool() || it.type->tool->max_charges == 0 || it.ammo_remaining( this ) > 0;
     } );
 }
@@ -9011,10 +9011,10 @@ std::vector<item *> Character::all_items_with( const itype_id &type,
     return all_items_with( "HAS TYPE " + type.str(), type, {}, nullptr, do_and_check_func );
 }
 
-std::vector<item *> Character::all_items_with( const flag_id &flag,
+std::vector<item *> Character::all_items_with( const flag_id &type_flag,
         const std::function<bool( item & )> &do_and_check_func )
 {
-    return all_items_with( "HAS FLAG " + flag.str(), {}, flag, nullptr, do_and_check_func );
+    return all_items_with( "HAS FLAG " + type_flag.str(), {}, type_flag, nullptr, do_and_check_func );
 }
 
 std::vector<item *> Character::all_items_with( const std::string &key,
@@ -9025,11 +9025,11 @@ std::vector<item *> Character::all_items_with( const std::string &key,
 }
 
 std::vector<item *> Character::all_items_with( const std::string &key, const itype_id &type,
-        const flag_id &flag, bool( item::*filter_func )() const,
+        const flag_id &type_flag, bool( item::*filter_func )() const,
         const std::function<bool( item & )> &do_and_check_func )
 {
     std::vector<item *> ret;
-    do_to_items_with( key, type, flag, filter_func, [&ret, &do_and_check_func]( item & it ) {
+    do_to_items_with( key, type, type_flag, filter_func, [&ret, &do_and_check_func]( item & it ) {
         if( do_and_check_func( it ) ) {
             ret.push_back( &it );
         }
@@ -9043,10 +9043,10 @@ std::vector<const item *> Character::all_items_with( const itype_id &type,
     return all_items_with( "HAS TYPE " + type.str(), type, {}, nullptr, check_func );
 }
 
-std::vector<const item *> Character::all_items_with( const flag_id &flag,
+std::vector<const item *> Character::all_items_with( const flag_id &type_flag,
         const std::function<bool( const item & )> &check_func ) const
 {
-    return all_items_with( "HAS FLAG " + flag.str(), {}, flag, nullptr, check_func );
+    return all_items_with( "HAS FLAG " + type_flag.str(), {}, type_flag, nullptr, check_func );
 }
 
 std::vector<const item *> Character::all_items_with( const std::string &key,
@@ -9057,11 +9057,11 @@ std::vector<const item *> Character::all_items_with( const std::string &key,
 }
 
 std::vector<const item *> Character::all_items_with( const std::string &key, const itype_id &type,
-        const flag_id &flag, bool( item::*filter_func )() const,
+        const flag_id &type_flag, bool( item::*filter_func )() const,
         const std::function<bool( const item & )> &check_func ) const
 {
     std::vector<const item *> ret;
-    do_to_items_with( key, type, flag, filter_func, [&ret, &check_func]( const item & it ) {
+    do_to_items_with( key, type, type_flag, filter_func, [&ret, &check_func]( const item & it ) {
         if( check_func( it ) ) {
             ret.push_back( &it );
         }
@@ -9072,8 +9072,8 @@ std::vector<const item *> Character::all_items_with( const std::string &key, con
 void Character::add_to_inv_search_caches( item &it ) const
 {
     for( auto &cache : inv_search_caches ) {
-        if( ( cache.second.flag.is_valid() && !it.has_flag( cache.second.flag ) ) ||
-            ( cache.second.type.is_valid() && it.typeId() != cache.second.type ) ||
+        if( ( cache.second.type.is_valid() && it.typeId() != cache.second.type ) ||
+            ( cache.second.type_flag.is_valid() && !it.type->has_flag( cache.second.type_flag ) ) ||
             ( cache.second.filter_func && !( it.*cache.second.filter_func )() ) ) {
             continue;
         }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2924,6 +2924,12 @@ std::list<item> Character::remove_worn_items_with( const std::function<bool( ite
     return worn.remove_worn_items_with( filter, *this );
 }
 
+void Character::clear_worn()
+{
+    worn.worn.clear();
+    inv_search_caches.clear();
+}
+
 std::list<item *> Character::get_dependent_worn_items( const item &it )
 {
     std::list<item *> dependent;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2943,7 +2943,6 @@ std::list<item *> Character::get_dependent_worn_items( const item &it )
 item Character::remove_weapon()
 {
     item tmp = weapon;
-    remove_from_inv_search_caches( weapon );
     weapon = item();
     get_event_bus().send<event_type::character_wields_item>( getID(), weapon.typeId() );
     cached_info.erase( "weapon_value" );
@@ -9032,21 +9031,6 @@ void Character::add_to_inv_search_caches( item &it ) const
         }
         cache.second.items.push_back( it.get_safe_reference() );
     }
-}
-
-void Character::remove_from_inv_search_caches( item &it ) const
-{
-    it.visit_items( [this]( item * i, item * ) {
-        for( auto iter = inv_search_caches.begin(); iter != inv_search_caches.end(); ) {
-            if( ( !iter->second.flag.is_valid() || i->has_flag( iter->second.flag ) ) &&
-                ( iter->second.filter_func == nullptr || ( i->*iter->second.filter_func )() ) ) {
-                iter = inv_search_caches.erase( iter );
-            } else {
-                ++iter;
-            }
-        }
-        return VisitResponse::NEXT;
-    } );
 }
 
 bool Character::has_charges( const itype_id &it, int quantity,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8930,30 +8930,30 @@ void Character::do_to_items_with( const std::string &key, const flag_id &flag,
 }
 
 bool Character::has_any_item_with( const flag_id &flag,
-                                   const std::function<bool( item & )> &do_and_check_func ) const
+                                   const std::function<bool( const item & )> &check_func ) const
 {
-    return has_any_item_with( "HAS FLAG " + flag.str(), flag, nullptr, do_and_check_func );
+    return has_any_item_with( "HAS FLAG " + flag.str(), flag, nullptr, check_func );
 }
 
 bool Character::has_any_item_with( const std::string &key, bool( item::*filter_func )() const,
-                                   const std::function<bool( item & )> &do_and_check_func ) const
+                                   const std::function<bool( const item & )> &check_func ) const
 {
-    return has_any_item_with( key, {}, filter_func, do_and_check_func );
+    return has_any_item_with( key, {}, filter_func, check_func );
 }
 
 bool Character::has_any_item_with( const std::string &key, const flag_id &flag,
                                    bool( item::*filter_func )() const,
-                                   const std::function<bool( item & )> &do_and_check_func ) const
+                                   const std::function<bool( const item & )> &check_func ) const
 {
     bool aborted = false;
 
-    // If the cache already exists, use it. Stop iterating if the do_and_check_func ever returns true. Remove any invalid item references encountered.
+    // If the cache already exists, use it. Stop iterating if the check_func ever returns true. Remove any invalid item references encountered.
     auto found_cache = inv_search_caches.find( key );
     if( found_cache != inv_search_caches.end() ) {
         for( auto iter = found_cache->second.items.begin();
              iter != found_cache->second.items.end(); ) {
             if( *iter ) {
-                if( do_and_check_func( **iter ) ) {
+                if( check_func( **iter ) ) {
                     aborted = true;
                     break;
                 }
@@ -8971,8 +8971,8 @@ bool Character::has_any_item_with( const std::string &key, const flag_id &flag,
                 ( filter_func == nullptr || ( it->*filter_func )() ) ) {
 
                 inv_search_caches[key].items.push_back( it->get_safe_reference() );
-                // If do_and_check_func returns true, stop running it but keep populating the cache.
-                if( !aborted && do_and_check_func( *it ) ) {
+                // If check_func returns true, stop running it but keep populating the cache.
+                if( !aborted && check_func( *it ) ) {
                     aborted = true;
                 }
             }
@@ -9016,25 +9016,25 @@ std::vector<item *> Character::all_items_with( const std::string &key, const fla
 }
 
 std::vector<const item *> Character::all_items_with( const flag_id &flag,
-        const std::function<bool( const item & )> &do_and_check_func ) const
+        const std::function<bool( const item & )> &check_func ) const
 {
-    all_items_with( "HAS FLAG " + flag.str(), flag, nullptr, do_and_check_func );
+    all_items_with( "HAS FLAG " + flag.str(), flag, nullptr, check_func );
 }
 
 std::vector<const item *> Character::all_items_with( const std::string &key,
         bool( item::*filter_func )() const,
-        const std::function<bool( const item & )> &do_and_check_func ) const
+        const std::function<bool( const item & )> &check_func ) const
 {
-    all_items_with( key, {}, filter_func, do_and_check_func );
+    all_items_with( key, {}, filter_func, check_func );
 }
 
 std::vector<const item *> Character::all_items_with( const std::string &key, const flag_id &flag,
         bool( item::*filter_func )() const,
-        const std::function<bool( const item & )> &do_and_check_func ) const
+        const std::function<bool( const item & )> &check_func ) const
 {
     std::vector<const item *> ret;
-    do_to_items_with( key, flag, filter_func, [&ret, &do_and_check_func]( const item & it ) {
-        if( do_and_check_func( it ) ) {
+    do_to_items_with( key, flag, filter_func, [&ret, &check_func]( const item & it ) {
+        if( check_func( it ) ) {
             ret.push_back( &it );
         }
     } );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9084,8 +9084,7 @@ units::energy Character::consume_ups( units::energy qty, const int radius )
 
     // UPS from inventory
     if( qty != 0_kJ ) {
-        std::set<item *> &ups_items = all_items_with( flag_IS_UPS );
-        for( const item *i : ups_items ) {
+        for( const item *i : all_items_with( flag_IS_UPS ) ) {
             if( i->is_tool() && i->type->tool->fuel_efficiency >= 0 ) {
                 qty -= const_cast<item *>( i )->energy_consume( qty, tripoint_zero, nullptr,
                         i->type->tool->fuel_efficiency );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8949,7 +8949,6 @@ bool Character::has_any_item_with( const std::string &key, const flag_id &flag,
     // If the cache already exists, use it. Stop iterating if the do_and_check_func ever returns true. Remove any invalid item references encountered.
     auto found_cache = inv_search_caches.find( key );
     if( found_cache != inv_search_caches.end() ) {
-        auto t1 = std::chrono::high_resolution_clock::now();
         for( auto iter = found_cache->second.items.begin();
              iter != found_cache->second.items.end(); ) {
             if( *iter ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8903,8 +8903,8 @@ void Character::do_to_items_with( const std::string &key, bool( item::*filter_fu
     do_to_items_with( key, {}, {}, filter_func, do_func );
 }
 
-void Character::do_to_items_with( const std::string &key, const itype_id &type, const flag_id &type_flag,
-                                  bool( item::*filter_func )() const,
+void Character::do_to_items_with( const std::string &key, const itype_id &type,
+                                  const flag_id &type_flag, bool( item::*filter_func )() const,
                                   const std::function<void( item & )> &do_func ) const
 {
     // If the cache already exists, use it. Remove all invalid item references.
@@ -9000,7 +9000,8 @@ bool Character::has_any_item_with( const std::string &key, const itype_id &type,
 
 bool Character::has_any_item_with_flag_and_charges( const flag_id &type_flag ) const
 {
-    return has_any_item_with( "HAS FLAG " + type_flag.str(), {}, type_flag, nullptr, [this]( const item & it ) {
+    return has_any_item_with( "HAS FLAG " + type_flag.str(), {}, type_flag,
+    nullptr, [this]( const item & it ) {
         return !it.is_tool() || it.type->tool->max_charges == 0 || it.ammo_remaining( this ) > 0;
     } );
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11601,27 +11601,6 @@ stat_mod Character::get_pain_penalty() const
     return ret;
 }
 
-std::list<item *> Character::get_radio_items()
-{
-    std::list<item *> rc_items;
-    const invslice &stacks = inv->slice();
-    for( const auto &stack : stacks ) {
-        item &stack_iter = stack->front();
-        if( stack_iter.has_flag( flag_RADIO_ACTIVATION ) ) {
-            rc_items.push_back( &stack_iter );
-        }
-    }
-
-    worn.append_radio_items( rc_items );
-
-    if( is_armed() ) {
-        if( weapon.has_flag( flag_RADIO_ACTIVATION ) ) {
-            rc_items.push_back( &weapon );
-        }
-    }
-    return rc_items;
-}
-
 int Character::get_lift_str() const
 {
     int str = get_arm_str();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2929,6 +2929,12 @@ void Character::clear_worn()
     inv_search_caches.clear();
 }
 
+void Character::clear_inv()
+{
+    inv->clear();
+    inv_search_caches.clear();
+}
+
 std::list<item *> Character::get_dependent_worn_items( const item &it )
 {
     std::list<item *> dependent;
@@ -8662,7 +8668,7 @@ void Character::migrate_items_to_storage( bool disintegrate )
         }
         return VisitResponse::SKIP;
     } );
-    inv->clear();
+    clear_inv();
 }
 
 std::string Character::is_snuggling() const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2938,7 +2938,7 @@ std::list<item *> Character::get_dependent_worn_items( const item &it )
 item Character::remove_weapon()
 {
     item tmp = weapon;
-    remove_from_inv_search_cache( weapon );
+    remove_from_inv_search_caches( weapon );
     weapon = item();
     get_event_bus().send<event_type::character_wields_item>( getID(), weapon.typeId() );
     cached_info.erase( "weapon_value" );
@@ -8896,10 +8896,10 @@ bool Character::has_item_with_flag( const flag_id &flag, bool need_charges ) con
 std::set<item *> &Character::all_items_with_flag( const flag_id &flag ) const
 {
     std::string flag_string = flag.c_str();
-    auto iter = inv_search_cache.find( flag_string );
+    auto iter = inv_search_caches.find( flag_string );
 
     // If the flag set already exists in the cache, return it.
-    if( iter != inv_search_cache.end() ) {
+    if( iter != inv_search_caches.end() ) {
         return iter->second;
     }
 
@@ -8915,14 +8915,14 @@ std::set<item *> &Character::all_items_with_flag( const flag_id &flag ) const
         } );
     }
     for( const item *it : items_with_flag ) {
-        inv_search_cache[flag_string].insert( const_cast<item *>( it ) );
+        inv_search_caches[flag_string].insert( const_cast<item *>( it ) );
     }
-    return inv_search_cache[flag_string];
+    return inv_search_caches[flag_string];
 }
 
-void Character::add_to_inv_search_cache( item &it ) const
+void Character::add_to_inv_search_caches( item &it ) const
 {
-    for( auto &cached_items : inv_search_cache ) {
+    for( auto &cached_items : inv_search_caches ) {
         if( cached_items.first == flag_LIGHT.c_str() ) {
             if( it.type->light_emission > 0 ) {
                 cached_items.second.insert( &it );
@@ -8933,12 +8933,12 @@ void Character::add_to_inv_search_cache( item &it ) const
     }
 }
 
-void Character::remove_from_inv_search_cache( item &it ) const
+void Character::remove_from_inv_search_caches( item &it ) const
 {
-    if( inv_search_cache.empty() ) {
+    if( inv_search_caches.empty() ) {
         return;
     }
-    for( auto &cached_items : inv_search_cache ) {
+    for( auto &cached_items : inv_search_caches ) {
         cached_items.second.erase( &it );
     }
 }
@@ -9322,7 +9322,7 @@ void Character::on_item_acquire( const item &it )
     bool update_overmap_seen = false;
 
     it.visit_items( [this, &check_for_zoom, &update_overmap_seen]( item * cont_it, item * ) {
-        add_to_inv_search_cache( *cont_it );
+        add_to_inv_search_caches( *cont_it );
         if( check_for_zoom && !update_overmap_seen && cont_it->has_flag( flag_ZOOM ) ) {
             update_overmap_seen = true;
         }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2270,10 +2270,9 @@ void Character::process_turn()
     // Didn't just pick something up
     last_item = itype_null;
 
-    visit_items( [this]( item * e, item * ) {
-        e->process_relic( this, pos() );
-        return VisitResponse::NEXT;
-    } );
+    for( item *relic : all_items_with( "IS RELIC", &item::is_relic ) ) {
+        relic->process_relic( this, pos() );
+    }
 
     suffer();
     // NPCs currently don't make any use of their scent, pointless to calculate it

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11900,9 +11900,12 @@ void Character::process_items()
 
     // Load all items that use the UPS and have their own battery to their minimal functional charge,
     // The tool is not really useful if its charges are below charges_to_use
-    const auto inv_use_ups = items_with( []( const item & itm ) {
-        return itm.has_flag( flag_USE_UPS ) && itm.ammo_data();
-    } );
+    std::vector<item *> inv_use_ups;
+    for( item *flagged_item : all_items_with_flag( flag_USE_UPS ) ) {
+        if( flagged_item->ammo_data() ) {
+            inv_use_ups.push_back( flagged_item );
+        }
+    }
     if( !inv_use_ups.empty() ) {
         const units::energy available_charges = available_ups();
         units::energy ups_used = 0_kJ;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1311,7 +1311,7 @@ bool Character::sight_impaired() const
 bool Character::has_alarm_clock() const
 {
     map &here = get_map();
-    return cache_has_item_with_flag_and_charges( flag_ALARMCLOCK ) ||
+    return cache_has_item_with_flag( flag_ALARMCLOCK, true ) ||
            ( here.veh_at( pos() ) &&
              !empty( here.veh_at( pos() )->vehicle().get_avail_parts( "ALARMCLOCK" ) ) ) ||
            has_flag( json_flag_ALARMCLOCK );
@@ -1320,7 +1320,7 @@ bool Character::has_alarm_clock() const
 bool Character::has_watch() const
 {
     map &here = get_map();
-    return cache_has_item_with_flag_and_charges( flag_WATCH ) ||
+    return cache_has_item_with_flag( flag_WATCH, true ) ||
            ( here.veh_at( pos() ) &&
              !empty( here.veh_at( pos() )->vehicle().get_avail_parts( "WATCH" ) ) ) ||
            has_flag( json_flag_WATCH );
@@ -9050,11 +9050,20 @@ bool Character::cache_has_item_with( const std::string &key, const itype_id &typ
     return aborted;
 }
 
-bool Character::cache_has_item_with_flag_and_charges( const flag_id &type_flag ) const
+bool Character::has_item_with_flag( const flag_id &flag, bool need_charges ) const
 {
-    return cache_has_item_with( "HAS FLAG " + type_flag.str(), {}, type_flag,
-    nullptr, [this]( const item & it ) {
-        return !it.is_tool() || it.type->tool->max_charges == 0 || it.ammo_remaining( this ) > 0;
+    return has_item_with( [&flag, &need_charges, this]( const item & it ) {
+        return it.has_flag( flag ) && ( !need_charges || !it.is_tool() ||
+                                        it.type->tool->max_charges == 0 || it.ammo_remaining( this ) > 0 );
+    } );
+}
+
+bool Character::cache_has_item_with_flag( const flag_id &type_flag, bool need_charges ) const
+{
+    return cache_has_item_with( "HAS FLAG " + type_flag.str(), {}, type_flag, nullptr,
+    [this, &need_charges]( const item & it ) {
+        return !need_charges || !it.is_tool() || it.type->tool->max_charges == 0 ||
+               it.ammo_remaining( this ) > 0;
     } );
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2270,7 +2270,7 @@ void Character::process_turn()
     // Didn't just pick something up
     last_item = itype_null;
 
-    for( item *relic : all_items_with( "IS RELIC", &item::is_relic ) ) {
+    for( item *relic : all_items_with( "is_relic", &item::is_relic ) ) {
         relic->process_relic( this, pos() );
     }
 
@@ -5800,7 +5800,7 @@ float Character::active_light() const
     float lumination = 0.0f;
 
     int maxlum = 0;
-    for( item *flagged_item : all_items_with( "IS EMISSIVE", &item::is_emissive ) ) {
+    for( item *flagged_item : all_items_with( "is_emissive", &item::is_emissive ) ) {
         const int lumit = flagged_item->getlight_emit();
         if( maxlum < lumit ) {
             maxlum = lumit;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8920,7 +8920,7 @@ std::set<item *> &Character::all_items_with( const flag_id &flag ) const
     return inv_search_caches[key].items;
 }
 
-std::set<item *> &Character::all_items_with( std::string key,
+std::set<item *> &Character::all_items_with( const std::string &key,
         bool( item::*filter_func )() const ) const
 {
     auto iter = inv_search_caches.find( key );
@@ -8941,7 +8941,7 @@ std::set<item *> &Character::all_items_with( std::string key,
     return inv_search_caches[key].items;
 }
 
-std::set<item *> &Character::all_items_with( std::string key, const flag_id &flag,
+std::set<item *> &Character::all_items_with( const std::string &key, const flag_id &flag,
         bool( item::*filter_func )() const ) const
 {
     auto iter = inv_search_caches.find( key );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -12093,7 +12093,7 @@ void Character::process_items()
 
     // Load all items that use the UPS and have their own battery to their minimal functional charge,
     // The tool is not really useful if its charges are below charges_to_use
-    std::vector<item *> inv_use_ups = cache_get_items_with( flag_USE_UPS, [&inv_use_ups]( item & it ) {
+    std::vector<item *> inv_use_ups = cache_get_items_with( flag_USE_UPS, []( item & it ) {
         return !!it.ammo_data();
     } );
     if( !inv_use_ups.empty() ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2929,12 +2929,6 @@ void Character::clear_worn()
     inv_search_caches.clear();
 }
 
-void Character::clear_inv()
-{
-    inv->clear();
-    inv_search_caches.clear();
-}
-
 std::list<item *> Character::get_dependent_worn_items( const item &it )
 {
     std::list<item *> dependent;
@@ -8668,7 +8662,7 @@ void Character::migrate_items_to_storage( bool disintegrate )
         }
         return VisitResponse::SKIP;
     } );
-    clear_inv();
+    inv->clear();
 }
 
 std::string Character::is_snuggling() const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8976,9 +8976,12 @@ void Character::add_to_inv_search_caches( item &it ) const
 
 void Character::remove_from_inv_search_caches( item &it ) const
 {
-    for( auto &cache : inv_search_caches ) {
-        cache.second.items.erase( &it );
-    }
+    it.visit_items( [this]( item * it, item * ) {
+        for( auto &cache : inv_search_caches ) {
+            cache.second.items.erase( it );
+        }
+        return VisitResponse::NEXT;
+    } );
 }
 
 bool Character::has_charges( const itype_id &it, int quantity,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8911,7 +8911,7 @@ void Character::cache_visit_items_with( const std::string &key, const itype_id &
     auto found_cache = inv_search_caches.find( key );
     if( found_cache != inv_search_caches.end() ) {
         inv_search_caches[key].items.erase( std::remove_if( inv_search_caches[key].items.begin(),
-        inv_search_caches[key].items.end(), [&do_func]( const safe_reference<item> it ) {
+        inv_search_caches[key].items.end(), [&do_func]( const safe_reference<item> &it ) {
             if( it ) {
                 do_func( *it );
                 return false;
@@ -8963,7 +8963,7 @@ void Character::cache_visit_items_with( const std::string &key, const itype_id &
     auto found_cache = inv_search_caches.find( key );
     if( found_cache != inv_search_caches.end() ) {
         inv_search_caches[key].items.erase( std::remove_if( inv_search_caches[key].items.begin(),
-        inv_search_caches[key].items.end(), [&do_func]( const safe_reference<item> it ) {
+        inv_search_caches[key].items.end(), [&do_func]( const safe_reference<item> &it ) {
             if( it ) {
                 do_func( *it );
                 return false;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8888,13 +8888,13 @@ bool Character::in_sleep_state() const
 void Character::do_to_items_with( const flag_id &flag,
                                   const std::function<void( item & )> &do_func ) const
 {
-    return do_to_items_with( "HAS FLAG " + flag.str(), flag, nullptr, do_func );
+    do_to_items_with( "HAS FLAG " + flag.str(), flag, nullptr, do_func );
 }
 
 void Character::do_to_items_with( const std::string &key, bool( item::*filter_func )() const,
                                   const std::function<void( item & )> &do_func ) const
 {
-    return do_to_items_with( key, {}, filter_func, do_func );
+    do_to_items_with( key, {}, filter_func, do_func );
 }
 
 void Character::do_to_items_with( const std::string &key, const flag_id &flag,
@@ -8992,14 +8992,14 @@ bool Character::has_any_item_with_flag_and_charges( const flag_id &flag ) const
 std::vector<item *> Character::all_items_with( const flag_id &flag,
         const std::function<bool( item & )> &do_and_check_func )
 {
-    all_items_with( "HAS FLAG " + flag.str(), flag, nullptr, do_and_check_func );
+    return all_items_with( "HAS FLAG " + flag.str(), flag, nullptr, do_and_check_func );
 }
 
 std::vector<item *> Character::all_items_with( const std::string &key,
         bool( item::*filter_func )() const,
         const std::function<bool( item & )> &do_and_check_func )
 {
-    all_items_with( key, {}, filter_func, do_and_check_func );
+    return all_items_with( key, {}, filter_func, do_and_check_func );
 }
 
 std::vector<item *> Character::all_items_with( const std::string &key, const flag_id &flag,
@@ -9018,14 +9018,14 @@ std::vector<item *> Character::all_items_with( const std::string &key, const fla
 std::vector<const item *> Character::all_items_with( const flag_id &flag,
         const std::function<bool( const item & )> &check_func ) const
 {
-    all_items_with( "HAS FLAG " + flag.str(), flag, nullptr, check_func );
+    return all_items_with( "HAS FLAG " + flag.str(), flag, nullptr, check_func );
 }
 
 std::vector<const item *> Character::all_items_with( const std::string &key,
         bool( item::*filter_func )() const,
         const std::function<bool( const item & )> &check_func ) const
 {
-    all_items_with( key, {}, filter_func, check_func );
+    return all_items_with( key, {}, filter_func, check_func );
 }
 
 std::vector<const item *> Character::all_items_with( const std::string &key, const flag_id &flag,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7456,7 +7456,7 @@ void Character::recalculate_enchantment_cache()
     // start by resetting the cache to all inventory items
     *enchantment_cache = inv->get_active_enchantment_cache( *this );
 
-    visit_items( [&]( const item * it, item * ) {
+    for( item *it : all_items_with( "is_relic", &item::is_relic ) ) {
         for( const enchant_cache &ench : it->get_proc_enchantments() ) {
             if( ench.is_active( *this, *it ) ) {
                 enchantment_cache->force_add( ench );
@@ -7467,8 +7467,7 @@ void Character::recalculate_enchantment_cache()
                 enchantment_cache->force_add( ench, *this );
             }
         }
-        return VisitResponse::NEXT;
-    } );
+    }
 
     // get from traits/ mutations
     for( const std::pair<const trait_id, trait_data> &mut_map : my_mutations ) {

--- a/src/character.h
+++ b/src/character.h
@@ -2735,10 +2735,13 @@ class Character : public Creature, public visitable
                                   bool( item::*filter_func )() const,
                                   const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         /**
-        * @brief Find if the character has an item with a specific flag and, if needed, has charges. Uses or creates caches from @ref inv_search_caches.
+        * @brief Find if the character has an item with a specific flag. Can also checks for charges, if needed.
         */
-        bool cache_has_item_with_flag_and_charges( const flag_id &type_flag ) const;
-
+        bool has_item_with_flag( const flag_id &flag, bool need_charges = false ) const;
+        /**
+        * @brief Find if the character has an item whose type has a specific flag. Can also checks for charges, if needed. Uses or creates caches from @ref inv_search_caches.
+        */
+        bool cache_has_item_with_flag( const flag_id &type_flag, bool need_charges = false ) const;
         /**
          * @brief Returns all items with the given flag and/or that pass the given boolean item function, using or creating caches from @ref inv_search_caches.
          * @param type Only get items of this item type.

--- a/src/character.h
+++ b/src/character.h
@@ -2691,13 +2691,13 @@ class Character : public Creature, public visitable
         bool is_hauling() const;
 
         // Returns a set of all items that have the given flag (@ref item::has_flag). Uses or creates caches from @ref inv_search_caches.
-        std::set<item *> &all_items_with( const flag_id &flag ) const;
+        std::vector<item *> &all_items_with( const flag_id &flag ) const;
         // Returns a set of all items that pass the specified boolean item function. Uses or creates caches from @ref inv_search_caches with the given key.
-        std::set<item *> &all_items_with( const std::string &key,
-                                          bool( item::*filter_func )() const ) const;
+        std::vector<item *> &all_items_with( const std::string &key,
+                                             bool( item::*filter_func )() const ) const;
         // Returns a set of all items that have the given flag (@ref item::has_flag) and pass the specified boolean item function. Uses or creates caches from @ref inv_search_caches with the given key.
-        std::set<item *> &all_items_with( const std::string &key, const flag_id &flag,
-                                          bool( item::*filter_func )() const ) const;
+        std::vector<item *> &all_items_with( const std::string &key, const flag_id &flag,
+                                             bool( item::*filter_func )() const ) const;
 
         // Has a weapon, inventory item or worn item with flag. Uses or creates caches from @ref inv_search_caches.
         bool has_item_with_flag( const flag_id &flag, bool need_charges = false ) const;
@@ -3848,9 +3848,9 @@ class Character : public Creature, public visitable
         struct inv_search_cache {
             flag_id flag;
             bool ( item::*filter_func )() const;
-            std::set<item *> items;
+            std::vector<item *> items;
         };
-        mutable std::map<std::string, inv_search_cache> inv_search_caches;
+        mutable std::unordered_map<std::string, inv_search_cache> inv_search_caches;
     protected:
         // Bionic IDs are unique only within a character. Used to unambiguously identify bionics in a character
         bionic_uid weapon_bionic_uid = 0;

--- a/src/character.h
+++ b/src/character.h
@@ -1945,6 +1945,7 @@ class Character : public Creature, public visitable
         std::list<item> remove_worn_items_with( const std::function<bool( item & )> &filter );
 
         void clear_worn();
+        void clear_inv(); // Should always be used instead of Character.inv->clear();
 
         // returns a list of all item_location the character has, including items contained in other items.
         // only for CONTAINER pocket type; does not look for magazines

--- a/src/character.h
+++ b/src/character.h
@@ -888,8 +888,6 @@ class Character : public Creature, public visitable
         bool takeoff( item_location loc, std::list<item> *res = nullptr );
         bool takeoff( int pos );
 
-        /** Returns list of rc items in player inventory. **/
-        std::list<item *> get_radio_items();
         /** Handles health fluctuations over time */
         virtual void update_health();
         /** Updates all "biology" by one turn. Should be called once every turn. */

--- a/src/character.h
+++ b/src/character.h
@@ -2688,20 +2688,20 @@ class Character : public Creature, public visitable
         void stop_hauling();
         bool is_hauling() const;
 
-        // Has a weapon, inventory item or worn item with flag. Uses or creates flag sets from @ref flagged_item_cache.
+        // Has a weapon, inventory item or worn item with flag. Uses or creates flag sets from @ref inv_search_cache.
         bool has_item_with_flag( const flag_id &flag, bool need_charges = false ) const;
         /**
-         * Returns a set of all items that have the given flag (@ref item::has_flag). Uses or creates flag sets from @ref flagged_item_cache.
+         * Returns a set of all items that have the given flag (@ref item::has_flag). Uses or creates flag sets from @ref inv_search_cache.
          */
         std::set<item *> &all_items_with_flag( const flag_id &flag ) const;
         /**
-         * Add the specified item to the flags sets in @ref flagged_item_cache. Will NOT add any new flag sets to the cache.
+         * Add the specified item to the flags sets in @ref inv_search_cache. Will NOT add any new flag sets to the cache.
          */
-        void add_to_flagged_item_cache( item &it ) const;
+        void add_to_inv_search_cache( item &it ) const;
         /**
-         * Remove the specified item from all the flag sets of @ref flagged_item_cache.
+         * Remove the specified item from all the flag sets of @ref inv_search_cache.
          */
-        void remove_from_flagged_item_cache( item &it ) const;
+        void remove_from_inv_search_cache( item &it ) const;
 
         bool has_charges( const itype_id &it, int quantity,
                           const std::function<bool( const item & )> &filter = return_true<item> ) const override;
@@ -3837,8 +3837,8 @@ class Character : public Creature, public visitable
         mutable bool pseudo_items_valid = false;
         mutable std::vector<const item *> pseudo_items;
 
-        /** Cached results for @ref has_item_with_flag and @ref all_items_with_flag */
-        mutable std::map<flag_id, std::set<item *>> flagged_item_cache;
+        /** Cached results for functions that search through the inventory, like @ref all_items_with_flag */
+        mutable std::map<std::string, std::set<item *>> inv_search_cache;
     protected:
         // Bionic IDs are unique only within a character. Used to unambiguously identify bionics in a character
         bionic_uid weapon_bionic_uid = 0;

--- a/src/character.h
+++ b/src/character.h
@@ -2696,39 +2696,39 @@ class Character : public Creature, public visitable
          * @param filter_func Only process on items that return true with this boolean item function. This is cached, so avoid using functions with varying results.
          * @param do_func A lambda function to apply on all items that pass the filters.
          */
-        void do_to_items_with( const itype_id &type,
-                               const std::function<void( item & )> &do_func ) const;
-        void do_to_items_with( const flag_id &type_flag,
-                               const std::function<void( item & )> &do_func ) const;
-        void do_to_items_with( const std::string &key, bool( item::*filter_func )() const,
-                               const std::function<void( item & )> &do_func ) const;
-        void do_to_items_with( const std::string &key, const itype_id &type,
-                               const flag_id &type_flag, bool( item::*filter_func )() const,
-                               const std::function<void( item & )> &do_func ) const;
+        void cache_visit_items_with( const itype_id &type,
+                                     const std::function<void( item & )> &do_func ) const;
+        void cache_visit_items_with( const flag_id &type_flag,
+                                     const std::function<void( item & )> &do_func ) const;
+        void cache_visit_items_with( const std::string &key, bool( item::*filter_func )() const,
+                                     const std::function<void( item & )> &do_func ) const;
+        void cache_visit_items_with( const std::string &key, const itype_id &type,
+                                     const flag_id &type_flag, bool( item::*filter_func )() const,
+                                     const std::function<void( item & )> &do_func ) const;
         /**
         * @brief Returns true if the character has an item with given flag and/or that passes the given boolean item function, using or creating caches from @ref inv_search_caches.
-        * @brief If you want to iterate over the entire cache, `do_to_items_with` should be used instead, as it's more optimized for processing entire caches.
+        * @brief If you want to iterate over the entire cache, `cache_visit_items_with` should be used instead, as it's more optimized for processing entire caches.
         * @param type Look for items of this item type.
         * @param type_flag Look for items whose type has this flag.
         * @param key A string to use as the cache's key. Should usually be the same name as filter_func. Unneeded if checking only for a flag.
         * @param filter_func Look for items that return true with this boolean item function.
         * @param check_func An optional lambda function applied to items that pass the flag/bool function filters.
-        * If it returns true, abort iteration and make has_any_item_with return true. These results are not cached, unlike filter_func.
+        * If it returns true, abort iteration and make cache_has_item_with return true. These results are not cached, unlike filter_func.
         * @return True if the character has an item that passes the criteria, including check_func if provided.
         */
-        bool has_any_item_with( const itype_id &type,
-                                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
-        bool has_any_item_with( const flag_id &type_flag,
-                                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
-        bool has_any_item_with( const std::string &key, bool( item::*filter_func )() const,
-                                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
-        bool has_any_item_with( const std::string &key, const itype_id &type, const flag_id &type_flag,
-                                bool( item::*filter_func )() const,
-                                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
+        bool cache_has_item_with( const itype_id &type,
+                                  const std::function<bool( const item & )> &check_func = return_true<item> ) const;
+        bool cache_has_item_with( const flag_id &type_flag,
+                                  const std::function<bool( const item & )> &check_func = return_true<item> ) const;
+        bool cache_has_item_with( const std::string &key, bool( item::*filter_func )() const,
+                                  const std::function<bool( const item & )> &check_func = return_true<item> ) const;
+        bool cache_has_item_with( const std::string &key, const itype_id &type, const flag_id &type_flag,
+                                  bool( item::*filter_func )() const,
+                                  const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         /**
         * @brief Find if the character has an item with a specific flag and, if needed, has charges. Uses or creates caches from @ref inv_search_caches.
         */
-        bool has_any_item_with_flag_and_charges( const flag_id &type_flag ) const;
+        bool cache_has_item_with_flag_and_charges( const flag_id &type_flag ) const;
 
         /**
          * @brief Returns all items with the given flag and/or that pass the given boolean item function, using or creating caches from @ref inv_search_caches.
@@ -2740,23 +2740,24 @@ class Character : public Creature, public visitable
          * If it returns true, the item is added to the return vector. These results are not cached, unlike filter_func.
          * @return A vector of pointers to all items that pass the criteria.
          */
-        std::vector<item *> all_items_with( const itype_id &type,
-                                            const std::function<bool( item & )> &do_and_check_func = return_true<item> );
-        std::vector<item *> all_items_with( const flag_id &type_flag,
-                                            const std::function<bool( item & )> &do_and_check_func = return_true<item> );
-        std::vector<item *> all_items_with( const std::string &key, bool( item::*filter_func )() const,
-                                            const std::function<bool( item & )> &do_and_check_func = return_true<item> );
-        std::vector<item *> all_items_with( const std::string &key, const itype_id &type,
-                                            const flag_id &type_flag, bool( item::*filter_func )() const,
-                                            const std::function<bool( item & )> &do_and_check_func = return_true<item> );
-        std::vector<const item *> all_items_with( const itype_id &type,
+        std::vector<item *> cache_get_items_with( const itype_id &type,
+                const std::function<bool( item & )> &do_and_check_func = return_true<item> );
+        std::vector<item *> cache_get_items_with( const flag_id &type_flag,
+                const std::function<bool( item & )> &do_and_check_func = return_true<item> );
+        std::vector<item *> cache_get_items_with( const std::string &key,
+                bool( item::*filter_func )() const,
+                const std::function<bool( item & )> &do_and_check_func = return_true<item> );
+        std::vector<item *> cache_get_items_with( const std::string &key, const itype_id &type,
+                const flag_id &type_flag, bool( item::*filter_func )() const,
+                const std::function<bool( item & )> &do_and_check_func = return_true<item> );
+        std::vector<const item *> cache_get_items_with( const itype_id &type,
                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
-        std::vector<const item *> all_items_with( const flag_id &type_flag,
+        std::vector<const item *> cache_get_items_with( const flag_id &type_flag,
                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
-        std::vector<const item *> all_items_with( const std::string &key,
+        std::vector<const item *> cache_get_items_with( const std::string &key,
                 bool( item::*filter_func )() const,
                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
-        std::vector<const item *> all_items_with( const std::string &key, const itype_id &type,
+        std::vector<const item *> cache_get_items_with( const std::string &key, const itype_id &type,
                 const flag_id &type_flag, bool( item::*filter_func )() const,
                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         /**
@@ -3898,7 +3899,7 @@ class Character : public Creature, public visitable
         mutable bool pseudo_items_valid = false;
         mutable std::vector<const item *> pseudo_items;
 
-        /** Cached results for functions that search through the inventory, like @ref do_to_items_with */
+        /** Cached results for functions that search through the inventory, like @ref cache_visit_items_with */
         struct inv_search_cache {
             itype_id type;
             flag_id type_flag;

--- a/src/character.h
+++ b/src/character.h
@@ -1945,7 +1945,6 @@ class Character : public Creature, public visitable
         std::list<item> remove_worn_items_with( const std::function<bool( item & )> &filter );
 
         void clear_worn();
-        void clear_inv(); // Should always be used instead of Character.inv->clear();
 
         // returns a list of all item_location the character has, including items contained in other items.
         // only for CONTAINER pocket type; does not look for magazines

--- a/src/character.h
+++ b/src/character.h
@@ -2688,12 +2688,20 @@ class Character : public Creature, public visitable
         void stop_hauling();
         bool is_hauling() const;
 
-        // Has a weapon, inventory item or worn item with flag
+        // Has a weapon, inventory item or worn item with flag. Uses or creates flag sets from @ref flagged_item_cache.
         bool has_item_with_flag( const flag_id &flag, bool need_charges = false ) const;
         /**
-         * All items that have the given flag (@ref item::has_flag).
+         * Returns a set of all items that have the given flag (@ref item::has_flag). Uses or creates flag sets from @ref flagged_item_cache.
          */
-        std::vector<const item *> all_items_with_flag( const flag_id &flag ) const;
+        std::set<item *> &all_items_with_flag( const flag_id &flag ) const;
+        /**
+         * Add the specified item to the flags sets in @ref flagged_item_cache. Will NOT add any new flag sets to the cache.
+         */
+        void add_to_flagged_item_cache( item &it ) const;
+        /**
+         * Remove the specified item from all the flag sets of @ref flagged_item_cache.
+         */
+        void remove_from_flagged_item_cache( item &it ) const;
 
         bool has_charges( const itype_id &it, int quantity,
                           const std::function<bool( const item & )> &filter = return_true<item> ) const override;
@@ -3828,6 +3836,9 @@ class Character : public Creature, public visitable
 
         mutable bool pseudo_items_valid = false;
         mutable std::vector<const item *> pseudo_items;
+
+        /** Cached results for @ref has_item_with_flag and @ref all_items_with_flag */
+        mutable std::map<flag_id, std::set<item *>> flagged_item_cache;
     protected:
         // Bionic IDs are unique only within a character. Used to unambiguously identify bionics in a character
         bionic_uid weapon_bionic_uid = 0;

--- a/src/character.h
+++ b/src/character.h
@@ -2690,26 +2690,26 @@ class Character : public Creature, public visitable
 
         /**
          * @brief Applies a lambda function on all items with the given flag and/or that pass the given boolean item function, using or creating caches from @ref inv_search_caches.
-         * @param type Only process on items with this item type.
-         * @param flag Only process on items with this flag.
+         * @param type Only process on items of this item type.
+         * @param type_flag Only process on items whose type has this flag.
          * @param key A string to use as the key in the cache. Should usually be the same name as filter_func.
          * @param filter_func Only process on items that return true with this boolean item function. This is cached, so avoid using functions with varying results.
          * @param do_func A lambda function to apply on all items that pass the filters.
          */
         void do_to_items_with( const itype_id &type,
                                const std::function<void( item & )> &do_func ) const;
-        void do_to_items_with( const flag_id &flag,
+        void do_to_items_with( const flag_id &type_flag,
                                const std::function<void( item & )> &do_func ) const;
         void do_to_items_with( const std::string &key, bool( item::*filter_func )() const,
                                const std::function<void( item & )> &do_func ) const;
-        void do_to_items_with( const std::string &key, const itype_id &type, const flag_id &flag,
+        void do_to_items_with( const std::string &key, const itype_id &type, const flag_id &type_flag,
                                bool( item::*filter_func )() const,
                                const std::function<void( item & )> &do_func ) const;
         /**
         * @brief Returns true if the character has an item with given flag and/or that passes the given boolean item function, using or creating caches from @ref inv_search_caches.
         * @brief If you want to iterate over the entire cache, `do_to_items_with` should be used instead, as it's more optimized for processing entire caches.
-        * @param type Look for items with this item type.
-        * @param flag Look for items with this flag.
+        * @param type Look for items of this item type.
+        * @param type_flag Look for items whose type has this flag.
         * @param key A string to use as the cache's key. Should usually be the same name as filter_func. Unneeded if checking only for a flag.
         * @param filter_func Look for items that return true with this boolean item function.
         * @param check_func An optional lambda function applied to items that pass the flag/bool function filters.
@@ -2718,22 +2718,22 @@ class Character : public Creature, public visitable
         */
         bool has_any_item_with( const itype_id &type,
                                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
-        bool has_any_item_with( const flag_id &flag,
+        bool has_any_item_with( const flag_id &type_flag,
                                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         bool has_any_item_with( const std::string &key, bool( item::*filter_func )() const,
                                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
-        bool has_any_item_with( const std::string &key, const itype_id &type, const flag_id &flag,
+        bool has_any_item_with( const std::string &key, const itype_id &type, const flag_id &type_flag,
                                 bool( item::*filter_func )() const,
                                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         /**
         * @brief Find if the character has an item with a specific flag and, if needed, has charges. Uses or creates caches from @ref inv_search_caches.
         */
-        bool has_any_item_with_flag_and_charges( const flag_id &flag ) const;
+        bool has_any_item_with_flag_and_charges( const flag_id &type_flag ) const;
 
         /**
          * @brief Returns all items with the given flag and/or that pass the given boolean item function, using or creating caches from @ref inv_search_caches.
-         * @param type Only get items with this item type.
-         * @param flag Only get items with this flag.
+         * @param type Only get items of this item type.
+         * @param type_flag Only get items whose type has this flag.
          * @param key A string to use as the cache's key. Should usually be the same name as filter_func. Unneeded if checking only for a flag.
          * @param filter_func Only get items that return true with this boolean item function.
          * @param do_and_check_func An optional lambda function applied to items that pass the flag/bool function filters.
@@ -2742,22 +2742,22 @@ class Character : public Creature, public visitable
          */
         std::vector<item *> all_items_with( const itype_id &type,
                                             const std::function<bool( item & )> &do_and_check_func = return_true<item> );
-        std::vector<item *> all_items_with( const flag_id &flag,
+        std::vector<item *> all_items_with( const flag_id &type_flag,
                                             const std::function<bool( item & )> &do_and_check_func = return_true<item> );
         std::vector<item *> all_items_with( const std::string &key, bool( item::*filter_func )() const,
                                             const std::function<bool( item & )> &do_and_check_func = return_true<item> );
         std::vector<item *> all_items_with( const std::string &key, const itype_id &type,
-                                            const flag_id &flag, bool( item::*filter_func )() const,
+                                            const flag_id &type_flag, bool( item::*filter_func )() const,
                                             const std::function<bool( item & )> &do_and_check_func = return_true<item> );
         std::vector<const item *> all_items_with( const itype_id &type,
                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
-        std::vector<const item *> all_items_with( const flag_id &flag,
+        std::vector<const item *> all_items_with( const flag_id &type_flag,
                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         std::vector<const item *> all_items_with( const std::string &key,
                 bool( item::*filter_func )() const,
                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         std::vector<const item *> all_items_with( const std::string &key, const itype_id &type,
-                const flag_id &flag, bool( item::*filter_func )() const,
+                const flag_id &type_flag, bool( item::*filter_func )() const,
                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         /**
          * Add an item to existing @ref inv_search_caches that it meets the criteria for. Will NOT create any new caches.
@@ -3901,7 +3901,7 @@ class Character : public Creature, public visitable
         /** Cached results for functions that search through the inventory, like @ref do_to_items_with */
         struct inv_search_cache {
             itype_id type;
-            flag_id flag;
+            flag_id type_flag;
             bool ( item::*filter_func )() const;
             std::list<safe_reference<item>> items;
         };

--- a/src/character.h
+++ b/src/character.h
@@ -2690,21 +2690,25 @@ class Character : public Creature, public visitable
 
         /**
          * @brief Applies a lambda function on all items with the given flag and/or that pass the given boolean item function, using or creating caches from @ref inv_search_caches.
+         * @param type Only process on items with this item type.
          * @param flag Only process on items with this flag.
          * @param key A string to use as the key in the cache. Should usually be the same name as filter_func.
          * @param filter_func Only process on items that return true with this boolean item function. This is cached, so avoid using functions with varying results.
          * @param do_func A lambda function to apply on all items that pass the filters.
          */
+        void do_to_items_with( const itype_id &type,
+                               const std::function<void( item & )> &do_func ) const;
         void do_to_items_with( const flag_id &flag,
                                const std::function<void( item & )> &do_func ) const;
         void do_to_items_with( const std::string &key, bool( item::*filter_func )() const,
                                const std::function<void( item & )> &do_func ) const;
-        void do_to_items_with( const std::string &key, const flag_id &flag,
+        void do_to_items_with( const std::string &key, const itype_id &type, const flag_id &flag,
                                bool( item::*filter_func )() const,
                                const std::function<void( item & )> &do_func ) const;
         /**
         * @brief Returns true if the character has an item with given flag and/or that passes the given boolean item function, using or creating caches from @ref inv_search_caches.
         * @brief If you want to iterate over the entire cache, `do_to_items_with` should be used instead, as it's more optimized for processing entire caches.
+        * @param type Look for items with this item type.
         * @param flag Look for items with this flag.
         * @param key A string to use as the cache's key. Should usually be the same name as filter_func. Unneeded if checking only for a flag.
         * @param filter_func Look for items that return true with this boolean item function.
@@ -2712,11 +2716,13 @@ class Character : public Creature, public visitable
         * If it returns true, abort iteration and make has_any_item_with return true. These results are not cached, unlike filter_func.
         * @return True if the character has an item that passes the criteria, including check_func if provided.
         */
+        bool has_any_item_with( const itype_id &type,
+                                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         bool has_any_item_with( const flag_id &flag,
                                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         bool has_any_item_with( const std::string &key, bool( item::*filter_func )() const,
                                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
-        bool has_any_item_with( const std::string &key, const flag_id &flag,
+        bool has_any_item_with( const std::string &key, const itype_id &type, const flag_id &flag,
                                 bool( item::*filter_func )() const,
                                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         /**
@@ -2726,6 +2732,7 @@ class Character : public Creature, public visitable
 
         /**
          * @brief Returns all items with the given flag and/or that pass the given boolean item function, using or creating caches from @ref inv_search_caches.
+         * @param type Only get items with this item type.
          * @param flag Only get items with this flag.
          * @param key A string to use as the cache's key. Should usually be the same name as filter_func. Unneeded if checking only for a flag.
          * @param filter_func Only get items that return true with this boolean item function.
@@ -2733,20 +2740,24 @@ class Character : public Creature, public visitable
          * If it returns true, the item is added to the return vector. These results are not cached, unlike filter_func.
          * @return A vector of pointers to all items that pass the criteria.
          */
+        std::vector<item *> all_items_with( const itype_id &type,
+                                            const std::function<bool( item & )> &do_and_check_func = return_true<item> );
         std::vector<item *> all_items_with( const flag_id &flag,
                                             const std::function<bool( item & )> &do_and_check_func = return_true<item> );
         std::vector<item *> all_items_with( const std::string &key, bool( item::*filter_func )() const,
                                             const std::function<bool( item & )> &do_and_check_func = return_true<item> );
-        std::vector<item *> all_items_with( const std::string &key, const flag_id &flag,
-                                            bool( item::*filter_func )() const,
+        std::vector<item *> all_items_with( const std::string &key, const itype_id &type,
+                                            const flag_id &flag, bool( item::*filter_func )() const,
                                             const std::function<bool( item & )> &do_and_check_func = return_true<item> );
+        std::vector<const item *> all_items_with( const itype_id &type,
+                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         std::vector<const item *> all_items_with( const flag_id &flag,
                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         std::vector<const item *> all_items_with( const std::string &key,
                 bool( item::*filter_func )() const,
                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
-        std::vector<const item *> all_items_with( const std::string &key, const flag_id &flag,
-                bool( item::*filter_func )() const,
+        std::vector<const item *> all_items_with( const std::string &key, const itype_id &type,
+                const flag_id &flag, bool( item::*filter_func )() const,
                 const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         /**
          * Add an item to existing @ref inv_search_caches that it meets the criteria for. Will NOT create any new caches.
@@ -3889,6 +3900,7 @@ class Character : public Creature, public visitable
 
         /** Cached results for functions that search through the inventory, like @ref do_to_items_with */
         struct inv_search_cache {
+            itype_id type;
             flag_id flag;
             bool ( item::*filter_func )() const;
             std::list<safe_reference<item>> items;

--- a/src/character.h
+++ b/src/character.h
@@ -2688,12 +2688,16 @@ class Character : public Creature, public visitable
         void stop_hauling();
         bool is_hauling() const;
 
+        // Returns a set of all items that have the given flag (@ref item::has_flag). Uses or creates caches from @ref inv_search_caches.
+        std::set<item *> &all_items_with( const flag_id &flag ) const;
+        // Returns a set of all items that pass the specified boolean item function. Uses or creates caches from @ref inv_search_caches with the given key.
+        std::set<item *> &all_items_with( std::string key, bool( item::*filter_func )() const ) const;
+        // Returns a set of all items that have the given flag (@ref item::has_flag) and pass the specified boolean item function. Uses or creates caches from @ref inv_search_caches with the given key.
+        std::set<item *> &all_items_with( std::string key, const flag_id &flag,
+                                          bool( item::*filter_func )() const ) const;
+
         // Has a weapon, inventory item or worn item with flag. Uses or creates caches from @ref inv_search_caches.
         bool has_item_with_flag( const flag_id &flag, bool need_charges = false ) const;
-        /**
-         * Returns a set of all items that have the given flag (@ref item::has_flag). Uses or creates caches from @ref inv_search_caches.
-         */
-        std::set<item *> &all_items_with_flag( const flag_id &flag ) const;
         /**
          * Add the specified item to the caches in @ref inv_search_caches. Will NOT add any new caches.
          */
@@ -3838,7 +3842,12 @@ class Character : public Creature, public visitable
         mutable std::vector<const item *> pseudo_items;
 
         /** Cached results for functions that search through the inventory, like @ref all_items_with_flag */
-        mutable std::map<std::string, std::set<item *>> inv_search_caches;
+        struct inv_search_cache {
+            flag_id flag;
+            bool ( item::*filter_func )() const;
+            std::set<item *> items;
+        };
+        mutable std::map<std::string, inv_search_cache> inv_search_caches;
     protected:
         // Bionic IDs are unique only within a character. Used to unambiguously identify bionics in a character
         bionic_uid weapon_bionic_uid = 0;

--- a/src/character.h
+++ b/src/character.h
@@ -2697,14 +2697,23 @@ class Character : public Creature, public visitable
          * @param do_func A lambda function to apply on all items that pass the filters.
          */
         void cache_visit_items_with( const itype_id &type,
-                                     const std::function<void( item & )> &do_func ) const;
+                                     const std::function<void( item & )> &do_func );
         void cache_visit_items_with( const flag_id &type_flag,
-                                     const std::function<void( item & )> &do_func ) const;
+                                     const std::function<void( item & )> &do_func );
         void cache_visit_items_with( const std::string &key, bool( item::*filter_func )() const,
-                                     const std::function<void( item & )> &do_func ) const;
+                                     const std::function<void( item & )> &do_func );
         void cache_visit_items_with( const std::string &key, const itype_id &type,
                                      const flag_id &type_flag, bool( item::*filter_func )() const,
-                                     const std::function<void( item & )> &do_func ) const;
+                                     const std::function<void( item & )> &do_func );
+        void cache_visit_items_with( const itype_id &type,
+                                     const std::function<void( const item & )> &do_func ) const;
+        void cache_visit_items_with( const flag_id &type_flag,
+                                     const std::function<void( const item & )> &do_func ) const;
+        void cache_visit_items_with( const std::string &key, bool( item::*filter_func )() const,
+                                     const std::function<void( const item & )> &do_func ) const;
+        void cache_visit_items_with( const std::string &key, const itype_id &type,
+                                     const flag_id &type_flag, bool( item::*filter_func )() const,
+                                     const std::function<void( const item & )> &do_func ) const;
         /**
         * @brief Returns true if the character has an item with given flag and/or that passes the given boolean item function, using or creating caches from @ref inv_search_caches.
         * @brief If you want to iterate over the entire cache, `cache_visit_items_with` should be used instead, as it's more optimized for processing entire caches.

--- a/src/character.h
+++ b/src/character.h
@@ -2710,17 +2710,17 @@ class Character : public Creature, public visitable
         * @param flag Look for items with this flag.
         * @param key A string to use as the cache's key. Should usually be the same name as filter_func. Unneeded if checking only for a flag.
         * @param filter_func Look for items that return true with this boolean item function.
-        * @param do_and_check_func An optional lambda function applied to items that pass the flag/bool function filters.
+        * @param check_func An optional lambda function applied to items that pass the flag/bool function filters.
         * If it returns true, abort iteration and make has_any_item_with return true. These results are not cached, unlike filter_func.
-        * @return True if the character has an item that passes the criteria, including do_and_check_func if provided.
+        * @return True if the character has an item that passes the criteria, including check_func if provided.
         */
         bool has_any_item_with( const flag_id &flag,
-                                const std::function<bool( item & )> &do_and_check_func = return_true<item> ) const;
+                                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         bool has_any_item_with( const std::string &key, bool( item::*filter_func )() const,
-                                const std::function<bool( item & )> &do_and_check_func = return_true<item> ) const;
+                                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         bool has_any_item_with( const std::string &key, const flag_id &flag,
                                 bool( item::*filter_func )() const,
-                                const std::function<bool( item & )> &do_and_check_func = return_true<item> ) const;
+                                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         /**
         * @brief Find if the character has an item with a specific flag and, if needed, has charges. Uses or creates caches from @ref inv_search_caches.
         */
@@ -2743,13 +2743,13 @@ class Character : public Creature, public visitable
                                             bool( item::*filter_func )() const,
                                             const std::function<bool( item & )> &do_and_check_func = return_true<item> );
         std::vector<const item *> all_items_with( const flag_id &flag,
-                const std::function<bool( const item & )> &do_and_check_func = return_true<item> ) const;
+                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         std::vector<const item *> all_items_with( const std::string &key,
                 bool( item::*filter_func )() const,
-                const std::function<bool( const item & )> &do_and_check_func = return_true<item> ) const;
+                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         std::vector<const item *> all_items_with( const std::string &key, const flag_id &flag,
                 bool( item::*filter_func )() const,
-                const std::function<bool( const item & )> &do_and_check_func = return_true<item> ) const;
+                const std::function<bool( const item & )> &check_func = return_true<item> ) const;
         /**
          * Add an item to existing @ref inv_search_caches that it meets the criteria for. Will NOT create any new caches.
          */

--- a/src/character.h
+++ b/src/character.h
@@ -2691,9 +2691,9 @@ class Character : public Creature, public visitable
         bool is_hauling() const;
 
         /**
-         * @brief Apply a lambda function on all items that pass given criteria: either they have a specific flag, pass a specific boolean item function, or both. Uses or creates caches from @ref inv_search_caches.
+         * @brief Apply a lambda function on all items that have the given flag and/or pass the given boolean item function, using or creating caches from @ref inv_search_caches.
          * @param flag Only process on items with this flag.
-         * @param key A string to use as the key in the cache. Should usually be the same name as the filter function.
+         * @param key A string to use as the key in the cache. Should usually be the same name as filter_func.
          * @param filter_func Only process on items that return true with this boolean item function. This is cached, so avoid using functions with varying results.
          * @param do_func A lambda function to apply on all items that pass the filters.
          */
@@ -2704,28 +2704,27 @@ class Character : public Creature, public visitable
         void do_to_items_with( const std::string &key, const flag_id &flag,
                                bool( item::*filter_func )() const,
                                const std::function<void( item & )> &do_func ) const;
-
         /**
-         * @brief Apply a lambda function on all items that either have a specific flag, pass a specific boolean item function, or both. Uses or creates caches from @ref inv_search_caches.
-         * @brief If `do_func` ever returns true, this process will abort. If this is not needed, `do_to_items_with` should be used instead, as it's more optimized for processing entire caches.
-         * @param flag Only process on items with this flag.
-         * @param key A string to use as the cache's key. Should usually be the same name as the filter function. Unneeded if checking only for a flag.
-         * @param filter_func Only process on items that return true with this boolean item function. This is cached, so avoid using functions with varying results.
-         * @param do_func A lambda function to apply on all items that pass the filters. If it returns true, all remaining items will be skipped.
-         * @return True if the process was aborted at any point.
-         */
-        bool do_to_items_with_until( const flag_id &flag,
-                                     const std::function<bool( item & )> &do_func ) const;
-        bool do_to_items_with_until( const std::string &key, bool( item::*filter_func )() const,
-                                     const std::function<bool( item & )> &do_func ) const;
-        bool do_to_items_with_until( const std::string &key, const flag_id &flag,
-                                     bool( item::*filter_func )() const,
-                                     const std::function<bool( item & )> &do_func ) const;
-
+        * @brief Find if the character has an item that has the given flag and/or passes the given boolean item function, using or creating caches from @ref inv_search_caches.
+        * `do_and_check_func` is called on items that pass those filters, and if it returns true, the iteration will abort.
+        * @brief If you want to iterate over the entire cache, `do_to_items_with` should be used instead, as it's more optimized for processing entire caches.
+        * @param flag Look for items with this flag.
+        * @param key A string to use as the cache's key. Should usually be the same name as filter_func. Unneeded if checking only for a flag.
+        * @param filter_func Look for items that return true with this boolean item function.
+        * @param do_and_check_func An optional lambda function applied to items that pass the flag/func filters, which must also return true for the item to count. These results are not cached, unlike filter_func.
+        * @return True if the character has an item that passes the criteria, including do_and_check_func if provided.
+        */
+        bool has_any_item_with( const flag_id &flag,
+                                const std::function<bool( item & )> &do_and_check_func = return_true<item> ) const;
+        bool has_any_item_with( const std::string &key, bool( item::*filter_func )() const,
+                                const std::function<bool( item & )> &do_and_check_func = return_true<item> ) const;
+        bool has_any_item_with( const std::string &key, const flag_id &flag,
+                                bool( item::*filter_func )() const,
+                                const std::function<bool( item & )> &do_and_check_func = return_true<item> ) const;
         /**
-         * @brief Fetches all items that pass a given criteria: either they have a specific flag, pass a specific boolean item function, or both. Uses or creates caches from @ref inv_search_caches.
+         * @brief Fetches all items that has the given flag and/or passes the given boolean item function, using or creating caches from @ref inv_search_caches.
          * @param flag Only get items with this flag.
-         * @param key A string to use as the cache's key. Should usually be the same name as the filter function. Unneeded if checking only for a flag.
+         * @param key A string to use as the cache's key. Should usually be the same name as filter_func. Unneeded if checking only for a flag.
          * @param filter_func Only get items that return true with this boolean item function.
          * @return A vector of pointers to all items that pass the criteria.
          */
@@ -2734,22 +2733,6 @@ class Character : public Creature, public visitable
                                             bool( item::*filter_func )() const ) const;
         std::vector<item *> get_items_with( const std::string &key, const flag_id &flag,
                                             bool( item::*filter_func )() const ) const;
-
-        /**
-        * @brief Find if the character has an item that passes a given criteria: either they have a specific flag, pass a specific boolean item function, or both. Uses or creates caches from @ref inv_search_caches.
-        * @param flag Look for items with this flag.
-        * @param key A string to use as the cache's key. Should usually be the same name as the filter function. Unneeded if checking only for a flag.
-        * @param filter_func Look for items that return true with this boolean item function.
-        * @param check_func An optional lambda function the item must also pass. These results are not cached, unlike filter_func.
-        * @return True if the character has an item that passes the criteria.
-        */
-        bool has_any_item_with( const flag_id &flag,
-                                const std::function<bool( item & )> &check_func = return_true<item> ) const;
-        bool has_any_item_with( const std::string &key, bool( item::*filter_func )() const,
-                                const std::function<bool( item & )> &check_func = return_true<item> ) const;
-        bool has_any_item_with( const std::string &key, const flag_id &flag,
-                                bool( item::*filter_func )() const,
-                                const std::function<bool( item & )> &check_func = return_true<item> ) const;
         /**
         * @brief Find if the character has an item with a specific flag and, if needed, has charges. Uses or creates caches from @ref inv_search_caches.
         */

--- a/src/character.h
+++ b/src/character.h
@@ -2693,9 +2693,10 @@ class Character : public Creature, public visitable
         // Returns a set of all items that have the given flag (@ref item::has_flag). Uses or creates caches from @ref inv_search_caches.
         std::set<item *> &all_items_with( const flag_id &flag ) const;
         // Returns a set of all items that pass the specified boolean item function. Uses or creates caches from @ref inv_search_caches with the given key.
-        std::set<item *> &all_items_with( std::string key, bool( item::*filter_func )() const ) const;
+        std::set<item *> &all_items_with( const std::string &key,
+                                          bool( item::*filter_func )() const ) const;
         // Returns a set of all items that have the given flag (@ref item::has_flag) and pass the specified boolean item function. Uses or creates caches from @ref inv_search_caches with the given key.
-        std::set<item *> &all_items_with( std::string key, const flag_id &flag,
+        std::set<item *> &all_items_with( const std::string &key, const flag_id &flag,
                                           bool( item::*filter_func )() const ) const;
 
         // Has a weapon, inventory item or worn item with flag. Uses or creates caches from @ref inv_search_caches.

--- a/src/character.h
+++ b/src/character.h
@@ -2688,20 +2688,20 @@ class Character : public Creature, public visitable
         void stop_hauling();
         bool is_hauling() const;
 
-        // Has a weapon, inventory item or worn item with flag. Uses or creates flag sets from @ref inv_search_cache.
+        // Has a weapon, inventory item or worn item with flag. Uses or creates caches from @ref inv_search_caches.
         bool has_item_with_flag( const flag_id &flag, bool need_charges = false ) const;
         /**
-         * Returns a set of all items that have the given flag (@ref item::has_flag). Uses or creates flag sets from @ref inv_search_cache.
+         * Returns a set of all items that have the given flag (@ref item::has_flag). Uses or creates caches from @ref inv_search_caches.
          */
         std::set<item *> &all_items_with_flag( const flag_id &flag ) const;
         /**
-         * Add the specified item to the flags sets in @ref inv_search_cache. Will NOT add any new flag sets to the cache.
+         * Add the specified item to the caches in @ref inv_search_caches. Will NOT add any new caches.
          */
-        void add_to_inv_search_cache( item &it ) const;
+        void add_to_inv_search_caches( item &it ) const;
         /**
-         * Remove the specified item from all the flag sets of @ref inv_search_cache.
+         * Remove the specified item from all the caches of @ref inv_search_caches.
          */
-        void remove_from_inv_search_cache( item &it ) const;
+        void remove_from_inv_search_caches( item &it ) const;
 
         bool has_charges( const itype_id &it, int quantity,
                           const std::function<bool( const item & )> &filter = return_true<item> ) const override;
@@ -3838,7 +3838,7 @@ class Character : public Creature, public visitable
         mutable std::vector<const item *> pseudo_items;
 
         /** Cached results for functions that search through the inventory, like @ref all_items_with_flag */
-        mutable std::map<std::string, std::set<item *>> inv_search_cache;
+        mutable std::map<std::string, std::set<item *>> inv_search_caches;
     protected:
         // Bionic IDs are unique only within a character. Used to unambiguously identify bionics in a character
         bionic_uid weapon_bionic_uid = 0;

--- a/src/character.h
+++ b/src/character.h
@@ -2691,7 +2691,7 @@ class Character : public Creature, public visitable
         bool is_hauling() const;
 
         /**
-         * @brief Apply a lambda function on all items that have the given flag and/or pass the given boolean item function, using or creating caches from @ref inv_search_caches.
+         * @brief Applies a lambda function on all items with the given flag and/or that pass the given boolean item function, using or creating caches from @ref inv_search_caches.
          * @param flag Only process on items with this flag.
          * @param key A string to use as the key in the cache. Should usually be the same name as filter_func.
          * @param filter_func Only process on items that return true with this boolean item function. This is cached, so avoid using functions with varying results.
@@ -2705,7 +2705,7 @@ class Character : public Creature, public visitable
                                bool( item::*filter_func )() const,
                                const std::function<void( item & )> &do_func ) const;
         /**
-        * @brief Find if the character has an item that has the given flag and/or passes the given boolean item function, using or creating caches from @ref inv_search_caches.
+        * @brief Returns true if the character has an item with given flag and/or that passes the given boolean item function, using or creating caches from @ref inv_search_caches.
         * @brief If you want to iterate over the entire cache, `do_to_items_with` should be used instead, as it's more optimized for processing entire caches.
         * @param flag Look for items with this flag.
         * @param key A string to use as the cache's key. Should usually be the same name as filter_func. Unneeded if checking only for a flag.
@@ -2727,7 +2727,7 @@ class Character : public Creature, public visitable
         bool has_any_item_with_flag_and_charges( const flag_id &flag ) const;
 
         /**
-         * @brief Fetches all items that has the given flag and/or passes the given boolean item function, using or creating caches from @ref inv_search_caches.
+         * @brief Returns all items with the given flag and/or that pass the given boolean item function, using or creating caches from @ref inv_search_caches.
          * @param flag Only get items with this flag.
          * @param key A string to use as the cache's key. Should usually be the same name as filter_func. Unneeded if checking only for a flag.
          * @param filter_func Only get items that return true with this boolean item function.
@@ -2735,19 +2735,19 @@ class Character : public Creature, public visitable
          * If it returns true, the item is added to the return vector. These results are not cached, unlike filter_func.
          * @return A vector of pointers to all items that pass the criteria.
          */
-        std::vector<item *> get_items_with( const flag_id &flag,
+        std::vector<item *> all_items_with( const flag_id &flag,
                                             const std::function<bool( item & )> &do_and_check_func = return_true<item> );
-        std::vector<item *> get_items_with( const std::string &key, bool( item::*filter_func )() const,
+        std::vector<item *> all_items_with( const std::string &key, bool( item::*filter_func )() const,
                                             const std::function<bool( item & )> &do_and_check_func = return_true<item> );
-        std::vector<item *> get_items_with( const std::string &key, const flag_id &flag,
+        std::vector<item *> all_items_with( const std::string &key, const flag_id &flag,
                                             bool( item::*filter_func )() const,
                                             const std::function<bool( item & )> &do_and_check_func = return_true<item> );
-        std::vector<const item *> get_items_with( const flag_id &flag,
+        std::vector<const item *> all_items_with( const flag_id &flag,
                 const std::function<bool( const item & )> &do_and_check_func = return_true<item> ) const;
-        std::vector<const item *> get_items_with( const std::string &key,
+        std::vector<const item *> all_items_with( const std::string &key,
                 bool( item::*filter_func )() const,
                 const std::function<bool( const item & )> &do_and_check_func = return_true<item> ) const;
-        std::vector<const item *> get_items_with( const std::string &key, const flag_id &flag,
+        std::vector<const item *> all_items_with( const std::string &key, const flag_id &flag,
                 bool( item::*filter_func )() const,
                 const std::function<bool( const item & )> &do_and_check_func = return_true<item> ) const;
         /**

--- a/src/character.h
+++ b/src/character.h
@@ -2742,10 +2742,6 @@ class Character : public Creature, public visitable
          * Add an item to existing @ref inv_search_caches that it meets the criteria for. Will NOT create any new caches.
          */
         void add_to_inv_search_caches( item &it ) const;
-        /**
-         * Remove the specified item from all the caches of @ref inv_search_caches.
-         */
-        void remove_from_inv_search_caches( item &it ) const;
 
         bool has_charges( const itype_id &it, int quantity,
                           const std::function<bool( const item & )> &filter = return_true<item> ) const override;

--- a/src/character.h
+++ b/src/character.h
@@ -2706,7 +2706,7 @@ class Character : public Creature, public visitable
                                const std::function<void( item & )> &do_func ) const;
 
         /**
-         * @brief Apply a lambda function on all items that either have a specific flag, pass a specific boolean item function, or both. Uses or creates caches from @ref inv_search_caches. 
+         * @brief Apply a lambda function on all items that either have a specific flag, pass a specific boolean item function, or both. Uses or creates caches from @ref inv_search_caches.
          * @brief If `do_func` ever returns true, this process will abort. If this is not needed, `do_to_items_with` should be used instead, as it's more optimized for processing entire caches.
          * @param flag Only process on items with this flag.
          * @param key A string to use as the cache's key. Should usually be the same name as the filter function. Unneeded if checking only for a flag.
@@ -2735,8 +2735,25 @@ class Character : public Creature, public visitable
         std::vector<item *> get_items_with( const std::string &key, const flag_id &flag,
                                             bool( item::*filter_func )() const ) const;
 
-        // Has a weapon, inventory item or worn item with flag. Uses or creates caches from @ref inv_search_caches.
-        bool has_item_with_flag( const flag_id &flag, bool need_charges = false ) const;
+        /**
+        * @brief Find if the character has an item that passes a given criteria: either they have a specific flag, pass a specific boolean item function, or both. Uses or creates caches from @ref inv_search_caches.
+        * @param flag Look for items with this flag.
+        * @param key A string to use as the cache's key. Should usually be the same name as the filter function. Unneeded if checking only for a flag.
+        * @param filter_func Look for items that return true with this boolean item function.
+        * @param check_func An optional lambda function the item must also pass. These results are not cached, unlike filter_func.
+        * @return True if the character has an item that passes the criteria.
+        */
+        bool has_any_item_with( const flag_id &flag,
+                                const std::function<bool( item & )> &check_func = return_true<item> ) const;
+        bool has_any_item_with( const std::string &key, bool( item::*filter_func )() const,
+                                const std::function<bool( item & )> &check_func = return_true<item> ) const;
+        bool has_any_item_with( const std::string &key, const flag_id &flag,
+                                bool( item::*filter_func )() const,
+                                const std::function<bool( item & )> &check_func = return_true<item> ) const;
+        /**
+        * @brief Find if the character has an item with a specific flag and, if needed, has charges. Uses or creates caches from @ref inv_search_caches.
+        */
+        bool has_any_item_with_flag_and_charges( const flag_id &flag ) const;
 
         /**
          * Add an item to existing @ref inv_search_caches that it meets the criteria for. Will NOT create any new caches.

--- a/src/character.h
+++ b/src/character.h
@@ -2702,8 +2702,8 @@ class Character : public Creature, public visitable
                                const std::function<void( item & )> &do_func ) const;
         void do_to_items_with( const std::string &key, bool( item::*filter_func )() const,
                                const std::function<void( item & )> &do_func ) const;
-        void do_to_items_with( const std::string &key, const itype_id &type, const flag_id &type_flag,
-                               bool( item::*filter_func )() const,
+        void do_to_items_with( const std::string &key, const itype_id &type,
+                               const flag_id &type_flag, bool( item::*filter_func )() const,
                                const std::function<void( item & )> &do_func ) const;
         /**
         * @brief Returns true if the character has an item with given flag and/or that passes the given boolean item function, using or creating caches from @ref inv_search_caches.

--- a/src/character.h
+++ b/src/character.h
@@ -1625,7 +1625,7 @@ class Character : public Creature, public visitable
         /** Returns solar items connected to cable charger bionic */
         std::vector<item *> get_cable_solar();
         /** Returns vehicles connected to cable charger bionic */
-        std::vector<vehicle *> get_cable_vehicle();
+        std::vector<vehicle *> get_cable_vehicle() const;
 
         /**Get stat bonus from bionic*/
         int get_mod_stat_from_bionic( const character_stat &Stat ) const;

--- a/src/character.h
+++ b/src/character.h
@@ -1944,6 +1944,8 @@ class Character : public Creature, public visitable
          */
         std::list<item> remove_worn_items_with( const std::function<bool( item & )> &filter );
 
+        void clear_worn();
+
         // returns a list of all item_location the character has, including items contained in other items.
         // only for CONTAINER pocket type; does not look for magazines
         std::vector<item_location> all_items_loc();

--- a/src/character.h
+++ b/src/character.h
@@ -2706,12 +2706,12 @@ class Character : public Creature, public visitable
                                const std::function<void( item & )> &do_func ) const;
         /**
         * @brief Find if the character has an item that has the given flag and/or passes the given boolean item function, using or creating caches from @ref inv_search_caches.
-        * `do_and_check_func` is called on items that pass those filters, and if it returns true, the iteration will abort.
         * @brief If you want to iterate over the entire cache, `do_to_items_with` should be used instead, as it's more optimized for processing entire caches.
         * @param flag Look for items with this flag.
         * @param key A string to use as the cache's key. Should usually be the same name as filter_func. Unneeded if checking only for a flag.
         * @param filter_func Look for items that return true with this boolean item function.
-        * @param do_and_check_func An optional lambda function applied to items that pass the flag/func filters, which must also return true for the item to count. These results are not cached, unlike filter_func.
+        * @param do_and_check_func An optional lambda function applied to items that pass the flag/bool function filters.
+        * If it returns true, abort iteration and make has_any_item_with return true. These results are not cached, unlike filter_func.
         * @return True if the character has an item that passes the criteria, including do_and_check_func if provided.
         */
         bool has_any_item_with( const flag_id &flag,
@@ -2722,22 +2722,34 @@ class Character : public Creature, public visitable
                                 bool( item::*filter_func )() const,
                                 const std::function<bool( item & )> &do_and_check_func = return_true<item> ) const;
         /**
-         * @brief Fetches all items that has the given flag and/or passes the given boolean item function, using or creating caches from @ref inv_search_caches.
-         * @param flag Only get items with this flag.
-         * @param key A string to use as the cache's key. Should usually be the same name as filter_func. Unneeded if checking only for a flag.
-         * @param filter_func Only get items that return true with this boolean item function.
-         * @return A vector of pointers to all items that pass the criteria.
-         */
-        std::vector<item *> get_items_with( const flag_id &flag ) const;
-        std::vector<item *> get_items_with( const std::string &key,
-                                            bool( item::*filter_func )() const ) const;
-        std::vector<item *> get_items_with( const std::string &key, const flag_id &flag,
-                                            bool( item::*filter_func )() const ) const;
-        /**
         * @brief Find if the character has an item with a specific flag and, if needed, has charges. Uses or creates caches from @ref inv_search_caches.
         */
         bool has_any_item_with_flag_and_charges( const flag_id &flag ) const;
 
+        /**
+         * @brief Fetches all items that has the given flag and/or passes the given boolean item function, using or creating caches from @ref inv_search_caches.
+         * @param flag Only get items with this flag.
+         * @param key A string to use as the cache's key. Should usually be the same name as filter_func. Unneeded if checking only for a flag.
+         * @param filter_func Only get items that return true with this boolean item function.
+         * @param do_and_check_func An optional lambda function applied to items that pass the flag/bool function filters.
+         * If it returns true, the item is added to the return vector. These results are not cached, unlike filter_func.
+         * @return A vector of pointers to all items that pass the criteria.
+         */
+        std::vector<item *> get_items_with( const flag_id &flag,
+                                            const std::function<bool( item & )> &do_and_check_func = return_true<item> );
+        std::vector<item *> get_items_with( const std::string &key, bool( item::*filter_func )() const,
+                                            const std::function<bool( item & )> &do_and_check_func = return_true<item> );
+        std::vector<item *> get_items_with( const std::string &key, const flag_id &flag,
+                                            bool( item::*filter_func )() const,
+                                            const std::function<bool( item & )> &do_and_check_func = return_true<item> );
+        std::vector<const item *> get_items_with( const flag_id &flag,
+                const std::function<bool( const item & )> &do_and_check_func = return_true<item> ) const;
+        std::vector<const item *> get_items_with( const std::string &key,
+                bool( item::*filter_func )() const,
+                const std::function<bool( const item & )> &do_and_check_func = return_true<item> ) const;
+        std::vector<const item *> get_items_with( const std::string &key, const flag_id &flag,
+                bool( item::*filter_func )() const,
+                const std::function<bool( const item & )> &do_and_check_func = return_true<item> ) const;
         /**
          * Add an item to existing @ref inv_search_caches that it meets the criteria for. Will NOT create any new caches.
          */

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2014,7 +2014,7 @@ void outfit::fire_options( Character &guy, std::vector<std::string> &options,
 {
     for( item &clothing : worn ) {
 
-        std::vector<item *> guns = guy.all_items_with( "is_gun", &item::is_gun,
+        std::vector<item *> guns = guy.cache_get_items_with( "is_gun", &item::is_gun,
         [&guy]( const item & it ) {
             return !guy.is_wielding( it );
         } );

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1130,7 +1130,7 @@ std::list<item> outfit::remove_worn_items_with( const std::function<bool( item &
     for( auto iter = worn.begin(); iter != worn.end(); ) {
         if( filter( *iter ) ) {
             iter->on_takeoff( guy );
-            guy.remove_from_inv_search_cache( *iter );
+            guy.remove_from_inv_search_caches( *iter );
             result.splice( result.begin(), worn, iter++ );
         } else {
             ++iter;
@@ -1485,7 +1485,7 @@ bool outfit::takeoff( item_location loc, std::list<item> *res, Character &guy )
     } );
 
     item takeoff_copy( it );
-    guy.remove_from_inv_search_cache( *iter );
+    guy.remove_from_inv_search_caches( *iter );
     worn.erase( iter );
     takeoff_copy.on_takeoff( guy );
     if( res == nullptr ) {

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1130,7 +1130,7 @@ std::list<item> outfit::remove_worn_items_with( const std::function<bool( item &
     for( auto iter = worn.begin(); iter != worn.end(); ) {
         if( filter( *iter ) ) {
             iter->on_takeoff( guy );
-            guy.remove_from_flagged_item_cache( *iter );
+            guy.remove_from_inv_search_cache( *iter );
             result.splice( result.begin(), worn, iter++ );
         } else {
             ++iter;
@@ -1485,7 +1485,7 @@ bool outfit::takeoff( item_location loc, std::list<item> *res, Character &guy )
     } );
 
     item takeoff_copy( it );
-    guy.remove_from_flagged_item_cache( *iter );
+    guy.remove_from_inv_search_cache( *iter );
     worn.erase( iter );
     takeoff_copy.on_takeoff( guy );
     if( res == nullptr ) {

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1130,6 +1130,7 @@ std::list<item> outfit::remove_worn_items_with( const std::function<bool( item &
     for( auto iter = worn.begin(); iter != worn.end(); ) {
         if( filter( *iter ) ) {
             iter->on_takeoff( guy );
+            guy.remove_from_flagged_item_cache( *iter );
             result.splice( result.begin(), worn, iter++ );
         } else {
             ++iter;
@@ -1484,6 +1485,7 @@ bool outfit::takeoff( item_location loc, std::list<item> *res, Character &guy )
     } );
 
     item takeoff_copy( it );
+    guy.remove_from_flagged_item_cache( *iter );
     worn.erase( iter );
     takeoff_copy.on_takeoff( guy );
     if( res == nullptr ) {

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2014,8 +2014,9 @@ void outfit::fire_options( Character &guy, std::vector<std::string> &options,
 {
     for( item &clothing : worn ) {
 
-        std::vector<item *> guns = clothing.items_with( []( const item & it ) {
-            return it.is_gun();
+        std::vector<item *> guns = guy.all_items_with( "is_gun", &item::is_gun,
+        [&guy]( const item & it ) {
+            return !guy.is_wielding( it );
         } );
 
         if( !guns.empty() && clothing.type->can_use( "holster" ) ) {

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1130,7 +1130,6 @@ std::list<item> outfit::remove_worn_items_with( const std::function<bool( item &
     for( auto iter = worn.begin(); iter != worn.end(); ) {
         if( filter( *iter ) ) {
             iter->on_takeoff( guy );
-            guy.remove_from_inv_search_caches( *iter );
             result.splice( result.begin(), worn, iter++ );
         } else {
             ++iter;
@@ -1484,10 +1483,9 @@ bool outfit::takeoff( item_location loc, std::list<item> *res, Character &guy )
         return &it == &wit;
     } );
 
+    it.on_takeoff( guy );
     item takeoff_copy( it );
-    guy.remove_from_inv_search_caches( *iter );
     worn.erase( iter );
-    takeoff_copy.on_takeoff( guy );
     if( res == nullptr ) {
         guy.i_add( takeoff_copy, true, &it, &it, true, !guy.has_weapon() );
     } else {
@@ -1503,11 +1501,6 @@ void outfit::damage_mitigate( const bodypart_id &bp, damage_unit &dam ) const
             cloth.mitigate_damage( dam );
         }
     }
-}
-
-void outfit::clear()
-{
-    worn.clear();
 }
 
 bool outfit::empty() const

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1744,15 +1744,6 @@ std::list<item> outfit::use_amount( const itype_id &it, int quantity,
     return used;
 }
 
-void outfit::append_radio_items( std::list<item *> &rc_items )
-{
-    for( item &elem : worn ) {
-        if( elem.has_flag( flag_RADIO_ACTIVATION ) ) {
-            rc_items.push_back( &elem );
-        }
-    }
-}
-
 void outfit::add_dependent_item( std::list<item *> &dependent, const item &it )
 {
     // Adds dependent worn items recursively

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -231,7 +231,7 @@ class outfit
         const item &i_at( int position ) const;
 
         VisitResponse visit_items( const std::function<VisitResponse( item *, item * )> &func ) const;
-        std::list<item> remove_items_with( Character *carrier,
+        std::list<item> remove_items_with( Character &guy,
                                            const std::function<bool( const item & )> &filter, int &count );
 
         void organize_items_menu();

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -231,7 +231,7 @@ class outfit
         const item &i_at( int position ) const;
 
         VisitResponse visit_items( const std::function<VisitResponse( item *, item * )> &func ) const;
-        std::list<item> remove_items_with( Character &guy,
+        std::list<item> remove_items_with( Character *carrier,
                                            const std::function<bool( const item & )> &filter, int &count );
 
         void organize_items_menu();

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -174,7 +174,6 @@ class outfit
         std::unordered_set<bodypart_id> where_discomfort( const Character &guy ) const;
         // used in game::wield
         void insert_item_at_index( const item &clothing, int index );
-        void append_radio_items( std::list<item *> &rc_items );
         void check_and_recover_morale( player_morale &test_morale ) const;
         void absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
                             std::list<item> &worn_remains, bool &armor_destroyed );

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -59,6 +59,7 @@ struct dispose_option {
 
 class outfit
 {
+        friend class Character;
     private:
         std::list<item> worn;
     public:
@@ -217,7 +218,6 @@ class outfit
         void activate_combat_items( npc &guy );
         void deactivate_combat_items( npc &guy );
 
-        void clear();
         bool empty() const;
         item &front();
         size_t size() const;

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -80,7 +80,7 @@ void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nes
 
 std::vector<const item *> Character::get_ammo( const ammotype &at ) const
 {
-    return items_with( [at]( const item & it ) {
+    return all_items_with( "is_ammo", &item::is_ammo, [at]( const item & it ) {
         return it.ammo_type() == at;
     } );
 }
@@ -277,12 +277,15 @@ bool Character::has_gun_for_ammo( const ammotype &at ) const
 
 bool Character::has_magazine_for_ammo( const ammotype &at ) const
 {
-    return has_item_with( [&at]( const item & it ) {
+    if( has_any_item_with( "is_magazine", &item::is_magazine, [&at]( const item & it ) {
+    return !it.has_flag( flag_NO_RELOAD ) && it.ammo_types().count( at );
+    } ) ) {
+        return true;
+    }
+    return has_any_item_with( "is_gun", &item::is_gun, [&at]( const item & it ) {
         return !it.has_flag( flag_NO_RELOAD ) &&
-               ( ( it.is_magazine() && it.ammo_types().count( at ) ) ||
-                 ( it.is_gun() && it.magazine_integral() && it.ammo_types().count( at ) ) ||
-                 ( it.is_gun() && it.magazine_current() != nullptr &&
-                   it.magazine_current()->ammo_types().count( at ) ) );
+               ( ( it.magazine_integral() && it.ammo_types().count( at ) ) ||
+                 ( it.magazine_current() != nullptr && it.magazine_current()->ammo_types().count( at ) ) );
     } );
 }
 

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -270,9 +270,8 @@ bool Character::gunmod_remove( item &gun, item &mod )
 
 bool Character::has_gun_for_ammo( const ammotype &at ) const
 {
-    return has_item_with( [at]( const item & it ) {
-        // item::ammo_type considers the active gunmod.
-        return it.is_gun() && it.ammo_types().count( at );
+    return do_to_items_with_until( "is_gun", &item::is_gun, [&at]( const item & it ) {
+        return it.ammo_types().count( at );
     } );
 }
 

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -270,7 +270,7 @@ bool Character::gunmod_remove( item &gun, item &mod )
 
 bool Character::has_gun_for_ammo( const ammotype &at ) const
 {
-    return do_to_items_with_until( "is_gun", &item::is_gun, [&at]( const item & it ) {
+    return has_any_item_with( "is_gun", &item::is_gun, [&at]( const item & it ) {
         return it.ammo_types().count( at );
     } );
 }

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -80,7 +80,7 @@ void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nes
 
 std::vector<const item *> Character::get_ammo( const ammotype &at ) const
 {
-    return all_items_with( "is_ammo", &item::is_ammo, [at]( const item & it ) {
+    return cache_get_items_with( "is_ammo", &item::is_ammo, [at]( const item & it ) {
         return it.ammo_type() == at;
     } );
 }
@@ -270,19 +270,19 @@ bool Character::gunmod_remove( item &gun, item &mod )
 
 bool Character::has_gun_for_ammo( const ammotype &at ) const
 {
-    return has_any_item_with( "is_gun", &item::is_gun, [&at]( const item & it ) {
+    return cache_has_item_with( "is_gun", &item::is_gun, [&at]( const item & it ) {
         return it.ammo_types().count( at );
     } );
 }
 
 bool Character::has_magazine_for_ammo( const ammotype &at ) const
 {
-    if( has_any_item_with( "is_magazine", &item::is_magazine, [&at]( const item & it ) {
+    if( cache_has_item_with( "is_magazine", &item::is_magazine, [&at]( const item & it ) {
     return !it.has_flag( flag_NO_RELOAD ) && it.ammo_types().count( at );
     } ) ) {
         return true;
     }
-    return has_any_item_with( "is_gun", &item::is_gun, [&at]( const item & it ) {
+    return cache_has_item_with( "is_gun", &item::is_gun, [&at]( const item & it ) {
         return !it.has_flag( flag_NO_RELOAD ) &&
                ( ( it.magazine_integral() && it.ammo_types().count( at ) ) ||
                  ( it.magazine_current() != nullptr && it.magazine_current()->ammo_types().count( at ) ) );

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -307,6 +307,11 @@ item_location Character::i_add( item it, int &copies_remaining,
                                 const item *original_inventory_item, const bool allow_drop,
                                 const bool allow_wield, bool ignore_pkt_settings )
 {
+    if( it.count_by_charges() ) {
+        it.charges = copies_remaining;
+        copies_remaining = 0;
+        return i_add( it, true, avoid, original_inventory_item, allow_drop, allow_wield, ignore_pkt_settings );
+    }
     invalidate_inventory_validity_cache();
     invalidate_leak_level_cache();
     item_location added = try_add( it, copies_remaining, avoid, original_inventory_item, allow_wield,

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -302,7 +302,7 @@ unload_options::query_unload_result unload_options::query_unload()
 plot_options::query_seed_result plot_options::query_seed()
 {
     Character &player_character = get_player_character();
-    std::vector<item *> seed_inv = player_character.all_items_with( "is_seed", &item::is_seed );
+    std::vector<item *> seed_inv = player_character.cache_get_items_with( "is_seed", &item::is_seed );
     zone_manager &mgr = zone_manager::get_manager();
     map &here = get_map();
     const std::unordered_set<tripoint_abs_ms> zone_src_set =

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -302,7 +302,7 @@ unload_options::query_unload_result unload_options::query_unload()
 plot_options::query_seed_result plot_options::query_seed()
 {
     Character &player_character = get_player_character();
-    std::vector<item *> seed_inv = player_character.all_items_with( "is_seed", &item::is_seed );
+    std::vector<item *> seed_inv = player_character.get_items_with( "is_seed", &item::is_seed );
     zone_manager &mgr = zone_manager::get_manager();
     map &here = get_map();
     const std::unordered_set<tripoint_abs_ms> zone_src_set =

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -302,7 +302,7 @@ unload_options::query_unload_result unload_options::query_unload()
 plot_options::query_seed_result plot_options::query_seed()
 {
     Character &player_character = get_player_character();
-    std::set<item *> &seed_inv = player_character.all_items_with( "is_seed", &item::is_seed );
+    std::vector<item *> seed_inv = player_character.all_items_with( "is_seed", &item::is_seed );
     zone_manager &mgr = zone_manager::get_manager();
     map &here = get_map();
     const std::unordered_set<tripoint_abs_ms> zone_src_set =
@@ -311,7 +311,7 @@ plot_options::query_seed_result plot_options::query_seed()
         tripoint elem_loc = here.getlocal( elem );
         for( item &it : here.i_at( elem_loc ) ) {
             if( it.is_seed() ) {
-                seed_inv.insert( &it );
+                seed_inv.push_back( &it );
             }
         }
     }

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -302,7 +302,7 @@ unload_options::query_unload_result unload_options::query_unload()
 plot_options::query_seed_result plot_options::query_seed()
 {
     Character &player_character = get_player_character();
-    std::set<item *> &seed_inv = player_character.all_items_with( "IS SEED", &item::is_seed );
+    std::set<item *> &seed_inv = player_character.all_items_with( "is_seed", &item::is_seed );
     zone_manager &mgr = zone_manager::get_manager();
     map &here = get_map();
     const std::unordered_set<tripoint_abs_ms> zone_src_set =

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -302,7 +302,7 @@ unload_options::query_unload_result unload_options::query_unload()
 plot_options::query_seed_result plot_options::query_seed()
 {
     Character &player_character = get_player_character();
-    std::vector<item *> seed_inv = player_character.get_items_with( "is_seed", &item::is_seed );
+    std::vector<item *> seed_inv = player_character.all_items_with( "is_seed", &item::is_seed );
     zone_manager &mgr = zone_manager::get_manager();
     map &here = get_map();
     const std::unordered_set<tripoint_abs_ms> zone_src_set =

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -302,10 +302,7 @@ unload_options::query_unload_result unload_options::query_unload()
 plot_options::query_seed_result plot_options::query_seed()
 {
     Character &player_character = get_player_character();
-
-    std::vector<item *> seed_inv = player_character.items_with( []( const item & itm ) {
-        return itm.is_seed();
-    } );
+    std::set<item *> &seed_inv = player_character.all_items_with( "IS SEED", &item::is_seed );
     zone_manager &mgr = zone_manager::get_manager();
     map &here = get_map();
     const std::unordered_set<tripoint_abs_ms> zone_src_set =
@@ -314,7 +311,7 @@ plot_options::query_seed_result plot_options::query_seed()
         tripoint elem_loc = here.getlocal( elem );
         for( item &it : here.i_at( elem_loc ) ) {
             if( it.is_seed() ) {
-                seed_inv.push_back( &it );
+                seed_inv.insert( &it );
             }
         }
     }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1923,7 +1923,7 @@ static void character_edit_menu()
                 break;
             }
             you.worn.on_takeoff( you );
-            you.worn.clear();
+            you.clear_worn();
             you.inv->clear();
             you.remove_weapon();
             break;

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1924,7 +1924,7 @@ static void character_edit_menu()
             }
             you.worn.on_takeoff( you );
             you.clear_worn();
-            you.clear_inv();
+            you.inv->clear();
             you.remove_weapon();
             break;
         case D_DROP_ITEMS:

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1924,7 +1924,7 @@ static void character_edit_menu()
             }
             you.worn.on_takeoff( you );
             you.clear_worn();
-            you.inv->clear();
+            you.clear_inv();
             you.remove_weapon();
             break;
         case D_DROP_ITEMS:

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -112,7 +112,7 @@ vehicle *display::vehicle_driven( const Character &u )
 std::string display::get_temp( const Character &u )
 {
     std::string temp;
-    if( u.has_item_with_flag( json_flag_THERMOMETER ) ||
+    if( u.has_any_item_with( json_flag_THERMOMETER ) ||
         u.has_flag( STATIC( json_character_flag( "THERMOMETER" ) ) ) ) {
         temp = print_temperature( get_weather().get_temperature( u.pos() ) );
     }

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -112,7 +112,7 @@ vehicle *display::vehicle_driven( const Character &u )
 std::string display::get_temp( const Character &u )
 {
     std::string temp;
-    if( u.has_any_item_with( json_flag_THERMOMETER ) ||
+    if( u.cache_has_item_with( json_flag_THERMOMETER ) ||
         u.has_flag( STATIC( json_character_flag( "THERMOMETER" ) ) ) ) {
         temp = print_temperature( get_weather().get_temperature( u.pos() ) );
     }

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -623,8 +623,8 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
     std::string can_see;
     nc_color see_color;
 
-    bool u_has_radio = player_character.has_any_item_with_flag_and_charges( json_flag_TWO_WAY_RADIO );
-    bool guy_has_radio = has_any_item_with_flag_and_charges( json_flag_TWO_WAY_RADIO );
+    bool u_has_radio = player_character.cache_has_item_with_flag_and_charges( json_flag_TWO_WAY_RADIO );
+    bool guy_has_radio = cache_has_item_with_flag_and_charges( json_flag_TWO_WAY_RADIO );
     // is the NPC even in the same area as the player?
     if( rl_dist( player_abspos, global_omt_location() ) > 3 ||
         ( rl_dist( player_character.pos(), pos() ) > SEEX * 2 || !player_character.sees( pos() ) ) ) {

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -623,8 +623,8 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
     std::string can_see;
     nc_color see_color;
 
-    bool u_has_radio = player_character.has_item_with_flag( json_flag_TWO_WAY_RADIO, true );
-    bool guy_has_radio = has_item_with_flag( json_flag_TWO_WAY_RADIO, true );
+    bool u_has_radio = player_character.has_any_item_with_flag_and_charges( json_flag_TWO_WAY_RADIO );
+    bool guy_has_radio = has_any_item_with_flag_and_charges( json_flag_TWO_WAY_RADIO );
     // is the NPC even in the same area as the player?
     if( rl_dist( player_abspos, global_omt_location() ) > 3 ||
         ( rl_dist( player_character.pos(), pos() ) > SEEX * 2 || !player_character.sees( pos() ) ) ) {

--- a/src/faction.cpp
+++ b/src/faction.cpp
@@ -623,8 +623,8 @@ int npc::faction_display( const catacurses::window &fac_w, const int width ) con
     std::string can_see;
     nc_color see_color;
 
-    bool u_has_radio = player_character.cache_has_item_with_flag_and_charges( json_flag_TWO_WAY_RADIO );
-    bool guy_has_radio = cache_has_item_with_flag_and_charges( json_flag_TWO_WAY_RADIO );
+    bool u_has_radio = player_character.cache_has_item_with_flag( json_flag_TWO_WAY_RADIO, true );
+    bool guy_has_radio = cache_has_item_with_flag( json_flag_TWO_WAY_RADIO, true );
     // is the NPC even in the same area as the player?
     if( rl_dist( player_abspos, global_omt_location() ) > 3 ||
         ( rl_dist( player_character.pos(), pos() ) > SEEX * 2 || !player_character.sees( pos() ) ) ) {

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -172,7 +172,6 @@ const flag_id flag_ITEM_BROKEN( "ITEM_BROKEN" );
 const flag_id flag_LASER_SIGHT( "LASER_SIGHT" );
 const flag_id flag_LEAK_ALWAYS( "LEAK_ALWAYS" );
 const flag_id flag_LEAK_DAM( "LEAK_DAM" );
-const flag_id flag_LIGHT( "LIGHT" ); // Note: not a valid item flag. Used for @ref inv_search_caches
 const flag_id flag_LITCIG( "LITCIG" );
 const flag_id flag_LUPINE( "LUPINE" );
 const flag_id flag_MAGIC_FOCUS( "MAGIC_FOCUS" );

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -172,7 +172,7 @@ const flag_id flag_ITEM_BROKEN( "ITEM_BROKEN" );
 const flag_id flag_LASER_SIGHT( "LASER_SIGHT" );
 const flag_id flag_LEAK_ALWAYS( "LEAK_ALWAYS" );
 const flag_id flag_LEAK_DAM( "LEAK_DAM" );
-const flag_id flag_LIGHT( "LIGHT" ); // Note: not a valid item flag. Used for @ref inv_search_cache
+const flag_id flag_LIGHT( "LIGHT" ); // Note: not a valid item flag. Used for @ref inv_search_caches
 const flag_id flag_LITCIG( "LITCIG" );
 const flag_id flag_LUPINE( "LUPINE" );
 const flag_id flag_MAGIC_FOCUS( "MAGIC_FOCUS" );

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -172,6 +172,7 @@ const flag_id flag_ITEM_BROKEN( "ITEM_BROKEN" );
 const flag_id flag_LASER_SIGHT( "LASER_SIGHT" );
 const flag_id flag_LEAK_ALWAYS( "LEAK_ALWAYS" );
 const flag_id flag_LEAK_DAM( "LEAK_DAM" );
+const flag_id flag_LIGHT( "LIGHT" );
 const flag_id flag_LITCIG( "LITCIG" );
 const flag_id flag_LUPINE( "LUPINE" );
 const flag_id flag_MAGIC_FOCUS( "MAGIC_FOCUS" );

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -172,7 +172,7 @@ const flag_id flag_ITEM_BROKEN( "ITEM_BROKEN" );
 const flag_id flag_LASER_SIGHT( "LASER_SIGHT" );
 const flag_id flag_LEAK_ALWAYS( "LEAK_ALWAYS" );
 const flag_id flag_LEAK_DAM( "LEAK_DAM" );
-const flag_id flag_LIGHT( "LIGHT" ); // Note: not a valid item flag. Used for @ref flagged_item_cache
+const flag_id flag_LIGHT( "LIGHT" ); // Note: not a valid item flag. Used for @ref inv_search_cache
 const flag_id flag_LITCIG( "LITCIG" );
 const flag_id flag_LUPINE( "LUPINE" );
 const flag_id flag_MAGIC_FOCUS( "MAGIC_FOCUS" );

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -172,7 +172,7 @@ const flag_id flag_ITEM_BROKEN( "ITEM_BROKEN" );
 const flag_id flag_LASER_SIGHT( "LASER_SIGHT" );
 const flag_id flag_LEAK_ALWAYS( "LEAK_ALWAYS" );
 const flag_id flag_LEAK_DAM( "LEAK_DAM" );
-const flag_id flag_LIGHT( "LIGHT" );
+const flag_id flag_LIGHT( "LIGHT" ); // Note: not a valid item flag. Used for @ref flagged_item_cache
 const flag_id flag_LITCIG( "LITCIG" );
 const flag_id flag_LUPINE( "LUPINE" );
 const flag_id flag_MAGIC_FOCUS( "MAGIC_FOCUS" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -182,7 +182,7 @@ extern const flag_id flag_ITEM_BROKEN;
 extern const flag_id flag_LASER_SIGHT;
 extern const flag_id flag_LEAK_ALWAYS;
 extern const flag_id flag_LEAK_DAM;
-extern const flag_id flag_LIGHT; // Note: not a valid item flag. Used for @ref inv_search_cache
+extern const flag_id flag_LIGHT; // Note: not a valid item flag. Used for @ref inv_search_caches
 extern const flag_id flag_LITCIG;
 extern const flag_id flag_LUPINE;
 extern const flag_id flag_MAGIC_FOCUS;

--- a/src/flag.h
+++ b/src/flag.h
@@ -182,7 +182,7 @@ extern const flag_id flag_ITEM_BROKEN;
 extern const flag_id flag_LASER_SIGHT;
 extern const flag_id flag_LEAK_ALWAYS;
 extern const flag_id flag_LEAK_DAM;
-extern const flag_id flag_LIGHT;
+extern const flag_id flag_LIGHT; // Note: not a valid item flag. Used for @ref flagged_item_cache
 extern const flag_id flag_LITCIG;
 extern const flag_id flag_LUPINE;
 extern const flag_id flag_MAGIC_FOCUS;

--- a/src/flag.h
+++ b/src/flag.h
@@ -182,7 +182,7 @@ extern const flag_id flag_ITEM_BROKEN;
 extern const flag_id flag_LASER_SIGHT;
 extern const flag_id flag_LEAK_ALWAYS;
 extern const flag_id flag_LEAK_DAM;
-extern const flag_id flag_LIGHT; // Note: not a valid item flag. Used for @ref flagged_item_cache
+extern const flag_id flag_LIGHT; // Note: not a valid item flag. Used for @ref inv_search_cache
 extern const flag_id flag_LITCIG;
 extern const flag_id flag_LUPINE;
 extern const flag_id flag_MAGIC_FOCUS;

--- a/src/flag.h
+++ b/src/flag.h
@@ -182,7 +182,6 @@ extern const flag_id flag_ITEM_BROKEN;
 extern const flag_id flag_LASER_SIGHT;
 extern const flag_id flag_LEAK_ALWAYS;
 extern const flag_id flag_LEAK_DAM;
-extern const flag_id flag_LIGHT; // Note: not a valid item flag. Used for @ref inv_search_caches
 extern const flag_id flag_LITCIG;
 extern const flag_id flag_LUPINE;
 extern const flag_id flag_MAGIC_FOCUS;

--- a/src/flag.h
+++ b/src/flag.h
@@ -182,6 +182,7 @@ extern const flag_id flag_ITEM_BROKEN;
 extern const flag_id flag_LASER_SIGHT;
 extern const flag_id flag_LEAK_ALWAYS;
 extern const flag_id flag_LEAK_DAM;
+extern const flag_id flag_LIGHT;
 extern const flag_id flag_LITCIG;
 extern const flag_id flag_LUPINE;
 extern const flag_id flag_MAGIC_FOCUS;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -11423,7 +11423,7 @@ void game::water_affect_items( Character &ch ) const
                    && !loc.protected_from_liquids() ) {
             wet.emplace_back( loc );
         } else if( loc->typeId() == itype_towel && !loc.protected_from_liquids() ) {
-            loc->convert( itype_towel_wet ).active = true;
+            loc->convert( itype_towel_wet, &ch ).active = true;
         }
     }
 

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -880,7 +880,7 @@ static std::string get_consume_needs_hint( Character &you )
     int kcal_spent_today = you.as_avatar()->get_daily_spent_kcal( false );
     int kcal_spent_yesterday = you.as_avatar()->get_daily_spent_kcal( true );
     bool has_fitness_band =  you.is_wearing( itype_fitness_band ) || you.has_bionic( bio_fitnessband );
-    bool has_tracker = has_fitness_band || you.has_any_item_with( json_flag_CALORIES_INTAKE );
+    bool has_tracker = has_fitness_band || you.cache_has_item_with( json_flag_CALORIES_INTAKE );
 
     std::string kcal_estimated_intake;
     if( kcal_ingested_today == 0 ) {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -880,7 +880,7 @@ static std::string get_consume_needs_hint( Character &you )
     int kcal_spent_today = you.as_avatar()->get_daily_spent_kcal( false );
     int kcal_spent_yesterday = you.as_avatar()->get_daily_spent_kcal( true );
     bool has_fitness_band =  you.is_wearing( itype_fitness_band ) || you.has_bionic( bio_fitnessband );
-    bool has_tracker = has_fitness_band || you.has_item_with_flag( json_flag_CALORIES_INTAKE );
+    bool has_tracker = has_fitness_band || you.has_any_item_with( json_flag_CALORIES_INTAKE );
 
     std::string kcal_estimated_intake;
     if( kcal_ingested_today == 0 ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1279,7 +1279,7 @@ static void loot()
     Character &player_character = get_player_character();
     int flags = 0;
     zone_manager &mgr = zone_manager::get_manager();
-    const bool has_fertilizer = player_character.has_any_item_with( flag_FERTILIZER );
+    const bool has_fertilizer = player_character.cache_has_item_with( flag_FERTILIZER );
 
     // reset any potentially disabled zones from a past activity
     mgr.reset_disabled();

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1279,7 +1279,7 @@ static void loot()
     Character &player_character = get_player_character();
     int flags = 0;
     zone_manager &mgr = zone_manager::get_manager();
-    const bool has_fertilizer = player_character.has_item_with_flag( flag_FERTILIZER );
+    const bool has_fertilizer = player_character.has_any_item_with( flag_FERTILIZER );
 
     // reset any potentially disabled zones from a past activity
     mgr.reset_disabled();

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -805,7 +805,7 @@ class atm_menu
         //!Move money from bank account onto cash card.
         bool do_withdraw_money() {
 
-            std::vector<item *> cash_cards_on_hand = you.get_items_with( "is_cash_card", &item::is_cash_card );
+            std::vector<item *> cash_cards_on_hand = you.all_items_with( "is_cash_card", &item::is_cash_card );
             if( cash_cards_on_hand.empty() ) {
                 //Just in case we run into an edge case
                 popup( _( "You do not have a cash card to withdraw money!" ) );
@@ -864,7 +864,7 @@ class atm_menu
                     return false;
                 }
             } else {
-                const std::vector<item *> cash_cards = you.get_items_with( "is_cash_card", &item::is_cash_card );
+                const std::vector<item *> cash_cards = you.all_items_with( "is_cash_card", &item::is_cash_card );
                 if( cash_cards.empty() ) {
                     popup( _( "You do not have a cash card." ) );
                     return false;
@@ -911,7 +911,7 @@ class atm_menu
         //!Move the money from all the cash cards in inventory to a single card.
         bool do_transfer_all_money() {
             item *dst;
-            std::vector<item *> cash_cards_on_hand = you.get_items_with( "is_cash_card", &item::is_cash_card );
+            std::vector<item *> cash_cards_on_hand = you.all_items_with( "is_cash_card", &item::is_cash_card );
             if( you.activity.id() == ACT_ATM ) {
                 dst = you.activity.targets.front().get_item();
                 you.activity.set_to_null(); // stop for now, if required, it will be created again.
@@ -2520,7 +2520,7 @@ void iexamine::dirtmound( Character &you, const tripoint &examp )
         add_msg(m_info, _("It is too dark to plant anything now."));
         return;
     }*/
-    std::vector<item *> seed_inv = you.get_items_with( "is_seed", &item::is_seed );
+    std::vector<item *> seed_inv = you.all_items_with( "is_seed", &item::is_seed );
     if( seed_inv.empty() ) {
         add_msg( m_info, _( "You have no seeds to plant." ) );
         return;
@@ -2754,7 +2754,7 @@ void iexamine::fertilize_plant( Character &you, const tripoint &tile,
 itype_id iexamine::choose_fertilizer( Character &you, const std::string &pname,
                                       bool ask_player )
 {
-    std::vector<item *> f_inv = you.get_items_with( flag_FERTILIZER );
+    std::vector<item *> f_inv = you.all_items_with( flag_FERTILIZER );
     if( f_inv.empty() ) {
         add_msg( m_info, _( "You have no fertilizer for the %s." ), pname );
         return itype_id();
@@ -4982,7 +4982,7 @@ void iexamine::pay_gas( Character &you, const tripoint &examp )
     }
 
     if( refund == choice ) {
-        std::vector<item *> cash_cards = you.get_items_with( "is_cash_card", &item::is_cash_card );
+        std::vector<item *> cash_cards = you.all_items_with( "is_cash_card", &item::is_cash_card );
         if( cash_cards.empty() ) {
             popup( _( "You do not have a cash card to refund money!" ) );
             return;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2448,7 +2448,7 @@ void iexamine::fungus( Character &you, const tripoint &examp )
 /**
  *  Make lists of unique seed types and names for the menu(no multiple hemp seeds etc)
  */
-std::vector<seed_tuple> iexamine::get_seed_entries( const std::vector<item *> &seed_inv )
+std::vector<seed_tuple> iexamine::get_seed_entries( const std::set<item *> &seed_inv )
 {
     std::map<itype_id, int> seed_map;
     for( const item *seed : seed_inv ) {
@@ -2526,9 +2526,7 @@ void iexamine::dirtmound( Character &you, const tripoint &examp )
         add_msg(m_info, _("It is too dark to plant anything now."));
         return;
     }*/
-    std::vector<item *> seed_inv = you.items_with( []( const item & itm ) {
-        return itm.is_seed();
-    } );
+    std::set<item *> &seed_inv = you.all_items_with( "IS SEED", &item::is_seed );
     if( seed_inv.empty() ) {
         add_msg( m_info, _( "You have no seeds to plant." ) );
         return;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -4684,7 +4684,7 @@ static int findBestGasDiscount( Character &you )
 {
     int discount = 0;
 
-    you.cache_visit_items_with( flag_GAS_DISCOUNT, [&discount]( item & it ) {
+    you.cache_visit_items_with( flag_GAS_DISCOUNT, [&discount]( const item & it ) {
         discount = std::max( discount, getGasDiscountCardQuality( it ) );
     } );
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3496,9 +3496,7 @@ void iexamine::fvat_empty( Character &you, const tripoint &examp )
     if( !brew_present ) {
         add_msg( _( "This keg is empty." ) );
         // TODO: Allow using brews from crafting inventory
-        const auto b_inv = you.items_with( []( const item & it ) {
-            return it.is_brewable();
-        } );
+        const auto b_inv = you.all_items_with( "is_brewable", &item::is_brewable );
         if( b_inv.empty() ) {
             add_msg( m_info, _( "You have no brew to ferment." ) );
             return;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2762,7 +2762,7 @@ void iexamine::fertilize_plant( Character &you, const tripoint &tile,
 itype_id iexamine::choose_fertilizer( Character &you, const std::string &pname,
                                       bool ask_player )
 {
-    std::set<item *> &f_inv = you.all_items_with_flag( flag_FERTILIZER );
+    std::set<item *> &f_inv = you.all_items_with( flag_FERTILIZER );
     if( f_inv.empty() ) {
         add_msg( m_info, _( "You have no fertilizer for the %s." ), pname );
         return itype_id();
@@ -4691,7 +4691,7 @@ static int findBestGasDiscount( Character &you )
 {
     int discount = 0;
 
-    for( const item *it : you.all_items_with_flag( flag_GAS_DISCOUNT ) ) {
+    for( const item *it : you.all_items_with( flag_GAS_DISCOUNT ) ) {
         discount = std::max( discount, getGasDiscountCardQuality( *it ) );
     }
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2762,7 +2762,7 @@ void iexamine::fertilize_plant( Character &you, const tripoint &tile,
 itype_id iexamine::choose_fertilizer( Character &you, const std::string &pname,
                                       bool ask_player )
 {
-    std::vector<const item *> f_inv = you.all_items_with_flag( flag_FERTILIZER );
+    std::set<item *> &f_inv = you.all_items_with_flag( flag_FERTILIZER );
     if( f_inv.empty() ) {
         add_msg( m_info, _( "You have no fertilizer for the %s." ), pname );
         return itype_id();
@@ -2770,7 +2770,7 @@ itype_id iexamine::choose_fertilizer( Character &you, const std::string &pname,
 
     std::vector<itype_id> f_types;
     std::vector<std::string> f_names;
-    for( const item *&f : f_inv ) {
+    for( const item * const &f : f_inv ) {
         if( std::find( f_types.begin(), f_types.end(), f->typeId() ) == f_types.end() ) {
             f_types.push_back( f->typeId() );
             f_names.push_back( f->tname() );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -722,7 +722,7 @@ class atm_menu
                           _( "You need a charged cash card before you can deposit money!" ) );
             }
 
-            if( card_count >= 1 && you.has_any_item_with( flag_OLD_CURRENCY ) ) {
+            if( card_count >= 1 && you.cache_has_item_with( flag_OLD_CURRENCY ) ) {
                 add_choice( exchange_cash, _( "Exchange Cash for eCash (1%% fee)" ) );
             }
 
@@ -805,7 +805,8 @@ class atm_menu
         //!Move money from bank account onto cash card.
         bool do_withdraw_money() {
 
-            std::vector<item *> cash_cards_on_hand = you.all_items_with( "is_cash_card", &item::is_cash_card );
+            std::vector<item *> cash_cards_on_hand = you.cache_get_items_with( "is_cash_card",
+                    &item::is_cash_card );
             if( cash_cards_on_hand.empty() ) {
                 //Just in case we run into an edge case
                 popup( _( "You do not have a cash card to withdraw money!" ) );
@@ -864,7 +865,8 @@ class atm_menu
                     return false;
                 }
             } else {
-                const std::vector<item *> cash_cards = you.all_items_with( "is_cash_card", &item::is_cash_card );
+                const std::vector<item *> cash_cards = you.cache_get_items_with( "is_cash_card",
+                                                       &item::is_cash_card );
                 if( cash_cards.empty() ) {
                     popup( _( "You do not have a cash card." ) );
                     return false;
@@ -911,7 +913,8 @@ class atm_menu
         //!Move the money from all the cash cards in inventory to a single card.
         bool do_transfer_all_money() {
             item *dst;
-            std::vector<item *> cash_cards_on_hand = you.all_items_with( "is_cash_card", &item::is_cash_card );
+            std::vector<item *> cash_cards_on_hand = you.cache_get_items_with( "is_cash_card",
+                    &item::is_cash_card );
             if( you.activity.id() == ACT_ATM ) {
                 dst = you.activity.targets.front().get_item();
                 you.activity.set_to_null(); // stop for now, if required, it will be created again.
@@ -1748,7 +1751,7 @@ void iexamine::safe( Character &you, const tripoint &examp )
 {
     bool has_cracking_tool = you.has_flag( json_flag_SUPER_HEARING );
     // short-circuit to avoid the more expensive iteration over items
-    has_cracking_tool = has_cracking_tool || you.has_any_item_with( flag_SAFECRACK );
+    has_cracking_tool = has_cracking_tool || you.cache_has_item_with( flag_SAFECRACK );
 
     if( !has_cracking_tool ) {
         you.moves -= to_moves<int>( 10_seconds );
@@ -2520,7 +2523,7 @@ void iexamine::dirtmound( Character &you, const tripoint &examp )
         add_msg(m_info, _("It is too dark to plant anything now."));
         return;
     }*/
-    std::vector<item *> seed_inv = you.all_items_with( "is_seed", &item::is_seed );
+    std::vector<item *> seed_inv = you.cache_get_items_with( "is_seed", &item::is_seed );
     if( seed_inv.empty() ) {
         add_msg( m_info, _( "You have no seeds to plant." ) );
         return;
@@ -2754,7 +2757,7 @@ void iexamine::fertilize_plant( Character &you, const tripoint &tile,
 itype_id iexamine::choose_fertilizer( Character &you, const std::string &pname,
                                       bool ask_player )
 {
-    std::vector<item *> f_inv = you.all_items_with( flag_FERTILIZER );
+    std::vector<item *> f_inv = you.cache_get_items_with( flag_FERTILIZER );
     if( f_inv.empty() ) {
         add_msg( m_info, _( "You have no fertilizer for the %s." ), pname );
         return itype_id();
@@ -3496,7 +3499,7 @@ void iexamine::fvat_empty( Character &you, const tripoint &examp )
     if( !brew_present ) {
         add_msg( _( "This keg is empty." ) );
         // TODO: Allow using brews from crafting inventory
-        const auto b_inv = you.all_items_with( "is_brewable", &item::is_brewable );
+        const auto b_inv = you.cache_get_items_with( "is_brewable", &item::is_brewable );
         if( b_inv.empty() ) {
             add_msg( m_info, _( "You have no brew to ferment." ) );
             return;
@@ -4681,7 +4684,7 @@ static int findBestGasDiscount( Character &you )
 {
     int discount = 0;
 
-    you.do_to_items_with( flag_GAS_DISCOUNT, [&discount]( item & it ) {
+    you.cache_visit_items_with( flag_GAS_DISCOUNT, [&discount]( item & it ) {
         discount = std::max( discount, getGasDiscountCardQuality( it ) );
     } );
 
@@ -4980,7 +4983,7 @@ void iexamine::pay_gas( Character &you, const tripoint &examp )
     }
 
     if( refund == choice ) {
-        std::vector<item *> cash_cards = you.all_items_with( "is_cash_card", &item::is_cash_card );
+        std::vector<item *> cash_cards = you.cache_get_items_with( "is_cash_card", &item::is_cash_card );
         if( cash_cards.empty() ) {
             popup( _( "You do not have a cash card to refund money!" ) );
             return;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -805,7 +805,7 @@ class atm_menu
         //!Move money from bank account onto cash card.
         bool do_withdraw_money() {
 
-            std::set<item *> &_cash_cards_on_hand = you.all_items_with( "IS CASH CARD", &item::is_cash_card );
+            std::set<item *> &_cash_cards_on_hand = you.all_items_with( "is_cash_card", &item::is_cash_card );
             if( _cash_cards_on_hand.empty() ) {
                 //Just in case we run into an edge case
                 popup( _( "You do not have a cash card to withdraw money!" ) );
@@ -867,7 +867,7 @@ class atm_menu
                     return false;
                 }
             } else {
-                const std::set<item *> &cash_cards = you.all_items_with( "IS CASH CARD", &item::is_cash_card );
+                const std::set<item *> &cash_cards = you.all_items_with( "is_cash_card", &item::is_cash_card );
                 if( cash_cards.empty() ) {
                     popup( _( "You do not have a cash card." ) );
                     return false;
@@ -914,7 +914,7 @@ class atm_menu
         //!Move the money from all the cash cards in inventory to a single card.
         bool do_transfer_all_money() {
             item *dst;
-            std::set<item *> &cash_cards_on_hand = you.all_items_with( "IS CASH CARD", &item::is_cash_card );
+            std::set<item *> &cash_cards_on_hand = you.all_items_with( "is_cash_card", &item::is_cash_card );
             if( you.activity.id() == ACT_ATM ) {
                 dst = you.activity.targets.front().get_item();
                 you.activity.set_to_null(); // stop for now, if required, it will be created again.
@@ -2523,7 +2523,7 @@ void iexamine::dirtmound( Character &you, const tripoint &examp )
         add_msg(m_info, _("It is too dark to plant anything now."));
         return;
     }*/
-    std::set<item *> &seed_inv = you.all_items_with( "IS SEED", &item::is_seed );
+    std::set<item *> &seed_inv = you.all_items_with( "is_seed", &item::is_seed );
     if( seed_inv.empty() ) {
         add_msg( m_info, _( "You have no seeds to plant." ) );
         return;
@@ -4985,7 +4985,7 @@ void iexamine::pay_gas( Character &you, const tripoint &examp )
     }
 
     if( refund == choice ) {
-        std::set<item *> &_cash_cards = you.all_items_with( "IS CASH CARD", &item::is_cash_card );
+        std::set<item *> &_cash_cards = you.all_items_with( "is_cash_card", &item::is_cash_card );
         if( _cash_cards.empty() ) {
             popup( _( "You do not have a cash card to refund money!" ) );
             return;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -805,15 +805,12 @@ class atm_menu
         //!Move money from bank account onto cash card.
         bool do_withdraw_money() {
 
-            std::set<item *> &_cash_cards_on_hand = you.all_items_with( "is_cash_card", &item::is_cash_card );
-            if( _cash_cards_on_hand.empty() ) {
+            std::vector<item *> &cash_cards_on_hand = you.all_items_with( "is_cash_card", &item::is_cash_card );
+            if( cash_cards_on_hand.empty() ) {
                 //Just in case we run into an edge case
                 popup( _( "You do not have a cash card to withdraw money!" ) );
                 return false;
             }
-            std::vector<item *> cash_cards_on_hand;
-            cash_cards_on_hand.reserve( _cash_cards_on_hand.size() );
-            cash_cards_on_hand = { _cash_cards_on_hand.begin(), _cash_cards_on_hand.end() };
 
             const int amount = prompt_for_amount( n_gettext(
                     "Withdraw how much?  Max: %d cent.  (0 to cancel) ",
@@ -867,7 +864,7 @@ class atm_menu
                     return false;
                 }
             } else {
-                const std::set<item *> &cash_cards = you.all_items_with( "is_cash_card", &item::is_cash_card );
+                const std::vector<item *> &cash_cards = you.all_items_with( "is_cash_card", &item::is_cash_card );
                 if( cash_cards.empty() ) {
                     popup( _( "You do not have a cash card." ) );
                     return false;
@@ -914,7 +911,7 @@ class atm_menu
         //!Move the money from all the cash cards in inventory to a single card.
         bool do_transfer_all_money() {
             item *dst;
-            std::set<item *> &cash_cards_on_hand = you.all_items_with( "is_cash_card", &item::is_cash_card );
+            std::vector<item *> &cash_cards_on_hand = you.all_items_with( "is_cash_card", &item::is_cash_card );
             if( you.activity.id() == ACT_ATM ) {
                 dst = you.activity.targets.front().get_item();
                 you.activity.set_to_null(); // stop for now, if required, it will be created again.
@@ -2445,7 +2442,7 @@ void iexamine::fungus( Character &you, const tripoint &examp )
 /**
  *  Make lists of unique seed types and names for the menu(no multiple hemp seeds etc)
  */
-std::vector<seed_tuple> iexamine::get_seed_entries( const std::set<item *> &seed_inv )
+std::vector<seed_tuple> iexamine::get_seed_entries( const std::vector<item *> &seed_inv )
 {
     std::map<itype_id, int> seed_map;
     for( const item *seed : seed_inv ) {
@@ -2523,7 +2520,7 @@ void iexamine::dirtmound( Character &you, const tripoint &examp )
         add_msg(m_info, _("It is too dark to plant anything now."));
         return;
     }*/
-    std::set<item *> &seed_inv = you.all_items_with( "is_seed", &item::is_seed );
+    std::vector<item *> &seed_inv = you.all_items_with( "is_seed", &item::is_seed );
     if( seed_inv.empty() ) {
         add_msg( m_info, _( "You have no seeds to plant." ) );
         return;
@@ -2757,7 +2754,7 @@ void iexamine::fertilize_plant( Character &you, const tripoint &tile,
 itype_id iexamine::choose_fertilizer( Character &you, const std::string &pname,
                                       bool ask_player )
 {
-    std::set<item *> &f_inv = you.all_items_with( flag_FERTILIZER );
+    std::vector<item *> &f_inv = you.all_items_with( flag_FERTILIZER );
     if( f_inv.empty() ) {
         add_msg( m_info, _( "You have no fertilizer for the %s." ), pname );
         return itype_id();
@@ -4985,14 +4982,11 @@ void iexamine::pay_gas( Character &you, const tripoint &examp )
     }
 
     if( refund == choice ) {
-        std::set<item *> &_cash_cards = you.all_items_with( "is_cash_card", &item::is_cash_card );
-        if( _cash_cards.empty() ) {
+        std::vector<item *> &cash_cards = you.all_items_with( "is_cash_card", &item::is_cash_card );
+        if( cash_cards.empty() ) {
             popup( _( "You do not have a cash card to refund money!" ) );
             return;
         }
-        std::vector<item *> cash_cards;
-        cash_cards.reserve( _cash_cards.size() );
-        cash_cards = { _cash_cards.begin(), _cash_cards.end() };
 
         const std::optional<tripoint> pGasPump = getGasPumpByNumber( examp,
                 uistate.ags_pay_gas_selected_pump );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -722,7 +722,7 @@ class atm_menu
                           _( "You need a charged cash card before you can deposit money!" ) );
             }
 
-            if( card_count >= 1 && you.has_item_with_flag( flag_OLD_CURRENCY ) ) {
+            if( card_count >= 1 && you.has_any_item_with( flag_OLD_CURRENCY ) ) {
                 add_choice( exchange_cash, _( "Exchange Cash for eCash (1%% fee)" ) );
             }
 
@@ -1748,7 +1748,7 @@ void iexamine::safe( Character &you, const tripoint &examp )
 {
     bool has_cracking_tool = you.has_flag( json_flag_SUPER_HEARING );
     // short-circuit to avoid the more expensive iteration over items
-    has_cracking_tool = has_cracking_tool || you.has_item_with_flag( flag_SAFECRACK );
+    has_cracking_tool = has_cracking_tool || you.has_any_item_with( flag_SAFECRACK );
 
     if( !has_cracking_tool ) {
         you.moves -= to_moves<int>( 10_seconds );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -805,7 +805,7 @@ class atm_menu
         //!Move money from bank account onto cash card.
         bool do_withdraw_money() {
 
-            std::vector<item *> &cash_cards_on_hand = you.all_items_with( "is_cash_card", &item::is_cash_card );
+            std::vector<item *> cash_cards_on_hand = you.get_items_with( "is_cash_card", &item::is_cash_card );
             if( cash_cards_on_hand.empty() ) {
                 //Just in case we run into an edge case
                 popup( _( "You do not have a cash card to withdraw money!" ) );
@@ -864,7 +864,7 @@ class atm_menu
                     return false;
                 }
             } else {
-                const std::vector<item *> &cash_cards = you.all_items_with( "is_cash_card", &item::is_cash_card );
+                const std::vector<item *> cash_cards = you.get_items_with( "is_cash_card", &item::is_cash_card );
                 if( cash_cards.empty() ) {
                     popup( _( "You do not have a cash card." ) );
                     return false;
@@ -911,7 +911,7 @@ class atm_menu
         //!Move the money from all the cash cards in inventory to a single card.
         bool do_transfer_all_money() {
             item *dst;
-            std::vector<item *> &cash_cards_on_hand = you.all_items_with( "is_cash_card", &item::is_cash_card );
+            std::vector<item *> cash_cards_on_hand = you.get_items_with( "is_cash_card", &item::is_cash_card );
             if( you.activity.id() == ACT_ATM ) {
                 dst = you.activity.targets.front().get_item();
                 you.activity.set_to_null(); // stop for now, if required, it will be created again.
@@ -2520,7 +2520,7 @@ void iexamine::dirtmound( Character &you, const tripoint &examp )
         add_msg(m_info, _("It is too dark to plant anything now."));
         return;
     }*/
-    std::vector<item *> &seed_inv = you.all_items_with( "is_seed", &item::is_seed );
+    std::vector<item *> seed_inv = you.get_items_with( "is_seed", &item::is_seed );
     if( seed_inv.empty() ) {
         add_msg( m_info, _( "You have no seeds to plant." ) );
         return;
@@ -2754,7 +2754,7 @@ void iexamine::fertilize_plant( Character &you, const tripoint &tile,
 itype_id iexamine::choose_fertilizer( Character &you, const std::string &pname,
                                       bool ask_player )
 {
-    std::vector<item *> &f_inv = you.all_items_with( flag_FERTILIZER );
+    std::vector<item *> f_inv = you.get_items_with( flag_FERTILIZER );
     if( f_inv.empty() ) {
         add_msg( m_info, _( "You have no fertilizer for the %s." ), pname );
         return itype_id();
@@ -4683,9 +4683,9 @@ static int findBestGasDiscount( Character &you )
 {
     int discount = 0;
 
-    for( const item *it : you.all_items_with( flag_GAS_DISCOUNT ) ) {
-        discount = std::max( discount, getGasDiscountCardQuality( *it ) );
-    }
+    you.do_to_items_with( flag_GAS_DISCOUNT, [&discount]( item & it ) {
+        discount = std::max( discount, getGasDiscountCardQuality( it ) );
+    } );
 
     return discount;
 }
@@ -4982,7 +4982,7 @@ void iexamine::pay_gas( Character &you, const tripoint &examp )
     }
 
     if( refund == choice ) {
-        std::vector<item *> &cash_cards = you.all_items_with( "is_cash_card", &item::is_cash_card );
+        std::vector<item *> cash_cards = you.get_items_with( "is_cash_card", &item::is_cash_card );
         if( cash_cards.empty() ) {
             popup( _( "You do not have a cash card to refund money!" ) );
             return;

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -6,6 +6,7 @@
 #include <list>
 #include <memory>
 #include <optional>
+#include <set>
 #include <tuple>
 #include <vector>
 

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -155,7 +155,7 @@ std::list<item> get_harvest_items( const itype &type, int plant_count,
                                    int seed_count, bool byproducts );
 
 // Planting functions
-std::vector<seed_tuple> get_seed_entries( const std::vector<item *> &seed_inv );
+std::vector<seed_tuple> get_seed_entries( const std::set<item *> &seed_inv );
 int query_seed( const std::vector<seed_tuple> &seed_entries );
 void plant_seed( Character &you, const tripoint &examp, const itype_id &seed_id );
 void harvest_plant_ex( Character &you, const tripoint &examp );

--- a/src/iexamine.h
+++ b/src/iexamine.h
@@ -156,7 +156,7 @@ std::list<item> get_harvest_items( const itype &type, int plant_count,
                                    int seed_count, bool byproducts );
 
 // Planting functions
-std::vector<seed_tuple> get_seed_entries( const std::set<item *> &seed_inv );
+std::vector<seed_tuple> get_seed_entries( const std::vector<item *> &seed_inv );
 int query_seed( const std::vector<seed_tuple> &seed_entries );
 void plant_seed( Character &you, const tripoint &examp, const itype_id &seed_id );
 void harvest_plant_ex( Character &you, const tripoint &examp );

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -256,9 +256,6 @@ class inventory : public visitable
         override;
         std::list<item> remove_items_with( const std::function<bool( const item & )> &filter,
                                            int count = INT_MAX ) override;
-        std::list<item> remove_items_with( Character *carrier,
-                                           const std::function<bool( const item & )> &filter,
-                                           int count = INT_MAX );
         int charges_of( const itype_id &what, int limit = INT_MAX,
                         const std::function<bool( const item & )> &filter = return_true<item>,
                         const std::function<void( int )> &visitor = nullptr, bool in_tools = false ) const override;

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -256,6 +256,9 @@ class inventory : public visitable
         override;
         std::list<item> remove_items_with( const std::function<bool( const item & )> &filter,
                                            int count = INT_MAX ) override;
+        std::list<item> remove_items_with( Character *carrier,
+                                           const std::function<bool( const item & )> &filter,
+                                           int count = INT_MAX );
         int charges_of( const itype_id &what, int limit = INT_MAX,
                         const std::function<bool( const item & )> &filter = return_true<item>,
                         const std::function<void( int )> &visitor = nullptr, bool in_tools = false ) const override;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -614,9 +614,6 @@ item item::make_corpse( const mtype_id &mt, time_point turn, const std::string &
 
 item &item::convert( const itype_id &new_type, Character *carrier )
 {
-    if( carrier ) {
-        carrier->remove_from_inv_search_caches( *this );
-    }
     // Carry over relative rot similar to crafting
     const double rel_rot = get_relative_rot();
     type = find_type( new_type );
@@ -6223,7 +6220,6 @@ void item::on_wear( Character &p )
 void item::on_takeoff( Character &p )
 {
     p.on_item_takeoff( *this );
-    p.remove_from_inv_search_caches( *this );
 
     if( is_sided() ) {
         set_side( side::BOTH );
@@ -14413,9 +14409,9 @@ int item::get_recursive_disassemble_moves( const Character &guy ) const
 }
 
 void item::remove_internal( const std::function<bool( item & )> &filter,
-                            int &count, std::list<item> &res, Character *carrier )
+                            int &count, std::list<item> &res )
 {
-    contents.remove_internal( filter, count, res, carrier );
+    contents.remove_internal( filter, count, res );
 }
 
 std::list<const item *> item::all_items_top() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -638,10 +638,7 @@ item &item::convert( const itype_id &new_type, Character *carrier )
         active = true;
     }
     if( carrier ) {
-        visit_items( [&carrier]( item * cont_it, item * ) {
-            carrier->add_to_inv_search_caches( *cont_it );
-            return VisitResponse::NEXT;
-        } );
+        carrier->on_item_acquire( *this );
     }
 
     return *this;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6115,16 +6115,16 @@ nc_color item::color_in_inventory( const Character *const ch ) const
         // Likewise, ammo is green if you have guns that use it
         // ltred if you have the gun but no mags
         // Gun with integrated mag counts as both
-        bool has_gun = player_character.has_any_item_with( "is_gun", &item::is_gun,
+        bool has_gun = player_character.cache_has_item_with( "is_gun", &item::is_gun,
         [this]( const item & i ) {
             return i.ammo_types().count( ammo_type() );
         } );
-        bool has_mag = player_character.has_any_item_with( "is_gun", &item::is_gun,
+        bool has_mag = player_character.cache_has_item_with( "is_gun", &item::is_gun,
         [this]( const item & i ) {
             return i.magazine_integral() && i.ammo_types().count( ammo_type() );
         } );
         has_mag = has_mag ? true :
-                  player_character.has_any_item_with( "is_magazine", &item::is_magazine,
+                  player_character.cache_has_item_with( "is_magazine", &item::is_magazine,
         [this]( const item & i ) {
             return i.ammo_types().count( ammo_type() );
         } );
@@ -6137,7 +6137,7 @@ nc_color item::color_in_inventory( const Character *const ch ) const
     } else if( is_magazine() ) {
         // Magazines are green if you have guns and ammo for them
         // ltred if you have one but not the other
-        bool has_gun = player_character.has_any_item_with( "is_gun", &item::is_gun,
+        bool has_gun = player_character.cache_has_item_with( "is_gun", &item::is_gun,
         [this]( const item & it ) {
             return it.magazine_compatible().count( typeId() ) > 0;
         } );
@@ -13103,7 +13103,7 @@ bool item::process_link( map &here, Character *carrier, const tripoint &pos )
         return itm.get_var( "cable" ) == "plugged_in";
     };
     if( link->s_state == link_state::ups ) {
-        if( carrier == nullptr || !carrier->has_any_item_with( flag_IS_UPS, used_ups ) ) {
+        if( carrier == nullptr || !carrier->cache_has_item_with( flag_IS_UPS, used_ups ) ) {
             add_msg_if_player_sees( pos, m_bad,
                                     string_format( is_cable_item ? _( "The %s has come loose from the UPS." ) :
                                                    _( "The %s's cable has come loose from the UPS." ), type_name() ) );
@@ -13419,7 +13419,7 @@ bool item::process_linked_item( Character *carrier, const tripoint & /*pos*/,
         active = false;
         return false;
     }
-    bool has_connected_cable = carrier->has_any_item_with( "can_link_up", &item::can_link_up,
+    bool has_connected_cable = carrier->cache_has_item_with( "can_link_up", &item::can_link_up,
     [&required_state]( const item & it ) {
         return it.link && it.link->has_state( required_state );
     } );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -158,6 +158,7 @@ static const itype_id itype_battery( "battery" );
 static const itype_id itype_blood( "blood" );
 static const itype_id itype_brass_catcher( "brass_catcher" );
 static const itype_id itype_bullet_crossbow( "bullet_crossbow" );
+static const itype_id itype_cash_card( "cash_card" );
 static const itype_id itype_cig_butt( "cig_butt" );
 static const itype_id itype_cig_lit( "cig_lit" );
 static const itype_id itype_cigar_butt( "cigar_butt" );
@@ -8436,6 +8437,11 @@ bool item::ready_to_revive( map &here, const tripoint &pos ) const
 bool item::is_money() const
 {
     return ammo_types().count( ammo_money );
+}
+
+bool item::is_cash_card() const
+{
+    return typeId() == itype_cash_card;
 }
 
 bool item::is_software() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14400,9 +14400,9 @@ int item::get_recursive_disassemble_moves( const Character &guy ) const
 }
 
 void item::remove_internal( const std::function<bool( item & )> &filter,
-                            int &count, std::list<item> &res )
+                            int &count, std::list<item> &res, Character *carrier )
 {
-    contents.remove_internal( filter, count, res );
+    contents.remove_internal( filter, count, res, carrier );
 }
 
 std::list<const item *> item::all_items_top() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6225,6 +6225,7 @@ void item::on_wear( Character &p )
 void item::on_takeoff( Character &p )
 {
     p.on_item_takeoff( *this );
+    p.remove_from_inv_search_caches( *this );
 
     if( is_sided() ) {
         set_side( side::BOTH );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -614,7 +614,7 @@ item item::make_corpse( const mtype_id &mt, time_point turn, const std::string &
 item &item::convert( const itype_id &new_type, Character *carrier )
 {
     if( carrier ) {
-        carrier->remove_from_inv_search_cache( *this );
+        carrier->remove_from_inv_search_caches( *this );
     }
     // Carry over relative rot similar to crafting
     const double rel_rot = get_relative_rot();
@@ -637,7 +637,7 @@ item &item::convert( const itype_id &new_type, Character *carrier )
         active = true;
     }
     if( carrier ) {
-        carrier->add_to_inv_search_cache( *this );
+        carrier->add_to_inv_search_caches( *this );
     }
 
     return *this;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -637,7 +637,10 @@ item &item::convert( const itype_id &new_type, Character *carrier )
         active = true;
     }
     if( carrier ) {
-        carrier->add_to_inv_search_caches( *this );
+        visit_items( [&carrier]( item * cont_it, item * ) {
+            carrier->add_to_inv_search_caches( *cont_it );
+            return VisitResponse::NEXT;
+        } );
     }
 
     return *this;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6115,13 +6115,20 @@ nc_color item::color_in_inventory( const Character *const ch ) const
         // Likewise, ammo is green if you have guns that use it
         // ltred if you have the gun but no mags
         // Gun with integrated mag counts as both
-        bool has_gun = player_character.has_item_with( [this]( const item & i ) {
-            return i.is_gun() && i.ammo_types().count( ammo_type() );
+        bool has_gun = player_character.has_any_item_with( "is_gun", &item::is_gun,
+        [this]( const item & i ) {
+            return i.ammo_types().count( ammo_type() );
         } );
-        bool has_mag = player_character.has_item_with( [this]( const item & i ) {
-            return ( i.is_gun() && i.magazine_integral() && i.ammo_types().count( ammo_type() ) ) ||
-                   ( i.is_magazine() && i.ammo_types().count( ammo_type() ) );
+        bool has_mag = player_character.has_any_item_with( "is_gun", &item::is_gun,
+        [this]( const item & i ) {
+            return i.magazine_integral() && i.ammo_types().count( ammo_type() );
         } );
+        has_mag = has_mag ? true :
+                  player_character.has_any_item_with( "is_magazine", &item::is_magazine,
+        [this]( const item & i ) {
+            return i.ammo_types().count( ammo_type() );
+        } );
+
         if( has_gun && has_mag ) {
             ret = c_green;
         } else if( has_gun || has_mag ) {
@@ -6130,8 +6137,9 @@ nc_color item::color_in_inventory( const Character *const ch ) const
     } else if( is_magazine() ) {
         // Magazines are green if you have guns and ammo for them
         // ltred if you have one but not the other
-        bool has_gun = player_character.has_item_with( [this]( const item & it ) {
-            return it.is_gun() && it.magazine_compatible().count( typeId() ) > 0;
+        bool has_gun = player_character.has_any_item_with( "is_gun", &item::is_gun,
+        [this]( const item & it ) {
+            return it.magazine_compatible().count( typeId() ) > 0;
         } );
         bool has_ammo = !player_character.find_ammo( *this, false, -1 ).empty();
         if( has_gun && has_ammo ) {
@@ -13411,7 +13419,8 @@ bool item::process_linked_item( Character *carrier, const tripoint & /*pos*/,
         active = false;
         return false;
     }
-    bool has_connected_cable = carrier->has_any_item_with( "can_link_up", &item::can_link_up, [&required_state]( const item & it ) {
+    bool has_connected_cable = carrier->has_any_item_with( "can_link_up", &item::can_link_up,
+    [&required_state]( const item & it ) {
         return it.link && it.link->has_state( required_state );
     } );
     if( !has_connected_cable ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14552,6 +14552,11 @@ item *item::get_item_with( const std::function<bool( const item & )> &filter )
     return contents.get_item_with( filter );
 }
 
+const item *item::get_item_with( const std::function<bool( const item & )> &filter ) const
+{
+    return contents.get_item_with( filter );
+}
+
 size_t item::num_item_stacks() const
 {
     return contents.num_item_stacks();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -614,7 +614,7 @@ item item::make_corpse( const mtype_id &mt, time_point turn, const std::string &
 item &item::convert( const itype_id &new_type, Character *carrier )
 {
     if( carrier ) {
-        carrier->remove_from_flagged_item_cache( *this );
+        carrier->remove_from_inv_search_cache( *this );
     }
     // Carry over relative rot similar to crafting
     const double rel_rot = get_relative_rot();
@@ -637,7 +637,7 @@ item &item::convert( const itype_id &new_type, Character *carrier )
         active = true;
     }
     if( carrier ) {
-        carrier->add_to_flagged_item_cache( *this );
+        carrier->add_to_inv_search_cache( *this );
     }
 
     return *this;

--- a/src/item.h
+++ b/src/item.h
@@ -352,6 +352,7 @@ class item : public visitable
         bool ready_to_revive( map &here, const tripoint &pos ) const;
 
         bool is_money() const;
+        bool is_cash_card() const;
         bool is_software() const;
         bool is_software_storage() const;
 

--- a/src/item.h
+++ b/src/item.h
@@ -2866,6 +2866,7 @@ class item : public visitable
         item &only_item();
         const item &only_item() const;
         item *get_item_with( const std::function<bool( const item & )> &filter );
+        const item *get_item_with( const std::function<bool( const item & )> &filter ) const;
 
         /**
          * returns the number of items stacks in contents

--- a/src/item.h
+++ b/src/item.h
@@ -234,9 +234,10 @@ class item : public visitable
         /**
          * Filter converting this instance to another type preserving all other aspects
          * @param new_type the type id to convert to
+         * @param carrier A pointer to the character that's carrying the item, nullptr if none, which is the default.
          * @return same instance to allow method chaining
          */
-        item &convert( const itype_id &new_type );
+        item &convert( const itype_id &new_type, Character *carrier = nullptr );
 
         /**
          * Filter converting this instance to the inactive type

--- a/src/item.h
+++ b/src/item.h
@@ -2822,12 +2822,9 @@ class item : public visitable
         VisitResponse visit_contents( const std::function<VisitResponse( item *, item * )> &func,
                                       item *parent = nullptr );
         void remove_internal( const std::function<bool( item & )> &filter,
-                              int &count, std::list<item> &res, Character *carrier = nullptr );
-        item remove_item( item &it, Character *carrier = nullptr );
+                              int &count, std::list<item> &res );
         std::list<item> remove_items_with( const std::function<bool( const item & )> &filter,
                                            int count = INT_MAX ) override;
-        std::list<item> remove_items_with( Character *carrier,
-                                           const std::function<bool( const item &e )> &filter, int count );
 
         /** returns a list of pointers to all top-level items that are not mods */
         std::list<const item *> all_items_top() const;

--- a/src/item.h
+++ b/src/item.h
@@ -1463,6 +1463,11 @@ class item : public visitable
             void deserialize( const JsonObject &data );
         };
         /**
+         * @brief Returns true if the item is/has a cable that can link up to other things.
+         */
+        bool can_link_up() const;
+
+        /**
          * @brief Sets max_length and efficiency of a link, taking cable extensions into account.
          * @brief max_length is set to the sum of all cable lengths.
          * @brief efficiency is set to the product of all efficiencies multiplied together.

--- a/src/item.h
+++ b/src/item.h
@@ -2820,9 +2820,12 @@ class item : public visitable
         VisitResponse visit_contents( const std::function<VisitResponse( item *, item * )> &func,
                                       item *parent = nullptr );
         void remove_internal( const std::function<bool( item & )> &filter,
-                              int &count, std::list<item> &res );
+                              int &count, std::list<item> &res, Character *carrier = nullptr );
+        item remove_item( item &it, Character *carrier = nullptr );
         std::list<item> remove_items_with( const std::function<bool( const item & )> &filter,
                                            int count = INT_MAX ) override;
+        std::list<item> remove_items_with( Character *carrier,
+                                           const std::function<bool( const item &e )> &filter, int count );
 
         /** returns a list of pointers to all top-level items that are not mods */
         std::list<const item *> all_items_top() const;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2366,10 +2366,10 @@ units::volume item_contents::get_nested_content_volume_recursive( const
 }
 
 void item_contents::remove_internal( const std::function<bool( item & )> &filter,
-                                     int &count, std::list<item> &res, Character *carrier )
+                                     int &count, std::list<item> &res )
 {
     for( item_pocket &pocket : contents ) {
-        if( pocket.remove_internal( filter, count, res, carrier ) ) {
+        if( pocket.remove_internal( filter, count, res ) ) {
             return;
         }
     }

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -2366,10 +2366,10 @@ units::volume item_contents::get_nested_content_volume_recursive( const
 }
 
 void item_contents::remove_internal( const std::function<bool( item & )> &filter,
-                                     int &count, std::list<item> &res )
+                                     int &count, std::list<item> &res, Character *carrier )
 {
     for( item_pocket &pocket : contents ) {
-        if( pocket.remove_internal( filter, count, res ) ) {
+        if( pocket.remove_internal( filter, count, res, carrier ) ) {
             return;
         }
     }

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1589,6 +1589,20 @@ item *item_contents::get_item_with( const std::function<bool( const item &it )> 
     return nullptr;
 }
 
+const item *item_contents::get_item_with( const std::function<bool( const item &it )> &filter ) const
+{
+    for( const item_pocket &pocket : contents ) {
+        if( pocket.is_type( item_pocket::pocket_type::CABLE ) ) {
+            continue;
+        }
+        const item *it = pocket.get_item_with( filter );
+        if( it != nullptr ) {
+            return it;
+        }
+    }
+    return nullptr;
+}
+
 void item_contents::remove_items_if( const std::function<bool( item & )> &filter )
 {
     for( item_pocket &pocket : contents ) {

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1589,7 +1589,8 @@ item *item_contents::get_item_with( const std::function<bool( const item &it )> 
     return nullptr;
 }
 
-const item *item_contents::get_item_with( const std::function<bool( const item &it )> &filter ) const
+const item *item_contents::get_item_with( const std::function<bool( const item &it )> &filter )
+const
 {
     for( const item_pocket &pocket : contents ) {
         if( pocket.is_type( item_pocket::pocket_type::CABLE ) ) {

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -352,7 +352,7 @@ class item_contents
         VisitResponse visit_contents( const std::function<VisitResponse( item *, item * )> &func,
                                       item *parent = nullptr );
         void remove_internal( const std::function<bool( item & )> &filter,
-                              int &count, std::list<item> &res, Character *carrier = nullptr );
+                              int &count, std::list<item> &res );
 
         void info( std::vector<iteminfo> &info, const iteminfo_query *parts ) const;
 

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -320,6 +320,7 @@ class item_contents
         const item &only_item() const;
         const item &first_item() const;
         item *get_item_with( const std::function<bool( const item & )> &filter );
+        const item *get_item_with( const std::function<bool( const item & )> &filter ) const;
         void remove_items_if( const std::function<bool( item & )> &filter );
 
         // whether the contents has a pocket with the associated type

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -352,7 +352,7 @@ class item_contents
         VisitResponse visit_contents( const std::function<VisitResponse( item *, item * )> &func,
                                       item *parent = nullptr );
         void remove_internal( const std::function<bool( item & )> &filter,
-                              int &count, std::list<item> &res );
+                              int &count, std::list<item> &res, Character *carrier = nullptr );
 
         void info( std::vector<iteminfo> &info, const iteminfo_query *parts ) const;
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -633,7 +633,9 @@ class item_location::impl::item_in_container : public item_location::impl
         }
 
         void remove_item() override {
-            container->remove_item( *target() );
+            Character *carrier = where_recursive() != type::character ? nullptr :
+                                 get_creature_tracker().creature_at<Character>( position() );
+            container->remove_item( *target(), carrier );
             container->on_contents_changed();
         }
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -633,9 +633,7 @@ class item_location::impl::item_in_container : public item_location::impl
         }
 
         void remove_item() override {
-            Character *carrier = where_recursive() != type::character ? nullptr :
-                                 get_creature_tracker().creature_at<Character>( position() );
-            container->remove_item( *target(), carrier );
+            container->remove_item( *target() );
             container->on_contents_changed();
         }
 

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2065,13 +2065,10 @@ void item_pocket::add( const item &it, item **ret )
     }
 }
 
-void item_pocket::add( const item &it, const int copies, item **ret )
+void item_pocket::add( const item &it, const int copies, std::vector<item *> &added )
 {
-    std::list<item>::iterator first = contents.insert( contents.end(), copies, it );
-    if( ret == nullptr ) {
-        restack();
-    } else {
-        *ret = restack( &*first );
+    for( auto iter = contents.insert( contents.end(), copies, it ); iter != contents.end(); iter++ ) {
+        added.push_back( &*iter );
     }
 }
 

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1715,7 +1715,7 @@ bool item_pocket::remove_internal( const std::function<bool( item & )> &filter,
     for( auto it = contents.begin(); it != contents.end(); ) {
         if( filter( *it ) ) {
             if( carrier ) {
-                carrier->remove_from_inv_search_cache( *it );
+                carrier->remove_from_inv_search_caches( *it );
             }
             res.splice( res.end(), contents, it++ );
             if( --count == 0 ) {

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1917,6 +1917,16 @@ item *item_pocket::get_item_with( const std::function<bool( const item & )> &fil
     return nullptr;
 }
 
+const item *item_pocket::get_item_with( const std::function<bool( const item & )> &filter ) const
+{
+    for( const item &it : contents ) {
+        if( filter( it ) ) {
+            return &it;
+        }
+    }
+    return nullptr;
+}
+
 void item_pocket::remove_items_if( const std::function<bool( item & )> &filter )
 {
     contents.remove_if( filter );

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1710,16 +1710,19 @@ std::optional<item> item_pocket::remove_item( const item &it )
 }
 
 bool item_pocket::remove_internal( const std::function<bool( item & )> &filter,
-                                   int &count, std::list<item> &res )
+                                   int &count, std::list<item> &res, Character *carrier )
 {
     for( auto it = contents.begin(); it != contents.end(); ) {
         if( filter( *it ) ) {
+            if( carrier ) {
+                carrier->remove_from_flagged_item_cache( *it );
+            }
             res.splice( res.end(), contents, it++ );
             if( --count == 0 ) {
                 return true;
             }
         } else {
-            it->remove_internal( filter, count, res );
+            it->remove_internal( filter, count, res, carrier );
             ++it;
         }
     }

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1710,19 +1710,16 @@ std::optional<item> item_pocket::remove_item( const item &it )
 }
 
 bool item_pocket::remove_internal( const std::function<bool( item & )> &filter,
-                                   int &count, std::list<item> &res, Character *carrier )
+                                   int &count, std::list<item> &res )
 {
     for( auto it = contents.begin(); it != contents.end(); ) {
         if( filter( *it ) ) {
-            if( carrier ) {
-                carrier->remove_from_inv_search_caches( *it );
-            }
             res.splice( res.end(), contents, it++ );
             if( --count == 0 ) {
                 return true;
             }
         } else {
-            it->remove_internal( filter, count, res, carrier );
+            it->remove_internal( filter, count, res );
             ++it;
         }
     }

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1715,7 +1715,7 @@ bool item_pocket::remove_internal( const std::function<bool( item & )> &filter,
     for( auto it = contents.begin(); it != contents.end(); ) {
         if( filter( *it ) ) {
             if( carrier ) {
-                carrier->remove_from_flagged_item_cache( *it );
+                carrier->remove_from_inv_search_cache( *it );
             }
             res.splice( res.end(), contents, it++ );
             if( --count == 0 ) {

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -310,6 +310,7 @@ class item_pocket
         void clear_items();
         bool has_item( const item &it ) const;
         item *get_item_with( const std::function<bool( const item & )> &filter );
+        const item *get_item_with( const std::function<bool( const item & )> &filter ) const;
         void remove_items_if( const std::function<bool( item & )> &filter );
         /**
          * Is part of the recursive call of item::process. see that function for additional comments

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -365,7 +365,7 @@ class item_pocket
 
         // this is used for the visitable interface. returns true if no further visiting is required
         bool remove_internal( const std::function<bool( item & )> &filter,
-                              int &count, std::list<item> &res, Character *carrier = nullptr );
+                              int &count, std::list<item> &res );
         // @relates visitable
         VisitResponse visit_contents( const std::function<VisitResponse( item *, item * )> &func,
                                       item *parent = nullptr );

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -365,7 +365,7 @@ class item_pocket
 
         // this is used for the visitable interface. returns true if no further visiting is required
         bool remove_internal( const std::function<bool( item & )> &filter,
-                              int &count, std::list<item> &res );
+                              int &count, std::list<item> &res, Character *carrier = nullptr );
         // @relates visitable
         VisitResponse visit_contents( const std::function<VisitResponse( item *, item * )> &func,
                                       item *parent = nullptr );

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -336,7 +336,7 @@ class item_pocket
           * may create a new pocket
           */
         void add( const item &it, item **ret = nullptr );
-        void add( const item &it, int copies, item **ret );
+        void add( const item &it, int copies, std::vector<item *> &added );
         bool can_unload_liquid() const;
 
         int fill_with( const item &contained, Character &guy, int amount = 0,

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4307,7 +4307,7 @@ std::optional<int> iuse::portable_game( Character *p, item *it, const tripoint &
                 p->add_msg_if_player( _( "You and your friend play on your %s for a while." ), it_name );
             }
             for( npc *n : friends_w_game ) {
-                std::vector<item *> nit = n->cache_get_items_with( it->typeId(), [&it]( const item & i ) {
+                std::vector<item *> nit = n->cache_get_items_with( it->typeId(), []( const item & i ) {
                     return i.ammo_sufficient( nullptr );
                 } );
                 n->assign_activity( game_act );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7363,7 +7363,7 @@ std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint & 
             }
         }
 
-        std::set<item *> radio_containers = p->all_items_with_flag( flag_RADIO_CONTAINER );
+        std::set<item *> radio_containers = p->all_items_with( flag_RADIO_CONTAINER );
 
         for( item *items : radio_containers ) {
             item *itm = items->get_item_with( [&]( const item & c ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2360,7 +2360,7 @@ std::optional<int> iuse::rm13armor_off( Character *p, item *it, const tripoint &
         p->add_msg_if_player( _( "Vision enhancement system:      ONLINE." ) );
         p->add_msg_if_player( _( "Electro-reactive armor system:  ONLINE." ) );
         p->add_msg_if_player( _( "All systems nominal." ) );
-        it->convert( itype_id( oname ) ).active = true;
+        it->convert( itype_id( oname ), p ).active = true;
         p->calc_encumbrance();
         return 1;
     }
@@ -2382,7 +2382,7 @@ std::optional<int> iuse::rm13armor_on( Character *p, item *it, const tripoint & 
         p->add_msg_if_player( _( "RivOS v2.19 shutdown sequence initiated." ) );
         p->add_msg_if_player( _( "Shutting down." ) );
         p->add_msg_if_player( _( "Your RM13 combat armor turns off." ) );
-        it->convert( itype_id( oname ) ).active = false;
+        it->convert( itype_id( oname ), p ).active = false;
         p->calc_encumbrance();
     }
     return 1;
@@ -2396,7 +2396,7 @@ std::optional<int> iuse::unpack_item( Character *p, item *it, const tripoint & )
     std::string oname = it->typeId().str() + "_on";
     p->moves -= to_moves<int>( 10_seconds );
     p->add_msg_if_player( _( "You unpack your %s for use." ), it->tname() );
-    it->convert( itype_id( oname ) ).active = false;
+    it->convert( itype_id( oname ), p ).active = false;
     // Check if unpacking led to invalid container state
     p->invalidate_inventory_validity_cache();
     return 0;
@@ -2457,7 +2457,7 @@ std::optional<int> iuse::pack_item( Character *p, item *it, const tripoint & )
         }
         p->moves -= to_moves<int>( 10_seconds );
         p->add_msg_if_player( _( "You pack your %s for storage." ), it->tname() );
-        it->convert( itype_id( oname ) ).active = false;
+        it->convert( itype_id( oname ), p ).active = false;
     }
     return 0;
 }
@@ -2493,7 +2493,7 @@ std::optional<int> iuse::water_purifier( Character *p, item *it, const tripoint 
     p->moves -= to_moves<int>( 2_seconds );
 
     for( item *water : liquids ) {
-        water->convert( itype_water_clean ).poison = 0;
+        water->convert( itype_water_clean, p ).poison = 0;
     }
     return charges_of_water;
 }
@@ -2504,7 +2504,7 @@ std::optional<int> iuse::radio_off( Character *p, item *it, const tripoint & )
         p->add_msg_if_player( _( "It's dead." ) );
     } else {
         p->add_msg_if_player( _( "You turn the radio on." ) );
-        it->convert( itype_radio_on ).active = true;
+        it->convert( itype_radio_on, p ).active = true;
     }
     return 1;
 }
@@ -3019,7 +3019,7 @@ static int toolweapon_off( Character &p, item &it, const bool fast_startup,
         }
         sounds::sound( p.pos(), volume, sounds::sound_t::combat, msg_success );
         // 4 is the length of "_off".
-        it.convert( itype_id( it.typeId().str().substr( 0, it.typeId().str().size() - 4 ) + "_on" ) );
+        it.convert( itype_id( it.typeId().str().substr( 0, it.typeId().str().size() - 4 ) + "_on" ), &p );
         it.active = true;
         return 1;
     } else {
@@ -3109,7 +3109,7 @@ static int toolweapon_running( Character *p, item &it, const tripoint &pos,
         if( p ) {
             p->add_msg_if_player( _( "Your %s gurgles in the water and stops." ), it.tname() );
         }
-        it.convert( *it.type->revert_to ).active = false;
+        it.convert( *it.type->revert_to, p ).active = false;
     } else if( one_in( sound_chance ) ) {
         sounds::ambient_sound( pos, volume, sounds::sound_t::activity, sound );
     }
@@ -3125,7 +3125,7 @@ std::optional<int> iuse::toolweapon_deactivate( Character *p, item *it, const tr
         sfx::fade_audio_channel( sfx::channel::chainsaw_theme, 3000 );
     }
     p->add_msg_if_player( _( "Your %s goes quiet." ), it->tname() );
-    it->convert( *it->type->revert_to ).active = false;
+    it->convert( *it->type->revert_to, p ).active = false;
     return 0; // Don't consume charges when turning off.
 }
 
@@ -3370,7 +3370,7 @@ std::optional<int> iuse::geiger( Character *p, item *it, const tripoint & )
             break;
         case 2:
             p->add_msg_if_player( _( "The geiger counter's scan LED turns on." ) );
-            it->convert( itype_geiger_on ).active = true;
+            it->convert( itype_geiger_on, p ).active = true;
             break;
         default:
             return std::nullopt;
@@ -3692,7 +3692,7 @@ std::optional<int> iuse::molotov_lit( Character *p, item *it, const tripoint &po
     // 20% chance of going out harmlessly.
     if( one_in( 5 ) ) {
         p->add_msg_if_player( _( "Your lit Molotov goes out." ) );
-        it->convert( itype_molotov ).active = false;
+        it->convert( itype_molotov, p ).active = false;
     }
     return 0;
 }
@@ -3707,7 +3707,7 @@ std::optional<int> iuse::firecracker_pack( Character *p, item *it, const tripoin
         return std::nullopt;
     }
     p->add_msg_if_player( _( "You light the pack of firecrackers." ) );
-    it->convert( itype_firecracker_pack_act );
+    it->convert( itype_firecracker_pack_act, p );
     it->countdown_point = calendar::turn + 27_seconds;
     it->set_age( 0_turns );
     it->active = true;
@@ -3744,7 +3744,7 @@ std::optional<int> iuse::firecracker( Character *p, item *it, const tripoint & )
         return std::nullopt;
     }
     p->add_msg_if_player( _( "You light the firecracker." ) );
-    it->convert( itype_firecracker_act );
+    it->convert( itype_firecracker_act, p );
     it->countdown_point = calendar::turn + 2_seconds;
     it->active = true;
     return 1;
@@ -3761,7 +3761,7 @@ std::optional<int> iuse::mininuke( Character *p, item *it, const tripoint & )
     p->add_msg_if_player( _( "You set the timer to %s." ),
                           to_string( time_duration::from_turns( time ) ) );
     get_event_bus().send<event_type::activates_mininuke>( p->getID() );
-    it->convert( itype_mininuke_act );
+    it->convert( itype_mininuke_act, p );
     it->countdown_point = calendar::turn + time_duration::from_seconds( time );
     it->active = true;
     return 1;
@@ -3888,7 +3888,7 @@ std::optional<int> iuse::shocktonfa_off( Character *p, item *it, const tripoint 
                 return std::nullopt;
             } else {
                 p->add_msg_if_player( _( "You turn the light on." ) );
-                it->convert( itype_shocktonfa_on ).active = true;
+                it->convert( itype_shocktonfa_on, p ).active = true;
                 return 1;
             }
         }
@@ -3904,7 +3904,7 @@ std::optional<int> iuse::shocktonfa_on( Character *p, item *it, const tripoint &
     } else {
         if( !it->ammo_sufficient( p ) ) {
             p->add_msg_if_player( m_info, _( "Your tactical tonfa is out of power." ) );
-            it->convert( itype_shocktonfa_off ).active = false;
+            it->convert( itype_shocktonfa_off, p ).active = false;
         } else {
             int choice = uilist( _( "tactical tonfa" ), {
                 _( "Zap something" ), _( "Turn off light" )
@@ -3916,7 +3916,7 @@ std::optional<int> iuse::shocktonfa_on( Character *p, item *it, const tripoint &
                 }
                 case 1: {
                     p->add_msg_if_player( _( "You turn off the light." ) );
-                    it->convert( itype_shocktonfa_off ).active = false;
+                    it->convert( itype_shocktonfa_off, p ).active = false;
                 }
             }
         }
@@ -3936,13 +3936,13 @@ std::optional<int> iuse::mp3( Character *p, item *it, const tripoint & )
     } else {
         p->add_msg_if_player( m_info, _( "You put in the earbuds and start listening to music." ) );
         if( it->typeId() == itype_mp3 ) {
-            it->convert( itype_mp3_on ).active = true;
+            it->convert( itype_mp3_on, p ).active = true;
         } else if( it->typeId() == itype_smart_phone ) {
-            it->convert( itype_smartphone_music ).active = true;
+            it->convert( itype_smartphone_music, p ).active = true;
         } else if( it->typeId() == itype_afs_atomic_smartphone ) {
-            it->convert( itype_afs_atomic_smartphone_music ).active = true;
+            it->convert( itype_afs_atomic_smartphone_music, p ).active = true;
         } else if( it->typeId() == itype_afs_wraitheon_smartphone ) {
-            it->convert( itype_afs_atomic_wraitheon_music ).active = true;
+            it->convert( itype_afs_atomic_wraitheon_music, p ).active = true;
         }
         p->mod_moves( -200 );
     }
@@ -4027,16 +4027,16 @@ std::optional<int> iuse::mp3_deactivate( Character *p, item *it, const tripoint 
 
     if( it->typeId() == itype_mp3_on ) {
         p->add_msg_if_player( _( "The mp3 player turns off." ) );
-        it->convert( itype_mp3 ).active = false;
+        it->convert( itype_mp3, p ).active = false;
     } else if( it->typeId() == itype_smartphone_music ) {
         p->add_msg_if_player( _( "The phone turns off." ) );
-        it->convert( itype_smart_phone ).active = false;
+        it->convert( itype_smart_phone, p ).active = false;
     } else if( it->typeId() == itype_afs_atomic_smartphone_music ) {
         p->add_msg_if_player( _( "The phone turns off." ) );
-        it->convert( itype_afs_atomic_smartphone ).active = false;
+        it->convert( itype_afs_atomic_smartphone, p ).active = false;
     } else if( it->typeId() == itype_afs_atomic_wraitheon_music ) {
         p->add_msg_if_player( _( "The phone turns off." ) );
-        it->convert( itype_afs_wraitheon_smartphone ).active = false;
+        it->convert( itype_afs_wraitheon_smartphone, p ).active = false;
     }
     p->mod_moves( -200 );
     music::deactivate_music_id( music::music_id::mp3 );
@@ -4139,7 +4139,7 @@ std::optional<int> iuse::solarpack( Character *p, item *it, const tripoint & )
     p->add_msg_if_player(
         _( "You unfold the solar array from the pack.  You still need to connect it with a cable." ) );
 
-    it->convert( itype_id( it->typeId().str() + "_on" ) );
+    it->convert( itype_id( it->typeId().str() + "_on" ), p );
     return 0;
 }
 
@@ -4160,7 +4160,7 @@ std::optional<int> iuse::solarpack_off( Character *p, item *it, const tripoint &
 
     // 3 = "_on"
     it->convert( itype_id( it->typeId().str().substr( 0,
-                           it->typeId().str().size() - 3 ) ) ).active = false;
+                           it->typeId().str().size() - 3 ) ), p ).active = false;
     p->process_items(); // Process carried items to disconnect any connected cables
     return 0;
 }
@@ -4494,7 +4494,7 @@ std::optional<int> iuse::vortex( Character *p, item *it, const tripoint & )
         }
         p->add_msg_if_player( m_warning, _( "Air swirls all over…" ) );
         p->moves -= to_moves<int>( 1_seconds );
-        it->convert( itype_spiral_stone );
+        it->convert( itype_spiral_stone, p );
         mon->friendly = -1;
         return 1;
     }
@@ -5080,7 +5080,7 @@ static bool heat_item( Character &p )
 std::optional<int> iuse::heatpack( Character *p, item *it, const tripoint & )
 {
     if( heat_item( *p ) ) {
-        it->convert( itype_heatpack_used );
+        it->convert( itype_heatpack_used, p );
     }
     return 0;
 }
@@ -5182,7 +5182,7 @@ int iuse::towel_common( Character *p, item *it, bool )
         if( it && it->typeId() == itype_towel ) {
             it->item_counter = to_turns<int>( 30_minutes );
             // change "towel" to a "towel_wet" (different flavor text/color)
-            it->convert( itype_towel_wet );
+            it->convert( itype_towel_wet, p );
         }
 
         // default message
@@ -7171,7 +7171,7 @@ std::optional<int> iuse::radiocar( Character *p, item *it, const tripoint & )
             return std::nullopt;
         }
 
-        it->convert( itype_radio_car_on ).active = true;
+        it->convert( itype_radio_car_on, p ).active = true;
 
         p->add_msg_if_player(
             _( "You turned on your RC car; now place it on the ground, and use your radio control to play." ) );
@@ -7227,7 +7227,7 @@ std::optional<int> iuse::radiocaron( Character *p, item *it, const tripoint & )
 {
     if( !it->ammo_sufficient( p ) ) {
         // Deactivate since other mode has an iuse too.
-        it->convert( itype_radio_car ).active = false;
+        it->convert( itype_radio_car, p ).active = false;
         return 0;
     }
 
@@ -7240,7 +7240,7 @@ std::optional<int> iuse::radiocaron( Character *p, item *it, const tripoint & )
     }
 
     if( choice == 0 ) {
-        it->convert( itype_radio_car ).active = false;
+        it->convert( itype_radio_car, p ).active = false;
 
         p->add_msg_if_player( _( "You turned off your RC car." ) );
         return 1;
@@ -7711,7 +7711,7 @@ std::optional<int> iuse::multicooker( Character *p, item *it, const tripoint &po
             it->erase_var( "DISH" );
             it->erase_var( "COOKTIME" );
             it->erase_var( "RECIPE" );
-            it->convert( itype_multi_cooker );
+            it->convert( itype_multi_cooker, p );
         }
         return 0;
     }
@@ -7830,7 +7830,7 @@ std::optional<int> iuse::multicooker( Character *p, item *it, const tripoint &po
             p->add_msg_if_player( m_good,
                                   _( "The screen flashes blue symbols and scales as the multi-cooker begins to shake." ) );
 
-            it->convert( itype_multi_cooker_filled ).active = true;
+            it->convert( itype_multi_cooker_filled, p ).active = true;
             it->ammo_consume( charges_to_start - charge_buffer, pos, p );
 
             p->practice( skill_cooking, meal->difficulty * 3 ); //little bonus
@@ -7917,7 +7917,7 @@ std::optional<int> iuse::multicooker_tick( Character *p, item *it, const tripoin
     if( it->ammo_remaining( p, true ) < charge_buffer ) {
         it->active = false;
         it->erase_var( "RECIPE" );
-        it->convert( itype_multi_cooker );
+        it->convert( itype_multi_cooker, p );
         //drain the buffer amount given at activation
         it->ammo_consume( charge_buffer, pos, p );
         p->add_msg_if_player( m_info,
@@ -7951,7 +7951,7 @@ std::optional<int> iuse::multicooker_tick( Character *p, item *it, const tripoin
 
         it->active = false;
         it->erase_var( "COOKTIME" );
-        it->convert( itype_multi_cooker );
+        it->convert( itype_multi_cooker, p );
         if( it->can_contain( meal ).success() ) {
             it->put_in( meal, item_pocket::pocket_type::CONTAINER );
         } else {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7363,9 +7363,9 @@ std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint & 
             }
         }
 
-        if( p->has_any_item_with( flag_RADIO_CONTAINER, [&p, &signal]( item & it ) {
-        item *itm = it.get_item_with( [&]( const item & c ) {
-            return c.has_flag( flag_BOMB ) && c.has_flag( signal );
+        if( p->has_any_item_with( flag_RADIO_CONTAINER, [&p, &signal]( const item & it ) {
+        item *itm = const_cast<item &>( it ).get_item_with( [&]( const item & c ) {
+                return c.has_flag( flag_BOMB ) && c.has_flag( signal );
             } );
 
             if( itm != nullptr ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7353,25 +7353,26 @@ std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint & 
     } else {
         const flag_id signal( "RADIOSIGNAL_" + std::to_string( choice ) );
 
-        auto item_list = p->get_radio_items();
-        for( item *&elem : item_list ) {
-            if( elem->has_flag( flag_BOMB ) && elem->has_flag( signal ) ) {
+        if( p->has_any_item_with( flag_RADIO_ACTIVATION, [&p,&signal]( const item & it ) {
+            if( it.has_flag( flag_BOMB ) && it.has_flag( signal ) ) {
                 p->add_msg_if_player( m_warning,
-                                      _( "The %s in your inventory would explode on this signal.  Place it down before sending the signal." ),
-                                      elem->display_name() );
-                return std::nullopt;
+                    _( "The %s in your inventory would explode on this signal.  Place it down before sending the signal." ),
+                    it.display_name() );
+                    return true;
             }
+            return false;
+        } ) ) {
+            return std::nullopt;
         }
 
-        if( p->has_any_item_with( flag_RADIO_CONTAINER, [&p, &signal]( const item & it ) {
-        item *itm = const_cast<item &>( it ).get_item_with( [&]( const item & c ) {
+        if( p->has_any_item_with( flag_RADIO_CONTAINER, [&p,&signal]( const item & it ) {
+            const item *rad_cont = it.get_item_with( [&signal]( const item & c ) {
                 return c.has_flag( flag_BOMB ) && c.has_flag( signal );
             } );
-
-            if( itm != nullptr ) {
+            if( rad_cont != nullptr ) {
                 p->add_msg_if_player( m_warning,
                                       _( "The %1$s in your %2$s would explode on this signal.  Place it down before sending the signal." ),
-                                      itm->display_name(), it.display_name() );
+                                      rad_cont->display_name(), it.display_name() );
                 return true;
             }
             return false;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7363,9 +7363,7 @@ std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint & 
             }
         }
 
-        std::set<item *> radio_containers = p->all_items_with( flag_RADIO_CONTAINER );
-
-        for( item *items : radio_containers ) {
+        for( item *items : p->all_items_with( flag_RADIO_CONTAINER ) ) {
             item *itm = items->get_item_with( [&]( const item & c ) {
                 return c.has_flag( flag_BOMB ) && c.has_flag( signal );
             } );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7363,17 +7363,19 @@ std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint & 
             }
         }
 
-        for( item *items : p->all_items_with( flag_RADIO_CONTAINER ) ) {
-            item *itm = items->get_item_with( [&]( const item & c ) {
-                return c.has_flag( flag_BOMB ) && c.has_flag( signal );
+        if( p->do_to_items_with_until( flag_RADIO_CONTAINER, [&p, &signal]( item & it ) {
+        item *itm = it.get_item_with( [&]( const item & c ) {
+            return c.has_flag( flag_BOMB ) && c.has_flag( signal );
             } );
 
             if( itm != nullptr ) {
                 p->add_msg_if_player( m_warning,
                                       _( "The %1$s in your %2$s would explode on this signal.  Place it down before sending the signal." ),
-                                      itm->display_name(), items->display_name() );
-                return std::nullopt;
+                                      itm->display_name(), it.display_name() );
+                return true;
             }
+        } ) ) {
+            return std::nullopt;
         }
 
         p->add_msg_if_player( _( "Click." ) );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -458,7 +458,7 @@ void remove_radio_mod( item &it, Character &p )
 // Checks that the player can smoke
 std::optional<std::string> iuse::can_smoke( const Character &you )
 {
-    auto cigs = you.all_items_with( flag_LITCIG, []( const item & it ) {
+    auto cigs = you.cache_get_items_with( flag_LITCIG, []( const item & it ) {
         return it.active;
     } );
 
@@ -2512,7 +2512,7 @@ std::optional<int> iuse::radio_off( Character *p, item *it, const tripoint & )
 std::optional<int> iuse::directional_antenna( Character *p, item *, const tripoint & )
 {
     // Find out if we have an active radio
-    auto radios = p->all_items_with( itype_radio_on );
+    auto radios = p->cache_get_items_with( itype_radio_on );
     // If we don't wield the radio, also check on the ground
     if( radios.empty() ) {
         map_stack items = get_map().i_at( p->pos() );
@@ -4307,7 +4307,7 @@ std::optional<int> iuse::portable_game( Character *p, item *it, const tripoint &
                 p->add_msg_if_player( _( "You and your friend play on your %s for a while." ), it_name );
             }
             for( npc *n : friends_w_game ) {
-                std::vector<item *> nit = n->all_items_with( it->typeId(), [&it]( const item & i ) {
+                std::vector<item *> nit = n->cache_get_items_with( it->typeId(), [&it]( const item & i ) {
                     return i.ammo_sufficient( nullptr );
                 } );
                 n->assign_activity( game_act );
@@ -7351,7 +7351,7 @@ std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint & 
     } else {
         const flag_id signal( "RADIOSIGNAL_" + std::to_string( choice ) );
 
-        if( p->has_any_item_with( flag_BOMB, [&p, &signal]( const item & it ) {
+        if( p->cache_has_item_with( flag_BOMB, [&p, &signal]( const item & it ) {
         if( it.has_flag( flag_RADIO_ACTIVATION ) && it.has_flag( signal ) ) {
                 p->add_msg_if_player( m_warning,
                                       _( "The %s in your inventory would explode on this signal.  Place it down before sending the signal." ),
@@ -7363,7 +7363,7 @@ std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint & 
             return std::nullopt;
         }
 
-        if( p->has_any_item_with( flag_RADIO_CONTAINER, [&p, &signal]( const item & it ) {
+        if( p->cache_has_item_with( flag_RADIO_CONTAINER, [&p, &signal]( const item & it ) {
         const item *rad_cont = it.get_item_with( [&signal]( const item & c ) {
             return c.has_flag( flag_BOMB ) && c.has_flag( signal );
             } );

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7363,9 +7363,7 @@ std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint & 
             }
         }
 
-        std::vector<item *> radio_containers = p->items_with( []( const item & itm ) {
-            return itm.has_flag( flag_RADIO_CONTAINER );
-        } );
+        std::set<item *> radio_containers = p->all_items_with_flag( flag_RADIO_CONTAINER );
 
         for( item *items : radio_containers ) {
             item *itm = items->get_item_with( [&]( const item & c ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -7363,7 +7363,7 @@ std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint & 
             }
         }
 
-        if( p->do_to_items_with_until( flag_RADIO_CONTAINER, [&p, &signal]( item & it ) {
+        if( p->has_any_item_with( flag_RADIO_CONTAINER, [&p, &signal]( item & it ) {
         item *itm = it.get_item_with( [&]( const item & c ) {
             return c.has_flag( flag_BOMB ) && c.has_flag( signal );
             } );
@@ -7374,6 +7374,7 @@ std::optional<int> iuse::radiocontrol( Character *p, item *it, const tripoint & 
                                       itm->display_name(), it.display_name() );
                 return true;
             }
+            return false;
         } ) ) {
             return std::nullopt;
         }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4451,7 +4451,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
             }
         }
         if( targets.count( link_state::ups ) > 0 ) {
-            if( !( p->all_items_with_flag( flag_IS_UPS ) ).empty() ) {
+            if( !( p->all_items_with( flag_IS_UPS ) ).empty() ) {
                 link_menu.addentry( 21, has_loose_end, -1, _( "Attach to UPS" ) );
             }
         }
@@ -4543,7 +4543,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
             link_menu.addentry( 20, has_loose_end && !it.link->has_state( link_state::bio_cable ),
                                 -1, _( "Attach loose end to Cable Charger System CBM" ) );
         }
-        if( targets.count( link_state::ups ) > 0 && !( p->all_items_with_flag( flag_IS_UPS ) ).empty() ) {
+        if( targets.count( link_state::ups ) > 0 && !( p->all_items_with( flag_IS_UPS ) ).empty() ) {
             link_menu.addentry( 21, has_loose_end && it.link->has_state( link_state::bio_cable ),
                                 -1, _( "Attach loose end to UPS" ) );
         }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4450,7 +4450,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
                 link_menu.addentry( 20, has_loose_end, -1, _( "Attach to Cable Charger System CBM" ) );
             }
         }
-        if( targets.count( link_state::ups ) > 0 && p->has_any_item_with( flag_IS_UPS ) ) {
+        if( targets.count( link_state::ups ) > 0 && p->cache_has_item_with( flag_IS_UPS ) ) {
             link_menu.addentry( 21, has_loose_end, -1, _( "Attach to UPS" ) );
         }
         if( targets.count( link_state::solarpack ) > 0 ) {
@@ -4541,7 +4541,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
             link_menu.addentry( 20, has_loose_end && !it.link->has_state( link_state::bio_cable ),
                                 -1, _( "Attach loose end to Cable Charger System CBM" ) );
         }
-        if( targets.count( link_state::ups ) > 0 && p->has_any_item_with( flag_IS_UPS ) ) {
+        if( targets.count( link_state::ups ) > 0 && p->cache_has_item_with( flag_IS_UPS ) ) {
             link_menu.addentry( 21, has_loose_end && it.link->has_state( link_state::bio_cable ),
                                 -1, _( "Attach loose end to UPS" ) );
         }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5080,7 +5080,7 @@ std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
                 return false;
             }
             if( !inv.has_flag( flag_CABLE_SPOOL ) ) {
-                return can_extend_devices && inv.type->can_use( "link_up" );
+                return can_extend_devices && inv.can_link_up();
             }
             return can_extend.find( inv.typeId().c_str() ) != can_extend.end() && &inv != &it;
         };
@@ -5088,7 +5088,7 @@ std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
                    _( "You don't have a compatible cable." ) );
     } else {
         const auto filter = [&it]( const item & inv ) {
-            if( !inv.has_flag( flag_CABLE_SPOOL ) || !inv.type->can_use( "link_up" ) ||
+            if( !inv.has_flag( flag_CABLE_SPOOL ) || !inv.can_link_up() ||
                 ( inv.link && ( it.link_length() >= 0 || inv.link->has_state( link_state::needs_reeling ) ) ) ) {
                 return false;
             }
@@ -5178,7 +5178,7 @@ std::optional<int> link_up_actor::remove_extensions( Character *p, item &it ) co
 {
     std::list<item *> all_cables = it.all_items_ptr( item_pocket::pocket_type::CABLE );
     all_cables.remove_if( []( const item * cable ) {
-        return !cable->has_flag( flag_CABLE_SPOOL ) || !cable->type->can_use( "link_up" );
+        return !cable->has_flag( flag_CABLE_SPOOL ) || !cable->can_link_up();
     } );
 
     if( all_cables.empty() ) {

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4450,10 +4450,8 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
                 link_menu.addentry( 20, has_loose_end, -1, _( "Attach to Cable Charger System CBM" ) );
             }
         }
-        if( targets.count( link_state::ups ) > 0 ) {
-            if( !( p->all_items_with( flag_IS_UPS ) ).empty() ) {
-                link_menu.addentry( 21, has_loose_end, -1, _( "Attach to UPS" ) );
-            }
+        if( targets.count( link_state::ups ) > 0 && p->has_item_with_flag( flag_IS_UPS ) ) {
+            link_menu.addentry( 21, has_loose_end, -1, _( "Attach to UPS" ) );
         }
         if( targets.count( link_state::solarpack ) > 0 ) {
             const bool has_solar_pack_on = p->worn_with_flag( flag_SOLARPACK_ON );
@@ -4543,7 +4541,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
             link_menu.addentry( 20, has_loose_end && !it.link->has_state( link_state::bio_cable ),
                                 -1, _( "Attach loose end to Cable Charger System CBM" ) );
         }
-        if( targets.count( link_state::ups ) > 0 && !( p->all_items_with( flag_IS_UPS ) ).empty() ) {
+        if( targets.count( link_state::ups ) > 0 && p->has_item_with_flag( flag_IS_UPS ) ) {
             link_menu.addentry( 21, has_loose_end && it.link->has_state( link_state::bio_cable ),
                                 -1, _( "Attach loose end to UPS" ) );
         }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -285,7 +285,7 @@ void iuse_transform::do_transform( Character *p, item &it ) const
     // defined here to allow making a new item assigned to the pointer
     item obj_it;
     if( container.is_empty() ) {
-        obj = &it.convert( target );
+        obj = &it.convert( target, p );
         if( ammo_qty >= 0 || !random_ammo_qty.empty() ) {
             int qty;
             if( !random_ammo_qty.empty() ) {
@@ -307,7 +307,7 @@ void iuse_transform::do_transform( Character *p, item &it ) const
             }
         }
     } else {
-        obj = &it.convert( container );
+        obj = &it.convert( container, p );
         int count = std::max( ammo_qty, 1 );
         item cont;
         if( target->count_by_charges() ) {
@@ -1881,7 +1881,7 @@ std::optional<int> fireweapon_off_actor::use( Character *p, item &it,
             p->add_msg_if_player( "%s", success_message );
         }
 
-        it.convert( target_id );
+        it.convert( target_id, p );
         it.active = true;
     } else if( !failure_message.empty() ) {
         p->add_msg_if_player( m_bad, "%s", failure_message );
@@ -3435,7 +3435,7 @@ int heal_actor::finish_using( Character &healer, Character &patient, item &it,
         // If the item is a tool, `make` it the new form
         // Otherwise it probably was consumed, so create a new one
         if( it.is_tool() ) {
-            it.convert( used_up_item_id );
+            it.convert( used_up_item_id, &healer );
             for( const auto &flag : used_up_item_flags ) {
                 it.set_flag( flag );
             }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4450,7 +4450,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
                 link_menu.addentry( 20, has_loose_end, -1, _( "Attach to Cable Charger System CBM" ) );
             }
         }
-        if( targets.count( link_state::ups ) > 0 && p->has_item_with_flag( flag_IS_UPS ) ) {
+        if( targets.count( link_state::ups ) > 0 && p->has_any_item_with( flag_IS_UPS ) ) {
             link_menu.addentry( 21, has_loose_end, -1, _( "Attach to UPS" ) );
         }
         if( targets.count( link_state::solarpack ) > 0 ) {
@@ -4541,7 +4541,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
             link_menu.addentry( 20, has_loose_end && !it.link->has_state( link_state::bio_cable ),
                                 -1, _( "Attach loose end to Cable Charger System CBM" ) );
         }
-        if( targets.count( link_state::ups ) > 0 && p->has_item_with_flag( flag_IS_UPS ) ) {
+        if( targets.count( link_state::ups ) > 0 && p->has_any_item_with( flag_IS_UPS ) ) {
             link_menu.addentry( 21, has_loose_end && it.link->has_state( link_state::bio_cable ),
                                 -1, _( "Attach loose end to UPS" ) );
         }

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1500,7 +1500,7 @@ void talk_function::field_plant( npc &p, const std::string &place )
         popup( _( "It is too cold to plant anything now." ) );
         return;
     }
-    std::vector<item *> seed_inv = player_character.all_items_with( "is_seed", &item::is_seed,
+    std::vector<item *> seed_inv = player_character.cache_get_items_with( "is_seed", &item::is_seed,
     []( const item & itm ) {
         return itm.typeId() != itype_marloss_seed && itm.typeId() != itype_fungal_seeds;
     } );

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -1500,9 +1500,9 @@ void talk_function::field_plant( npc &p, const std::string &place )
         popup( _( "It is too cold to plant anything now." ) );
         return;
     }
-    std::vector<item *> seed_inv = player_character.items_with( []( const item & itm ) {
-        return itm.is_seed() && itm.typeId() != itype_marloss_seed &&
-               itm.typeId() != itype_fungal_seeds;
+    std::vector<item *> seed_inv = player_character.all_items_with( "is_seed", &item::is_seed,
+    []( const item & itm ) {
+        return itm.typeId() != itype_marloss_seed && itm.typeId() != itype_fungal_seeds;
     } );
     if( seed_inv.empty() ) {
         popup( _( "You have no seeds to plant!" ) );

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -386,9 +386,7 @@ void add_leash( monster &z )
         return;
     }
     Character &player_character = get_player_character();
-    std::vector<item *> rope_inv = player_character.items_with( []( const item & itm ) {
-        return itm.has_flag( json_flag_TIE_UP );
-    } );
+    std::vector<item *> rope_inv = player_character.all_items_with( json_flag_TIE_UP );
     if( rope_inv.empty() ) {
         return;
     }
@@ -535,9 +533,7 @@ void insert_battery( monster &z )
         return;
     }
     Character &player_character = get_player_character();
-    std::vector<item *> bat_inv = player_character.items_with( []( const item & itm ) {
-        return itm.has_flag( json_flag_MECH_BAT );
-    } );
+    std::vector<item *> bat_inv = player_character.all_items_with( json_flag_MECH_BAT );
     if( bat_inv.empty() ) {
         return;
     }

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -654,9 +654,7 @@ bool monexamine::pet_menu( monster &z )
         amenu.addentry( unleash, true, 'L', _( "Remove leash from %s" ), pet_name );
     }
     if( !z.has_effect( effect_leashed ) && !z.has_flag( mon_flag_RIDEABLE_MECH ) ) {
-        std::vector<item *> rope_inv = player_character.items_with( []( const item & itm ) {
-            return itm.has_flag( json_flag_TIE_UP );
-        } );
+        std::set<item *> rope_inv = player_character.all_items_with_flag( json_flag_TIE_UP );
         if( !rope_inv.empty() ) {
             amenu.addentry( leash, true, 't', _( "Attach leash to %s" ), pet_name );
         } else {

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -654,8 +654,7 @@ bool monexamine::pet_menu( monster &z )
         amenu.addentry( unleash, true, 'L', _( "Remove leash from %s" ), pet_name );
     }
     if( !z.has_effect( effect_leashed ) && !z.has_flag( mon_flag_RIDEABLE_MECH ) ) {
-        std::set<item *> &rope_inv = player_character.all_items_with( json_flag_TIE_UP );
-        if( !rope_inv.empty() ) {
+        if( player_character.has_item_with_flag( json_flag_TIE_UP ) ) {
             amenu.addentry( leash, true, 't', _( "Attach leash to %s" ), pet_name );
         } else {
             amenu.addentry( leash, false, 't', _( "You need any type of rope to leash %s" ),

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -654,7 +654,7 @@ bool monexamine::pet_menu( monster &z )
         amenu.addentry( unleash, true, 'L', _( "Remove leash from %s" ), pet_name );
     }
     if( !z.has_effect( effect_leashed ) && !z.has_flag( mon_flag_RIDEABLE_MECH ) ) {
-        std::set<item *> rope_inv = player_character.all_items_with( json_flag_TIE_UP );
+        std::set<item *> &rope_inv = player_character.all_items_with( json_flag_TIE_UP );
         if( !rope_inv.empty() ) {
             amenu.addentry( leash, true, 't', _( "Attach leash to %s" ), pet_name );
         } else {

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -386,7 +386,7 @@ void add_leash( monster &z )
         return;
     }
     Character &player_character = get_player_character();
-    std::vector<item *> rope_inv = player_character.all_items_with( json_flag_TIE_UP );
+    std::vector<item *> rope_inv = player_character.cache_get_items_with( json_flag_TIE_UP );
     if( rope_inv.empty() ) {
         return;
     }
@@ -533,7 +533,7 @@ void insert_battery( monster &z )
         return;
     }
     Character &player_character = get_player_character();
-    std::vector<item *> bat_inv = player_character.all_items_with( json_flag_MECH_BAT );
+    std::vector<item *> bat_inv = player_character.cache_get_items_with( json_flag_MECH_BAT );
     if( bat_inv.empty() ) {
         return;
     }
@@ -650,7 +650,7 @@ bool monexamine::pet_menu( monster &z )
         amenu.addentry( unleash, true, 'L', _( "Remove leash from %s" ), pet_name );
     }
     if( !z.has_effect( effect_leashed ) && !z.has_flag( mon_flag_RIDEABLE_MECH ) ) {
-        if( player_character.has_any_item_with( json_flag_TIE_UP ) ) {
+        if( player_character.cache_has_item_with( json_flag_TIE_UP ) ) {
             amenu.addentry( leash, true, 't', _( "Attach leash to %s" ), pet_name );
         } else {
             amenu.addentry( leash, false, 't', _( "You need any type of rope to leash %s" ),
@@ -686,7 +686,7 @@ bool monexamine::pet_menu( monster &z )
         }
     }
     if( z.has_flag( mon_flag_PET_MOUNTABLE ) && !z.has_effect( effect_monster_saddled ) &&
-        player_character.has_any_item_with( json_flag_TACK ) ) {
+        player_character.cache_has_item_with( json_flag_TACK ) ) {
         if( player_character.get_skill_level( skill_survival ) >= 1 ) {
             amenu.addentry( attach_saddle, true, 'h', _( "Tack up %s" ), pet_name );
         } else {

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -654,7 +654,7 @@ bool monexamine::pet_menu( monster &z )
         amenu.addentry( unleash, true, 'L', _( "Remove leash from %s" ), pet_name );
     }
     if( !z.has_effect( effect_leashed ) && !z.has_flag( mon_flag_RIDEABLE_MECH ) ) {
-        if( player_character.has_item_with_flag( json_flag_TIE_UP ) ) {
+        if( player_character.has_any_item_with( json_flag_TIE_UP ) ) {
             amenu.addentry( leash, true, 't', _( "Attach leash to %s" ), pet_name );
         } else {
             amenu.addentry( leash, false, 't', _( "You need any type of rope to leash %s" ),
@@ -690,7 +690,7 @@ bool monexamine::pet_menu( monster &z )
         }
     }
     if( z.has_flag( mon_flag_PET_MOUNTABLE ) && !z.has_effect( effect_monster_saddled ) &&
-        player_character.has_item_with_flag( json_flag_TACK ) ) {
+        player_character.has_any_item_with( json_flag_TACK ) ) {
         if( player_character.get_skill_level( skill_survival ) >= 1 ) {
             amenu.addentry( attach_saddle, true, 'h', _( "Tack up %s" ), pet_name );
         } else {

--- a/src/monexamine.cpp
+++ b/src/monexamine.cpp
@@ -654,7 +654,7 @@ bool monexamine::pet_menu( monster &z )
         amenu.addentry( unleash, true, 'L', _( "Remove leash from %s" ), pet_name );
     }
     if( !z.has_effect( effect_leashed ) && !z.has_flag( mon_flag_RIDEABLE_MECH ) ) {
-        std::set<item *> rope_inv = player_character.all_items_with_flag( json_flag_TIE_UP );
+        std::set<item *> rope_inv = player_character.all_items_with( json_flag_TIE_UP );
         if( !rope_inv.empty() ) {
             amenu.addentry( leash, true, 't', _( "Attach leash to %s" ), pet_name );
         } else {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1943,9 +1943,7 @@ void npc::decide_needs()
     needrank[need_weapon] = weapon_value( weap );
     needrank[need_food] = 15 - get_hunger();
     needrank[need_drink] = 15 - get_thirst();
-    const auto inv_food = items_with( []( const item & itm ) {
-        return itm.is_food();
-    } );
+    const std::set<item *> &inv_food = all_items_with( "IS FOOD", &item::is_food );
     for( const item *food : inv_food ) {
         needrank[ need_food ] += nutrition_for( *food ) / 4.0;
         needrank[ need_drink ] += food->get_comestible()->quench / 4.0;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -760,7 +760,7 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
     }
 
     set_wielded_item( item( "null", calendar::turn_zero ) );
-    inv->clear();
+    clear_inv();
     personality.aggression = rng( -10, 10 );
     personality.bravery    = rng( -3, 10 );
     personality.collector  = rng( -1, 10 );
@@ -1076,7 +1076,7 @@ void starting_clothes( npc &who, const npc_class_id &type, bool male )
 void starting_inv( npc &who, const npc_class_id &type )
 {
     std::list<item> res;
-    who.inv->clear();
+    who.clear_inv();
     if( item_group::group_is_defined( type->carry_override ) ) {
         *who.inv += item_group::items_from( type->carry_override );
         return;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1943,7 +1943,7 @@ void npc::decide_needs()
     needrank[need_weapon] = weapon_value( weap );
     needrank[need_food] = 15 - get_hunger();
     needrank[need_drink] = 15 - get_thirst();
-    const std::set<item *> &inv_food = all_items_with( "IS FOOD", &item::is_food );
+    const std::set<item *> &inv_food = all_items_with( "is_food", &item::is_food );
     for( const item *food : inv_food ) {
         needrank[ need_food ] += nutrition_for( *food ) / 4.0;
         needrank[ need_drink ] += food->get_comestible()->quench / 4.0;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1943,10 +1943,9 @@ void npc::decide_needs()
     needrank[need_weapon] = weapon_value( weap );
     needrank[need_food] = 15 - get_hunger();
     needrank[need_drink] = 15 - get_thirst();
-    const std::set<item *> &inv_food = all_items_with( "is_food", &item::is_food );
-    for( const item *food : inv_food ) {
-        needrank[ need_food ] += nutrition_for( *food ) / 4.0;
-        needrank[ need_drink ] += food->get_comestible()->quench / 4.0;
+    for( item *food_it : all_items_with( "is_food", &item::is_food ) ) {
+        needrank[ need_food ] += nutrition_for( *food_it ) / 4.0;
+        needrank[ need_drink ] += food_it->get_comestible()->quench / 4.0;
     }
     needs.clear();
     size_t j;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1060,7 +1060,7 @@ void starting_clothes( npc &who, const npc_class_id &type, bool male )
     }
 
     who.worn.on_takeoff( who );
-    who.worn.clear();
+    who.clear_worn();
     for( item &it : ret ) {
         if( it.has_flag( flag_VARSIZE ) ) {
             it.set_flag( flag_FIT );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1943,10 +1943,10 @@ void npc::decide_needs()
     needrank[need_weapon] = weapon_value( weap );
     needrank[need_food] = 15 - get_hunger();
     needrank[need_drink] = 15 - get_thirst();
-    for( item *food_it : all_items_with( "is_food", &item::is_food ) ) {
-        needrank[ need_food ] += nutrition_for( *food_it ) / 4.0;
-        needrank[ need_drink ] += food_it->get_comestible()->quench / 4.0;
-    }
+    do_to_items_with( "is_food", &item::is_food, [&]( const item & it ) {
+        needrank[ need_food ] += nutrition_for( it ) / 4.0;
+        needrank[ need_drink ] += it.get_comestible()->quench / 4.0;
+    } );
     needs.clear();
     size_t j;
     bool serious = false;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -760,7 +760,7 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
     }
 
     set_wielded_item( item( "null", calendar::turn_zero ) );
-    clear_inv();
+    inv->clear();
     personality.aggression = rng( -10, 10 );
     personality.bravery    = rng( -3, 10 );
     personality.collector  = rng( -1, 10 );
@@ -1076,7 +1076,7 @@ void starting_clothes( npc &who, const npc_class_id &type, bool male )
 void starting_inv( npc &who, const npc_class_id &type )
 {
     std::list<item> res;
-    who.clear_inv();
+    who.inv->clear();
     if( item_group::group_is_defined( type->carry_override ) ) {
         *who.inv += item_group::items_from( type->carry_override );
         return;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1943,7 +1943,7 @@ void npc::decide_needs()
     needrank[need_weapon] = weapon_value( weap );
     needrank[need_food] = 15 - get_hunger();
     needrank[need_drink] = 15 - get_thirst();
-    do_to_items_with( "is_food", &item::is_food, [&]( const item & it ) {
+    cache_visit_items_with( "is_food", &item::is_food, [&]( const item & it ) {
         needrank[ need_food ] += nutrition_for( it ) / 4.0;
         needrank[ need_drink ] += it.get_comestible()->quench / 4.0;
     } );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4079,8 +4079,8 @@ void npc::reach_omt_destination()
             Character &player_character = get_player_character();
             talk_function::assign_guard( *this );
             if( rl_dist( player_character.pos(), pos() ) > SEEX * 2 ) {
-                if( player_character.cache_has_item_with_flag_and_charges( flag_TWO_WAY_RADIO ) &&
-                    cache_has_item_with_flag_and_charges( flag_TWO_WAY_RADIO ) ) {
+                if( player_character.cache_has_item_with_flag( flag_TWO_WAY_RADIO, true ) &&
+                    cache_has_item_with_flag( flag_TWO_WAY_RADIO, true ) ) {
                     add_msg_if_player_sees( pos(), m_info, _( "From your two-way radio you hear %s reporting in, "
                                             "'I've arrived, boss!'" ), disp_name() );
                 }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3894,7 +3894,7 @@ bool npc::consume_food()
     int want_hunger = std::max( 0, get_hunger() );
     int want_quench = std::max( 0, get_thirst() );
 
-    const std::vector<item *> inv_food = all_items_with( "is_food", &item::is_food );
+    const std::vector<item *> inv_food = cache_get_items_with( "is_food", &item::is_food );
 
     if( inv_food.empty() ) {
         if( !is_player_ally() ) {
@@ -4079,8 +4079,8 @@ void npc::reach_omt_destination()
             Character &player_character = get_player_character();
             talk_function::assign_guard( *this );
             if( rl_dist( player_character.pos(), pos() ) > SEEX * 2 ) {
-                if( player_character.has_any_item_with_flag_and_charges( flag_TWO_WAY_RADIO ) &&
-                    has_any_item_with_flag_and_charges( flag_TWO_WAY_RADIO ) ) {
+                if( player_character.cache_has_item_with_flag_and_charges( flag_TWO_WAY_RADIO ) &&
+                    cache_has_item_with_flag_and_charges( flag_TWO_WAY_RADIO ) ) {
                     add_msg_if_player_sees( pos(), m_info, _( "From your two-way radio you hear %s reporting in, "
                                             "'I've arrived, boss!'" ), disp_name() );
                 }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3894,7 +3894,7 @@ bool npc::consume_food()
     int want_hunger = std::max( 0, get_hunger() );
     int want_quench = std::max( 0, get_thirst() );
 
-    const std::vector<item *> inv_food = get_items_with( "is_food", &item::is_food );
+    const std::vector<item *> inv_food = all_items_with( "is_food", &item::is_food );
 
     if( inv_food.empty() ) {
         if( !is_player_ally() ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3894,7 +3894,7 @@ bool npc::consume_food()
     int want_hunger = std::max( 0, get_hunger() );
     int want_quench = std::max( 0, get_thirst() );
 
-    const std::set<item *> &inv_food = all_items_with( "IS FOOD", &item::is_food );
+    const std::set<item *> &inv_food = all_items_with( "is_food", &item::is_food );
 
     if( inv_food.empty() ) {
         if( !is_player_ally() ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3894,7 +3894,7 @@ bool npc::consume_food()
     int want_hunger = std::max( 0, get_hunger() );
     int want_quench = std::max( 0, get_thirst() );
 
-    const std::set<item *> &inv_food = all_items_with( "is_food", &item::is_food );
+    const std::vector<item *> &inv_food = all_items_with( "is_food", &item::is_food );
 
     if( inv_food.empty() ) {
         if( !is_player_ally() ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3894,7 +3894,7 @@ bool npc::consume_food()
     int want_hunger = std::max( 0, get_hunger() );
     int want_quench = std::max( 0, get_thirst() );
 
-    const std::vector<item *> &inv_food = all_items_with( "is_food", &item::is_food );
+    const std::vector<item *> inv_food = get_items_with( "is_food", &item::is_food );
 
     if( inv_food.empty() ) {
         if( !is_player_ally() ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4079,8 +4079,8 @@ void npc::reach_omt_destination()
             Character &player_character = get_player_character();
             talk_function::assign_guard( *this );
             if( rl_dist( player_character.pos(), pos() ) > SEEX * 2 ) {
-                if( player_character.has_item_with_flag( flag_TWO_WAY_RADIO, true ) &&
-                    has_item_with_flag( flag_TWO_WAY_RADIO, true ) ) {
+                if( player_character.has_any_item_with_flag_and_charges( flag_TWO_WAY_RADIO ) &&
+                    has_any_item_with_flag_and_charges( flag_TWO_WAY_RADIO ) ) {
                     add_msg_if_player_sees( pos(), m_info, _( "From your two-way radio you hear %s reporting in, "
                                             "'I've arrived, boss!'" ), disp_name() );
                 }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3894,9 +3894,7 @@ bool npc::consume_food()
     int want_hunger = std::max( 0, get_hunger() );
     int want_quench = std::max( 0, get_thirst() );
 
-    const auto inv_food = items_with( []( const item & itm ) {
-        return itm.is_food();
-    } );
+    const std::set<item *> &inv_food = all_items_with( "IS FOOD", &item::is_food );
 
     if( inv_food.empty() ) {
         if( !is_player_ally() ) {

--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -56,7 +56,7 @@ void player_difficulty::reset_npc( Character &dummy )
     // delete all worn items.
     dummy.clear_worn();
     dummy.calc_encumbrance();
-    dummy.inv->clear();
+    dummy.clear_inv();
     dummy.remove_weapon();
     dummy.clear_mutations();
 

--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -54,7 +54,7 @@ void player_difficulty::reset_npc( Character &dummy )
     dummy.normalize(); // In particular this clears martial arts style
 
     // delete all worn items.
-    dummy.worn.clear();
+    dummy.clear_worn();
     dummy.calc_encumbrance();
     dummy.inv->clear();
     dummy.remove_weapon();

--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -56,7 +56,7 @@ void player_difficulty::reset_npc( Character &dummy )
     // delete all worn items.
     dummy.clear_worn();
     dummy.calc_encumbrance();
-    dummy.clear_inv();
+    dummy.inv->clear();
     dummy.remove_weapon();
     dummy.clear_mutations();
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -843,7 +843,7 @@ void Character::load( const JsonObject &data )
     update_bionic_power_capacity();
     data.read( "death_eocs", death_eocs );
     worn.on_takeoff( *this );
-    worn.clear();
+    clear_worn();
     // deprecate after 0.G
     if( data.has_array( "worn" ) ) {
         std::list<item> items;

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -988,7 +988,7 @@ void Character::load( const JsonObject &data )
         set_part_frostbite_timer( bodypart_id( "foot_r" ), frostbite_timer[11] );
     }
 
-    inv->clear();
+    clear_inv();
     if( data.has_member( "inv" ) ) {
         inv->json_load_items( data.get_member( "inv" ) );
     }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -988,7 +988,7 @@ void Character::load( const JsonObject &data )
         set_part_frostbite_timer( bodypart_id( "foot_r" ), frostbite_timer[11] );
     }
 
-    clear_inv();
+    inv->clear();
     if( data.has_member( "inv" ) ) {
         inv->json_load_items( data.get_member( "inv" ) );
     }

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -656,7 +656,7 @@ bool talker_character_const::wielded_with_flag( const flag_id &flag ) const
 
 bool talker_character_const::has_item_with_flag( const flag_id &flag ) const
 {
-    return me_chr_const->has_item_with_flag( flag );
+    return me_chr_const->has_any_item_with( flag );
 }
 
 int talker_character_const::item_rads( const flag_id &flag, aggregate_type agg_func ) const

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -662,7 +662,7 @@ bool talker_character_const::has_item_with_flag( const flag_id &flag ) const
 int talker_character_const::item_rads( const flag_id &flag, aggregate_type agg_func ) const
 {
     std::vector<int> rad_vals;
-    for( const item *it : me_chr_const->all_items_with_flag( flag ) ) {
+    for( const item *it : me_chr_const->all_items_with( flag ) ) {
         if( me_chr_const->is_worn( *it ) || me_chr_const->is_wielding( *it ) ) {
             rad_vals.emplace_back( it->irradiation );
         }

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -662,11 +662,11 @@ bool talker_character_const::has_item_with_flag( const flag_id &flag ) const
 int talker_character_const::item_rads( const flag_id &flag, aggregate_type agg_func ) const
 {
     std::vector<int> rad_vals;
-    for( const item *it : me_chr_const->all_items_with( flag ) ) {
-        if( me_chr_const->is_worn( *it ) || me_chr_const->is_wielding( *it ) ) {
-            rad_vals.emplace_back( it->irradiation );
+    me_chr_const->do_to_items_with( flag, [&]( const item & it ) {
+        if( me_chr_const->is_worn( it ) || me_chr_const->is_wielding( it ) ) {
+            rad_vals.emplace_back( it.irradiation );
         }
-    }
+    } );
     return aggregate( rad_vals, agg_func );
 }
 

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -656,13 +656,13 @@ bool talker_character_const::wielded_with_flag( const flag_id &flag ) const
 
 bool talker_character_const::has_item_with_flag( const flag_id &flag ) const
 {
-    return me_chr_const->has_any_item_with( flag );
+    return me_chr_const->cache_has_item_with( flag );
 }
 
 int talker_character_const::item_rads( const flag_id &flag, aggregate_type agg_func ) const
 {
     std::vector<int> rad_vals;
-    me_chr_const->do_to_items_with( flag, [&]( const item & it ) {
+    me_chr_const->cache_visit_items_with( flag, [&]( const item & it ) {
         if( me_chr_const->is_worn( it ) || me_chr_const->is_wielding( it ) ) {
             rad_vals.emplace_back( it.irradiation );
         }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -908,9 +908,7 @@ void vehicle::honk_horn() const
 void vehicle::reload_seeds( const tripoint &pos )
 {
     Character &player_character = get_player_character();
-    std::vector<item *> seed_inv = player_character.items_with( []( const item & itm ) {
-        return itm.is_seed();
-    } );
+    std::set<item *> &seed_inv = player_character.all_items_with( "IS SEED", &item::is_seed );
 
     auto seed_entries = iexamine::get_seed_entries( seed_inv );
     seed_entries.emplace( seed_entries.begin(), itype_null, _( "No seed" ), 0 );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -908,7 +908,7 @@ void vehicle::honk_horn() const
 void vehicle::reload_seeds( const tripoint &pos )
 {
     Character &player_character = get_player_character();
-    std::vector<item *> seed_inv = player_character.all_items_with( "is_seed", &item::is_seed );
+    std::vector<item *> seed_inv = player_character.cache_get_items_with( "is_seed", &item::is_seed );
 
     auto seed_entries = iexamine::get_seed_entries( seed_inv );
     seed_entries.emplace( seed_entries.begin(), itype_null, _( "No seed" ), 0 );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -908,7 +908,7 @@ void vehicle::honk_horn() const
 void vehicle::reload_seeds( const tripoint &pos )
 {
     Character &player_character = get_player_character();
-    std::vector<item *> seed_inv = player_character.get_items_with( "is_seed", &item::is_seed );
+    std::vector<item *> seed_inv = player_character.all_items_with( "is_seed", &item::is_seed );
 
     auto seed_entries = iexamine::get_seed_entries( seed_inv );
     seed_entries.emplace( seed_entries.begin(), itype_null, _( "No seed" ), 0 );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -908,7 +908,7 @@ void vehicle::honk_horn() const
 void vehicle::reload_seeds( const tripoint &pos )
 {
     Character &player_character = get_player_character();
-    std::vector<item *> &seed_inv = player_character.all_items_with( "is_seed", &item::is_seed );
+    std::vector<item *> seed_inv = player_character.get_items_with( "is_seed", &item::is_seed );
 
     auto seed_entries = iexamine::get_seed_entries( seed_inv );
     seed_entries.emplace( seed_entries.begin(), itype_null, _( "No seed" ), 0 );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -908,7 +908,7 @@ void vehicle::honk_horn() const
 void vehicle::reload_seeds( const tripoint &pos )
 {
     Character &player_character = get_player_character();
-    std::set<item *> &seed_inv = player_character.all_items_with( "is_seed", &item::is_seed );
+    std::vector<item *> &seed_inv = player_character.all_items_with( "is_seed", &item::is_seed );
 
     auto seed_entries = iexamine::get_seed_entries( seed_inv );
     seed_entries.emplace( seed_entries.begin(), itype_null, _( "No seed" ), 0 );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -908,7 +908,7 @@ void vehicle::honk_horn() const
 void vehicle::reload_seeds( const tripoint &pos )
 {
     Character &player_character = get_player_character();
-    std::set<item *> &seed_inv = player_character.all_items_with( "IS SEED", &item::is_seed );
+    std::set<item *> &seed_inv = player_character.all_items_with( "is_seed", &item::is_seed );
 
     auto seed_entries = iexamine::get_seed_entries( seed_inv );
     seed_entries.emplace( seed_entries.begin(), itype_null, _( "No seed" ), 0 );

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -615,7 +615,7 @@ std::list<item> inventory::remove_items_with( Character *carrier,
             if( filter( *istack_iter ) ) {
                 count--;
                 if( carrier ) {
-                    carrier->remove_from_inv_search_cache( *istack_iter );
+                    carrier->remove_from_inv_search_caches( *istack_iter );
                 }
                 res.splice( res.end(), istack, istack_iter++ );
                 // The non-first items of a stack may have different invlets, the code
@@ -652,7 +652,7 @@ std::list<item> outfit::remove_items_with( Character *carrier,
     for( auto iter = worn.begin(); iter != worn.end(); ) {
         if( filter( *iter ) ) {
             iter->on_takeoff( *carrier );
-            carrier->remove_from_inv_search_cache( *iter );
+            carrier->remove_from_inv_search_caches( *iter );
             res.splice( res.end(), worn, iter++ );
             if( --count == 0 ) {
                 return res;

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -652,7 +652,6 @@ std::list<item> outfit::remove_items_with( Character *carrier,
     for( auto iter = worn.begin(); iter != worn.end(); ) {
         if( filter( *iter ) ) {
             iter->on_takeoff( *carrier );
-            carrier->remove_from_inv_search_caches( *iter );
             res.splice( res.end(), worn, iter++ );
             if( --count == 0 ) {
                 return res;

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -615,7 +615,7 @@ std::list<item> inventory::remove_items_with( Character *carrier,
             if( filter( *istack_iter ) ) {
                 count--;
                 if( carrier ) {
-                    carrier->remove_from_flagged_item_cache( *istack_iter );
+                    carrier->remove_from_inv_search_cache( *istack_iter );
                 }
                 res.splice( res.end(), istack, istack_iter++ );
                 // The non-first items of a stack may have different invlets, the code
@@ -652,7 +652,7 @@ std::list<item> outfit::remove_items_with( Character *carrier,
     for( auto iter = worn.begin(); iter != worn.end(); ) {
         if( filter( *iter ) ) {
             iter->on_takeoff( *carrier );
-            carrier->remove_from_flagged_item_cache( *iter );
+            carrier->remove_from_inv_search_cache( *iter );
             res.splice( res.end(), worn, iter++ );
             if( --count == 0 ) {
                 return res;

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -1110,16 +1110,7 @@ void debug_menu::wishitem( Character *you, const tripoint &pos )
             if( !canceled ) {
                 did_amount_prompt = true;
                 if( you != nullptr ) {
-                    if( granted.count_by_charges() ) {
-                        if( amount > 0 ) {
-                            granted.charges = amount;
-                            if( you->can_stash( granted ) ) {
-                                you->i_add( granted );
-                            } else {
-                                get_map().add_item_or_charges( you->pos(), granted );
-                            }
-                        }
-                    } else {
+                    if( amount > 0 ) {
                         int stashable_copy_num = amount;
                         you->i_add( granted, stashable_copy_num, true, nullptr, nullptr, true, false );
                     }

--- a/tests/char_exposure_test.cpp
+++ b/tests/char_exposure_test.cpp
@@ -21,7 +21,7 @@ TEST_CASE( "character_body_part_exposure", "[char][bodypart][exposure]" )
     std::map<bodypart_id, float> bp_exposure;
 
     GIVEN( "nothing is worn" ) {
-        dummy.worn.clear();
+        dummy.clear_worn();
 
         THEN( "exposure is 100% on all body parts" ) {
             bp_exposure = dummy.bodypart_exposure();

--- a/tests/char_sight_test.cpp
+++ b/tests/char_sight_test.cpp
@@ -227,7 +227,7 @@ TEST_CASE( "character_sight_limits", "[character][sight][vision]" )
         REQUIRE( dummy.has_trait( trait_MYOPIC ) );
 
         WHEN( "without glasses" ) {
-            dummy.worn.clear();
+            dummy.clear_worn();
             REQUIRE_FALSE( dummy.worn_with_flag( flag_FIX_NEARSIGHT ) );
 
             THEN( "impaired sight, with 12 tiles of range" ) {
@@ -291,7 +291,7 @@ TEST_CASE( "ursine_vision", "[character][ursine][vision]" )
         dummy.toggle_trait( trait_URSINE_EYE );
         REQUIRE( dummy.has_trait( trait_URSINE_EYE ) );
 
-        dummy.worn.clear();
+        dummy.clear_worn();
         REQUIRE_FALSE( dummy.worn_with_flag( flag_FIX_NEARSIGHT ) );
 
         WHEN( "under a new moon" ) {

--- a/tests/char_suffer_test.cpp
+++ b/tests/char_suffer_test.cpp
@@ -130,7 +130,7 @@ TEST_CASE( "suffering_from_albinism", "[char][suffer][albino]" )
         REQUIRE( dummy.has_trait( trait_ALBINO ) );
 
         WHEN( "totally naked and exposed" ) {
-            dummy.worn.clear();
+            dummy.clear_worn();
 
             // 60 times * 12 bodyparts * 0.25 chance for medium effect
             THEN( "they lose 80 to 280 focus per hour" ) {
@@ -163,7 +163,7 @@ TEST_CASE( "suffering_from_albinism", "[char][suffer][albino]" )
         }
 
         WHEN( "entire body is covered with clothing" ) {
-            dummy.worn.clear();
+            dummy.clear_worn();
             dummy.wear_item( zentai, false );
 
             // WHEN( "not wearing sunglasses" ) {
@@ -229,7 +229,7 @@ TEST_CASE( "suffering_from_sunburn", "[char][suffer][sunburn]" )
 
         std::map<bodypart_id, int> bp_hp_lost;
         WHEN( "totally naked and exposed, with sunglasses" ) {
-            dummy.worn.clear();
+            dummy.clear_worn();
             dummy.wear_item( shades, false );
             REQUIRE( dummy.worn_with_flag( flag_SUN_GLASSES ) );
 
@@ -252,7 +252,7 @@ TEST_CASE( "suffering_from_sunburn", "[char][suffer][sunburn]" )
         }
 
         WHEN( "naked and wielding an umbrella, with sunglasses" ) {
-            dummy.worn.clear();
+            dummy.clear_worn();
             dummy.wield( umbrella );
             REQUIRE( dummy.get_wielded_item()->has_flag( flag_RAIN_PROTECT ) );
             dummy.wear_item( shades, false );
@@ -273,7 +273,7 @@ TEST_CASE( "suffering_from_sunburn", "[char][suffer][sunburn]" )
         }
 
         WHEN( "wielding an umbrella, without sunglasses" ) {
-            dummy.worn.clear();
+            dummy.clear_worn();
             dummy.wield( umbrella );
             REQUIRE( dummy.get_wielded_item()->has_flag( flag_RAIN_PROTECT ) );
             REQUIRE_FALSE( dummy.worn_with_flag( flag_SUN_GLASSES ) );
@@ -298,7 +298,7 @@ TEST_CASE( "suffering_from_sunburn", "[char][suffer][sunburn]" )
         }
 
         WHEN( "torso and arms are 90% covered" ) {
-            dummy.worn.clear();
+            dummy.clear_worn();
             dummy.wear_item( longshirt, false );
 
             THEN( "damage to torso is 0 and halved for arms" ) {
@@ -324,7 +324,7 @@ TEST_CASE( "suffering_from_sunburn", "[char][suffer][sunburn]" )
         }
 
         WHEN( "entire body is covered" ) {
-            dummy.worn.clear();
+            dummy.clear_worn();
             dummy.wear_item( zentai, false );
 
             WHEN( "not wearing sunglasses" ) {

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -364,7 +364,7 @@ TEST_CASE( "crafting_with_a_companion", "[.]" )
 static void give_tools( const std::vector<item> &tools )
 {
     Character &player_character = get_player_character();
-    player_character.worn.clear();
+    player_character.clear_worn();
     player_character.calc_encumbrance();
     player_character.inv->clear();
     player_character.remove_weapon();

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -366,7 +366,7 @@ static void give_tools( const std::vector<item> &tools )
     Character &player_character = get_player_character();
     player_character.clear_worn();
     player_character.calc_encumbrance();
-    player_character.inv->clear();
+    player_character.clear_inv();
     player_character.remove_weapon();
     const item backpack( "debug_backpack" );
     player_character.worn.wear_item( player_character, backpack, false, false );

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -366,7 +366,7 @@ static void give_tools( const std::vector<item> &tools )
     Character &player_character = get_player_character();
     player_character.clear_worn();
     player_character.calc_encumbrance();
-    player_character.clear_inv();
+    player_character.inv->clear();
     player_character.remove_weapon();
     const item backpack( "debug_backpack" );
     player_character.worn.wear_item( player_character, backpack, false, false );

--- a/tests/encumbrance_test.cpp
+++ b/tests/encumbrance_test.cpp
@@ -24,7 +24,7 @@ static void test_encumbrance_on(
     CAPTURE( body_part );
     p.set_body();
     p.clear_mutations();
-    p.worn.clear();
+    p.clear_worn();
     if( tweak_player ) {
         tweak_player( p );
     }

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -458,7 +458,7 @@ static void invlet_test( avatar &dummy, const inventory_location from, const inv
 
         // remove all items
         dummy.inv->clear();
-        dummy.worn.clear();
+        dummy.clear_worn();
         dummy.remove_weapon();
         get_map().i_clear( dummy.pos() );
         dummy.worn.wear_item( dummy, item( "backpack" ), false, false );
@@ -540,7 +540,7 @@ static void stack_invlet_test( avatar &dummy, inventory_location from, inventory
 
     // remove all items
     dummy.inv->clear();
-    dummy.worn.clear();
+    dummy.clear_worn();
     dummy.remove_weapon();
     get_map().i_clear( dummy.pos() );
     dummy.worn.wear_item( dummy, item( "backpack" ), false, false );
@@ -593,7 +593,7 @@ static void swap_invlet_test( avatar &dummy, inventory_location loc )
 
     // remove all items
     dummy.inv->clear();
-    dummy.worn.clear();
+    dummy.clear_worn();
     dummy.remove_weapon();
     get_map().i_clear( dummy.pos() );
 
@@ -678,7 +678,7 @@ static void merge_invlet_test( avatar &dummy, inventory_location from )
 
         // remove all items
         dummy.inv->clear();
-        dummy.worn.clear();
+        dummy.clear_worn();
         dummy.remove_weapon();
         get_map().i_clear( dummy.pos() );
         dummy.worn.wear_item( dummy, item( "backpack" ), false, false );

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -457,7 +457,7 @@ static void invlet_test( avatar &dummy, const inventory_location from, const inv
         invlet_state expected_second_invlet_state = second_invlet_state;
 
         // remove all items
-        dummy.inv->clear();
+        dummy.clear_inv();
         dummy.clear_worn();
         dummy.remove_weapon();
         get_map().i_clear( dummy.pos() );
@@ -486,36 +486,36 @@ static void invlet_test( avatar &dummy, const inventory_location from, const inv
         item *final_first = nullptr;
         item *final_second = nullptr;
         switch( action ) {
-            case REMOVE_1ST_REMOVE_2ND_ADD_1ST_ADD_2ND:
-                move_item( dummy, "2", to, from );
-                move_item( dummy, "1", from, to );
-                move_item( dummy, "2", from, to );
-                final_first = &item_at( dummy, "1", to );
-                final_second = &item_at( dummy, "2", to );
-                break;
-            case REMOVE_1ST_REMOVE_2ND_ADD_2ND_ADD_1ST:
-                move_item( dummy, "2", to, from );
-                move_item( dummy, "2", from, to );
-                move_item( dummy, "1", from, to );
-                final_first = &item_at( dummy, "1", to );
-                final_second = &item_at( dummy, "2", to );
-                break;
-            case REMOVE_1ST_ADD_1ST:
-                move_item( dummy, "1", from, to );
-                final_first = &item_at( dummy, "1", to );
-                final_second = &item_at( dummy, "2", to );
-                break;
-            default:
-                FAIL( "unimplemented" );
-                break;
+        case REMOVE_1ST_REMOVE_2ND_ADD_1ST_ADD_2ND:
+            move_item( dummy, "2", to, from );
+            move_item( dummy, "1", from, to );
+            move_item( dummy, "2", from, to );
+            final_first = &item_at( dummy, "1", to );
+            final_second = &item_at( dummy, "2", to );
+            break;
+        case REMOVE_1ST_REMOVE_2ND_ADD_2ND_ADD_1ST:
+            move_item( dummy, "2", to, from );
+            move_item( dummy, "2", from, to );
+            move_item( dummy, "1", from, to );
+            final_first = &item_at( dummy, "1", to );
+            final_second = &item_at( dummy, "2", to );
+            break;
+        case REMOVE_1ST_ADD_1ST:
+            move_item( dummy, "1", from, to );
+            final_first = &item_at( dummy, "1", to );
+            final_second = &item_at( dummy, "2", to );
+            break;
+        default:
+            FAIL( "unimplemented" );
+            break;
         }
 
         invlet_state final_first_invlet_state = check_invlet( dummy, *final_first, invlet );
         invlet_state final_second_invlet_state = check_invlet( dummy, *final_second, invlet );
 
         INFO( test_action_desc( action, from, to, first_invlet_state, second_invlet_state,
-                                expected_first_invlet_state, expected_second_invlet_state, final_first_invlet_state,
-                                final_second_invlet_state ) );
+            expected_first_invlet_state, expected_second_invlet_state, final_first_invlet_state,
+            final_second_invlet_state ) );
         REQUIRE( final_first->typeId() == tshirt.typeId() );
         REQUIRE( final_second->typeId() == jeans.typeId() );
         CHECK( final_first_invlet_state == expected_first_invlet_state );
@@ -539,7 +539,7 @@ static void stack_invlet_test( avatar &dummy, inventory_location from, inventory
     }
 
     // remove all items
-    dummy.inv->clear();
+    dummy.clear_inv();
     dummy.clear_worn();
     dummy.remove_weapon();
     get_map().i_clear( dummy.pos() );
@@ -568,9 +568,9 @@ static void stack_invlet_test( avatar &dummy, inventory_location from, inventory
     ss << "3. " << move_action_desc( 0, from, to ) << std::endl;
     ss << "expect the two items to have different invlets" << std::endl;
     ss << "actually the two items have " <<
-       ( item_at( dummy, "1", to ).invlet != item_at( dummy, "2",
-               from ).invlet ? "different" : "the same" ) <<
-       " invlets" << std::endl;
+        ( item_at( dummy, "1", to ).invlet != item_at( dummy, "2",
+            from ).invlet ? "different" : "the same" ) <<
+        " invlets" << std::endl;
     INFO( ss.str() );
     REQUIRE( item_at( dummy, "1", to ).typeId() == tshirt1.typeId() );
     REQUIRE( item_at( dummy, "2", from ).typeId() == tshirt2.typeId() );
@@ -592,7 +592,7 @@ static void swap_invlet_test( avatar &dummy, inventory_location loc )
     REQUIRE( loc != GROUND );
 
     // remove all items
-    dummy.inv->clear();
+    dummy.clear_inv();
     dummy.clear_worn();
     dummy.remove_weapon();
     get_map().i_clear( dummy.pos() );
@@ -627,10 +627,10 @@ static void swap_invlet_test( avatar &dummy, inventory_location loc )
 
     std::stringstream ss;
     ss << "1. add two items of the same type to " << location_desc( loc ) <<
-       ", and ensure them do not stack" << std::endl;
+        ", and ensure them do not stack" << std::endl;
     ss << "2. assign different invlets to the two items" << std::endl;
     ss << "3. swap the invlets by assign one of the items with the invlet of the other item" <<
-       std::endl;
+        std::endl;
     ss << "4. move the items to " << location_desc( GROUND ) << std::endl;
     ss << "5. move the items to " << location_desc( loc ) << " again" << std::endl;
     ss << "expect the items to keep their swapped invlets" << std::endl;
@@ -672,12 +672,12 @@ static void merge_invlet_test( avatar &dummy, inventory_location from )
         invlet_state second_invlet_state = static_cast<invlet_state>( id / INVLET_STATE_NUM );
         // what the invlet should be for the merged stack
         invlet_state expected_merged_invlet_state = first_invlet_state != NONE ? first_invlet_state :
-                second_invlet_state;
+            second_invlet_state;
         char expected_merged_invlet = first_invlet_state != NONE ? invlet_1 : second_invlet_state != NONE ?
-                                      invlet_2 : 0;
+            invlet_2 : 0;
 
         // remove all items
-        dummy.inv->clear();
+        dummy.clear_inv();
         dummy.clear_worn();
         dummy.remove_weapon();
         get_map().i_clear( dummy.pos() );

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -457,7 +457,7 @@ static void invlet_test( avatar &dummy, const inventory_location from, const inv
         invlet_state expected_second_invlet_state = second_invlet_state;
 
         // remove all items
-        dummy.clear_inv();
+        dummy.inv->clear();
         dummy.clear_worn();
         dummy.remove_weapon();
         get_map().i_clear( dummy.pos() );
@@ -539,7 +539,7 @@ static void stack_invlet_test( avatar &dummy, inventory_location from, inventory
     }
 
     // remove all items
-    dummy.clear_inv();
+    dummy.inv->clear();
     dummy.clear_worn();
     dummy.remove_weapon();
     get_map().i_clear( dummy.pos() );
@@ -592,7 +592,7 @@ static void swap_invlet_test( avatar &dummy, inventory_location loc )
     REQUIRE( loc != GROUND );
 
     // remove all items
-    dummy.clear_inv();
+    dummy.inv->clear();
     dummy.clear_worn();
     dummy.remove_weapon();
     get_map().i_clear( dummy.pos() );
@@ -677,7 +677,7 @@ static void merge_invlet_test( avatar &dummy, inventory_location from )
                                       invlet_2 : 0;
 
         // remove all items
-        dummy.clear_inv();
+        dummy.inv->clear();
         dummy.clear_worn();
         dummy.remove_weapon();
         get_map().i_clear( dummy.pos() );

--- a/tests/invlet_test.cpp
+++ b/tests/invlet_test.cpp
@@ -486,36 +486,36 @@ static void invlet_test( avatar &dummy, const inventory_location from, const inv
         item *final_first = nullptr;
         item *final_second = nullptr;
         switch( action ) {
-        case REMOVE_1ST_REMOVE_2ND_ADD_1ST_ADD_2ND:
-            move_item( dummy, "2", to, from );
-            move_item( dummy, "1", from, to );
-            move_item( dummy, "2", from, to );
-            final_first = &item_at( dummy, "1", to );
-            final_second = &item_at( dummy, "2", to );
-            break;
-        case REMOVE_1ST_REMOVE_2ND_ADD_2ND_ADD_1ST:
-            move_item( dummy, "2", to, from );
-            move_item( dummy, "2", from, to );
-            move_item( dummy, "1", from, to );
-            final_first = &item_at( dummy, "1", to );
-            final_second = &item_at( dummy, "2", to );
-            break;
-        case REMOVE_1ST_ADD_1ST:
-            move_item( dummy, "1", from, to );
-            final_first = &item_at( dummy, "1", to );
-            final_second = &item_at( dummy, "2", to );
-            break;
-        default:
-            FAIL( "unimplemented" );
-            break;
+            case REMOVE_1ST_REMOVE_2ND_ADD_1ST_ADD_2ND:
+                move_item( dummy, "2", to, from );
+                move_item( dummy, "1", from, to );
+                move_item( dummy, "2", from, to );
+                final_first = &item_at( dummy, "1", to );
+                final_second = &item_at( dummy, "2", to );
+                break;
+            case REMOVE_1ST_REMOVE_2ND_ADD_2ND_ADD_1ST:
+                move_item( dummy, "2", to, from );
+                move_item( dummy, "2", from, to );
+                move_item( dummy, "1", from, to );
+                final_first = &item_at( dummy, "1", to );
+                final_second = &item_at( dummy, "2", to );
+                break;
+            case REMOVE_1ST_ADD_1ST:
+                move_item( dummy, "1", from, to );
+                final_first = &item_at( dummy, "1", to );
+                final_second = &item_at( dummy, "2", to );
+                break;
+            default:
+                FAIL( "unimplemented" );
+                break;
         }
 
         invlet_state final_first_invlet_state = check_invlet( dummy, *final_first, invlet );
         invlet_state final_second_invlet_state = check_invlet( dummy, *final_second, invlet );
 
         INFO( test_action_desc( action, from, to, first_invlet_state, second_invlet_state,
-            expected_first_invlet_state, expected_second_invlet_state, final_first_invlet_state,
-            final_second_invlet_state ) );
+                                expected_first_invlet_state, expected_second_invlet_state, final_first_invlet_state,
+                                final_second_invlet_state ) );
         REQUIRE( final_first->typeId() == tshirt.typeId() );
         REQUIRE( final_second->typeId() == jeans.typeId() );
         CHECK( final_first_invlet_state == expected_first_invlet_state );
@@ -568,9 +568,9 @@ static void stack_invlet_test( avatar &dummy, inventory_location from, inventory
     ss << "3. " << move_action_desc( 0, from, to ) << std::endl;
     ss << "expect the two items to have different invlets" << std::endl;
     ss << "actually the two items have " <<
-        ( item_at( dummy, "1", to ).invlet != item_at( dummy, "2",
-            from ).invlet ? "different" : "the same" ) <<
-        " invlets" << std::endl;
+       ( item_at( dummy, "1", to ).invlet != item_at( dummy, "2",
+               from ).invlet ? "different" : "the same" ) <<
+       " invlets" << std::endl;
     INFO( ss.str() );
     REQUIRE( item_at( dummy, "1", to ).typeId() == tshirt1.typeId() );
     REQUIRE( item_at( dummy, "2", from ).typeId() == tshirt2.typeId() );
@@ -627,10 +627,10 @@ static void swap_invlet_test( avatar &dummy, inventory_location loc )
 
     std::stringstream ss;
     ss << "1. add two items of the same type to " << location_desc( loc ) <<
-        ", and ensure them do not stack" << std::endl;
+       ", and ensure them do not stack" << std::endl;
     ss << "2. assign different invlets to the two items" << std::endl;
     ss << "3. swap the invlets by assign one of the items with the invlet of the other item" <<
-        std::endl;
+       std::endl;
     ss << "4. move the items to " << location_desc( GROUND ) << std::endl;
     ss << "5. move the items to " << location_desc( loc ) << " again" << std::endl;
     ss << "expect the items to keep their swapped invlets" << std::endl;
@@ -672,9 +672,9 @@ static void merge_invlet_test( avatar &dummy, inventory_location from )
         invlet_state second_invlet_state = static_cast<invlet_state>( id / INVLET_STATE_NUM );
         // what the invlet should be for the merged stack
         invlet_state expected_merged_invlet_state = first_invlet_state != NONE ? first_invlet_state :
-            second_invlet_state;
+                second_invlet_state;
         char expected_merged_invlet = first_invlet_state != NONE ? invlet_1 : second_invlet_state != NONE ?
-            invlet_2 : 0;
+                                      invlet_2 : 0;
 
         // remove all items
         dummy.clear_inv();

--- a/tests/item_pickup_test.cpp
+++ b/tests/item_pickup_test.cpp
@@ -45,7 +45,7 @@ TEST_CASE( "putting_items_into_inventory_with_put_in_or_i_add", "[pickup][invent
     REQUIRE_FALSE( character_has_item_with_var_val( they, "uid", rope_uid ) );
 
     WHEN( "avatar wears a hiking backpack from the ground with wear_item" ) {
-        they.worn.clear();
+        they.clear_worn();
         // Get the backpack from the iterator returned by wear_item,
         // for the reference to the backpack that the avatar is wearing now
         std::optional<std::list<item>::iterator> worn = they.wear_item( backpack_map );
@@ -97,7 +97,7 @@ TEST_CASE( "putting_items_into_inventory_with_put_in_or_i_add", "[pickup][invent
     // But Character::pick_up cannot wield or wear items in the act of picking them up;
     // the available storage needs to be worn ahead of time.
     GIVEN( "avatar is not wearing anything that can store items" ) {
-        they.worn.clear();
+        they.clear_worn();
 
         WHEN( "avatar tries to get the backpack with pick_up" ) {
             item_location backpack_loc( map_cursor( ground ), &backpack_map );

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -333,7 +333,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in hand" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item aspirin( "aspirin" );
 
@@ -347,7 +347,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in backpack" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item aspirin( "aspirin" );
             item backpack( "backpack" );
@@ -364,7 +364,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in small plastic bottle" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item aspirin( "aspirin" );
             item bottle_small( "bottle_plastic_small" );
@@ -381,7 +381,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in backpack inside duffel bag" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item aspirin( "aspirin" );
             item backpack( "backpack" );
@@ -400,7 +400,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in backpack inside body bag" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item aspirin( "aspirin" );
             item backpack( "backpack" );
@@ -424,7 +424,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in hand" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item smart_phone( itype_test_smart_phone );
 
@@ -438,7 +438,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in backpack" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item smart_phone( itype_test_smart_phone );
             item backpack( itype_test_backpack );
@@ -455,7 +455,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in body bag" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item smart_phone( itype_test_smart_phone );
             item body_bag( "test_waterproof_bag" );
@@ -472,7 +472,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in backpack inside duffel bag" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item smart_phone( itype_test_smart_phone );
             item backpack( itype_test_backpack );
@@ -491,7 +491,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in backpack inside body bag" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item smart_phone( itype_test_smart_phone );
             item backpack( itype_test_backpack );
@@ -515,7 +515,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in hand" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item mp3( itype_test_mp3 );
 
@@ -529,7 +529,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in backpack" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item mp3( itype_test_mp3 );
             item backpack( itype_test_backpack );
@@ -548,7 +548,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in body bag" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item mp3( itype_test_mp3 );
             item body_bag( itype_test_waterproof_bag );
@@ -567,7 +567,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in backpack inside duffel bag" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item mp3( itype_test_mp3 );
             item backpack( itype_test_backpack );
@@ -588,7 +588,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in backpack inside body bag" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item mp3( itype_test_mp3 );
             item backpack( itype_test_backpack );
@@ -609,7 +609,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in hand" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item mp3( itype_test_mp3 );
 
@@ -623,7 +623,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in hand" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item mp3( itype_test_mp3 );
 
@@ -646,7 +646,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "item in hand" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item towel( "towel" );
 
@@ -660,7 +660,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "wearing item" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item towel( "towel" );
 
@@ -674,7 +674,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "inside a backpack" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item towel( "towel" );
             item backpack( "backpack" );
@@ -691,7 +691,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
         WHEN( "inside a body bag" ) {
             guy.unwield();
-            guy.worn.clear();
+            guy.clear_worn();
 
             item towel( "towel" );
             item body_bag( "test_waterproof_bag" );
@@ -798,7 +798,7 @@ TEST_CASE( "module_inheritance", "[item][armor]" )
     clear_avatar();
     guy.set_body();
     guy.clear_mutations();
-    guy.worn.clear();
+    guy.clear_worn();
 
     item test_exo( "test_modular_exosuit" );
     item test_module( "test_exo_lense_module" );

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -432,7 +432,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_any_item_with( flag_ITEM_BROKEN ) );
+                CHECK( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_ITEM_BROKEN ); } ) );
             }
         }
 
@@ -449,7 +449,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_any_item_with( flag_ITEM_BROKEN ) );
+                CHECK( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_ITEM_BROKEN ); } ) );
             }
         }
 
@@ -466,7 +466,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_any_item_with( flag_ITEM_BROKEN ) );
+                CHECK_FALSE( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_ITEM_BROKEN ); } ) );
             }
         }
 
@@ -485,7 +485,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_any_item_with( flag_ITEM_BROKEN ) );
+                CHECK( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_ITEM_BROKEN ); } ) );
             }
         }
 
@@ -504,7 +504,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_any_item_with( flag_ITEM_BROKEN ) );
+                CHECK_FALSE( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_ITEM_BROKEN ); } ) );
             }
         }
     }
@@ -654,7 +654,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_any_item_with( flag_WET ) );
+                CHECK( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_WET ); } ) );
             }
         }
 
@@ -668,7 +668,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_any_item_with( flag_WET ) );
+                CHECK( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_WET ); } ) );
             }
         }
 
@@ -685,7 +685,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_any_item_with( flag_WET ) );
+                CHECK( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_WET ); } ) );
             }
         }
 
@@ -702,7 +702,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_any_item_with( flag_WET ) );
+                CHECK_FALSE( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_WET ); } ) );
             }
         }
     }

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -341,7 +341,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should dissolve in water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_any_item_with( flag_WATER_DISSOLVE ) );
+                CHECK_FALSE( guy.cache_has_item_with( flag_WATER_DISSOLVE ) );
             }
         }
 
@@ -358,7 +358,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should dissolve in water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_any_item_with( flag_WATER_DISSOLVE ) );
+                CHECK_FALSE( guy.cache_has_item_with( flag_WATER_DISSOLVE ) );
             }
         }
 
@@ -375,7 +375,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not dissolve in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_any_item_with( flag_WATER_DISSOLVE ) );
+                CHECK( guy.cache_has_item_with( flag_WATER_DISSOLVE ) );
             }
         }
 
@@ -394,7 +394,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should dissolve in water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_any_item_with( flag_WATER_DISSOLVE ) );
+                CHECK_FALSE( guy.cache_has_item_with( flag_WATER_DISSOLVE ) );
             }
         }
 
@@ -413,7 +413,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not dissolve in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_any_item_with( flag_WATER_DISSOLVE ) );
+                CHECK( guy.cache_has_item_with( flag_WATER_DISSOLVE ) );
             }
         }
     }
@@ -432,7 +432,9 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_ITEM_BROKEN ); } ) );
+                CHECK( guy.has_item_with( []( const item & it ) {
+                    return it.has_flag( flag_ITEM_BROKEN );
+                } ) );
             }
         }
 
@@ -449,7 +451,9 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_ITEM_BROKEN ); } ) );
+                CHECK( guy.has_item_with( []( const item & it ) {
+                    return it.has_flag( flag_ITEM_BROKEN );
+                } ) );
             }
         }
 
@@ -466,7 +470,9 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_ITEM_BROKEN ); } ) );
+                CHECK_FALSE( guy.has_item_with( []( const item & it ) {
+                    return it.has_flag( flag_ITEM_BROKEN );
+                } ) );
             }
         }
 
@@ -485,7 +491,9 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_ITEM_BROKEN ); } ) );
+                CHECK( guy.has_item_with( []( const item & it ) {
+                    return it.has_flag( flag_ITEM_BROKEN );
+                } ) );
             }
         }
 
@@ -504,7 +512,9 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_ITEM_BROKEN ); } ) );
+                CHECK_FALSE( guy.has_item_with( []( const item & it ) {
+                    return it.has_flag( flag_ITEM_BROKEN );
+                } ) );
             }
         }
     }
@@ -654,7 +664,9 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_WET ); } ) );
+                CHECK( guy.has_item_with( []( const item & it ) {
+                    return it.has_flag( flag_WET );
+                } ) );
             }
         }
 
@@ -668,7 +680,9 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_WET ); } ) );
+                CHECK( guy.has_item_with( []( const item & it ) {
+                    return it.has_flag( flag_WET );
+                } ) );
             }
         }
 
@@ -685,7 +699,9 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_WET ); } ) );
+                CHECK( guy.has_item_with( []( const item & it ) {
+                    return it.has_flag( flag_WET );
+                } ) );
             }
         }
 
@@ -702,7 +718,9 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with( []( const item & it ) { return it.has_flag( flag_WET ); } ) );
+                CHECK_FALSE( guy.has_item_with( []( const item & it ) {
+                    return it.has_flag( flag_WET );
+                } ) );
             }
         }
     }

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -341,7 +341,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should dissolve in water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.cache_has_item_with( flag_WATER_DISSOLVE ) );
+                CHECK_FALSE( guy.has_item_with_flag( flag_WATER_DISSOLVE ) );
             }
         }
 
@@ -358,7 +358,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should dissolve in water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.cache_has_item_with( flag_WATER_DISSOLVE ) );
+                CHECK_FALSE( guy.has_item_with_flag( flag_WATER_DISSOLVE ) );
             }
         }
 
@@ -375,7 +375,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not dissolve in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.cache_has_item_with( flag_WATER_DISSOLVE ) );
+                CHECK( guy.has_item_with_flag( flag_WATER_DISSOLVE ) );
             }
         }
 
@@ -394,7 +394,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should dissolve in water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.cache_has_item_with( flag_WATER_DISSOLVE ) );
+                CHECK_FALSE( guy.has_item_with_flag( flag_WATER_DISSOLVE ) );
             }
         }
 
@@ -413,7 +413,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not dissolve in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.cache_has_item_with( flag_WATER_DISSOLVE ) );
+                CHECK( guy.has_item_with_flag( flag_WATER_DISSOLVE ) );
             }
         }
     }
@@ -432,9 +432,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with( []( const item & it ) {
-                    return it.has_flag( flag_ITEM_BROKEN );
-                } ) );
+                CHECK( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
             }
         }
 
@@ -451,9 +449,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with( []( const item & it ) {
-                    return it.has_flag( flag_ITEM_BROKEN );
-                } ) );
+                CHECK( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
             }
         }
 
@@ -470,9 +466,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with( []( const item & it ) {
-                    return it.has_flag( flag_ITEM_BROKEN );
-                } ) );
+                CHECK_FALSE( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
             }
         }
 
@@ -491,9 +485,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with( []( const item & it ) {
-                    return it.has_flag( flag_ITEM_BROKEN );
-                } ) );
+                CHECK( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
             }
         }
 
@@ -512,9 +504,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with( []( const item & it ) {
-                    return it.has_flag( flag_ITEM_BROKEN );
-                } ) );
+                CHECK_FALSE( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
             }
         }
     }
@@ -664,9 +654,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with( []( const item & it ) {
-                    return it.has_flag( flag_WET );
-                } ) );
+                CHECK( guy.has_item_with_flag( flag_WET ) );
             }
         }
 
@@ -680,9 +668,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with( []( const item & it ) {
-                    return it.has_flag( flag_WET );
-                } ) );
+                CHECK( guy.has_item_with_flag( flag_WET ) );
             }
         }
 
@@ -699,9 +685,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with( []( const item & it ) {
-                    return it.has_flag( flag_WET );
-                } ) );
+                CHECK( guy.has_item_with_flag( flag_WET ) );
             }
         }
 
@@ -718,9 +702,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with( []( const item & it ) {
-                    return it.has_flag( flag_WET );
-                } ) );
+                CHECK_FALSE( guy.has_item_with_flag( flag_WET ) );
             }
         }
     }

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -341,7 +341,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should dissolve in water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with_flag( flag_WATER_DISSOLVE ) );
+                CHECK_FALSE( guy.has_any_item_with( flag_WATER_DISSOLVE ) );
             }
         }
 
@@ -358,7 +358,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should dissolve in water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with_flag( flag_WATER_DISSOLVE ) );
+                CHECK_FALSE( guy.has_any_item_with( flag_WATER_DISSOLVE ) );
             }
         }
 
@@ -375,7 +375,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not dissolve in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with_flag( flag_WATER_DISSOLVE ) );
+                CHECK( guy.has_any_item_with( flag_WATER_DISSOLVE ) );
             }
         }
 
@@ -394,7 +394,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should dissolve in water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with_flag( flag_WATER_DISSOLVE ) );
+                CHECK_FALSE( guy.has_any_item_with( flag_WATER_DISSOLVE ) );
             }
         }
 
@@ -413,7 +413,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not dissolve in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with_flag( flag_WATER_DISSOLVE ) );
+                CHECK( guy.has_any_item_with( flag_WATER_DISSOLVE ) );
             }
         }
     }
@@ -432,7 +432,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
+                CHECK( guy.has_any_item_with( flag_ITEM_BROKEN ) );
             }
         }
 
@@ -449,7 +449,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
+                CHECK( guy.has_any_item_with( flag_ITEM_BROKEN ) );
             }
         }
 
@@ -466,7 +466,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
+                CHECK_FALSE( guy.has_any_item_with( flag_ITEM_BROKEN ) );
             }
         }
 
@@ -485,7 +485,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
+                CHECK( guy.has_any_item_with( flag_ITEM_BROKEN ) );
             }
         }
 
@@ -504,7 +504,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not be broken by water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with_flag( flag_ITEM_BROKEN ) );
+                CHECK_FALSE( guy.has_any_item_with( flag_ITEM_BROKEN ) );
             }
         }
     }
@@ -654,7 +654,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with_flag( flag_WET ) );
+                CHECK( guy.has_any_item_with( flag_WET ) );
             }
         }
 
@@ -668,7 +668,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with_flag( flag_WET ) );
+                CHECK( guy.has_any_item_with( flag_WET ) );
             }
         }
 
@@ -685,7 +685,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK( guy.has_item_with_flag( flag_WET ) );
+                CHECK( guy.has_any_item_with( flag_WET ) );
             }
         }
 
@@ -702,7 +702,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
 
             THEN( "should not get wet in water" ) {
                 g->water_affect_items( guy );
-                CHECK_FALSE( guy.has_item_with_flag( flag_WET ) );
+                CHECK_FALSE( guy.has_any_item_with( flag_WET ) );
             }
         }
     }

--- a/tests/move_cost_test.cpp
+++ b/tests/move_cost_test.cpp
@@ -72,14 +72,14 @@ TEST_CASE( "footwear_may_affect_movement_cost", "[move_cost][shoes]" )
     REQUIRE( ava.get_modifier( character_modifier_limb_footing_movecost_mod ) == 1 );
 
     SECTION( "without shoes" ) {
-        ava.worn.clear();
+        ava.clear_worn();
         REQUIRE_FALSE( ava.is_wearing_shoes() );
         // Having no shoes adds +8 per foot to base run cost
         CHECK( ava.run_cost( 100 ) == 116 );
     }
 
     SECTION( "wearing sneakers" ) {
-        ava.worn.clear();
+        ava.clear_worn();
         ava.wear_item( item( "sneakers" ) );
         REQUIRE( ava.is_wearing_shoes() );
         REQUIRE( ava.get_modifier( character_modifier_limb_run_cost_mod ) == Approx( 1.0 ) );
@@ -88,7 +88,7 @@ TEST_CASE( "footwear_may_affect_movement_cost", "[move_cost][shoes]" )
     }
 
     SECTION( "wearing swim fins" ) {
-        ava.worn.clear();
+        ava.clear_worn();
         ava.wear_item( item( "swim_fins" ) );
         REQUIRE( ava.is_wearing_shoes() );
         REQUIRE( ava.get_modifier( character_modifier_limb_run_cost_mod ) == Approx( 1.11696 ) );
@@ -97,7 +97,7 @@ TEST_CASE( "footwear_may_affect_movement_cost", "[move_cost][shoes]" )
     }
 
     GIVEN( "wearing rollerblades (ROLLER_INLINE)" ) {
-        ava.worn.clear();
+        ava.clear_worn();
         ava.wear_item( item( "roller_blades" ) );
         REQUIRE( ava.worn_with_flag( flag_ROLLER_INLINE ) );
         REQUIRE( ava.get_modifier( character_modifier_limb_run_cost_mod ) == Approx( 1.11696 ) );
@@ -117,7 +117,7 @@ TEST_CASE( "footwear_may_affect_movement_cost", "[move_cost][shoes]" )
     }
 
     GIVEN( "wearing roller skates (ROLLER_QUAD)" ) {
-        ava.worn.clear();
+        ava.clear_worn();
         ava.wear_item( item( "rollerskates" ) );
         REQUIRE( ava.worn_with_flag( flag_ROLLER_QUAD ) );
         REQUIRE( ava.get_modifier( character_modifier_limb_run_cost_mod ) == Approx( 1.11696 ) );
@@ -137,7 +137,7 @@ TEST_CASE( "footwear_may_affect_movement_cost", "[move_cost][shoes]" )
     }
 
     GIVEN( "wearing heelys (ROLLER_ONE)" ) {
-        ava.worn.clear();
+        ava.clear_worn();
         ava.wear_item( item( "roller_shoes_on" ) );
         REQUIRE( ava.worn_with_flag( flag_ROLLER_ONE ) );
         REQUIRE( ava.get_modifier( character_modifier_limb_run_cost_mod ) == Approx( 1.0 ) );
@@ -168,12 +168,12 @@ TEST_CASE( "mutations_may_affect_movement_cost", "[move_cost][mutation]" )
 
     GIVEN( "no mutations" ) {
         THEN( "wearing sneakers gives baseline 100 movement speed" ) {
-            ava.worn.clear();
+            ava.clear_worn();
             ava.wear_item( item( "sneakers" ) );
             CHECK( ava.run_cost( 100 ) == Approx( base_cost ) );
         }
         THEN( "being barefoot gives a +16 movement cost penalty" ) {
-            ava.worn.clear();
+            ava.clear_worn();
             CHECK( ava.run_cost( 100 ) == Approx( base_cost + 16 ) );
         }
     }
@@ -181,7 +181,7 @@ TEST_CASE( "mutations_may_affect_movement_cost", "[move_cost][mutation]" )
     GIVEN( "LEG_TENTACLES" ) {
         ava.toggle_trait( trait_LEG_TENTACLES );
         THEN( "barefoot penalty does not apply, but movement is slower" ) {
-            ava.worn.clear();
+            ava.clear_worn();
             CHECK( ava.run_cost( 100 ) == Approx( 1.2 * base_cost ) );
         }
     }
@@ -189,7 +189,7 @@ TEST_CASE( "mutations_may_affect_movement_cost", "[move_cost][mutation]" )
     GIVEN( "HOOVES" ) {
         ava.toggle_trait( trait_HOOVES );
         THEN( "barefoot penalty does not apply" ) {
-            ava.worn.clear();
+            ava.clear_worn();
             CHECK( ava.run_cost( 100 ) == Approx( base_cost ) );
         }
     }
@@ -197,7 +197,7 @@ TEST_CASE( "mutations_may_affect_movement_cost", "[move_cost][mutation]" )
     GIVEN( "TOUGH_FEET" ) {
         ava.toggle_trait( trait_TOUGH_FEET );
         THEN( "barefoot penalty does not apply" ) {
-            ava.worn.clear();
+            ava.clear_worn();
             CHECK( ava.run_cost( 100 ) == Approx( base_cost ) );
         }
     }
@@ -205,12 +205,12 @@ TEST_CASE( "mutations_may_affect_movement_cost", "[move_cost][mutation]" )
     GIVEN( "PADDED_FEET" ) {
         ava.toggle_trait( trait_PADDED_FEET );
         THEN( "wearing sneakers gives baseline 100 movement speed" ) {
-            ava.worn.clear();
+            ava.clear_worn();
             ava.wear_item( item( "sneakers" ) );
             CHECK( ava.run_cost( 100 ) == Approx( base_cost ) );
         }
         THEN( "being barefoot is faster than wearing sneakers" ) {
-            ava.worn.clear();
+            ava.clear_worn();
             CHECK( ava.run_cost( 100 ) == Approx( 0.9 * base_cost ) );
         }
     }

--- a/tests/new_character_test.cpp
+++ b/tests/new_character_test.cpp
@@ -156,7 +156,7 @@ TEST_CASE( "starting_items", "[slow]" )
                     continue; // Trait conflict: this prof/scen/trait combo is impossible to attain
                 }
                 for( int i = 0; i < 2; i++ ) {
-                    player_character.worn.clear();
+                    player_character.clear_worn();
                     player_character.remove_weapon();
                     player_character.inv->clear();
                     player_character.calc_encumbrance();

--- a/tests/new_character_test.cpp
+++ b/tests/new_character_test.cpp
@@ -158,7 +158,7 @@ TEST_CASE( "starting_items", "[slow]" )
                 for( int i = 0; i < 2; i++ ) {
                     player_character.clear_worn();
                     player_character.remove_weapon();
-                    player_character.clear_inv();
+                    player_character.inv->clear();
                     player_character.calc_encumbrance();
                     player_character.male = i == 0;
 

--- a/tests/new_character_test.cpp
+++ b/tests/new_character_test.cpp
@@ -158,7 +158,7 @@ TEST_CASE( "starting_items", "[slow]" )
                 for( int i = 0; i < 2; i++ ) {
                     player_character.clear_worn();
                     player_character.remove_weapon();
-                    player_character.inv->clear();
+                    player_character.clear_inv();
                     player_character.calc_encumbrance();
                     player_character.male = i == 0;
 

--- a/tests/npc_attack_test.cpp
+++ b/tests/npc_attack_test.cpp
@@ -150,7 +150,7 @@ TEST_CASE( "NPC_faces_zombies", "[npc_attack]" )
             }
         }
         WHEN( "NPC has power armor" ) {
-            main_npc.worn.clear();
+            main_npc.clear_worn();
 
             item armor( "power_armor_basic" );
             std::optional<std::list<item>::iterator> wear_success = main_npc.wear_item( armor );
@@ -188,7 +188,7 @@ TEST_CASE( "NPC_faces_zombies", "[npc_attack]" )
             }
         }
         WHEN( "NPC has a headlamp" ) {
-            main_npc.worn.clear();
+            main_npc.clear_worn();
 
             item headlamp( "wearable_light" );
             std::optional<std::list<item>::iterator> wear_success = main_npc.wear_item( headlamp );

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -1736,7 +1736,7 @@ static const std::vector<std::function<player_activity()>> test_activities {
 
 static void cleanup( avatar &dummy )
 {
-    dummy.clear_inv();
+    dummy.inv->clear();
     clear_map();
 
     REQUIRE( dummy.activity.get_distractions().empty() );

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -212,7 +212,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
         }
 
         GIVEN( "player has a stethoscope" ) {
-            dummy.worn.clear();
+            dummy.clear_worn();
             dummy.remove_weapon();
             dummy.add_bionic( bio_ears );
             mp.furn_set( safe, f_safe_l );
@@ -245,7 +245,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
                 }
 
                 THEN( "player loses their stethoscope" ) {
-                    dummy.worn.clear();
+                    dummy.clear_worn();
                     dummy.remove_weapon();
                     REQUIRE( !dummy.has_item_with_flag( flag_SAFECRACK ) );
 

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -182,7 +182,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
 
         GIVEN( "player without the required tools" ) {
             mp.furn_set( safe, f_safe_l );
-            REQUIRE( !dummy.has_any_item_with( flag_SAFECRACK ) );
+            REQUIRE( !dummy.cache_has_item_with( flag_SAFECRACK ) );
             REQUIRE( !dummy.has_flag( json_flag_SUPER_HEARING ) );
             REQUIRE( dummy.activity.id() == ACT_CRACKING );
             REQUIRE( mp.furn( safe ) == f_safe_l );
@@ -198,7 +198,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
         GIVEN( "player has a stethoscope" ) {
             dummy.i_add( item( "stethoscope" ) );
             mp.furn_set( safe, f_safe_l );
-            REQUIRE( dummy.has_any_item_with( flag_SAFECRACK ) );
+            REQUIRE( dummy.cache_has_item_with( flag_SAFECRACK ) );
             REQUIRE( !dummy.has_flag( json_flag_SUPER_HEARING ) );
             REQUIRE( dummy.activity.id() == ACT_CRACKING );
             REQUIRE( mp.furn( safe ) == f_safe_l );
@@ -216,7 +216,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
             dummy.remove_weapon();
             dummy.add_bionic( bio_ears );
             mp.furn_set( safe, f_safe_l );
-            REQUIRE( !dummy.has_any_item_with( flag_SAFECRACK ) );
+            REQUIRE( !dummy.cache_has_item_with( flag_SAFECRACK ) );
             REQUIRE( dummy.has_flag( json_flag_SUPER_HEARING ) );
             REQUIRE( dummy.activity.id() == ACT_CRACKING );
             REQUIRE( mp.furn( safe ) == f_safe_l );
@@ -233,7 +233,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
             dummy.clear_bionics();
             dummy.i_add( item( "stethoscope" ) );
             mp.furn_set( safe, f_safe_l );
-            REQUIRE( dummy.has_any_item_with( flag_SAFECRACK ) );
+            REQUIRE( dummy.cache_has_item_with( flag_SAFECRACK ) );
             REQUIRE( !dummy.has_flag( json_flag_SUPER_HEARING ) );
             REQUIRE( dummy.activity.id() == ACT_CRACKING );
             REQUIRE( mp.furn( safe ) == f_safe_l );
@@ -247,7 +247,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
                 THEN( "player loses their stethoscope" ) {
                     dummy.clear_worn();
                     dummy.remove_weapon();
-                    REQUIRE( !dummy.has_any_item_with( flag_SAFECRACK ) );
+                    REQUIRE( !dummy.cache_has_item_with( flag_SAFECRACK ) );
 
                     process_activity( dummy );
                     THEN( "activity is canceled" ) {
@@ -286,7 +286,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
         GIVEN( "player cracks one safe" ) {
             dummy.i_add( item( "stethoscope" ) );
             mp.furn_set( safe, f_safe_l );
-            REQUIRE( dummy.has_any_item_with( flag_SAFECRACK ) );
+            REQUIRE( dummy.cache_has_item_with( flag_SAFECRACK ) );
             REQUIRE( dummy.activity.id() == ACT_CRACKING );
             REQUIRE( mp.furn( safe ) == f_safe_l );
 

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -182,7 +182,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
 
         GIVEN( "player without the required tools" ) {
             mp.furn_set( safe, f_safe_l );
-            REQUIRE( !dummy.has_item_with_flag( flag_SAFECRACK ) );
+            REQUIRE( !dummy.has_any_item_with( flag_SAFECRACK ) );
             REQUIRE( !dummy.has_flag( json_flag_SUPER_HEARING ) );
             REQUIRE( dummy.activity.id() == ACT_CRACKING );
             REQUIRE( mp.furn( safe ) == f_safe_l );
@@ -198,7 +198,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
         GIVEN( "player has a stethoscope" ) {
             dummy.i_add( item( "stethoscope" ) );
             mp.furn_set( safe, f_safe_l );
-            REQUIRE( dummy.has_item_with_flag( flag_SAFECRACK ) );
+            REQUIRE( dummy.has_any_item_with( flag_SAFECRACK ) );
             REQUIRE( !dummy.has_flag( json_flag_SUPER_HEARING ) );
             REQUIRE( dummy.activity.id() == ACT_CRACKING );
             REQUIRE( mp.furn( safe ) == f_safe_l );
@@ -216,7 +216,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
             dummy.remove_weapon();
             dummy.add_bionic( bio_ears );
             mp.furn_set( safe, f_safe_l );
-            REQUIRE( !dummy.has_item_with_flag( flag_SAFECRACK ) );
+            REQUIRE( !dummy.has_any_item_with( flag_SAFECRACK ) );
             REQUIRE( dummy.has_flag( json_flag_SUPER_HEARING ) );
             REQUIRE( dummy.activity.id() == ACT_CRACKING );
             REQUIRE( mp.furn( safe ) == f_safe_l );
@@ -233,7 +233,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
             dummy.clear_bionics();
             dummy.i_add( item( "stethoscope" ) );
             mp.furn_set( safe, f_safe_l );
-            REQUIRE( dummy.has_item_with_flag( flag_SAFECRACK ) );
+            REQUIRE( dummy.has_any_item_with( flag_SAFECRACK ) );
             REQUIRE( !dummy.has_flag( json_flag_SUPER_HEARING ) );
             REQUIRE( dummy.activity.id() == ACT_CRACKING );
             REQUIRE( mp.furn( safe ) == f_safe_l );
@@ -247,7 +247,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
                 THEN( "player loses their stethoscope" ) {
                     dummy.clear_worn();
                     dummy.remove_weapon();
-                    REQUIRE( !dummy.has_item_with_flag( flag_SAFECRACK ) );
+                    REQUIRE( !dummy.has_any_item_with( flag_SAFECRACK ) );
 
                     process_activity( dummy );
                     THEN( "activity is canceled" ) {
@@ -286,7 +286,7 @@ TEST_CASE( "safecracking", "[activity][safecracking]" )
         GIVEN( "player cracks one safe" ) {
             dummy.i_add( item( "stethoscope" ) );
             mp.furn_set( safe, f_safe_l );
-            REQUIRE( dummy.has_item_with_flag( flag_SAFECRACK ) );
+            REQUIRE( dummy.has_any_item_with( flag_SAFECRACK ) );
             REQUIRE( dummy.activity.id() == ACT_CRACKING );
             REQUIRE( mp.furn( safe ) == f_safe_l );
 

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -1736,7 +1736,7 @@ static const std::vector<std::function<player_activity()>> test_activities {
 
 static void cleanup( avatar &dummy )
 {
-    dummy.inv->clear();
+    dummy.clear_inv();
     clear_map();
 
     REQUIRE( dummy.activity.get_distractions().empty() );

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -72,7 +72,7 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.normalize(); // In particular this clears martial arts style
 
     // delete all worn items.
-    dummy.worn.clear();
+    dummy.clear_worn();
     dummy.calc_encumbrance();
     dummy.invalidate_crafting_inventory();
     dummy.inv->clear();
@@ -207,7 +207,7 @@ void clear_avatar()
 void equip_shooter( npc &shooter, const std::vector<std::string> &apparel )
 {
     CHECK( !shooter.in_vehicle );
-    shooter.worn.clear();
+    shooter.clear_worn();
     shooter.inv->clear();
     for( const std::string &article : apparel ) {
         shooter.wear_item( item( article ) );

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -75,7 +75,7 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.clear_worn();
     dummy.calc_encumbrance();
     dummy.invalidate_crafting_inventory();
-    dummy.inv->clear();
+    dummy.clear_inv();
     dummy.remove_weapon();
     dummy.clear_mutations();
     dummy.mutation_category_level.clear();
@@ -208,7 +208,7 @@ void equip_shooter( npc &shooter, const std::vector<std::string> &apparel )
 {
     CHECK( !shooter.in_vehicle );
     shooter.clear_worn();
-    shooter.inv->clear();
+    shooter.clear_inv();
     for( const std::string &article : apparel ) {
         shooter.wear_item( item( article ) );
     }

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -75,7 +75,7 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.clear_worn();
     dummy.calc_encumbrance();
     dummy.invalidate_crafting_inventory();
-    dummy.clear_inv();
+    dummy.inv->clear();
     dummy.remove_weapon();
     dummy.clear_mutations();
     dummy.mutation_category_level.clear();
@@ -208,7 +208,7 @@ void equip_shooter( npc &shooter, const std::vector<std::string> &apparel )
 {
     CHECK( !shooter.in_vehicle );
     shooter.clear_worn();
-    shooter.clear_inv();
+    shooter.inv->clear();
     for( const std::string &article : apparel ) {
         shooter.wear_item( item( article ) );
     }

--- a/tests/player_test.cpp
+++ b/tests/player_test.cpp
@@ -162,19 +162,19 @@ TEST_CASE( "sweating", "[char][suffer][.bodytemp]" )
 
     GIVEN( "avatar wears outfit and sweats for an hour" ) {
         WHEN( "wearing fur" ) {
-            dummy.worn.clear();
+            dummy.clear_worn();
             dummy.wear_item( fur_jumper, false );
 
             temperature_and_sweat_check( &dummy, 100, 8100 );
         }
         WHEN( "wearing cotton" ) {
-            dummy.worn.clear();
+            dummy.clear_worn();
             dummy.wear_item( cotton_jumper, false );
 
             temperature_and_sweat_check( &dummy, 100, 7900 );
         }
         WHEN( "wearing lycra" ) {
-            dummy.worn.clear();
+            dummy.clear_worn();
             dummy.wear_item( lycra_jumper, false );
 
             temperature_and_sweat_check( &dummy, 100, 7000 );

--- a/tests/reload_magazine_test.cpp
+++ b/tests/reload_magazine_test.cpp
@@ -49,7 +49,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location] [re
     CHECK( mag_cap > 0 );
 
     avatar &player_character = get_avatar();
-    player_character.worn.clear();
+    player_character.clear_worn();
     player_character.inv->clear();
     player_character.remove_weapon();
     player_character.wear_item( item( "backpack" ) ); // so we don't drop anything
@@ -344,7 +344,7 @@ TEST_CASE( "reload_revolver", "[visitable] [item] [item_location] [reload]" )
     CHECK( alt_ammo != bad_ammo );
 
     Character &player_character = get_player_character();
-    player_character.worn.clear();
+    player_character.clear_worn();
     player_character.inv->clear();
     player_character.remove_weapon();
     player_character.wear_item( item( "backpack" ) ); // so we don't drop anything

--- a/tests/reload_magazine_test.cpp
+++ b/tests/reload_magazine_test.cpp
@@ -50,7 +50,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location] [re
 
     avatar &player_character = get_avatar();
     player_character.clear_worn();
-    player_character.inv->clear();
+    player_character.clear_inv();
     player_character.remove_weapon();
     player_character.wear_item( item( "backpack" ) ); // so we don't drop anything
 
@@ -345,7 +345,7 @@ TEST_CASE( "reload_revolver", "[visitable] [item] [item_location] [reload]" )
 
     Character &player_character = get_player_character();
     player_character.clear_worn();
-    player_character.inv->clear();
+    player_character.clear_inv();
     player_character.remove_weapon();
     player_character.wear_item( item( "backpack" ) ); // so we don't drop anything
 

--- a/tests/reload_magazine_test.cpp
+++ b/tests/reload_magazine_test.cpp
@@ -50,7 +50,7 @@ TEST_CASE( "reload_magazine", "[magazine] [visitable] [item] [item_location] [re
 
     avatar &player_character = get_avatar();
     player_character.clear_worn();
-    player_character.clear_inv();
+    player_character.inv->clear();
     player_character.remove_weapon();
     player_character.wear_item( item( "backpack" ) ); // so we don't drop anything
 
@@ -345,7 +345,7 @@ TEST_CASE( "reload_revolver", "[visitable] [item] [item_location] [reload]" )
 
     Character &player_character = get_player_character();
     player_character.clear_worn();
-    player_character.clear_inv();
+    player_character.inv->clear();
     player_character.remove_weapon();
     player_character.wear_item( item( "backpack" ) ); // so we don't drop anything
 

--- a/tests/reloading_test.cpp
+++ b/tests/reloading_test.cpp
@@ -954,7 +954,7 @@ TEST_CASE( "automatic_reloading_action", "[reload],[gun]" )
     }
 
     GIVEN( "a player wielding an unloaded gun, carrying an unloaded magazine, and carrying ammo for the magazine" ) {
-        dummy.worn.clear();
+        dummy.clear_worn();
         dummy.worn.wear_item( dummy, item( "backpack" ), false, false );
         item_location ammo = dummy.i_add( item( "9mm", calendar::turn_zero, 50 ) );
         const cata::value_ptr<islot_ammo> &ammo_type = ammo->type->ammo;

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -151,7 +151,7 @@ struct vision_test_case {
     void test_all() const {
         Character &player_character = get_player_character();
         g->place_player( tripoint( 60, 60, 0 ) );
-        player_character.worn.clear(); // Remove any light-emitting clothing
+        player_character.clear_worn(); // Remove any light-emitting clothing
         player_character.clear_effects();
         player_character.clear_bionics();
         player_character.clear_mutations(); // remove mutations that potentially affect vision

--- a/tests/wield_times_test.cpp
+++ b/tests/wield_times_test.cpp
@@ -21,7 +21,7 @@ static const itype_id itype_metal_tank( "metal_tank" );
 static void wield_check_from_inv( avatar &guy, const itype_id &item_name, const int expected_moves )
 {
     guy.remove_weapon();
-    guy.worn.clear();
+    guy.clear_worn();
     item spawned_item( item_name, calendar::turn, 1 );
     item backpack( "backpack" );
     REQUIRE( backpack.can_contain( spawned_item ).success() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Cache results of item search functions"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
One of the larger CPU hogs when moving around with extremely large inventories is `all_items_with_flag` and similar inventory searching functions. These iterate through every single item in the character's inventory to find specific ones. These functions are called very often, and sometimes for fairly minor reasons such as looking for a watch to determine if the sidebar should show the exact time or the sundial. As these results aren't cached, every function like this will do their own iteration through the entire inventory every turn - some even do this every frame.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds `inv_search_cache` to the character class. This map is used to cache the results of a new suite of functions that search through the inventory for certain items: `cache_visit_items_with` for applying code to the filtered items, `cache_has_item_with` for getting a boolean result, and `cache_get_items_with` for creating a vector. These functions can filter items based on having a specified item type, having a specified flag on their type, having a true result from a specified simple boolean item function, or a combination of the 3. All of these results are cached, making it extremely fast to request the same filters in the future. In addition to the filter parameters, the functions also accept a lambda function parameter that can be run on all the filtered items to further filter the results. Though the lambda's results are not cached, the preceding cached filters can help narrow things down so the lambda will only have to process a fraction of a character's items rather than all of them. The non-cache-using `has_item_with_flag` function is still around, as there are item instance flags like `WET` or `ITEM_BROKEN` that shouldn't be cached.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I reworked everything from my first attempt based on feedback received, so there was already an alternative I considered so much it became the real thing.

The UI functions that call item searches every draw frame seem like they could be optimized further - for example, the game is updating the lightmap every frame, and that update includes searching the player's inventory for their most luminous item. In practice this seems unnecessary, as even if the player drops said item they'll keep their same "lit_up" buff until the game turn ticks over to the next. It might work to only update the character's maximum inventory luminosity every turn instead, rather than every frame. However... the cached item results work well enough already that their CPU impact is almost entirely reduced, so I deemed it unnecessary.

#### Testing
Added and removed inventory items in all available ways to ensure they didn't crash. Loaded a worn pocket universe with 10,000 caffeine pills, 10,000 bottles of water, and 10,000 wrist watches, and noted that the inv_search_cache functions had little notable CPU impact. Ran the full test suite locally and got all green results.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
- [x] Rework `items_with` to also work with the cache.
- [x] Use said rework for lights instead of the special case it's using now.
- [x] Implement it for other uses of `items_with`.

I didn't actually end up using multiple filter parameters at once in the new functions, but I feel like they could be useful somewhere so I kept them.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
