### PR TITLE
@ menu UI scrolling

### DIFF
--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -488,6 +488,8 @@ bool return_false( const T & )
 /**
  * Joins an iterable (class implementing begin() and end()) of elements into a single
  * string with specified delimiter by using `<<` ostream operator on each element
+ *
+ * keyword: implode
  */
 template<typename Container>
 std::string string_join( const Container &iterable, const std::string &joiner )
@@ -505,6 +507,8 @@ std::string string_join( const Container &iterable, const std::string &joiner )
 
 /**
 * Splits a string by delimiter into a vector of strings
+*
+* keyword: explode
 */
 std::vector<std::string> string_split( std::string_view string, char delim );
 

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -805,23 +805,11 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
     }
     center_print( w_skills, 0, cstatus, _( title_SKILLS ) );
 
-    size_t min = 0;
-    size_t max = 0;
-
-    const size_t half_y = ( skill_win_size_y - 1 ) / 2;
-
-    if( !is_current_tab || line <= half_y ) {
-        min = 0;
-    } else if( line >= skillslist.size() - half_y ) {
-        min = ( skillslist.size() < skill_win_size_y - 1 ? 0 : skillslist.size() -
-                skill_win_size_y + 1 );
-    } else {
-        min = line - half_y;
-    }
-    max = std::min( min + skill_win_size_y - 1, skillslist.size() );
+    const auto& [i_start, i_end] = subindex_around_cursor( skillslist.size(), skill_win_size_y - 1,
+                                   line, is_current_tab );
 
     int y_pos = 1;
-    for( size_t i = min; i < max; ++i, ++y_pos ) {
+    for( int i = i_start; i < i_end; ++i, ++y_pos ) {
         const Skill *aSkill = skillslist[i].skill;
         if( skillslist[i].is_header ) {
             const SkillDisplayType t = SkillDisplayType::get_skill_type( aSkill->display_category() );
@@ -843,7 +831,7 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
                 locked = true;
             }
             level_num = you.enchantment_cache->modify_value( aSkill->ident(), level_num );
-            if( is_current_tab && i == line ) {
+            if( is_current_tab && i == static_cast<int>( line ) ) {
                 ui.set_cursor( w_skills, point( 1, y_pos ) );
                 if( locked ) {
                     cstatus = h_yellow;

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -810,7 +810,6 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
         if( skillslist[i].is_header ) {
             const SkillDisplayType t = SkillDisplayType::get_skill_type( aSkill->display_category() );
             std::string type_name = t.display_string();
-            mvwprintz( w_skills, point( 0, y_pos ), c_light_gray, std::string( grid_width, ' ' ) );
             center_print( w_skills, y_pos, c_yellow, type_name );
         } else {
             const SkillLevel &level = you.get_skill_level_object( aSkill->ident() );
@@ -840,7 +839,6 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
                 } else {
                     cstatus = training ? h_light_blue : h_blue;
                 }
-                mvwprintz( w_skills, point( 1, y_pos ), cstatus, std::string( width - 1, ' ' ) );
             } else {
                 if( locked ) {
                     cstatus = c_yellow;
@@ -851,7 +849,6 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
                 } else {
                     cstatus = training ? c_light_blue : c_blue;
                 }
-                mvwprintz( w_skills, point( 1, y_pos ), c_light_gray, std::string( width - 1, ' ' ) );
             }
             mvwprintz( w_skills, point( 1, y_pos ), cstatus, "%s:", aSkill->name() );
             if( aSkill->ident() == skill_dodge ) {

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -787,11 +787,8 @@ struct HeaderSkill {
 
 static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
                              Character &you, unsigned int line, const player_display_tab curtab,
-                             std::vector<HeaderSkill> &skillslist,
-                             const size_t skill_win_size_y )
+                             std::vector<HeaderSkill> &skillslist )
 {
-    const int col_width = getmaxx( w_skills ) - 1;
-
     werase( w_skills );
     const bool is_current_tab = curtab == player_display_tab::skills;
     nc_color cstatus = is_current_tab ? h_light_gray : c_light_gray;
@@ -800,8 +797,12 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
     }
     center_print( w_skills, 0, cstatus, _( title_SKILLS ) );
 
-    const auto& [i_start, i_end] = subindex_around_cursor( skillslist.size(), skill_win_size_y - 1,
-                                   line, is_current_tab );
+    const int height = getmaxy( w_skills ) - 1;
+    const bool do_draw_scrollbar = height < static_cast<int>( skillslist.size() );
+    const int width = getmaxx( w_skills ) - 1 - ( do_draw_scrollbar ? 1 : 0 );
+
+    const auto& [i_start, i_end] = subindex_around_cursor( skillslist.size(), height, line,
+                                   is_current_tab );
 
     int y_pos = 1;
     for( int i = i_start; i < i_end; ++i, ++y_pos ) {
@@ -839,7 +840,7 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
                 } else {
                     cstatus = training ? h_light_blue : h_blue;
                 }
-                mvwprintz( w_skills, point( 1, y_pos ), cstatus, std::string( col_width, ' ' ) );
+                mvwprintz( w_skills, point( 1, y_pos ), cstatus, std::string( width - 1, ' ' ) );
             } else {
                 if( locked ) {
                     cstatus = c_yellow;
@@ -850,26 +851,22 @@ static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
                 } else {
                     cstatus = training ? c_light_blue : c_blue;
                 }
-                mvwprintz( w_skills, point( 1, y_pos ), c_light_gray, std::string( col_width, ' ' ) );
+                mvwprintz( w_skills, point( 1, y_pos ), c_light_gray, std::string( width - 1, ' ' ) );
             }
             mvwprintz( w_skills, point( 1, y_pos ), cstatus, "%s:", aSkill->name() );
             if( aSkill->ident() == skill_dodge ) {
-                mvwprintz( w_skills, point( 14, y_pos ), cstatus, "%4.1f/%-2d(%2d%%)",
-                           you.get_dodge(),
-                           level_num,
-                           ( exercise < 0 ? 0 : exercise ) );
+                mvwprintz( w_skills, point( width - 11, y_pos ), cstatus, "%4.1f/%-2d(%2d%%)", you.get_dodge(),
+                           level_num, ( exercise < 0 ? 0 : exercise ) );
             } else {
-                mvwprintz( w_skills, point( 19, y_pos ), cstatus, "%-2d(%2d%%)",
-                           level_num,
+                mvwprintz( w_skills, point( width - 6, y_pos ), cstatus, "%-2d(%2d%%)", level_num,
                            ( exercise < 0 ? 0 : exercise ) );
             }
         }
     }
 
-    if( is_current_tab && skillslist.size() > skill_win_size_y - 1 ) {
-        draw_scrollbar( w_skills, line - 1, skill_win_size_y - 1, skillslist.size() - 1,
-                        // NOLINTNEXTLINE(cata-use-named-point-constants)
-                        point( 0, 1 ) );
+    if( do_draw_scrollbar ) {
+        draw_scrollbar( w_skills, i_start, height, skillslist.size(), point( width + 1, 1 ), c_white,
+                        true );
     }
     wnoutrefresh( w_skills );
 }
@@ -1898,7 +1895,7 @@ void Character::disp_info( bool customize_character )
         borders.draw_border( w_skills_border );
         wnoutrefresh( w_skills_border );
         ui_skills.disable_cursor();
-        draw_skills_tab( ui_skills, w_skills, *this, line, curtab, skillslist, skill_win_size_y );
+        draw_skills_tab( ui_skills, w_skills, *this, line, curtab, skillslist );
     } );
 
     // info panel

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -307,6 +307,24 @@ enum class player_display_tab : int {
 };
 } // namespace
 
+static void draw_x_info( const catacurses::window &w_info, const std::string &description,
+                         const unsigned info_line )
+{
+    std::vector<std::string> text_lines = foldstring( description, FULL_SCREEN_WIDTH - 3 );
+    const int winh = catacurses::getmaxy( w_info );
+    const bool do_scroll = text_lines.size() > static_cast<unsigned>( std::abs( winh ) );
+    const int first_line = do_scroll ? info_line % ( text_lines.size() + 1 - winh ) : 0;
+    const int last_line = do_scroll ? first_line + winh : text_lines.size();
+    for( int i = first_line; i < last_line; i++ ) {
+        trim_and_print( w_info, point( 1, i - first_line ), FULL_SCREEN_WIDTH - ( do_scroll ? 3 : 2 ),
+                        c_light_gray, text_lines[i] );
+    }
+    if( do_scroll ) {
+        draw_scrollbar( w_info, first_line, winh, text_lines.size(), point( FULL_SCREEN_WIDTH - 1, 0 ),
+                        c_white, true );
+    }
+}
+
 static void draw_proficiencies_tab( ui_adaptor &ui, const catacurses::window &win,
                                     const unsigned line, const Character &guy,
                                     const player_display_tab curtab, const input_context &ctxt )
@@ -639,20 +657,9 @@ static void draw_traits_info( const catacurses::window &w_info, const unsigned l
     werase( w_info );
     if( line < traitslist.size() ) {
         const trait_and_var &cur = traitslist[line];
-        std::vector<std::string> desc =
-            foldstring( string_format( "%s: %s", colorize( cur.name(), cur.trait->get_display_color() ),
-                                       cur.desc() ), FULL_SCREEN_WIDTH - 3 );
-        const int winh = catacurses::getmaxy( w_info );
-        const bool do_scroll = desc.size() > static_cast<unsigned>( std::abs( winh ) );
-        const int fline = do_scroll ? info_line % ( desc.size() + 1 - winh ) : 0;
-        const int lline = do_scroll ? fline + winh : desc.size();
-        for( int i = fline; i < lline; i++ ) {
-            trim_and_print( w_info, point( 1, i - fline ), FULL_SCREEN_WIDTH - 3, c_light_gray, desc[i] );
-        }
-        if( do_scroll ) {
-            draw_scrollbar( w_info, fline, winh, desc.size(), point( FULL_SCREEN_WIDTH - 3, 0 ), c_white,
-                            true );
-        }
+        const std::string desc =
+            string_format( "%s: %s", colorize( cur.name(), cur.trait->get_display_color() ), cur.desc() );
+        draw_x_info( w_info, desc, info_line );
     }
     wnoutrefresh( w_info );
 }

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1009,7 +1009,6 @@ static void draw_speed_tab( ui_adaptor &ui, const catacurses::window &w_speed,
                             const Character &you,
                             const std::vector<speedlist_entry> &speedlist, const int move_cost )
 {
-    //FIXME this tab needs to support scrolling
     werase( w_speed );
     const bool is_current_tab = curtab == player_display_tab::speed;
     if( is_current_tab ) {
@@ -1964,7 +1963,8 @@ void Character::disp_info( bool customize_character )
 
     bool done = false;
 
-    std::vector<catacurses::window *> windows{ &w_stats, &w_encumb, & w_skills, &w_traits, &w_bionics, &w_effects, &w_proficiencies };
+    // needs to have the same windows in the same order as player_display_tab so that mouse scrolling can work
+    std::vector<catacurses::window *> windows{ &w_stats, &w_encumb, &w_speed, &w_skills, &w_traits, &w_bionics, &w_effects, &w_proficiencies };
 
     do {
         ui_manager::redraw_invalidated();

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1032,10 +1032,10 @@ static void draw_speed_tab( ui_adaptor &ui, const catacurses::window &w_speed,
         if( entry.val != 0 ) {
             const char prefix = entry.val < 0 ? '-' : '+';
             const char suffix = entry.percent ? '%' : ' ';
-            if( entry.val < 1000 ) {
+            if( std::abs( entry.val ) < 1000 ) {
                 mvwprintz( w_speed, pos + point( 19, 0 ), hcol, "%c%3d%c", prefix, std::abs( entry.val ), suffix );
             } else {
-                // broken limbs can cause this
+                // broken limbs or very big numbers can cause this
                 mvwprintz( w_speed, pos + point( 19, 0 ), hcol, "%c!!!%c", prefix, suffix );
             }
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "@ menu improvements"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I misunderstood an issue, so I fixed this instead.
I guess more changes after #50892.
Added scrolling if needed, better safe than sorry.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Make info bars scrollable for skills, effects, bionics, and proficiencies. Only effects needed that, but better safe than sorry.
<details><summary>Read about asthma</summary>

before
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/53ca7845-5452-4d8f-887f-fd7e87949312)

---
after
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/1df5003e-0656-41d4-bfbc-853afe3e745f)
</details>

Unify visual style and underlying code for scrollbars in the info bar for skills, effects, bionics, and proficiencies. And move the scrollbar to the far right.
<details><summary>Srollbar was one to the right</summary>

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/8d96c70b-1d2c-47d2-909b-2e4d6ae2afb4)
</details>

Move the skill tab scrollbar to the right to match others (and always show, if needed).

<details><summary>Srollbar to the right</summary>

before
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/ed1a238f-4980-4599-9bb2-e9af8f2da3d8)

---
after
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/cf3b8801-c5cb-4542-b059-b571b877f4df)
</details>

Fix: Pointing (with the mouse) at a menu selected the previous menu.
<details><summary>Mouse hover</summary>

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/25a42eec-2063-4060-af45-63915d07c5dc)
</details>

In the speed tab, show `!!!` for values above 1000.
<details><summary>!!!</summary>

before
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/e2365ff6-ec4c-454e-9f7e-f1cff8348689)

---
after
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/160a54fb-9072-4da1-aeca-61bb279c2343)
</details>

Docs: Add implode, and explode keywords to string_split, and string_join, so people like me can find these in a minute rather than 15 minutes.
<details><summary>Search in Sublime Text</summary>

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/20aa34c0-cb2c-4632-a80f-31744af9946e)
</details>


Refactor & pointless code removal.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Enlongate texts to see if wrapping works for skills, bionics, and proficiencies.
See that effects info wraps (e.g. on Asthma).
Resize to check scrollbar appears in the right format just when it's needed. And that no text in the skills tab is overwritten.
Removed spaces seem to be useless, visually checked that it looks the same.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Things to do:
You cannot scroll up in the info panel (wrap down) unlike other tabs. This is caused by (only) `if (info_line > 0) {--info_line};`

Notes:
Stat info isn't scrollable, since it is very much line-by-line handmade.
Until now, it didn't occur to me that I could play two cataclysms at once!
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/86235ccd-8398-4aa6-8ea0-d279be1a129f)



<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
