### PR TITLE
Fix field base camp version 2 NE shack/tent progression

### DIFF
--- a/data/json/recipes/basecamps/base/recipe_modular_hub/version_2/recipe_modular_field_common.json
+++ b/data/json/recipes/basecamps/base/recipe_modular_hub/version_2/recipe_modular_field_common.json
@@ -98,7 +98,7 @@
         "fbmh_2_bed_palette": "Bed"
       }
     },
-    "blueprint_requires": [ { "id": "fbmh_2_room_1_2" } ],
+    "blueprint_requires": [ { "id": "fbmh_2_room_NE", "amount": 2 } ],
     "blueprint_provides": [ { "id": "fbmh_2_bed_NE_2" } ],
     "blueprint_excludes": [ { "id": "fbmh_2_bed_NE_2" } ]
   },

--- a/data/json/recipes/basecamps/base/recipe_modular_hub/version_2/recipe_modular_field_construction.json
+++ b/data/json/recipes/basecamps/base/recipe_modular_hub/version_2/recipe_modular_field_construction.json
@@ -103,7 +103,7 @@
         "fbmh_2_wood_palette": "Wooden walls and wooden roof"
       }
     },
-    "blueprint_requires": [ { "id": "fbmh_2_room_1_3" } ],
+    "blueprint_requires": [ { "id": "fbmh_2_room_NE", "amount": 4 } ],
     "blueprint_provides": [ { "id": "fbmh_2_room_ENE", "amount": 4 } ],
     "blueprint_excludes": [ { "id": "fbmh_2_room_ENE" } ]
   },

--- a/data/json/recipes/basecamps/base/recipe_modular_hub/version_2/recipe_modular_field_tent.json
+++ b/data/json/recipes/basecamps/base/recipe_modular_hub/version_2/recipe_modular_field_tent.json
@@ -29,7 +29,7 @@
     "time": "3 h",
     "construction_blueprint": "fbmh_2_tent_room_ENE",
     "blueprint_name": "east north east tent",
-    "blueprint_requires": [ { "id": "fbmh_2_room_NE", "amount": 4 }, { "id": "fbmh_2_fire_NE" }, { "id": "fbmh_2_bed_NE_2" } ],
+    "blueprint_requires": [ { "id": "fbmh_2_room_NE", "amount": 4 } ],
     "blueprint_provides": [ { "id": "fbmh_2_room_ENE", "amount": 4 } ],
     "blueprint_excludes": [ { "id": "fbmh_2_room_ENE" } ],
     "components": [ [ [ "large_tent_kit", 1 ], [ "broketent", 4 ], [ "tent_kit", 3 ], [ "shelter_kit", 4 ] ] ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #67979 

The criteria for NE shack/tent progression were incorrect in a few ways:
- The tent path still required cooking and bedding, while the construction path no longer did.
- The bed progression required the building step 2 for the second bed even when a tent was constructed.
- The construction path allowed the construction of a second building before all three steps of the first one had been completed.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change requires criteria for recipes to be what they should be to progress the upgrade paths correctly.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Constructed field base camp version 2.
- Constructed a tent.
- Verified that both tent and building progression was available.
- Restarted and created the camp again.
- Constructed the first building stage (mi-go resin, as that's the easiest).
- Verified cooking, bed, and the second stage was available, but not further tent or buildings.
- Constructed the second building stage.
- Verified cooking, bed, and the third stage was available, but not further tent or buildings.
- Constructed the third building stage.
- Verified cooking, bed, and now tent and the next building was available for construction.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
