### PR TITLE
prevent the default backgrounds from being added to templates and random scenarios

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -683,7 +683,7 @@ bool avatar::create( character_type type, const std::string &tempname )
         pool = pool_type::MULTI_POOL;
     }
 
-    bool default_backgrounds = true;
+    bool default_backgrounds = false;
     switch( type ) {
         case character_type::CUSTOM:
             randomize_cosmetics();
@@ -693,17 +693,14 @@ bool avatar::create( character_type type, const std::string &tempname )
             //random scenario, default name if exist
             randomize( true );
             tabs.position.last();
-            default_backgrounds = false;
             break;
         case character_type::NOW:
             //default world, fixed scenario, random name
             randomize( false, true );
-            default_backgrounds = false;
             break;
         case character_type::FULL_RANDOM:
             //default world, random scenario, random name
             randomize( true, true );
-            default_backgrounds = false;
             break;
         case character_type::TEMPLATE:
             if( !load_template( tempname, /*out*/ pool ) ) {
@@ -717,11 +714,10 @@ bool avatar::create( character_type type, const std::string &tempname )
                 forget_all_recipes();
             }
             tabs.position.last();
-            default_backgrounds = false;
             break;
     }
 
-    if (default_backgrounds)
+    if( default_backgrounds )
         //to check which starts add the basic adult backgrounds
     {
         add_default_background();

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -683,22 +683,27 @@ bool avatar::create( character_type type, const std::string &tempname )
         pool = pool_type::MULTI_POOL;
     }
 
+    bool default_backgrounds = true;
     switch( type ) {
         case character_type::CUSTOM:
             randomize_cosmetics();
+            default_backgrounds = true;
             break;
         case character_type::RANDOM:
             //random scenario, default name if exist
             randomize( true );
             tabs.position.last();
+            default_backgrounds = false;
             break;
         case character_type::NOW:
             //default world, fixed scenario, random name
             randomize( false, true );
+            default_backgrounds = false;
             break;
         case character_type::FULL_RANDOM:
             //default world, random scenario, random name
             randomize( true, true );
+            default_backgrounds = false;
             break;
         case character_type::TEMPLATE:
             if( !load_template( tempname, /*out*/ pool ) ) {
@@ -712,10 +717,15 @@ bool avatar::create( character_type type, const std::string &tempname )
                 forget_all_recipes();
             }
             tabs.position.last();
+            default_backgrounds = false;
             break;
     }
 
-    add_default_background();
+    if (default_backgrounds)
+        //to check which starts add the basic adult backgrounds
+    {
+        add_default_background();
+    }
 
     auto nameExists = [&]( const std::string & name ) {
         return world_generator->active_world->save_exists( save_t::from_save_id( name ) ) &&


### PR DESCRIPTION
#### Summary
Bugfixes "Don't apply the default backgrounds for non custom starts"

#### Purpose of change

fixes #68006

#### Describe the solution
made it so that only custom start automatically adds the basic adult background group

#### Describe alternatives you've considered
don't do this or add the backgrounds to "Play Now!" as well

#### Testing
Tested it, the other starts were indeed randomized

#### Additional context

cheers to @dseguin for incentivising me to add these
