### PR TITLE
Some book spawning changes & locking bronze behind a book recipe

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations.json
@@ -2059,7 +2059,6 @@
       { "group": "ammo_pocket_batteries_full", "prob": 50 },
       [ "file", 20 ],
       [ "howto_computer", 20 ],
-      [ "glassblowing_book", 4 ],
       [ "manual_fabrication", 30 ],
       [ "usb_drive", 5 ],
       { "group": "book_mag_tech", "prob": 70 },

--- a/data/json/itemgroups/books.json
+++ b/data/json/itemgroups/books.json
@@ -412,8 +412,7 @@
       { "item": "vacuum_sealing", "prob": 5 },
       { "item": "arduino_experiments", "prob": 5 },
       { "item": "fermenting_book", "prob": 8 },
-      { "item": "book_pneumatics", "prob": 3 },
-      { "item": "distilling_cookbook", "prob": 8 }
+      { "item": "book_pneumatics", "prob": 3 }
     ]
   },
   {
@@ -495,7 +494,6 @@
       { "item": "book_lockpick", "prob": 2 },
       { "item": "basic_chemistry", "prob": 5 },
       { "item": "fermenting_book", "prob": 8 },
-      { "item": "distilling_cookbook", "prob": 8 },
       { "item": "textbook_arthropod", "prob": 5 },
       { "item": "textbook_botany", "prob": 5 },
       { "item": "theater_props", "prob": 2 }
@@ -595,6 +593,7 @@
       { "item": "textbook_gaswarfare", "prob": 15 },
       { "item": "text_gunsmith", "prob": 10 },
       { "item": "glassblowing_book", "prob": 12 },
+      { "item": "alloy_book", "prob": 12 },
       { "item": "plastics_book", "prob": 12 },
       { "item": "cookbook_human", "prob": 10 },
       { "item": "collector_book", "prob": 10 },

--- a/data/json/items/book/fabrication.json
+++ b/data/json/items/book/fabrication.json
@@ -46,6 +46,27 @@
     "melee_damage": { "bash": 4 }
   },
   {
+    "id": "alloy_book",
+    "type": "BOOK",
+    "category": "manuals",
+    "name": { "str": "Alloying reference manual" },
+    "description": "A textbook with information about alloying various types of metals.",
+    "weight": "1500 g",
+    "volume": "1250 ml",
+    "price": 4500,
+    "price_postapoc": 250,
+    "material": [ "paper", "cardboard" ],
+    "symbol": "?",
+    "color": "blue",
+    "skill": "fabrication",
+    "required_level": 4,
+    "max_level": 7,
+    "proficiencies": [ { "proficiency": "prof_metalworking", "time_factor": 0.7, "fail_factor": 0.5 } ],
+    "intelligence": 8,
+    "time": "30 m",
+    "melee_damage": { "bash": 4 }
+  },
+  {
     "id": "theater_props",
     "type": "BOOK",
     "category": "manuals",

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -115,7 +115,7 @@
     "difficulty": 2,
     "time": "10 m",
     "batch_time_factors": [ 90, 4 ],
-    "autolearn": true,
+    "book_learn": [ [ "alloy_book", 4 ] ],
     "using": [ [ "forging_standard", 1 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_redsmithing" } ],
     "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],

--- a/data/mods/innawood/recipes/other/materials.json
+++ b/data/mods/innawood/recipes/other/materials.json
@@ -232,5 +232,30 @@
     "qualities": [ { "id": "CHEM", "level": 2 }, { "id": "CONTAIN", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 30, "LIST" ] ] ],
     "components": [ [ [ "meal_chitin_piece", 30 ] ], [ [ "lye", 4 ], [ "lye_potassium", 6 ] ], [ [ "any_strong_acid", 1, "LIST" ] ] ]
+  },
+  {
+    "result": "scrap_bronze",
+    "type": "recipe",
+    "activity_level": "ACTIVE_EXERCISE",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_MATERIALS",
+    "skill_used": "fabrication",
+    "difficulty": 2,
+    "time": "10 m",
+    "batch_time_factors": [ 90, 4 ],
+    "autolearn": true,
+    "using": [ [ "forging_standard", 1 ] ],
+    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_redsmithing" } ],
+    "tools": [ [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ] ],
+    "components": [
+      [
+        [ "tin", 12 ],
+        [ "aluminum_foil", 371 ],
+        [ "chem_aluminium_powder", 29 ],
+        [ "can_drink", 2 ],
+        [ "scrap_aluminum", 1 ]
+      ],
+      [ [ "copper_scrap_equivalent", 1, "LIST" ] ]
+    ]
   }
 ]

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -77,6 +77,7 @@ allosaurid
 allosaurus
 allosaurusid
 allotrope
+alloying
 allucination
 alnico
 alquerque
@@ -2154,10 +2155,10 @@ pasteurize
 pathfinding
 patios
 pauldrons
-pebbled
 peacoat
 peanutbutter
 pearlescent
+pebbled
 peccari
 peccary
 pecial
@@ -3125,8 +3126,8 @@ underbarrel
 underbody
 undercovering
 underfongen
-underhill
 undergrown
+underhill
 underlayer
 underlayers
 undersides
@@ -3294,8 +3295,8 @@ wasnt
 wastebread
 watchband
 waterfowl
-waterproofed
 waterkin
+waterproofed
 waterskin
 waterskins
 waterskis


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Alloying bronze is really not something that'd pop into your brain as you get better at carpentry. Without a reference or prior experience, you'd be going in blind regardless of your skill level.

While I was here I cleaned up some itemgroup weirdness reported on the devcord earlier
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- locks the recipe to craft bronze behind a new alloying reference manual. The manual is currently only in the esoteric books itemgroup but I'm open to possibly including it in other itemgroups as well. Innawood got its own custom recipe that's still autolearned
- glassblowing book is (again) removed from school itemgroups - it's a pretty niche thing that I am 99% sure you wouldn't find at most schools. I also... already did that once. So I'm not sure why it's still there? But school itemgroups are nested to hell and back so that's that
- removed "guide to home distillation" from school book itemgroups
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Locking other alloy materials, like steel grades, behind the alloying reference manual? But I am not experienced enough with steel and don't want to step on @Drew4484's turf. Drew, if you want me to lock them behind it lemme know and I will
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The book and recipe seem to work as intended in the game
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
