### PR TITLE
gives the mercenary officer/ghost custom descriptions

### DIFF
--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1363,7 +1363,7 @@
   {
     "id": "mon_XEDRA_officer",
     "type": "MONSTER",
-    "description": "A figure in a high-tech suit, their outline contorted as though you were viewing them through a prism.  Their movements are strained but determined, pushing through apparent pain with feverish resolve, deadset on reaching their target.",
+    "description": "A figure in a high-tech suit, their outline contorted as though you were viewing them through a prism.  Their movements are strained but determined, pushing through apparent pain with feverish resolve, dead-set on reaching their target.",
     "name": { "str": "mercenary officer" },
     "copy-from": "mon_zombie_bio_op",
     "hp": 150,

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1363,6 +1363,7 @@
   {
     "id": "mon_XEDRA_officer",
     "type": "MONSTER",
+    "description": "A figure in a high-tech suit, their outline contorted as though you were viewing them through a prism.  Their movements are strained but determined, pushing through apparent pain with feverish resolve, deadset on reaching their target.",
     "name": { "str": "mercenary officer" },
     "copy-from": "mon_zombie_bio_op",
     "hp": 150,
@@ -1385,6 +1386,7 @@
   {
     "id": "mon_XEDRA_soldier",
     "type": "MONSTER",
+    "description": "A figure in combat gear, distorted and shattered like broken glass.  They thrash around as they move, an expression of shock and anguish frozen on their face.",
     "name": { "str": "mercenary ghost" },
     "copy-from": "mon_zombie_soldier_blackops_1",
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The soldier fades away to nothing." }


### PR DESCRIPTION
#### Summary
Bugfixes "Mercenary Officer and Mercenary Ghost enemies no longer copy descriptions from the blackops zombie and bio-operator"

#### Purpose of change

Fixes #65925

#### Describe the solution

Added `"description":` lines along with a description that I thought fit, drawing from the descriptions of the impaled spikes holding the enemies along with their behavior.

#### Describe alternatives you've considered

Since they're not my monsters I'm open to changing the descriptions to match whatever Candlebury wants them to be.

#### Testing

N/A

#### Additional context

Yes I know I made this issue report, nobody touched it so I decided to.
