### PR TITLE
Players can teach proficiencies/spells/styles to NPCs

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -7,7 +7,8 @@
     "initiate": [ "You decide to not use any martial arts.", "%s enters a generic combat stance." ],
     "arm_block": 1,
     "leg_block": 99,
-    "allow_all_weapons": true
+    "allow_all_weapons": true,
+    "teachable": false
   },
   {
     "type": "martial_art",
@@ -18,7 +19,8 @@
     "arm_block": 1,
     "leg_block": 99,
     "force_unarmed": true,
-    "prevent_weapon_blocking": true
+    "prevent_weapon_blocking": true,
+    "teachable": false
   },
   {
     "type": "martial_art",

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -1889,19 +1889,20 @@ static bool magic_train( player_activity *act, Character *you )
     }
     const spell_id &sp_id = spell_id( act->name );
     if( sp_id.is_valid() ) {
-        const bool knows = get_player_character().magic->knows_spell( sp_id );
+        const bool knows = you->magic->knows_spell( sp_id );
         if( knows ) {
             spell &studying = you->magic->get_spell( sp_id );
             const int expert_multiplier = act->values.empty() ? 0 : act->values[0];
             const int xp = roll_remainder( studying.exp_modifier( *you ) * expert_multiplier );
             studying.gain_exp( *you, xp );
-            you->add_msg_if_player( m_good, _( "You learn a little about the spell: %s" ),
-                                    sp_id->name );
+            you->add_msg_player_or_npc( m_good, _( "You learn a little about the spell: %s" ),
+                                        _( "<npcname> learns a little about the spell: %s" ), sp_id->name );
         } else {
             you->magic->learn_spell( act->name, *you );
             // you can decline to learn this spell , as it may lock you out of other magic.
             if( you->magic->knows_spell( sp_id ) ) {
-                add_msg( m_good, _( "You learn %s." ), sp_id->name.translated() );
+                you->add_msg_player_or_npc( m_good, _( "You learn %s." ),
+                                            _( "<npcname> learns %s." ), sp_id->name.translated() );
             } else {
                 act->set_to_null();
             }

--- a/src/character.h
+++ b/src/character.h
@@ -1425,20 +1425,20 @@ class Character : public Creature, public visitable
          * @return Skills of which this NPC has a higher level than the given player. In other
          * words: skills this NPC could teach the player.
          */
-        std::vector<skill_id> skills_offered_to( const Character &you ) const;
+        std::vector<skill_id> skills_offered_to( const Character *you ) const;
         /**
          * Proficiencies we know that the character doesn't
          */
-        std::vector<proficiency_id> proficiencies_offered_to( const Character &guy ) const;
+        std::vector<proficiency_id> proficiencies_offered_to( const Character *guy ) const;
         /**
          * Martial art styles that we known, but the player p doesn't.
          */
-        std::vector<matype_id> styles_offered_to( const Character &you ) const;
+        std::vector<matype_id> styles_offered_to( const Character *you ) const;
         /**
          * Spells that the NPC knows but that the player p doesn't.
          * not const because get_spell isn't const and both this and p call it
          */
-        std::vector<spell_id> spells_offered_to( const Character &you ) const;
+        std::vector<spell_id> spells_offered_to( const Character *you ) const;
 
         int calc_spell_training_cost( bool knows, int difficulty, int level ) const;
 
@@ -2630,6 +2630,8 @@ class Character : public Creature, public visitable
         int scent = 0;
         pimpl<bionic_collection> my_bionics;
         pimpl<character_martial_arts> martial_arts_data;
+        std::vector<matype_id> known_styles( bool teachable_only ) const;
+        bool has_martialart( const matype_id &m ) const;
 
         stomach_contents stomach;
         stomach_contents guts;

--- a/src/character_martial_arts.cpp
+++ b/src/character_martial_arts.cpp
@@ -158,6 +158,20 @@ std::vector<matype_id> character_martial_arts::get_unknown_styles( const charact
     return ret;
 }
 
+std::vector<matype_id> character_martial_arts::get_known_styles( bool teachable_only ) const
+{
+    if( !teachable_only ) {
+        return ma_styles;
+    }
+    std::vector<matype_id> ret;
+    for( const matype_id &i : ma_styles ) {
+        if( i->teachable ) {
+            ret.push_back( i );
+        }
+    }
+    return ret;
+}
+
 void character_martial_arts::serialize( JsonOut &json ) const
 {
     json.start_object();

--- a/src/character_martial_arts.h
+++ b/src/character_martial_arts.h
@@ -99,6 +99,7 @@ class character_martial_arts
         std::vector<matec_id> get_all_techniques( const item_location &weap, const Character &u ) const;
         std::vector<matype_id> get_unknown_styles( const character_martial_arts &from,
                 bool teachable_only ) const;
+        std::vector<matype_id> get_known_styles( bool teachable_only ) const;
         /** Returns true if the player has a weapon or martial arts skill available with the entered technique */
         bool has_technique( const Character &guy, const matec_id &id, const item &weap ) const;
         /** Returns the first valid grab break technique */

--- a/src/character_proficiency.cpp
+++ b/src/character_proficiency.cpp
@@ -107,11 +107,11 @@ void Character::set_proficiency_practice( const proficiency_id &id, const time_d
     _proficiencies->practice( id, amount, std::nullopt );
 }
 
-std::vector<proficiency_id> Character::proficiencies_offered_to( const Character &guy ) const
+std::vector<proficiency_id> Character::proficiencies_offered_to( const Character *guy ) const
 {
     std::vector<proficiency_id> ret;
     for( const proficiency_id &known : known_proficiencies() ) {
-        if( known->is_teachable() && !guy.has_proficiency( known ) ) {
+        if( known->is_teachable() && ( !guy || !guy->has_proficiency( known ) ) ) {
             ret.push_back( known );
         }
     }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1864,7 +1864,7 @@ void known_magic::learn_spell( const spell_type *sp, Character &guy, bool force 
                     trait_cancel += ".";
                 }
             }
-            if( query_yn(
+            if( !guy.is_avatar() || query_yn(
                     _( "Learning this spell will make you a\n\n%s: %s\n\nand lock you out of\n\n%s\n\nContinue?" ),
                     sp->spell_class->name(), sp->spell_class->desc(), trait_cancel ) ) {
                 guy.set_mutation( sp->spell_class );
@@ -1878,9 +1878,10 @@ void known_magic::learn_spell( const spell_type *sp, Character &guy, bool force 
     if( force || can_learn_spell( guy, sp->id ) ) {
         spellbook.emplace( sp->id, temp_spell );
         get_event_bus().send<event_type::character_learns_spell>( guy.getID(), sp->id );
-        guy.add_msg_if_player( m_good, _( "You learned %s!" ), sp->name );
+        guy.add_msg_player_or_npc( m_good, _( "You learned %s!" ), _( "<npcname> learned %s!" ), sp->name );
     } else {
-        guy.add_msg_if_player( m_bad, _( "You can't learn this spell." ) );
+        guy.add_msg_player_or_npc( m_bad, _( "You can't learn this spell." ),
+                                   _( "<npcname> can't learn this spell." ) );
     }
 }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -428,31 +428,42 @@ std::vector<int> npcs_select_menu( const std::vector<Character *> &npc_list,
     return picked;
 }
 
-static skill_id skill_select_menu( const Character &c, const std::string &prompt )
+static std::string training_select_menu( const Character &c, const std::string &prompt )
 {
     int i = 0;
     uilist nmenu;
     nmenu.text = prompt;
+    std::vector<std::string> trainlist;
     for( const std::pair<const skill_id, SkillLevel> &s : *c._skills ) {
-        if( !s.first->is_teachable() ) {
-            continue;
-        }
-        bool enabled = s.second.level() > 0;
-        std::string entry = string_format( "%s (%d)", s.first.str(), s.second.level() );
+        bool enabled = s.first->is_teachable() && s.second.level() > 0;
+        std::string entry = string_format( "%s: %s (%d)", _( "Skill" ), s.first.str(), s.second.level() );
         nmenu.addentry( i, enabled, MENU_AUTOASSIGN, entry );
+        trainlist.emplace_back( s.first.c_str() );
+        i++;
+    }
+    for( const proficiency_id &p : c.known_proficiencies() ) {
+        std::string entry = string_format( "%s: %s", _( "Proficiency" ), p->name() );
+        nmenu.addentry( i, p->is_teachable(), MENU_AUTOASSIGN, entry );
+        trainlist.emplace_back( p.c_str() );
+        i++;
+    }
+    for( const matype_id &m : c.known_styles( true ) ) {
+        std::string entry = string_format( "%s: %s", _( "Style" ), m->name.translated() );
+        nmenu.addentry( i, m->teachable, MENU_AUTOASSIGN, entry );
+        trainlist.emplace_back( m.c_str() );
+        i++;
+    }
+    for( const spell_id &s : c.magic->spells() ) {
+        std::string entry = string_format( "%s: %s", _( "Spell" ), s->name.translated() );
+        nmenu.addentry( i, s->teachable, MENU_AUTOASSIGN, entry );
+        trainlist.emplace_back( s.c_str() );
         i++;
     }
     nmenu.query();
-    if( nmenu.ret > -1 ) {
-        i = 0;
-        for( const std::pair<const skill_id, SkillLevel> &s : *c._skills ) {
-            if( i == nmenu.ret ) {
-                return s.first;
-            }
-            i++;
-        }
+    if( nmenu.ret > -1 && nmenu.ret < static_cast<int>( trainlist.size() ) ) {
+        return trainlist[nmenu.ret];
     }
-    return skill_id();
+    return "";
 }
 
 static void npc_batch_override_toggle(
@@ -826,18 +837,45 @@ void game::chat()
             break;
         }
         case NPC_CHAT_START_SEMINAR: {
-            // TODO: Also allow group training of martial arts/spells/proficiencies
-            const skill_id &sk = skill_select_menu( player_character,
-                                                    _( "Which skill would you like to teach?" ) );
-            if( !sk.is_valid() ) {
+            const std::string &t = training_select_menu( player_character,
+                                   _( "What would you like to teach?" ) );
+            if( t.empty() ) {
                 return;
             }
+            int id_type = -1;
             std::vector<Character *> clist( followers.begin(), followers.end() );
-            std::vector<int> selected = npcs_select_menu( clist,
-            _( "Who should participate in the training seminar?" ), [&]( const Character * n ) {
-                return !n ||
-                       n->get_knowledge_level( sk ) >= static_cast<int>( player_character.get_skill_level( sk ) );
-            } );
+            const std::string query_str = _( "Who should participate in the training seminar?" );
+            std::vector<int> selected;
+            skill_id sk( t );
+            if( sk.is_valid() ) {
+                selected = npcs_select_menu( clist, query_str, [&]( const Character * n ) {
+                    return !n ||
+                           n->get_knowledge_level( sk ) >= static_cast<int>( player_character.get_skill_level( sk ) );
+                } );
+                id_type = 0;
+            }
+            matype_id ma( t );
+            if( ma.is_valid() ) {
+                selected = npcs_select_menu( clist, query_str, [&]( const Character * n ) {
+                    return !n || n->has_martialart( ma );
+                } );
+                id_type = 1;
+            }
+            proficiency_id pr( t );
+            if( pr.is_valid() ) {
+                selected = npcs_select_menu( clist, query_str, [&]( const Character * n ) {
+                    return !n || n->has_proficiency( pr );
+                } );
+                id_type = 2;
+            }
+            spell_id sp( t );
+            if( sp.is_valid() ) {
+                selected = npcs_select_menu( clist, query_str, [&]( const Character * n ) {
+                    return !n || ( n->magic->knows_spell( sp ) &&
+                                   n->magic->get_spell( sp ).get_level() >= player_character.magic->get_spell( sp ).get_level() );
+                } );
+                id_type = 3;
+            }
             if( selected.empty() ) {
                 return;
             }
@@ -848,10 +886,10 @@ void game::chat()
                 }
             }
             talk_function::teach_domain d;
-            d.skill = sk;
-            d.style = matype_id();
-            d.prof = proficiency_id();
-            d.spell = spell_id();
+            d.skill = id_type == 0 ? sk : skill_id();
+            d.style = id_type == 1 ? ma : matype_id();
+            d.prof = id_type == 2 ? pr : proficiency_id();
+            d.spell = id_type == 3 ? sp : spell_id();
             talk_function::start_training_gen( player_character, to_train, d );
             break;
         }
@@ -1336,13 +1374,17 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic )
             return _( "Shall we resume?" );
         } else if( actor( true )->skills_offered_to( *actor( false ) ).empty() &&
                    actor( true )->styles_offered_to( *actor( false ) ).empty() &&
-                   actor( true )->spells_offered_to( *actor( false ) ).empty() ) {
+                   actor( true )->spells_offered_to( *actor( false ) ).empty() &&
+                   actor( true )->proficiencies_offered_to( *actor( false ) ).empty() ) {
             return _( "Sorry, but it doesn't seem I have anything to teach you." );
         } else {
             return _( "Here's what I can teach you…" );
         }
     } else if( topic == "TALK_TRAIN_NPC" ) {
-        if( actor( false )->skills_offered_to( *actor( true ) ).empty() ) {
+        if( actor( false )->skills_offered_to( *actor( true ) ).empty() &&
+            actor( false )->styles_offered_to( *actor( true ) ).empty() &&
+            actor( false )->spells_offered_to( *actor( true ) ).empty() &&
+            actor( false )->proficiencies_offered_to( *actor( true ) ).empty() ) {
             return _( "Sorry, there's nothing I can learn from you." );
         } else {
             return _( "Sure, I'm all ears." );
@@ -1528,30 +1570,76 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             }
         }
     } else if( the_topic.id == "TALK_TRAIN_NPC" ) {
-        const std::vector<skill_id> &trainable = actor( false )->skills_offered_to( *actor( true ) );
-        if( trainable.empty() ) {
+        const std::vector<matype_id> &styles = actor( false )->styles_offered_to( *actor( true ) );
+        const std::vector<skill_id> &skills = actor( false )->skills_offered_to( *actor( true ) );
+        const std::vector<spell_id> &spells = actor( false )->spells_offered_to( *actor( true ) );
+        const std::vector<proficiency_id> &profs =
+            actor( false )->proficiencies_offered_to( *actor( true ) );
+        if( skills.empty() && styles.empty() && spells.empty() && profs.empty() ) {
             add_response_none( _( "Oh, okay." ) );
             return;
         }
-        for( const skill_id &s : trainable ) {
-            const std::string &text = actor( true )->skill_training_text( *actor( true ), s );
-            if( !text.empty() && !s->obsolete() ) {
-                add_response( text, "TALK_TRAIN_NPC_START", s );
+        for( const spell_id &sp : spells ) {
+            const std::string &text =
+                string_format( "%s: %s", _( "Spell" ), actor( false )->spell_training_text( *actor( true ), sp ) );
+            if( !text.empty() ) {
+                add_response( text, "TALK_TRAIN_NPC_START", sp );
+            }
+        }
+        for( const matype_id &ma : styles ) {
+            const std::string &text =
+                string_format( "%s: %s", _( "Style" ), actor( false )->style_training_text( *actor( true ), ma ) );
+            if( !text.empty() ) {
+                add_response( text, "TALK_TRAIN_NPC_START", ma.obj() );
+            }
+        }
+        for( const skill_id &sk : skills ) {
+            const std::string &text =
+                string_format( "%s: %s", _( "Skill" ), actor( false )->skill_training_text( *actor( true ), sk ) );
+            if( !text.empty() && !sk->obsolete() ) {
+                add_response( text, "TALK_TRAIN_NPC_START", sk );
+            }
+        }
+        for( const proficiency_id &pr : profs ) {
+            const std::string &text =
+                string_format( "%s: %s", _( "Proficiency" ),
+                               actor( false )->proficiency_training_text( *actor( true ), pr ) );
+            if( !text.empty() ) {
+                add_response( text, "TALK_TRAIN_NPC_START", pr );
             }
         }
         add_response_none( _( "Eh, never mind." ) );
     } else if( the_topic.id == "TALK_TRAIN_SEMINAR" ) {
-        const std::vector<skill_id> &slist = actor( true )->skills_teacheable();
-        if( slist.empty() ) {
+        const std::vector<skill_id> &sklist = actor( true )->skills_teacheable();
+        const std::vector<proficiency_id> &prlist = actor( true )->proficiencies_teacheable();
+        const std::vector<matype_id> &malist = actor( true )->styles_teacheable();
+        const std::vector<spell_id> &splist = actor( true )->spells_teacheable();
+        if( sklist.empty() && prlist.empty() && malist.empty() && splist.empty() ) {
             add_response_none( _( "Oh, okay." ) );
             return;
         }
-        for( const skill_id &sk : slist ) {
+        for( const skill_id &sk : sklist ) {
             if( sk->obsolete() ) {
                 continue;
             }
-            const std::string &text = actor( true )->skill_seminar_text( sk );
+            const std::string &text =
+                string_format( "%s: %s", _( "Skill" ), actor( true )->skill_seminar_text( sk ) );
             add_response( text, "TALK_TRAIN_SEMINAR_START", sk );
+        }
+        for( const proficiency_id &pr : prlist ) {
+            const std::string &text =
+                string_format( "%s: %s", _( "Proficiency" ), actor( true )->proficiency_seminar_text( pr ) );
+            add_response( text, "TALK_TRAIN_SEMINAR_START", pr );
+        }
+        for( const matype_id &ma : malist ) {
+            const std::string &text =
+                string_format( "%s: %s", _( "Style" ), actor( true )->style_seminar_text( ma ) );
+            add_response( text, "TALK_TRAIN_SEMINAR_START", ma.obj() );
+        }
+        for( const spell_id &sp : splist ) {
+            const std::string &text =
+                string_format( "%s: %s", _( "Spell" ), actor( true )->spell_seminar_text( sp ) );
+            add_response( text, "TALK_TRAIN_SEMINAR_START", sp );
         }
         add_response_none( _( "Eh, never mind." ) );
     } else if( the_topic.id == "TALK_TRAIN" ) {
@@ -1564,10 +1652,16 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             if( !skillt.is_valid() ) {
                 const matype_id styleid = matype_id( backlog.name );
                 if( !styleid.is_valid() ) {
-                    const spell_id &sp_id = spell_id( backlog.name );
-                    if( actor( true )->knows_spell( sp_id ) ) {
+                    const proficiency_id profid = proficiency_id( backlog.name );
+                    if( !profid.is_valid() ) {
+                        const spell_id &sp_id = spell_id( backlog.name );
+                        if( actor( true )->knows_spell( sp_id ) ) {
+                            add_response( string_format( _( "Yes, let's resume training %s" ),
+                                                         sp_id->name ), "TALK_TRAIN_START", sp_id );
+                        }
+                    } else {
                         add_response( string_format( _( "Yes, let's resume training %s" ),
-                                                     sp_id->name ), "TALK_TRAIN_START", sp_id );
+                                                     profid->name() ), "TALK_TRAIN_START", profid );
                     }
                 } else {
                     const martialart &style = styleid.obj();
@@ -1589,25 +1683,32 @@ void dialogue::gen_responses( const talk_topic &the_topic )
             return;
         }
         for( const spell_id &sp : teachable ) {
-            const std::string &text = actor( true )->spell_training_text( *actor( false ), sp );
+            const std::string &text =
+                string_format( "%s: %s", _( "Spell" ), actor( true )->spell_training_text( *actor( false ), sp ) );
             if( !text.empty() ) {
                 add_response( text, "TALK_TRAIN_START", sp );
             }
         }
         for( const matype_id &style_id : styles ) {
-            const std::string &text = actor( true )->style_training_text( *actor( false ), style_id );
+            const std::string &text =
+                string_format( "%s: %s", _( "Style" ),
+                               actor( true )->style_training_text( *actor( false ), style_id ) );
             if( !text.empty() ) {
                 add_response( text, "TALK_TRAIN_START", style_id.obj() );
             }
         }
         for( const skill_id &trained : trainable ) {
-            const std::string &text = actor( true )->skill_training_text( *actor( false ), trained );
+            const std::string &text =
+                string_format( "%s: %s", _( "Skill" ),
+                               actor( true )->skill_training_text( *actor( false ), trained ) );
             if( !text.empty() && !trained->obsolete() ) {
                 add_response( text, "TALK_TRAIN_START", trained );
             }
         }
         for( const proficiency_id &trained : proficiencies ) {
-            const std::string &text = actor( true )->proficiency_training_text( *actor( false ), trained );
+            const std::string &text =
+                string_format( "%s: %s", _( "Proficiency" ),
+                               actor( true )->proficiency_training_text( *actor( false ), trained ) );
             if( !text.empty() ) {
                 add_response( text, "TALK_TRAIN_START", trained );
             }

--- a/src/talker.h
+++ b/src/talker.h
@@ -265,19 +265,37 @@ class talker
         virtual std::string skill_training_text( const talker &, const skill_id & ) const {
             return {};
         }
+        virtual std::vector<proficiency_id> proficiencies_teacheable() const {
+            return {};
+        }
         virtual std::vector<proficiency_id> proficiencies_offered_to( const talker & ) const {
+            return {};
+        }
+        virtual std::string proficiency_seminar_text( const proficiency_id & ) const {
             return {};
         }
         virtual std::string proficiency_training_text( const talker &, const proficiency_id & ) const {
             return {};
         }
+        virtual std::vector<matype_id> styles_teacheable() const {
+            return {};
+        }
         virtual std::vector<matype_id> styles_offered_to( const talker & ) const {
+            return {};
+        }
+        virtual std::string style_seminar_text( const matype_id & ) const {
             return {};
         }
         virtual std::string style_training_text( const talker &, const matype_id & ) const {
             return {};
         }
+        virtual std::vector<spell_id> spells_teacheable() const {
+            return {};
+        }
         virtual std::vector<spell_id> spells_offered_to( talker & ) const {
+            return {};
+        }
+        virtual std::string spell_seminar_text( const spell_id & ) const {
             return {};
         }
         virtual std::string spell_training_text( talker &, const spell_id & ) const {

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -908,22 +908,30 @@ void talker_character::remove_bionic( const bionic_id &old_bionic )
     }
 }
 
-std::vector<skill_id> talker_character::skills_teacheable() const
+std::vector<skill_id> talker_character_const::skills_teacheable() const
 {
-    std::vector<skill_id> ret;
-    for( const auto &pair : *me_chr->_skills ) {
-        const skill_id &id = pair.first;
-        if( pair.second.level() > 0 && id->is_teachable() ) {
-            ret.push_back( id );
-        }
-    }
-    return ret;
+    return me_chr_const->skills_offered_to( nullptr );
+}
+
+std::vector<proficiency_id> talker_character_const::proficiencies_teacheable() const
+{
+    return me_chr_const->proficiencies_offered_to( nullptr );
+}
+
+std::vector<matype_id> talker_character_const::styles_teacheable() const
+{
+    return me_chr_const->styles_offered_to( nullptr );
+}
+
+std::vector<spell_id> talker_character_const::spells_teacheable() const
+{
+    return me_chr_const->spells_offered_to( nullptr );
 }
 
 std::vector<skill_id> talker_character_const::skills_offered_to( const talker &student ) const
 {
     if( student.get_character() ) {
-        return me_chr_const->skills_offered_to( *student.get_character() );
+        return me_chr_const->skills_offered_to( student.get_character() );
     } else {
         return {};
     }
@@ -956,7 +964,7 @@ std::vector<proficiency_id> talker_character_const::proficiencies_offered_to(
     const talker &student ) const
 {
     if( student.get_character() ) {
-        return me_chr_const->proficiencies_offered_to( *student.get_character() );
+        return me_chr_const->proficiencies_offered_to( student.get_character() );
     } else {
         return {};
     }
@@ -990,7 +998,7 @@ std::string talker_character_const::proficiency_training_text( const talker &stu
 std::vector<matype_id> talker_character_const::styles_offered_to( const talker &student ) const
 {
     if( student.get_character() ) {
-        return me_chr_const->styles_offered_to( *student.get_character() );
+        return me_chr_const->styles_offered_to( student.get_character() );
     } else {
         return {};
     }
@@ -1012,7 +1020,7 @@ std::string talker_character_const::style_training_text( const talker &student,
 std::vector<spell_id> talker_character_const::spells_offered_to( talker &student ) const
 {
     if( student.get_character() ) {
-        return me_chr_const->spells_offered_to( *student.get_character() );
+        return me_chr_const->spells_offered_to( student.get_character() );
     } else {
         return {};
     }
@@ -1029,7 +1037,9 @@ std::string talker_character_const::spell_training_text( talker &student, const 
     const int cost = me_chr_const->calc_spell_training_cost( knows, temp_spell.get_difficulty( *pupil ),
                      temp_spell.get_level() );
     std::string text;
-    if( knows ) {
+    if( cost == 0 && ( !me_chr_const->is_npc() || me_chr_const->as_npc()->is_ally( *pupil ) ) ) {
+        text = temp_spell.name();
+    } else if( knows ) {
         text = string_format( _( "%s: 1 hour lesson (cost %s)" ), temp_spell.name(),
                               format_money( cost ) );
     } else {
@@ -1039,10 +1049,25 @@ std::string talker_character_const::spell_training_text( talker &student, const 
     return text;
 }
 
-std::string talker_character::skill_seminar_text( const skill_id &s ) const
+std::string talker_character_const::skill_seminar_text( const skill_id &s ) const
 {
-    int lvl = me_chr->get_skill_level( s );
+    int lvl = me_chr_const->get_skill_level( s );
     return string_format( "%s (%d)", s.obj().name(), lvl );
+}
+
+std::string talker_character_const::proficiency_seminar_text( const proficiency_id &p ) const
+{
+    return p->name();
+}
+
+std::string talker_character_const::style_seminar_text( const matype_id &m ) const
+{
+    return m->name.translated();
+}
+
+std::string talker_character_const::spell_seminar_text( const spell_id &s ) const
+{
+    return s->name.translated();
 }
 
 std::vector<bodypart_id> talker_character::get_all_body_parts( bool all, bool main_only ) const

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -93,14 +93,22 @@ class talker_character_const: public talker_cloner<talker_character_const>
         std::string get_value( const std::string &var_name ) const override;
 
         // stats, skills, traits, bionics, magic, and proficiencies
+        std::vector<skill_id> skills_teacheable() const override;
         std::vector<skill_id> skills_offered_to( const talker &student ) const override;
+        std::string skill_seminar_text( const skill_id &s ) const override;
         std::string skill_training_text( const talker &, const skill_id & ) const override;
+        std::vector<proficiency_id> proficiencies_teacheable() const override;
         std::vector<proficiency_id> proficiencies_offered_to( const talker &student ) const override;
+        std::string proficiency_seminar_text( const proficiency_id & ) const override;
         std::string proficiency_training_text( const talker &student,
                                                const proficiency_id &proficiency ) const override;
+        std::vector<matype_id> styles_teacheable() const override;
         std::vector<matype_id> styles_offered_to( const talker &student ) const override;
+        std::string style_seminar_text( const matype_id & ) const override;
         std::string style_training_text( const talker &, const matype_id & ) const override;
+        std::vector<spell_id> spells_teacheable() const override;
         std::vector<spell_id> spells_offered_to( talker &student ) const override;
+        std::string spell_seminar_text( const spell_id & ) const override;
         std::string spell_training_text( talker &, const spell_id & ) const override;
 
         // inventory, buying, and selling
@@ -253,8 +261,6 @@ class talker_character: public talker_cloner<talker_character, talker_character_
         void set_height( int ) override;
         void add_bionic( const bionic_id &new_bionic ) override;
         void remove_bionic( const bionic_id &old_bionic ) override;
-        std::vector<skill_id> skills_teacheable() const override;
-        std::string skill_seminar_text( const skill_id &s ) const override;
         std::vector<bodypart_id> get_all_body_parts( bool all, bool main_only ) const override;
         int get_part_hp_cur( const bodypart_id &id ) const override;
         int get_part_hp_max( const bodypart_id &id ) const override;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The player can ask NPCs to teach them all kinds of trainings, but the player themself is limited to only teaching skills. The same goes for training seminars.

Since the infrastructure is already in place, it's pretty simple to expand that option to allow players to teach proficiencies, spells, and martial art styles as well.

#### Describe the solution
Expand teaching options for players teaching NPCs and training seminars to include trainings other than skills. Skills/styles/proficiencies/spells that have `"teachable": false` remain unteachable.

#### Describe alternatives you've considered


#### Testing
https://github.com/CleverRaven/Cataclysm-DDA/assets/12537966/a04c1ff8-8bc1-4edd-be7f-a451ecb14b0b

#### Additional context
