### PR TITLE
Change up how rubik translation works

### DIFF
--- a/data/json/npcs/exodii/exodii_merchant_definitions.json
+++ b/data/json/npcs/exodii/exodii_merchant_definitions.json
@@ -64,5 +64,14 @@
     "name": { "str": "Rubik's PA md. 68 Battle Rifle" },
     "description": "The most popular gun to use the 12.3ln cartridge was, of course, the PA md. 71.  Its predecessor, the md. 68, was viewed by many as a sort of failure: although it was reliable and powerful, it was too heavy to be used as a good infantry weapon, and not really heavy enough to be a good support gun.  Enough were made, though, that during the zombie apocalypse, it gained a great deal of resurgent popularity as a light emplacement gun that used readily available ammunition.  It perfectly served the purposes of the Exodii, who had far less concern about its unwieldiness.\n\nThis particular rifle has been painted a dusty pink color and has a picture of a smiling eel twisting along the barrel.",
     "extend": { "flags": [ "TRADER_KEEP_EQUIPPED", "NO_TURRET" ] }
+  },
+  {
+    "type": "mutation",
+    "id": "rubik_translate",
+    "name": { "str": "Rubik Personal Translator Access" },
+    "points": 0,
+    "description": "You can understand what Rubik means to say.",
+    "valid": false,
+    "purifiable": false
   }
 ]

--- a/data/json/npcs/exodii/exodii_merchant_definitions.json
+++ b/data/json/npcs/exodii/exodii_merchant_definitions.json
@@ -72,6 +72,7 @@
     "points": 0,
     "description": "You can understand what Rubik means to say.",
     "valid": false,
+    "player_display": false,
     "purifiable": false
   }
 ]

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -325,7 +325,7 @@
     "dynamic_line": {
       "u_has_trait": "rubik_translate",
       "no": "That be a right welcher, eh?  Afore us'n were to this land, the preface were on a half-score century by the reckonin'.  Landed us in amidst of a war'd turned wrong, for an' as the dead had come back in.  By the butcher's block, not much an unusual case, really.  The enemy makes us fight.  By an' by, we came in, an' by then the killin' fields were plump and ready to harvest the bronze.  'Tain't no steel-of-the-lake, but 'tis a good dross metal for holdin' off a nibblin' mouth, so we kept a few o' their vestments an' stickers for to trade.",
-      "yes": "It's a bit of a shock, eh?  Before we came to this land, we were in a place about a half-score century earlier, we reckon'.  Landed in the middle of a war that turned wrong when the dead started joinin' back in.  Truth be told, not a very unusual situation, really.  The enemy makes us fight.  By and by, we came in, an' by then the killin' fields were ripe to harvest their bronze.  It's no steel-of-the-lake, but it's a good strong metal for holdin' off a nibblin' mouth, so we kept some of their armor and weapons to trade."
+      "yes": "It's a bit of a shock, eh?  Before we came to this land, we were in a place about a half-score century earlier, we reckon'.  Landed in the middle of a war that turned wrong when the dead started joinin' back in.  Truth be told, not much an unusual case, really.  The enemy makes us fight.  By and by, we came in, an' by then the killin' fields were ripe to harvest their bronze.  It's no steel-of-the-lake, but it's a good strong metal for holdin' off a nibblin' mouth, so we kept some of their armor and weapons to trade."
     },
     "//~": "It's a bit of a surprise, isn't it?  Before we came here, we were in a place about 600 years earlier in time, or so.  We landed in the middle of a war that turned wrong when the dead started joining back in.  Truth be told, not a very unusual situation.  The enemy makes us fight.  By and by, we came in, and by then the killing fields were ready for us to harvest their bronze.  It's no steel-of-the-lake, but it's a good strong metal for stopping a nibbling mouth, so we kept some of their armour and weapons to trade.",
     "responses": [
@@ -357,7 +357,11 @@
   {
     "id": "TALK_EXODII_MERCHANT_Stock_Nomad2",
     "type": "talk_topic",
-    "dynamic_line": "This 'n that, an I'm ken.  It be made for a fine wander, beladen with the goods o' the hunt, y'see.  By which I'm to say, 'tis well suited to carry all ye can wrest from the cold arms o' the deadlands, without troublin' your gait nor makin' it easy for the cold clutch o' the scrabblin' arm.  Be an' it is tough as a tarket's nut, I'd razz.",
+    "dynamic_line": {
+      "u_has_trait": "rubik_translate",
+      "no": "This 'n that, an I'm ken.  It be made for a fine wander, beladen with the goods o' the hunt, y'see.  By which I'm to say, 'tis well suited to carry all ye can wrest from the cold arms o' the deadlands, without troublin' your gait nor makin' it easy for the cold clutch o' the scrabblin' arm.  Be an' it is tough as a tarket's nut, I'd razz.",
+      "yes": "This an' that, you ken.  It's made for a fine wanderer, loaded with the goods o' the hunt, y'see.  By which I mean, 'tis well suited to carry all you can wrestle from the cold arms o' the deadlands, without weighing you down nor makin' it easy for the cold grip of a grabbin' arm.  Plus, it is tough as a tarket's nut, I'd say."
+    },
     "//~": "This and that, you know.  It's made for a travelling scavenger, you see.  What I mean is, it's well suited to carry around whatever you pick up in the wastelands, without making it too hard to get around nor giving any easy handholds for scrambling arms.  That, and I'd say it's as tough as nails.",
     "responses": [
       { "text": "Why do I have to make it myself?", "topic": "TALK_EXODII_MERCHANT_Stock_Nomad3" },
@@ -369,7 +373,11 @@
   {
     "id": "TALK_EXODII_MERCHANT_Stock_Nomad3",
     "type": "talk_topic",
-    "dynamic_line": "'Tis as simple as comes to a wobble.  Our vestment be oft made from the fine clothes and hides of the land, and our jibber tears the stuff o' life apart here and there when us'n travel.  For as some can be saved if care be taken, there be no case to store nigh enough o' this.  That, an' our manuc-makers run as hot as a sunstone, no spit'n taste for that which we don't use usselves.",
+    "dynamic_line": {
+      "u_has_trait": "rubik_translate",
+      "no": "'Tis as simple as comes to a wobble.  Our vestment be oft made from the fine clothes and hides of the land, and our jibber tears the stuff o' life apart here and there when us'n travel.  For as some can be saved if care be taken, there be no case to store nigh enough o' this.  That, an' our manuc-makers run as hot as a sunstone, no spit'n taste for that which we don't use usselves.",
+      "yes": "It's simply as comes to how we teleport.  Our clothes are often made from the fine cloth and hides of the land, and our device tears living stuff apart here and there when we travel.  Although some can be saved if we're careful, there's no place to store nearly enough of it.  That, an' our manufacturers run all the time, no time to waste for that which we don't use ourselves."
+    },
     "//~": "It's a simple matter of how we teleport.  Our clothes are often made from cloth and hides from wherever we visit, and our teleporter tears living stuff apart here and there when we travel.  Some can be saved if we take care, but there's no room to store nearly enough extra.  That, and our fabricators are always busy, no time to waste on stuff we don't need for ourselves",
     "responses": [
       { "text": "What makes your specific armor so great?", "topic": "TALK_EXODII_MERCHANT_Stock_Nomad2" },
@@ -382,14 +390,24 @@
     "id": "TALK_EXODII_MERCHANT_Talk",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_var": "rubik_intro",
-      "type": "dialogue",
-      "context": "started",
-      "value": "yes",
-      "yes": "Sure as you c'n try.  Us're not the greatest yarker, nor do it all for gratis, kennit.",
-      "no": "Oy, c'n I bark you summat first?"
+      "u_has_trait": "rubik_translate",
+      "no": {
+        "u_has_var": "rubik_intro",
+        "type": "dialogue",
+        "context": "started",
+        "value": "yes",
+        "yes": "Sure as you c'n try.  Us're not the greatest yarker, nor do it all for gratis, kennit.",
+        "no": "Oy, c'n I bark you summat first?"
+      },
+      "yes": {
+        "u_has_var": "rubik_intro",
+        "type": "dialogue",
+        "context": "started",
+        "value": "yes",
+        "yes": "Sure, you can try.  I'm not the greatest speaker, nor will I chat forever for free, you understand.",
+        "no": "Oy, can I ask you something first?"
+      }
     },
-    "//~": "Yes: You can surely try.  I'm not the greatest speaker, and I won't just chat forever for free, you know.  No: Hey, can I ask you something first?",
     "speaker_effect": { "effect": { "u_add_var": "rubik_intro", "type": "dialogue", "context": "started", "value": "yes" } },
     "responses": [
       { "text": "Like, ask me a question?  Sure, I guess.", "topic": "TALK_EXODII_MERCHANT_Talk_Intro1a" },
@@ -404,19 +422,24 @@
     "id": "TALK_EXODII_MERCHANT_Talk_Intro1a",
     "type": "talk_topic",
     "dynamic_line": "'Ow long's it been since the mess happened?",
+    "//": "Line doesn't change if translated.",
     "responses": [ { "text": "[Tell them]", "topic": "TALK_EXODII_MERCHANT_Talk_Intro2" } ]
   },
   {
     "id": "TALK_EXODII_MERCHANT_Talk_Intro1b",
     "type": "talk_topic",
     "dynamic_line": "Thank ye.  When you an' Rubik first met, how long'd it been since the mess begun?",
+    "//": "Line doesn't change if translated.",
     "responses": [ { "text": "[Tell them]", "topic": "TALK_EXODII_MERCHANT_Talk_Intro2" } ]
   },
   {
     "id": "TALK_EXODII_MERCHANT_Talk_Intro2",
     "type": "talk_topic",
-    "dynamic_line": "Lovely!  Benzete's gonna be a pair, that's a track!  I mean, they'll be right happy.  This is their first jump, and it's a flappin' duck.",
-    "//~": "Lovely!  Benzete (this is a name) is going to be beside themselves, that's for sure.  I mean, they'll be really happy.  This is their first jump, and it's a lucky one.",
+    "dynamic_line": {
+      "u_has_trait": "rubik_translate",
+      "no": "Lovely!  Benzete's gonna be a pair, that's a track!  I mean, they'll be right happy.  This is their first jump, and it's a flappin' duck.",
+      "yes": "Lovely!  Benzete's gonna be beside themself, that's a fact!  This is their first jump, and it's a lucky one."
+    },
     "speaker_effect": { "effect": { "u_add_var": "rubik_intro", "type": "dialogue", "context": "midpoint", "value": "yes" } },
     "responses": [
       { "text": "What makes it such a good jump?", "topic": "TALK_EXODII_MERCHANT_Talk_Intro3" },
@@ -428,8 +451,11 @@
   {
     "id": "TALK_EXODII_MERCHANT_Talk_Intro2a",
     "type": "talk_topic",
-    "dynamic_line": "So 'twere an I recalt, us're yarkin' of Benzete an' their great first jump.",
-    "//~": "As I recall, we were talking about Benzete and how this is a great jump for their first time.",
+    "dynamic_line": {
+      "u_has_trait": "rubik_translate",
+      "no": "So 'twere an I recalt, us're yarkin' of Benzete an' their great first jump.",
+      "yes": "So as I recall, we're talkin' of Benzete and their great first jump."
+    },
     "responses": [
       { "text": "What makes it such a good jump?", "topic": "TALK_EXODII_MERCHANT_Talk_Intro3" },
       { "text": "Who is Benzete?", "topic": "TALK_EXODII_MERCHANT_Talk_IntroBenzete1" },
@@ -440,13 +466,26 @@
   {
     "id": "TALK_EXODII_MERCHANT_Talk_Intro3",
     "type": "talk_topic",
-    "dynamic_line": "Us gotta leave the old world afore it's worn right to the gums, an y'ken, and find a nice twitchy one on t'other side.  Your deadland be a brand shiny",
+    "dynamic_line": {
+      "u_has_trait": "rubik_translate",
+      "no": "Us gotta leave the old world afore it's worn right to the gums, an y'ken, and find a nice twitchy one on t'other side.  Your deadland be a brand shiny",
+      "yes": "We had to leave the old world before it's worn right to the gums, you understand, and find a nice, fresh, still twitchin' one on the other side.  Your deadland is freshly dead, brand new."
+    },
     "//~": "We've got to leave the old world before it gets too worn out, you see, and find a nice fresh one on the other side.  Your deadland is as fresh as it gets.",
     "responses": [
-      { "text": "I'm not following that at all.", "topic": "TALK_EXODII_MERCHANT_Talk_Intro3a" },
+      {
+        "text": "I'm not following that at all.",
+        "topic": "TALK_EXODII_MERCHANT_Talk_Intro3a",
+        "condition": { "not": { "u_has_trait": "rubik_translate" } }
+      },
       {
         "text": "[INT 9] So you mean, we have a nice, freshly dead world for you to visit?",
-        "condition": { "u_has_intelligence": 9 },
+        "condition": { "and": [ { "u_has_intelligence": 9 }, { "not": { "u_has_trait": "rubik_translate" } } ] },
+        "topic": "TALK_EXODII_MERCHANT_Talk_Intro4b"
+      },
+      {
+        "text": "So we have a nice, freshly dead world for you to visit?",
+        "condition": { "u_has_trait": "rubik_translate" },
         "topic": "TALK_EXODII_MERCHANT_Talk_Intro4b"
       },
       { "text": "Who is Benzete?", "topic": "TALK_EXODII_MERCHANT_Talk_IntroBenzete1" },
@@ -458,6 +497,7 @@
     "id": "TALK_EXODII_MERCHANT_Talk_Intro3a",
     "type": "talk_topic",
     "dynamic_line": "Neverken.  Right and so, the enemy is new here, and us'n have a few good hours in the sun beforenext the jump.",
+    "//": "this dialogue option is not available if you have translation on",
     "//~": "No worries.  I mean, the enemy is new here, and we have a bit of safe time ahead of us before we have to jump away again.",
     "responses": [
       {
@@ -473,6 +513,7 @@
     "id": "TALK_EXODII_MERCHANT_Talk_Intro4a",
     "type": "talk_topic",
     "dynamic_line": "That be a part an' switch, but this be'n nice for all, overtop the last jump by heads.  Otherlands with fusillies and mobbings, us'n gets a fine change on that.",
+    "//": "this dialogue option is not available if you have translation on",
     "//~": "That's a part of it, sure, but this is nice for other reasons, and much better than our last jump.  Otherlands with fusillies and mobbings are really useful to us.",
     "speaker_effect": {
       "effect": { "u_add_var": "u_knows_exodiilore", "type": "knowledge", "context": "exodii_transdimensional", "value": "yes" }
@@ -486,7 +527,11 @@
   {
     "id": "TALK_EXODII_MERCHANT_Talk_Intro4b",
     "type": "talk_topic",
-    "dynamic_line": "You kennit rightly!  That and this be'n nice for all, overtop the last jump by heads.  Otherlands with fusillies and mobbings, us'n gets a fine change on that.",
+    "dynamic_line": {
+      "u_has_trait": "rubik_translate",
+      "no": "You kennit rightly!  That and this be'n nice for all, overtop the last jump by heads.  Otherlands with fusillies and mobbings, us'n gets a fine change on that.",
+      "yes": "Yes.  That and this one's nice for other things, better than the last jump by a long shot.  Otherlands with firearms and vehicles, we can really do well in places like that."
+    },
     "//~": "That's exactly it!  This is nice for many reasons, and much better than our last jump.  Otherlands with fusillies and mobbings are really useful to us.",
     "responses": [
       {

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -134,19 +134,38 @@
     "id": "TALK_EXODII_MERCHANT",
     "type": "talk_topic",
     "dynamic_line": {
-      "u_has_effect": "u_exodii_interaction_timer_short",
-      "yes": [ "Back in a blink and a whiff, eh?", "Forgot sommat?", "Ah, a returnin', an I'm ken." ],
+      "u_has_trait": "rubik_translate",
       "no": {
-        "u_has_var": "u_met_Rubik",
-        "type": "general",
-        "context": "meeting",
-        "value": "yes",
-        "yes": [
-          "And a fine return, matey.",
-          "Fine and you still ain't dead.  What brings ye roun' Rubik's neckawoods?",
-          "Bright and sunny, you're back!  I got goods for ye, if you got goods for me."
-        ],
-        "no": "Oy, you ain't dead.  Lookin' t'trade?"
+        "u_has_effect": "u_exodii_interaction_timer_short",
+        "yes": [ "Back in a blink and a whiff, eh?", "Forgot sommat?", "Ah, a returnin', an I'm ken." ],
+        "no": {
+          "u_has_var": "u_met_Rubik",
+          "type": "general",
+          "context": "meeting",
+          "value": "yes",
+          "yes": [
+            "And a fine return, matey.",
+            "Fine and you still ain't dead.  What brings ye roun' Rubik's neckawoods?",
+            "Bright and sunny, you're back!  I got goods for ye, if you got goods for me."
+          ],
+          "no": "Oy, you ain't dead.  Lookin' t'trade?"
+        }
+      },
+      "yes": {
+        "u_has_effect": "u_exodii_interaction_timer_short",
+        "yes": [ "So, you're back, hey?", "Forgot something?", "Ah, a repeat customer, I ken." ],
+        "no": {
+          "u_has_var": "u_met_Rubik",
+          "type": "general",
+          "context": "meeting",
+          "value": "yes",
+          "yes": [
+            "Welcome back, matey.",
+            "Nice to see you still ain't dead.  What brings you round Rubik's neck of the woods?",
+            "Bright and sunny, you're back!  I got goods for you, if you got goods for me."
+          ],
+          "no": "Oy, you ain't dead.  Lookin' to trade?"
+        }
       }
     },
     "speaker_effect": [
@@ -267,14 +286,22 @@
   {
     "id": "TALK_EXODII_MERCHANT_New",
     "type": "talk_topic",
-    "dynamic_line": "Us call us the Exodii, eh?  An' other things, but that'n's good.  This're our home, such as it.  This'n's monicked as Rubik, and tassed with a trade an'.  You lookin' to trade?  Us'n's alay for the scrap, metal an' more as it be.",
+    "dynamic_line": {
+      "u_has_trait": "rubik_translate",
+      "no": "Us call us the Exodii, eh?  An' other things, but that'n's good.  This're our home, such as it.  This'n's monicked as Rubik, and tassed with a trade an'.  You lookin' to trade?  Us'n's alay for the scrap, metal an' more as it be.",
+      "yes": "We call ourselves the Exodii, eh?  And other things, but that's good.  This is our home, such as it is.  This one's called Rubik, and assigned to trade with you.  You looking to trade?  We're always looking for scrap, metal and more."
+    },
     "//~": "We call ourselves the Exodii, eh?  And other things, but that's good.  This is our home, such as it is.  I'm called Rubik, and I've been assigned to trade with you.  Are you looking to trade?  We're always looking for scrap, metal and more.",
     "responses": [ { "text": "Well, I'd better be going.  Bye.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_EXODII_MERCHANT_DoneTrade",
     "type": "talk_topic",
-    "dynamic_line": [ "Good an' fine, then.", "Have it as ye'll see.", "For a card an' a wink, eh?" ],
+    "dynamic_line": {
+      "u_has_trait": "rubik_translate",
+      "no": [ "Good an' fine, then.", "Have it as ye'll see.", "For a card an' a wink, eh?" ],
+      "yes": [ "Sounds good then.", "See what you like.", "Not a bad deal, eh?" ]
+    },
     "//~": "For a card an' a wink, eh? --> That was a good exchange",
     "speaker_effect": {
       "condition": {

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -322,7 +322,11 @@
   {
     "id": "TALK_EXODII_MERCHANT_Stock_Medieval",
     "type": "talk_topic",
-    "dynamic_line": "That be a right welcher, eh?  Afore us'n were to this land, the preface were on a half-score century by the reckonin'.  Landed us in amidst of a war'd turned wrong, for an' as the dead had come back in.  By the butcher's block, not much an unusual case, really.  The enemy makes us fight.  By an' by, we came in, an' by then the killin' fields were plump and ready to harvest the bronze.  'Tain't no steel-of-the-lake, but 'tis a good dross metal for holdin' off a nibblin' mouth, so we kept a few o' their vestments an' stickers for to trade.",
+    "dynamic_line": {
+      "u_has_trait": "rubik_translate",
+      "no": "That be a right welcher, eh?  Afore us'n were to this land, the preface were on a half-score century by the reckonin'.  Landed us in amidst of a war'd turned wrong, for an' as the dead had come back in.  By the butcher's block, not much an unusual case, really.  The enemy makes us fight.  By an' by, we came in, an' by then the killin' fields were plump and ready to harvest the bronze.  'Tain't no steel-of-the-lake, but 'tis a good dross metal for holdin' off a nibblin' mouth, so we kept a few o' their vestments an' stickers for to trade.",
+      "yes": "It's a bit of a shock, eh?  Before we came to this land, we were in a place about a half-score century earlier, we reckon'.  Landed in the middle of a war that turned wrong when the dead started joinin' back in.  Truth be told, not a very unusual situation, really.  The enemy makes us fight.  By and by, we came in, an' by then the killin' fields were ripe to harvest their bronze.  It's no steel-of-the-lake, but it's a good strong metal for holdin' off a nibblin' mouth, so we kept some of their armor and weapons to trade."
+    },
     "//~": "It's a bit of a surprise, isn't it?  Before we came here, we were in a place about 600 years earlier in time, or so.  We landed in the middle of a war that turned wrong when the dead started joining back in.  Truth be told, not a very unusual situation.  The enemy makes us fight.  By and by, we came in, and by then the killing fields were ready for us to harvest their bronze.  It's no steel-of-the-lake, but it's a good strong metal for stopping a nibbling mouth, so we kept some of their armour and weapons to trade.",
     "responses": [
       {
@@ -336,7 +340,11 @@
   {
     "id": "TALK_EXODII_MERCHANT_Stock_Nomad",
     "type": "talk_topic",
-    "dynamic_line": "Ah, a real monger's eye, ye be.  Them's the mettle o' many a year of trials.  Us'n've been clashin wi' the enemy for a long an' then, an' o'er the turns us've worked out some vestments for the job.  Keep's a walker walkin' longer, an I'm ken.  This'n keeps some o' the parst in an' around, but ye'd be tassed to make the vestment with the grease o' your own brow.",
+    "dynamic_line": {
+      "u_has_trait": "rubik_translate",
+      "no": "Ah, a real monger's eye, ye be.  Them's the mettle o' many a year of trials.  Us'n've been clashin' wi' the enemy for a long an' then, an' o'er the turns us've worked out some vestments for the job.  Keep's a walker walkin' longer, an I'm ken.  This'n keeps some o' the parts in an' around, but ye'd be tassed to make the vestment with the grease o' your own brow.",
+      "yes": "Ah, a real discernin' eye, you've got.  They're the result o' many a year of trials.  We've been clashin' with the enemy for a long while, an' over the years we've worked out some clothes for the job.  Keep's a survivor survivin' longer, you ken.  This one keeps some of the parts in and around, but you'd have to make the clothes with the sweat off your own brow."
+    },
     "//~": "Ah, you've got a discerning eye.  They're the result of many years of work.  We've been fighting the enemy for a long time, and over the years we've worked out some armour for the job.  Keeps you going a bit longer in the field, if you ask me.  I keep some of the parts in stock, but you'll have to put it together yourself.",
     "responses": [
       { "text": "What makes your specific armor so great?", "topic": "TALK_EXODII_MERCHANT_Stock_Nomad2" },

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -28,7 +28,7 @@
       "TALK_EXODII_MERCHANT_Translate2",
       "TALK_EXODII_MERCHANT_Translate3",
       "TALK_EXODII_MERCHANT_TranslateOff",
-      "TALK_EXODII_MERCHANT_TranslateExplain",
+      "TALK_EXODII_MERCHANT_TranslateExplain"
     ],
     "type": "talk_topic",
     "responses": [
@@ -523,7 +523,7 @@
     "type": "talk_topic",
     "dynamic_line": "That be a part an' switch, but this be'n nice for all, overtop the last jump by heads.  Otherlands with fusillies and mobbings, us'n gets a fine change on that.",
     "//": "this dialogue option is not available if you have translation on",
-    "//~": "That's a part of it, sure, but this is nice for other reasons, and much better than our last jump.  Otherlands with fusillies and mobbings are really useful to us.",
+    "//~": "That's a part of it, sure, but this is nice for other reasons, and much better than our last jump.  Otherlands with fusillies (guns) and mobbings (cars/vehicles) are really useful to us.",
     "speaker_effect": {
       "effect": { "u_add_var": "u_knows_exodiilore", "type": "knowledge", "context": "exodii_transdimensional", "value": "yes" }
     },
@@ -541,11 +541,16 @@
       "no": "You kennit rightly!  That and this be'n nice for all, overtop the last jump by heads.  Otherlands with fusillies and mobbings, us'n gets a fine change on that.",
       "yes": "Yes.  That and this one's nice for other things, better than the last jump by a long shot.  Otherlands with firearms and vehicles, we can really do well in places like that."
     },
-    "//~": "That's exactly it!  This is nice for many reasons, and much better than our last jump.  Otherlands with fusillies and mobbings are really useful to us.",
+    "//~": "That's exactly it!  This is nice for many reasons, and much better than our last jump.  Otherlands with fusillies (guns) and mobbings (cars/vehicles) are really useful to us.",
     "responses": [
       {
         "text": "I don't know what fusillies and mobbings are.",
-        "condition": { "not": { "u_has_var": "fussily", "type": "dictionary", "context": "known", "value": "yes" } },
+        "condition": {
+          "and": [
+            { "not": { "u_has_var": "fussily", "type": "dictionary", "context": "known", "value": "yes" } },
+            { "not": { "u_has_trait": "rubik_translate" } }
+          ]
+        },
         "topic": "TALK_EXODII_MERCHANT_Talk_Intro5"
       },
       {
@@ -560,6 +565,7 @@
     "id": "TALK_EXODII_MERCHANT_Talk_Intro5",
     "type": "talk_topic",
     "dynamic_line": "Oh, rights.  Many lands be'd assert on thosun's.  A fusilly, she's a weapon, shoots a shot at high speeds usin' bang.  A mobbing, he's a grand box o' metal, pushed by burnin' and boomin' from wit'in, kennit?",
+    "//": "this dialogue option is not available if you have translation on",
     "//~": "Oh, yeah.  Lots of places have different words for those.  A fusilly is a weapon that fires a bullet at high speeds using propellant.  A mobbing is a big metal box that's moved around by an internal explosion.  Do you get it?",
     "responses": [
       {
@@ -576,6 +582,7 @@
     "id": "TALK_EXODII_MERCHANT_Talk_Intro6",
     "type": "talk_topic",
     "dynamic_line": "Right so, us'n'll write it in the dicky.  Here, a shiny brass farthing for crossin' the nation.",
+    "//": "this dialogue option is not available if you have translation on",
     "//~": "Great, I'll put that in the dictionary.  Here's a token of my gratitude for your explanation.",
     "speaker_effect": {
       "effect": [
@@ -596,10 +603,23 @@
   {
     "id": "TALK_EXODII_MERCHANT_Talk_IntroBenzete1",
     "type": "talk_topic",
-    "dynamic_line": "Them's an otherlander from thrice jumps an' change, wide as the sky.  They's got happily on sommat for the tracking, you ken?",
+    "dynamic_line": {
+      "u_has_trait": "rubik_translate",
+      "no": "Them's an otherlander from thrice jumps an' change, wide as the sky.  They's got happily on sommat for the tracking, you ken?",
+      "yes": "They're an otherlander from three jumps and change ago, very green.  They're all happily on about the tracking, you ken?"
+    },
     "//~": "They're an otherlander from around three jumps ago, a real optimistic greenhorn.  They're really interested in how we do tracking, you see?",
     "responses": [
-      { "text": "I… didn't really follow that.", "topic": "TALK_EXODII_MERCHANT_Talk_IntroBenzete2" },
+      {
+        "text": "I… didn't really follow that.",
+        "topic": "TALK_EXODII_MERCHANT_Talk_IntroBenzete2",
+        "condition": { "not": { "u_has_trait": "rubik_translate" } }
+      },
+      {
+        "text": "I'm not quite sure what you mean about tracking.",
+        "topic": "TALK_EXODII_MERCHANT_Talk_IntroBenzete2",
+        "condition": { "u_has_trait": "rubik_translate" }
+      },
       { "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
       { "text": "I've gotta go.  See you later, Rubik.", "topic": "TALK_DONE" }
     ]
@@ -607,10 +627,23 @@
   {
     "id": "TALK_EXODII_MERCHANT_Talk_IntroBenzete2",
     "type": "talk_topic",
-    "dynamic_line": "Hmm.  They… planned out the last jump?  Like as an apprentice to the ol' sexten.",
+    "dynamic_line": {
+      "u_has_trait": "rubik_translate",
+      "no": "Hmm.  They… planned out the last jump?  Like as an apprentice to the ol' sexten.",
+      "yes": "I mean they plan out the jumps, like an apprentice to the old tracker."
+    },
     "//~": "Hmm.  They… planned out the last jump?  Like an apprentice to the old tracker.",
     "responses": [
-      { "text": "Oh, like a navigator?", "topic": "TALK_EXODII_MERCHANT_Talk_IntroBenzete3" },
+      {
+        "text": "Oh, like a navigator?",
+        "topic": "TALK_EXODII_MERCHANT_Talk_IntroBenzete3",
+        "condition": { "not": { "u_has_trait": "rubik_translate" } }
+      },
+      {
+        "text": "You said this was an especially good jump?",
+        "condition": { "not": { "u_has_var": "rubik_intro", "type": "dialogue", "context": "completed", "value": "yes" } },
+        "topic": "TALK_EXODII_MERCHANT_Talk_Intro3"
+      },
       { "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
       { "text": "I've gotta go.  See you later, Rubik.", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -86,6 +86,16 @@
         "topic": "TALK_EXODII_MERCHANT_ExodizeTest"
       },
       {
+        "text": "Do all your friends talk like you do?",
+        "condition": { "and": [ { "u_has_trait": "CBM_Interface" }, { "not": { "u_has_trait": "rubik_translate" } } ] },
+        "topic": "TALK_EXODII_MERCHANT_Translate1"
+      },
+      {
+        "text": "I have to admit, I miss your old weird way of talking.  Can you change me back?",
+        "condition": { "u_has_trait": "rubik_translate" },
+        "topic": "TALK_EXODII_MERCHANT_TranslateOff"
+      },
+      {
         "text": "I think I'm ready to try becoming a cyborg now.",
         "condition": {
           "and": [
@@ -1008,6 +1018,7 @@
     "//~": "I'm a lowlife from old Upper Landing, this is my way of talking.  Everyone from where I come from talks like this.",
     "responses": [
       { "text": "Tell me about \"ol' Upper Landing\".  What was your home like?", "topic": "TALK_EXODII_MERCHANT_Home" },
+      { "text": "Do all your friends here talk like you?", "topic": "TALK_EXODII_MERCHANT_Translate1" },
       { "text": "What was it you were saying before?", "topic": "TALK_NONE" },
       { "text": "Well, I'd better be going.  Bye.", "topic": "TALK_DONE" }
     ]
@@ -1041,6 +1052,54 @@
       },
       { "text": "Well, a person can get sick of trying to piece it together.  See you later.", "topic": "TALK_DONE" }
     ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_Translate1",
+    "type": "talk_topic",
+    "dynamic_line": "Nay, and that asayfore.  Rubik be the only 'un from King's Landing in this-else.",
+    "//~": "No, not so much.  I'm the only person from King's Landing around here.",
+    "responses": [
+      {
+        "text": "How do you communicate with each other if you all have different languages?  And more importantly, I get some of that?  It's exhausting trying to follow what you're saying.",
+        "condition": { "and": [ { "u_has_trait": "CBM_Interface" }, { "not": { "u_has_trait": "rubik_translate" } } ] },
+        "topic": "TALK_EXODII_MERCHANT_Translate2"
+      },
+      {
+        "text": "I have to admit, I miss your old weird way of talking.  Can you change me back?",
+        "condition": { "u_has_trait": "rubik_translate" },
+        "topic": "TALK_EXODII_MERCHANT_TranslateOff"
+      },
+      { "text": "Well, a person can get sick of trying to piece it together.  See you later.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_Translate2",
+    "type": "talk_topic",
+    "dynamic_line": "*lets out a distant sigh.  \"'Tis a fine and, but seein' as you've a bit o' the wire-and-jamble in yon ears, ol' Rubik can mayhaps remedy.  Truly be as what ye're desire?\"",
+    "//~": "That can be tough, but since you've got a CBM interface, maybe I can help you out.  Is that what you really want?",
+    "responses": [
+      { "text": "Yes.  Please, hit me with some of that sweet translator juice.", "topic": "TALK_EXODII_MERCHANT_Translate3" },
+      { "text": "On second thought, I don't mind your weird dialect.  I changed my mind.", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_Translate3",
+    "type": "talk_topic",
+    "dynamic_line": "*jumbles around in a drawer for a moment and comes up with a device that looks faintly like a voltmeter.  They plug it into their arm, fiddle around for a minute, and then look up at you.  \"Is ol' Rubik translating all right?  Can you follow this'n?\"  You can hear them speaking out loud in their usual dialect, and echoing faintly in your head in plainer English.",
+    "speaker_effect": { "effect": { "u_add_trait": "rubik_translate" } },
+    "responses": [
+      {
+        "text": "Thanks, it seems like it is working.  Feels a bit strange though, I might need a moment.",
+        "topic": "TALK_DONE"
+      }
+    ]
+  },
+  {
+    "id": "TALK_EXODII_MERCHANT_TranslateOff",
+    "type": "talk_topic",
+    "dynamic_line": "*pulls out the weird voltmeter again and fiddles with it.  \"Quick as a sly yark, an I'm ken.\"",
+    "speaker_effect": { "effect": { "u_remove_trait": "rubik_translate" } },
+    "responses": [ { "text": "Thanks, although I'm already kind of questioning my choices.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_EXODII_MERCHANT_Meetcute",

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -24,7 +24,11 @@
       "TALK_EXODII_MERCHANT_DoneTrade",
       "TALK_EXODII_MERCHANT_Exodus2",
       "TALK_EXODII_MERCHANT_ExodizeNope",
-      "TALK_EXODII_MERCHANT_Survival2"
+      "TALK_EXODII_MERCHANT_Survival2",
+      "TALK_EXODII_MERCHANT_Translate2",
+      "TALK_EXODII_MERCHANT_Translate3",
+      "TALK_EXODII_MERCHANT_TranslateOff",
+      "TALK_EXODII_MERCHANT_TranslateExplain",
     ],
     "type": "talk_topic",
     "responses": [
@@ -89,6 +93,11 @@
         "text": "Do all your friends talk like you do?",
         "condition": { "and": [ { "u_has_trait": "CBM_Interface" }, { "not": { "u_has_trait": "rubik_translate" } } ] },
         "topic": "TALK_EXODII_MERCHANT_Translate1"
+      },
+      {
+        "text": "How does this translator work?",
+        "condition": { "u_has_trait": "rubik_translate" },
+        "topic": "TALK_EXODII_MERCHANT_TranslateExplain"
       },
       {
         "text": "I have to admit, I miss your old weird way of talking.  Can you change me back?",
@@ -1175,9 +1184,17 @@
     ]
   },
   {
+    "id": "TALK_EXODII_MERCHANT_TranslateExplain",
+    "type": "talk_topic",
+    "dynamic_line": "It's a fine bit of work, I ken.  You can hear my real voice, right?  This one's own brain jobby picks up word-thoughts and makes 'em to some kind of machine-talk, sends it to your brain jobby, which puts it into your ears.  We usually leave it turned off for security, so nobody can shimmy into it.  That's a small risk, the shimmyin', but you see it's a risk no less, so must we leave it off.  Ol' Rubik's given you close-up access to their jobby, and there you have it.  You're a trusted customer, you ken.",
+    "//": "Only available if you have the translator on, no translation needed.",
+    "responses": [ { "text": "Interesting.  I'd better go.", "topic": "TALK_DONE" } ]
+  },
+  {
     "id": "TALK_EXODII_MERCHANT_TranslateOff",
     "type": "talk_topic",
-    "dynamic_line": "*pulls out the weird voltmeter again and fiddles with it.  \"Quick as a sly yark, an I'm ken.\"",
+    "dynamic_line": "*pulls out the weird voltmeter again and fiddles with it.  \"Quick as a yark, I'd razz.\"",
+    "//~": "Quick as you can ask",
     "speaker_effect": { "effect": { "u_remove_trait": "rubik_translate" } },
     "responses": [ { "text": "Thanks, although I'm already kind of questioning my choices.", "topic": "TALK_DONE" } ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Adds Rubik Translation accessibility option to mainline"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Closes #66515

Rubik's complex dialect is a challenge for ESL speakers, which is why there's a mod to remove it, but it can also be a challenge for content addition or even just for english speakers who don't want to deal with riddles.

#### Describe the solution
Adds the option to get Rubik to give you access to their internal translator, that lets them communicate with other exodii.  This works as an in-game switch. I will also change the mod to work using the same switch - ie. adding a trait to the player - but have it on by default instead of off by default.

Now, if people want to add new content to Rubik and I'm not around to translate, they could either check first to see if there's a translator, or have Rubik turn on translation beforehand, or just have it not show up unless you've got the translator enabled.

The rubik translator is not meant to be perfect but does remove a lot of their more impenetrable slang terms. I hope to keep some of their voice. I'm leaving the translator tips, which specifically remove a lot of the slang.

#### Describe alternatives you've considered
There are a few other ways to do this but this lets us keep Rubik weird but also make them more accessible.

#### Testing
Draft phase. Shouldn't have much that can go wrong.

#### Additional context
I am a little sad about this but I can see the need.

As I go along I am working on populating a lexicon: https://gist.github.com/I-am-Erk/8031db1a8470ed5d7c8bdea64d0d1638
