### PR TITLE
[Defense Mode]: My Sweet Cataclysm compatibility

### DIFF
--- a/data/mods/Defense_Mode/eocs.json
+++ b/data/mods/Defense_Mode/eocs.json
@@ -71,7 +71,8 @@
           [ "DEFENSE_MODE_WAVE_SPAWN_GOBLINS", { "const": 1 } ],
           [ "DEFENSE_MODE_WAVE_SPAWN_ORCS", { "const": 1 } ],
           [ "DEFENSE_MODE_WAVE_SPAWN_MEGAFAUNA", { "const": 1 } ],
-          [ "DEFENSE_MODE_WAVE_SPAWN_PSYCHICS", { "const": 1 } ]
+          [ "DEFENSE_MODE_WAVE_SPAWN_PSYCHICS", { "const": 1 } ],
+          [ "DEFENSE_MODE_WAVE_SPAWN_CANDY", { "const": 1 } ]
         ]
       }
     ]
@@ -95,7 +96,8 @@
           [ "DEFENSE_MODE_WAVE_SPAWN_GOBLINS", { "const": 1 } ],
           [ "DEFENSE_MODE_WAVE_SPAWN_ORCS", { "const": 1 } ],
           [ "DEFENSE_MODE_WAVE_SPAWN_MEGAFAUNA", { "const": 1 } ],
-          [ "DEFENSE_MODE_WAVE_SPAWN_PSYCHICS", { "const": 1 } ]
+          [ "DEFENSE_MODE_WAVE_SPAWN_PSYCHICS", { "const": 1 } ],
+          [ "DEFENSE_MODE_WAVE_SPAWN_CANDY", { "const": 1 } ]
         ]
       }
     ]

--- a/data/mods/Defense_Mode/menu_screen.json
+++ b/data/mods/Defense_Mode/menu_screen.json
@@ -22,7 +22,8 @@
             { "math": [ "goblins_allowed", "==", "1" ] },
             { "math": [ "golems_allowed", "==", "1" ] },
             { "math": [ "orcs_allowed", "==", "1" ] },
-            { "math": [ "mindovermatter_allowed", "==", "1" ] }
+            { "math": [ "mindovermatter_allowed", "==", "1" ] },
+            { "math": [ "candymonsters_allowed", "==", "1" ] }
           ]
         },
         "topic": "TALK_DONE"
@@ -191,6 +192,18 @@
         "topic": "TALK_DEFENSE_MODE_ENEMY_SELECTION"
       },
       {
+        "text": "Allow sweets.",
+        "condition": { "and": [ { "mod_is_loaded": "my_sweet_cataclysm" }, { "math": [ "candymonsters_allowed", "==", "0" ] } ] },
+        "effect": { "math": [ "candymonsters_allowed", "=", "1" ] },
+        "topic": "TALK_DEFENSE_MODE_ENEMY_SELECTION"
+      },
+      {
+        "text": "Disable sweets.",
+        "condition": { "and": [ { "mod_is_loaded": "my_sweet_cataclysm" }, { "math": [ "candymonsters_allowed", "==", "1" ] } ] },
+        "effect": { "math": [ "candymonsters_allowed", "=", "0" ] },
+        "topic": "TALK_DEFENSE_MODE_ENEMY_SELECTION"
+      },
+      {
         "text": "Play!",
         "condition": {
           "or": [
@@ -206,7 +219,8 @@
             { "math": [ "goblins_allowed", "==", "1" ] },
             { "math": [ "golems_allowed", "==", "1" ] },
             { "math": [ "orcs_allowed", "==", "1" ] },
-            { "math": [ "mindovermatter_allowed", "==", "1" ] }
+            { "math": [ "mindovermatter_allowed", "==", "1" ] },
+            { "math": [ "candymonsters_allowed", "==", "1" ] }
           ]
         },
         "topic": "TALK_DONE"

--- a/data/mods/Defense_Mode/mod_interactions/My_Sweet_Cataclysm/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/My_Sweet_Cataclysm/eocs.json
@@ -1,0 +1,34 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "DEFENSE_MODE_WAVE_SPAWN_CANDY",
+    "condition": { "math": [ "candymonsters_allowed", "==", "1" ] },
+    "effect": [
+      {
+        "u_spawn_monster": "GROUP_SWEET_HORDE",
+        "real_count": { "global_val": "wave_number", "default": 1 },
+        "outdoor_only": true,
+        "group": true,
+        "min_radius": 20,
+        "max_radius": 40
+      },
+      {
+        "u_spawn_monster": "GROUP_SWEET_HORDE",
+        "real_count": { "global_val": "wave_number", "default": 1 },
+        "outdoor_only": true,
+        "group": true,
+        "min_radius": 20,
+        "max_radius": 40
+      },
+      {
+        "u_spawn_monster": "GROUP_SWEET_HORDE",
+        "real_count": { "global_val": "wave_number", "default": 1 },
+        "outdoor_only": true,
+        "group": true,
+        "min_radius": 20,
+        "max_radius": 40
+      }
+    ],
+    "false_effect": { "run_eocs": "DEFENSE_MODE_WAVE_SPAWN_FALLBACK" }
+  }
+]

--- a/data/mods/My_Sweet_Cataclysm/modinteractions/Defense_Mode/monstergroups.json
+++ b/data/mods/My_Sweet_Cataclysm/modinteractions/Defense_Mode/monstergroups.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "GROUP_SWEET_HORDE",
+    "type": "monstergroup",
+    "monsters": [ 
+     { "monster": "mon_marshmallow_guy_dm" },
+     { "monster": "mon_marshmallow_buff_dm" },
+     { "monster": "mon_marshmallow_guy_armored_dm" },
+     { "monster": "mon_marshmallow_buff_armored_dm" },
+     { "monster": "mon_gummy_dm" },
+     { "monster": "mon_gummy_gator_dm" },
+     { "monster": "mon_cracker_dm" },
+     { "monster": "mon_cookie_dm" },
+     { "monster": "mon_cookie_hydra_dm" },
+     { "monster": "mon_spider_gum_dm" },
+     { "monster": "mon_gum_spider_wolf_dm" },
+     { "monster": "mon_licorice_snake_dm" }
+    ]
+  }
+]

--- a/data/mods/My_Sweet_Cataclysm/modinteractions/Defense_Mode/monstergroups.json
+++ b/data/mods/My_Sweet_Cataclysm/modinteractions/Defense_Mode/monstergroups.json
@@ -2,19 +2,19 @@
   {
     "name": "GROUP_SWEET_HORDE",
     "type": "monstergroup",
-    "monsters": [ 
-     { "monster": "mon_marshmallow_guy_dm" },
-     { "monster": "mon_marshmallow_buff_dm" },
-     { "monster": "mon_marshmallow_guy_armored_dm" },
-     { "monster": "mon_marshmallow_buff_armored_dm" },
-     { "monster": "mon_gummy_dm" },
-     { "monster": "mon_gummy_gator_dm" },
-     { "monster": "mon_cracker_dm" },
-     { "monster": "mon_cookie_dm" },
-     { "monster": "mon_cookie_hydra_dm" },
-     { "monster": "mon_spider_gum_dm" },
-     { "monster": "mon_gum_spider_wolf_dm" },
-     { "monster": "mon_licorice_snake_dm" }
+    "monsters": [
+      { "monster": "mon_marshmallow_guy_dm" },
+      { "monster": "mon_marshmallow_buff_dm" },
+      { "monster": "mon_marshmallow_guy_armored_dm" },
+      { "monster": "mon_marshmallow_buff_armored_dm" },
+      { "monster": "mon_gummy_dm" },
+      { "monster": "mon_gummy_gator_dm" },
+      { "monster": "mon_cracker_dm" },
+      { "monster": "mon_cookie_dm" },
+      { "monster": "mon_cookie_hydra_dm" },
+      { "monster": "mon_spider_gum_dm" },
+      { "monster": "mon_gum_spider_wolf_dm" },
+      { "monster": "mon_licorice_snake_dm" }
     ]
   }
 ]

--- a/data/mods/My_Sweet_Cataclysm/modinteractions/Defense_Mode/monsters.json
+++ b/data/mods/My_Sweet_Cataclysm/modinteractions/Defense_Mode/monsters.json
@@ -1,0 +1,135 @@
+[
+  {
+    "id": "mon_marshmallow_guy_dm",
+    "copy-from": "mon_marshmallow_guy",
+    "type": "MONSTER",
+    "species": [ "DM_SWEETS" ],
+    "default_faction": "marshmallow_boys",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_marshmallow_buff_dm",
+    "copy-from": "mon_marshmallow_buff",
+    "type": "MONSTER",
+    "species": [ "DM_SWEETS" ],
+    "default_faction": "marshmallow_boys",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_marshmallow_guy_armored_dm",
+    "copy-from": "mon_marshmallow_guy_armored",
+    "type": "MONSTER",
+    "species": [ "DM_SWEETS" ],
+    "default_faction": "marshmallow_boys",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_marshmallow_buff_armored_dm",
+    "copy-from": "mon_marshmallow_buff_armored",
+    "type": "MONSTER",
+    "species": [ "DM_SWEETS" ],
+    "default_faction": "marshmallow_boys",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_gummy_dm",
+    "copy-from": "mon_gummy",
+    "type": "MONSTER",
+    "species": [ "DM_SWEETS" ],
+    "default_faction": "marshmallow_boys",
+    "hp": 50,
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_gummy_gator_dm",
+    "copy-from": "mon_gummy_gator",
+    "type": "MONSTER",
+    "species": [ "DM_SWEETS" ],
+    "default_faction": "marshmallow_boys",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_cracker_dm",
+    "copy-from": "mon_cracker",
+    "type": "MONSTER",
+    "species": [ "DM_SWEETS" ],
+    "default_faction": "marshmallow_boys",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_cookie_dm",
+    "copy-from": "mon_cookie",
+    "type": "MONSTER",
+    "species": [ "DM_SWEETS" ],
+    "default_faction": "marshmallow_boys",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_cookie_hydra_dm",
+    "copy-from": "mon_cookie_hydra",
+    "type": "MONSTER",
+    "species": [ "DM_SWEETS" ],
+    "default_faction": "marshmallow_boys",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_spider_gum_dm",
+    "copy-from": "mon_spider_gum",
+    "type": "MONSTER",
+    "species": [ "DM_SWEETS" ],
+    "default_faction": "marshmallow_boys",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_gum_spider_wolf_dm",
+    "copy-from": "mon_gum_spider_wolf",
+    "type": "MONSTER",
+    "species": [ "DM_SWEETS" ],
+    "default_faction": "marshmallow_boys",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_licorice_snake_dm",
+    "copy-from": "mon_licorice_snake",
+    "type": "MONSTER",
+    "species": [ "DM_SWEETS" ],
+    "default_faction": "marshmallow_boys",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  }
+]

--- a/data/mods/My_Sweet_Cataclysm/modinteractions/Defense_Mode/species.json
+++ b/data/mods/My_Sweet_Cataclysm/modinteractions/Defense_Mode/species.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "SPECIES",
+    "id": "DM_SWEETS",
+    "flags": [ "ALL_SEEING", "NEMESIS" ],
+    "footsteps": "shlop."
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Add Defense Mode compatibility with My Sweet Cataclysm."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Continue to add more long-desired (and fun) mod compatability.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Implement necessary JSON structures for sugary enemies to spawn in Defense Mode when My Sweet Cataclysm is enabled, including monsters, EOCs, species, and spawn groups.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Went into the game, fought some marshmallows and got a sugar crash from feasting on their flesh.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
In the future, if possible, I might try and modify more things besides start locations with these mod connections. It would be nice to start in a wizard tower or a house of graham crackers in a chocolate bog.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
