### PR TITLE
[Magiclysm] Add ancient stone circle (with translocate altar)

### DIFF
--- a/data/mods/Magiclysm/furniture_and_terrain/furniture.json
+++ b/data/mods/Magiclysm/furniture_and_terrain/furniture.json
@@ -6,7 +6,7 @@
     "move_cost_mod": 10,
     "symbol": "H",
     "color": "white",
-    "looks_like": "f_altar",
+    "looks_like": "f_boulder_earthshaper",
     "coverage": 40,
     "required_str": 30,
     "description": "An ancient stone altar, moss-grown and weather-worn.",

--- a/data/mods/Magiclysm/furniture_and_terrain/furniture.json
+++ b/data/mods/Magiclysm/furniture_and_terrain/furniture.json
@@ -1,0 +1,50 @@
+[
+  {
+    "type": "furniture",
+    "id": "f_teleport_altar",
+    "name": "stone altar",
+    "move_cost_mod": 10,
+    "symbol": "H",
+    "color": "white",
+    "looks_like": "f_altar",
+    "coverage": 40,
+    "required_str": 30,
+    "description": "An ancient stone altar, moss-grown and weather-worn.",
+    "examine_action": "translocator",
+    "bash": {
+      "str_min": 30,
+      "str_max": 160,
+      "sound": "smash!",
+      "sound_fail": "thump.",
+      "items": [ { "item": "rock", "count": [ 5, 15 ] }, { "item": "sharp_rock", "count": [ 3, 5 ] } ]
+    },
+    "flags": [ "TRANSPARENT", "SHORT", "FLAT_SURF", "TRANSLOCATOR" ]
+  },
+  {
+    "type": "furniture",
+    "id": "f_myst_standing_stone",
+    "looks_like": "f_boulder_large",
+    "name": "standing stone",
+    "description": "A tall standing stone.  It is covered in carvings, but they are so worn by wind and rain you can't make out what they might have been.",
+    "symbol": "O",
+    "color": "light_gray",
+    "move_cost_mod": -1,
+    "coverage": 65,
+    "required_str": 32,
+    "flags": [ "NOITEM", "MINEABLE", "BLOCK_WIND" ],
+    "bash": {
+      "str_min": 64,
+      "str_max": 160,
+      "sound": "smash!",
+      "sound_fail": "thump.",
+      "items": [
+        { "item": "rock", "count": [ 10, 22 ] },
+        { "item": "sharp_rock", "count": [ 3, 7 ] },
+        { "item": "material_limestone", "charges": [ 2, 5 ], "prob": 30 },
+        { "item": "material_rocksalt", "count": [ 0, 1 ], "prob": 10 },
+        { "item": "material_rhodonite", "count": [ 0, 1 ], "prob": 1 },
+        { "item": "material_zincite", "count": [ 0, 5 ], "prob": 2 }
+      ]
+    }
+  }
+]

--- a/data/mods/Magiclysm/worldgen/overmap_specials.json
+++ b/data/mods/Magiclysm/worldgen/overmap_specials.json
@@ -245,5 +245,15 @@
     "city_sizes": [ 0, 20 ],
     "occurrences": [ 0, 2 ],
     "spawns": { "group": "GROUP_FOREST", "population": [ 1, 7 ], "radius": [ 1, 3 ] }
+  },
+  {
+    "type": "overmap_special",
+    "id": "standing_teleport_stones",
+    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "standing_teleport_stones" } ],
+    "locations": [ "wilderness" ],
+    "city_distance": [ 20, -1 ],
+    "city_sizes": [ 0, 20 ],
+    "occurrences": [ 66, 100 ],
+    "flags": [ "UNIQUE" ]
   }
 ]

--- a/data/mods/Magiclysm/worldgen/overmap_terrain.json
+++ b/data/mods/Magiclysm/worldgen/overmap_terrain.json
@@ -489,5 +489,14 @@
     "color": "blue",
     "flags": [ "NO_ROTATE" ],
     "see_cost": 5
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "standing_teleport_stones" ],
+    "name": "standing stones",
+    "sym": "O",
+    "color": "dark_gray",
+    "flags": [ "NO_ROTATE", "REQUIRES_PREDECESSOR" ],
+    "see_cost": 5
   }
 ]

--- a/data/mods/Magiclysm/worldgen/overmap_terrain.json
+++ b/data/mods/Magiclysm/worldgen/overmap_terrain.json
@@ -493,7 +493,7 @@
   {
     "type": "overmap_terrain",
     "id": [ "standing_teleport_stones" ],
-    "name": "standing stones",
+    "name": "ancient ring of stones",
     "sym": "O",
     "color": "dark_gray",
     "flags": [ "NO_ROTATE", "REQUIRES_PREDECESSOR" ],

--- a/data/mods/Magiclysm/worldgen/teleport_standing_stones.json
+++ b/data/mods/Magiclysm/worldgen/teleport_standing_stones.json
@@ -1,0 +1,46 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "standing_teleport_stones",
+    "object": {
+      "fill_ter": "t_region_groundcover",
+      "fallback_predecessor_mapgen": "field",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "          S,S           ",
+        "        S,,,,,S         ",
+        "      S,,,S,S,,,S       ",
+        "      ,,,,,,,,,,,       ",
+        "     S,,,S,,,S,,,S      ",
+        "     ,,,,,,S,,,,,,      ",
+        "    S,,,S,mmm,S,,,S     ",
+        "     ,,,,,mAm,,,,,      ",
+        "    S,,,S,mmm,S,,,S     ",
+        "     ,,,,,,S,,,,,,      ",
+        "     S,,,S,,,S,,,S      ",
+        "      ,,,,,,,,,,,       ",
+        "      S,,,S,S,,,S       ",
+        "        S,,,,,S         ",
+        "          S,S           ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "terrain": {
+        ",": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_dirt", 25 ] ],
+        "S": [ [ "t_moss", 50 ], [ "t_grass", 25 ], [ "t_dirt", 25 ] ],
+        "m": [ [ "t_moss", 100 ] ],
+        "A": [ [ "t_moss", 100 ] ],
+        " ": "t_null"
+      },
+      "furniture": { "S": [ [ "f_myst_standing_stone", 65 ], [ "f_rubble_rock", 35 ] ], "A": "f_teleport_altar" },
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Add ancient stone circle (with translocate altar)"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

How did people translocate before modern technology was invented? Obviously, they built big megaliths and used them.  What else would those standing stones be for?
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add an "ancient ring of stones" overmap special. It's two concentric rings of stones (or maybe rubble--it's been a while) with an altar in the center that acts as a beacon for translocating to. This does not make the spell Translocate Self easier to find, but it does let the player (especially innawoods) have places they can go if they can't find teleporters.  The trade-off is that the ring could be anywhere and is almost definitely not near a city. 

The ring of stones is unique, with a 2/3 chance to spawn per overmap. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Teleported around a bunch and found some rings.  The vast majority of the time, they were off in the wild by themselves, and if they were near something it was another wilderness building. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/a736f7ab-ea1c-479d-b968-410af7834e11)


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
