### PR TITLE
Bugfix: Exploding 💥 zombie cows with landmines

### DIFF
--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -415,6 +415,7 @@ static std::vector<tripoint> shrapnel( const Creature *source, const tripoint &s
     fragment_cloud initial_cloud = accumulate_fragment_cloud( obstacle_cache[src.x][src.y],
     { fragment_velocity, static_cast<float>( fragment_count ) }, 1 );
     visited_cache[src.x][src.y] = initial_cloud;
+    visited_cache[src.x][src.y].density = static_cast<float>( fragment_count );
 
     castLightAll<fragment_cloud, fragment_cloud, shrapnel_calc, shrapnel_check,
                  update_fragment_cloud, accumulate_fragment_cloud>


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Exploding zombie cows with landmines"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Fixes an issue where a zombie cow stepping on a landmine would previously not damage the cow at all. The mine exploded but the cow took no damage.
* Fixes #60363

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

* The issue before was
	* The method `map::build_obstacle_cache` sets initial values for `.density`
	* Because of the cow size, the `density` on the tile of the cow got set to `0`. [Link](https://github.com/CleverRaven/Cataclysm-DDA/blob/cdda-experimental-2023-08-27-0712/src/map.cpp#L8998)
	* When `density` is zero, no damage will be done.
* The intention with `initial_cloud` seems to be that the density instead should be equal to the fragment count, and decreasing outward.
* Therefore, this change simply sets the initial value for `.density` regardless of the size of any creature that might be placed there.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

1. Place landmine.
2. Debug spawn zombie cow
3. Make zombie cow step on landmine
4. Notice whether the cow took any damage. With the suggested fix, it now does.

Below are tables of the values for `density` for each tile surrounding the cow stepping on the landmine. The cow steps on the tile center.

Zombie cow on landmine, density before:
```
|  0  |  0  |  0  |
|  0  |  0  |  0  |
|  0  |  0  |  0  |
```

Zombie cow on landmine, density after:
```
|  0  |  0  |  0  |
|  0  | 160 |  0  |
|  0  |  0  |  0  |
```

Regular zombie on landmine, density before:
```
|  15 |  15 |  15 |
|  15 | 160 |  15 |
|  15 |  15 |  15 |
```

Regular zombie on landmine, density after (no change, still works):
```
|  15 |  15 |  15 |
|  15 | 160 |  15 |
|  15 |  15 |  15 |
```

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
