### PR TITLE
[Magiclysm] Fix Electric Waves enchant

### DIFF
--- a/data/mods/Magiclysm/Spells/stormshaper.json
+++ b/data/mods/Magiclysm/Spells/stormshaper.json
@@ -877,6 +877,7 @@
     "shape": "blast",
     "min_damage": 10,
     "max_damage": 35,
+    "min_range": 1,
     "damage_type": "electric",
     "flags": [ "LOUD", "RANDOM_DURATION", "RANDOM_AOE", "RANDOM_DAMAGE" ],
     "min_duration": 50,

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -508,7 +508,6 @@
     "remove_message": "The energy streams calm down.",
     "rating": "good",
     "show_intensity": false,
-    "//": "When #61693 will be resolved (or, in other words, the spell will start to throw electric waves, as it says), the ITEM_DAMAGE_ELEC must be removed, and the spell description must be edited.  Alternatively, the effect may be moved into electric gloves, instead of their flat bonus.",
     "enchantments": [ "enchant_stormshaper_electric_waves" ]
   },
   {

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -503,18 +503,13 @@
     "id": "electric_waves",
     "type": "effect_type",
     "name": [ "Electric Waves" ],
-    "desc": [ "Your body throw a massive electric charges when you attack monsters." ],
+    "desc": [ "Your body will release a massive electric charges when you attack monsters." ],
     "apply_message": "A powerful energy streams out of your hands.",
-    "remove_message": "Energy streams calm down.",
+    "remove_message": "The energy streams calm down.",
     "rating": "good",
     "show_intensity": false,
     "//": "When #61693 will be resolved (or, in other words, the spell will start to throw electric waves, as it says), the ITEM_DAMAGE_ELEC must be removed, and the spell description must be edited.  Alternatively, the effect may be moved into electric gloves, instead of their flat bonus.",
-    "enchantments": [
-      {
-        "hit_me_effect": [ { "id": "electric_waves_damage", "once_in": 3 } ],
-        "values": [ { "value": "ITEM_DAMAGE_ELEC", "add": { "u_val": "spell_level", "spell": "electric_waves" } } ]
-      }
-    ]
+    "enchantments": [ "enchant_stormshaper_electric_waves" ]
   },
   {
     "id": "electric_arts",

--- a/data/mods/Magiclysm/enchantments/Spells.json
+++ b/data/mods/Magiclysm/enchantments/Spells.json
@@ -1,0 +1,10 @@
+[
+  {
+    "type": "enchantment",
+    "id": "enchant_stormshaper_electric_waves",
+    "condition": "ALWAYS",
+    "has": "HELD",
+    "hit_me_effect": [ { "id": "electric_waves_damage", "hit_self": false, "once_in": 3 } ],
+    "hit_you_effect": [ { "id": "electric_waves_damage", "hit_self": false } ]
+  }
+]

--- a/data/mods/Magiclysm/enchantments/Spells.json
+++ b/data/mods/Magiclysm/enchantments/Spells.json
@@ -5,6 +5,6 @@
     "condition": "ALWAYS",
     "has": "HELD",
     "hit_me_effect": [ { "id": "electric_waves_damage", "hit_self": false, "once_in": 3 } ],
-    "hit_you_effect": [ { "id": "electric_waves_damage", "hit_self": false } ]
+    "hit_you_effect": [ { "id": "electric_waves_damage", "hit_self": false, "once_in": 3 } ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix Electric Waves enchant"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The Electric Waves spell had a note that said

> "//": "When #61693 will be resolved (or, in other words, the spell will start to throw electric waves, as it says), the ITEM_DAMAGE_ELEC must be removed, and the spell description must be edited.  Alternatively, the effect may be moved into electric gloves, instead of their flat bonus.",

Well, that bug was fixed, so I set out to fix Electric Waves

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Move the electric waves hit_me and hit_you effects into a dedicated enchant.  Set them both to "once_in": 3, and set the range of the electric_waves_damage spell it casts to 1 (from 0)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Casting Electric Waves now means lighting explodes everywhere in melee combat.  Make sure you're immune to electricity before using it!
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
The spell description says that you release lightning when you attack--it's currently set up to do both when you attack and when you are attacked, but that was the behavior before I touched it.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
