### PR TITLE
Prevent the vmenu from drawing junk in w_terrain

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6805,6 +6805,9 @@ void map::drawsq( const catacurses::window &w, const tripoint &p,
     const tripoint view_center = params.center();
     const int k = p.x + getmaxx( w ) / 2 - view_center.x;
     const int j = p.y + getmaxy( w ) / 2 - view_center.y;
+    if( k < 0 || k >= getmaxx( w ) || j < 0 || j >= getmaxy( w ) ) {
+        return;
+    }
     wmove( w, point( k, j ) );
 
     const const_maptile tile = maptile_at( p );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent the vmenu from drawing junk in w_terrain"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

I noticed that in curses, it's not uncommon to see junk on the screen when using the "look around" menu (keybinding: V), as the screenshot below shows.

![cata-vjunk](https://github.com/CleverRaven/Cataclysm-DDA/assets/16765166/936917a0-74c6-4cb0-849c-e6c88fed6adc)

Here's a savefile where it's evident; after loading it, press V, and it should show the monsters menu with the first monster highlighted.
[ZZTEST.zip](https://github.com/CleverRaven/Cataclysm-DDA/files/12423721/ZZTEST.zip)


#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

GDB excerpt:
```
Breakpoint 8, map::drawsq (this=this@entry=0x55686d6d0a30, w=..., p=..., params=...) at src/map.cpp:6792
6792    {
(gdb) step
6794        if( is_draw_tiles_mode() ) {
(gdb) next
6801        if( !inbounds( p ) ) {
(gdb) 
6805        const tripoint view_center = params.center();
(gdb) 
6806        const int k = p.x + getmaxx( w ) / 2 - view_center.x;
(gdb) print view_center
$19 = {static dimension = 3, x = 25, y = 109, z = 21864}
(gdb) next
6807        const int j = p.y + getmaxy( w ) / 2 - view_center.y;
(gdb) 
6808        wmove( w, point( k, j ) );
(gdb) print j
$20 = -15
(gdb) print k
$21 = 122
(gdb) step
point::point (Y=-15, X=122, this=0x7ffd64b6c408) at src/point.h:26
26          constexpr point( int X, int Y ) : x( X ), y( Y ) {}
(gdb) step
catacurses::wmove (win=..., p=...) at src/ncurses_def.cpp:144
144         if( !win ) {
(gdb) print p
$22 = (const point &) @0x7ffd64b6c408: {static dimension = 2, x = 122, y = -15}
(gdb) step
catacurses::window::operator bool (this=this@entry=0x55686d957a78) at src/ncurses_def.cpp:144
144         if( !win ) {
(gdb) 
std::__shared_ptr<void, (__gnu_cxx::_Lock_policy)2>::operator bool (this=this@entry=0x55686d957a78) at /usr/include/c++/8/bits/shared_ptr_base.h:1310
1310          explicit operator bool() const // never throws
(gdb) 
catacurses::wmove (win=..., p=...) at src/ncurses_def.cpp:147
147         return curses_check_result( ::wmove( win.get<::WINDOW>(), p.y, p.x ), OK, "wmove" );
(gdb) step
map::drawsq (this=this@entry=0x55686d6d0a30, w=..., p=..., params=...) at src/map.cpp:6810
6810        const const_maptile tile = maptile_at( p );
(gdb) bt
#0  map::drawsq (this=this@entry=0x55686d6d0a30, w=..., p=..., params=...) at src/map.cpp:6810
#1  0x000055686a6a5b22 in (anonymous namespace)::draw_line_curses (g=..., center=..., ret=std::vector of length 46, capacity 46 = {...}, noreveal=noreveal@entry=false) at src/animation.cpp:661
#2  0x000055686a6a5d09 in game::draw_line (this=0x55686d957820, p=..., center=..., points=std::vector of length 46, capacity 46 = {...}, noreveal=noreveal@entry=false) at src/animation.cpp:690
#3  0x000055686ad8ebba in draw_trail (start=..., end=..., bDrawX=<optimized out>) at /usr/include/c++/8/bits/unique_ptr.h:342
#4  0x000055686ad8edbe in <lambda()>::operator() (__closure=<optimized out>) at /usr/include/c++/8/optional:1211
#5  std::_Function_handler<void(), create_trail_callback(const std::optional<tripoint>&, const std::optional<tripoint>&, bool const&)::<lambda()> >::_M_invoke(const std::_Any_data &) (__functor=...)
    at /usr/include/c++/8/bits/std_function.h:297
#6  0x000055686a538d5a in std::function<void ()>::operator()() const (this=<optimized out>) at /usr/include/c++/8/bits/std_function.h:260
#7  0x000055686ad8b6dc in game::draw_callback_t::operator() (this=<optimized out>) at src/game.cpp:3719
#8  0x000055686adb8ace in game::draw (this=0x55686d957820, ui=...) at src/game.cpp:3876
#9  0x000055686adb8b94 in game::<lambda(ui_adaptor&)>::operator() (ui=..., __closure=<optimized out>) at /usr/include/c++/8/bits/unique_ptr.h:342
#10 std::_Function_handler<void(ui_adaptor&), game::create_or_get_main_ui_adaptor()::<lambda(ui_adaptor&)> >::_M_invoke(const std::_Any_data &, ui_adaptor &) (__functor=..., __args#0=...)
    at /usr/include/c++/8/bits/std_function.h:297
#11 0x000055686bec46e2 in std::function<void (ui_adaptor&)>::operator()(ui_adaptor&) const (this=this@entry=0x55686d957060, __args#0=...) at /usr/include/c++/8/bits/std_function.h:260
#12 0x000055686bec4241 in ui_adaptor::redraw_invalidated () at src/ui_manager.cpp:411
#13 0x000055686bec4343 in ui_adaptor::redraw () at src/ui_manager.cpp:321
#14 0x000055686bec438d in ui_manager::redraw () at src/ui_manager.cpp:465
#15 0x000055686ade0793 in game::list_monsters (this=this@entry=0x55686d957820, monster_list=std::vector of length 3, capacity 4 = {...}) at src/game.cpp:9055
#16 0x000055686add9a05 in game::list_items_monsters (this=this@entry=0x55686d957820) at src/game.cpp:8216
#17 0x000055686ae8d2b7 in game::do_regular_action (this=this@entry=0x55686d957820, act=@0x7ffd64b6d5cc: ACTION_LIST_ITEMS, player_character=..., 
    mouse_target=std::optional<tripoint> [no contained value]) at src/handle_action.cpp:2289
#18 0x000055686ae924d2 in game::handle_action (this=0x55686d957820) at src/handle_action.cpp:3043
#19 0x000055686ac096e0 in do_turn () at /usr/include/c++/8/bits/unique_ptr.h:342
#20 0x000055686b30fbd7 in main (argc=<optimized out>, argv=<optimized out>) at src/main.cpp:782
(gdb) 
```

Notice that in `map::drawsq`, it passes an invalid negative argument to `catacurses::wmove`, (j = -15) which passes that same invalid negative argument to the ncurses function `wmove`, which (not shown) returns `ERR`  rather than `OK`.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

I could've checked the bounds in `map::drawsq`'s callers rather than in `map::drawsq` itself, but I guess this way is better because it seems like that would be mixing low level and high level details in the same place. Not to mention that doing it this way only requires adding 3 lines of code.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

I haven't done much testing yet besides verifying that it fixes the case in ZZTEST. I plan to test it more during the next couple days.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

I've marked this WIP because I noticed that in `ncurses_def.cpp`, it ignores the return value:
```
static void curses_check_result( const int result, const int expected, const char *const /*name*/ )
     39 {
     40     if( result != expected ) {
     41         // TODO: debug message
     42     }
     43 }
```

Why? Is it failing so often that checking it would interfere with normal gameplay, or is it just that no one got around to it (including making sure that if debugmsg calls a curses function that fails, it doesn't cause infinite recursion)? I plan to look into that to see what happens.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
