### PR TITLE
Nerf lift thrust of rotorcraft by 6 orders of magnitude

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4251,7 +4251,7 @@ double vehicle::lift_thrust_of_rotorcraft( const bool fuelled, const bool safe )
         rotor_area_in_feet += ( M_PI / 4 ) * std::pow( rotor_diameter_in_feet, 2 );
     }
     // take off 15 % due to the imaginary tail rotor power.
-    double engine_power_in_hp = 1.34102 * units::to_milliwatt( total_power( fuelled, safe ) );
+    double engine_power_in_hp = 0.00134102 * units::to_watt( total_power( fuelled, safe ) );
     // lift_thrust in lbthrust
     double lift_thrust = ( 8.8658 * std::pow( engine_power_in_hp / rotor_area_in_feet,
                            -0.3107 ) ) * engine_power_in_hp;


### PR DESCRIPTION
#### Summary

Bugfixes "Nerf lift thrust of rotorcraft by 6 orders of magnitude"

#### Purpose of change

Fixes #67911

#### Describe the solution

Make horses 1000x less powerful, use watts instead of milliwatts.