### PR TITLE
Infrastructure for netherum labyrinths / labyrinthine structures

### DIFF
--- a/data/json/furniture_and_terrain/terrain-netherum_labyrinth.json
+++ b/data/json/furniture_and_terrain/terrain-netherum_labyrinth.json
@@ -26,7 +26,7 @@
     "id": "t_nl_elevator_floor",
     "name": "janky elevator floor",
     "description": "This looks like someone made an elevator out of an old phone booth or some similar kind of thing.  It's small, but could fit a few people cramped in.",
-    "symbol": "$",
+    "symbol": "#",
     "color": "black_blue",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "INDOORS", "FLAT" ]
@@ -35,14 +35,42 @@
     "type": "terrain",
     "id": "t_nl_elevator_wall",
     "name": "janky elevator wall",
-    "looks_like": "t_metal_wall",
+    "looks_like": "t_scrap_wall",
     "description": "This looks like someone made an elevator out of an old phone booth or some similar kind of thing.  It's small, but could fit a few people cramped in.",
     "symbol": "LINE_OXOX",
-    "color": "cyan",
-    "move_cost": 0,
+    "color": "blue",
+    "move_cost": -1,
     "coverage": 100,
     "roof": "t_nl_roof",
     "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ]
+  },
+  {
+    "type": "terrain",
+    "id": "t_nl_elevator_door_c",
+    "name": "janky elevator door",
+    "looks_like": "t_door_metal_c",
+    "description": "A hinged door blocking off a janky, rickety-looking elevator made out of scrap.",
+    "symbol": "$",
+    "color": "black_blue",
+    "move_cost": -1,
+    "coverage": 100,
+    "roof": "t_nl_roof",
+    "flags": [ "NOITEM", "DOOR", "CONNECT_WITH_WALL", "BLOCK_WIND", "SUPPORTS_ROOF" ],
+    "open": "t_nl_elevator_door_o"
+  },
+  {
+    "type": "terrain",
+    "id": "t_nl_elevator_door_o",
+    "name": "janky elevator door",
+    "looks_like": "t_door_metal_c",
+    "description": "A hinged door blocking off a janky, rickety-looking elevator made out of scrap.",
+    "symbol": "\",
+    "color": "black_blue",
+    "move_cost": 2,
+    "coverage": 20,
+    "roof": "t_nl_roof",
+    "flags": [ "NOITEM", "DOOR", "CONNECT_WITH_WALL", "BLOCK_WIND", "SUPPORTS_ROOF" ],
+    "close": "t_nl_elevator_door_c"
   },
   {
     "type": "terrain",
@@ -104,6 +132,7 @@
     "color": "light_cyan",
     "connect_groups": "METALFLOOR",
     "connects_to": "METALFLOOR",
+    "looks_like": "t_metal_floor",
     "move_cost": 2,
     "roof": "t_nl_roof",
     "flags": [ "TRANSPARENT", "INDOORS", "FLAT", "ROAD" ],
@@ -126,6 +155,7 @@
     "move_cost": 2,
     "roof": "t_nl_roof",
     "flags": [ "TRANSPARENT", "INDOORS" ],
+    "looks_like": "t_broken_metal_floor",
     "bash": {
       "sound": "thump",
       "ter_set": "t_nl_chasm",
@@ -144,11 +174,12 @@
     "type": "terrain",
     "id": "t_nl_scrap_floor",
     "name": "scrap metal floor",
-    "description": "A crudely welded-together metal floor with steel trusses and supporting girders.",
+    "description": "A floor assembled from various scraps of metal.  Though their placement seems random, you keep seeing spots where they form faces.",
     "symbol": ".",
     "color": "cyan",
     "move_cost": 2,
     "roof": "t_nl_roof",
+    "looks_like": "t_scrap_floor",
     "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "ROAD" ],
     "bash": {
       "str_min": 50,
@@ -158,5 +189,16 @@
       "str_min_supported": 100,
       "items": [ { "item": "steel_chunk", "count": [ 5, 11 ] } ]
     }
+  },
+  {
+    "type": "terrain",
+    "id": "t_nl_metal_roof",
+    "name": "swirling metal roof",
+    "description": "A section of sturdy metal roofing that seems to swirl and twist with an unfamiliar, ever-shifting pattern.",
+    "symbol": ".",
+    "looks_like": "t_metal_roof",
+    "color": "dark_gray",
+    "move_cost": 2,
+    "flags": [ "TRANSPARENT", "FLAT", "ROAD" ]
   }
 ]

--- a/data/json/furniture_and_terrain/terrain-netherum_labyrinth.json
+++ b/data/json/furniture_and_terrain/terrain-netherum_labyrinth.json
@@ -1,0 +1,162 @@
+[
+  {
+    "type": "terrain",
+    "id": "t_nl_mist",
+    "name": "swirling mist",
+    "description": "A swirling, exotic patern of shapes, floating in an ill-defined darkness.  Staring at it too long hurts your brain.",
+    "symbol": "LINE_OXOX",
+    "color": "green",
+    "coverage": 100,
+    "move_cost": -1,
+    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "BLOCK_WIND" ]
+  },
+  {
+    "type": "terrain",
+    "id": "t_nl_chasm",
+    "name": "sparkling chasm",
+    "description": "At a glance this just looks like darkness.  Then, gazing deeper, you think it might be full of stars.  Still deeper, perhaps those stars are eyes?",
+    "symbol": "*",
+    "color": "dark_grey",
+    "move_cost": -1,
+    "//": "Future: stepping on this should teleport you out of the labyrinth",
+    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "INDOORS", "FLAT", "NOITEM" ]
+  },
+  {
+    "type": "terrain",
+    "id": "t_nl_elevator_floor",
+    "name": "janky elevator floor",
+    "description": "This looks like someone made an elevator out of an old phone booth or some similar kind of thing.  It's small, but could fit a few people cramped in.",
+    "symbol": "$",
+    "color": "black_blue",
+    "move_cost": 2,
+    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "INDOORS", "FLAT" ]
+  },
+  {
+    "type": "terrain",
+    "id": "t_nl_elevator_wall",
+    "name": "janky elevator wall",
+    "looks_like": "t_metal_wall",
+    "description": "This looks like someone made an elevator out of an old phone booth or some similar kind of thing.  It's small, but could fit a few people cramped in.",
+    "symbol": "LINE_OXOX",
+    "color": "cyan",
+    "move_cost": 0,
+    "coverage": 100,
+    "roof": "t_nl_roof",
+    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ]
+  },
+  {
+    "type": "terrain",
+    "id": "t_nl_metal_wall",
+    "name": "metallic wall",
+    "looks_like": "t_metal_wall",
+    "description": "A durable wall of ordinary looking sheet metal, at first.  Staring closer, the welds and joins seem to form strange fractal patterns.",
+    "symbol": "LINE_OXOX",
+    "color": "cyan",
+    "move_cost": 0,
+    "coverage": 100,
+    "roof": "t_nl_roof",
+    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
+    "oxytorch": {
+      "result": "t_nl_mist",
+      "duration": "24 seconds",
+      "byproducts": [ { "item": "steel_plate", "count": [ 2, 3 ] }, { "item": "steel_chunk", "count": [ 12, 20 ] } ]
+    },
+    "bash": {
+      "str_min": 150,
+      "str_max": 400,
+      "sound": "metal wailing!",
+      "sound_fail": "clang!",
+      "ter_set": "t_nl_mist",
+      "items": [
+        { "item": "steel_lump", "count": [ 1, 4 ] },
+        { "item": "steel_chunk", "count": [ 3, 12 ] },
+        { "item": "scrap", "count": [ 9, 36 ] }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_nl_scrap_wall",
+    "name": "scrap metal wall",
+    "looks_like": "t_scrap_wall",
+    "description": "A relatively simple wall made of cobbled-together scrap metal.  The wires and bolts holding it together seem to be in just slightly different configurations whenever you look back at it.",
+    "symbol": "LINE_OXOX",
+    "color": "dark_gray",
+    "move_cost": 0,
+    "coverage": 100,
+    "roof": "t_nl_roof",
+    "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "REDUCE_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
+    "bash": {
+      "str_min": 80,
+      "str_max": 200,
+      "sound": "metal crying!",
+      "sound_fail": "clang!",
+      "ter_set": "t_nl_mist",
+      "items": [ { "item": "steel_chunk", "count": [ 10, 22 ] } ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_nl_metal_floor",
+    "name": "metallic floor",
+    "description": "Diamond-treaded metallic flooring.  Something seems off about the diamond tread; you keep imagining that the bumps spell out words, but when you look closer they're in very ordinary patterns.",
+    "symbol": ".",
+    "color": "light_cyan",
+    "connect_groups": "METALFLOOR",
+    "connects_to": "METALFLOOR",
+    "move_cost": 2,
+    "roof": "t_nl_roof",
+    "flags": [ "TRANSPARENT", "INDOORS", "FLAT", "ROAD" ],
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_nl_broken_metal_floor",
+      "str_min": 200,
+      "str_max": 500,
+      "str_min_supported": 200,
+      "items": [ { "item": "steel_chunk", "count": [ 2, 4 ] }, { "item": "scrap", "count": [ 1, 3 ] } ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_nl_broken_metal_floor",
+    "name": "broken metal floor",
+    "description": "Something has cratered this metal flooring.  It will be difficult to move things across.  Through the cracks and dents emanates a faint eery glow.",
+    "symbol": ".",
+    "color": "light_cyan",
+    "move_cost": 2,
+    "roof": "t_nl_roof",
+    "flags": [ "TRANSPARENT", "INDOORS" ],
+    "bash": {
+      "sound": "thump",
+      "ter_set": "t_nl_chasm",
+      "str_min": 200,
+      "str_max": 500,
+      "sound": "Bang!",
+      "str_min_supported": 200,
+      "items": [
+        { "item": "steel_lump", "count": [ 1, 4 ] },
+        { "item": "steel_chunk", "count": [ 3, 12 ] },
+        { "item": "scrap", "count": [ 9, 36 ] }
+      ]
+    }
+  },
+  {
+    "type": "terrain",
+    "id": "t_nl_scrap_floor",
+    "name": "scrap metal floor",
+    "description": "A crudely welded-together metal floor with steel trusses and supporting girders.",
+    "symbol": ".",
+    "color": "cyan",
+    "move_cost": 2,
+    "roof": "t_nl_roof",
+    "flags": [ "TRANSPARENT", "SUPPORTS_ROOF", "COLLAPSES", "INDOORS", "FLAT", "ROAD" ],
+    "bash": {
+      "str_min": 50,
+      "str_max": 400,
+      "sound": "SMASH!",
+      "ter_set": "t_nl_chasm",
+      "str_min_supported": 100,
+      "items": [ { "item": "steel_chunk", "count": [ 5, 11 ] } ]
+    }
+  }
+]

--- a/data/json/furniture_and_terrain/terrain-netherum_labyrinth.json
+++ b/data/json/furniture_and_terrain/terrain-netherum_labyrinth.json
@@ -85,7 +85,7 @@
     "roof": "t_nl_roof",
     "flags": [ "NOITEM", "SUPPORTS_ROOF", "WALL", "NO_SCENT", "AUTO_WALL_SYMBOL", "MINEABLE", "BLOCK_WIND" ],
     "oxytorch": {
-      "result": "t_nl_mist",
+      "result": "t_nl_broken_metal_floor",
       "duration": "24 seconds",
       "byproducts": [ { "item": "steel_plate", "count": [ 2, 3 ] }, { "item": "steel_chunk", "count": [ 12, 20 ] } ]
     },
@@ -94,7 +94,7 @@
       "str_max": 400,
       "sound": "metal wailing!",
       "sound_fail": "clang!",
-      "ter_set": "t_nl_mist",
+      "ter_set": "t_nl_broken_metal_floor",
       "items": [
         { "item": "steel_lump", "count": [ 1, 4 ] },
         { "item": "steel_chunk", "count": [ 3, 12 ] },
@@ -119,7 +119,7 @@
       "str_max": 200,
       "sound": "metal crying!",
       "sound_fail": "clang!",
-      "ter_set": "t_nl_mist",
+      "ter_set": "t_nl_broken_metal_floor",
       "items": [ { "item": "steel_chunk", "count": [ 10, 22 ] } ]
     }
   },

--- a/data/json/furniture_and_terrain/terrain-netherum_labyrinth.json
+++ b/data/json/furniture_and_terrain/terrain-netherum_labyrinth.json
@@ -3,7 +3,7 @@
     "type": "terrain",
     "id": "t_nl_mist",
     "name": "swirling mist",
-    "description": "A swirling, exotic patern of shapes, floating in an ill-defined darkness.  Staring at it too long hurts your brain.",
+    "description": "A swirling, exotic pattern of shapes, floating in an ill-defined darkness.  Staring at it too long hurts your brain.",
     "symbol": "LINE_OXOX",
     "color": "green",
     "coverage": 100,

--- a/data/json/furniture_and_terrain/terrain-netherum_labyrinth.json
+++ b/data/json/furniture_and_terrain/terrain-netherum_labyrinth.json
@@ -64,7 +64,7 @@
     "name": "janky elevator door",
     "looks_like": "t_door_metal_c",
     "description": "A hinged door blocking off a janky, rickety-looking elevator made out of scrap.",
-    "symbol": "\",
+    "symbol": "/",
     "color": "black_blue",
     "move_cost": 2,
     "coverage": 20,

--- a/data/json/mapgen/labyrinth/labyrinth_base.json
+++ b/data/json/mapgen/labyrinth/labyrinth_base.json
@@ -1,0 +1,130 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "labyrinth" ],
+    "object": {
+      "fill_ter": "t_nl_mist",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "terrain": { " ": "t_nl_mist" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "labyrinth_f1.01_NW",
+    "//": "Northwest corner of the 1st floor labyrinth, option 01",
+    "object": {
+      "mapgensize": [ 24,24 ],
+      "rows": [
+        "                        ",
+        " EEEEE                  ",
+        " EeeeE                  ",
+        " EeeeE                  ",
+        " EEÉEE           #######",
+        " |...|           #___+_#",
+        " |...|           #___#_+",
+        " |...||||||||||||#####_#",
+        " |......|.......|||||__+",
+        " ||.....+........+__|_##",
+        "  ||....|........###|+| ",
+        "   |||+|||||.......#__| ",
+        "    |.....||.......#__| ",
+        "    |......|.......#__| ",
+        "    |......|.......#__| ",
+        "    |......||......#+|| ",
+        "    |.......+.........| ",
+        "    |.......+.........| ",
+        "    |......|||||||||||| ",
+        "    |......|            ",
+        "    ||....||            ",
+        "     ||||||             ",
+        "                        ",
+        "                        "
+      ],
+      "terrain": { 
+        " ": "t_nl_mist",
+        "e": "t_nl_elevator_floor",
+        "E": "t_nl_elevator_wall",
+        "É": "t_nl_elevator_door_c",
+        "|": "t_nl_metal_wall",
+        "#": "t_nl_scrap_wall",
+        "+": "t_nl_metal_door_c",
+        ".": "t_nl_metal_floor",
+        "_": "t_nl_scrap_floor"
+      }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "labyrinth_f1.01_NE",
+    "//": "Northeast corner of the 1st floor labyrinth, option 01",
+    "object": {
+      "mapgensize": [ 24,24 ],
+      "rows": [
+        "            ||||||      ",
+        "          |||....|||    ",
+        " ||||||  ||........||   ",
+        " |....| ||..........||  ",
+        " |****| |............|  ",
+        "##****|||............|| ",
+        "......|...............| ",
+        "#.....+...............| ",
+        "......|...............| ",
+        "##****|||............|| ",
+        " |****| |............|  ",
+        " |....| ||..........||  ",
+        " ||||||  ||........||   ",
+        "          |||....|||    ",
+        "            ||||||      ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        "
+      ],
+      "terrain": { 
+        " ": "t_nl_mist",
+        "*": "t_nl_chasm",
+        "e": "t_nl_elevator_floor",
+        "E": "t_nl_elevator_wall",
+        "É": "t_nl_elevator_door_c",
+        "|": "t_nl_metal_wall",
+        "#": "t_nl_scrap_wall",
+        "+": "t_nl_metal_door_c",
+        ".": "t_nl_metal_floor",
+        "_": "t_nl_scrap_floor"
+      }
+    }
+  }
+]

--- a/data/json/mapgen/labyrinth/labyrinth_base.json
+++ b/data/json/mapgen/labyrinth/labyrinth_base.json
@@ -40,7 +40,7 @@
     "nested_mapgen_id": "labyrinth_f1.01_NW",
     "//": "Northwest corner of the 1st floor labyrinth, option 01",
     "object": {
-      "mapgensize": [ 24,24 ],
+      "mapgensize": [ 24, 24 ],
       "rows": [
         "                        ",
         " EEEEE                  ",
@@ -67,7 +67,7 @@
         "                        ",
         "                        "
       ],
-      "terrain": { 
+      "terrain": {
         " ": "t_nl_mist",
         "e": "t_nl_elevator_floor",
         "E": "t_nl_elevator_wall",
@@ -86,7 +86,7 @@
     "nested_mapgen_id": "labyrinth_f1.01_NE",
     "//": "Northeast corner of the 1st floor labyrinth, option 01",
     "object": {
-      "mapgensize": [ 24,24 ],
+      "mapgensize": [ 24, 24 ],
       "rows": [
         "            ||||||      ",
         "          |||....|||    ",
@@ -113,7 +113,7 @@
         "                        ",
         "                        "
       ],
-      "terrain": { 
+      "terrain": {
         " ": "t_nl_mist",
         "*": "t_nl_chasm",
         "e": "t_nl_elevator_floor",


### PR DESCRIPTION
#### Summary
Content "Adds the early working parts to a new dungeon type"

#### Purpose of change
Since I started adding the exodii in 2020-2021, and then getting floored with the life of a healthcare practitioner during a pandemic, their core necessary content has been languishing. It's starting to move again, thanks to sarius skelrets and mng cataclysm, but we're still behind on a key feature - exodii/cbm related dungeons. These should serve as a place to go raiding for alien technology and cybernetics, eventually allowing them to be moved from labs. This in turn should be the last death knell for the "one stop shop" labs of old, where you go in as an early game character and come out with every reward the game has to offer and nothing much left to do with them.

#### Describe the solution
Labyrinthine structures are a long-planned exodii dungeon type that will serve as new, raidable content from the late-early game up to the endgame (I hope!) and will provide a place to go spelunking for CBMs and artifacts, as well as just a different sort of content than most of what we currently have. While I envision a somewhat procedural type of content for the eventual future, this will represent a single static "demo" of what they could be like. 

I will work on this PR basically until it becomes too much to review, and then I'll complete it and start working on the next. What I plan is:
- You can ask Rubik for ideas about where to get more high tech salvage. They suggest you could check out a labyrinth they spotted, and they give you some of the backstory as to what these things are. (A labyrinth is a netherum place kind of similar to the mines we have in game already, but the exodii create them on purpose as a way of generating useful resources). This creates a single specific labyrinth, which cannot otherwise spawn randomly.
- The labyrinth shows as a stone and steel spire with an elevator built onto it. Activating this elevator causes an EoC to trigger, taking you underground into a newly formed floor of the dungeon. Leaving the dungeon despawns this floor , so if you leave to lick your wounds and come back, the enemies will form anew. The type of floor generated will be cached until you complete it by reaching the elevator at the other end, so you can't shuffle the rooms by leaving and coming back (although for now, I will only be creating one type of room anyway). 
- The dungeon room is surrounded by indestructible material but the interiors can still be blown up, allowing you to use standard cataclysm !!fun!! to explore interesting workarounds.
- This first dungeon area will be a 4x4 set of rooms containing fairly normal encounters with zomborgs and some netherum copies of exodii units, toned down for playability, as well as some environmental hazards. There'll be some minor puzzles and secrets but nothing too out of the ordinary yet.
- In the future, you'll be able to go to deeper levels, each elevator pass will take you to something a little more nether-ish and less normal.


##### Enemies for this pass:
These guys will be the filler enemies:
- zomborg, unchanged from outside.
- tinlegs: looks mostly like a quad but smaller. Fast moving, high armour but low hp, hitting them in the legs (weakpoint) causes them to crumple and be much easier to kill even if you can't overcome their armour. melee only.
- stomper: humanoid, like an exodii worker. Has a medium-ranged attack. Decent HP and armour. Resistant to ranged attacks but quite vulnerable in melee.
- blazer: a turret, fires blasts of heat and lightning. Semi rare.

I also want some enemies that add interesting drain attacks as I have outlined in #55795.  These guys would be the 'feature' enemies or threats in some of the rooms, but wouldn't spawn everywhere.

If you have some ideas for rooms I could create that ask interesting questions of the player, and are doable with our current EOC system, feel free to suggest - though please, if you don't already know at least a bit about our capabilities, don't overflow me with your cool ideas that I can't use without a ton of programming.

#### Describe alternatives you've considered

I'd really like this to actually be in another dimension, but the code isn't there yet. When that's possible, I'd like to migrate this to that system

#### Testing
Draft

#### Additional context

For the moment I am not sure if it will be possible for your NPCs to accompany you into the dungeon or not. They run a very high risk of getting despawned when the floor despawns, so we might have to get you to leave them behind.