### PR TITLE
[CR]Cost reduction of batch item picking and dropping

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -503,6 +503,7 @@ class pickup_activity_actor : public activity_actor
          * if not grabbing from the ground.
          */
         std::optional<tripoint> starting_pos;
+        int batch_num = 1;
 
     public:
         pickup_activity_actor( const std::vector<item_location> &target_items,
@@ -1024,6 +1025,7 @@ class drop_activity_actor : public activity_actor
         contents_change_handler handler;
         tripoint placement;
         bool force_ground = false;
+        int batch_num = 1;
 };
 
 class stash_activity_actor: public activity_actor
@@ -1058,6 +1060,7 @@ class stash_activity_actor: public activity_actor
         std::vector<drop_or_stash_item_info> items;
         contents_change_handler handler;
         tripoint placement;
+        int batch_num = 1;
 };
 
 class harvest_activity_actor : public activity_actor

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -88,7 +88,7 @@ class item_location
 
         /** Calculate (but do not deduct) number of moves required to obtain an item
          *  @see item_location::obtain */
-        int obtain_cost( const Character &ch, int qty = -1 ) const;
+        int obtain_cost( const Character &ch, int qty = -1, int batch_size = 1 ) const;
 
         /** Removes the selected item from the game
          *  @warning all further operations using this class are invalid */
@@ -159,4 +159,7 @@ class item_location
 };
 std::unique_ptr<talker> get_talker_for( item_location &it );
 std::unique_ptr<talker> get_talker_for( item_location *it );
+
+bool can_batch_move( const item_location lhs, const item_location rhs );
+
 #endif // CATA_SRC_ITEM_LOCATION_H

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -161,10 +161,10 @@ bool Pickup::query_thief()
 // Returns false if pickup caused a prompt and the player selected to cancel pickup
 static bool pick_one_up( item_location &loc, int quantity, bool &got_water, bool &got_gas,
                          PickupMap &mapPickup,
-                         bool autopickup, bool &stash_successful, bool &got_frozen_liquid )
+                         bool autopickup, bool &stash_successful, bool &got_frozen_liquid, int batch_num )
 {
     Character &player_character = get_player_character();
-    int moves_taken = loc.obtain_cost( player_character, quantity );
+    int moves_taken = loc.obtain_cost( player_character, quantity, batch_num );
     bool picked_up = false;
     bool crushed = false;
 
@@ -311,7 +311,7 @@ static bool pick_one_up( item_location &loc, int quantity, bool &got_water, bool
 }
 
 bool Pickup::do_pickup( std::vector<item_location> &targets, std::vector<int> &quantities,
-                        bool autopickup, bool &stash_successful )
+                        bool autopickup, bool &stash_successful, int &batch_num )
 {
     bool got_water = false;
     bool got_gas = false;
@@ -337,9 +337,11 @@ bool Pickup::do_pickup( std::vector<item_location> &targets, std::vector<int> &q
             continue;
         }
 
+        bool next_batch_ok = !targets.empty() ? can_batch_move( target, targets.back() ) : false;
         problem = !pick_one_up( target, quantity, got_water, got_gas, mapPickup, autopickup,
                                 stash_successful,
-                                got_frozen_liquid );
+                                got_frozen_liquid, batch_num );
+        batch_num = next_batch_ok ? batch_num + 1 : 1;
     }
 
     if( !mapPickup.empty() ) {

--- a/src/pickup.h
+++ b/src/pickup.h
@@ -18,7 +18,7 @@ namespace Pickup
  * `true` in other cases.
  */
 bool do_pickup( std::vector<item_location> &targets, std::vector<int> &quantities,
-                bool autopickup, bool &stash_successful );
+                bool autopickup, bool &stash_successful, int &batch_num );
 bool query_thief();
 
 enum from_where : int {


### PR DESCRIPTION
#### Summary
Features "Batch time saving cost for moving stacks of items"

#### Purpose of change
Implement https://github.com/CleverRaven/Cataclysm-DDA/issues/67385

Moving n items takes n times as long as moving one item now.
In reality, no one drops 1 kg of salt on the floor in 1 gram portions.

#### Describe the solution
- Apply the formula suggested on https://github.com/CleverRaven/Cataclysm-DDA/issues/67385.

items dropped | Σ 10/(n+9)
-- | --
1 | 1
2 |1.91
10 | 7.19
100 | 24.44
1000 | 46.65
10000 | 69.60
- Apply the same formula both when picking up and dropping items.
- Movement costs when picking up items on adjacent tiles only apply to the first one.

#### Describe alternatives you've considered

#### Testing
drop 1000 salts to floor from backpack
Before: 25:00
After: 1:05

pick 1000 salts from floor to backpack
Before: 13:20
After: 0:32

#### Additional context
- Please comment if you have any thoughts on this proposal.
- There may be a more efficient way to examine stacked items.
- There are cases where the cost to move small items becomes 0. Is that appropriate?
- I think it would be better to review the entire process and make it more efficient, but I don't have the time to tackle that. If anyone wants to work on this issue, I'll close the PR and leave it to you.