### PR TITLE
Object creator merge windows into a tabbed view

### DIFF
--- a/object_creator/creator_main_window.cpp
+++ b/object_creator/creator_main_window.cpp
@@ -5,14 +5,13 @@
 #include "mod_selection_window.h"
 #include "enum_conversions.h"
 #include "translations.h"
-#include "worldfactory.h"
-#include "mod_manager.h"
 
 #include <QtWidgets/qapplication.h>
 #include <QtWidgets/qmainwindow.h>
 #include <QtWidgets/qpushbutton.h>
-#include <QtCore/QSettings>
 #include <QtWidgets/qstackedwidget.h>
+#include <QtWidgets/qmenubar.h>
+
 
 namespace io
 {
@@ -34,9 +33,7 @@ namespace io
 
 int creator::main_window::execute( QApplication &app )
 {
-    const int default_text_box_height = 20;
-    const int default_text_box_width = 100;
-    const QSize default_text_box_size( default_text_box_width, default_text_box_height );
+
     //Create the main window
     QMainWindow creator_main_window;
 
@@ -53,11 +50,33 @@ int creator::main_window::execute( QApplication &app )
 
     //Set the current widget to the mod selection window
     stackedWidget.setCurrentWidget( &mod_selection );
+
+
+    //Create a menu bar with one menu called navigation
+    //The navigation menu has three actions, one for each window
+    QMenuBar menu_bar( &creator_main_window );
+    QMenu* navigation_menu = menu_bar.addMenu( pgettext( "menu", "Navigation" ) );
+    QAction* spell_action = navigation_menu->addAction( pgettext( "menu", "Spell" ) );
+    QAction* item_group_action = navigation_menu->addAction( pgettext( "menu", "Item group" ) );
+    QAction* mod_selection_action = navigation_menu->addAction( pgettext( "menu", "Mod selection" ) );
+
+    // Connect the navigation menu items to slots that switch the current widget of the stacked widget
+    QObject::connect( spell_action, &QAction::triggered, [&]() {
+        stackedWidget.setCurrentWidget( &spell_editor );
+    } );
+    QObject::connect( item_group_action, &QAction::triggered, [&]() {
+        stackedWidget.setCurrentWidget( &item_group_editor );
+    } );
+    QObject::connect( mod_selection_action, &QAction::triggered, [&]() {
+        stackedWidget.setCurrentWidget( &mod_selection );
+    } );
+
+
+    // Set the menu bar as the main window's menu bar
+    creator_main_window.setMenuBar( &menu_bar );
     
-    int row = 0;
-    int col = 0;
-    int max_row = 0;
-    int max_col = 0;
+    //Make the main window fullscreen
+    creator_main_window.showFullScreen();
 
 
 

--- a/object_creator/creator_main_window.cpp
+++ b/object_creator/creator_main_window.cpp
@@ -54,39 +54,6 @@ int creator::main_window::execute( QApplication &app )
     spell_window spell_editor( &title_menu );
     item_group_window item_group_editor( &title_menu );
 
-    QLabel mods_label;
-    mods_label.setParent( &title_menu );
-    mods_label.setText( QString( "Select mods (restart required):" ) );
-    mods_label.resize( default_text_box_size * 2 );
-    mods_label.move( QPoint( col * default_text_box_width, row++ * default_text_box_height ) );
-    mods_label.show();
-    row++;
-
-    //We always load 'dda' so we exclude it from the mods list
-    QStringList all_mods;
-    for( const mod_id &e : world_generator->get_mod_manager().all_mods() ) {
-        if( !e->obsolete && e->ident.str() != "dda" ) {
-            all_mods.append( e->ident.c_str() );
-        }
-    }
-
-    dual_list_box mods_box;
-    mods_box.initialize( all_mods );
-    mods_box.resize( QSize( default_text_box_width * 8, default_text_box_height * 10 ) );
-    mods_box.setParent( &title_menu );
-    mods_box.move( QPoint( col * default_text_box_width, row * default_text_box_height ) );
-    mods_box.show();
-    //The user's mod selection gets saved to a file
-    QObject::connect( &mods_box, &dual_list_box::pressed, [&]() {
-        settings.setValue( "mods/include", mods_box.get_included() );
-    } );
-
-    //A previous selection of mods is loaded from disk and applied to the modlist widget
-    if( settings.contains( "mods/include" ) ) {
-        QStringList modlist = settings.value( "mods/include" ).value<QStringList>();
-        mods_box.set_included( modlist );
-    }
-
     row += 11;
 
     QPushButton spell_button( _( "Spell Creator" ), &title_menu );

--- a/object_creator/creator_main_window.cpp
+++ b/object_creator/creator_main_window.cpp
@@ -2,6 +2,7 @@
 
 #include "spell_window.h"
 #include "item_group_window.h"
+#include "mod_selection_window.h"
 #include "enum_conversions.h"
 #include "translations.h"
 #include "worldfactory.h"
@@ -11,6 +12,7 @@
 #include <QtWidgets/qmainwindow.h>
 #include <QtWidgets/qpushbutton.h>
 #include <QtCore/QSettings>
+#include <QtWidgets/qstackedwidget.h>
 
 namespace io
 {
@@ -35,60 +37,28 @@ int creator::main_window::execute( QApplication &app )
     const int default_text_box_height = 20;
     const int default_text_box_width = 100;
     const QSize default_text_box_size( default_text_box_width, default_text_box_height );
+    //Create the main window
+    QMainWindow creator_main_window;
+
+    //Create a stacked widget and add it to the main window
+    QStackedWidget stackedWidget( &creator_main_window );
+    creator_main_window.setCentralWidget( &stackedWidget );
+
+    //Add the spell_window and item_group_window to the stacked widget
+    spell_window spell_editor( &stackedWidget );
+    item_group_window item_group_editor( &stackedWidget );
+
+    //Add the mod selection window to the stacked widget
+    mod_selection_window mod_selection( &stackedWidget );
+
+    //Set the current widget to the mod selection window
+    stackedWidget.setCurrentWidget( &mod_selection );
     
     int row = 0;
     int col = 0;
     int max_row = 0;
     int max_col = 0;
 
-    //Does nothing on it's own but once settings.setvalue() is called it will create
-    //an ini file in C:\Users\User\AppData\Roaming\CleverRaven or equivalent directory
-    QSettings settings( QSettings::IniFormat, QSettings::UserScope,
-                        "CleverRaven", "Cataclysm - DDA" );
-
-    // =========================================================================================
-    // first column of boxes
-    row = 0;
-
-    QMainWindow title_menu;
-    spell_window spell_editor( &title_menu );
-    item_group_window item_group_editor( &title_menu );
-
-    row += 11;
-
-    QPushButton spell_button( _( "Spell Creator" ), &title_menu );
-    spell_button.move( QPoint( col * default_text_box_width, row * default_text_box_height ) );
-    QObject::connect( &spell_button, &QPushButton::released,
-    [&]() {
-        title_menu.hide();
-        spell_editor.show();
-    } );
-
-
-    // =========================================================================================
-    // second column of boxes
-    col++;
-
-    QPushButton item_group_button( _( "Item group Creator" ), &title_menu );
-    item_group_button.move( QPoint( col * default_text_box_width, row++ * default_text_box_height ) );
-    item_group_button.resize( 150, 30 );
-
-    QObject::connect( &item_group_button, &QPushButton::released,
-    [&]() {
-        title_menu.hide();
-        item_group_editor.show();
-    } );
-
-    title_menu.show();
-    spell_button.show();
-    item_group_button.show();
-
-    row += 3;
-    col += 6;
-    max_row = std::max( max_row, row );
-    max_col = std::max( max_col, col );
-    title_menu.resize( QSize( ( max_col + 1 ) * default_text_box_width,
-        ( max_row )*default_text_box_height ) );
 
 
     return app.exec();

--- a/object_creator/creator_main_window.cpp
+++ b/object_creator/creator_main_window.cpp
@@ -2,7 +2,6 @@
 
 #include "spell_window.h"
 #include "item_group_window.h"
-#include "mod_selection_window.h"
 #include "enum_conversions.h"
 #include "translations.h"
 
@@ -49,8 +48,8 @@ int creator::main_window::execute( QApplication &app )
     tabWidget->addTab(&item_group_editor, "Item group");
 
     //Create the mod selection window and add it as a tab
-    mod_selection_window mod_selection;
-    tabWidget->addTab(&mod_selection, "Mod selection");
+    mod_selection = new mod_selection_window();
+    tabWidget->addTab(mod_selection, "Mod selection");
     
     //Make the main window maximized
     creator_main_window.showMaximized();

--- a/object_creator/creator_main_window.cpp
+++ b/object_creator/creator_main_window.cpp
@@ -8,9 +8,7 @@
 
 #include <QtWidgets/qapplication.h>
 #include <QtWidgets/qmainwindow.h>
-#include <QtWidgets/qpushbutton.h>
-#include <QtWidgets/qstackedwidget.h>
-#include <QtWidgets/qmenubar.h>
+#include <QtWidgets/qtabwidget.h>
 
 
 namespace io
@@ -37,48 +35,25 @@ int creator::main_window::execute( QApplication &app )
     //Create the main window
     QMainWindow creator_main_window;
 
-    //Create a stacked widget and add it to the main window
-    QStackedWidget stackedWidget( &creator_main_window );
-    creator_main_window.setCentralWidget( &stackedWidget );
 
-    //Add the spell_window and item_group_window to the stacked widget
-    spell_window spell_editor( &stackedWidget );
-    item_group_window item_group_editor( &stackedWidget );
+    //Create a tab widget and add it to the main window
+    QTabWidget* tabWidget = new QTabWidget(&creator_main_window);
+    creator_main_window.setCentralWidget(tabWidget);
 
-    //Add the mod selection window to the stacked widget
-    mod_selection_window mod_selection( &stackedWidget );
+    //Create the spell window and add it as a tab
+    spell_window spell_editor;
+    tabWidget->addTab(&spell_editor, "Spell");
 
-    //Set the current widget to the mod selection window
-    stackedWidget.setCurrentWidget( &mod_selection );
+    //Create the item group window and add it as a tab
+    item_group_window item_group_editor;
+    tabWidget->addTab(&item_group_editor, "Item group");
 
-
-    //Create a menu bar with one menu called navigation
-    //The navigation menu has three actions, one for each window
-    QMenuBar menu_bar( &creator_main_window );
-    QMenu* navigation_menu = menu_bar.addMenu( pgettext( "menu", "Navigation" ) );
-    QAction* spell_action = navigation_menu->addAction( pgettext( "menu", "Spell" ) );
-    QAction* item_group_action = navigation_menu->addAction( pgettext( "menu", "Item group" ) );
-    QAction* mod_selection_action = navigation_menu->addAction( pgettext( "menu", "Mod selection" ) );
-
-    // Connect the navigation menu items to slots that switch the current widget of the stacked widget
-    QObject::connect( spell_action, &QAction::triggered, [&]() {
-        stackedWidget.setCurrentWidget( &spell_editor );
-    } );
-    QObject::connect( item_group_action, &QAction::triggered, [&]() {
-        stackedWidget.setCurrentWidget( &item_group_editor );
-    } );
-    QObject::connect( mod_selection_action, &QAction::triggered, [&]() {
-        stackedWidget.setCurrentWidget( &mod_selection );
-    } );
-
-
-    // Set the menu bar as the main window's menu bar
-    creator_main_window.setMenuBar( &menu_bar );
+    //Create the mod selection window and add it as a tab
+    mod_selection_window mod_selection;
+    tabWidget->addTab(&mod_selection, "Mod selection");
     
-    //Make the main window fullscreen
-    creator_main_window.showFullScreen();
-
-
+    //Make the main window maximized
+    creator_main_window.showMaximized();
 
     return app.exec();
 }

--- a/object_creator/creator_main_window.h
+++ b/object_creator/creator_main_window.h
@@ -2,6 +2,7 @@
 #define CATA_OBJECT_CREATOR_CREATOR_MAIN_WINDOW_H
 
 #include "enum_traits.h"
+#include "mod_selection_window.h"
 
 class QApplication;
 
@@ -12,6 +13,7 @@ class main_window
     public:
         int execute( QApplication &app );
     private:
+        mod_selection_window* mod_selection;
 };
 
 enum class jsobj_type {

--- a/object_creator/item_group_window.cpp
+++ b/object_creator/item_group_window.cpp
@@ -162,15 +162,18 @@ creator::item_group_window::item_group_window( QWidget *parent, Qt::WindowFlags 
     scrollArea->setSizePolicy( QSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding ) );
     scrollArea->setWidgetResizable( true );
 
-    item_group_json.setMinimumSize( QSize( 600, 500 ) );
-    item_group_json.setMaximumWidth(700);
-    item_group_json.setReadOnly( true );
-    mainColumn3->addWidget( &item_group_json );
-
     group_container = new nested_group_container( scrollArea, this );
     scrollArea->setWidget( group_container );
     mainColumn2->addWidget( scrollArea );
 
+
+    // =========================================================================================
+    // third column
+
+    item_group_json.setMinimumSize( QSize( 400, 300 ) );
+    item_group_json.setMaximumWidth(500);
+    item_group_json.setReadOnly( true );
+    mainColumn3->addWidget( &item_group_json );
 
     // =========================================================================================
     // Finalize

--- a/object_creator/item_group_window.cpp
+++ b/object_creator/item_group_window.cpp
@@ -10,23 +10,20 @@
 #include <QtCore/QCoreApplication>
 
 creator::item_group_window::item_group_window( QWidget *parent, Qt::WindowFlags flags )
-    : QFrame( parent, flags )
+    : QWidget ( parent, flags )
 {
-    // QWidget* wid = new QWidget( this );
-    // this->addWidget( wid );
+
     this->setAcceptDrops( true );
 
     QHBoxLayout* mainRow = new QHBoxLayout;
     QVBoxLayout* mainColumn1 = new QVBoxLayout;
     QVBoxLayout* mainColumn2 = new QVBoxLayout;
+    QVBoxLayout* mainColumn3 = new QVBoxLayout;
 
     this->setLayout( mainRow );
     mainRow->addLayout( mainColumn1, 0 );
     mainRow->addLayout( mainColumn2, 1 );
-
-    item_group_json.resize( QSize( 800, 600 ) );
-    item_group_json.setReadOnly( true );
-
+    mainRow->addLayout( mainColumn3, 2 );
 
     // =========================================================================================
     // first column of boxes
@@ -165,6 +162,10 @@ creator::item_group_window::item_group_window( QWidget *parent, Qt::WindowFlags 
     scrollArea->setSizePolicy( QSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding ) );
     scrollArea->setWidgetResizable( true );
 
+    item_group_json.setMinimumSize( QSize( 600, 500 ) );
+    item_group_json.setMaximumWidth(700);
+    item_group_json.setReadOnly( true );
+    mainColumn3->addWidget( &item_group_json );
 
     group_container = new nested_group_container( scrollArea, this );
     scrollArea->setWidget( group_container );
@@ -328,7 +329,7 @@ bool creator::item_group_window::event( QEvent* event )
         return true;
     }
     //call the event method of the base class for the events that aren't handled
-    return QFrame::event( event );
+    return QWidget::event( event );
 }
 
 

--- a/object_creator/item_group_window.cpp
+++ b/object_creator/item_group_window.cpp
@@ -10,17 +10,17 @@
 #include <QtCore/QCoreApplication>
 
 creator::item_group_window::item_group_window( QWidget *parent, Qt::WindowFlags flags )
-    : QMainWindow( parent, flags )
+    : QFrame( parent, flags )
 {
-    QWidget* wid = new QWidget( this );
-    this->setCentralWidget( wid );
+    // QWidget* wid = new QWidget( this );
+    // this->addWidget( wid );
     this->setAcceptDrops( true );
 
     QHBoxLayout* mainRow = new QHBoxLayout;
     QVBoxLayout* mainColumn1 = new QVBoxLayout;
     QVBoxLayout* mainColumn2 = new QVBoxLayout;
 
-    wid->setLayout( mainRow );
+    this->setLayout( mainRow );
     mainRow->addLayout( mainColumn1, 0 );
     mainRow->addLayout( mainColumn2, 1 );
 
@@ -328,7 +328,7 @@ bool creator::item_group_window::event( QEvent* event )
         return true;
     }
     //call the event method of the base class for the events that aren't handled
-    return QMainWindow::event( event );
+    return QFrame::event( event );
 }
 
 

--- a/object_creator/item_group_window.h
+++ b/object_creator/item_group_window.h
@@ -21,7 +21,7 @@
 namespace creator
 {
     class nested_group_container;
-    class item_group_window : public QFrame
+    class item_group_window : public QWidget
     {
 
     public:

--- a/object_creator/item_group_window.h
+++ b/object_creator/item_group_window.h
@@ -21,7 +21,7 @@
 namespace creator
 {
     class nested_group_container;
-    class item_group_window : public QMainWindow
+    class item_group_window : public QFrame
     {
 
     public:

--- a/object_creator/mod_selection_window.h
+++ b/object_creator/mod_selection_window.h
@@ -14,9 +14,9 @@
 
 namespace creator
 {
-class mod_selection_window : public QFrame
+class mod_selection_window : public QWidget
 {
-    Q_OBJECT
+
 
     public:
         mod_selection_window( QWidget *parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags() );
@@ -30,8 +30,6 @@ class mod_selection_window : public QFrame
         }
 
     private:
-        QLabel* mods_label;
-        QSpinBox* mods_box;
 };
 }
 

--- a/object_creator/mod_selection_window.h
+++ b/object_creator/mod_selection_window.h
@@ -1,0 +1,38 @@
+#ifndef CATA_OBJECT_CREATOR_MOD_SELECTION_WINDOW_H
+#define CATA_OBJECT_CREATOR_MOD_SELECTION_WINDOW_H
+
+//Include Qframe, QLabel and QSpinBox for the mod selection window
+#include <QtWidgets/qframe.h>
+#include <QtWidgets/qlabel.h>
+#include <QtWidgets/qspinbox.h>
+
+#include "dual_list_box.h"
+#include "mod_manager.h"
+#include "worldfactory.h"
+
+
+
+namespace creator
+{
+class mod_selection_window : public QFrame
+{
+    Q_OBJECT
+
+    public:
+        mod_selection_window( QWidget *parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags() );
+
+        void show() {
+            QWidget::show();
+        }
+
+        void hide() {
+            QWidget::hide();
+        }
+
+    private:
+        QLabel* mods_label;
+        QSpinBox* mods_box;
+};
+}
+
+#endif // CATA_OBJECT_CREATOR_MOD_SELECTION_WINDOW_H

--- a/object_creator/mod_selection_window.h
+++ b/object_creator/mod_selection_window.h
@@ -5,11 +5,11 @@
 #include <QtWidgets/qframe.h>
 #include <QtWidgets/qlabel.h>
 #include <QtWidgets/qspinbox.h>
+#include <QtCore/QSettings>
 
 #include "dual_list_box.h"
 #include "mod_manager.h"
 #include "worldfactory.h"
-
 
 
 namespace creator
@@ -30,6 +30,8 @@ class mod_selection_window : public QWidget
         }
 
     private:
+        dual_list_box mods_box;
+        QSettings* settings;
 };
 }
 

--- a/object_creator/mods_selection_window.cpp
+++ b/object_creator/mods_selection_window.cpp
@@ -1,6 +1,5 @@
 #include "mod_selection_window.h"
 
-#include <QtCore/QSettings>
 
 creator::mod_selection_window::mod_selection_window( QWidget *parent, Qt::WindowFlags flags )
     : QWidget ( parent, flags )
@@ -22,22 +21,23 @@ creator::mod_selection_window::mod_selection_window( QWidget *parent, Qt::Window
 
     //Does nothing on it's own but once settings.setvalue() is called it will create
     //an ini file in C:\Users\User\AppData\Roaming\CleverRaven or equivalent directory
-    QSettings settings( QSettings::IniFormat, QSettings::UserScope,
+    settings = new QSettings( QSettings::IniFormat, QSettings::UserScope,
                         "CleverRaven", "Cataclysm - DDA" );
 
-    dual_list_box* mods_box = new dual_list_box();
-    mods_box->initialize( all_mods );
-    mod_layout->addWidget( mods_box );
 
-    //The user's mod selection gets saved to a file
-    QObject::connect( mods_box, &dual_list_box::pressed, [&]() {
-        settings.setValue( "mods/include", mods_box->get_included() );
+    mods_box.initialize( all_mods );
+    mod_layout->addWidget( &mods_box );
+
+    //When one of the buttons on the mods_box is pressed,
+    //Get all items from the included list and save them to the ini file
+    QObject::connect( &mods_box, &dual_list_box::pressed, [&]() {
+        settings->setValue( "mods/include", mods_box.get_included() );
     } );
 
     //A previous selection of mods is loaded from disk and applied to the modlist widget
-    if( settings.contains( "mods/include" ) ) {
-        QStringList modlist = settings.value( "mods/include" ).value<QStringList>();
-        mods_box->set_included( modlist );
+    if( settings->contains( "mods/include" ) ) {
+        QStringList modlist = settings->value( "mods/include" ).value<QStringList>();
+        mods_box.set_included( modlist );
     }
 
 }

--- a/object_creator/mods_selection_window.cpp
+++ b/object_creator/mods_selection_window.cpp
@@ -3,34 +3,14 @@
 #include <QtCore/QSettings>
 
 creator::mod_selection_window::mod_selection_window( QWidget *parent, Qt::WindowFlags flags )
-    : QFrame( parent, flags )
+    : QWidget ( parent, flags )
 {
-    
-    const int default_text_box_height = 20;
-    const int default_text_box_width = 100;
-    const QSize default_text_box_size( default_text_box_width, default_text_box_height );
-    
-    int row = 0;
-    int col = 0;
-
-
-    QHBoxLayout* mod_layout = new QHBoxLayout;
-    mod_layout->setMargin( 0 );
-    mod_layout->setContentsMargins( 0,0,0,0 );
+    QVBoxLayout* mod_layout = new QVBoxLayout();
     this->setLayout( mod_layout ) ;
-
-
-    // =========================================================================================
-    // first column of boxes
-    row = 0;
-
-    QLabel mods_label;
-    mods_label.setParent( this );
-    mods_label.setText( QString( "Select mods (restart required):" ) );
-    mods_label.resize( default_text_box_size * 2 );
-    mods_label.move( QPoint( col * default_text_box_width, row++ * default_text_box_height ) );
-    mods_label.show();
-    row++;
+ 
+ 
+    QLabel* mods_label = new QLabel( "Select mods (restart required):", this );
+    mod_layout->addWidget( mods_label );
 
     //We always load 'dda' so we exclude it from the mods list
     QStringList all_mods;
@@ -45,24 +25,19 @@ creator::mod_selection_window::mod_selection_window( QWidget *parent, Qt::Window
     QSettings settings( QSettings::IniFormat, QSettings::UserScope,
                         "CleverRaven", "Cataclysm - DDA" );
 
-    dual_list_box mods_box;
-    mods_box.initialize( all_mods );
-    mods_box.resize( QSize( default_text_box_width * 8, default_text_box_height * 10 ) );
-    mods_box.setParent( this );
-    mods_box.move( QPoint( col * default_text_box_width, row * default_text_box_height ) );
-    mods_box.show();
+    dual_list_box* mods_box = new dual_list_box();
+    mods_box->initialize( all_mods );
+    mod_layout->addWidget( mods_box );
+
     //The user's mod selection gets saved to a file
-    QObject::connect( &mods_box, &dual_list_box::pressed, [&]() {
-        settings.setValue( "mods/include", mods_box.get_included() );
+    QObject::connect( mods_box, &dual_list_box::pressed, [&]() {
+        settings.setValue( "mods/include", mods_box->get_included() );
     } );
 
     //A previous selection of mods is loaded from disk and applied to the modlist widget
     if( settings.contains( "mods/include" ) ) {
         QStringList modlist = settings.value( "mods/include" ).value<QStringList>();
-        mods_box.set_included( modlist );
+        mods_box->set_included( modlist );
     }
 
-    // Add the widgets to the layout
-    mod_layout->addWidget( &mods_label );
-    mod_layout->addWidget( &mods_box );
 }

--- a/object_creator/mods_selection_window.cpp
+++ b/object_creator/mods_selection_window.cpp
@@ -1,0 +1,68 @@
+#include "mod_selection_window.h"
+
+#include <QtCore/QSettings>
+
+creator::mod_selection_window::mod_selection_window( QWidget *parent, Qt::WindowFlags flags )
+    : QFrame( parent, flags )
+{
+    
+    const int default_text_box_height = 20;
+    const int default_text_box_width = 100;
+    const QSize default_text_box_size( default_text_box_width, default_text_box_height );
+    
+    int row = 0;
+    int col = 0;
+
+
+    QHBoxLayout* mod_layout = new QHBoxLayout;
+    mod_layout->setMargin( 0 );
+    mod_layout->setContentsMargins( 0,0,0,0 );
+    this->setLayout( mod_layout ) ;
+
+
+    // =========================================================================================
+    // first column of boxes
+    row = 0;
+
+    QLabel mods_label;
+    mods_label.setParent( this );
+    mods_label.setText( QString( "Select mods (restart required):" ) );
+    mods_label.resize( default_text_box_size * 2 );
+    mods_label.move( QPoint( col * default_text_box_width, row++ * default_text_box_height ) );
+    mods_label.show();
+    row++;
+
+    //We always load 'dda' so we exclude it from the mods list
+    QStringList all_mods;
+    for( const mod_id &e : world_generator->get_mod_manager().all_mods() ) {
+        if( !e->obsolete && e->ident.str() != "dda" ) {
+            all_mods.append( e->ident.c_str() );
+        }
+    }
+
+    //Does nothing on it's own but once settings.setvalue() is called it will create
+    //an ini file in C:\Users\User\AppData\Roaming\CleverRaven or equivalent directory
+    QSettings settings( QSettings::IniFormat, QSettings::UserScope,
+                        "CleverRaven", "Cataclysm - DDA" );
+
+    dual_list_box mods_box;
+    mods_box.initialize( all_mods );
+    mods_box.resize( QSize( default_text_box_width * 8, default_text_box_height * 10 ) );
+    mods_box.setParent( this );
+    mods_box.move( QPoint( col * default_text_box_width, row * default_text_box_height ) );
+    mods_box.show();
+    //The user's mod selection gets saved to a file
+    QObject::connect( &mods_box, &dual_list_box::pressed, [&]() {
+        settings.setValue( "mods/include", mods_box.get_included() );
+    } );
+
+    //A previous selection of mods is loaded from disk and applied to the modlist widget
+    if( settings.contains( "mods/include" ) ) {
+        QStringList modlist = settings.value( "mods/include" ).value<QStringList>();
+        mods_box.set_included( modlist );
+    }
+
+    // Add the widgets to the layout
+    mod_layout->addWidget( &mods_label );
+    mod_layout->addWidget( &mods_box );
+}

--- a/object_creator/spell_window.cpp
+++ b/object_creator/spell_window.cpp
@@ -65,7 +65,7 @@ static spell_type default_spell_type()
 }
 
 creator::spell_window::spell_window( QWidget *parent, Qt::WindowFlags flags )
-    : QFrame( parent, flags )
+    : QWidget ( parent, flags )
 {
     editable_spell = default_spell_type();
 
@@ -77,9 +77,6 @@ creator::spell_window::spell_window( QWidget *parent, Qt::WindowFlags flags )
     int col = 0;
     int max_row = 0;
     int max_col = 0;
-
-    spell_json.resize( QSize( 800, 600 ) );
-    spell_json.setReadOnly( true );
 
 
     // =========================================================================================
@@ -1242,6 +1239,19 @@ creator::spell_window::spell_window( QWidget *parent, Qt::WindowFlags flags )
         write_json();
     } );
 
+
+    // =========================================================================================
+    // eight column of boxes (just json output)
+    max_row = std::max( max_row, row );
+    row = 0;
+    col++;
+
+    spell_json.setParent( this );
+    spell_json.resize( QSize( 800, 600 ) );
+    spell_json.setReadOnly( true );
+    spell_json.move( QPoint( col * default_text_box_width, row++ * default_text_box_height ) );
+    spell_json.show();
+    
     max_row = std::max( max_row, row );
     max_col = std::max( max_col, col );
     this->resize( QSize( ( max_col + 1 ) * default_text_box_width,

--- a/object_creator/spell_window.cpp
+++ b/object_creator/spell_window.cpp
@@ -65,7 +65,7 @@ static spell_type default_spell_type()
 }
 
 creator::spell_window::spell_window( QWidget *parent, Qt::WindowFlags flags )
-    : QMainWindow( parent, flags )
+    : QFrame( parent, flags )
 {
     editable_spell = default_spell_type();
 

--- a/object_creator/spell_window.h
+++ b/object_creator/spell_window.h
@@ -17,7 +17,7 @@
 
 namespace creator
 {
-class spell_window : public QMainWindow
+class spell_window : public QFrame
 {
     public:
         spell_window( QWidget *parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags() );

--- a/object_creator/spell_window.h
+++ b/object_creator/spell_window.h
@@ -17,7 +17,7 @@
 
 namespace creator
 {
-class spell_window : public QFrame
+class spell_window : public QWidget
 {
     public:
         spell_window( QWidget *parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Merge Object Creator windows into a tabbed view"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
To be able to switch between editors more easily. Before this change, you had to re-open the object creator to pick a different window. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Remove everything from the main window and replace it with a tabbed view
- Have the separate windows be a tab in the tabbed view
- This is mostly just a functional change. I basically didn't do anything on the existing UI elements
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Instead of a tabbed view, I tried to do a menu bar with a 'navigation' option. When a option from the navigation menu was selected, it would open the window corresponding to the selected menu item. You could have 1 window open at a time (like the tabbed view) but the new windows would change position and size and it's not as convenient as the tabbed view.
- In the long term, I'd like it to work like a web browser, where you have your tabbed view and it lets you pop-out one of the tabs so you can get the most out of your multi-screen setup.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
On windows and linux:
- Checked that all the controls are functional
- Mods are loaded in correctly

On windows:

Spell tab:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/50166150/a1fc0d00-0bdd-4ee3-bd83-b230766abe19)

Item group tab:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/50166150/2af50849-2223-486f-91f4-ddacf8ce3b3e)

Mod selection tab:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/50166150/12ef9193-a060-45eb-92ad-6ac15ce6cb72)


On Linux:
[Screencast from 30.08.2023 20:43:24.webm](https://github.com/CleverRaven/Cataclysm-DDA/assets/50166150/01425f35-cdec-4650-a892-6f1a5cafb752)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I looked back at KorgGent's work but couldn't find anything about the broaded design of the Object Creator itself. I have some ideas, but if you think about what the Object Creator can do for us and how it will grow, I feel like it will be a good idea to come up with some good design concepts. If someone wants to exchange ideas I'm all for it. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
