### PR TITLE
item: aggressively aggregate contents type

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -82,7 +82,17 @@
     "to_hit": -2,
     "effects": [ "NEVER_MISFIRES", "NON_FOULING", "RECOVER_80" ],
     "qualities": [ [ "HAMMER", 1 ] ],
-    "melee_damage": { "bash": 7 }
+    "melee_damage": { "bash": 7 },
+    "variant_type": "generic",
+    "variants": [
+      { "id": "test_rock_blue", "name": { "str": "blue test_rock" }, "description": "It's a blue test rock", "append": true },
+      {
+        "id": "test_rock_green",
+        "name": { "str": "green test_rock" },
+        "description": "It's a green test rock",
+        "append": true
+      }
+    ]
   },
   {
     "type": "TOOL_ARMOR",

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -33,7 +33,7 @@ static const flag_id json_flag_FIX_NEARSIGHT( "FIX_NEARSIGHT" );
 static const flag_id json_flag_HOT( "HOT" );
 
 static const item_category_id item_category_container( "container" );
-static const item_category_id item_category_food( "food" );
+static const item_category_id item_category_spare_parts( "spare_parts" );
 
 static const itype_id itype_test_backpack( "test_backpack" );
 static const itype_id itype_test_duffelbag( "test_duffelbag" );
@@ -901,19 +901,21 @@ TEST_CASE( "rigid_splint_compliance", "[item][armor]" )
 
 TEST_CASE( "item_single_type_contents", "[item]" )
 {
+    item rock( "test_rock" );
+    std::array<std::string, 2> const variants = { "test_rock_blue", "test_rock_green" };
     item walnut( "walnut" );
-    item nail( "nail" );
     item bag( "bag_plastic" );
     REQUIRE( bag.get_category_of_contents().id == item_category_container );
     int const num = GENERATE( 1, 2 );
     bool ret = true;
     for( int i = 0; i < num; i++ ) {
-        ret &= bag.put_in( walnut, item_pocket::pocket_type::CONTAINER ).success();
+        rock.set_itype_variant( variants[i] );
+        ret &= bag.put_in( rock, item_pocket::pocket_type::CONTAINER ).success();
     }
     REQUIRE( ret );
     CAPTURE( num, bag.display_name() );
-    CHECK( bag.get_category_of_contents() == *item_category_food );
-    REQUIRE( nail.get_category_of_contents().id != walnut.get_category_of_contents().id );
-    REQUIRE( bag.put_in( nail, item_pocket::pocket_type::CONTAINER ).success() );
+    CHECK( bag.get_category_of_contents() == *item_category_spare_parts );
+    REQUIRE( walnut.get_category_of_contents().id != rock.get_category_of_contents().id );
+    REQUIRE( bag.put_in( walnut, item_pocket::pocket_type::CONTAINER ).success() );
     CHECK( bag.get_category_of_contents().id == item_category_container );
 }

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -8,6 +8,7 @@
 #include "character.h"
 #include "flag.h"
 #include "item.h"
+#include "item_category.h"
 #include "item_pocket.h"
 #include "itype.h"
 #include "options_helpers.h"
@@ -521,6 +522,7 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
     item backpack_hiking( itype_backpack_hiking );
     item purse( itype_purse );
     item rock( itype_test_rock );
+    rock.clear_itype_variant();
     item rock2( itype_rock );
     const std::string color_pref =
         "<color_c_green>++</color>\u00A0";
@@ -544,9 +546,28 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
                    " " + rocks_nested_tname + " (2)" );
         }
         SECTION( "several stacks" ) {
+            REQUIRE( rock.get_category_shallow().id != purse.get_category_shallow().id );
+            backpack_hiking.put_in( rock, item_pocket::pocket_type::CONTAINER );
+            backpack_hiking.put_in( purse, item_pocket::pocket_type::CONTAINER );
+            CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym + " 2 items" );
+        }
+        SECTION( "several stacks of same category" ) {
+            REQUIRE( rock.get_category_shallow().id == rock2.get_category_shallow().id );
             backpack_hiking.put_in( rock, item_pocket::pocket_type::CONTAINER );
             backpack_hiking.put_in( rock2, item_pocket::pocket_type::CONTAINER );
-            CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym + " 2 items" );
+            CHECK( backpack_hiking.tname( 1 ) ==
+                   color_pref + "hiking backpack " + nesting_sym + " " +
+                   colorize( rock.get_category_shallow().name(), c_magenta ) );
+        }
+        SECTION( "several stacks of variants" ) {
+            item rock_blue( itype_test_rock );
+            item rock_green( itype_test_rock );
+            rock_blue.set_itype_variant( "test_rock_blue" );
+            rock_green.set_itype_variant( "test_rock_green" );
+            backpack_hiking.put_in( rock_blue, item_pocket::pocket_type::CONTAINER );
+            backpack_hiking.put_in( rock_green, item_pocket::pocket_type::CONTAINER );
+            CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym +
+                   " " + rocks_nested_tname + " (3)" );
         }
         SECTION( "container has whitelist" ) {
             std::string const wlmark = "⁺";


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Too many checks are performed when expanding contents name so a lot of containers that should reasonably be named `container > contents_name (X)` are instead shown as `container > X items`

* Follow up for #63579
* Fixes #67603
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Only consider item type and contents. In addition,
 - if the items are different variants of the same type, display the base name
 - if the items are of different types but same category, display category name

See screenshots below.

TODO:
- [ ] figure out corpse name
- [ ] aggregate status too instead of just using first one (cold/rotten/poor fit/relic charges/etc)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Updated test units.

<details>
<summary>Backpack with different contents in the same category</summary>

Before:
![category before](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/a280cd08-3450-4052-ab9b-52d5ba850bf6)


After:
![category after](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/3325f91d-b2e1-4c65-b20d-a4103d611501)

</details>

<details>
<summary>Bag with several variants of same item</summary>

Before:
![variants before](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/3cc3bd10-8ca4-4edd-9adf-9f596ed1c9cf)

After:
![variants after](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/5b5c8147-e0ed-42c6-9318-480dbdc19db5)

</details>

<details>
<summary>Bag with several stacks of same item of varying freshness (#67603)</summary>

Before:
![rot before](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/d58c2f69-218d-4d81-bd2a-dd386ebb5f62)


After:
![rot after](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/1ac8b6f7-13bb-452a-8094-47278784ca18)


</details>

<details>
<summary>Nested food of various type</summary>

Before:
![nested before](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/207288b1-8f02-48d2-973e-6a5447dc1c32)

After:
![nested after](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/bf06ee2f-dff8-484f-81c0-8a71121af7ec)

</details>



<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
There are probably tons of edge cases.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
