### PR TITLE
JSON-ize faction camp hunting returns

### DIFF
--- a/data/json/monstergroups/misc.json
+++ b/data/json/monstergroups/misc.json
@@ -511,5 +511,65 @@
     "type": "monstergroup",
     "name": "GROUP_JABBERWOCK",
     "monsters": [ { "monster": "mon_jabberwock" } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_CAMP_HUNTING",
+    "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
+    "//1": "Can be overwritten by mods.",
+    "//2": "This group always has a chance of being the result, regardless of mission type.",
+    "monsters": [
+      { "monster": "mon_beaver", "weight": 10 },
+      { "monster": "mon_fox_red", "weight": 10 },
+      { "monster": "mon_fox_gray", "weight": 10 },
+      { "monster": "mon_mink", "weight": 5 },
+      { "monster": "mon_muskrat", "weight": 10 },
+      { "monster": "mon_otter", "weight": 10 },
+      { "monster": "mon_duck", "weight": 10 },
+      { "monster": "mon_cockatrice", "weight": 1 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_CAMP_TRAPPING",
+    "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
+    "//1": "Can be overwritten by mods.",
+    "//2": "This group can only be picked from when the trapping mission is used, in addition to GROUP_CAMP_HUNTING.",
+    "monsters": [
+      { "monster": "mon_black_rat", "weight": 40 },
+      { "monster": "mon_chipmunk", "weight": 30 },
+      { "monster": "mon_groundhog", "weight": 30 },
+      { "monster": "mon_hare", "weight": 20 },
+      { "monster": "mon_lemming", "weight": 40 },
+      { "monster": "mon_opossum", "weight": 10 },
+      { "monster": "mon_rabbit", "weight": 20 },
+      { "monster": "mon_squirrel", "weight": 20 },
+      { "monster": "mon_weasel", "weight": 20 },
+      { "monster": "mon_chicken", "weight": 10 },
+      { "monster": "mon_grouse", "weight": 10 },
+      { "monster": "mon_pheasant", "weight": 10 },
+      { "monster": "mon_turkey", "weight": 20 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_CAMP_HUNTING_LARGE",
+    "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
+    "//1": "Can be overwritten by mods.",
+    "//2": "This group can only be picked from when the hunt large animals mission is used, in addition to GROUP_CAMP_HUNTING.",
+    "monsters": [
+      { "monster": "mon_chicken", "weight": 20 },
+      { "monster": "mon_grouse", "weight": 2 },
+      { "monster": "mon_pheasant", "weight": 2 },
+      { "monster": "mon_turkey", "weight": 10 },
+      { "monster": "mon_bear", "weight": 1 },
+      { "monster": "mon_cougar", "weight": 5 },
+      { "monster": "mon_cow", "weight": 1 },
+      { "monster": "mon_coyote", "weight": 15 },
+      { "monster": "mon_deer", "weight": 2 },
+      { "monster": "mon_moose", "weight": 1 },
+      { "monster": "mon_pig", "weight": 1 },
+      { "monster": "mon_wolf", "weight": 10 }
+    ]
   }
 ]

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -105,35 +105,9 @@ static const itype_id itype_fungal_seeds( "fungal_seeds" );
 static const itype_id itype_log( "log" );
 static const itype_id itype_marloss_seed( "marloss_seed" );
 
-static const mtype_id mon_bear( "mon_bear" );
-static const mtype_id mon_beaver( "mon_beaver" );
-static const mtype_id mon_black_rat( "mon_black_rat" );
-static const mtype_id mon_chicken( "mon_chicken" );
-static const mtype_id mon_chipmunk( "mon_chipmunk" );
-static const mtype_id mon_cockatrice( "mon_cockatrice" );
-static const mtype_id mon_cougar( "mon_cougar" );
-static const mtype_id mon_cow( "mon_cow" );
-static const mtype_id mon_coyote( "mon_coyote" );
-static const mtype_id mon_deer( "mon_deer" );
-static const mtype_id mon_duck( "mon_duck" );
-static const mtype_id mon_fox_gray( "mon_fox_gray" );
-static const mtype_id mon_fox_red( "mon_fox_red" );
-static const mtype_id mon_groundhog( "mon_groundhog" );
-static const mtype_id mon_grouse( "mon_grouse" );
-static const mtype_id mon_hare( "mon_hare" );
-static const mtype_id mon_lemming( "mon_lemming" );
-static const mtype_id mon_mink( "mon_mink" );
-static const mtype_id mon_moose( "mon_moose" );
-static const mtype_id mon_muskrat( "mon_muskrat" );
-static const mtype_id mon_opossum( "mon_opossum" );
-static const mtype_id mon_otter( "mon_otter" );
-static const mtype_id mon_pheasant( "mon_pheasant" );
-static const mtype_id mon_pig( "mon_pig" );
-static const mtype_id mon_rabbit( "mon_rabbit" );
-static const mtype_id mon_squirrel( "mon_squirrel" );
-static const mtype_id mon_turkey( "mon_turkey" );
-static const mtype_id mon_weasel( "mon_weasel" );
-static const mtype_id mon_wolf( "mon_wolf" );
+static const mongroup_id GROUP_CAMP_HUNTING( "GROUP_CAMP_HUNTING" );
+static const mongroup_id GROUP_CAMP_HUNTING_LARGE( "GROUP_CAMP_HUNTING_LARGE" );
+static const mongroup_id GROUP_CAMP_TRAPPING( "GROUP_CAMP_TRAPPING" );
 
 static const oter_str_id oter_forest_wet( "forest_wet" );
 
@@ -4243,47 +4217,23 @@ void basecamp::search_results( int skill, const item_group_id &group_id, int att
 
 void basecamp::hunting_results( int skill, const mission_id &miss_id, int attempts, int difficulty )
 {
-    // no item groups for corpses, so we'll have to improvise
+    // corpses do not exist as discrete items, so we use monster groups instead
     weighted_int_list<mtype_id> hunting_targets;
-    hunting_targets.add( mon_beaver, 10 );
-    hunting_targets.add( mon_fox_red, 10 );
-    hunting_targets.add( mon_fox_gray, 10 );
-    hunting_targets.add( mon_mink, 5 );
-    hunting_targets.add( mon_muskrat, 10 );
-    hunting_targets.add( mon_otter, 10 );
-    hunting_targets.add( mon_duck, 10 );
-    hunting_targets.add( mon_cockatrice, 1 );
+    for( const MonsterGroupEntry &target : GROUP_CAMP_HUNTING->monsters ) {
+        hunting_targets.add( target.name, target.frequency );
+    }
     if( miss_id.id == Camp_Trapping ) {
-        hunting_targets.add( mon_black_rat, 40 );
-        hunting_targets.add( mon_chipmunk, 30 );
-        hunting_targets.add( mon_groundhog, 30 );
-        hunting_targets.add( mon_hare, 20 );
-        hunting_targets.add( mon_lemming, 40 );
-        hunting_targets.add( mon_opossum, 10 );
-        hunting_targets.add( mon_rabbit, 20 );
-        hunting_targets.add( mon_squirrel, 20 );
-        hunting_targets.add( mon_weasel, 20 );
-        hunting_targets.add( mon_chicken, 10 );
-        hunting_targets.add( mon_grouse, 10 );
-        hunting_targets.add( mon_pheasant, 10 );
-        hunting_targets.add( mon_turkey, 20 );
+        for( const MonsterGroupEntry &target : GROUP_CAMP_TRAPPING->monsters ) {
+            hunting_targets.add( target.name, target.frequency );
+        }
     } else if( miss_id.id == Camp_Hunting ) {
-        hunting_targets.add( mon_chicken, 20 );
-        // good luck hunting upland game birds without dogs
-        hunting_targets.add( mon_grouse, 2 );
-        hunting_targets.add( mon_pheasant, 2 );
-        hunting_targets.add( mon_turkey, 10 );
-        hunting_targets.add( mon_bear, 1 );
-        hunting_targets.add( mon_cougar, 5 );
-        hunting_targets.add( mon_cow, 1 );
-        hunting_targets.add( mon_coyote, 15 );
-        hunting_targets.add( mon_deer, 2 );
-        hunting_targets.add( mon_moose, 1 );
-        hunting_targets.add( mon_pig, 1 );
-        hunting_targets.add( mon_wolf, 10 );
+        for( const MonsterGroupEntry &target : GROUP_CAMP_HUNTING_LARGE->monsters ) {
+            hunting_targets.add( target.name, target.frequency );
+        }
     }
     for( int i = 0; i < attempts; i++ ) {
         if( skill > rng( 0, difficulty ) ) {
+            // TODO: replace this with MonsterGroupManager::GetResultFromGroup
             const mtype_id *target = hunting_targets.pick();
             item result = item::make_corpse( *target, calendar::turn, "" );
             if( !result.is_null() ) {


### PR DESCRIPTION
#### Summary
Mods "JSON-ize faction camp hunting returns"

#### Purpose of change
Implement #60541

Hardcoded monster lists are not good. Most contributors are json contributors and can't touch it there, plus it adds compiling overhead.

#### Describe the solution
Move it to json!

None of the return logic or entries were touched, they were just ported straight to json. New groups (defined in JSON) were created to represent the previous returns and comments added so they are not mistakenly changed/modders can find it.

#### Describe alternatives you've considered
Rather than bespoke groups it could be using existing monster groups (e.g. GROUP_SAFE) but that might cause the group to have two different directions for balancing - one for population and one for hunting returns. Having a distinct group allows either to be balanced as needed, although it's slightly more json work.

#### Testing
Compiled, did some hunting. Got returns as I expected. Made some really silly edits to the group weights (local only, not committed) and observed the returns following the weights I set.

Test save with pre-built camp for mergers to use:
[Normal World-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/12525492/Normal.World-trimmed.tar.gz)


#### Additional context
@LyleSY I saw you wanted this a while ago and I never got around to it because I thought it would be more annoying than this. Turns out it's pretty easy.
