### PR TITLE
It gets hot (Overheat mechanics for energy guns)

### DIFF
--- a/data/json/faults/faults_guns.json
+++ b/data/json/faults/faults_guns.json
@@ -28,5 +28,32 @@
     "type": "fault",
     "name": { "str": "Fouling" },
     "description": "Fouling is caused by firing gunpowder loads repeatedly, which reduces reliability and can eventually cause damage to the gun.  Fouling accumulates slowly (unless blackpowder is used) due to the design of modern smokeless powder found in the vast majority of retail cartridges and it is not a significant problem until high levels of fouling are reached due to firing thousands of rounds without cleaning your firearm."
+  },
+  {
+    "id": "fault_overheat_explosion",
+    "type": "fault",
+    "name": { "str": "Fatal containment failure" },
+    "description": "It got hot."
+  },
+  {
+    "id": "fault_overheat_venting",
+    "type": "fault",
+    "name": { "str": "Emergency venting" },
+    "description": "This weapon can uncontrollably vent coolant when overheated."
+  },
+  {
+    "id": "fault_overheat_melting",
+    "type": "fault",
+    "name": { "str": "Fused internals" },
+    "description": "Excessive heat has rendered this weapon inoperable.",
+    "item_prefix": "ruined",
+    "flags": [ "RUINED_GUN" ]
+  },
+  {
+    "id": "fault_overheat_safety",
+    "type": "fault",
+    "name": { "str": "Overheat safety" },
+    "description": "This weapon will attempt to enter a cooling cycle when overheated.",
+    "flags": [ "JAMMED_GUN" ]
   }
 ]

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -191,6 +191,11 @@
     "conflicts": [ "PARTIAL_DEAF" ]
   },
   {
+    "id": "OVERHEATS",
+    "type": "json_flag",
+    "info": "Continuously firing this weapon will cause it to <bad>overheat</bad> and <info>can potentially damage it</info>."
+  },
+  {
     "id": "DIAMOND",
     "type": "json_flag",
     "info": "This item has a <good>diamond coating</good> improving its <info>cutting or piercing damage</info>.",

--- a/data/json/items/gun/ups.json
+++ b/data/json/items/gun/ups.json
@@ -23,6 +23,9 @@
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 3 ] ],
     "loudness": 23,
     "energy_drain": "60 kJ",
+    "overheat_threshold": 100,
+    "cooling_value": 3,
+    "heat_per_shot": 10,
     "reload": 0,
     "valid_mod_locations": [
       [ "emitter", 1 ],
@@ -35,7 +38,8 @@
       [ "underbarrel", 1 ]
     ],
     "ammo_effects": [ "DRAW_LASER_BEAM", "EMP" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS" ],
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
+    "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
     "melee_damage": { "bash": 12 }
   },
   {
@@ -125,6 +129,9 @@
     "dispersion": 10,
     "durability": 8,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ], [ "AUTO", "auto", 4 ] ],
+    "overheat_threshold": 100,
+    "cooling_value": 2,
+    "heat_per_shot": 5,
     "loudness": 12,
     "energy_drain": "40 kJ",
     "reload": 0,
@@ -140,7 +147,8 @@
       [ "underbarrel", 1 ]
     ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS" ],
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
+    "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
     "melee_damage": { "bash": 12 }
   },
   {
@@ -190,9 +198,13 @@
     "loudness": 7,
     "energy_drain": "10 kJ",
     "reload": 200,
+    "overheat_threshold": 60,
+    "cooling_value": 2,
+    "heat_per_shot": 6,
     "valid_mod_locations": [ [ "emitter", 1 ], [ "grip", 1 ], [ "lens", 1 ], [ "rail", 1 ], [ "sights", 1 ], [ "stock", 1 ], [ "underbarrel", 1 ] ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS" ],
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "USE_UPS", "OVERHEATS" ],
+    "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
     "melee_damage": { "bash": 5 }
   },
   {

--- a/data/json/items/gun/ups.json
+++ b/data/json/items/gun/ups.json
@@ -68,6 +68,10 @@
     "modes": [ [ "DEFAULT", "3 rd.", 3 ], [ "BURST", "5 rd.", 5 ], [ "AUTO", "high auto", 15 ] ],
     "ammo_effects": [ "LASER", "PLASMA_BUBBLE", "INCENDIARY" ],
     "flags": [ "NO_UNLOAD", "NEVER_JAMS", "NO_UNWIELD", "NO_SALVAGE", "NO_REPAIR", "UNBREAKABLE_MELEE", "NON_FOULING", "USE_UPS" ],
+    "overheat_threshold": 200,
+    "cooling_value": 2,
+    "heat_per_shot": 6,
+    "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
     "melee_damage": { "bash": 8 }
   },
   {
@@ -105,6 +109,10 @@
       "NEEDS_NO_LUBE",
       "USE_UPS"
     ],
+    "overheat_threshold": 100,
+    "cooling_value": 2,
+    "heat_per_shot": 17,
+    "faults": [ "fault_overheat_melting", "fault_overheat_safety" ],
     "melee_damage": { "bash": 6 }
   },
   {

--- a/data/mods/Aftershock/itemgroups/weapons/energy_gun_groups.json
+++ b/data/mods/Aftershock/itemgroups/weapons/energy_gun_groups.json
@@ -41,7 +41,7 @@
     "subtype": "distribution",
     "ammo": 100,
     "magazine": 100,
-    "items": [ [ "afs_pam-41", 30 ] ]
+    "items": [ [ "afs_pam-41", 30 ], [ "afs_magnadrive_230k", 30 ] ]
   },
   {
     "id": "afs_any_energy_mag",
@@ -66,7 +66,7 @@
     "type": "item_group",
     "subtype": "distribution",
     "ammo": 100,
-    "items": [ [ "afs_4g_plasma", 30 ] ]
+    "items": [ [ "afs_4g_plasma", 30 ], [ "afs_20g_plasma", 20 ] ]
   },
   {
     "type": "item_group",

--- a/data/mods/Aftershock/items/gun/plasma.json
+++ b/data/mods/Aftershock/items/gun/plasma.json
@@ -27,6 +27,47 @@
     "melee_damage": { "bash": 6 }
   },
   {
+    "id": "afs_magnadrive_230k",
+    "type": "GUN",
+    "name": { "str": "Magnadrive 230K" },
+    "copy-from": "afs_plasma_base",
+    "looks_like": "plasma_gun",
+    "description": "A heavy plasma railgun that easily defeats most forms of conventional armor and flash-incinerates anything  behind it.  Its large size and liability to overheat make it unsuitable for infantry use, but it is a common sight on military vehicles and in the hands of power-armored troops, especially when heavy armor is expected.",
+    "weight": "8500 g",
+    "volume": "4 L",
+    "longest_side": "45 cm",
+    "price": "15 kUSD",
+    "price_postapoc": "15 kUSD",
+    "range": 15,
+    "ranged_damage": [
+      { "damage_type": "bullet", "amount": 15, "armor_penetration": 30 },
+      { "damage_type": "heat", "amount": 40, "armor_penetration": 10 }
+    ],
+    "delete": { "ammo_effects": [ "FLAME" ] },
+    "extend": { "flags": [ "OVERHEATS" ] },
+    "ammo": [ "afs_shydrogen" ],
+    "dispersion": 200,
+    "ammo_to_fire": 2,
+    "overheat_threshold": 100,
+    "cooling_value": 3,
+    "heat_per_shot": 30,
+    "recoil": 30,
+    "durability": 4,
+    "loudness": 5,
+    "reload": 1800,
+    "pocket_data": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "holster": true,
+        "magazine_well": "120 ml",
+        "max_contains_volume": "20 L",
+        "max_contains_weight": "20 kg",
+        "item_restriction": [ "afs_20g_plasma", "afs_4g_plasma" ]
+      }
+    ],
+    "faults": [ "fault_overheat_explosion", "fault_overheat_venting", "fault_overheat_safety" ]
+  },
+  {
     "id": "afs_pam-41",
     "type": "GUN",
     "name": { "str": "PAM-41 2g" },
@@ -77,7 +118,7 @@
     "charges_per_use": 2,
     "use_action": [ "OXYTORCH" ],
     "qualities": [ [ "WELD", 2 ] ],
-    "flags": [ "ALLOWS_REMOTE_USE" ],
+    "flags": [ "ALLOWS_REMOTE_USE", "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE", "OVERHEATS" ],
     "gun_data": {
       "dispersion": 1500,
       "ammo_to_fire": 2,
@@ -88,6 +129,9 @@
       "delete": { "ammo_effects": [ "FLAME", "EXPLOSIVE_SMALL" ] },
       "extend": { "ammo_effects": [ "DAZZLE_BEAM" ] },
       "range": 3,
+      "overheat_threshold": 100,
+      "cooling_value": 3,
+      "heat_per_shot": 27,
       "ranged_damage": [
         { "damage_type": "bullet", "amount": 35, "armor_penetration": 30 },
         { "damage_type": "heat", "amount": 30, "armor_penetration": 10 }
@@ -103,6 +147,7 @@
         "max_contains_weight": "20 kg",
         "item_restriction": [ "afs_40g_plasma_civ" ]
       }
-    ]
+    ],
+    "faults": [ "fault_overheat_melting" ]
   }
 ]

--- a/data/mods/Aftershock/items/magazine/plasma.json
+++ b/data/mods/Aftershock/items/magazine/plasma.json
@@ -19,6 +19,25 @@
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "airtight": true, "ammo_restriction": { "afs_shydrogen": 4 } } ]
   },
   {
+    "id": "afs_20g_plasma",
+    "looks_like": "plasma",
+    "type": "MAGAZINE",
+    "name": { "str": "20g plasma cell" },
+    "description": "A reinforced canister that can safely store up to 20 grams of solid hydrogen in a cryo-pressurized state.",
+    "weight": "30 g",
+    "volume": "120 ml",
+    "price": "1400 USD",
+    "price_postapoc": "1400 USD",
+    "material": [ "hydrogen_cell" ],
+    "symbol": "o",
+    "color": "light_blue",
+    "ammo_type": [ "afs_shydrogen" ],
+    "flags": [ "NO_UNLOAD", "NO_RELOAD" ],
+    "capacity": 4,
+    "reload_time": 10,
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "airtight": true, "ammo_restriction": { "afs_shydrogen": 20 } } ]
+  },
+  {
     "id": "afs_40g_plasma_civ",
     "looks_like": "plasma",
     "type": "MAGAZINE",

--- a/src/character.h
+++ b/src/character.h
@@ -2895,6 +2895,9 @@ class Character : public Creature, public visitable
         /** Returns true if a gun misfires, jams, or has other problems, else returns false */
         bool handle_gun_damage( item &it );
 
+        /**Handles overheat mechanics for guns, returns true if the gun cant fire due to overheat effects*/
+        bool handle_gun_overheat( item &it );
+
         /** Get maximum recoil penalty due to vehicle motion */
         double recoil_vehicle() const;
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6420,9 +6420,9 @@ std::string item::overheat_symbol() const
         case 3:
             return string_format( _( "<color_light_red>\u2585HEAT </color>" ) );
         case 4:
-            return string_format( _( "<color_red>\u2587HEAT! </color>" ) );
+            return string_format( _( "<color_red>\u2587HEAT! </color>" ) ); // NOLINT(cata-text-style)
         case 5:
-            return string_format( _( "<color_pink>\u2588HEAT!! </color>" ) );
+            return string_format( _( "<color_pink>\u2588HEAT!! </color>" ) ); // NOLINT(cata-text-style)
         default:
             return "";
     }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -138,6 +138,8 @@ static const efftype_id effect_shakes( "shakes" );
 static const efftype_id effect_sleep( "sleep" );
 static const efftype_id effect_weed_high( "weed_high" );
 
+static const fault_id fault_overheat_safety( "fault_overheat_safety" );
+
 static const furn_str_id furn_f_metal_smoking_rack_active( "f_metal_smoking_rack_active" );
 static const furn_str_id furn_f_smoking_rack_active( "f_smoking_rack_active" );
 static const furn_str_id furn_f_water_mill_active( "f_water_mill_active" );
@@ -1451,6 +1453,9 @@ bool item::stacks_with( const item &rhs, bool check_components, bool combine_liq
         return false;
     }
     if( techniques != rhs.techniques ) {
+        return false;
+    }
+    if( overheat_symbol() != rhs.overheat_symbol() ) {
         return false;
     }
     // Guns with enough fouling to change the indicator symbol don't stack
@@ -6397,6 +6402,32 @@ std::string item::dirt_symbol() const
     }
 }
 
+std::string item::overheat_symbol() const
+{
+
+    if( !is_gun() || type->gun->overheat_threshold <= 0.0 ) {
+        return "";
+    }
+    if( faults.count( fault_overheat_safety ) ) {
+        return string_format( _( "<color_light_green>\u2588VNT </color>" ) );
+    }
+    switch( std::min( 5, static_cast<int>( get_var( "gun_heat",
+                                           0 ) / ( type->gun->overheat_threshold ) * 5.0 ) ) ) {
+        case 1:
+            return "";
+        case 2:
+            return string_format( _( "<color_yellow>\u2583HEAT </color>" ) );
+        case 3:
+            return string_format( _( "<color_light_red>\u2585HEAT </color>" ) );
+        case 4:
+            return string_format( _( "<color_red>\u2587HEAT! </color>" ) );
+        case 5:
+            return string_format( _( "<color_pink>\u2588HEAT!! </color>" ) );
+        default:
+            return "";
+    }
+}
+
 std::string item::degradation_symbol() const
 {
     const int inc = max_damage() / 5;
@@ -6438,6 +6469,7 @@ std::string item::tname( unsigned int quantity, bool with_prefix, unsigned int t
         }
     }
     damtext += dirt_symbol();
+    damtext += overheat_symbol();
 
     if( get_option<std::string>( "ASTERISK_POSITION" ) == "prefix" && with_prefix ) {
         if( is_favorite ) {
@@ -12323,7 +12355,7 @@ int item::processing_speed() const
 
     if( active || ethereal || wetness || link ||
         has_flag( flag_RADIO_ACTIVATION ) || has_relic_recharge() ||
-        has_fault_flag( flag_BLACKPOWDER_FOULING_DAMAGE ) ) {
+        has_fault_flag( flag_BLACKPOWDER_FOULING_DAMAGE ) || get_var( "gun_heat", 0 ) > 0 ) {
         // Unless otherwise indicated, update every turn.
         return 1;
     }
@@ -13479,6 +13511,32 @@ bool item::process_blackpowder_fouling( Character *carrier )
     return false;
 }
 
+bool item::process_gun_cooling( Character *carrier )
+{
+    double heat = get_var( "gun_heat", 0 );
+    double threshold = type->gun->overheat_threshold;
+    heat -= type->gun->cooling_value;
+    set_var( "gun_heat", std::max( 0.0, heat ) );
+    if( faults.count( fault_overheat_safety ) && heat < threshold * 0.2 ) {
+        faults.erase( fault_overheat_safety );
+        if( carrier ) {
+            carrier->add_msg_if_player( m_good, _( "Your %s beeps as its cooling cycle concludes." ), tname() );
+        }
+    }
+    if( carrier ) {
+        if( heat > threshold ) {
+            carrier->add_msg_if_player( m_bad,
+                                        _( "You can feel the struggling systems of your %s beneath the blare of the overheat alarm." ),
+                                        tname() );
+        } else if( heat > threshold * 0.8 ) {
+            carrier->add_msg_if_player( m_bad, _( "Your %s frantically sounds an overheat alarm." ), tname() );
+        } else if( heat > threshold * 0.6 ) {
+            carrier->add_msg_if_player( m_warning, _( "Your %s sounds a heat warning chime!" ), tname() );
+        }
+    }
+    return false;
+}
+
 bool item::process( map &here, Character *carrier, const tripoint &pos, float insulation,
                     temperature_flag flag, float spoil_multiplier_parent, bool recursive )
 {
@@ -13640,6 +13698,9 @@ bool item::process_internal( map &here, Character *carrier, const tripoint &pos,
         // guns are never active so we only need to tick this on inactive items. For performance reasons.
         if( has_fault_flag( flag_BLACKPOWDER_FOULING_DAMAGE ) ) {
             return process_blackpowder_fouling( carrier );
+        }
+        if( get_var( "gun_heat", 0 ) > 0 ) {
+            return process_gun_cooling( carrier );
         }
     }
 

--- a/src/item.h
+++ b/src/item.h
@@ -373,6 +373,11 @@ class item : public visitable
         std::string dirt_symbol() const;
 
         /**
+         * Returns a symbol for indicating the overheat level for a gun.
+         */
+        std::string overheat_symbol() const;
+
+        /**
          * Returns a symbol indicating the current degradation of the item.
          */
         std::string degradation_symbol() const;
@@ -2954,6 +2959,7 @@ class item : public visitable
         bool process_link( map &here, Character *carrier, const tripoint &pos );
         bool process_linked_item( Character *carrier, const tripoint &pos, link_state required_state );
         bool process_blackpowder_fouling( Character *carrier );
+        bool process_gun_cooling( Character *carrier );
         bool process_tool( Character *carrier, const tripoint &pos );
 
     public:

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2724,6 +2724,9 @@ void Item_factory::load( islot_gun &slot, const JsonObject &jo, const std::strin
     assign( jo, "min_cycle_recoil", slot.min_cycle_recoil, strict, 0 );
     assign( jo, "ammo_effects", slot.ammo_effects, strict );
     assign( jo, "ammo_to_fire", slot.ammo_to_fire, strict, 0 );
+    assign( jo, "heat_per_shot", slot.heat_per_shot, strict, 0.0 );
+    assign( jo, "cooling_value", slot.cooling_value, strict, 0.0 );
+    assign( jo, "overheat_threshold", slot.overheat_threshold, strict, -1.0 );
 
     if( jo.has_array( "valid_mod_locations" ) ) {
         slot.valid_mod_locations.clear();

--- a/src/itype.h
+++ b/src/itype.h
@@ -755,6 +755,24 @@ struct islot_gun : common_ranged_data {
 
     int ammo_to_fire = 1;
 
+    /**
+    * The amount by which the item's overheat value is reduced every turn. Used in
+    * overheat-based guns.
+    */
+    double cooling_value = 100.0;
+
+    /**
+    *  Used only in overheat-based guns. No melting LMG barrels yet.
+    */
+    double heat_per_shot = 0.0;
+
+    /**
+    * Used in overheat-based guns.
+    * Heat value at which critical overheat faults might occur.
+    * A value beneath 0.0 means that the gun cannot overheat.
+    */
+    double overheat_threshold = -1.0;
+
     std::map<ammotype, std::set<itype_id>> cached_ammos;
 
     /**


### PR DESCRIPTION
#### Summary
Features  "Add overheat mechanics to energy guns."

#### Purpose of change

Energy weapons, with their lack of recoil and generally deep magazines are pretty hard to balance properly, especially as they become more powerfull, since the player can just stand somewhere and turn into a deadly accurate floodlamp of death after a few seconds of aiming.  Overheating is a good way to limit this ability.

Also anything close to a combat pulse laser would make tons of heat as I understand it.

#### Describe the solution

Guns can now define the fields `heat_per_shot` `overheat_threshold` and `cooling_value`  and the faults included here to display safe or potentially deadly overheat effects (which are mostly explained in the fault descriptions themselves). Overall, they can be used to create the standard overheat events of FPS's, cheap guns that melt during sustained fire,  and 40K style exploding plasma rifles.

Includes a demo Plasma gun for Aftershock and the vanilla lasers have been expanded to also overheat (mostly safely).

#### Testing
Used both overheat prone guns and normal ones.