### PR TITLE
Coconut additions

### DIFF
--- a/data/json/items/comestibles/drink_other.json
+++ b/data/json/items/comestibles/drink_other.json
@@ -343,6 +343,28 @@
     "fun": 6
   },
   {
+    "id": "coconut_water",
+    "type": "COMESTIBLE",
+    "symbol": "~",
+    "color": "light_cyan",
+    "spoils_in": "3 days",
+    "name": { "str_sp": "coconut water" },
+    "description": "Sweet-tasting cloudy liquid extracted from a coconut.",
+    "charges": 1,
+    "price": 50,
+    "price_postapoc": 10,
+    "material": [ "water" ],
+    "weight": "250 g",
+    "volume": "250 ml",
+    "comestible_type": "DRINK",
+    "container": "carton_sealed",
+    "quench": 47,
+    "calories": 47,
+    "fun": 3,
+    "phase": "liquid",
+    "vitamins": [ [ "calcium", 6 ], [ "iron", 4 ], [ "vitC", 10 ] ]
+  },
+  {
     "type": "COMESTIBLE",
     "id": "salca",
     "name": { "str_sp": "salca" },

--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -653,6 +653,32 @@
     "qualities": [ [ "CONTAIN", 1 ] ]
   },
   {
+    "id": "bowl_coconut",
+    "type": "GENERIC",
+    "category": "container",
+    "name": { "str": "coconut bowl" },
+    "looks_like": "bowl_wood",
+    "description": "A single half of a coconut with the meat removed.  Usable as a bowl to hold some liquid.",
+    "weight": "55 g",
+    "volume": "300 ml",
+    "price": 100,
+    "price_postapoc": 10,
+    "material": [ "wood" ],
+    "symbol": ")",
+    "color": "brown",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "watertight": true,
+        "rigid": true,
+        "open_container": true,
+        "max_contains_volume": "250 ml",
+        "max_contains_weight": "3 kg"
+      }
+    ],
+    "qualities": [ [ "CONTAIN", 1 ] ]
+  },
+  {
     "id": "bowl_skull",
     "type": "GENERIC",
     "category": "container",

--- a/data/json/uncraft/comestibles/fruit.json
+++ b/data/json/uncraft/comestibles/fruit.json
@@ -29,7 +29,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "time": "2 m",
     "qualities": [ { "id": "CUT", "level": 1 }, { "id": "HAMMER", "level": 1 } ],
-    "components": [ [ [ "coconut_flesh", 5 ] ] ]
+    "components": [ [ [ "coconut_flesh", 4 ] ], [ [ "coconut_water", 1 ] ], [ [ "bowl_coconut", 2 ] ] ]
   },
   {
     "result": "irradiated_watermelon",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Add coconut bowls and coconut water"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adding more useful things that can be obtained from coconuts.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add coconut water which can be consumed to quench thirst, and coconut bowls to contain some liquid.

Modify coconut disassembly to yield coconut water and two coconut bowls. Amount of coconut meat portions produced was reduced from 5 to 4 to conserve weight.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Allowing to disassemble coconuts with just a cutting tool, no hammering tool needed.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Disassembled a coconut in game, checked that yielded items are correct.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Minor issue: coconut water can't be consumed right as the coconut is disassembled, and has to be put into a liquid container first (produced coconut bowls aren't considered valid liquid containers for this purpose, but this is probably working as intended).
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
