### PR TITLE
Aftershock: Rebalance Gibson  S86

### DIFF
--- a/data/mods/Aftershock/items/gun/25mm.json
+++ b/data/mods/Aftershock/items/gun/25mm.json
@@ -16,7 +16,7 @@
     "color": "brown",
     "min_strength": 18,
     "ranged_damage": { "damage_type": "bullet", "amount": 10 },
-    "skill": "launcher",
+    "skill": "rifle",
     "modes": [ [ "DEFAULT", "DOUBLE", 4 ] ],
     "dispersion": 90,
     "durability": 6,


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Rebalance Gibson  S86"

#### Purpose of change

The gun under performed even in incredibly favorable situations, since aftershock wants to have very few guns inside it, that's not very good.

#### Describe the solution

Launcher -> Rifle

That's it, Its OP now.

#### Testing

Hah it shoots exploding shells.
