### PR TITLE
[Magiclysm] Edit Nature's Commune to provide morale and only be castable outdoors

### DIFF
--- a/data/mods/Magiclysm/Spells/druid.json
+++ b/data/mods/Magiclysm/Spells/druid.json
@@ -479,10 +479,12 @@
   {
     "type": "effect_on_condition":,
     "id": "EOC_NATURE_COMMUNE",
+    "condition": "u_is_outside",
     "effect": [
       { "u_add_effect": "natures_commune", "duration": { "math": [ "( 10000 + (u_val('spell_level', 'spell: druid_natures_commune') * 2000) )" ] } },
       { "u_add_morale": "morale_forest_unity", "bonus": 10, "max_bonus": 15, "duration": { "math": [ "( 10000 + (u_val('spell_level', 'spell: druid_natures_commune') * 2000) )" ] }, "decay_start": { "math": [ "(( 10000 + (u_val('spell_level', 'spell: druid_natures_commune') * 2000) ) / 2)" ] } }
-    ]
+    ],
+    "false_effect": [ { "u_message": "You must be standing in nature to commune with nature", "type": "bad" } ]
   },
   {
     "id": "druid_growth",

--- a/data/mods/Magiclysm/Spells/druid.json
+++ b/data/mods/Magiclysm/Spells/druid.json
@@ -472,26 +472,43 @@
     "final_energy_cost": 400,
     "energy_increment": 10,
     "max_level": 20,
-    "min_duration": 10000,
-    "max_duration": 40000,
-    "duration_increment": 2000
+    "min_duration": 30000,
+    "max_duration": 360000,
+    "duration_increment": 16500
   },
   {
-    "type": "effect_on_condition":,
+    "type": "effect_on_condition",
     "id": "EOC_NATURE_COMMUNE",
-    "condition": { "and": [ "u_is_outside", { 
-      { "not": { "u_near_om_location": "road_curved", "range": 1 } }, 
-      { "not": { "u_near_om_location": "road_four_way", "range": 1 } },
-      { "not": { "u_near_om_location": "road_tee", "range": 1 } },
-      { "not": { "u_near_om_location": "road_straight", "range": 1 } },
-      { "not": { "u_near_om_location": "road_end", "range": 1 } }
-    ] 
+    "condition": {
+      "and": [
+        "u_is_outside",
+        { "not": { "u_near_om_location": "road_curved", "range": 1 } },
+        { "not": { "u_near_om_location": "road_four_way", "range": 1 } },
+        { "not": { "u_near_om_location": "road_tee", "range": 1 } },
+        { "not": { "u_near_om_location": "road_straight", "range": 1 } },
+        { "not": { "u_near_om_location": "road_end", "range": 1 } },
+        { "not": { "u_near_om_location": "road_sw", "range": 1 } },
+        { "not": { "u_near_om_location": "road_ne", "range": 1 } },
+        { "not": { "u_near_om_location": "road_ew", "range": 1 } },
+        { "not": { "u_near_om_location": "road_ns", "range": 1 } },
+        { "not": { "u_near_om_location": "road_nesw", "range": 1 } },
+        { "not": { "u_near_om_location": "road", "range": 1 } }
+      ]
     },
     "effect": [
-      { "u_add_effect": "natures_commune", "duration": { "math": [ "( 10000 + (u_val('spell_level', 'spell: druid_natures_commune') * 2000) )" ] } },
-      { "u_add_morale": "morale_forest_unity", "bonus": 10, "max_bonus": 15, "duration": { "math": [ "( 10000 + (u_val('spell_level', 'spell: druid_natures_commune') * 2000) )" ] }, "decay_start": { "math": [ "(( 10000 + (u_val('spell_level', 'spell: druid_natures_commune') * 2000) ) / 2)" ] } }
+      {
+        "u_add_effect": "natures_commune",
+        "duration": { "math": [ "( 30000 + (u_val('spell_level', 'spell: druid_natures_commune') * 16500) )" ] }
+      },
+      {
+        "u_add_morale": "morale_forest_unity",
+        "bonus": 10,
+        "max_bonus": 15,
+        "duration": { "math": [ "( 30000 + (u_val('spell_level', 'spell: druid_natures_commune') * 16500) )" ] },
+        "decay_start": { "math": [ "(( 30000 + (u_val('spell_level', 'spell: druid_natures_commune') * 16500) ) / 2)" ] }
+      }
     ],
-    "false_effect": [ { "u_message": "You must be standing in nature to commune with nature", "type": "bad" } ]
+    "false_effect": [ { "u_message": "You must be surrounded by nature to commune with nature", "type": "bad" } ]
   },
   {
     "id": "druid_growth",

--- a/data/mods/Magiclysm/Spells/druid.json
+++ b/data/mods/Magiclysm/Spells/druid.json
@@ -460,8 +460,8 @@
     "name": "Nature's Commune",
     "description": "You concentrate on the nature around you and commune with it, improving your health and calming the nearby wildlife.",
     "valid_targets": [ "self" ],
-    "effect": "attack",
-    "effect_str": "natures_commune",
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_NATURE_COMMUNE",
     "shape": "blast",
     "flags": [ "CONCENTRATE", "SOMATIC", "VERBAL", "NO_LEGS", "NO_HANDS" ],
     "energy_source": "MANA",
@@ -475,6 +475,14 @@
     "min_duration": 10000,
     "max_duration": 40000,
     "duration_increment": 2000
+  },
+  {
+    "type": "effect_on_condition":,
+    "id": "EOC_NATURE_COMMUNE",
+    "effect": [
+      { "u_add_effect": "natures_commune", "duration": { "math": [ "( 10000 + (u_val('spell_level', 'spell: druid_natures_commune') * 2000) )" ] } },
+      { "u_add_morale": "morale_forest_unity", "bonus": 10, "max_bonus": 15, "duration": { "math": [ "( 10000 + (u_val('spell_level', 'spell: druid_natures_commune') * 2000) )" ] }, "decay_start": { "math": [ "(( 10000 + (u_val('spell_level', 'spell: druid_natures_commune') * 2000) ) / 2)" ] } }
+    ]
   },
   {
     "id": "druid_growth",

--- a/data/mods/Magiclysm/Spells/druid.json
+++ b/data/mods/Magiclysm/Spells/druid.json
@@ -458,7 +458,7 @@
     "id": "druid_natures_commune",
     "type": "SPELL",
     "name": "Nature's Commune",
-    "description": "You concentrate on the nature around you and commune with it, improving your health and calming the nearby wildlife.",
+    "description": "You concentrate on the nature around you and commune with it, improving your health and calming the nearby wildlife.  This spell may only be cast outdoors.",
     "valid_targets": [ "self" ],
     "effect": "effect_on_condition",
     "effect_str": "EOC_NATURE_COMMUNE",

--- a/data/mods/Magiclysm/Spells/druid.json
+++ b/data/mods/Magiclysm/Spells/druid.json
@@ -498,14 +498,14 @@
     "effect": [
       {
         "u_add_effect": "natures_commune",
-        "duration": { "math": [ "( 30000 + (u_val('spell_level', 'spell: druid_natures_commune') * 16500) )" ] }
+        "duration": { "math": [ "( 300 + (u_val('spell_level', 'spell: druid_natures_commune') * 165)) " ] }
       },
       {
         "u_add_morale": "morale_forest_unity",
         "bonus": 10,
         "max_bonus": 15,
-        "duration": { "math": [ "( 30000 + (u_val('spell_level', 'spell: druid_natures_commune') * 16500) )" ] },
-        "decay_start": { "math": [ "(( 30000 + (u_val('spell_level', 'spell: druid_natures_commune') * 16500) ) / 2)" ] }
+        "duration": { "math": [ "( 300 + (u_val('spell_level', 'spell: druid_natures_commune') * 165) )" ] },
+        "decay_start": { "math": [ "(( 300 + (u_val('spell_level', 'spell: druid_natures_commune') * 165) ) / 2)" ] }
       }
     ],
     "false_effect": [ { "u_message": "You must be surrounded by nature to commune with nature", "type": "bad" } ]

--- a/data/mods/Magiclysm/Spells/druid.json
+++ b/data/mods/Magiclysm/Spells/druid.json
@@ -479,7 +479,14 @@
   {
     "type": "effect_on_condition":,
     "id": "EOC_NATURE_COMMUNE",
-    "condition": "u_is_outside",
+    "condition": { "and": [ "u_is_outside", { 
+      { "not": { "u_near_om_location": "road_curved", "range": 1 } }, 
+      { "not": { "u_near_om_location": "road_four_way", "range": 1 } },
+      { "not": { "u_near_om_location": "road_tee", "range": 1 } },
+      { "not": { "u_near_om_location": "road_straight", "range": 1 } },
+      { "not": { "u_near_om_location": "road_end", "range": 1 } }
+    ] 
+    },
     "effect": [
       { "u_add_effect": "natures_commune", "duration": { "math": [ "( 10000 + (u_val('spell_level', 'spell: druid_natures_commune') * 2000) )" ] } },
       { "u_add_morale": "morale_forest_unity", "bonus": 10, "max_bonus": 15, "duration": { "math": [ "( 10000 + (u_val('spell_level', 'spell: druid_natures_commune') * 2000) )" ] }, "decay_start": { "math": [ "(( 10000 + (u_val('spell_level', 'spell: druid_natures_commune') * 2000) ) / 2)" ] } }

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -382,9 +382,8 @@
     "apply_message": "A warm embrace surrounds you, like that of a mother with her child.",
     "remove_message": "Your commune with Mother Nature fades.",
     "rating": "good",
-    "max_duration": "20 m",
-    "//": "No morale_mod is currently possible in effects, but this effect should give +5/+10 morale whenever that it's implemented.",
-    "base_mods": { "health_min": [ 1 ], "health_chance": [ 40 ], "h_mod_min": [ 1 ], "h_mod_chance": [ 80 ] }
+    "max_duration": "120 m",
+    "base_mods": { "health_min": [ 1 ], "health_chance": [ 40 ], "h_mod_min": [ 1 ], "h_mod_chance": [ 80 ], "health_tick": [ 30 ] }
   },
   {
     "type": "effect_type",

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -380,7 +380,7 @@
     "name": [ "Nature's Commune" ],
     "desc": [ "You can feel Mother Nature welcoming you, revitalizing your body and calming the natural fauna around you." ],
     "apply_message": "A warm embrace surrounds you, like that of a mother with her child.",
-    "remove_message": "Your commune with Mother Nature fades.",
+    "remove_message": "Your communion with Mother Nature fades.",
     "rating": "good",
     "max_duration": "120 m",
     "base_mods": { "health_min": [ 1 ], "health_chance": [ 40 ], "h_mod_min": [ 1 ], "h_mod_chance": [ 80 ], "health_tick": [ 30 ] }

--- a/data/mods/Magiclysm/morale_types.json
+++ b/data/mods/Magiclysm/morale_types.json
@@ -3,5 +3,10 @@
     "id": "morale_iocus",
     "type": "morale_type",
     "text": "Enjoyed Iocus"
+  },
+  {
+    "id": "morale_forest_unity",
+    "type": "morale_type",
+    "text": "Peace of the Forest"
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Edit Nature's Commune"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The Nature's Commune druid spell had a note that it should provide a morale effect once that's possible through effects. Well, it's not possible through effects, but it is through EoCs
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Edit the Nature's Commune to an EoC, which provides the original Nature's Commune effect (Health bonus) and also provide a small morale bonus (+10, max +15, in line with original comment). I also changed it so you can only cast it outdoors and not within 1 overmap tile of a road, which should prevent it from being cast in cities or underground. In exchange, I made the duration much longer (max 1 hour, from around 8 minutes) and changed the health_tick of the effect to 30 (from 1). 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works!  Go out there and frolic beneath the boughs!
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
The spell also says it makes animals calmer but at the moment this is still impossible without giving the caster the hardcoded Animal Empathy mutations.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
