### PR TITLE
[Magiclysm] "Frost Cream Man" Profession now has the Driving proficiency

### DIFF
--- a/data/mods/Magiclysm/professions.json
+++ b/data/mods/Magiclysm/professions.json
@@ -970,6 +970,7 @@
     "name": { "male": "Frost Cream Man", "female": "Frost Cream Woman" },
     "description": "You learned Kelvinist spells to keep equipment costs down on your ice cream truck.  While their tastes have changed, the kids still scream for you.",
     "points": 4,
+    "proficiencies": [ "prof_driver" ],
     "spells": [ { "id": "chilling_touch", "level": 3 }, { "id": "frost_spray", "level": 3 } ],
     "skills": [
       { "level": 2, "name": "speech" },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Recently Driving was changed so that you need a proficiency to properly steer the car, and the proficiency was added to every profession that started with a vehicle. Whoever did this apparently missed this profession, so I added it in.

#### Describe the solution

Gave the "Frost Cream Man/Woman" Profession the `prof_driving` proficiency.


#### Testing
 
N/A

