### PR TITLE
[MoM] Add overheating to LV-429

### DIFF
--- a/data/mods/MindOverMatter/itemgroups/matrix_technology_labs.json
+++ b/data/mods/MindOverMatter/itemgroups/matrix_technology_labs.json
@@ -72,6 +72,12 @@
   {
     "type": "item_group",
     "subtype": "distribution",
+    "id": "dist_pulse_rifles_heavy_prototype",
+    "items": [ { "item": "mom_pulse_rifle", "prob": 1 }, { "item": "mom_pulse_rifle_prototype", "prob": 4 } ]
+  },
+  {
+    "type": "item_group",
+    "subtype": "distribution",
     "id": "dist_psionic_shield_belts",
     "groups": [ [ "dist_fire_shield_belts", 1 ], [ "dist_shield_belts", 1 ] ]
   },

--- a/data/mods/MindOverMatter/items/weapons.json
+++ b/data/mods/MindOverMatter/items/weapons.json
@@ -68,7 +68,7 @@
     "range": 35,
     "dispersion": 10,
     "overheat_threshold": 100,
-    "cooling_value": 5,
+    "cooling_value": 4,
     "heat_per_shot": 21,
     "recoil": 0,
     "durability": 4,
@@ -101,6 +101,9 @@
     "copy-from": "mom_pulse_rifle",
     "name": { "str": "LV429-P Pulse Rifle" },
     "description": "The LV429 fires a series of extremely short high-energy laser pulses, more like bullets than a traditional laser beam, greatly reducing dwell time and increasing weapon effectiveness.  Matrix crystal technology has made the weapon compact enough to be man-portable and provided it with enough power for essentially unlimited operation.  This is a prototype, obvious from the bright red coloration of the barrel and grip, as well as the word \"prototype\" written in large letters on the stock and the flammable symbol next to it.",
+    "overheat_threshold": 100,
+    "cooling_value": 5,
+    "heat_per_shot": 21,
     "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "2 s", "regenerate_ammo": true } },
     "//": "Recharge time is 8 seconds due to bug #48019, making it actually 1 second. Reduce to 1 seconds if that ever gets fixed."
   }

--- a/data/mods/MindOverMatter/items/weapons.json
+++ b/data/mods/MindOverMatter/items/weapons.json
@@ -53,7 +53,7 @@
     "type": "GUN",
     "reload_noise_volume": 10,
     "name": { "str": "LV429 Pulse Rifle" },
-    "description": "The LV429 fires a series of extremely short high-energy laser pulses, more like bullets than a traditional laser beam, greatly reducing dwell time and weapon effectiveness.  Matrix crystal technology has made the weapon compact enough to be man-portable and provided it with enough power for essentially unlimited operation, but heat dissipation is still a problem, preventing it from being fired more than once every few seconds.",
+    "description": "The LV429 fires a series of extremely short high-energy laser pulses, more like bullets than a traditional laser beam, greatly reducing dwell time and increasing weapon effectiveness.  Matrix crystal technology has made the weapon compact enough to be man-portable and provided it with enough power for essentially unlimited combat operations, but heat dissipation is still a problem, preventing it from being fired more than once every few seconds.",
     "weight": "4350 g",
     "volume": "3 L",
     "longest_side": "965 mm",
@@ -67,9 +67,13 @@
     "skill": "rifle",
     "range": 35,
     "dispersion": 10,
-    "durability": 10,
+    "overheat_threshold": 100,
+    "cooling_value": 5,
+    "heat_per_shot": 21,
+    "recoil": 0,
+    "durability": 3,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ] ],
-    "loudness": 23,
+    "loudness": 5,
     "reload": 0,
     "clip_size": 1,
     "valid_mod_locations": [
@@ -84,9 +88,20 @@
     ],
     "ammo": [ "mom_pulse_rifle_ammo" ],
     "ammo_effects": [ "LASER", "INCENDIARY" ],
-    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "NO_REPAIR" ],
+    "flags": [ "NEVER_JAMS", "NO_UNLOAD", "NON_FOULING", "NEEDS_NO_LUBE", "NO_REPAIR", "OVERHEATS" ],
+    "faults": [ "fault_overheat_explosion", "fault_overheat_melting" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "mom_pulse_rifle_ammo": 1 } } ],
     "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "8 s", "regenerate_ammo": true } },
     "//": "Recharge time is 8 seconds due to bug #48019, making it actually 4 seconds. Reduce to 4 seconds if that ever gets fixed."
+  },
+  {
+    "id": "mom_pulse_rifle_prototype",
+    "looks_like": "ar15",
+    "type": "GUN",
+    "copy-from": "mom_pulse_rifle",
+    "name": { "str": "LV429-P Pulse Rifle" },
+    "description": "The LV429 fires a series of extremely short high-energy laser pulses, more like bullets than a traditional laser beam, greatly reducing dwell time and increasing weapon effectiveness.  Matrix crystal technology has made the weapon compact enough to be man-portable and provided it with enough power for essentially unlimited operation.  This is a prototype, obvious from the bright red coloration of the barrel and grip, as well as the word \"prototype\" written in large letters on the stock and the flammable symbol next to it.",
+    "relic_data": { "charge_info": { "recharge_type": "periodic", "time": "2 s", "regenerate_ammo": true } },
+    "//": "Recharge time is 8 seconds due to bug #48019, making it actually 1 second. Reduce to 1 seconds if that ever gets fixed."
   }
 ]

--- a/data/mods/MindOverMatter/items/weapons.json
+++ b/data/mods/MindOverMatter/items/weapons.json
@@ -71,7 +71,7 @@
     "cooling_value": 5,
     "heat_per_shot": 21,
     "recoil": 0,
-    "durability": 3,
+    "durability": 4,
     "modes": [ [ "DEFAULT", "semi-auto", 1 ] ],
     "loudness": 5,
     "reload": 0,

--- a/data/mods/MindOverMatter/mapgen/nested/office_phavian_modular.json
+++ b/data/mods/MindOverMatter/mapgen/nested/office_phavian_modular.json
@@ -717,7 +717,7 @@
     "type": "mapgen",
     "method": "json",
     "//": "A nested map for the Phavian secret office lab room south of the hall, door in the upper left.  This is a weapons lab",
-    "weight": 50,
+    "weight": 450,
     "nested_mapgen_id": "office_phavian_lab_DN8x8",
     "object": {
       "mapgensize": [ 8, 8 ],
@@ -726,19 +726,23 @@
         "........",
         "...çç...",
         "...ⱮⱮ..ç",
-        "C..Aɱ..ç",
+        "C..Aɱ..è",
         "C......M",
         "CA....cɱ",
         "C.....UU"
       ],
       "palettes": [ "office_phavian_palette" ],
+      "furniture": { "è": "f_lab_bench" },
       "place_item": [
         { "item": "grenade_inferno", "x": 7, "y": 3, "chance": 30, "repeat": [ 1, 2 ] },
-        { "item": "mom_pulse_rifle", "x": 7, "y": 4, "chance": 15 },
         { "item": "grenade_inferno", "x": 7, "y": 4, "chance": 60, "repeat": [ 1, 3 ] },
         { "item": "schematics_grenade_inferno", "x": 7, "y": 7, "chance": 60 }
       ],
       "items": {
+        "è": [
+          { "item": "psi_lab", "chance": 20, "repeat": [ 1, 3 ] },
+          { "item": "dist_pulse_rifles_heavy_prototype", "chance": 40 }
+        ],
         "l": [ { "item": "lab_torso", "chance": 40, "repeat": [ 1, 8 ] }, { "item": "lab_shoes", "chance": 40, "repeat": [ 1, 8 ] } ],
         "U": [ { "item": "psi_lab", "chance": 50, "repeat": [ 1, 3 ] } ],
         "&": { "item": "trash", "chance": 75, "repeat": [ 1, 2 ] }
@@ -753,7 +757,7 @@
     "type": "mapgen",
     "method": "json",
     "//": "A nested map for the Phavian secret office lab room north of the hall, door in the lower right.  This is a weapons lab",
-    "weight": 50,
+    "weight": 450,
     "nested_mapgen_id": "office_phavian_lab_DS8x8",
     "object": {
       "mapgensize": [ 8, 8 ],
@@ -761,20 +765,24 @@
         "UU.....C",
         "ɱc....AC",
         "M......C",
-        "ç..ɱA..C",
+        "è..ɱA..C",
         "ç..ⱮⱮ...",
         "...çç...",
         "........",
         "....l&.."
       ],
+      "furniture": { "è": "f_lab_bench" },
       "palettes": [ "office_phavian_palette" ],
       "place_item": [
         { "item": "grenade_inferno", "x": 0, "y": 4, "chance": 30, "repeat": [ 1, 2 ] },
-        { "item": "mom_pulse_rifle", "x": 0, "y": 3, "chance": 15 },
         { "item": "grenade_inferno", "x": 0, "y": 3, "chance": 60, "repeat": [ 1, 3 ] },
         { "item": "schematics_grenade_inferno", "x": 0, "y": 0, "chance": 60 }
       ],
       "items": {
+        "è": [
+          { "item": "psi_lab", "chance": 20, "repeat": [ 1, 3 ] },
+          { "item": "dist_pulse_rifles_heavy_prototype", "chance": 40 }
+        ],
         "l": [ { "item": "lab_torso", "chance": 40, "repeat": [ 1, 8 ] }, { "item": "lab_shoes", "chance": 40, "repeat": [ 1, 8 ] } ],
         "U": [ { "item": "psi_lab", "chance": 50, "repeat": [ 1, 3 ] } ],
         "&": { "item": "trash", "chance": 75, "repeat": [ 1, 2 ] }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Add overheating to LV-429"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

High heat was supposed to be the flaw of the  LV-429, but there was previously no way to represent that in game. Now there is, so it's time to implement it. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add 
`"overheat_threshold": 100,
    "cooling_value": 4,
    "heat_per_shot": 21,` to the LV-429. Also add an LV-429-P prototype, which does not have the in-built heat limiter and so can be fired much more often. Since it's powered with pyrokinetic matrix technology, the only flaws are "melts" and "explodes." Good luck. 

I fixed the durability as part of this PR as well--at 10 it was much too high. I set it to 4, half that of a laser rifle. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/96987977-9df1-43a1-85a6-07aa6656f570)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/f01f120e-97ca-4ac6-b90e-c2b08ee20297)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
