### PR TITLE
Remove bed requirement for base expansion

### DIFF
--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -309,11 +309,6 @@ bool basecamp::has_provides( const std::string &req, const std::optional<point> 
     return false;
 }
 
-bool basecamp::can_expand() const
-{
-    return has_provides( "bed", base_camps::base_dir, directions.size() * 2 );
-}
-
 bool basecamp::has_water() const
 {
     // special case required for fbmh_well_north constructed between b9162 (Jun 16, 2019) and b9644 (Sep 20, 2019)

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -205,7 +205,6 @@ class basecamp
         void update_provides( const std::string &bldg, expansion_data &e_data );
         void update_in_progress( const std::string &bldg, const point &dir );
 
-        bool can_expand() const;
         /// Returns the name of the building the current building @ref dir upgrades into,
         /// "null" if there isn't one
         std::string next_upgrade( const point &dir, int offset = 1 ) const;

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -710,7 +710,7 @@ void talk_function::start_camp( npc &p )
     }
     std::optional<basecamp *> camp = get_basecamp( p, camp_type.str() );
     if( camp.has_value() ) {
-        for( int tab_num = base_camps::TAB_MAIN; tab_num < base_camps::TAB_NW; tab_num++ ) {
+        for( int tab_num = base_camps::TAB_MAIN; tab_num <= base_camps::TAB_NW; tab_num++ ) {
             std::vector<ui_mission_id> temp;
             camp.value()->hidden_missions.push_back( temp );
         }
@@ -1374,7 +1374,7 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
 
     // Missions that belong exclusively to the central tile
     {
-        if( can_expand() ) {
+        if( directions.size() < 8 ) {
             const mission_id miss_id = { Camp_Survey_Expansion, "", {}, base_dir };
             comp_list npc_list = get_mission_workers( miss_id );
             entry = string_format( _( "Notes:\n"
@@ -1402,15 +1402,6 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
                 bool avail = update_time_left( entry, npc_list );
                 mission_key.add_return( miss_id, _( "Recover Surveyor" ),
                                         entry, avail );
-            }
-        } else {
-            // Unless maximum expansions have been reached, show "Expand Base",
-            // but in a disabled state, with a message about what is required.
-            if( directions.size() < 8 ) {
-                const mission_id miss_id = { Camp_Survey_Expansion, "", {}, base_dir };
-                entry = _( "You will need more beds before you can expand your base." );
-                mission_key.add_start( miss_id, name_display_of( miss_id ),
-                                       entry, false );
             }
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #67889 
Fix #67848

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove the usage of "bed" tokens as a condition for base camp expansion, and added removal of the order when all potential expansion slots have been used (not to be confused by available slots: there are no checks to weed out slots the base camp can't expand into).

As a bonus, the probably bug behind #67848 was fixed as that was required to test the target change.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

N/A

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Loaded an old save used for base camp testing and created a field base camp version 1 (one type that used to depend on bed counts).
- Send companion to survey an expansion and tried to create the first one in the list in the NW location, causing the game to terminate.
- Debugged the cause of the game blowing up and found it to be initiation of a list to be one too few. Odd, since I believe exactly the same bug was encountered and fixed when the functionality to hide orders was introduced. Remembered that someone had issued a bug report a few days ago, giving rise to the suspicion that someone has (re)introduced the bug recently, but I haven't tried to investigate this.
- Fixed the bug (less than check to less than or equal in a loop).
- Restarted testing from scratch and created one expansion in each of the 8 expansion directions (different types in different slots, from the list in order, because why not add variation in case there is something there?).
- Found that the expansion order remained when all slots were filled.
- Checked the original code and failed to see there was any such check there.
- Added a check to remove the command when it could no longer possibly be useful.
- Retested as above (same expansions: the creativity has limits).
- Verified that the expansion command was no longer available when all 8 expansions had been introduced.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Nothing has been done to individual base camp versions to deal with potential references to bed restrictions.

While doing the changes I also searched the code for all usages of "bed", and the only one found was something associated with vehicles. There were also a couple of checks for "BED", so it's probably safe to remove all allocations of "bed" from base camp recipes, as they should have no usages anymore.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
