### PR TITLE
recipe result: mention in sealed container

### DIFF
--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -742,7 +742,8 @@ item_info_data recipe_result_info_cache::get_result_data( const recipe *rec, con
     const std::string recipe_output_string = _( "Recipe Outputs" );
     const std::string recipe_result_string = _( "Recipe Result" );
     const std::string container_string = _( "Container" );
-    const std::string in_container_string = _( "In container" );
+    // Every learnable recipe in a container is sealed.
+    const std::string in_container_string = _( "In sealed container" );
     const std::string container_info_string = _( "Container Information" );
 
     //Set up summary at top so people know they can look further to learn about byproducts and such


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
fix: #65384

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Write off every item in a container as being in a sealed container.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/0ace6876-f2d0-4982-b8f0-4e9d574edced)

**Reason**
Looking through the data, every recipe that is spawned in a container is either:
1. Sealed and defined in `data\json\recipes\recipe_food.json` or `data\json\recipes\food\canned.json`.
1. Or it is unlearnable, in a flash drive and defined in `data\json\recipes\recipe_companion.json`.

It kinda makes sence, what other reason would there be to have result in a container? And what would that recipe look like?

If it changes in future, this introduced this bug. But until then, it is more clear this way.


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

in `src/recipe.h` define 
```cpp
bool recipe::is_sealed() const { return sealed; }
```
`sealed` is defined within `recipe` class and is a bool
And use it where these changes were.



#### Testing
Look at `fruit jam` in the crafting menu.



#### Additional context

