### PR TITLE
Heavy punching bag uses heavy punching bag sack

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -7820,11 +7820,11 @@
     "time": "60 m",
     "qualities": [ [ { "id": "DRILL", "level": 1 } ], [ { "id": "WRENCH_FINE", "level": 1 } ] ],
     "components": [
+      [ [ "heavy_punching_bag_sack", 1 ] ],
       [ [ "nuts_bolts", 4 ] ],
       [ [ "chain", 4 ] ],
       [ [ "blanket", 6 ] ],
       [ [ "material_sand", 4000 ] ],
-      [ [ "bag_plastic", 4 ] ],
       [ [ "duct_tape", 20 ] ]
     ],
     "pre_flags": [ "INDOORS" ],

--- a/data/json/furniture_and_terrain/furniture-recreation.json
+++ b/data/json/furniture_and_terrain/furniture-recreation.json
@@ -397,8 +397,7 @@
         { "item": "nuts_bolts", "charges": 4 },
         { "item": "chain", "count": 4 },
         { "item": "blanket", "count": 6 },
-        { "item": "material_sand", "charges": 4000 },
-        { "item": "bag_plastic", "count": 4 }
+        { "item": "material_sand", "charges": 4000 }
       ]
     },
     "bash": {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #67036

The `hang a heavy punching bag` construction/deconstruction was odd in a couple ways:
- Construction/deconstruction involved `4 plastic bags`. This doesn't make sense.
- Deconstruction yielded a `heavy punching bag sack`. Construction, however, didn't require the item.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changed the recipes to no longer involve `plastic bags`. Changed the construction recipe to use a `heavy punching bag sack`.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

- Spawned materials required for `hang a heavy punching bag` construction 
- `hang a heavy punching bag`  
- Observed `hanging heavy punching bag sack` being consumed
- Deconstruct `heavy punching bag` 
- Spawn `20 duct tape` (required for construction but lost on deconstruction)
- `hang a heavy punching bag`
- Observed `hanging heavy punching bag sack` being consumed again
- Observed `plastic bags` never being involved during testing
- Punched `heavy punching bag` in celebration

#### Additional context
This is my first pull request ever both on GitHub and for CDDA. I beg for your patience if I forget something obvious.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->