### PR TITLE
Raise margin on nicotine addiction test

### DIFF
--- a/tests/addiction_test.cpp
+++ b/tests/addiction_test.cpp
@@ -150,7 +150,7 @@ TEST_CASE( "hardcoded_and_json_addictions", "[addiction]" )
     SECTION( "nicotine hardcoded test, intensity 20" ) {
         int res = suffer_addiction( addiction_test_nicotine, 20, u, max_iters, totals );
         CHECK( res == Approx( 70 ).margin( 40 ) );
-        CHECK( totals.fatigue == Approx( 70 ).margin( 30 ) );
+        CHECK( totals.fatigue == Approx( 70 ).margin( 35 ) );
         CHECK( totals.morale <= 0 );
         CHECK( totals.stim <= 0 );
     }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Less test flakes

#### Describe the solution

Raise the margin of nicotine addiction test a bit

#### Describe alternatives you've considered

#### Testing

#### Additional context

https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/5991269656/job/16249444353#step:20:42