### PR TITLE
spell-highlight: properly highlight spell target tiles in TILES build when not using tileset

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -3423,7 +3423,7 @@ void target_ui::draw_terrain_overlay()
 
     // Draw spell AOE
     if( mode == TargetMode::Spell ) {
-        drawsq_params params;
+        drawsq_params params = drawsq_params().highlight( true ).center( center );
         for( const tripoint &tile : spell_aoe ) {
             if( tile.z != center.z ) {
                 continue;


### PR DESCRIPTION
#### Summary
Bugfixes "Show spell target tiles in TILES builds when not using tileset"

#### Purpose of change
Fixes #50082 

The commit comment linked there provided working code for this PR. Surprised this was not taken care of in the last two years when it's such a simple fix. I suppose that shows how few players using TILES builds also play without tilesets.

Reproduction of bug taken from linked issue.
1. Disable tiles
2. Create world with Magiclysm
3. Start as Shock Officer (Or some other character with AOE spell)
4. Try to cast Windstrike or Jolt
5. Affected area rendered as empty terrain. No highlighting to see bounds; if there's any monsters in affected area - they're rendered invisible.

#### Describe the solution
Initialize `drawsq_params` so that it will highlight instead of using default initialization.

#### Testing
With Tileset
![spell-tiles](https://github.com/CleverRaven/Cataclysm-DDA/assets/8597997/7b30fea0-1718-4170-bc18-99570a4075bb)
Without Tileset
![spell-ascii](https://github.com/CleverRaven/Cataclysm-DDA/assets/8597997/36547218-f79f-41eb-97d6-8d663fdb2d0b)