### PR TITLE
Install newer ccache in ci to avoid hardlink cache statistics bug

### DIFF
--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -260,7 +260,7 @@ jobs:
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && matrix.os == 'ubuntu-20.04' }}
       run: |
           sudo apt-get remove --purge -y ccache
-          curl -sL https://github.com/ccache/ccache/releases/download/v4.8/ccache-4.8-linux-x86_64.tar.xz | sudo tar Jxvf - --strip-components 1 -C /usr/bin ccache-4.8-linux-x86_64/ccache
+          curl -sL https://github.com/ccache/ccache/releases/download/v4.8.3/ccache-4.8.3-linux-x86_64.tar.xz | sudo tar Jxvf - --strip-components 1 -C /usr/bin ccache-4.8.3-linux-x86_64/ccache
           ccache --version
     - name: set up a mock GCC toolchain root for Clang (Ubuntu)
       if: ${{ env.SKIP == 'false' && runner.os == 'Linux' && (matrix.compiler == 'clang++-12') }}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
ccache 4.8.3 has the hardlink stats bug which caused / required #67577. Make the ubuntu build install that version of ccache so the cache size is correctly counted.

The osx build gets ccache from homebrew which will eventually update from 4.8.2 to 4.8.3.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change 4.8 to 4.8.3 in the right places in the workflow file.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
General build matrix on this PR. It worked:
```
Cache directory:      /home/runner/.cache/ccache
Config file:          /home/runner/.config/ccache/ccache.conf
System config file:   /usr/local/etc/ccache.conf
Stats updated:        Tue Sep  5 21:54:35 2023
Cacheable calls:        590 / 593 (99.49%)
  Hits:                 585 / 590 (99.15%)
    Direct:             581 / 585 (99.32%)
    Preprocessed:         4 / 585 ( 0.68%)
  Misses:                 5 / 590 ( 0.85%)
Uncacheable calls:        3 / 593 ( 0.51%)
  Called for linking:     2 /   3 (66.67%)
  No input file:          1 /   3 (33.33%)
Successful lookups:
  Direct:               581 / 590 (98.47%)
  Preprocessed:           4 /   9 (44.44%)
Local storage:
  Cache size (GB):      9.4 / 5.0 (189.0%)       <------ bad value
  Files:              16946
  Hits:                 587 / 592 (99.16%)
  Misses:                 5 / 592 ( 0.84%)
  Reads:               1182
  Writes:                12
Set cache size limit to 2.0 GB
Cache directory:      /home/runner/.cache/ccache
Config file:          /home/runner/.config/ccache/ccache.conf
System config file:   /usr/local/etc/ccache.conf
Stats updated:        Tue Sep  5 21:54:43 2023
Cacheable calls:       590 / 593 (99.49%)
  Hits:                585 / 590 (99.15%)
    Direct:            581 / 585 (99.32%)
    Preprocessed:        4 / 585 ( 0.68%)
  Misses:                5 / 590 ( 0.85%)
Uncacheable calls:       3 / 593 ( 0.51%)
  Called for linking:    2 /   3 (66.67%)
  No input file:         1 /   3 (33.33%)
Successful lookups:
  Direct:              581 / 590 (98.47%)
  Preprocessed:          4 /   9 (44.44%)
Local storage:
  Cache size (GB):     1.8 / 2.0 (92.11%)       <------ good value
  Files:              7367
  Cleanups:             16
  Hits:                58 / 59 (99.16%)
  Misses:                5 / 592 ( 0.84%)
  Reads:              11
  Writes:               12
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
