### PR TITLE
Construct open air

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -6799,6 +6799,22 @@
   },
   {
     "type": "construction",
+    "id": "constr_open_air",
+    "skill": "survival",
+    "group": "construct_open_air",
+    "category": "CONSTRUCT",
+    "difficulty": 0,
+    "time": "20m",
+    "on_display": true,
+    "qualities": [ { "id": "DIG", "level": 2 } ],
+    "pre_terrain": "t_pit",
+    "post_terrain": "t_open_air",
+    "byproducts": [ { "group": "digging_soil_loam_50L", "count": 5 } ],
+    "activity_level": "EXTRA_EXERCISE",
+    "do_turn_special": "do_turn_shovel"
+  },
+  {
+    "type": "construction",
     "id": "constr_pit_underground",
     "group": "dig_a_pit",
     "category": "DIG",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -972,7 +972,7 @@
   {
     "type": "construction_group",
     "id": "construct_open_air",
-    "name": "Turn a Pit into Open Air"
+    "name": "Dig out pit completely and remove anything remaining"
   },
   {
     "type": "construction_group",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -971,6 +971,11 @@
   },
   {
     "type": "construction_group",
+    "id": "construct_open_air",
+    "name": "Turn a Pit into Open Air"
+  },
+  {
+    "type": "construction_group",
     "id": "dig_a_water_channel",
     "name": "Dig a Water Channel"
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Allow turning a Pit terrain into Open Air terrain, to enable building ramps downstairs.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Expand the Pit into Open Air, in order to enable other types of construction on level z-1.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Use explosives and forgo hard work. Modify existing Dig a Pit recipe to check for non-solid tile on z-1 and collapse Pit into Open Air accordingly, but that's too complicated for me right now.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Broke my legs jumping off ledge to z-1.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I just want my self-made drive-in cave.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
