### PR TITLE
WIP: Limbify and unhardcode attack vectors

### DIFF
--- a/data/json/mutations/mutation_techs.json
+++ b/data/json/mutations/mutation_techs.json
@@ -7,10 +7,8 @@
     "unarmed_allowed": true,
     "melee_allowed": true,
     "attack_override": true,
-    "weighting": -2,
+    "weighting": 200,
     "crit_ok": true,
-    "required_char_flags": [ "SEESLEEP" ],
-    "forbidden_char_flags": [ "EYE_MEMBRANE" ],
     "repeat_min": 1,
     "repeat_max": 5,
     "mult_bonuses": [ { "stat": "damage", "type": "bullet", "scale": 15 } ],
@@ -30,6 +28,17 @@
         "message": "You bleed the %s dry!"
       },
       { "id": "downed", "chance": 50, "duration": 2, "message": "You bonk the %s real good", "req_flag": "DREAMY" }
-    ]
+    ],
+    "wip_attack_vectors": [ "test_test" ],
+    "attack_vectors": [ "HAND" ]
+  },
+  {
+    "type": "attack_vector",
+    "id": "test_test", 
+    "limbs": [ "debug_tail" ],
+    "limb_types": [ "sensor" ],
+    "sub_limbs": [ "sub_limb_debug_tail"],
+    "encumbrance_limit": 33,
+    "bp_hp_limit": 75
   }
 ]

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -582,6 +582,11 @@ float body_part_type::unarmed_damage( const damage_type_id &dt ) const
     return damage.type_damage( dt );
 }
 
+float body_part_type::total_unarmed_damage() const
+{
+    return damage.total_damage();
+}
+
 float body_part_type::unarmed_arpen( const damage_type_id &dt ) const
 {
     return damage.type_arpen( dt );

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -359,6 +359,8 @@ struct body_part_type {
         }
 
         float unarmed_damage( const damage_type_id &dt ) const;
+        // return the total amount of unarmed damage this limb would do
+        float total_unarmed_damage() const;
         float unarmed_arpen( const damage_type_id &dt ) const;
 
         float damage_resistance( const damage_type_id &dt ) const;

--- a/src/character_martial_arts.h
+++ b/src/character_martial_arts.h
@@ -80,6 +80,8 @@ class character_martial_arts
         /** Fires all kill-triggered martial arts events */
         void ma_onkill_effects( Character &owner );
 
+        // Selects a valid attack vector
+        attack_vector_id choose_attack_vector( const Character &user, const matec_id &tech ) const;
         /** Returns an attack vector that the player can use */
         std::string get_valid_attack_vector( const Character &user,
                                              const std::vector<std::string> &attack_vectors ) const;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -406,6 +406,7 @@ void DynamicDataLoader::initialize()
     add( "technique", &load_technique );
     add( "weapon_category", &weapon_category::load_weapon_categories );
     add( "martial_art", &load_martial_art );
+    add( "attack_vector", &wip_attack_vector::load_attack_vectors );
     add( "effect_type", &load_effect_type );
     add( "oter_id_migration", &overmap::load_oter_id_migration );
     add( "overmap_terrain", &overmap_terrains::load );

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -57,6 +57,32 @@ class weapon_category
 
 matype_id martial_art_learned_from( const itype & );
 
+struct wip_attack_vector {
+    attack_vector_id id;
+    translation name;
+    // Used with a weapon, precludes most other checks
+    bool weapon = false;
+    // If true the vector will always be preferentially used when eligable
+    bool primary = false;
+    // Explicit bodypart definitions
+    std::vector<bodypart_str_id> limbs;
+    // Flexible bodypart type definition
+    std::vector<body_part_type::type> limb_types;
+    // Explicit sublimb requirement
+    std::vector<sub_bodypart_str_id> sub_limbs;
+
+    // Encumbrance limit in absolute encumbrance
+    int encumbrance_limit = 100;
+    // Percent of bodypart HP required
+    int bp_hp_limit = 100;
+
+    bool was_loaded = false;
+
+    static void load_attack_vectors( const JsonObject &jo, const std::string &src );
+    static void reset();
+    void load( const JsonObject &jo, std::string_view );
+};
+
 struct ma_requirements {
     bool was_loaded = false;
 
@@ -157,6 +183,7 @@ class ma_technique
         // What way is the technique delivered to the target?
         std::vector<std::string> attack_vectors; // by priority
         std::vector<std::string> attack_vectors_random; // randomly
+        std::vector<attack_vector_id> wip_attack_vectors;
 
         int repeat_min = 1;    // Number of times the technique is repeated on a successful proc
         int repeat_max = 1;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1593,6 +1593,8 @@ std::vector<matec_id> Character::evaluate_techniques( Creature &t, const item_lo
             continue;
         }
 
+        attack_vector_id wip = martial_arts_data->choose_attack_vector( *this, tec.id );
+
         // Does the player have a functional attack vector to deliver the technique?
         std::vector<std::string> shuffled_attack_vectors = tec.attack_vectors_random;
         std::shuffle( shuffled_attack_vectors.begin(), shuffled_attack_vectors.end(), rng_get_engine() );

--- a/src/type_id.h
+++ b/src/type_id.h
@@ -23,6 +23,9 @@ struct ammo_effect;
 using ammo_effect_id = int_id<ammo_effect>;
 using ammo_effect_str_id = string_id<ammo_effect>;
 
+struct wip_attack_vector;
+using attack_vector_id = string_id<wip_attack_vector>;
+
 struct bionic_data;
 using bionic_id = string_id<bionic_data>;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Unhardcode and limbify attack vectors"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Attack vectors are currently hardcoded, undocumented and pretty janky. This aims to fix most of that.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
- [x] turn attack vectors into their own JSON object
- [x] Add filtering on limb type, limb id or included sublimbs
- [x] Add filtering based on selected bodypart encumbrance/health

TODO:
- [ ]   Actually integrate into the melee attack sequence, deprecating the old struct
- [ ] Allow defining the number of used vectors to facilitate using only the unarmed damage boni of the involved limbs
- [ ] Whatever comes up next

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
This is a very early draft I needed to spool off of the main limb dev branch, but might as well put it up already ~~to keep me honest~~.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
