### PR TITLE
Improve turn performance by caching default input ctx

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2398,7 +2398,14 @@ tripoint game::mouse_edge_scrolling_overmap( input_context &ctxt )
     return ret.first;
 }
 
-input_context get_default_mode_input_context()
+static input_context default_mode_input_context = create_default_mode_input_context();
+
+input_context &get_default_mode_input_context()
+{
+    return default_mode_input_context;
+}
+
+input_context create_default_mode_input_context()
 {
     input_context ctxt( "DEFAULTMODE", keyboard_mode::keycode );
     // Because those keys move the character, they don't pan, as their original name says

--- a/src/game.h
+++ b/src/game.h
@@ -57,7 +57,8 @@ extern int savegame_loading_version;
 
 class input_context;
 
-input_context get_default_mode_input_context();
+input_context create_default_mode_input_context();
+input_context &get_default_mode_input_context();
 
 enum quit_status {
     QUIT_NO = 0,    // Still playing


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Improve turn performance by caching default input ctx"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Slightly faster turns by caching the list of default actions, instead of recreating that list for each turn.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
* Adds `static` variable for `input_context default_mode_input_context`.
* Reason for making this a static variable is
	* `get_default_mode_input_context` is called for each `do_turn`
	* we should not need to recreate the vector of actions for each turn
* Changes `get_default_mode_input_context` so that it now returns a reference to the same instance each time, and not a new copy.

#### Describe alternatives you've considered

* Also making it `const`

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Tested that rebinding keys still works
* Playing a bit, picking up items, dropping, crafting.
* Cancelling ongoing craft
* Cancelling "wait 1 hour"
* Note: have **not** tested android build - but reusing the same instance of `input_context` should work like it does on desktop version, right?

Before:
![get_default_mode_input_context before](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/4e88b4da-55e4-4c5a-a340-6f2f4efe49fe)

After:
![get_default_mode_input_context after](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/683a03d5-ffaa-4801-a5b4-d14e02cc4294)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
