### PR TITLE
[Magiclysm] Add RNG to crystallized mana spawns

### DIFF
--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -328,7 +328,7 @@
       { "group": "potions_rare", "prob": 5 },
       { "group": "alchemy_items", "prob": 30 },
       { "group": "magical_reagents", "prob": 20 },
-      [ "crystallized_mana", 55 ],
+      { "item": "crystallized_mana", "prob": 55, "charges-min": 5, "charges-max": 150 },
       { "item": "small_mana_crystal", "prob": 40, "charges-min": 5, "charges-max": 50 }
     ]
   },
@@ -875,7 +875,7 @@
       { "group": "magic_CBM", "prob": 2 },
       { "item": "lair_map", "prob": 20 },
       { "item": "retreat_map", "prob": 30 },
-      [ "crystallized_mana", 50 ],
+      { "item": "crystallized_mana", "prob": 50, "charges-min": 5, "charges-max": 150 },
       { "item": "small_mana_crystal", "prob": 40, "charges-min": 5, "charges-max": 50 },
       { "item": "magic_knife_bag", "prob": 25 }
     ]
@@ -1348,7 +1348,7 @@
         "distribution": [ { "group": "enchanted_rings_common", "prob": 30 }, { "group": "enchanted_rings_uncommon", "prob": 10 } ],
         "prob": 40
       },
-      [ "crystallized_mana", 50 ],
+      { "item": "crystallized_mana", "prob": 50, "charges-min": 5, "charges-max": 150 },
       [ "copper_circlet", 10 ],
       [ "cauldron_orichalcum", 1 ],
       { "item": "small_mana_crystal", "prob": 40, "charges-min": 5, "charges-max": 50 }

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -328,7 +328,7 @@
       { "group": "potions_rare", "prob": 5 },
       { "group": "alchemy_items", "prob": 30 },
       { "group": "magical_reagents", "prob": 20 },
-      { "item": "crystallized_mana", "prob": 55, "charges-min": 5, "charges-max": 100 },
+      { "item": "crystallized_mana", "prob": 55, "charges-min": 1, "charges-max": 10 },
       { "item": "small_mana_crystal", "prob": 40, "charges-min": 5, "charges-max": 50 }
     ]
   },
@@ -875,7 +875,7 @@
       { "group": "magic_CBM", "prob": 2 },
       { "item": "lair_map", "prob": 20 },
       { "item": "retreat_map", "prob": 30 },
-      { "item": "crystallized_mana", "prob": 50, "charges-min": 5, "charges-max": 100 },
+      { "item": "crystallized_mana", "prob": 50, "charges-min": 1, "charges-max": 10 },
       { "item": "small_mana_crystal", "prob": 40, "charges-min": 5, "charges-max": 50 },
       { "item": "magic_knife_bag", "prob": 25 }
     ]
@@ -1348,7 +1348,7 @@
         "distribution": [ { "group": "enchanted_rings_common", "prob": 30 }, { "group": "enchanted_rings_uncommon", "prob": 10 } ],
         "prob": 40
       },
-      { "item": "crystallized_mana", "prob": 50, "charges-min": 5, "charges-max": 100 },
+      { "item": "crystallized_mana", "prob": 50, "charges-min": 1, "charges-max": 10 },
       [ "copper_circlet", 10 ],
       [ "cauldron_orichalcum", 1 ],
       { "item": "small_mana_crystal", "prob": 40, "charges-min": 5, "charges-max": 50 }

--- a/data/mods/Magiclysm/itemgroups/itemgroups.json
+++ b/data/mods/Magiclysm/itemgroups/itemgroups.json
@@ -328,7 +328,7 @@
       { "group": "potions_rare", "prob": 5 },
       { "group": "alchemy_items", "prob": 30 },
       { "group": "magical_reagents", "prob": 20 },
-      { "item": "crystallized_mana", "prob": 55, "charges-min": 5, "charges-max": 150 },
+      { "item": "crystallized_mana", "prob": 55, "charges-min": 5, "charges-max": 100 },
       { "item": "small_mana_crystal", "prob": 40, "charges-min": 5, "charges-max": 50 }
     ]
   },
@@ -875,7 +875,7 @@
       { "group": "magic_CBM", "prob": 2 },
       { "item": "lair_map", "prob": 20 },
       { "item": "retreat_map", "prob": 30 },
-      { "item": "crystallized_mana", "prob": 50, "charges-min": 5, "charges-max": 150 },
+      { "item": "crystallized_mana", "prob": 50, "charges-min": 5, "charges-max": 100 },
       { "item": "small_mana_crystal", "prob": 40, "charges-min": 5, "charges-max": 50 },
       { "item": "magic_knife_bag", "prob": 25 }
     ]
@@ -1348,7 +1348,7 @@
         "distribution": [ { "group": "enchanted_rings_common", "prob": 30 }, { "group": "enchanted_rings_uncommon", "prob": 10 } ],
         "prob": 40
       },
-      { "item": "crystallized_mana", "prob": 50, "charges-min": 5, "charges-max": 150 },
+      { "item": "crystallized_mana", "prob": 50, "charges-min": 5, "charges-max": 100 },
       [ "copper_circlet", 10 ],
       [ "cauldron_orichalcum", 1 ],
       { "item": "small_mana_crystal", "prob": 40, "charges-min": 5, "charges-max": 50 }

--- a/data/mods/Magiclysm/items/mana_crystals.json
+++ b/data/mods/Magiclysm/items/mana_crystals.json
@@ -19,7 +19,7 @@
     "volume": "100 ml",
     "ammo_type": "crystallized_mana",
     "material": [ "crystallized_mana" ],
-    "count": 100,
+    "count": 10,
     "looks_like": "battery"
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Add RNG to crystallized mana spawns"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

There's a spell to create crystallized mana, but since crystallized mana spawns didn't have a range defined they all spawned with the max possible mana so you never need to use it.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a range to existing crystallized mana spawns. I set it from 1-10 because the Crystallized Mana spell only produces 1 at a time (5 for manatouched mutants), so there was probably an industrial bottleneck in terms of the number of mages willing to be sleepy 24/7 to churn the stuff out. Smashing big mana crystals still gives you dozens of crystallized mana as before--since that already had a range implemented I didn't change it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
