### PR TITLE
Instead of calling `exit()`, reset and signal the default handler

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -56,7 +56,7 @@
 #include "type_id.h"
 #include "ui_manager.h"
 #if defined(MACOSX)
-#   include <unitstd.h> // getpid()
+#   include <unistd.h> // getpid()
 #endif
 
 #if defined(PREFIX)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,7 +151,11 @@ void exit_handler( int s )
 
 #if !defined(_WIN32)
         if( s == 2 ) {
-            signal( s, SIG_DFL );
+            struct sigaction sigIntHandler;
+            sigIntHandler.sa_handler = SIG_DFL;
+            sigemptyset( &sigIntHandler.sa_mask );
+            sigIntHandler.sa_flags = 0;
+            sigaction( SIGINT, &sigIntHandler, nullptr );
             kill( getpid(), s );
         } else
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -149,7 +149,15 @@ void exit_handler( int s )
         signal( SIGABRT, SIG_DFL );
 #endif
 
-        exit( exit_status );
+#if !defined(_WIN32)
+        if( s == 2 ) {
+            signal( s, SIG_DFL );
+            kill( getpid(), s );
+        } else
+#endif
+        {
+            exit( exit_status );
+        }
     }
     inp_mngr.set_timeout( old_timeout );
     ui_manager::redraw_invalidated();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,6 +55,9 @@
 #include "translations.h"
 #include "type_id.h"
 #include "ui_manager.h"
+#if defined(MACOSX)
+#   include <unitstd.h> // getpid()
+#endif
 
 #if defined(PREFIX)
 #   undef PREFIX


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix signal handler: call to exit()"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Related to #8417 (yes, I sorted by oldest issues). Changes to the code as by the article mentioned [here](https://github.com/CleverRaven/Cataclysm-DDA/issues/8417#issuecomment-394116340).
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
If the signal handler was raised by `SIGINT` (2), the handler reset the signal disposition to `SIG_DFL` and send the same signal to itself (the process).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
* ✔ Use `sigaction()` instead of plain `signal()` inside the handler, but wasn't sure passing the `struct sigaction` object from the handler stack would survive unwinding, or whether `sigaction()` would care at all.
* ❌ Transform `exit_handler` to a variadic template function just to get rid of this `-999` calls. Could not get around _gcc_ warnings.
* ❌ Add the default value `-999` to `exit_handler` and change the other calls.
* ❌ Replace `2` with `SIGINT`.
* Write a PR text shorter then the patch itself.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
* Linux Curses, `CTRL+C`, `[N]o`, `CTRL+C` again, `[Y]es`, shell return code was `130`.
* Linux Tiles, `CTRL+C` from the terminal, `[N]o`, menu opens, `Esc`, `CTRL+C` from the terminal, `[Y]es`, shell return code was `130`.
* Windows builds and runs fine.
* Can't test the Android `#ifdef` section, nor anything MacOS.

The _menu opens_ above is maybe a bug in my system using WSLg, or the SDL input functions eating the keypress twice. Not a regression since the same happens without this PR changes.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
`object_creator/creator_main.cpp` should receive the same changes.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
