### PR TITLE
[DinoMod] dino camp hunting

### DIFF
--- a/data/mods/DinoMod/monstergroups/misc.json
+++ b/data/mods/DinoMod/monstergroups/misc.json
@@ -115,6 +115,7 @@
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
     "//1": "Can be overwritten by mods.",
     "//2": "This group always has a chance of being the result, regardless of mission type.",
+    "copy-from": "GROUP_CAMP_HUNTING",
     "monsters": [
       { "monster": "mon_gallimimus", "weight": 5 },
       { "monster": "mon_struthiomimus", "weight": 5 },
@@ -136,6 +137,7 @@
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
     "//1": "Can be overwritten by mods.",
     "//2": "This group can only be picked from when the trapping mission is used, in addition to GROUP_CAMP_HUNTING.",
+    "copy-from": "GROUP_CAMP_TRAPPING",
     "monsters": [
       { "monster": "mon_albertonykus", "weight": 10 },
       { "monster": "mon_compsognathus", "weight": 5 },
@@ -154,6 +156,7 @@
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
     "//1": "Can be overwritten by mods.",
     "//2": "This group can only be picked from when the hunt large animals mission is used, in addition to GROUP_CAMP_HUNTING.",
+    "copy-from": "GROUP_CAMP_HUNTING_LARGE",
     "monsters": [
       { "monster": "mon_tenontosaurus", "weight": 10 },
       { "monster": "mon_dryosaurus", "weight": 10 },

--- a/data/mods/DinoMod/monstergroups/misc.json
+++ b/data/mods/DinoMod/monstergroups/misc.json
@@ -108,5 +108,66 @@
       { "monster": "mon_zeinonychus", "weight": 25, "cost_multiplier": 30, "starts": 672, "pack_size": [ 2, 3 ] },
       { "monster": "mon_zeinonychus", "weight": 25, "cost_multiplier": 30, "starts": 2160, "pack_size": [ 2, 3 ] }
     ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_CAMP_HUNTING",
+    "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
+    "//1": "Can be overwritten by mods.",
+    "//2": "This group always has a chance of being the result, regardless of mission type.",
+    "monsters": [
+      { "monster": "mon_gallimimus", "weight": 5 },
+      { "monster": "mon_struthiomimus", "weight": 5 },
+      { "monster": "mon_ornithomimus", "weight": 5 },
+      { "monster": "mon_albertonykus", "weight": 10 },
+      { "monster": "mon_scutellosaurus", "weight": 5 },
+      { "monster": "mon_stegoceras", "weight": 3 },
+      { "monster": "mon_pachycephalosaurus", "weight": 3 },
+      { "monster": "mon_aquilops", "weight": 3 },
+      { "monster": "mon_leptoceratops", "weight": 3 },
+      { "monster": "mon_nanosaurus", "weight": 5 },
+      { "monster": "mon_thescelosaurus", "weight": 5 },
+      { "monster": "mon_dimorphodon", "weight": 5 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_CAMP_TRAPPING",
+    "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
+    "//1": "Can be overwritten by mods.",
+    "//2": "This group can only be picked from when the trapping mission is used, in addition to GROUP_CAMP_HUNTING.",
+    "monsters": [
+      { "monster": "mon_albertonykus", "weight": 10 },
+      { "monster": "mon_compsognathus", "weight": 5 },
+      { "monster": "mon_scutellosaurus", "weight": 5 },
+      { "monster": "mon_stegoceras", "weight": 3 },
+      { "monster": "mon_aquilops", "weight": 3 },
+      { "monster": "mon_leptoceratops", "weight": 3 },
+      { "monster": "mon_nanosaurus", "weight": 5 },
+      { "monster": "mon_dimorphodon", "weight": 5 },
+      { "monster": "mon_pteranodon", "weight": 5 }
+    ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_CAMP_HUNTING_LARGE",
+    "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
+    "//1": "Can be overwritten by mods.",
+    "//2": "This group can only be picked from when the hunt large animals mission is used, in addition to GROUP_CAMP_HUNTING.",
+    "monsters": [
+      { "monster": "mon_tenontosaurus", "weight": 10 },
+      { "monster": "mon_dryosaurus", "weight": 10 },
+      { "monster": "mon_camptosaurus", "weight": 10 },
+      { "monster": "mon_hadrosaurus", "weight": 10 },
+      { "monster": "mon_maiasaura", "weight": 10 },
+      { "monster": "mon_gryposaurus", "weight": 10 },
+      { "monster": "mon_prosaurolophus", "weight": 10 },
+      { "monster": "mon_saurolophus", "weight": 10 },
+      { "monster": "mon_edmontosaurus", "weight": 10 },
+      { "monster": "mon_parasaurolophus", "weight": 10 },
+      { "monster": "mon_lambeosaurus", "weight": 10 },
+      { "monster": "mon_corythosaurus", "weight": 10 },
+      { "monster": "mon_hypacrosaurus", "weight": 10 }
+    ]
   }
 ]

--- a/data/mods/DinoMod/monstergroups/misc.json
+++ b/data/mods/DinoMod/monstergroups/misc.json
@@ -115,15 +115,10 @@
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
     "//1": "Can be overwritten by mods.",
     "//2": "This group always has a chance of being the result, regardless of mission type.",
-    "copy-from": "GROUP_CAMP_HUNTING",
     "monsters": [
-      { "monster": "mon_gallimimus", "weight": 5 },
-      { "monster": "mon_struthiomimus", "weight": 5 },
-      { "monster": "mon_ornithomimus", "weight": 5 },
       { "monster": "mon_albertonykus", "weight": 10 },
       { "monster": "mon_scutellosaurus", "weight": 5 },
       { "monster": "mon_stegoceras", "weight": 3 },
-      { "monster": "mon_pachycephalosaurus", "weight": 3 },
       { "monster": "mon_aquilops", "weight": 3 },
       { "monster": "mon_leptoceratops", "weight": 3 },
       { "monster": "mon_nanosaurus", "weight": 5 },
@@ -137,7 +132,6 @@
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
     "//1": "Can be overwritten by mods.",
     "//2": "This group can only be picked from when the trapping mission is used, in addition to GROUP_CAMP_HUNTING.",
-    "copy-from": "GROUP_CAMP_TRAPPING",
     "monsters": [
       { "monster": "mon_albertonykus", "weight": 10 },
       { "monster": "mon_compsognathus", "weight": 5 },
@@ -146,7 +140,6 @@
       { "monster": "mon_aquilops", "weight": 3 },
       { "monster": "mon_leptoceratops", "weight": 3 },
       { "monster": "mon_nanosaurus", "weight": 5 },
-      { "monster": "mon_dimorphodon", "weight": 5 },
       { "monster": "mon_pteranodon", "weight": 5 }
     ]
   },
@@ -156,8 +149,11 @@
     "//": "Special group with hardcoded reference in basecamp::hunting_results. Does not actually spawn anywhere, used solely to determine returns from camp hunting mission.",
     "//1": "Can be overwritten by mods.",
     "//2": "This group can only be picked from when the hunt large animals mission is used, in addition to GROUP_CAMP_HUNTING.",
-    "copy-from": "GROUP_CAMP_HUNTING_LARGE",
     "monsters": [
+      { "monster": "mon_gallimimus", "weight": 5 },
+      { "monster": "mon_struthiomimus", "weight": 5 },
+      { "monster": "mon_ornithomimus", "weight": 5 },
+      { "monster": "mon_pachycephalosaurus", "weight": 3 },
       { "monster": "mon_tenontosaurus", "weight": 10 },
       { "monster": "mon_dryosaurus", "weight": 10 },
       { "monster": "mon_camptosaurus", "weight": 10 },


### PR DESCRIPTION
#### Summary
Mods "[DinoMod] dino camp hunting"

#### Purpose of change

Feature parity with main game

#### Describe the solution

Leverages the JSONization from #68014 and customizes those new monster groups with different North American dinos (and compies) that I think make sense for hunting small, trapping, and hunting large. Not including gigantic animals, super dangerous predators, or large dangerous pack animals like triceratops. 

Moved some larger corpses to the large group to better match the feel of the vanilla content

#### Describe alternatives you've considered

Add more kinds of dinos to the large hunting list, but didn't want to overstuff the list. Don't put anything big enough to zombify on the small hunt and trapping lists. Not sure if that's what was intended but what I have is pretty close to that

#### Testing

Game loads no errors. A camp NPC went trapping several times and brought back a mix of mundane and dino corpses

<img width="382" alt="Screenshot 2023-09-09 at 3 38 34 PM" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/26608431/796b0841-5999-433f-bf2a-bb73650cb491">


#### Additional context

N/A