### PR TITLE
Aftershock: Exosuit bugfixing

### DIFF
--- a/data/mods/Aftershock/items/armor/exosuit/exosuit_frame.json
+++ b/data/mods/Aftershock/items/armor/exosuit/exosuit_frame.json
@@ -338,7 +338,6 @@
       "FLASH_PROTECTION"
     ],
     "weight_capacity_bonus": "20 kg",
-    "relic_data": { "passive_effects": [ { "id": "ench_exo_strength" }, { "id": "ench_climate_control_all" } ] },
     "power_draw": "6173 mW",
     "revert_to": "modular_exosuit",
     "use_action": [ { "type": "transform", "menu_text": "Turn off", "msg": "The %s disengages.", "target": "modular_exosuit" } ],

--- a/data/mods/Aftershock/items/armor/exosuit/exosuit_modules.json
+++ b/data/mods/Aftershock/items/armor/exosuit/exosuit_modules.json
@@ -180,7 +180,6 @@
     "name": { "str": "exosuit load support module (on)", "str_pl": "exosuit load support modules (on)" },
     "description": "This module significantly increases the exosuit's weight bearing at the cost of increased power consumption.  It is turned on and continually drawing power.  Use it to turn it off.",
     "flags": [ "FRAGILE", "CANT_WEAR", "WATERPROOF", "USE_UPS", "EXO_MEDIUM_GADGET", "ONLY_ONE" ],
-    "relic_data": { "passive_effects": [ { "id": "afs_ench_exo_big_carry" } ] },
     "power_draw": "1 W",
     "revert_to": "exo_carry",
     "use_action": {
@@ -223,7 +222,6 @@
     "name": { "str": "exosuit small load support module (on)", "str_pl": "exosuit small load support modules (on)" },
     "description": "This module increases the exosuit's weight bearing at the cost of increased power consumption.  It is turned on and continually drawing power.  Use it to turn it off.",
     "flags": [ "FRAGILE", "CANT_WEAR", "WATERPROOF", "USE_UPS", "EXO_SMALL_GADGET" ],
-    "relic_data": { "passive_effects": [ { "id": "afs_ench_exo_small_carry" } ] },
     "power_draw": "500 mW",
     "revert_to": "exo_small_carry",
     "use_action": {
@@ -342,8 +340,7 @@
       "msg": "You turn off the recoil mitigation system.",
       "target": "exo_recoil"
     },
-    "flags": [ "USE_UPS", "CANT_WEAR", "EXO_SMALL_GADGET", "ONLY_ONE" ],
-    "relic_data": { "passive_effects": [ { "id": "afs_ench_exo_recoil" } ] }
+    "flags": [ "USE_UPS", "CANT_WEAR", "EXO_SMALL_GADGET", "ONLY_ONE" ]
   },
   {
     "id": "exo_bio_oxygen",
@@ -412,8 +409,7 @@
       "msg": "You deactivate your %s.",
       "target": "exo_bio_oxygen",
       "need_charges_msg": "The %s's tank is exhausted."
-    },
-    "relic_data": { "charge_info": { "regenerate_ammo": true, "recharge_type": "periodic", "time": "30 s" } }
+    }
   },
   {
     "id": "exo_imager",

--- a/data/mods/Aftershock/items/item_enchants.json
+++ b/data/mods/Aftershock/items/item_enchants.json
@@ -50,7 +50,7 @@
     "has": "WORN",
     "condition": "ACTIVE",
     "name": { "str": "Recoil Mitigation System" },
-    "values": [ { "value": "WEAPON_DISPERSION", "add": -50 } ],
+    "values": [ { "value": "WEAPON_DISPERSION", "multiply": -0.3 } ],
     "description": "Reduces weapon dispersion."
   },
   {


### PR DESCRIPTION
#### Summary
Bugfixes "Aftershock: Repair exosuit enchantments"

#### Purpose of change

Removes duplicate enchantments from the frames and modules that can be activated.

Makes the recoil module remove dispersion manipulatively instead of using a flat bonus that could be applied improperly.

#### Describe the solution

Minor JSON changes and removal of duplicate relic_data

#### Testing
Used an exosuit and the affected modules.
