### PR TITLE
Character creation: small screen fixes

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3528,7 +3528,7 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
     catacurses::window w_calendar;
     const auto init_windows = [&]( ui_adaptor & ui ) {
         const int freeWidth = TERMX - FULL_SCREEN_WIDTH;
-        isWide = ( TERMX > FULL_SCREEN_WIDTH && freeWidth > 15 );
+        isWide = freeWidth > 15;
         const int beginx2 = 46;
         const int ncol2 = 40;
         const int beginx3 = TERMX <= 88 ? TERMX - TERMX / 4 : 86;
@@ -3947,11 +3947,10 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
             }
         }
         if( isWide ) {
+            mvwprintz( w_addictions, point_zero, c_light_gray, _( "Starting addictions: " ) );
             if( prof_addictions.empty() ) {
-                mvwprintz( w_addictions, point_zero, c_light_gray, _( "Starting addictions: " ) );
                 wprintz( w_addictions, c_light_red, _( "None!" ) );
             } else {
-                mvwprintz( w_addictions, point_zero, c_light_gray, _( "Starting addictions: " ) );
                 for( const addiction &a : prof_addictions ) {
                     const char *format = "%1$s (%2$d) ";
                     wprintz( w_addictions, c_white, string_format( format, a.type->get_name().translated(),
@@ -3959,11 +3958,10 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
                 }
             }
         } else {
+            mvwprintz( w_addictions, point_zero, COL_HEADER, _( "Starting addictions: " ) );
             if( prof_addictions.empty() ) {
-                mvwprintz( w_addictions, point_zero, COL_HEADER, _( "Starting addictions: " ) );
                 wprintz( w_addictions, c_light_red, _( "None!" ) );
             } else {
-                mvwprintz( w_addictions, point_zero, COL_HEADER, _( "Starting addictions: " ) );
                 for( const addiction &a : prof_addictions ) {
                     const char *format = "%1$s (%2$d) ";
                     wprintz( w_addictions, c_light_gray, "\n" );
@@ -3983,11 +3981,6 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
         mvwprintz( w_profession, point_zero, COL_HEADER, _( "Profession: " ) );
         wprintz( w_profession, c_light_gray, you.prof->gender_appropriate_name( you.male ) );
         wnoutrefresh( w_profession );
-
-        werase( w_scenario );
-        mvwprintz( w_scenario, point_zero, COL_HEADER, _( "Scenario: " ) );
-        wprintz( w_scenario, c_light_gray, get_scenario()->gender_appropriate_name( you.male ) );
-        wnoutrefresh( w_scenario );
 
         werase( w_calendar );
         mvwprintz( w_calendar, point_zero, COL_HEADER, _( "Start of cataclysm:" ) );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1094,14 +1094,17 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
     tabs.set_up_tab_navigation( ctxt );
     ctxt.register_cardinal();
     ctxt.register_action( "HELP_KEYBINDINGS" );
+    const int iHeaderHeight = 6;
+    const int iHelpHeight = 4;
 
     ui_adaptor ui;
     catacurses::window w;
     catacurses::window w_description;
     const auto init_windows = [&]( ui_adaptor & ui ) {
+        const size_t iContentHeight = TERMY - iHeaderHeight - iHelpHeight - 1;
         w = catacurses::newwin( TERMY, TERMX, point_zero );
         w_description = catacurses::newwin( 30, TERMX - iSecondColumn - 1,
-                                            point( iSecondColumn, 6 ) );
+                                            point( iSecondColumn, iHeaderHeight ) );
         ui.position_from_window( w );
     };
     init_windows( ui );
@@ -1126,12 +1129,12 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
                         ctxt.get_desc( "RIGHT" ), ctxt.get_desc( "LEFT" ),
                         ctxt.get_desc( "NEXT_TAB" ), ctxt.get_desc( "PREV_TAB" ) );
 
-        const point opt_pos( 2, sel + 6 );
+        const point opt_pos( 2, sel + iHeaderHeight );
         ui.set_cursor( w, opt_pos );
         for( int i = 0; i < 4; i++ ) {
-            mvwprintz( w, point( 2, i + 6 ), i == sel ? COL_SELECT : c_light_gray, "%s:",
+            mvwprintz( w, point( 2, i + iHeaderHeight ), i == sel ? COL_SELECT : c_light_gray, "%s:",
                        stat_labels[i].translated() );
-            mvwprintz( w, point( 16, i + 6 ), c_light_gray, "%2d", *stats[i] );
+            mvwprintz( w, point( 16, i + iHeaderHeight ), c_light_gray, "%2d", *stats[i] );
         }
 
         draw_points( w, pool, u );
@@ -2088,9 +2091,8 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
     ui.on_redraw( [&]( ui_adaptor & ui ) {
         werase( w );
         tabs.draw( w );
-        mvwputch( w, point( TERMX / 2, iHeaderHeight - 1 ), BORDER_COLOR,
-                  LINE_OXXX );// '^|^' Tee pointing down
-        mvwputch( w, point( TERMX / 2, TERMY - 1 ), BORDER_COLOR, LINE_XXOX );// '_|_' Tee pointing up
+        mvwputch( w, point( TERMX / 2, iHeaderHeight - 1 ), BORDER_COLOR, LINE_OXXX );  // '┬'
+        mvwputch( w, point( TERMX / 2, TERMY - 1 ), BORDER_COLOR, LINE_XXOX );  // '┴'
         draw_filter_and_sorting_indicators( w, ctxt, filterstring, profession_sorter );
 
         const bool cur_id_is_valid = cur_id >= 0 && static_cast<size_t>( cur_id ) < sorted_profs.size();
@@ -2134,8 +2136,7 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
         //Draw options
         calcStartPos( iStartPos, cur_id, iContentHeight, profs_length );
         const int end_pos = iStartPos + std::min( iContentHeight, profs_length );
-        int i;
-        for( i = iStartPos; i < end_pos; i++ ) {
+        for( int i = iStartPos; i < end_pos; i++ ) {
             nc_color col;
             if( u.prof != &sorted_profs[i].obj() ) {
 
@@ -2152,7 +2153,7 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
                 col = ( cur_id_is_valid &&
                         sorted_profs[i] == sorted_profs[cur_id] ? hilite( c_light_green ) : COL_SKILL_USED );
             }
-            const point opt_pos( 2, 6 + i - iStartPos );
+            const point opt_pos( 2, iHeaderHeight + i - iStartPos );
             if( i == cur_id ) {
                 ui.set_cursor( w, opt_pos );
             }
@@ -2161,7 +2162,7 @@ void set_profession( tab_manager &tabs, avatar &u, pool_type pool )
         }
 
         list_sb.offset_x( 0 )
-        .offset_y( 6 )
+        .offset_y( iHeaderHeight )
         .content_size( profs_length )
         .viewport_pos( iStartPos )
         .viewport_size( iContentHeight )
@@ -2399,9 +2400,8 @@ void set_hobbies( tab_manager &tabs, avatar &u, pool_type pool )
     ui.on_redraw( [&]( ui_adaptor & ui ) {
         werase( w );
         tabs.draw( w );
-        mvwputch( w, point( TERMX / 2, iHeaderHeight - 1 ), BORDER_COLOR,
-                  LINE_OXXX );// '^|^' Tee pointing down
-        mvwputch( w, point( TERMX / 2, TERMY - 1 ), BORDER_COLOR, LINE_XXOX );// '_|_' Tee pointing up
+        mvwputch( w, point( TERMX / 2, iHeaderHeight - 1 ), BORDER_COLOR, LINE_OXXX );  // '┬'
+        mvwputch( w, point( TERMX / 2, TERMY - 1 ), BORDER_COLOR, LINE_XXOX );  // '┴'
         draw_filter_and_sorting_indicators( w, ctxt, filterstring, profession_sorter );
 
         const bool cur_id_is_valid = cur_id >= 0 && static_cast<size_t>( cur_id ) < sorted_hobbies.size();
@@ -2443,8 +2443,7 @@ void set_hobbies( tab_manager &tabs, avatar &u, pool_type pool )
         //Draw options
         calcStartPos( iStartPos, cur_id, iContentHeight, hobbies_length );
         const int end_pos = iStartPos + std::min( iContentHeight, hobbies_length );
-        int i;
-        for( i = iStartPos; i < end_pos; i++ ) {
+        for( int i = iStartPos; i < end_pos; i++ ) {
             nc_color col;
             if( u.hobbies.count( &sorted_hobbies[i].obj() ) != 0 ) {
                 col = ( cur_id_is_valid &&
@@ -2454,7 +2453,7 @@ void set_hobbies( tab_manager &tabs, avatar &u, pool_type pool )
                         sorted_hobbies[i] == sorted_hobbies[cur_id] ? COL_SELECT : c_light_gray );
             }
 
-            const point opt_pos( 2, 6 + i - iStartPos );
+            const point opt_pos( 2, iHeaderHeight + i - iStartPos );
             if( i == cur_id ) {
                 ui.set_cursor( w, opt_pos );
             }
@@ -3118,9 +3117,8 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
     ui.on_redraw( [&]( ui_adaptor & ui ) {
         werase( w );
         tabs.draw( w );
-        mvwputch( w, point( TERMX / 2, iHeaderHeight - 1 ), BORDER_COLOR,
-                  LINE_OXXX );// '^|^' Tee pointing down
-        mvwputch( w, point( TERMX / 2, TERMY - 1 ), BORDER_COLOR, LINE_XXOX );// '_|_' Tee pointing up
+        mvwputch( w, point( TERMX / 2, iHeaderHeight - 1 ), BORDER_COLOR, LINE_OXXX );  // '┬'
+        mvwputch( w, point( TERMX / 2, TERMY - 1 ), BORDER_COLOR, LINE_XXOX );  // '┴'
         draw_filter_and_sorting_indicators( w, ctxt, filterstring, scenario_sorter );
 
         const bool cur_id_is_valid = cur_id >= 0 && static_cast<size_t>( cur_id ) < sorted_scens.size();
@@ -3163,8 +3161,7 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
         //Draw options
         calcStartPos( iStartPos, cur_id, iContentHeight, scens_length );
         const int end_pos = iStartPos + std::min( iContentHeight, scens_length );
-        int i;
-        for( i = iStartPos; i < end_pos; i++ ) {
+        for( int i = iStartPos; i < end_pos; i++ ) {
             nc_color col;
             if( get_scenario() != sorted_scens[i] ) {
                 if( cur_id_is_valid && sorted_scens[i] == sorted_scens[cur_id] &&
@@ -3182,7 +3179,7 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
                 col = ( cur_id_is_valid &&
                         sorted_scens[i] == sorted_scens[cur_id] ? hilite( c_light_green ) : COL_SKILL_USED );
             }
-            const point opt_pos( 2, 6 + i - iStartPos );
+            const point opt_pos( 2, iHeaderHeight + i - iStartPos );
             if( i == cur_id ) {
                 ui.set_cursor( w, opt_pos );
             }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -1080,6 +1080,145 @@ void set_points( tab_manager &tabs, avatar &u, pool_type &pool )
     } while( true );
 }
 
+static std::string assemble_stat_details( avatar &u, const unsigned char sel )
+{
+    std::string description_str;
+    switch( sel ) {
+        case 0: {
+            u.recalc_hp();
+            u.set_stored_kcal( u.get_healthy_kcal() );
+            description_str =
+                string_format( _( "Base HP: %d" ), u.get_part_hp_max( bodypart_id( "head" ) ) )
+                + string_format( _( "\nCarry weight: %.1f %s" ), convert_weight( u.weight_capacity() ),
+                                 weight_units() )
+                + string_format( _( "\nResistance to knock down effect when hit: %.1f" ), u.stability_roll() )
+                + string_format( _( "\nIntimidation skill: %i" ), u.intimidation() )
+                + string_format( _( "\nMaximum oxygen: %i" ), u.get_oxygen_max() )
+                + string_format( _( "\nShout volume: %i" ), u.get_shout_volume() )
+                + string_format( _( "\nLifting strength: %i" ), u.get_lift_str() )
+                + string_format( _( "\nMove cost while swimming: %i" ), u.swim_speed() )
+                + colorize(
+                    string_format( _( "\nBash damage bonus: %.1f" ), u.bonus_damage( false ) ),
+                    COL_STAT_BONUS )
+                + _( "\n\nAffects:" )
+                + colorize(
+                    _( "\n- Throwing range, accuracy, and damage"
+                       "\n- Reload speed for weapons using muscle power to reload"
+                       "\n- Pull strength of some mutations"
+                       "\n- Resistance for being pulled or grabbed by some monsters"
+                       "\n- Speed of corpses pulping"
+                       "\n- Speed and effectiveness of prying things open, chopping wood, and mining"
+                       "\n- Chance of escaping grabs and traps"
+                       "\n- Power produced by muscle-powered vehicles"
+                       "\n- Most aspects of melee combat"
+                       "\n- Effectiveness of smashing furniture or terrain"
+                       "\n- Resistance to many diseases and poisons"
+                       "\n- Ability to drag heavy objects and grants bonus to speed when dragging them"
+                       "\n- Ability to wield heavy weapons with one hand"
+                       "\n- Ability to manage gun recoil"
+                       "\n- Duration of action of various drugs and alcohol" ),
+                    c_green );
+        }
+        break;
+
+        case 1: {
+            description_str =
+                colorize(
+                    string_format( _( "Melee to-hit bonus: +%.2f" ), u.get_melee_hit_base() )
+                    + string_format( _( "\nThrowing penalty per target's dodge: +%d" ),
+                                     u.throw_dispersion_per_dodge( false ) ),
+                    COL_STAT_BONUS );
+            if( u.ranged_dex_mod() != 0 ) {
+                description_str += colorize( string_format( _( "\nRanged penalty: -%d" ),
+                                             std::abs( u.ranged_dex_mod() ) ), COL_STAT_PENALTY );
+            } else {
+                description_str += "\n";
+            }
+            description_str +=
+                string_format( _( "\nDodge skill: %.f" ), u.get_dodge() )
+                + string_format( _( "\nMove cost while swimming: %i" ), u.swim_speed() )
+                + _( "\n\nAffects:" )
+                + colorize(
+                    _( "\n- Effectiveness of lockpicking"
+                       "\n- Resistance for being grabbed by some monsters"
+                       "\n- Chance of escaping grabs and traps"
+                       "\n- Effectiveness of disarming traps"
+                       "\n- Chance of success when manipulating with gun modifications"
+                       "\n- Effectiveness of repairing and modifying clothes and armor"
+                       "\n- Attack speed and chance of critical hits in melee combat"
+                       "\n- Effectiveness of stealing"
+                       "\n- Throwing speed"
+                       "\n- Aiming speed"
+                       "\n- Speed and effectiveness of chopping wood with powered tools"
+                       "\n- Chance to avoid traps"
+                       "\n- Chance to get better results when butchering corpses or cutting items"
+                       "\n- Chance of avoiding cuts on sharp terrain"
+                       "\n- Chance of losing control of vehicle when driving"
+                       "\n- Chance of damaging melee weapon on attack"
+                       "\n- Damage from falling" ),
+                    c_green );
+        }
+        break;
+
+        case 2: {
+            const int read_spd = u.read_speed();
+            description_str =
+                colorize( string_format( _( "Read times: %d%%" ), read_spd ),
+                          ( read_spd == 100 ? COL_STAT_NEUTRAL :
+                            ( read_spd < 100 ? COL_STAT_BONUS : COL_STAT_PENALTY ) ) )
+                + string_format( _( "\nPersuade/lie skill: %i" ), u.persuade_skill() )
+                + colorize( string_format( _( "\nCrafting bonus: %2d%%" ), u.get_int() ),
+                            COL_STAT_BONUS )
+                + _( "\n\nAffects:" )
+                + colorize(
+                    _( "\n- Speed of 'catching up' practical experience to theoretical knowledge"
+                       "\n- Detection and disarming traps"
+                       "\n- Chance of success when installing bionics"
+                       "\n- Chance of success when manipulating with gun modifications"
+                       "\n- Chance to learn a recipe when crafting from a book"
+                       "\n- Chance to learn martial arts techniques when using CQB bionic"
+                       "\n- Chance of hacking computers and card readers"
+                       "\n- Chance of successful robot reprogramming"
+                       "\n- Chance of successful decrypting memory cards"
+                       "\n- Chance of bypassing vehicle security system"
+                       "\n- Chance to get better results when disassembling items"
+                       "\n- Chance of being paralyzed by fear attack" ),
+                    c_green );
+        }
+        break;
+
+        case 3: {
+            if( u.ranged_per_mod() > 0 ) {
+                description_str =
+                    colorize( string_format( _( "Aiming penalty: -%d" ), u.ranged_per_mod() ),
+                              COL_STAT_PENALTY );
+            }
+            description_str +=
+                string_format( _( "\nPersuade/lie skill: %i" ), u.persuade_skill() )
+                + _( "\n\nAffects:" )
+                + colorize(
+                    _( "\n- Speed of 'catching up' practical experience to theoretical knowledge"
+                       "\n- Time needed for safe cracking"
+                       "\n- Sight distance on game map and overmap"
+                       "\n- Effectiveness of stealing"
+                       "\n- Throwing accuracy"
+                       "\n- Chance of losing control of vehicle when driving"
+                       "\n- Chance of spotting camouflaged creatures"
+                       "\n- Effectiveness of lockpicking"
+                       "\n- Effectiveness of foraging"
+                       "\n- Precision when examining wounds and using first aid skill"
+                       "\n- Detection and disarming traps"
+                       "\n- Morale bonus when playing a musical instrument"
+                       "\n- Effectiveness of repairing and modifying clothes and armor"
+                       "\n- Chance of critical hits in melee combat" ),
+                    c_green );
+        }
+        break;
+    }
+    return description_str;
+}
+
+/** Handle the stats tab of the character generation menu */
 void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
 {
     // TODO: Move this out to a common header and eliminate other separate instances of these strings.
@@ -1161,139 +1300,7 @@ void set_stats( tab_manager &tabs, avatar &u, pool_type pool )
         u.set_stored_kcal( u.get_healthy_kcal() );
         u.reset_bonuses(); // Removes pollution of stats by modifications appearing inside reset_stats(). Is reset_stats() even necessary in this context?
 
-        std::string description_str;
-        switch( sel ) {
-            case 0: {
-                u.recalc_hp();
-                u.set_stored_kcal( u.get_healthy_kcal() );
-                description_str =
-                    string_format( _( "Base HP: %d" ), u.get_part_hp_max( bodypart_id( "head" ) ) )
-                    + string_format( _( "\nCarry weight: %.1f %s" ), convert_weight( u.weight_capacity() ),
-                                     weight_units() )
-                    + string_format( _( "\nResistance to knock down effect when hit: %.1f" ), u.stability_roll() )
-                    + string_format( _( "\nIntimidation skill: %i" ), u.intimidation() )
-                    + string_format( _( "\nMaximum oxygen: %i" ), u.get_oxygen_max() )
-                    + string_format( _( "\nShout volume: %i" ), u.get_shout_volume() )
-                    + string_format( _( "\nLifting strength: %i" ), u.get_lift_str() )
-                    + string_format( _( "\nMove cost while swimming: %i" ), u.swim_speed() )
-                    + colorize(
-                        string_format( _( "\nBash damage bonus: %.1f" ), u.bonus_damage( false ) ),
-                        COL_STAT_BONUS )
-                    + _( "\n\nAffects:" )
-                    + colorize(
-                        _( "\n- Throwing range, accuracy, and damage"
-                           "\n- Reload speed for weapons using muscle power to reload"
-                           "\n- Pull strength of some mutations"
-                           "\n- Resistance for being pulled or grabbed by some monsters"
-                           "\n- Speed of corpses pulping"
-                           "\n- Speed and effectiveness of prying things open, chopping wood, and mining"
-                           "\n- Chance of escaping grabs and traps"
-                           "\n- Power produced by muscle-powered vehicles"
-                           "\n- Most aspects of melee combat"
-                           "\n- Effectiveness of smashing furniture or terrain"
-                           "\n- Resistance to many diseases and poisons"
-                           "\n- Ability to drag heavy objects and grants bonus to speed when dragging them"
-                           "\n- Ability to wield heavy weapons with one hand"
-                           "\n- Ability to manage gun recoil"
-                           "\n- Duration of action of various drugs and alcohol" ),
-                        c_green );
-            }
-            break;
-
-            case 1: {
-                description_str =
-                    colorize(
-                        string_format( _( "Melee to-hit bonus: +%.2f" ), u.get_melee_hit_base() )
-                        + string_format( _( "\nThrowing penalty per target's dodge: +%d" ),
-                                         u.throw_dispersion_per_dodge( false ) ),
-                        COL_STAT_BONUS );
-                if( u.ranged_dex_mod() != 0 ) {
-                    description_str += colorize( string_format( _( "\nRanged penalty: -%d" ),
-                                                 std::abs( u.ranged_dex_mod() ) ), COL_STAT_PENALTY );
-                } else {
-                    description_str += "\n";
-                }
-                description_str +=
-                    string_format( _( "\nDodge skill: %.f" ), u.get_dodge() )
-                    + string_format( _( "\nMove cost while swimming: %i" ), u.swim_speed() )
-                    + _( "\n\nAffects:" )
-                    + colorize(
-                        _( "\n- Effectiveness of lockpicking"
-                           "\n- Resistance for being grabbed by some monsters"
-                           "\n- Chance of escaping grabs and traps"
-                           "\n- Effectiveness of disarming traps"
-                           "\n- Chance of success when manipulating with gun modifications"
-                           "\n- Effectiveness of repairing and modifying clothes and armor"
-                           "\n- Attack speed and chance of critical hits in melee combat"
-                           "\n- Effectiveness of stealing"
-                           "\n- Throwing speed"
-                           "\n- Aiming speed"
-                           "\n- Speed and effectiveness of chopping wood with powered tools"
-                           "\n- Chance to avoid traps"
-                           "\n- Chance to get better results when butchering corpses or cutting items"
-                           "\n- Chance of avoiding cuts on sharp terrain"
-                           "\n- Chance of losing control of vehicle when driving"
-                           "\n- Chance of damaging melee weapon on attack"
-                           "\n- Damage from falling" ),
-                        c_green );
-            }
-            break;
-
-            case 2: {
-                const int read_spd = u.read_speed();
-                description_str =
-                    colorize( string_format( _( "Read times: %d%%" ), read_spd ),
-                              ( read_spd == 100 ? COL_STAT_NEUTRAL :
-                                ( read_spd < 100 ? COL_STAT_BONUS : COL_STAT_PENALTY ) ) )
-                    + string_format( _( "\nPersuade/lie skill: %i" ), u.persuade_skill() )
-                    + colorize( string_format( _( "\nCrafting bonus: %2d%%" ), u.get_int() ),
-                                COL_STAT_BONUS )
-                    + _( "\n\nAffects:" )
-                    + colorize(
-                        _( "\n- Speed of 'catching up' practical experience to theoretical knowledge"
-                           "\n- Detection and disarming traps"
-                           "\n- Chance of success when installing bionics"
-                           "\n- Chance of success when manipulating with gun modifications"
-                           "\n- Chance to learn a recipe when crafting from a book"
-                           "\n- Chance to learn martial arts techniques when using CQB bionic"
-                           "\n- Chance of hacking computers and card readers"
-                           "\n- Chance of successful robot reprogramming"
-                           "\n- Chance of successful decrypting memory cards"
-                           "\n- Chance of bypassing vehicle security system"
-                           "\n- Chance to get better results when disassembling items"
-                           "\n- Chance of being paralyzed by fear attack" ),
-                        c_green );
-            }
-            break;
-
-            case 3: {
-                if( u.ranged_per_mod() > 0 ) {
-                    description_str =
-                        colorize( string_format( _( "Aiming penalty: -%d" ), u.ranged_per_mod() ),
-                                  COL_STAT_PENALTY );
-                }
-                description_str +=
-                    string_format( _( "\nPersuade/lie skill: %i" ), u.persuade_skill() )
-                    + _( "\n\nAffects:" )
-                    + colorize(
-                        _( "\n- Speed of 'catching up' practical experience to theoretical knowledge"
-                           "\n- Time needed for safe cracking"
-                           "\n- Sight distance on game map and overmap"
-                           "\n- Effectiveness of stealing"
-                           "\n- Throwing accuracy"
-                           "\n- Chance of losing control of vehicle when driving"
-                           "\n- Chance of spotting camouflaged creatures"
-                           "\n- Effectiveness of lockpicking"
-                           "\n- Effectiveness of foraging"
-                           "\n- Precision when examining wounds and using first aid skill"
-                           "\n- Detection and disarming traps"
-                           "\n- Morale bonus when playing a musical instrument"
-                           "\n- Effectiveness of repairing and modifying clothes and armor"
-                           "\n- Chance of critical hits in melee combat" ),
-                        c_green );
-            }
-            break;
-        }
+        std::string description_str = assemble_stat_details(u, sel);
         fold_and_print( w_description, point_zero, getmaxx( w_description ), COL_STAT_NEUTRAL,
                         description_str );
         wnoutrefresh( w );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2743,7 +2743,7 @@ void set_skills( tab_manager &tabs, avatar &u, pool_type pool )
                                              "<color_light_green>%s</color> to return to the previous tab." ),
                                           ctxt.get_desc( "HELP_KEYBINDINGS" ), ctxt.get_desc( "UP" ), ctxt.get_desc( "DOWN" ),
                                           ctxt.get_desc( "RIGHT" ), ctxt.get_desc( "LEFT" ),
-                                          ctxt.get_desc( "NEXT_TAB" ), ctxt.get_desc( "PREV_TAB" ) ), TERMX - 2 );
+                                          ctxt.get_desc( "NEXT_TAB" ), ctxt.get_desc( "PREV_TAB" ) ), TERMX - 4 );
         iContentHeight = TERMY - static_cast<int>( keybinding_hint.size() ) - iHeaderHeight - 1;
         w = catacurses::newwin( TERMY, TERMX, point_zero );
         w_list = catacurses::newwin( iContentHeight, 35, point( 1, iHeaderHeight ) );
@@ -2845,7 +2845,7 @@ void set_skills( tab_manager &tabs, avatar &u, pool_type pool )
 
         nc_color cur_color = COL_NOTE_MINOR;
         for( size_t i = 0; i < keybinding_hint.size(); ++i ) {
-            print_colored_text( w_keybindings, point( 0, i ), cur_color, COL_NOTE_MINOR, keybinding_hint[i] );
+            print_colored_text( w_keybindings, point( 1, i ), cur_color, COL_NOTE_MINOR, keybinding_hint[i] );
         }
 
         if( details_recalc ) {

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -37,6 +37,7 @@
 #include "proficiency.h"
 #include "sdltiles.h"
 #include "skill.h"
+#include "skill_ui.h"
 #include "string_formatter.h"
 #include "string_input_popup.h"
 #include "translations.h"
@@ -778,13 +779,6 @@ static void draw_effects_info( const catacurses::window &w_info, const unsigned 
     wnoutrefresh( w_info );
 }
 
-struct HeaderSkill {
-    const Skill *skill;
-    bool is_header;
-    HeaderSkill( const Skill *skill, bool is_header ): skill( skill ), is_header( is_header ) {
-    }
-};
-
 static void draw_skills_tab( ui_adaptor &ui, const catacurses::window &w_skills,
                              Character &you, unsigned int line, const player_display_tab curtab,
                              std::vector<HeaderSkill> &skillslist )
@@ -1129,18 +1123,6 @@ static void draw_tip( const catacurses::window &w_tip, const Character &you,
     wnoutrefresh( w_tip );
 }
 
-static void skip_skill_headers( const std::vector<HeaderSkill> &skillslist, unsigned int &line,
-                                bool inc, unsigned int line_count )
-{
-    const unsigned int prev_line = line;
-    while( skillslist[line].is_header ) {
-        line = inc_clamp_wrap( line, inc, line_count );
-        if( line == prev_line ) {
-            break;
-        }
-    }
-}
-
 static void on_customize_character( Character &you )
 {
     uilist cmenu;
@@ -1294,7 +1276,7 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
     if( line_count > 0 ) {
         line = std::clamp( line, 0U, line_count - 1 );
         if( curtab == player_display_tab::skills ) {
-            skip_skill_headers( skillslist, line, true, line_count );
+            skip_skill_headers( skillslist, line, true );
         }
     } else {
         line = 0;
@@ -1309,9 +1291,10 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
             ui_tip.invalidate_ui();
         }
         if( curtab == player_display_tab::skills ) {
-            const bool inc = action == "DOWN" || action == "PAGE_DOWN" || action == "SCROLL_DOWN" ||
-                             action == "HOME";
-            skip_skill_headers( skillslist, line, inc, line_count );
+            // including actios "PAGE_UP", and "HOME", because these shouldn't wrap
+            const bool inc = action == "DOWN" || action == "PAGE_DOWN" || action == "PAGE_UP" ||
+                             action == "SCROLL_DOWN" || action == "HOME";
+            skip_skill_headers( skillslist, line, inc );
         }
         info_line = 0;
         invalidate_tab( curtab );
@@ -1628,15 +1611,7 @@ void Character::disp_info( bool customize_character )
         return a.get_sort_rank() < b.get_sort_rank();
     } );
 
-    std::vector<HeaderSkill> skillslist;
-    skill_displayType_id prev_type = skill_displayType_id::NULL_ID();
-    for( const Skill * const &s : player_skill ) {
-        if( s->display_category() != prev_type ) {
-            prev_type = s->display_category();
-            skillslist.emplace_back( s, true );
-        }
-        skillslist.emplace_back( s, false );
-    }
+    std::vector<HeaderSkill> skillslist = get_HeaderSkills( player_skill );
     const unsigned int skill_win_size_y_max = 1 + skillslist.size();
     const unsigned int info_win_size_y = 6;
 

--- a/src/skill_ui.cpp
+++ b/src/skill_ui.cpp
@@ -1,0 +1,33 @@
+#include "skill_ui.h"
+
+#include "type_id.h"
+#include "ui.h"
+
+std::vector<HeaderSkill> get_HeaderSkills( const std::vector<const Skill *> &sorted_skills )
+{
+    std::vector<HeaderSkill> skill_list;
+    skill_displayType_id prev_type = skill_displayType_id::NULL_ID();
+    for( const Skill * const &s : sorted_skills ) {
+        if( s->display_category() != prev_type ) {
+            prev_type = s->display_category();
+            skill_list.emplace_back( s, true );
+        }
+        skill_list.emplace_back( s, false );
+    }
+    return skill_list;
+}
+
+template void skip_skill_headers<int>( const std::vector<HeaderSkill> &, int &, bool );
+template void skip_skill_headers<unsigned>( const std::vector<HeaderSkill> &, unsigned &, bool );
+
+template<typename V>
+void skip_skill_headers( const std::vector<HeaderSkill> &skillslist, V &line, bool inc )
+{
+    const V prev_line = line;
+    while( skillslist[line].is_header ) {
+        line = inc_clamp_wrap( line, inc, skillslist.size() );
+        if( line == prev_line ) {
+            break;
+        }
+    }
+}

--- a/src/skill_ui.h
+++ b/src/skill_ui.h
@@ -1,0 +1,30 @@
+#pragma once
+#ifndef CATA_SRC_SKILL_UI
+#define CATA_SRC_SKILL_UI
+
+#include <vector>
+
+#include "skill.h"
+
+/**
+ * For building list of skills including category as headers.
+ */
+struct HeaderSkill {
+    const Skill *skill;
+    bool is_header;
+    HeaderSkill( const Skill *skill, bool is_header ): skill( skill ), is_header( is_header ) {
+    }
+};
+
+/**
+ * Build list of skills including category as headers.
+ */
+std::vector<HeaderSkill> get_HeaderSkills( const std::vector<const Skill *> &sorted_skills );
+
+/**
+ * In menus with skills ensure selected line is not a header.
+ */
+template<typename V>
+void skip_skill_headers( const std::vector<HeaderSkill> &skillslist, V &line, bool inc );
+
+#endif // CATA_SRC_SKILL_UI


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Character creation: small screen UI fixes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #67777

POINTS
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/d5726aae-91e9-4bc3-aee5-aa2bdfe67de6)

STATS
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/971e40dd-fae8-488a-8b8c-1ed4e1b4befa)

TRAITS
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/fd4f3b8c-d7ea-4843-a4cf-c87402d72ec6)

SKILLS
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/b2a3a0d6-5b3a-432e-85c6-109cf47552c4)

DESCRIPTION
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/08f1fe76-2f98-41da-841d-9a5c5c685612)


visible:
- [x] fix: SKILLS The help text doesn't update when keybinding is changed.
- [x] fix: help overflow (POINTS, STATS, SKILLS, DESCRIPTION)
- [x] fix: scrollable details (STATS, TRAITS)
- [x] fix: There should be space between the border and the text. (SKILLS)
- [x] fix: manny missing `┬`

non-visible:
- [x] fix: DESCRIPTION "switch gender" help string wasn't visible
  - but I removed it since it takes up precious space on small screens
  - position was hardcoded, so adding was hard, the position isn't hardcoded anymore
- [x] fix: SKILLS scroll_up or _down would trigger again if it scrolled on a header (in character creation)
  - It now moves only by one extra line
- [x] fix: scroll_up or _down could wrap, but shouldn't (in character creation on the SKILLS tab & in the @ menu in-game)

not fixed:
- [ ] SKILLS Cannot scroll up to view "Melee weapons" as it is not selectable entry in a list
  ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/e64a3d19-5d35-4428-b3e8-7fc7dc1abf2d)  

- [ ] DESCRIPTION
  ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/948037d4-33c4-4060-a596-05af95b52b8f)
  ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/decc0cd3-b5df-4430-9ffa-7eda35e9df45)

- [ ] Everywhere Summary overflow
  ![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/474901ea-5e33-48ef-bc1a-1a98a4d405f1)

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Apply the style of SCENARIO, PROFESSION, and BACKGROUND to TRAITS, and SKILLS descriptions.
Renamed variables and moved code to make it more clear that the code is the same.
Unify `player_display.cpp` & `newcharacter.cpp` skill listing into new `skill_ui.h`.
Detect DESCRIPTION's help height and make as big a window as needed to be.

Named some constants.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Less renaming & code movement.
Put `const int iHeaderHeight = 6` to global scope instead of defining it 6 times across different functions.

Maybe, make DESCRIPTION one window that can be scrolled. And move things around, so that everything with potentially
more entries is on that window. Including when the window isn't wide (2 cols).
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
On refactoring, switch between new and master .exe and check that the display is the same for all values.

Scroll things until you find something that looks weird.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
