### PR TITLE
Unload sparse items only zone option

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6773,8 +6773,8 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
                 if( you.rate_action_unload( *it->first ) == hint_rating::good &&
                     !it->first->any_pockets_sealed() ) {
                     std::unordered_map<std::string, int> item_counts;
-                    if (unload_sparse_only) {
-                        for( item *contained : it->first->all_items_top(item_pocket::pocket_type::CONTAINER) ) {
+                    if( unload_sparse_only ) {
+                        for( item *contained : it->first->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
                             if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                                 item_counts[contained->typeId().str()]++;
                             }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6783,7 +6783,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
                     for( item *contained : it->first->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
                         // no liquids don't want to spill stuff
                         if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
-                            if ( unload_sparse_only && item_counts[contained->typeId().str()] > 20) {
+                            if ( unload_sparse_only && item_counts[contained->typeId().str()] > get_option<int>("SPARSE_ITEM_THRESHOLD") ) {
                                 continue;
                             }
                             move_item( you, *contained, contained->count(), src_loc, src_loc, this_veh, this_part );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6732,6 +6732,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
         bool unload_mods = false;
         bool unload_molle = false;
         bool unload_sparse_only = false;
+        int unload_sparse_threshold = 20;
 
         std::vector<zone_data const *> const zones = mgr.get_zones_at( src, zone_type_zone_unload_all,
                 fac_id );
@@ -6742,6 +6743,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
             unload_molle |= options.unload_molle();
             unload_mods |= options.unload_mods();
             unload_sparse_only |= options.unload_sparse_only();
+            unload_sparse_threshold |= options.unload_sparse_threshold();
         }
 
         //Skip items that have already been processed
@@ -6784,7 +6786,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
                         // no liquids don't want to spill stuff
                         if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                             if( unload_sparse_only &&
-                                item_counts[contained->typeId().str()] > get_option<int>( "SPARSE_ITEM_THRESHOLD" ) ) {
+                                item_counts[contained->typeId().str()] > unload_sparse_threshold ) {
                                 continue;
                             }
                             move_item( you, *contained, contained->count(), src_loc, src_loc, this_veh, this_part );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6783,7 +6783,8 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
                     for( item *contained : it->first->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
                         // no liquids don't want to spill stuff
                         if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
-                            if ( unload_sparse_only && item_counts[contained->typeId().str()] > get_option<int>("SPARSE_ITEM_THRESHOLD") ) {
+                            if( unload_sparse_only &&
+                                item_counts[contained->typeId().str()] > get_option<int>( "SPARSE_ITEM_THRESHOLD" ) ) {
                                 continue;
                             }
                             move_item( you, *contained, contained->count(), src_loc, src_loc, this_veh, this_part );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6774,11 +6774,11 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
                 ( mgr.has_near( zone_type_zone_strip, abspos, 1, fac_id ) && it->first->is_corpse() ) ) {
                 if( you.rate_action_unload( *it->first ) == hint_rating::good &&
                     !it->first->any_pockets_sealed() ) {
-                    std::unordered_map<std::string, int> item_counts;
+                    std::unordered_map<itype_id, int> item_counts;
                     if( unload_sparse_only ) {
                         for( item *contained : it->first->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
                             if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
-                                item_counts[contained->typeId().str()]++;
+                                item_counts[contained->typeId()]++;
                             }
                         }
                     }
@@ -6786,7 +6786,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
                         // no liquids don't want to spill stuff
                         if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                             if( unload_sparse_only &&
-                                item_counts[contained->typeId().str()] > unload_sparse_threshold ) {
+                                item_counts[contained->typeId()] > unload_sparse_threshold ) {
                                 continue;
                             }
                             move_item( you, *contained, contained->count(), src_loc, src_loc, this_veh, this_part );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2236,7 +2236,8 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                         for( item *contained : it->first->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
                             // no liquids don't want to spill stuff
                             if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
-                                if ( unload_sparse_only && item_counts[contained->typeId().str()] > get_option<int>("SPARSE_ITEM_THRESHOLD") ) {
+                                if( unload_sparse_only &&
+                                    item_counts[contained->typeId().str()] > get_option<int>( "SPARSE_ITEM_THRESHOLD" ) ) {
                                     continue;
                                 }
                                 move_item( you, *contained, contained->count(), src_loc, src_loc, vpr_src );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2236,7 +2236,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                         for( item *contained : it->first->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
                             // no liquids don't want to spill stuff
                             if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
-                                if ( unload_sparse_only && item_counts[contained->typeId().str()] > 20 ) {
+                                if ( unload_sparse_only && item_counts[contained->typeId().str()] > get_option<int>("SPARSE_ITEM_THRESHOLD") ) {
                                     continue;
                                 }
                                 move_item( you, *contained, contained->count(), src_loc, src_loc, vpr_src );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2155,6 +2155,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
 
         bool unload_mods = false;
         bool unload_molle = false;
+        bool unload_sparse_only = false;
         bool unload_always = false;
 
         std::vector<zone_data const *> const zones = mgr.get_zones_at( src, zone_type_zone_unload_all,
@@ -2165,6 +2166,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
             unload_options const &options = dynamic_cast<const unload_options &>( zone->get_options() );
             unload_molle |= options.unload_molle();
             unload_mods |= options.unload_mods();
+            unload_sparse_only |= options.unload_sparse_only();
             unload_always |= options.unload_always();
         }
 
@@ -2216,9 +2218,27 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                 if( dest_set.empty() || unload_always ) {
                     if( you.rate_action_unload( *it->first ) == hint_rating::good &&
                         !it->first->any_pockets_sealed() ) {
+                        std::unordered_map<std::string, int> item_counts;
+                        if (unload_sparse_only) {
+                            for( item *contained : it->first->all_items_top(item_pocket::pocket_type::CONTAINER) ) {
+                                if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
+                                    // if undefined set to 1, otherwise increment
+                                    item_counts[contained->typeId().str()]++;
+                                    // print contents of item_counts to log
+                                    for( auto const& [key, val] : item_counts ) {
+                                        add_msg( "%s has %d %s",
+                                                       it->first->tname(), val, key );
+                                    }
+
+                                }
+                            }
+                        }
                         for( item *contained : it->first->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
                             // no liquids don't want to spill stuff
                             if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
+                                if ( unload_sparse_only && item_counts[contained->typeId().str()] > 20 ) {
+                                    continue;
+                                }
                                 move_item( you, *contained, contained->count(), src_loc, src_loc, vpr_src );
                                 it->first->remove_item( *contained );
                             }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2219,8 +2219,8 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                     if( you.rate_action_unload( *it->first ) == hint_rating::good &&
                         !it->first->any_pockets_sealed() ) {
                         std::unordered_map<std::string, int> item_counts;
-                        if (unload_sparse_only) {
-                            for( item *contained : it->first->all_items_top(item_pocket::pocket_type::CONTAINER) ) {
+                        if( unload_sparse_only ) {
+                            for( item *contained : it->first->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
                                 if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                                     // if undefined set to 1, otherwise increment
                                     item_counts[contained->typeId().str()]++;

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2224,12 +2224,6 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                                 if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                                     // if undefined set to 1, otherwise increment
                                     item_counts[contained->typeId().str()]++;
-                                    // print contents of item_counts to log
-                                    for( auto const& [key, val] : item_counts ) {
-                                        add_msg( "%s has %d %s",
-                                                 it->first->tname(), val, key );
-                                    }
-
                                 }
                             }
                         }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2227,7 +2227,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                                     // print contents of item_counts to log
                                     for( auto const& [key, val] : item_counts ) {
                                         add_msg( "%s has %d %s",
-                                                       it->first->tname(), val, key );
+                                                 it->first->tname(), val, key );
                                     }
 
                                 }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2220,11 +2220,11 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                 if( dest_set.empty() || unload_always ) {
                     if( you.rate_action_unload( *it->first ) == hint_rating::good &&
                         !it->first->any_pockets_sealed() ) {
-                        std::unordered_map<std::string, int> item_counts;
+                        std::unordered_map<itype_id, int> item_counts;
                         if( unload_sparse_only ) {
                             for( item *contained : it->first->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
                                 if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
-                                    item_counts[contained->typeId().str()]++;
+                                    item_counts[contained->typeId()]++;
                                 }
                             }
                         }
@@ -2232,7 +2232,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                             // no liquids don't want to spill stuff
                             if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                                 if( unload_sparse_only &&
-                                    item_counts[contained->typeId().str()] > unload_sparse_threshold ) {
+                                    item_counts[contained->typeId()] > unload_sparse_threshold ) {
                                     continue;
                                 }
                                 move_item( you, *contained, contained->count(), src_loc, src_loc, vpr_src );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2156,6 +2156,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
         bool unload_mods = false;
         bool unload_molle = false;
         bool unload_sparse_only = false;
+        int unload_sparse_threshold = 20;
         bool unload_always = false;
 
         std::vector<zone_data const *> const zones = mgr.get_zones_at( src, zone_type_zone_unload_all,
@@ -2167,6 +2168,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
             unload_molle |= options.unload_molle();
             unload_mods |= options.unload_mods();
             unload_sparse_only |= options.unload_sparse_only();
+            unload_sparse_threshold |= options.unload_sparse_threshold();
             unload_always |= options.unload_always();
         }
 
@@ -2222,7 +2224,6 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                         if( unload_sparse_only ) {
                             for( item *contained : it->first->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
                                 if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
-                                    // if undefined set to 1, otherwise increment
                                     item_counts[contained->typeId().str()]++;
                                 }
                             }
@@ -2231,7 +2232,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                             // no liquids don't want to spill stuff
                             if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                                 if( unload_sparse_only &&
-                                    item_counts[contained->typeId().str()] > get_option<int>( "SPARSE_ITEM_THRESHOLD" ) ) {
+                                    item_counts[contained->typeId().str()] > unload_sparse_threshold ) {
                                     continue;
                                 }
                                 move_item( you, *contained, contained->count(), src_loc, src_loc, vpr_src );

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -456,97 +456,6 @@ std::string loot_options::get_zone_name_suggestion() const
     return _( "Loot: Custom: No Filter" );
 }
 
-std::string unload_options::get_zone_name_suggestion() const
-{
-
-    return string_format( "%s%s%s%s%s", _( "Unload: " ),
-                          mods ? _( "mods, " ) : "",
-                          molle ? _( "MOLLE, " ) : "",
-                          sparse_only ? _( string_format( "ignore stacks over %i, ", sparse_threshold ) ) : "",
-                          always_unload ? _( "unload all" ) : _( "unload unmatched" ) );
-}
-
-std::vector<std::pair<std::string, std::string>> loot_options::get_descriptions() const
-{
-    std::vector<std::pair<std::string, std::string>> options;
-    options.emplace_back( _( "Loot: Custom: " ),
-                          !mark.empty() ? mark : _( "No filter" ) );
-
-    return options;
-}
-
-std::vector<std::pair<std::string, std::string>> unload_options::get_descriptions() const
-{
-    std::vector<std::pair<std::string, std::string>> options;
-    options.emplace_back( _( "Unload: " ),
-                          string_format( "%s%s%s%s",
-                                         mods ? _( "mods " ) : "",
-                                         molle ? _( "MOLLE " ) : "",
-                                         sparse_only ? _( string_format( "ignore stacks over %i, ", sparse_threshold ) ) : "",
-                                         always_unload ? _( "unload all" ) : _( "unload unmatched" ) ) );
-
-    return options;
-}
-
-void loot_options::serialize( JsonOut &json ) const
-{
-    json.member( "mark", mark );
-}
-
-void loot_options::deserialize( const JsonObject &jo_zone )
-{
-    jo_zone.read( "mark", mark );
-}
-
-void unload_options::serialize( JsonOut &json ) const
-{
-    json.member( "mark", mark );
-    json.member( "mods", mods );
-    json.member( "molle", molle );
-    json.member( "sparse_only", sparse_only );
-    json.member( "sparse_threshold", sparse_threshold );
-    json.member( "always_unload", always_unload );
-}
-
-void unload_options::deserialize( const JsonObject &jo_zone )
-{
-    jo_zone.read( "mark", mark );
-    jo_zone.read( "mods", mods );
-    jo_zone.read( "molle", molle );
-    jo_zone.read( "sparse_only", sparse_only );
-    jo_zone.read( "sparse_threshold", sparse_threshold );
-    jo_zone.read( "always_unload", always_unload );
-}
-
-bool blueprint_options::query_at_creation()
-{
-    return query_con() != canceled;
-}
-
-bool plot_options::query_at_creation()
-{
-    return query_seed() != canceled;
-}
-
-bool blueprint_options::query()
-{
-    return query_con() == changed;
-}
-
-bool plot_options::query()
-{
-    return query_seed() == changed;
-}
-
-std::string blueprint_options::get_zone_name_suggestion() const
-{
-    if( group ) {
-        return group->name();
-    }
-
-    return _( "No construction" );
-}
-
 std::string plot_options::get_zone_name_suggestion() const
 {
     if( !seed.is_empty() ) {
@@ -564,8 +473,11 @@ std::string plot_options::get_zone_name_suggestion() const
 
 std::string unload_options::get_zone_name_suggestion() const
 {
-    return string_format( "%s%s%s%s", _( "Unload: " ), mods ? _( "mods, " ) : "",
+
+    return string_format( "%s%s%s%s%s", _( "Unload: " ),
+                          mods ? _( "mods, " ) : "",
                           molle ? _( "MOLLE, " ) : "",
+                          sparse_only ? _( string_format( "ignore stacks over %i, ", sparse_threshold ) ) : "",
                           always_unload ? _( "unload all" ) : _( "unload unmatched" ) );
 }
 
@@ -610,7 +522,10 @@ std::vector<std::pair<std::string, std::string>> unload_options::get_description
 {
     std::vector<std::pair<std::string, std::string>> options;
     options.emplace_back( _( "Unload: " ),
-                          string_format( "%s%s%s", mods ? _( "mods " ) : "",  molle ? _( "MOLLE " ) : "",
+                          string_format( "%s%s%s%s",
+                                         mods ? _( "mods " ) : "",
+                                         molle ? _( "MOLLE " ) : "",
+                                         sparse_only ? _( string_format( "ignore stacks over %i, ", sparse_threshold ) ) : "",
                                          always_unload ? _( "unload all" ) : _( "unload unmatched" ) ) );
 
     return options;
@@ -672,6 +587,8 @@ void unload_options::serialize( JsonOut &json ) const
     json.member( "mark", mark );
     json.member( "mods", mods );
     json.member( "molle", molle );
+    json.member( "sparse_only", sparse_only );
+    json.member( "sparse_threshold", sparse_threshold );
     json.member( "always_unload", always_unload );
 }
 
@@ -680,6 +597,8 @@ void unload_options::deserialize( const JsonObject &jo_zone )
     jo_zone.read( "mark", mark );
     jo_zone.read( "mods", mods );
     jo_zone.read( "molle", molle );
+    jo_zone.read( "sparse_only", sparse_only );
+    jo_zone.read( "sparse_threshold", sparse_threshold );
     jo_zone.read( "always_unload", always_unload );
 }
 

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -318,10 +318,11 @@ unload_options::query_unload_result unload_options::query_unload()
                _( "Detach mods from weapons?  (Be careful as you may not have the skills to reattach them)" ) );
     sparse_only = query_yn( _
                             ( string_format( "Avoid unloading items stacks (not charges) greater than a certain amount?  (Amount defined in next window)" ) ) );
-    if (sparse_only) {
+    if( sparse_only ) {
         int threshold;
-        if (query_int( threshold, _( "What is the maximum stack size to unload?  (20 is a good default)" ))){
-            if (sparse_threshold < 1) {
+        if( query_int( threshold,
+                       _( "What is the maximum stack size to unload?  (20 is a good default)" ) ) ) {
+            if( sparse_threshold < 1 ) {
                 sparse_threshold = 1;
             } else {
                 sparse_threshold = threshold;
@@ -462,7 +463,7 @@ std::string unload_options::get_zone_name_suggestion() const
     return string_format( "%s%s%s%s%s", _( "Unload: " ),
                           mods ? _( "mods, " ) : "",
                           molle ? _( "MOLLE, " ) : "",
-                          sparse_only ? _(string_format("ignore stacks over %i, ", sparse_threshold) ) : "",
+                          sparse_only ? _( string_format( "ignore stacks over %i, ", sparse_threshold ) ) : "",
                           always_unload ? _( "unload all" ) : _( "unload unmatched" ) );
 }
 
@@ -482,7 +483,7 @@ std::vector<std::pair<std::string, std::string>> unload_options::get_description
                           string_format( "%s%s%s%s",
                                          mods ? _( "mods " ) : "",
                                          molle ? _( "MOLLE " ) : "",
-                                         sparse_only ? _( string_format("ignore stacks over %i, ", sparse_threshold) ) : "",
+                                         sparse_only ? _( string_format( "ignore stacks over %i, ", sparse_threshold ) ) : "",
                                          always_unload ? _( "unload all" ) : _( "unload unmatched" ) ) );
 
     return options;

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -314,10 +314,14 @@ loot_options::query_loot_result loot_options::query_loot()
 unload_options::query_unload_result unload_options::query_unload()
 {
     molle = query_yn( _( "Detach MOLLE attached pouches?" ) );
-    mods = query_yn( _( "Detach mods from weapons? (Be careful as you may not have the skills to reattach them)" ) );
-    int threshold = get_option<int>("SPARSE_ITEM_THRESHOLD");
-    sparse_only = query_yn( _(string_format("Avoid unloading items stacks (not charges) greater than %i? (Threshold can be adjusted in options)", threshold)));
-    always_unload = query_yn( _( "Always unload? (Unload even if the container has a valid sorting location)" ) );
+    mods = query_yn(
+               _( "Detach mods from weapons? (Be careful as you may not have the skills to reattach them)" ) );
+    int threshold = get_option<int>( "SPARSE_ITEM_THRESHOLD" );
+    sparse_only = query_yn( _
+                            ( string_format( "Avoid unloading items stacks (not charges) greater than %i? (Threshold can be adjusted in options)",
+                                    threshold ) ) );
+    always_unload = query_yn(
+                        _( "Always unload? (Unload even if the container has a valid sorting location)" ) );
     return changed;
 }
 

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -42,7 +42,6 @@
 #include "vehicle.h"
 #include "visitable.h"
 #include "vpart_position.h"
-#include "options.h"
 
 static const faction_id faction_your_followers( "your_followers" );
 

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -42,6 +42,7 @@
 #include "vehicle.h"
 #include "visitable.h"
 #include "vpart_position.h"
+#include "options.h"
 
 static const faction_id faction_your_followers( "your_followers" );
 
@@ -314,9 +315,9 @@ unload_options::query_unload_result unload_options::query_unload()
 {
     molle = query_yn( _( "Detach MOLLE attached pouches" ) );
     mods = query_yn( _( "Detach mods from weapons" ) );
-    sparse_only = query_yn(_("Avoid unloading items with quantity greater than 20 (Does not apply to item charges)" ) );
-    always_unload = query_yn(
-                        _( "Always unload (even if the container has a valid sorting location)" ) );
+    int threshold = get_option<int>("SPARSE_ITEM_THRESHOLD");
+    sparse_only = query_yn( _(string_format("Avoid unloading items stacks (not charges) greater than %i? (Threshold can be adjusted in options)", threshold)));
+    always_unload = query_yn( _( "Always unload (even if the container has a valid sorting location)" ) );
     return changed;
 }
 

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -315,13 +315,13 @@ unload_options::query_unload_result unload_options::query_unload()
 {
     molle = query_yn( _( "Detach MOLLE attached pouches?" ) );
     mods = query_yn(
-               _( "Detach mods from weapons? (Be careful as you may not have the skills to reattach them)" ) );
+               _( "Detach mods from weapons?  (Be careful as you may not have the skills to reattach them)" ) );
     int threshold = get_option<int>( "SPARSE_ITEM_THRESHOLD" );
     sparse_only = query_yn( _
-                            ( string_format( "Avoid unloading items stacks (not charges) greater than %i? (Threshold can be adjusted in options)",
+                            ( string_format( "Avoid unloading items stacks (not charges) greater than %i?  (Threshold can be adjusted in options)",
                                     threshold ) ) );
     always_unload = query_yn(
-                        _( "Always unload? (Unload even if the container has a valid sorting location)" ) );
+                        _( "Always unload?  (Unload even if the container has a valid sorting location)" ) );
     return changed;
 }
 

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -313,11 +313,11 @@ loot_options::query_loot_result loot_options::query_loot()
 
 unload_options::query_unload_result unload_options::query_unload()
 {
-    molle = query_yn( _( "Detach MOLLE attached pouches" ) );
-    mods = query_yn( _( "Detach mods from weapons" ) );
+    molle = query_yn( _( "Detach MOLLE attached pouches?" ) );
+    mods = query_yn( _( "Detach mods from weapons? (Be careful as you may not have the skills to reattach them)" ) );
     int threshold = get_option<int>("SPARSE_ITEM_THRESHOLD");
     sparse_only = query_yn( _(string_format("Avoid unloading items stacks (not charges) greater than %i? (Threshold can be adjusted in options)", threshold)));
-    always_unload = query_yn( _( "Always unload (even if the container has a valid sorting location)" ) );
+    always_unload = query_yn( _( "Always unload? (Unload even if the container has a valid sorting location)" ) );
     return changed;
 }
 

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -314,6 +314,7 @@ unload_options::query_unload_result unload_options::query_unload()
 {
     molle = query_yn( _( "Detach MOLLE attached pouches" ) );
     mods = query_yn( _( "Detach mods from weapons" ) );
+    sparse_only = query_yn(_("Avoid unloading items with quantity greater than 20 (Does not apply to item charges)" ) );
     always_unload = query_yn(
                         _( "Always unload (even if the container has a valid sorting location)" ) );
     return changed;
@@ -438,6 +439,94 @@ std::string loot_options::get_zone_name_suggestion() const
         return string_format( _( "Loot: Custom: %s" ), mark );
     }
     return _( "Loot: Custom: No Filter" );
+}
+
+std::string unload_options::get_zone_name_suggestion() const
+{
+    return string_format( "%s%s%s%s%s", _( "Unload: " ),
+                          mods ? _( "mods, " ) : "",
+                          molle ? _( "MOLLE, " ) : "",
+                          sparse_only ? _( "sparse only, " ) : "",
+                          always_unload ? _( "unload all" ) : _( "unload unmatched" ) );
+}
+
+std::vector<std::pair<std::string, std::string>> loot_options::get_descriptions() const
+{
+    std::vector<std::pair<std::string, std::string>> options;
+    options.emplace_back( _( "Loot: Custom: " ),
+                          !mark.empty() ? mark : _( "No filter" ) );
+
+    return options;
+}
+
+std::vector<std::pair<std::string, std::string>> unload_options::get_descriptions() const
+{
+    std::vector<std::pair<std::string, std::string>> options;
+    options.emplace_back( _( "Unload: " ),
+                          string_format( "%s%s%s%s",
+                                         mods ? _( "mods " ) : "",
+                                         molle ? _( "MOLLE " ) : "",
+                                         sparse_only ? _( "sparse only " ) : "",
+                                         always_unload ? _( "unload all" ) : _( "unload unmatched" ) ) );
+
+    return options;
+}
+
+void loot_options::serialize( JsonOut &json ) const
+{
+    json.member( "mark", mark );
+}
+
+void loot_options::deserialize( const JsonObject &jo_zone )
+{
+    jo_zone.read( "mark", mark );
+}
+
+void unload_options::serialize( JsonOut &json ) const
+{
+    json.member( "mark", mark );
+    json.member( "mods", mods );
+    json.member( "molle", molle );
+    json.member( "sparse_only", sparse_only );
+    json.member( "always_unload", always_unload );
+}
+
+void unload_options::deserialize( const JsonObject &jo_zone )
+{
+    jo_zone.read( "mark", mark );
+    jo_zone.read( "mods", mods );
+    jo_zone.read( "molle", molle );
+    jo_zone.read( "sparse_only", sparse_only );
+    jo_zone.read( "always_unload", always_unload );
+}
+
+bool blueprint_options::query_at_creation()
+{
+    return query_con() != canceled;
+}
+
+bool plot_options::query_at_creation()
+{
+    return query_seed() != canceled;
+}
+
+bool blueprint_options::query()
+{
+    return query_con() == changed;
+}
+
+bool plot_options::query()
+{
+    return query_seed() == changed;
+}
+
+std::string blueprint_options::get_zone_name_suggestion() const
+{
+    if( group ) {
+        return group->name();
+    }
+
+    return _( "No construction" );
 }
 
 std::string plot_options::get_zone_name_suggestion() const

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -284,6 +284,7 @@ class unload_options : public zone_options, public mark_option
         std::string mark;
         bool mods;
         bool molle;
+        bool sparse_only;
         bool always_unload;
 
         enum query_unload_result {
@@ -305,6 +306,10 @@ class unload_options : public zone_options, public mark_option
 
         bool unload_molle() const {
             return molle;
+        }
+
+        bool unload_sparse_only() const {
+            return sparse_only;
         }
 
         bool unload_always() const {

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -285,6 +285,7 @@ class unload_options : public zone_options, public mark_option
         bool mods;
         bool molle;
         bool sparse_only;
+        int sparse_threshold = 20;
         bool always_unload;
 
         enum query_unload_result {
@@ -310,6 +311,10 @@ class unload_options : public zone_options, public mark_option
 
         bool unload_sparse_only() const {
             return sparse_only;
+        }
+
+        int unload_sparse_threshold() const {
+            return sparse_threshold;
         }
 
         bool unload_always() const {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1589,6 +1589,13 @@ void options_manager::add_options_general()
 
     add_empty_line();
 
+    add( "SPARSE_ITEM_THRESHOLD", "general", to_translation( "Sparse unloading item limit" ),
+         to_translation( "Item stacks (not charges) greater than this number will be ignored when the 'unload sparse' option is enabled in 'Loot: Unload Everything' zones. Pass the salt." ),
+         0, 1000, 20
+    );
+
+    add_empty_line();
+
     add( "TURN_DURATION", "general", to_translation( "Realtime turn progression" ),
          to_translation( "If higher than 0, monsters will take periodic gameplay turns.  This value is the delay between each turn, in seconds.  Works best with Safe Mode disabled.  0 = disabled." ),
          0.0, 10.0, 0.0, 0.05

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1589,13 +1589,6 @@ void options_manager::add_options_general()
 
     add_empty_line();
 
-    add( "SPARSE_ITEM_THRESHOLD", "general", to_translation( "Sparse unloading item limit" ),
-         to_translation( "Item stacks (not charges) greater than this number will be ignored when the 'unload sparse' option is enabled in 'Loot: Unload Everything' zones.  Pass the salt." ),
-         0, 1000, 20
-       );
-
-    add_empty_line();
-
     add( "TURN_DURATION", "general", to_translation( "Realtime turn progression" ),
          to_translation( "If higher than 0, monsters will take periodic gameplay turns.  This value is the delay between each turn, in seconds.  Works best with Safe Mode disabled.  0 = disabled." ),
          0.0, 10.0, 0.0, 0.05

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1590,7 +1590,7 @@ void options_manager::add_options_general()
     add_empty_line();
 
     add( "SPARSE_ITEM_THRESHOLD", "general", to_translation( "Sparse unloading item limit" ),
-         to_translation( "Item stacks (not charges) greater than this number will be ignored when the 'unload sparse' option is enabled in 'Loot: Unload Everything' zones. Pass the salt." ),
+         to_translation( "Item stacks (not charges) greater than this number will be ignored when the 'unload sparse' option is enabled in 'Loot: Unload Everything' zones.  Pass the salt." ),
          0, 1000, 20
        );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1592,7 +1592,7 @@ void options_manager::add_options_general()
     add( "SPARSE_ITEM_THRESHOLD", "general", to_translation( "Sparse unloading item limit" ),
          to_translation( "Item stacks (not charges) greater than this number will be ignored when the 'unload sparse' option is enabled in 'Loot: Unload Everything' zones. Pass the salt." ),
          0, 1000, 20
-    );
+       );
 
     add_empty_line();
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Unload sparse items only zone option"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

This PR is intended to address two problems I encounter while playing:
1/ With recent change to movement of small items like powders, it has become highly undesirable to accidentally unload bags full of spices or tea leaves commonly found in kitchens. Doing so can cause players to inadvertently spend large amounts of in game time shuffling around high quantities of small items with little benefit. 

2/ I keep a 9 square personal unload zone for easy use of unloading stuff in the field, but sometimes forget to toggle it off in my home area, causing me to unload containers filled with large amounts of items such as chitin, patches, etc.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

The goal is to create on option to allow me to predictably unload certain containers while avoiding others by introducing another dialog option along with the existing 'Loot: Unload Everything' questions about molle, mods, and unload everything, asking if the players want to avoid unloading items in quantities. The threshold is set to 20 by default, which will allow wallets to be fully unloaded by default based on current spawn rates, but is customizable in game options should players prefer a different level. 

Additionally, I've applied a consistent formatting to the option questions, and added a cautionary note to the remove mods option about not necessarily being able to reattach mods that are removed to help new players avoid stripping a found tacticool rifle by accident. 

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

This stemmed from me taking some pretty elaborate steps to avoid unloading bags of salt, tea, etc, which are incredibly common. Additionally, with the max item count for storage mechanic, not inadvertently unloading containers full of fabric patches or chitin is a plus as well.

I think providing better strategies for moving large quantities of items could help mitigate this, but would have a much larger impact on gameplay that I am not looking to wade in to at the moment. I am considering some kind of loot insertion zone to proactively move large quantities of items to containers, but it is going to be a more extensive change, and would be complementary to this anyway.
#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Tested to confirm that items using charges (i.e. charcoal) are not impacted by this option, but that items in stacks (i.e. salt) are. Got a plastic bag of 100 salt, verified that it does not unload when the spare only option is selected for the unloading zone. Set the threshold to 100 and made sure the bag was unloaded. Set back to 20 to confirm it did not unload again. Tested with regular and personal zones.
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
