### PR TITLE
Use normal distribution for NPC altruism

### DIFF
--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -764,7 +764,8 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
     personality.aggression = rng( -10, 10 );
     personality.bravery    = rng( -3, 10 );
     personality.collector  = rng( -1, 10 );
-    personality.altruism   = rng( -10, 10 );
+    // Normal distribution. Mean = 0, stddev = 3, clamp at -10 and 10. Rounded to return integer value.
+    personality.altruism   = std::round( std::max( -10.0, std::min( normal_roll( 0, 3 ), 10.0 ) ) );
     moves = 100;
     mission = NPC_MISSION_NULL;
     male = one_in( 2 );


### PR DESCRIPTION
#### Summary
Balance "Most NPCs altruism (personality) scores are average (normal distribution) instead of pure random"

#### Purpose of change
NPC altruism is simply a RNG roll of (-10,10). This means that you are as likely to encounter Mother Teresa as you are to encounter someone who has a normal amount of altruism. Obviously, this is not very correct.

#### Describe the solution
Use normal_roll to get a [normal distribution](https://en.wikipedia.org/wiki/Normal_distribution).

This is a big distribution change, but it shouldn't need a lot of testing as it impacts very few things.
Altruism only affects:
-The willingness of NPCs to lend you credit
-The recruitment chance for "You can keep me safe." (Often way too high and the intended target of this change)
-Minor effect on two persuasion options when asking a NPC to lend you equipment
-Minor effect on two persuasion options when trying to calm down an aggressive/mugging NPC (don't believe this ever comes up, negative altruism is a pre-req for aggressive/mugging attitude)
-Moderate effect for asking island prisoner boss if you can keep the stuff you found.

#### Describe alternatives you've considered
The other personality scores could do with normal distributions as well, but altruism has very few effects and its effects are very obvious, so it is a pretty safe change.

#### Testing
Rerolled a NPC with `NO CLASS` about 100 times with a stddev of 2*, saw a handful of +4 and a handful of -4 (two standard deviations from the mean). Saw nothing outside that range, but the chance for them to show up is about ~1.2% so not seeing any within ~100 rolls is about expected. Most altruism scores were close to 0.

*Note: Commit uses stddev of 3, I believed it was more appropriate after seeing the test results.

#### Additional context
@I-am-Erk You did normal distributions before and you're into NPCs lately, so I'd appreciate if you could take a quick look.