### PR TITLE
[Magiclysm] Remove default skills from fantasy species choices

### DIFF
--- a/data/mods/Magiclysm/traits/fantasy_species.json
+++ b/data/mods/Magiclysm/traits/fantasy_species.json
@@ -6,7 +6,7 @@
     "name": "Elf (Species)",
     "description": "You are one of the Firstborn, called \"alfar\" or \"sidhe\" or, more recently, \"elves\" by the humans.  Your people had integrated into human society before the Cataclysm, doing jobs involving animals and nature since modern industry was never to your liking.  Had technological development continued, you might have been forced to make some unpleasant compromises, but not as unpleasant as you have during the end of the world.",
     "points": 4,
-    "skills": [ { "level": 2, "name": "archery" }, { "level": 2, "name": "gun" } ],
+    "proficiencies": [ "prof_spotting" ],
     "traits": [
       "THRESH_SPECIES_ELF",
       "ANIMALEMPATH2",
@@ -33,7 +33,6 @@
     "name": "Dwarf (Species)",
     "description": "You are a Child of the Stone, called \"dwarf\" by the humans.  The legends tell that long ago, your people were born of stone and mined your way up to the surface world and its light, where you found the other sapient species of Earth.  While the scale of the human world was always a bit of a problem, you fit in well due to your people's long tradition of craftsdwarfship and hard work.  Now that society has collapsed, maybe you can turn that same drive to rebuilding it.",
     "points": 4,
-    "skills": [ { "level": 2, "name": "fabrication" }, { "level": 2, "name": "mechanics" } ],
     "traits": [
       "THRESH_SPECIES_DWARF",
       "DARKSIGHT",
@@ -62,7 +61,6 @@
     "name": "Goblin (Species)",
     "description": "You are a goblin.  Before the Cataclysm your people were always a little out of place: the houses weren't designed for you, the shops weren't open when you were awake, and your appearance sometimes gave human or elven children nightmares that you were going to steal them or reminded dwarves of the ancient wars your peoples fought.  As it turned out, you weren't what any of them should have been worrying about.",
     "points": 4,
-    "skills": [ { "level": 2, "name": "survival" }, { "level": 2, "name": "traps" } ],
     "traits": [
       "THRESH_SPECIES_GOBLIN",
       "DARKSIGHT",
@@ -89,7 +87,7 @@
     "name": "Lizardfolk (Species)",
     "description": "You are one of the Scaled Ones, called \"lizardfolk\" by the warmbloods.  For generations, your tribe served a dragon as its eyes and ears in the outside world, until civilization encroached far enough that even all the dragon's might could not hold it back.  You were sent out to integrate into the modern world, but you were only there a few years before human science ended their world.  Now, you have to survive in the mess they've created.",
     "points": 4,
-    "skills": [ { "level": 2, "name": "swimming" }, { "level": 2, "name": "unarmed" } ],
+    "skills": [ { "level": 2, "name": "swimming" } ],
     "traits": [
       "THRESH_SPECIES_LIZARDFOLK",
       "LIZARDFOLK_BUILD",
@@ -119,7 +117,7 @@
     "name": "Ravenfolk (Species)",
     "description": "You are one of the Kor'uru, called \"ravenfolk\" by those who can't make the appropriate clacking sound due to their lack of beak.  While your people could not fly without the aid of magic, you were always drawn to explore the world, and had traveled to nearly every country and continent even before modern society made such travel easy.  You were well-integrated into society at all levels…and that made you just as vulnerable as everyone else when it fell.",
     "points": 4,
-    "skills": [ { "level": 2, "name": "swimming" }, { "level": 2, "name": "dodge" } ],
+    "proficiencies": [ "prof_spotting" ],
     "traits": [
       "THRESH_SPECIES_RAVENFOLK",
       "RAVENFOLK_BUILD",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Remove default skills from fantasy species choices"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

When I added the skills to the various fantasy species, it was because I was in TTRPG mode where I was trying to balance them.  But you can pick as many hobbies as you want, so if you want an elf who's an archer, you can just pick the archery hobbies, and that way your door-to-door saleself can be totally inept with a bow if that's what you prefer.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove all default skills from fantasy species (except lizardfolk).
Add the Spotting proficiency to ravenfolk and elves, to represent their by-default extra-keen eyesight.
Lizardfolk keep their levels of Athletics only because there's no Swimming proficiency (yet?).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/58d250f7-aaa8-419d-ab62-169751212ea4)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
