### PR TITLE
Fix visible tiles revealing invisible tiles below

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1756,13 +1756,6 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                         tripoint draw_loc = p.com.pos;
                         draw_loc.z = cur_zlevel;
 
-                        // Calculate ll and invisible if not in cache
-                        if( ll_invis_cache.count( draw_loc ) == 0 ) {
-                            ll_invis_cache[ draw_loc ] = calc_ll_invis( draw_loc );
-                        }
-                        const lit_level ll = ll_invis_cache[ draw_loc ].first;
-                        const std::array<bool, 5> invisible = ll_invis_cache[ draw_loc ].second;
-
                         if( const tile_render_info::vision_effect * const
                             var = std::get_if<tile_render_info::vision_effect>( &p.var ) ) {
                             if( f == &cata_tiles::draw_terrain ) {
@@ -1770,6 +1763,23 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                             }
                         } else if( const tile_render_info::sprite * const
                                    var = std::get_if<tile_render_info::sprite>( &p.var ) ) {
+
+                            // Get visibility variables
+                            lit_level ll;
+                            std::array<bool, 5> invisible;
+                            if( cur_zlevel == center.z ) {
+                                // For the same z-level, use tile_render_info vars
+                                ll = var->ll;
+                                invisible = var->invisible;
+                            } else {
+                                // Otherwise, recalculate ll and invisible
+                                if( ll_invis_cache.count( draw_loc ) == 0 ) {
+                                    ll_invis_cache[ draw_loc ] = calc_ll_invis( draw_loc );
+                                }
+                                ll = ll_invis_cache[ draw_loc ].first;
+                                invisible = ll_invis_cache[ draw_loc ].second;
+                            }
+
                             if( f == &cata_tiles::draw_vpart_no_roof || f == &cata_tiles::draw_vpart_roof ) {
                                 int temp_height_3d = p.com.height_3d;
                                 // Reset height_3d to base when drawing vehicles

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1772,11 +1772,11 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                                 invisible = var->invisible;
                             } else {
                                 // Otherwise, recalculate ll and invisible
-                                if( ll_invis_cache.count( draw_loc ) == 0 ) {
-                                    ll_invis_cache[ draw_loc ] = calc_ll_invis( draw_loc );
+                                if( here.ll_invis_cache.count( draw_loc ) == 0 ) {
+                                    here.ll_invis_cache[ draw_loc ] = calc_ll_invis( draw_loc );
                                 }
-                                ll = ll_invis_cache[ draw_loc ].first;
-                                invisible = ll_invis_cache[ draw_loc ].second;
+                                ll = here.ll_invis_cache[ draw_loc ].first;
+                                invisible = here.ll_invis_cache[ draw_loc ].second;
                             }
 
                             if( f == &cata_tiles::draw_vpart_no_roof || f == &cata_tiles::draw_vpart_roof ) {
@@ -2009,7 +2009,7 @@ std::pair<lit_level, std::array<bool, 5>> cata_tiles::calc_ll_invis( const tripo
 
 void cata_tiles::clear_draw_caches()
 {
-    ll_invis_cache.clear();
+    get_map().ll_invis_cache.clear();
 }
 
 void cata_tiles::draw_minimap( const point &dest, const tripoint &center, int width, int height )

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1745,7 +1745,6 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                 }
                 // For each layer
                 for( auto f : drawing_layers ) {
-                    std::map<tripoint, std::pair<lit_level, std::array<bool, 5>>> ll_invis_cache;
                     // For each tile
                     for( tile_render_info &p : draw_points[row] ) {
                         // Skip if z-level less than draw_min_z
@@ -2006,6 +2005,11 @@ std::pair<lit_level, std::array<bool, 5>> cata_tiles::calc_ll_invis( const tripo
 
     std::pair<lit_level, std::array<bool, 5>> ret( ll, invisible );
     return ret;
+}
+
+void cata_tiles::clear_draw_caches()
+{
+    ll_invis_cache.clear();
 }
 
 void cata_tiles::draw_minimap( const point &dest, const tripoint &center, int width, int height )

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1772,10 +1772,17 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                             } else {
                                 // Otherwise, recalculate ll and invisible
                                 if( here.ll_invis_cache.count( draw_loc ) == 0 ) {
-                                    here.ll_invis_cache[ draw_loc ] = calc_ll_invis( draw_loc );
+                                    const std::pair<lit_level, std::array<bool, 5>> ll_invis = calc_ll_invis( draw_loc );
+                                    ll = ll_invis.first;
+                                    invisible = ll_invis.second;
+                                    // Only cache ll_invis if not in test mode
+                                    if( !test_mode ) {
+                                        here.ll_invis_cache[ draw_loc ] = ll_invis;
+                                    }
+                                } else {
+                                    ll = here.ll_invis_cache[ draw_loc ].first;
+                                    invisible = here.ll_invis_cache[ draw_loc ].second;
                                 }
-                                ll = here.ll_invis_cache[ draw_loc ].first;
-                                invisible = here.ll_invis_cache[ draw_loc ].second;
                             }
 
                             if( f == &cata_tiles::draw_vpart_no_roof || f == &cata_tiles::draw_vpart_roof ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1754,7 +1754,6 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                         }
                         tripoint draw_loc = p.com.pos;
                         draw_loc.z = cur_zlevel;
-
                         if( const tile_render_info::vision_effect * const
                             var = std::get_if<tile_render_info::vision_effect>( &p.var ) ) {
                             if( f == &cata_tiles::draw_terrain ) {

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -411,6 +411,7 @@ class cata_tiles
         void draw( const point &dest, const tripoint &center, int width, int height,
                    std::multimap<point, formatted_text> &overlay_strings,
                    color_block_overlay_container &color_blocks );
+        std::pair<lit_level, std::array<bool, 5>> calc_ll_invis( const tripoint &draw_loc );
         void draw_om( const point &dest, const tripoint_abs_omt &center_abs_omt, bool blink );
 
         /** Minimap functionality */

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -805,8 +805,6 @@ class cata_tiles
 
         pimpl<pixel_minimap> minimap;
 
-        std::map<tripoint, std::pair<lit_level, std::array<bool, 5>>> ll_invis_cache;
-
     public:
         // Draw caches persist data between draws to avoid unnecessary recalculations
         // Any event that would invalidate cached data should also clear it

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -411,6 +411,8 @@ class cata_tiles
         void draw( const point &dest, const tripoint &center, int width, int height,
                    std::multimap<point, formatted_text> &overlay_strings,
                    color_block_overlay_container &color_blocks );
+        // Standalone version of the ll and invisible calculations normally done when accumulating draw_points
+        // Used to determine visibility of lower z-levels in 3D vision without generating extra draw_points and overlay_strings
         std::pair<lit_level, std::array<bool, 5>> calc_ll_invis( const tripoint &draw_loc );
         void draw_om( const point &dest, const tripoint_abs_omt &center_abs_omt, bool blink );
 

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -805,7 +805,15 @@ class cata_tiles
 
         pimpl<pixel_minimap> minimap;
 
+        std::map<tripoint, std::pair<lit_level, std::array<bool, 5>>> ll_invis_cache;
+
     public:
+        // Draw caches persist data between draws to avoid unnecessary recalculations
+        // Any event that would invalidate cached data should also clear it
+        // Currently only includes ll_invis_cache
+        // Performance gain from caching draw_points, overlay_strings and color_blocks is negligible
+        void clear_draw_caches();
+
         std::string memory_map_mode = "color_pixel_sepia";
 };
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -3868,11 +3868,6 @@ void game::draw( ui_adaptor &ui )
         return;
     }
 
-    //temporary fix for updating visibility for minimap
-    ter_view_p.z = ( u.pos() + u.view_offset ).z;
-    m.build_map_cache( ter_view_p.z );
-    m.update_visibility_cache( ter_view_p.z );
-
     werase( w_terrain );
     void_blink_curses();
     draw_ter();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7725,6 +7725,11 @@ look_around_result game::look_around(
                            get_map().get_abs_sub().x(), get_map().get_abs_sub().y(), center.z );
             u.view_offset.z = center.z - u.posz();
             m.invalidate_map_cache( center.z );
+            // Update map and visibility caches at target z-level
+            // Map cache is also built at player z-level to fix player not visible from higher z-levels
+            m.build_map_cache( u.posz() );
+            m.build_map_cache( center.z );
+            m.update_visibility_cache( center.z );
         } else if( action == "TRAVEL_TO" ) {
             const std::optional<std::vector<tripoint_bub_ms>> try_route = safe_route_to( u, lp,
             0,  []( const std::string & msg ) {

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -260,6 +260,7 @@ input_context game::get_player_input( std::string &action )
         ctxt = get_default_mode_input_context();
     }
 
+    m.build_map_cache( u.posz() );
     m.update_visibility_cache( u.posz() );
     const visibility_variables &cache = m.get_visibility_variables_cache();
     const level_cache &map_cache = m.get_cache_ref( u.posz() );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6565,6 +6565,9 @@ void map::update_submaps_with_active_items()
 void map::update_visibility_cache( const int zlev )
 {
     Character &player_character = get_player_character();
+    if ( player_character.pos().z - zlev < fov_3d_z_range && zlev > -OVERMAP_DEPTH ) {
+    	update_visibility_cache( zlev - 1 );
+    }
     visibility_variables_cache.variables_set = true; // Not used yet
     visibility_variables_cache.g_light_level = static_cast<int>( g->light_level( zlev ) );
     visibility_variables_cache.vision_threshold = player_character.get_vision_threshold(

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -109,6 +109,11 @@
 #include "weather.h"
 #include "weighted_list.h"
 
+#if defined(TILES)
+#include "cata_tiles.h" // all animation functions will be pushed out to a cata_tiles function in some manner
+#include "sdltiles.h"
+#endif
+
 static const ammotype ammo_battery( "battery" );
 
 static const damage_type_id damage_bash( "bash" );
@@ -6565,8 +6570,8 @@ void map::update_submaps_with_active_items()
 void map::update_visibility_cache( const int zlev )
 {
     Character &player_character = get_player_character();
-    if ( player_character.pos().z - zlev < fov_3d_z_range && zlev > -OVERMAP_DEPTH ) {
-    	update_visibility_cache( zlev - 1 );
+    if( player_character.pos().z - zlev < fov_3d_z_range && zlev > -OVERMAP_DEPTH ) {
+        update_visibility_cache( zlev - 1 );
     }
     visibility_variables_cache.variables_set = true; // Not used yet
     visibility_variables_cache.g_light_level = static_cast<int>( g->light_level( zlev ) );
@@ -6608,6 +6613,11 @@ void map::update_visibility_cache( const int zlev )
             }
         }
     }
+
+#if defined(TILES)
+    // clear previously cached visibility variables from cata_tiles
+    tilecontext->clear_draw_caches();
+#endif
 }
 
 const visibility_variables &map::get_visibility_variables_cache() const

--- a/src/map.h
+++ b/src/map.h
@@ -2277,6 +2277,8 @@ class map
 
         bool has_haulable_items( const tripoint &pos );
         std::vector<item_location> get_haulable_items( const tripoint &pos );
+
+        std::map<tripoint, std::pair<lit_level, std::array<bool, 5>>> ll_invis_cache;
 };
 
 map &get_map();

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -240,23 +240,28 @@ void player_activity::do_turn( Character &you )
     }
     // Only do once every two minutes to loosely simulate consume times,
     // the exact amount of time is added correctly below, here we just want to prevent eating something every second
-    if( calendar::once_every( 2_minutes ) && *this && !you.is_npc() && type->valid_auto_needs() &&
-        !you.has_effect( effect_nausea ) ) {
-        if( you.stomach.contains() <= you.stomach.capacity( you ) / 4 && you.get_kcal_percent() < 0.95f &&
-            !no_food_nearby_for_auto_consume ) {
-            int consume_moves = get_auto_consume_moves( you, true );
-            moves_left += consume_moves;
-            if( consume_moves == 0 ) {
-                no_food_nearby_for_auto_consume = true;
+    if( calendar::once_every( 2_minutes ) && *this && !you.is_npc() ) {
+        if( type->valid_auto_needs() && !you.has_effect( effect_nausea ) ) {
+            if( you.stomach.contains() <= you.stomach.capacity( you ) / 4 && you.get_kcal_percent() < 0.95f &&
+                !no_food_nearby_for_auto_consume ) {
+                int consume_moves = get_auto_consume_moves( you, true );
+                moves_left += consume_moves;
+                if( consume_moves == 0 ) {
+                    no_food_nearby_for_auto_consume = true;
+                }
+            }
+            if( you.get_thirst() > 130 && !no_drink_nearby_for_auto_consume ) {
+                int consume_moves = get_auto_consume_moves( you, false );
+                moves_left += consume_moves;
+                if( consume_moves == 0 ) {
+                    no_drink_nearby_for_auto_consume = true;
+                }
             }
         }
-        if( you.get_thirst() > 130 && !no_drink_nearby_for_auto_consume ) {
-            int consume_moves = get_auto_consume_moves( you, false );
-            moves_left += consume_moves;
-            if( consume_moves == 0 ) {
-                no_drink_nearby_for_auto_consume = true;
-            }
-        }
+        // Also update map and visibility caches every 2 minutes
+        map &here = get_map();
+        here.build_map_cache( you.pos().z );
+        here.update_visibility_cache( you.pos().z );
     }
     const float activity_mult = you.exertion_adjusted_move_multiplier( exertion_level() );
     if( type->based_on() == based_on_type::TIME ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix visible tiles revealing invisible tiles below"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The way 3D vision currently handles tile visibility is by calculating visibility variables for the current z-level and have every z-level underneath inherit the same values.  In cases where a tile on the current z-level should be visible but the tile underneath should not, the player will be able to see both tiles due to the non-visible tile underneath inheriting the visibility variables of the visible tile above it.  Correcting this will fix #66040.  Also a prerequisite for the lightmap changes in #67434.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
There are two parts to this solution:

1. Instead on updating the visibility cache on the current z-level only, we update the z-levels below as well, limited by the 3D vertical range setting.
2. In the tileset code, pull new variables from the visibility cache on each z-level to determine light level.

Naturally, these make processing visibility somewhat more CPU intensive.  To compensate, map cache and visibility cache are no longer calculated every draw.  Any event that alters these can simply call `map::build_map_cache` and `map::update_visibility_cache` instead.  This involves the removal of the temporary fix introduced in #15868.  The issues targeted by the fix (#15842 and #15854) are not reproducible.

Overall, these changes have a positive effect on draw performance leading to an 11% decrease in draw times.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiles ok.
Confirmed that invisible tiles no longer show as visible when viewing visible tiles on a higher z-level.

Before:
![before](https://github.com/CleverRaven/Cataclysm-DDA/assets/129854247/e5629116-fe83-49af-9bfb-df5605167f14)
After:
![after](https://github.com/CleverRaven/Cataclysm-DDA/assets/129854247/aa1df82b-8a0b-40c9-bf3d-6ef8f6a3ae09)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
