### PR TITLE
Add three new professions (+some items maybe), branch the priest profession

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3,27 +3,55 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "holster_supp_MEU",
-    "entries": [ { "item": "m1911", "variant": "m1911_MEU", "ammo-item": "45_acp", "charges": 7, "contents-item": [ "suppressor" ] } ]
+    "entries": [
+      {
+        "item": "m1911",
+        "variant": "m1911_MEU",
+        "ammo-item": "45_acp",
+        "charges": 7,
+        "contents-item": [ "suppressor" ]
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "holster_supp_usp9",
-    "entries": [ { "item": "usp_9mm", "ammo-item": "9mmfmj", "charges": 15, "contents-item": [ "suppressor_compact" ] } ]
+    "entries": [
+      {
+        "item": "usp_9mm",
+        "ammo-item": "9mmfmj",
+        "charges": 15,
+        "contents-item": [ "suppressor_compact" ]
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "army_grenades_40x46",
-    "entries": [ { "item": "40x46mm_m433", "charges": 4 } ]
+    "entries": [
+      {
+        "item": "40x46mm_m433",
+        "charges": 4
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "army_mags_1911",
     "entries": [
-      { "item": "m1911mag", "ammo-item": "45_acp", "charges": 7 },
-      { "item": "m1911mag", "ammo-item": "45_acp", "charges": 7 }
+      {
+        "item": "m1911mag",
+        "ammo-item": "45_acp",
+        "charges": 7
+      },
+      {
+        "item": "m1911mag",
+        "ammo-item": "45_acp",
+        "charges": 7
+      }
     ]
   },
   {
@@ -31,8 +59,16 @@
     "subtype": "collection",
     "id": "army_mags_m17",
     "entries": [
-      { "item": "p320mag_17rd_9x19mm", "ammo-item": "9mmfmj", "charges": 17 },
-      { "item": "p320mag_17rd_9x19mm", "ammo-item": "9mmfmj", "charges": 17 }
+      {
+        "item": "p320mag_17rd_9x19mm",
+        "ammo-item": "9mmfmj",
+        "charges": 17
+      },
+      {
+        "item": "p320mag_17rd_9x19mm",
+        "ammo-item": "9mmfmj",
+        "charges": 17
+      }
     ]
   },
   {
@@ -40,166 +76,363 @@
     "subtype": "collection",
     "id": "army_mags_300blk",
     "entries": [
-      { "item": "stanag30", "ammo-item": "300blk_ss", "charges": 30 },
-      { "item": "stanag30", "ammo-item": "300blk_ss", "charges": 30 }
+      {
+        "item": "stanag30",
+        "ammo-item": "300blk_ss",
+        "charges": 30
+      },
+      {
+        "item": "stanag30",
+        "ammo-item": "300blk_ss",
+        "charges": 30
+      }
     ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "army_mags_mp7",
-    "entries": [ { "item": "hk46mag", "ammo-item": "46mm", "charges": 20 }, { "item": "hk46mag", "ammo-item": "46mm", "charges": 20 } ]
+    "entries": [
+      {
+        "item": "hk46mag",
+        "ammo-item": "46mm",
+        "charges": 20
+      },
+      {
+        "item": "hk46mag",
+        "ammo-item": "46mm",
+        "charges": 20
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "holster_supp_57",
-    "entries": [ { "item": "fn57", "ammo-item": "57mm", "charges": 20 } ]
+    "entries": [
+      {
+        "item": "fn57",
+        "ammo-item": "57mm",
+        "charges": 20
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "army_mags_57",
-    "entries": [ { "item": "fn57mag", "ammo-item": "57mm", "charges": 20 }, { "item": "fn57mag", "ammo-item": "57mm", "charges": 20 } ]
+    "entries": [
+      {
+        "item": "fn57mag",
+        "ammo-item": "57mm",
+        "charges": 20
+      },
+      {
+        "item": "fn57mag",
+        "ammo-item": "57mm",
+        "charges": 20
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "army_mags_m14",
     "entries": [
-      { "item": "m14mag", "ammo-item": "762_51", "charges": 20 },
-      { "item": "m14mag", "ammo-item": "762_51", "charges": 20 }
+      {
+        "item": "m14mag",
+        "ammo-item": "762_51",
+        "charges": 20
+      },
+      {
+        "item": "m14mag",
+        "ammo-item": "762_51",
+        "charges": 20
+      }
     ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "army_mags_m4",
-    "entries": [ { "item": "stanag30", "ammo-item": "556", "charges": 30 }, { "item": "stanag30", "ammo-item": "556", "charges": 30 } ]
+    "entries": [
+      {
+        "item": "stanag30",
+        "ammo-item": "556",
+        "charges": 30
+      },
+      {
+        "item": "stanag30",
+        "ammo-item": "556",
+        "charges": 30
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "army_mags_mp5",
-    "entries": [ { "item": "mp5mag", "ammo-item": "9mm", "charges": 30 }, { "item": "mp5mag", "ammo-item": "9mm", "charges": 30 } ]
+    "entries": [
+      {
+        "item": "mp5mag",
+        "ammo-item": "9mm",
+        "charges": 30
+      },
+      {
+        "item": "mp5mag",
+        "ammo-item": "9mm",
+        "charges": 30
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "ranger_mags",
     "entries": [
-      { "item": "p320mag_13rd_357sig", "ammo-item": "357sig_fmj", "charges": 13 },
-      { "item": "p320mag_13rd_357sig", "ammo-item": "357sig_fmj", "charges": 13 }
+      {
+        "item": "p320mag_13rd_357sig",
+        "ammo-item": "357sig_fmj",
+        "charges": 13
+      },
+      {
+        "item": "p320mag_13rd_357sig",
+        "ammo-item": "357sig_fmj",
+        "charges": 13
+      }
     ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "charged_cell_phone",
-    "entries": [ { "item": "light_plus_battery_cell", "ammo-item": "battery", "charges": 150, "container-item": "cell_phone" } ]
+    "entries": [
+      {
+        "item": "light_plus_battery_cell",
+        "ammo-item": "battery",
+        "charges": 150,
+        "container-item": "cell_phone"
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "charged_laptop",
-    "entries": [ { "item": "medium_plus_battery_cell", "ammo-item": "battery", "charges": 600, "container-item": "laptop" } ]
+    "entries": [
+      {
+        "item": "medium_plus_battery_cell",
+        "ammo-item": "battery",
+        "charges": 600,
+        "container-item": "laptop"
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "charged_soldering_iron",
-    "entries": [ { "item": "light_plus_battery_cell", "ammo-item": "battery", "charges": 150, "container-item": "soldering_iron" } ]
+    "entries": [
+      {
+        "item": "light_plus_battery_cell",
+        "ammo-item": "battery",
+        "charges": 150,
+        "container-item": "soldering_iron"
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "charged_electrical_measuring",
     "entries": [
-      { "item": "light_battery_cell", "ammo-item": "battery", "charges": 100, "container-item": "voltmeter" },
-      { "item": "light_battery_cell", "ammo-item": "battery", "charges": 100, "container-item": "multimeter" }
+      {
+        "item": "light_battery_cell",
+        "ammo-item": "battery",
+        "charges": 100,
+        "container-item": "voltmeter"
+      },
+      {
+        "item": "light_battery_cell",
+        "ammo-item": "battery",
+        "charges": 100,
+        "container-item": "multimeter"
+      }
     ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "charged_smart_phone",
-    "entries": [ { "item": "smart_phone", "ammo-item": "battery", "charges": 120 } ]
+    "entries": [
+      {
+        "item": "smart_phone",
+        "ammo-item": "battery",
+        "charges": 120
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "charged_flashlight",
-    "entries": [ { "item": "light_disposable_cell", "ammo-item": "battery", "charges": 300, "container-item": "flashlight" } ]
+    "entries": [
+      {
+        "item": "light_disposable_cell",
+        "ammo-item": "battery",
+        "charges": 300,
+        "container-item": "flashlight"
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "charged_heavy_flashlight",
-    "entries": [ { "item": "light_disposable_cell", "ammo-item": "battery", "charges": 300, "container-item": "heavy_flashlight" } ]
+    "entries": [
+      {
+        "item": "light_disposable_cell",
+        "ammo-item": "battery",
+        "charges": 300,
+        "container-item": "heavy_flashlight"
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "charged_mp3",
-    "entries": [ { "item": "light_plus_battery_cell", "ammo-item": "battery", "charges": 150, "container-item": "mp3" } ]
+    "entries": [
+      {
+        "item": "light_plus_battery_cell",
+        "ammo-item": "battery",
+        "charges": 150,
+        "container-item": "mp3"
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "charged_two_way_radio",
-    "entries": [ { "item": "light_disposable_cell", "ammo-item": "battery", "charges": 300, "container-item": "two_way_radio" } ]
+    "entries": [
+      {
+        "item": "light_disposable_cell",
+        "ammo-item": "battery",
+        "charges": 300,
+        "container-item": "two_way_radio"
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "charged_powered_earmuffs",
-    "entries": [ { "item": "light_minus_battery_cell", "ammo-item": "battery", "charges": 50, "container-item": "powered_earmuffs" } ]
+    "entries": [
+      {
+        "item": "light_minus_battery_cell",
+        "ammo-item": "battery",
+        "charges": 50,
+        "container-item": "powered_earmuffs"
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "charged_tazer",
-    "entries": [ { "item": "medium_disposable_cell", "ammo-item": "battery", "charges": 1200, "container-item": "tazer" } ]
+    "entries": [
+      {
+        "item": "medium_disposable_cell",
+        "ammo-item": "battery",
+        "charges": 1200,
+        "container-item": "tazer"
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "charged_ref_lighter",
-    "entries": [ { "item": "ref_lighter", "charges": 50 } ]
+    "entries": [
+      {
+        "item": "ref_lighter",
+        "charges": 50
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "charged_matches",
-    "entries": [ { "item": "matches", "charges": 20 } ]
+    "entries": [
+      {
+        "item": "matches",
+        "charges": 20
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "charged_penblack",
-    "entries": [ { "item": "pen", "ammo-item": "black_pen_ink", "charges": 100 } ]
+    "entries": [
+      {
+        "item": "pen",
+        "ammo-item": "black_pen_ink",
+        "charges": 100
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "full_rebreather_mask",
-    "entries": [ { "item": "rebreather", "ammo-item": "rebreather_cartridge_o2", "charges": 180 } ]
+    "entries": [
+      {
+        "item": "rebreather",
+        "ammo-item": "rebreather_cartridge_o2",
+        "charges": 180
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "full_gasmask",
-    "entries": [ { "item": "mask_gas", "ammo-item": "gasfilter_med", "charges": 100 } ]
+    "entries": [
+      {
+        "item": "mask_gas",
+        "ammo-item": "gasfilter_med",
+        "charges": 100
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "army_mags_m2010",
     "entries": [
-      { "item": "m2010mag", "ammo-item": "300_winmag", "charges": 5 },
-      { "item": "m2010mag", "ammo-item": "300_winmag", "charges": 5 },
-      { "item": "m2010mag", "ammo-item": "300_winmag", "charges": 5 },
-      { "item": "m2010mag", "ammo-item": "300_winmag", "charges": 5 }
+      {
+        "item": "m2010mag",
+        "ammo-item": "300_winmag",
+        "charges": 5
+      },
+      {
+        "item": "m2010mag",
+        "ammo-item": "300_winmag",
+        "charges": 5
+      },
+      {
+        "item": "m2010mag",
+        "ammo-item": "300_winmag",
+        "charges": 5
+      },
+      {
+        "item": "m2010mag",
+        "ammo-item": "300_winmag",
+        "charges": 5
+      }
     ]
   },
   {
@@ -207,9 +440,21 @@
     "subtype": "collection",
     "id": "army_mags_tac338",
     "entries": [
-      { "item": "ai_338mag", "ammo-item": "338lapua_fmjbt", "charges": 5 },
-      { "item": "ai_338mag", "ammo-item": "338lapua_fmjbt", "charges": 5 },
-      { "item": "ai_338mag", "ammo-item": "338lapua_fmjbt", "charges": 5 }
+      {
+        "item": "ai_338mag",
+        "ammo-item": "338lapua_fmjbt",
+        "charges": 5
+      },
+      {
+        "item": "ai_338mag",
+        "ammo-item": "338lapua_fmjbt",
+        "charges": 5
+      },
+      {
+        "item": "ai_338mag",
+        "ammo-item": "338lapua_fmjbt",
+        "charges": 5
+      }
     ]
   },
   {
@@ -217,9 +462,21 @@
     "subtype": "collection",
     "id": "mags_50beowulf_ar15",
     "entries": [
-      { "item": "50beowulf_ar15mag", "ammo-item": "50beowulf_xtp", "charges": 10 },
-      { "item": "50beowulf_ar15mag", "ammo-item": "50beowulf_xtp", "charges": 10 },
-      { "item": "50beowulf_ar15mag", "ammo-item": "50beowulf_xtp", "charges": 10 }
+      {
+        "item": "50beowulf_ar15mag",
+        "ammo-item": "50beowulf_xtp",
+        "charges": 10
+      },
+      {
+        "item": "50beowulf_ar15mag",
+        "ammo-item": "50beowulf_xtp",
+        "charges": 10
+      },
+      {
+        "item": "50beowulf_ar15mag",
+        "ammo-item": "50beowulf_xtp",
+        "charges": 10
+      }
     ]
   },
   {
@@ -227,10 +484,26 @@
     "subtype": "collection",
     "id": "mags_ruger_arr",
     "entries": [
-      { "item": "ruger_arr_mag", "ammo-item": "450_ftx", "charges": 3 },
-      { "item": "ruger_arr_mag", "ammo-item": "450_ftx", "charges": 3 },
-      { "item": "ruger_arr_mag", "ammo-item": "450_ftx", "charges": 3 },
-      { "item": "ruger_arr_mag", "ammo-item": "450_ftx", "charges": 3 }
+      {
+        "item": "ruger_arr_mag",
+        "ammo-item": "450_ftx",
+        "charges": 3
+      },
+      {
+        "item": "ruger_arr_mag",
+        "ammo-item": "450_ftx",
+        "charges": 3
+      },
+      {
+        "item": "ruger_arr_mag",
+        "ammo-item": "450_ftx",
+        "charges": 3
+      },
+      {
+        "item": "ruger_arr_mag",
+        "ammo-item": "450_ftx",
+        "charges": 3
+      }
     ]
   },
   {
@@ -238,8 +511,16 @@
     "subtype": "collection",
     "id": "army_mags_m110",
     "entries": [
-      { "item": "hk417mag_20rd", "ammo-item": "762_51", "charges": 20 },
-      { "item": "hk417mag_20rd", "ammo-item": "762_51", "charges": 20 }
+      {
+        "item": "hk417mag_20rd",
+        "ammo-item": "762_51",
+        "charges": 20
+      },
+      {
+        "item": "hk417mag_20rd",
+        "ammo-item": "762_51",
+        "charges": 20
+      }
     ]
   },
   {
@@ -247,8 +528,16 @@
     "subtype": "collection",
     "id": "army_mags_usp45",
     "entries": [
-      { "item": "usp45mag", "ammo-item": "45_acp", "charges": 12 },
-      { "item": "usp45mag", "ammo-item": "45_acp", "charges": 12 }
+      {
+        "item": "usp45mag",
+        "ammo-item": "45_acp",
+        "charges": 12
+      },
+      {
+        "item": "usp45mag",
+        "ammo-item": "45_acp",
+        "charges": 12
+      }
     ]
   },
   {
@@ -256,8 +545,16 @@
     "subtype": "collection",
     "id": "army_mags_usp9",
     "entries": [
-      { "item": "usp9mag", "ammo-item": "9mmfmj", "charges": 15 },
-      { "item": "usp9mag", "ammo-item": "9mmfmj", "charges": 15 }
+      {
+        "item": "usp9mag",
+        "ammo-item": "9mmfmj",
+        "charges": 15
+      },
+      {
+        "item": "usp9mag",
+        "ammo-item": "9mmfmj",
+        "charges": 15
+      }
     ]
   },
   {
@@ -265,8 +562,16 @@
     "subtype": "collection",
     "id": "army_mags_glock17",
     "entries": [
-      { "item": "glock17_22", "ammo-item": "9mmfmj", "charges": 22 },
-      { "item": "glock17_22", "ammo-item": "9mmfmj", "charges": 22 }
+      {
+        "item": "glock17_22",
+        "ammo-item": "9mmfmj",
+        "charges": 22
+      },
+      {
+        "item": "glock17_22",
+        "ammo-item": "9mmfmj",
+        "charges": 22
+      }
     ]
   },
   {
@@ -274,10 +579,26 @@
     "subtype": "collection",
     "id": "speedloaders_s&w619_special",
     "entries": [
-      { "item": "38_speedloader", "ammo-item": "38_special", "charges": 7 },
-      { "item": "38_speedloader", "ammo-item": "38_special", "charges": 7 },
-      { "item": "38_speedloader", "ammo-item": "38_special", "charges": 7 },
-      { "item": "38_speedloader", "ammo-item": "38_special", "charges": 7 }
+      {
+        "item": "38_speedloader",
+        "ammo-item": "38_special",
+        "charges": 7
+      },
+      {
+        "item": "38_speedloader",
+        "ammo-item": "38_special",
+        "charges": 7
+      },
+      {
+        "item": "38_speedloader",
+        "ammo-item": "38_special",
+        "charges": 7
+      },
+      {
+        "item": "38_speedloader",
+        "ammo-item": "38_special",
+        "charges": 7
+      }
     ]
   },
   {
@@ -285,9 +606,21 @@
     "subtype": "collection",
     "id": "speedloaders_s&w619_magnum",
     "entries": [
-      { "item": "38_speedloader", "ammo-item": "357mag_fmj", "charges": 7 },
-      { "item": "38_speedloader", "ammo-item": "357mag_fmj", "charges": 7 },
-      { "item": "38_speedloader", "ammo-item": "357mag_fmj", "charges": 7 }
+      {
+        "item": "38_speedloader",
+        "ammo-item": "357mag_fmj",
+        "charges": 7
+      },
+      {
+        "item": "38_speedloader",
+        "ammo-item": "357mag_fmj",
+        "charges": 7
+      },
+      {
+        "item": "38_speedloader",
+        "ammo-item": "357mag_fmj",
+        "charges": 7
+      }
     ]
   },
   {
@@ -295,8 +628,16 @@
     "subtype": "collection",
     "id": "m1911_10_magazines_reloaded",
     "entries": [
-      { "item": "m1911_10mag", "ammo-item": "reloaded_10mm_fmj", "charges": 8 },
-      { "item": "m1911_10mag", "ammo-item": "reloaded_10mm_fmj", "charges": 8 }
+      {
+        "item": "m1911_10mag",
+        "ammo-item": "reloaded_10mm_fmj",
+        "charges": 8
+      },
+      {
+        "item": "m1911_10mag",
+        "ammo-item": "reloaded_10mm_fmj",
+        "charges": 8
+      }
     ]
   },
   {
@@ -304,7 +645,10 @@
     "subtype": "collection",
     "id": "quiver_modern_archer",
     "entries": [
-      { "item": "arrow_cf", "charges": 16 },
+      {
+        "item": "arrow_cf",
+        "charges": 16
+      },
       { "item": "bow_sight" },
       { "item": "bow_stabilizer_set" },
       { "item": "manual_archery" }
@@ -314,61 +658,111 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "quiver_bow_hunter",
-    "entries": [ { "item": "arrow_cf", "charges": 10 } ]
+    "entries": [
+      {
+        "item": "arrow_cf",
+        "charges": 10
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "quiver_crossbow_hunter",
-    "entries": [ { "item": "bolt_steel", "charges": 4 } ]
+    "entries": [
+      {
+        "item": "bolt_steel",
+        "charges": 4
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "bandolier_shotgun_hunter",
-    "entries": [ { "item": "shot_00", "charges": 18 } ]
+    "entries": [
+      {
+        "item": "shot_00",
+        "charges": 18
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "bandolier_rifle_hunter",
-    "entries": [ { "item": "270win_jsp", "charges": 16 } ]
+    "entries": [
+      {
+        "item": "270win_jsp",
+        "charges": 16
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "bandolier_swat_cqc1",
-    "entries": [ { "item": "shot_00", "charges": 12 } ]
+    "entries": [
+      {
+        "item": "shot_00",
+        "charges": 12
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "bandolier_swat_cqc2",
-    "entries": [ { "item": "shot_slug", "charges": 12 } ]
+    "entries": [
+      {
+        "item": "shot_slug",
+        "charges": 12
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "quiver_naturalist",
-    "entries": [ { "item": "arrow_wood", "charges": 20 } ]
+    "entries": [
+      {
+        "item": "arrow_wood",
+        "charges": 20
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "flintlock_pouch_reenactor",
-    "entries": [ { "item": "flintlock_ammo", "charges": 14 } ]
+    "entries": [
+      {
+        "item": "flintlock_ammo",
+        "charges": 14
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "bandolier_ww_gunslinger",
-    "entries": [ { "item": "45colt_jhp", "charges": 18 } ]
+    "entries": [
+      {
+        "item": "45colt_jhp",
+        "charges": 18
+      }
+    ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "bandolier_cowboy",
-    "entries": [ { "item": "357mag_jhp", "charges": 18 } ]
+    "entries": [
+      {
+        "item": "357mag_jhp",
+        "charges": 18
+      }
+    ]
   },
   {
     "type": "item_group",
@@ -386,7 +780,12 @@
     "type": "item_group",
     "subtype": "collection",
     "id": "ninja_grenade_pouch",
-    "entries": [ { "item": "flashbang" }, { "item": "flashbang" }, { "item": "smokebomb" }, { "item": "smokebomb" } ]
+    "entries": [
+      { "item": "flashbang" },
+      { "item": "flashbang" },
+      { "item": "smokebomb" },
+      { "item": "smokebomb" }
+    ]
   },
   {
     "type": "item_group",
@@ -405,87 +804,232 @@
     "type": "profession_item_substitutions",
     "trait": "WOOLALLERGY",
     "sub": [
-      { "item": "blazer", "new": [ "jacket_leather_red" ] },
-      { "item": "hat_hunting", "new": [ "hat_cotton" ] },
-      { "item": "hat_newsboy", "new": [ "hat_cotton" ] },
-      { "item": "peacoat", "new": [ "jacket_flannel" ] },
-      { "item": "sweater", "new": [ "sweatshirt" ] },
-      { "item": "boots_winter", "new": [ "boots_fur" ] },
-      { "item": "cloak_wool", "new": [ "cloak_leather" ] },
-      { "item": "gloves_wool", "new": [ "gloves_leather" ] },
-      { "item": "socks_wool", "new": [ "socks" ] },
-      { "item": "kilt", "new": [ "kilt_leather" ] },
-      { "item": "mask_ski", "new": [ "balclava" ] }
+      {
+        "item": "blazer",
+        "new": [ "jacket_leather_red" ]
+      },
+      {
+        "item": "hat_hunting",
+        "new": [ "hat_cotton" ]
+      },
+      {
+        "item": "hat_newsboy",
+        "new": [ "hat_cotton" ]
+      },
+      {
+        "item": "peacoat",
+        "new": [ "jacket_flannel" ]
+      },
+      {
+        "item": "sweater",
+        "new": [ "sweatshirt" ]
+      },
+      {
+        "item": "boots_winter",
+        "new": [ "boots_fur" ]
+      },
+      {
+        "item": "cloak_wool",
+        "new": [ "cloak_leather" ]
+      },
+      {
+        "item": "gloves_wool",
+        "new": [ "gloves_leather" ]
+      },
+      {
+        "item": "socks_wool",
+        "new": [ "socks" ]
+      },
+      {
+        "item": "kilt",
+        "new": [ "kilt_leather" ]
+      },
+      {
+        "item": "mask_ski",
+        "new": [ "balclava" ]
+      }
     ]
   },
   {
     "type": "profession_item_substitutions",
     "item": "sunglasses",
     "sub": [
-      { "present": [ "HYPEROPIC" ], "new": [ "fitover_sunglasses" ] },
-      { "present": [ "MYOPIC" ], "new": [ "fitover_sunglasses" ] }
+      {
+        "present": [ "HYPEROPIC" ],
+        "new": [ "fitover_sunglasses" ]
+      },
+      {
+        "present": [ "MYOPIC" ],
+        "new": [ "fitover_sunglasses" ]
+      }
     ]
   },
   {
     "type": "profession_item_substitutions",
     "item": "fancy_sunglasses",
     "sub": [
-      { "present": [ "HYPEROPIC" ], "new": [ "fitover_sunglasses" ] },
-      { "present": [ "MYOPIC" ], "new": [ "fitover_sunglasses" ] }
+      {
+        "present": [ "HYPEROPIC" ],
+        "new": [ "fitover_sunglasses" ]
+      },
+      {
+        "present": [ "MYOPIC" ],
+        "new": [ "fitover_sunglasses" ]
+      }
     ]
   },
   {
     "type": "profession_item_substitutions",
     "item": "hardtack",
     "sub": [
-      { "present": [ "ANTIWHEAT" ], "absent": [ "MEATARIAN" ], "new": [ "cornbread" ] },
-      { "present": [ "ANTIWHEAT", "MEATARIAN" ], "new": [ { "item": "meat_cooked", "ratio": 0.72 } ] }
+      {
+        "present": [ "ANTIWHEAT" ],
+        "absent": [ "MEATARIAN" ],
+        "new": [ "cornbread" ]
+      },
+      {
+        "present": [ "ANTIWHEAT", "MEATARIAN" ],
+        "new": [
+          {
+            "item": "meat_cooked",
+            "ratio": 0.72
+          }
+        ]
+      }
     ]
   },
   {
     "type": "profession_item_substitutions",
     "item": "gum",
-    "sub": [ { "present": [ "ANTIJUNK" ], "new": [ "nic_gum" ] } ]
+    "sub": [
+      {
+        "present": [ "ANTIJUNK" ],
+        "new": [ "nic_gum" ]
+      }
+    ]
   },
   {
     "type": "profession_item_substitutions",
     "item": "sandwich_pbj",
     "sub": [
-      { "present": [ "ANTIFRUIT" ], "absent": [ "ANTIWHEAT" ], "new": [ "sandwich_pbh" ] },
-      { "present": [ "ANTIWHEAT" ], "absent": [ "VEGETARIAN" ], "new": [ { "item": "cracklins", "ratio": 5.625 } ] },
-      { "present": [ "ANTIWHEAT", "VEGETARIAN" ], "new": [ "boiled_egg" ] }
+      {
+        "present": [ "ANTIFRUIT" ],
+        "absent": [ "ANTIWHEAT" ],
+        "new": [ "sandwich_pbh" ]
+      },
+      {
+        "present": [ "ANTIWHEAT" ],
+        "absent": [ "VEGETARIAN" ],
+        "new": [
+          {
+            "item": "cracklins",
+            "ratio": 5.625
+          }
+        ]
+      },
+      {
+        "present": [ "ANTIWHEAT", "VEGETARIAN" ],
+        "new": [ "boiled_egg" ]
+      }
     ]
   },
   {
     "type": "profession_item_substitutions",
     "item": "granola",
     "sub": [
-      { "present": [ "ANTIFRUIT" ], "absent": [ "MEATARIAN" ], "new": [ { "item": "pemmican", "ratio": 0.838 } ] },
-      { "present": [ "ANTIFRUIT", "MEATARIAN" ], "new": [ { "item": "jerky", "ratio": 4 } ] },
-      { "present": [ "ANTIWHEAT" ], "absent": [ "ANTIFRUIT" ], "new": [ { "item": "boiled_egg", "ratio": 0.818 } ] }
+      {
+        "present": [ "ANTIFRUIT" ],
+        "absent": [ "MEATARIAN" ],
+        "new": [
+          {
+            "item": "pemmican",
+            "ratio": 0.838
+          }
+        ]
+      },
+      {
+        "present": [ "ANTIFRUIT", "MEATARIAN" ],
+        "new": [
+          {
+            "item": "jerky",
+            "ratio": 4
+          }
+        ]
+      },
+      {
+        "present": [ "ANTIWHEAT" ],
+        "absent": [ "ANTIFRUIT" ],
+        "new": [
+          {
+            "item": "boiled_egg",
+            "ratio": 0.818
+          }
+        ]
+      }
     ]
   },
   {
     "type": "profession_item_substitutions",
     "item": "juice",
     "sub": [
-      { "present": [ "ANTIFRUIT" ], "absent": [ "ANTIJUNK" ], "new": [ "lemonlime" ] },
-      { "present": [ "ANTIFRUIT", "ANTIJUNK" ], "new": [ { "item": "water_clean", "ratio": 0.4 } ] }
+      {
+        "present": [ "ANTIFRUIT" ],
+        "absent": [ "ANTIJUNK" ],
+        "new": [ "lemonlime" ]
+      },
+      {
+        "present": [ "ANTIFRUIT", "ANTIJUNK" ],
+        "new": [
+          {
+            "item": "water_clean",
+            "ratio": 0.4
+          }
+        ]
+      }
     ]
   },
   {
     "type": "profession_item_substitutions",
     "item": "cheeseburger",
     "sub": [
-      { "present": [ "ANTIWHEAT" ], "absent": [ "ANTIJUNK" ], "new": [ { "item": "fries", "ratio": 4 } ] },
-      { "present": [ "ANTIWHEAT", "ANTIJUNK" ], "absent": [ "MEATARIAN" ], "new": [ "veggy_salad", "fork" ] },
-      { "present": [ "ANTIWHEAT", "ANTIJUNK", "MEATARIAN" ], "new": [ "fried_spam", "fork" ] },
-      { "present": [ "LACTOSE" ], "absent": [ "ANTIWHEAT", "VEGETARIAN" ], "new": [ "hamburger" ] },
-      { "present": [ "LACTOSE", "VEGETARIAN" ], "absent": [ "ANTIWHEAT" ], "new": [ "sandwich_veggy" ] },
+      {
+        "present": [ "ANTIWHEAT" ],
+        "absent": [ "ANTIJUNK" ],
+        "new": [
+          {
+            "item": "fries",
+            "ratio": 4
+          }
+        ]
+      },
+      {
+        "present": [ "ANTIWHEAT", "ANTIJUNK" ],
+        "absent": [ "MEATARIAN" ],
+        "new": [ "veggy_salad", "fork" ]
+      },
+      {
+        "present": [ "ANTIWHEAT", "ANTIJUNK", "MEATARIAN" ],
+        "new": [ "fried_spam", "fork" ]
+      },
+      {
+        "present": [ "LACTOSE" ],
+        "absent": [ "ANTIWHEAT", "VEGETARIAN" ],
+        "new": [ "hamburger" ]
+      },
+      {
+        "present": [ "LACTOSE", "VEGETARIAN" ],
+        "absent": [ "ANTIWHEAT" ],
+        "new": [ "sandwich_veggy" ]
+      },
       {
         "present": [ "VEGETARIAN" ],
         "absent": [ "ANTIWHEAT", "LACTOSE" ],
-        "new": [ { "item": "sandwich_cheese_grilled", "ratio": 0.5 } ]
+        "new": [
+          {
+            "item": "sandwich_cheese_grilled",
+            "ratio": 0.5
+          }
+        ]
       }
     ]
   },
@@ -493,17 +1037,38 @@
     "type": "profession_item_substitutions",
     "item": "pizza_meat",
     "sub": [
-      { "present": [ "VEGETARIAN" ], "absent": [ "ANTIWHEAT" ], "new": [ "pizza_veggy" ] },
-      { "present": [ "VEGETARIAN", "ANTIWHEAT" ], "new": [ "veggy_salad", "fork" ] },
+      {
+        "present": [ "VEGETARIAN" ],
+        "absent": [ "ANTIWHEAT" ],
+        "new": [ "pizza_veggy" ]
+      },
+      {
+        "present": [ "VEGETARIAN", "ANTIWHEAT" ],
+        "new": [ "veggy_salad", "fork" ]
+      },
       {
         "present": [ "ANTIWHEAT" ],
         "absent": [ "VEGETARIAN", "ANTIJUNK" ],
-        "new": [ { "item": "fchicken", "ratio": 1 } ]
+        "new": [
+          {
+            "item": "fchicken",
+            "ratio": 1
+          }
+        ]
       },
       {
         "present": [ "ANTIWHEAT", "ANTIJUNK" ],
         "absent": [ "VEGETARIAN" ],
-        "new": [ { "item": "fish_fried", "ratio": 2 }, { "item": "fork", "ratio": 0.5 } ]
+        "new": [
+          {
+            "item": "fish_fried",
+            "ratio": 2
+          },
+          {
+            "item": "fork",
+            "ratio": 0.5
+          }
+        ]
       }
     ]
   },
@@ -511,38 +1076,78 @@
     "type": "profession_item_substitutions",
     "item": "pizza_veggy",
     "sub": [
-      { "present": [ "ANTIWHEAT", "VEGETARIAN" ], "new": [ "veggy_salad", "fork" ] },
+      {
+        "present": [ "ANTIWHEAT", "VEGETARIAN" ],
+        "new": [ "veggy_salad", "fork" ]
+      },
       {
         "present": [ "ANTIWHEAT" ],
         "absent": [ "VEGETARIAN", "ANTIJUNK" ],
-        "new": [ { "item": "fchicken", "ratio": 1 } ]
+        "new": [
+          {
+            "item": "fchicken",
+            "ratio": 1
+          }
+        ]
       },
       {
         "present": [ "ANTIWHEAT", "ANTIJUNK" ],
         "absent": [ "VEGETARIAN" ],
-        "new": [ { "item": "fish_fried", "ratio": 2 }, { "item": "fork", "ratio": 0.5 } ]
+        "new": [
+          {
+            "item": "fish_fried",
+            "ratio": 2
+          },
+          {
+            "item": "fork",
+            "ratio": 0.5
+          }
+        ]
       },
-      { "present": [ "MEATARIAN" ], "absent": [ "ANTIWHEAT" ], "new": [ "pizza_meat" ] }
+      {
+        "present": [ "MEATARIAN" ],
+        "absent": [ "ANTIWHEAT" ],
+        "new": [ "pizza_meat" ]
+      }
     ]
   },
   {
     "type": "profession_item_substitutions",
     "item": "pudding",
     "sub": [
-      { "present": [ "ANTIJUNK" ], "absent": [ "LACTOSE" ], "new": [ "yoghurt" ] },
-      { "present": [ "ANTIWHEAT" ], "absent": [ "ANTIJUNK" ], "new": [ "neccowafers" ] },
-      { "present": [ "ANTIJUNK", "LACTOSE" ], "new": [ "boiled_egg" ] }
+      {
+        "present": [ "ANTIJUNK" ],
+        "absent": [ "LACTOSE" ],
+        "new": [ "yoghurt" ]
+      },
+      {
+        "present": [ "ANTIWHEAT" ],
+        "absent": [ "ANTIJUNK" ],
+        "new": [ "neccowafers" ]
+      },
+      {
+        "present": [ "ANTIJUNK", "LACTOSE" ],
+        "new": [ "boiled_egg" ]
+      }
     ]
   },
   {
     "type": "profession_item_substitutions",
     "item": "can_beans",
-    "sub": [ { "present": [ "MEATARIAN" ], "new": [ "can_spam" ] } ]
+    "sub": [
+      {
+        "present": [ "MEATARIAN" ],
+        "new": [ "can_spam" ]
+      }
+    ]
   },
   {
     "type": "profession_item_substitutions",
     "group": { "items": [ "glasses_eye" ] },
-    "bonus": { "present": [ "MYOPIC" ], "absent": [ "HYPEROPIC" ] }
+    "bonus": {
+      "present": [ "MYOPIC" ],
+      "absent": [ "HYPEROPIC" ]
+    }
   },
   {
     "type": "profession_item_substitutions",
@@ -552,11 +1157,22 @@
   {
     "type": "profession_item_substitutions",
     "group": { "items": [ "glasses_reading" ] },
-    "bonus": { "present": [ "HYPEROPIC" ], "absent": [ "MYOPIC" ] }
+    "bonus": {
+      "present": [ "HYPEROPIC" ],
+      "absent": [ "MYOPIC" ]
+    }
   },
   {
     "type": "profession_item_substitutions",
-    "group": { "entries": [ { "item": "inhaler", "ammo-item": "albuterol", "charges": 100 } ] },
+    "group": {
+      "entries": [
+        {
+          "item": "inhaler",
+          "ammo-item": "albuterol",
+          "charges": 100
+        }
+      ]
+    },
     "bonus": { "present": [ "ASTHMA" ] }
   },
   {
@@ -576,11 +1192,26 @@
     "description": "Circumstance left you wandering the world, alone.  Now there is nothing to go back to, even if you wanted to.  Perhaps your experience in fending for yourself will prove useful in this new world.",
     "points": 1,
     "skills": [
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "unarmed" },
-      { "level": 2, "name": "fabrication" },
-      { "level": 2, "name": "tailor" },
-      { "level": 2, "name": "cooking" }
+      {
+        "level": 2,
+        "name": "melee"
+      },
+      {
+        "level": 2,
+        "name": "unarmed"
+      },
+      {
+        "level": 2,
+        "name": "fabrication"
+      },
+      {
+        "level": 2,
+        "name": "tailor"
+      },
+      {
+        "level": 2,
+        "name": "cooking"
+      }
     ],
     "items": {
       "both": {
@@ -601,7 +1232,14 @@
           "can_beans",
           "pockknife"
         ],
-        "entries": [ { "group": "charged_cell_phone" }, { "group": "charged_matches" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_cell_phone" },
+          { "group": "charged_matches" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "boxer_briefs" ],
       "female": [ "bra", "panties" ]
@@ -616,7 +1254,10 @@
     "items": {
       "both": {
         "items": [ "jeans", "longshirt", "socks", "sneakers", "mbag", "pockknife", "water_clean", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_matches" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          { "group": "charged_matches" }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
@@ -628,11 +1269,24 @@
     "name": "Video Blogger",
     "description": "You made a career out of creating and commentating video content and posting it on various platforms.  Now most of your fans are dead, alongside your equipment.  Maybe you didn't cultivate the most practical skillset through your career, but you have learned a thing or two about troubleshooting software and getting people to listen to you.",
     "points": 2,
-    "skills": [ { "level": 4, "name": "speech" }, { "level": 4, "name": "computer" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "speech"
+      },
+      {
+        "level": 4,
+        "name": "computer"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "jeans", "longshirt", "socks", "sneakers", "backpack", "pockknife", "water_clean", "wearable_camera", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_laptop" }, { "group": "charged_matches" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          { "group": "charged_laptop" },
+          { "group": "charged_matches" }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
@@ -647,14 +1301,38 @@
     "points": 4,
     "proficiencies": [ "prof_fibers", "prof_knitting", "prof_carving" ],
     "skills": [
-      { "level": 3, "name": "fabrication" },
-      { "level": 3, "name": "mechanics" },
-      { "level": 3, "name": "chemistry" },
-      { "level": 3, "name": "electronics" },
-      { "level": 3, "name": "tailor" },
-      { "level": 3, "name": "cooking" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "computer" }
+      {
+        "level": 3,
+        "name": "fabrication"
+      },
+      {
+        "level": 3,
+        "name": "mechanics"
+      },
+      {
+        "level": 3,
+        "name": "chemistry"
+      },
+      {
+        "level": 3,
+        "name": "electronics"
+      },
+      {
+        "level": 3,
+        "name": "tailor"
+      },
+      {
+        "level": 3,
+        "name": "cooking"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "computer"
+      }
     ],
     "items": {
       "both": {
@@ -662,7 +1340,10 @@
         "entries": [
           { "group": "charged_smart_phone" },
           { "group": "charged_matches" },
-          { "item": "tshirt", "variant": "generic_tshirt" }
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -678,7 +1359,20 @@
     "description": "At the start of the Cataclysm, you hunkered down in a bomb shelter with your collection of guns.  You've spent the past months eating canned food and practicing your aim.  Now it is winter - time to face the world above.",
     "points": 4,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_gunsmithing_improv", "prof_gun_cleaning" ],
-    "skills": [ { "level": 3, "name": "gun" }, { "level": 3, "name": "rifle" }, { "level": 3, "name": "pistol" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "gun"
+      },
+      {
+        "level": 3,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -695,13 +1389,39 @@
         "entries": [
           { "group": "charged_two_way_radio" },
           { "group": "charged_matches" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "m1911", "ammo-item": "45_acp", "charges": 7, "container-item": "holster" },
-          { "item": "45_acp", "charges": 23 },
-          { "item": "garand", "ammo-item": "3006", "charges": 8, "contents-item": "shoulder_strap" },
-          { "item": "garandclip", "ammo-item": "3006", "charges": 8 },
-          { "item": "3006", "charges": 4 }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "m1911",
+            "ammo-item": "45_acp",
+            "charges": 7,
+            "container-item": "holster"
+          },
+          {
+            "item": "45_acp",
+            "charges": 23
+          },
+          {
+            "item": "garand",
+            "ammo-item": "3006",
+            "charges": 8,
+            "contents-item": "shoulder_strap"
+          },
+          {
+            "item": "garandclip",
+            "ammo-item": "3006",
+            "charges": 8
+          },
+          {
+            "item": "3006",
+            "charges": 4
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -716,7 +1436,12 @@
     "description": "Tailoring may not seem like the most useful skill when the world has ended.  Most people wouldn't expect a simple tailor to live very long.  This is your opportunity to prove them wrong.",
     "points": 2,
     "//": "Tailoring book and kit make an already decent class for careful folks much more powerful.",
-    "skills": [ { "level": 6, "name": "tailor" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "tailor"
+      }
+    ],
     "proficiencies": [
       "prof_fibers",
       "prof_leatherworking_basic",
@@ -741,7 +1466,14 @@
           "sf_watch",
           "hairpin"
         ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tailors_kit", "ammo-item": "thread", "charges": 100 } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tailors_kit",
+            "ammo-item": "thread",
+            "charges": 100
+          }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
@@ -753,17 +1485,34 @@
     "name": "Chef",
     "description": "Bork bork!  Years in the kitchen have left you carrying a prodigious bulk, but you managed to escape the carnage with your trusty butcher knife and only a small collection of stains on your uniform.",
     "points": 2,
-    "skills": [ { "name": "cooking", "level": 6 } ],
+    "skills": [
+      {
+        "name": "cooking",
+        "level": 6
+      }
+    ],
     "proficiencies": [ "prof_food_prep", "prof_knife_skills", "prof_baking", "prof_baking_desserts_1", "prof_frying" ],
     "items": {
       "both": {
         "items": [ "pants_checkered", "socks", "dress_shoes" ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "knife_butcher", "container-item": "sheath" },
-          { "item": "hat_chef", "variant": "white_hat_chef" },
-          { "item": "jacket_chef", "variant": "white_jacket_chef" },
-          { "item": "apron_cotton", "variant": "generic_apron_cotton" }
+          {
+            "item": "knife_butcher",
+            "container-item": "sheath"
+          },
+          {
+            "item": "hat_chef",
+            "variant": "white_hat_chef"
+          },
+          {
+            "item": "jacket_chef",
+            "variant": "white_jacket_chef"
+          },
+          {
+            "item": "apron_cotton",
+            "variant": "generic_apron_cotton"
+          }
         ]
       },
       "male": [ "briefs" ],
@@ -779,19 +1528,45 @@
     "items": {
       "both": {
         "items": [ "footrags", "loincloth", "cloak_wool", "ragpouch", "small_relic", "gloves_wraps", "tunic_rag" ],
-        "entries": [ { "item": "knife_baselard", "container-item": "sheath" } ]
+        "entries": [
+          {
+            "item": "knife_baselard",
+            "container-item": "sheath"
+          }
+        ]
       },
       "female": [ "chestwrap" ]
     },
     "proficiencies": [ "prof_fibers", "prof_carving", "prof_leatherworking_basic" ],
     "skills": [
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "throw" },
-      { "level": 3, "name": "archery" },
-      { "level": 3, "name": "fabrication" },
-      { "level": 3, "name": "tailor" },
-      { "level": 3, "name": "survival" },
-      { "level": 3, "name": "cooking" }
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 3,
+        "name": "archery"
+      },
+      {
+        "level": 3,
+        "name": "fabrication"
+      },
+      {
+        "level": 3,
+        "name": "tailor"
+      },
+      {
+        "level": 3,
+        "name": "survival"
+      },
+      {
+        "level": 3,
+        "name": "cooking"
+      }
     ],
     "traits": [ "PROF_CHURL", "ILLITERATE" ],
     "flags": [ "SCEN_ONLY" ]
@@ -803,19 +1578,39 @@
     "description": "Thanks to years of study and hard work in the lab, you're familiar with the basics of scientific inquiry.  Only one question remains: can you undo the very Cataclysm your colleagues helped create?",
     "points": 3,
     "skills": [
-      { "level": 4, "name": "mechanics" },
-      { "level": 4, "name": "chemistry" },
-      { "level": 4, "name": "electronics" },
-      { "level": 4, "name": "computer" }
+      {
+        "level": 4,
+        "name": "mechanics"
+      },
+      {
+        "level": 4,
+        "name": "chemistry"
+      },
+      {
+        "level": 4,
+        "name": "electronics"
+      },
+      {
+        "level": 4,
+        "name": "computer"
+      }
     ],
     "proficiencies": [ "prof_intro_chemistry", "prof_intro_biology" ],
     "items": {
       "both": {
         "items": [ "dress_shirt", "socks", "boots", "coat_lab", "gloves_rubber", "glasses_safety", "wristwatch" ],
         "entries": [
-          { "item": "pants", "variant": "pants_stone" },
+          {
+            "item": "pants",
+            "variant": "pants_stone"
+          },
           { "group": "charged_smart_phone" },
-          { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "chemistry_set" }
+          {
+            "item": "medium_battery_cell",
+            "ammo-item": "battery",
+            "charges": 500,
+            "container-item": "chemistry_set"
+          }
         ]
       },
       "male": [ "briefs" ],
@@ -829,15 +1624,35 @@
     "description": "You've always loved cars, and there's nothing like getting under the hood and fixing it yourself.  You've kept ahold of some handy tools for the job, and at least now you'll never want for parts.",
     "proficiencies": [ "prof_metalworking", "prof_welding_basic", "prof_elec_soldering", "prof_driver" ],
     "points": 2,
-    "skills": [ { "level": 4, "name": "mechanics" }, { "level": 4, "name": "driving" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "mechanics"
+      },
+      {
+        "level": 4,
+        "name": "driving"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "slingpack", "tank_top", "jeans", "socks", "boots_steel", "duct_tape", "screwdriver", "wristwatch", "mag_cars" ],
         "entries": [
-          { "item": "goggles_welding", "custom-flags": [ "no_auto_equip" ] },
+          {
+            "item": "goggles_welding",
+            "custom-flags": [ "no_auto_equip" ]
+          },
           { "group": "charged_smart_phone" },
-          { "item": "wrench", "container-item": "tool_belt" },
-          { "item": "medium_battery_cell", "ammo-item": "battery", "charges": 500, "container-item": "welder" }
+          {
+            "item": "wrench",
+            "container-item": "tool_belt"
+          },
+          {
+            "item": "medium_battery_cell",
+            "ammo-item": "battery",
+            "charges": 500,
+            "container-item": "welder"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -852,12 +1667,30 @@
     "points": 2,
     "proficiencies": [ "prof_lockpicking" ],
     "skills": [
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "unarmed" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "traps" },
-      { "level": 3, "name": "speech" }
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 3,
+        "name": "unarmed"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "traps"
+      },
+      {
+        "level": 3,
+        "name": "speech"
+      }
     ],
     "items": {
       "both": {
@@ -874,7 +1707,13 @@
           "wristwatch",
           "picklocks"
         ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "lighter", "charges": 100 } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "lighter",
+            "charges": 100
+          }
+        ]
       },
       "male": [ "boxer_briefs" ],
       "female": [ "sports_bra", "boxer_shorts" ]
@@ -887,7 +1726,16 @@
     "name": "Beekeeper",
     "description": "You used to be a professional apiarist, building and maintaining beehives.  You had to abandon your precious bees when the Cataclysm struck, but at least you managed to grab some utensils and honey.",
     "points": 2,
-    "skills": [ { "name": "fabrication", "level": 4 }, { "name": "survival", "level": 4 } ],
+    "skills": [
+      {
+        "name": "fabrication",
+        "level": 4
+      },
+      {
+        "name": "survival",
+        "level": 4
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -901,7 +1749,13 @@
           "honey_bottled",
           "honey_bottled"
         ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "honey_scraper", "container-item": "sheath" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "honey_scraper",
+            "container-item": "sheath"
+          }
+        ]
       },
       "male": [ "boxer_briefs" ],
       "female": [ "bra", "panties" ]
@@ -914,10 +1768,22 @@
     "description": "You played with the local team.  You're the only one left, but now you can use your trusty bat for another purpose.  Home run!",
     "points": 2,
     "skills": [
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "bashing" },
-      { "level": 4, "name": "throw" },
-      { "level": 4, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "bashing"
+      },
+      {
+        "level": 4,
+        "name": "throw"
+      },
+      {
+        "level": 4,
+        "name": "swimming"
+      }
     ],
     "proficiencies": [ "prof_athlete_basic" ],
     "items": {
@@ -925,8 +1791,14 @@
         "items": [ "baseball", "jacket_light", "jeans", "socks", "cleats", "helmet_ball", "sports_drink", "gum" ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "bat", "custom-flags": [ "auto_wield" ] },
-          { "item": "tshirt", "variant": "generic_tshirt" }
+          {
+            "item": "bat",
+            "custom-flags": [ "auto_wield" ]
+          },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -940,12 +1812,31 @@
     "name": "Basketball Player",
     "description": "Your first major game was abruptly cancelled when zombies stormed the court.  Quick feet and good reflexes meant you were among the lucky few to escape the stadium alive.",
     "points": 2,
-    "skills": [ { "level": 5, "name": "dodge" }, { "level": 5, "name": "throw" }, { "level": 4, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 5,
+        "name": "dodge"
+      },
+      {
+        "level": 5,
+        "name": "throw"
+      },
+      {
+        "level": 4,
+        "name": "swimming"
+      }
+    ],
     "proficiencies": [ "prof_athlete_basic" ],
     "items": {
       "both": {
         "items": [ "tank_top", "b_shorts", "socks_ankle", "sneakers", "basketball", "sports_drink", "runner_bag" ],
-        "entries": [ { "item": "jersey", "snippets": [ "basin" ] }, { "group": "charged_smart_phone" } ]
+        "entries": [
+          {
+            "item": "jersey",
+            "snippets": [ "basin" ]
+          },
+          { "group": "charged_smart_phone" }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "panties" ]
@@ -959,11 +1850,26 @@
     "description": "Your epic touchdown was ruined when your coach's guts were torn out by undead fans.  Now you're first pick in the apocalypse draft.",
     "points": 3,
     "skills": [
-      { "level": 5, "name": "throw" },
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "unarmed" },
-      { "level": 4, "name": "dodge" },
-      { "level": 4, "name": "swimming" }
+      {
+        "level": 5,
+        "name": "throw"
+      },
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "unarmed"
+      },
+      {
+        "level": 4,
+        "name": "dodge"
+      },
+      {
+        "level": 4,
+        "name": "swimming"
+      }
     ],
     "proficiencies": [ "prof_athlete_basic" ],
     "items": {
@@ -979,7 +1885,13 @@
           "sports_drink",
           "pants"
         ],
-        "entries": [ { "item": "jersey", "snippets": [ "endsville" ] }, { "group": "charged_smart_phone" } ]
+        "entries": [
+          {
+            "item": "jersey",
+            "snippets": [ "endsville" ]
+          },
+          { "group": "charged_smart_phone" }
+        ]
       },
       "male": [ "under_armor_shorts" ],
       "female": [ "sports_bra", "panties" ]
@@ -993,7 +1905,12 @@
     "description": "You are the true Foodperson.  Some might think Foodperson is just a mascot, but you know better.  The mask has become your face, you are real, and the only thing standing between this world and oblivion is you.",
     "points": 0,
     "traits": [ "PROF_FOODP" ],
-    "skills": [ { "level": 2, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 2,
+        "name": "speech"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -1008,10 +1925,21 @@
           "boots_rubber"
         ],
         "entries": [
-          { "item": "medium_disposable_cell", "ammo-item": "battery", "charges": 1200, "container-item": "foodperson_mask" },
-          { "item": "foodplace_snack_bar", "container-item": "fanny" },
+          {
+            "item": "medium_disposable_cell",
+            "ammo-item": "battery",
+            "charges": 1200,
+            "container-item": "foodperson_mask"
+          },
+          {
+            "item": "foodplace_snack_bar",
+            "container-item": "fanny"
+          },
           { "item": "foodplace_snack_bar" },
-          { "item": "bat", "custom-flags": [ "auto_wield" ] }
+          {
+            "item": "bat",
+            "custom-flags": [ "auto_wield" ]
+          }
         ]
       },
       "male": [ "briefs" ],
@@ -1025,7 +1953,16 @@
     "description": "You were a promising cyclist with a bright career in front of you before this all happened.  Perhaps you'll never get to participate in the grand tours now, but as the saying goes, life is like riding a bicycle: you've got to keep moving.",
     "points": 4,
     "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert", "prof_driver" ],
-    "skills": [ { "level": 5, "name": "driving" }, { "level": 4, "name": "dodge" } ],
+    "skills": [
+      {
+        "level": 5,
+        "name": "driving"
+      },
+      {
+        "level": 4,
+        "name": "dodge"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -1055,14 +1992,38 @@
     "points": 4,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 6, "name": "speech" },
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "rifle" },
-      { "level": 2, "name": "pistol" },
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "stabbing" },
-      { "level": 1, "name": "firstaid" },
-      { "level": 1, "name": "throw" }
+      {
+        "level": 6,
+        "name": "speech"
+      },
+      {
+        "level": 3,
+        "name": "gun"
+      },
+      {
+        "level": 3,
+        "name": "rifle"
+      },
+      {
+        "level": 2,
+        "name": "pistol"
+      },
+      {
+        "level": 2,
+        "name": "melee"
+      },
+      {
+        "level": 2,
+        "name": "stabbing"
+      },
+      {
+        "level": 1,
+        "name": "firstaid"
+      },
+      {
+        "level": 1,
+        "name": "throw"
+      }
     ],
     "items": {
       "both": {
@@ -1079,11 +2040,31 @@
           "binoculars"
         ],
         "entries": [
-          { "item": "cigar", "entry-wrapper": "case_cigar", "count": 2 },
-          { "item": "id_military", "container-item": "wallet_leather" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "m17", "ammo-item": "9mm", "container-item": "holster", "charges": 17 },
-          { "item": "p320mag_17rd_9x19mm", "ammo-item": "9mm", "charges": 17, "count": 2 },
+          {
+            "item": "cigar",
+            "entry-wrapper": "case_cigar",
+            "count": 2
+          },
+          {
+            "item": "id_military",
+            "container-item": "wallet_leather"
+          },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "m17",
+            "ammo-item": "9mm",
+            "container-item": "holster",
+            "charges": 17
+          },
+          {
+            "item": "p320mag_17rd_9x19mm",
+            "ammo-item": "9mm",
+            "charges": 17,
+            "count": 2
+          },
           { "item": "militarymap" }
         ]
       },
@@ -1096,22 +2077,55 @@
   {
     "type": "profession",
     "id": "marine",
-    "name": { "male": "Marine Infantryman", "female": "Marine Infantrywoman" },
+    "name": {
+      "male": "Marine Infantryman",
+      "female": "Marine Infantrywoman"
+    },
     "requirement": "achievement_reach_military_bunker",
     "description": "You are one of the few and the proud: a member of the US Marine Corps.  Now that military command has collapsed in on itself as far as you can tell, you suppose that it falls to you to carry the memory of the Corps forward into the future.  Semper fi.",
     "points": 6,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 5, "name": "gun" },
-      { "level": 5, "name": "rifle" },
-      { "level": 4, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "throw" },
-      { "level": 3, "name": "swimming" },
-      { "level": 2, "name": "survival" }
+      {
+        "level": 5,
+        "name": "gun"
+      },
+      {
+        "level": 5,
+        "name": "rifle"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 3,
+        "name": "swimming"
+      },
+      {
+        "level": 2,
+        "name": "survival"
+      }
     ],
     "items": {
       "both": {
@@ -1129,14 +2143,42 @@
         "entries": [
           { "group": "charged_two_way_radio" },
           { "group": "military_ballistic_vest_pristine" },
-          { "item": "tank_top", "variant": "tank_top_camo" },
-          { "item": "pants_army", "variant": "apants_MARPAT" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "legpouch_large", "contents-group": "army_mags_m4" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
-          { "item": "m18", "ammo-item": "9mm", "container-item": "holster", "charges": 17 },
-          { "item": "p320mag_17rd_9x19mm", "ammo-item": "9mm", "charges": 17, "count": 2 },
+          {
+            "item": "tank_top",
+            "variant": "tank_top_camo"
+          },
+          {
+            "item": "pants_army",
+            "variant": "apants_MARPAT"
+          },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_m4"
+          },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
+          {
+            "item": "m18",
+            "ammo-item": "9mm",
+            "container-item": "holster",
+            "charges": 17
+          },
+          {
+            "item": "p320mag_17rd_9x19mm",
+            "ammo-item": "9mm",
+            "charges": 17,
+            "count": 2
+          },
           {
             "item": "m4_cqbr",
             "variant": "m4_cqbr",
@@ -1167,17 +2209,50 @@
       "prof_gun_cleaning"
     ],
     "skills": [
-      { "level": 5, "name": "mechanics" },
-      { "level": 5, "name": "driving" },
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "rifle" },
-      { "level": 4, "name": "swimming" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "survival" },
-      { "level": 3, "name": "throw" }
+      {
+        "level": 5,
+        "name": "mechanics"
+      },
+      {
+        "level": 5,
+        "name": "driving"
+      },
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "rifle"
+      },
+      {
+        "level": 4,
+        "name": "swimming"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "survival"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      }
     ],
     "items": {
       "both": {
@@ -1193,12 +2268,21 @@
         ],
         "entries": [
           { "group": "charged_two_way_radio" },
-          { "item": "tank_top", "variant": "tank_top_camo" },
-          { "item": "pants_army", "variant": "mil_pants_navy" },
+          {
+            "item": "tank_top",
+            "variant": "tank_top_camo"
+          },
+          {
+            "item": "pants_army",
+            "variant": "mil_pants_navy"
+          },
           { "item": "wrench_large" },
           { "item": "screwdriver" },
           { "item": "hacksaw" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -1215,16 +2299,46 @@
     "points": 5,
     "proficiencies": [ "prof_spotting", "prof_gunsmithing_basic", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 7, "name": "swimming" },
-      { "level": 5, "name": "gun" },
-      { "level": 5, "name": "rifle" },
-      { "level": 4, "name": "pistol" },
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "stabbing" },
-      { "level": 4, "name": "dodge" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "survival" },
-      { "level": 3, "name": "throw" }
+      {
+        "level": 7,
+        "name": "swimming"
+      },
+      {
+        "level": 5,
+        "name": "gun"
+      },
+      {
+        "level": 5,
+        "name": "rifle"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "stabbing"
+      },
+      {
+        "level": 4,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "survival"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      }
     ],
     "items": {
       "both": {
@@ -1242,7 +2356,10 @@
           { "group": "charged_heavy_flashlight" },
           { "item": "barometer" },
           { "item": "hygrometer" },
-          { "item": "diveknife", "container-item": "sheath" }
+          {
+            "item": "diveknife",
+            "container-item": "sheath"
+          }
         ]
       },
       "male": [ "rashguard", "wetsuit_shorts" ],
@@ -1259,21 +2376,57 @@
     "points": 3,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "rifle" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "throw" },
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "stabbing" },
-      { "level": 2, "name": "dodge" },
-      { "level": 2, "name": "firstaid" },
-      { "level": 1, "name": "survival" },
-      { "level": 1, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 2,
+        "name": "melee"
+      },
+      {
+        "level": 2,
+        "name": "stabbing"
+      },
+      {
+        "level": 2,
+        "name": "dodge"
+      },
+      {
+        "level": 2,
+        "name": "firstaid"
+      },
+      {
+        "level": 1,
+        "name": "survival"
+      },
+      {
+        "level": 1,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
         "items": [ "pants", "socks", "sneakers", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "boxer_shorts" ]
@@ -1288,16 +2441,46 @@
     "points": 3,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "rifle" },
-      { "level": 3, "name": "throw" },
-      { "level": 2, "name": "pistol" },
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "stabbing" },
-      { "level": 2, "name": "dodge" },
-      { "level": 1, "name": "firstaid" },
-      { "level": 1, "name": "survival" },
-      { "level": 1, "name": "swimming" }
+      {
+        "level": 3,
+        "name": "gun"
+      },
+      {
+        "level": 3,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 2,
+        "name": "pistol"
+      },
+      {
+        "level": 2,
+        "name": "melee"
+      },
+      {
+        "level": 2,
+        "name": "stabbing"
+      },
+      {
+        "level": 2,
+        "name": "dodge"
+      },
+      {
+        "level": 1,
+        "name": "firstaid"
+      },
+      {
+        "level": 1,
+        "name": "survival"
+      },
+      {
+        "level": 1,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -1317,10 +2500,22 @@
         "entries": [
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "legpouch_large", "contents-group": "army_mags_m4" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_m4"
+          },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
           {
             "item": "modular_m4_carbine",
             "variant": "modular_m4a1",
@@ -1343,17 +2538,50 @@
     "points": 5,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_metalworking", "prof_welding_basic", "prof_welding", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 7, "name": "mechanics" },
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "rifle" },
-      { "level": 3, "name": "throw" },
-      { "level": 2, "name": "pistol" },
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "stabbing" },
-      { "level": 2, "name": "dodge" },
-      { "level": 1, "name": "firstaid" },
-      { "level": 1, "name": "survival" },
-      { "level": 1, "name": "swimming" }
+      {
+        "level": 7,
+        "name": "mechanics"
+      },
+      {
+        "level": 3,
+        "name": "gun"
+      },
+      {
+        "level": 3,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 2,
+        "name": "pistol"
+      },
+      {
+        "level": 2,
+        "name": "melee"
+      },
+      {
+        "level": 2,
+        "name": "stabbing"
+      },
+      {
+        "level": 2,
+        "name": "dodge"
+      },
+      {
+        "level": 1,
+        "name": "firstaid"
+      },
+      {
+        "level": 1,
+        "name": "survival"
+      },
+      {
+        "level": 1,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -1372,14 +2600,24 @@
         ],
         "entries": [
           { "group": "us_ballistic_vest_pristine" },
-          { "item": "water_clean", "container-item": "canteen" },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
           { "item": "wrench" },
           { "item": "lug_wrench" },
           { "item": "hacksaw" },
           { "item": "pliers" },
-          { "item": "goggles_welding", "custom-flags": [ "no_auto_equip" ] },
+          {
+            "item": "goggles_welding",
+            "custom-flags": [ "no_auto_equip" ]
+          },
           { "item": "jack" },
-          { "item": "tinyweldtank", "charges": 60, "container-item": "oxy_torch" }
+          {
+            "item": "tinyweldtank",
+            "charges": 60,
+            "container-item": "oxy_torch"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -1395,19 +2633,58 @@
     "points": 7,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_traps", "prof_trapsetting", "prof_disarming", "prof_spotting", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 7, "name": "traps" },
-      { "level": 6, "name": "fabrication" },
-      { "level": 6, "name": "mechanics" },
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "rifle" },
-      { "level": 3, "name": "throw" },
-      { "level": 3, "name": "swimming" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 2, "name": "pistol" },
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "stabbing" },
-      { "level": 2, "name": "dodge" },
-      { "level": 2, "name": "survival" }
+      {
+        "level": 7,
+        "name": "traps"
+      },
+      {
+        "level": 6,
+        "name": "fabrication"
+      },
+      {
+        "level": 6,
+        "name": "mechanics"
+      },
+      {
+        "level": 3,
+        "name": "gun"
+      },
+      {
+        "level": 3,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 3,
+        "name": "swimming"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 2,
+        "name": "pistol"
+      },
+      {
+        "level": 2,
+        "name": "melee"
+      },
+      {
+        "level": 2,
+        "name": "stabbing"
+      },
+      {
+        "level": 2,
+        "name": "dodge"
+      },
+      {
+        "level": 2,
+        "name": "survival"
+      }
     ],
     "items": {
       "both": {
@@ -1426,9 +2703,18 @@
         "entries": [
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "c4", "count": 3 }
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "c4",
+            "count": 3
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -1444,17 +2730,50 @@
     "points": 7,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 6, "name": "speech" },
-      { "level": 5, "name": "gun" },
-      { "level": 5, "name": "rifle" },
-      { "level": 4, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "survival" },
-      { "level": 3, "name": "throw" },
-      { "level": 3, "name": "swimming" }
+      {
+        "level": 6,
+        "name": "speech"
+      },
+      {
+        "level": 5,
+        "name": "gun"
+      },
+      {
+        "level": 5,
+        "name": "rifle"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "survival"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 3,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -1474,10 +2793,22 @@
         "entries": [
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
-          { "item": "shot_00", "count": 2 },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
+          {
+            "item": "shot_00",
+            "count": 2
+          },
           {
             "item": "mossberg_930",
             "variant": "m1014",
@@ -1500,16 +2831,46 @@
     "points": 5,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "rifle" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "throw" },
-      { "level": 2, "name": "survival" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 2,
+        "name": "survival"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -1529,10 +2890,22 @@
         "entries": [
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "legpouch_large", "contents-group": "army_mags_m4" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_m4"
+          },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
           {
             "item": "modular_m4_carbine",
             "variant": "modular_m4a1",
@@ -1554,16 +2927,46 @@
     "points": 8,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_wound_care", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 8, "name": "gun" },
-      { "level": 8, "name": "rifle" },
-      { "level": 6, "name": "pistol" },
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "stabbing" },
-      { "level": 4, "name": "dodge" },
-      { "level": 4, "name": "firstaid" },
-      { "level": 4, "name": "survival" },
-      { "level": 4, "name": "throw" },
-      { "level": 4, "name": "swimming" }
+      {
+        "level": 8,
+        "name": "gun"
+      },
+      {
+        "level": 8,
+        "name": "rifle"
+      },
+      {
+        "level": 6,
+        "name": "pistol"
+      },
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "stabbing"
+      },
+      {
+        "level": 4,
+        "name": "dodge"
+      },
+      {
+        "level": 4,
+        "name": "firstaid"
+      },
+      {
+        "level": 4,
+        "name": "survival"
+      },
+      {
+        "level": 4,
+        "name": "throw"
+      },
+      {
+        "level": 4,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -1583,13 +2986,40 @@
         "entries": [
           { "group": "charged_two_way_radio" },
           { "group": "charged_powered_earmuffs" },
-          { "item": "pants_army", "variant": "mil_pants_navy" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "legpouch_large", "contents-group": "army_mags_tac338" },
-          { "item": "knife_combat", "container-item": "sheath" },
-          { "item": "p226_9mm", "ammo-item": "9mm", "container-item": "holster", "charges": 15 },
-          { "item": "p226mag_15rd_9x19mm", "ammo-item": "9mm", "charges": 15, "count": 2 },
-          { "item": "tac338", "ammo-item": "338lapua_fmjbt", "charges": 5, "contents-item": [ "shoulder_strap" ] }
+          {
+            "item": "pants_army",
+            "variant": "mil_pants_navy"
+          },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_tac338"
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
+          {
+            "item": "p226_9mm",
+            "ammo-item": "9mm",
+            "container-item": "holster",
+            "charges": 15
+          },
+          {
+            "item": "p226mag_15rd_9x19mm",
+            "ammo-item": "9mm",
+            "charges": 15,
+            "count": 2
+          },
+          {
+            "item": "tac338",
+            "ammo-item": "338lapua_fmjbt",
+            "charges": 5,
+            "contents-item": [ "shoulder_strap" ]
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -1606,16 +3036,46 @@
     "points": 8,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_wound_care", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 7, "name": "gun" },
-      { "level": 7, "name": "rifle" },
-      { "level": 6, "name": "pistol" },
-      { "level": 5, "name": "melee" },
-      { "level": 5, "name": "stabbing" },
-      { "level": 5, "name": "dodge" },
-      { "level": 4, "name": "firstaid" },
-      { "level": 4, "name": "survival" },
-      { "level": 4, "name": "throw" },
-      { "level": 4, "name": "swimming" }
+      {
+        "level": 7,
+        "name": "gun"
+      },
+      {
+        "level": 7,
+        "name": "rifle"
+      },
+      {
+        "level": 6,
+        "name": "pistol"
+      },
+      {
+        "level": 5,
+        "name": "melee"
+      },
+      {
+        "level": 5,
+        "name": "stabbing"
+      },
+      {
+        "level": 5,
+        "name": "dodge"
+      },
+      {
+        "level": 4,
+        "name": "firstaid"
+      },
+      {
+        "level": 4,
+        "name": "survival"
+      },
+      {
+        "level": 4,
+        "name": "throw"
+      },
+      {
+        "level": 4,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -1634,15 +3094,45 @@
         "entries": [
           { "group": "charged_two_way_radio" },
           { "group": "charged_powered_earmuffs" },
-          { "item": "tank_top", "variant": "tank_top_camo" },
-          { "item": "pants_army", "variant": "mil_pants_navy" },
+          {
+            "item": "tank_top",
+            "variant": "tank_top_camo"
+          },
+          {
+            "item": "pants_army",
+            "variant": "mil_pants_navy"
+          },
           { "item": "grenade" },
-          { "item": "light_battery_cell", "ammo-item": "battery", "charges": 100, "container-item": "goggles_nv" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "legpouch_large", "contents-group": "army_mags_m4" },
-          { "item": "knife_combat", "container-item": "sheath" },
-          { "item": "p226_9mm", "ammo-item": "9mm", "container-item": "holster", "charges": 15 },
-          { "item": "p226mag_15rd_9x19mm", "ammo-item": "9mm", "charges": 15, "count": 2 },
+          {
+            "item": "light_battery_cell",
+            "ammo-item": "battery",
+            "charges": 100,
+            "container-item": "goggles_nv"
+          },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_m4"
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
+          {
+            "item": "p226_9mm",
+            "ammo-item": "9mm",
+            "container-item": "holster",
+            "charges": 15
+          },
+          {
+            "item": "p226mag_15rd_9x19mm",
+            "ammo-item": "9mm",
+            "charges": 15,
+            "count": 2
+          },
           {
             "item": "m4_cqbr",
             "variant": "m4_cqbr",
@@ -1666,17 +3156,50 @@
     "points": 8,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_traps", "prof_disarming", "prof_spotting", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 7, "name": "gun" },
-      { "level": 7, "name": "smg" },
-      { "level": 7, "name": "rifle" },
-      { "level": 5, "name": "melee" },
-      { "level": 5, "name": "stabbing" },
-      { "level": 5, "name": "dodge" },
-      { "level": 4, "name": "traps" },
-      { "level": 4, "name": "firstaid" },
-      { "level": 4, "name": "throw" },
-      { "level": 4, "name": "swimming" },
-      { "level": 4, "name": "survival" }
+      {
+        "level": 7,
+        "name": "gun"
+      },
+      {
+        "level": 7,
+        "name": "smg"
+      },
+      {
+        "level": 7,
+        "name": "rifle"
+      },
+      {
+        "level": 5,
+        "name": "melee"
+      },
+      {
+        "level": 5,
+        "name": "stabbing"
+      },
+      {
+        "level": 5,
+        "name": "dodge"
+      },
+      {
+        "level": 4,
+        "name": "traps"
+      },
+      {
+        "level": 4,
+        "name": "firstaid"
+      },
+      {
+        "level": 4,
+        "name": "throw"
+      },
+      {
+        "level": 4,
+        "name": "swimming"
+      },
+      {
+        "level": 4,
+        "name": "survival"
+      }
     ],
     "items": {
       "both": {
@@ -1694,11 +3217,26 @@
         ],
         "entries": [
           { "group": "charged_two_way_radio" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "glasses_bal", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "kukri", "container-item": "sheath" },
-          { "item": "chestrig", "contents-group": "army_mags_mp5" },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "glasses_bal",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "kukri",
+            "container-item": "sheath"
+          },
+          {
+            "item": "chestrig",
+            "contents-group": "army_mags_mp5"
+          },
           {
             "item": "hk_mp5",
             "ammo-item": "9mm",
@@ -1714,13 +3252,32 @@
   {
     "type": "profession",
     "id": "maid",
-    "name": { "male": "Butler", "female": "Maid" },
+    "name": {
+      "male": "Butler",
+      "female": "Maid"
+    },
     "description": "You were hired to take care of the housekeeping for a wealthy family.  Naturally, when things got bad, they all took off on a family vacation to somewhere unknown, leaving you to your fate.",
     "points": 1,
-    "skills": [ { "level": 3, "name": "tailor" }, { "level": 3, "name": "cooking" }, { "level": 3, "name": "driving" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "tailor"
+      },
+      {
+        "level": 3,
+        "name": "cooking"
+      },
+      {
+        "level": 3,
+        "name": "driving"
+      }
+    ],
     "proficiencies": [ "prof_food_prep", "prof_closures" ],
     "items": {
-      "both": { "items": [ "pocketwatch", "knife_steak" ], "entries": [ { "group": "charged_smart_phone" } ] },
+      "both": {
+        "items": [ "pocketwatch", "knife_steak" ],
+        "entries": [ { "group": "charged_smart_phone" } ]
+      },
       "male": [ "briefs", "socks", "dress_shoes", "tux", "glasses_monocle", "collarpin" ],
       "female": [ "panties", "bra", "stockings", "garter_belt", "dress_shoes", "maid_dress", "maid_hat", "corset_waist", "fc_hairpin" ]
     }
@@ -1728,7 +3285,10 @@
   {
     "type": "profession",
     "id": "captive",
-    "name": { "male": "Captive", "female": "Captive" },
+    "name": {
+      "male": "Captive",
+      "female": "Captive"
+    },
     "description": "You were following a road at night, trying to get away from the horrors of the city, when you heard a voice calling out in the dark.  You followed, hoping they were friendly, but suddenly felt a searing pain in your head and blacked out.  You just woke up in this strange place… are you even on Earth anymore?",
     "points": -2,
     "flags": [ "SCEN_ONLY" ]
@@ -1736,27 +3296,63 @@
   {
     "type": "profession",
     "id": "rescuer",
-    "name": { "male": "Rescuer", "female": "Rescuer" },
+    "name": {
+      "male": "Rescuer",
+      "female": "Rescuer"
+    },
     "requirement": "achievement_reach_mi-Go_encampment",
     "description": "You were ready.  You went in determined to find and rescue your friends.  Now the atmosphere in these twisting corridors grows heavy, and you don't feel quite so confident anymore.  You might be the one in need of a rescue soon.",
     "points": 3,
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "rifle" },
-      { "level": 4, "name": "pistol" },
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "stabbing" },
-      { "level": 4, "name": "dodge" },
-      { "level": 4, "name": "fabrication" },
-      { "level": 4, "name": "tailor" },
-      { "level": 3, "name": "throw" },
-      { "level": 3, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "rifle"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "stabbing"
+      },
+      {
+        "level": 4,
+        "name": "dodge"
+      },
+      {
+        "level": 4,
+        "name": "fabrication"
+      },
+      {
+        "level": 4,
+        "name": "tailor"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 3,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
         "items": [ "armor_farmor", "socks", "boots_fur", "hat_fur", "gloves_fur", "vest", "wristwatch", "bracelet_friendship" ],
         "entries": [
-          { "item": "knife_combat", "container-item": "sheath" },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
           {
             "item": "modular_m4_carbine",
             "variant": "modular_m4a1",
@@ -1764,9 +3360,21 @@
             "charges": 30,
             "contents-item": "shoulder_strap"
           },
-          { "item": "stanag30", "ammo-item": "556", "charges": 30 },
-          { "item": "stanag30", "ammo-item": "556", "charges": 30 },
-          { "item": "stanag30", "ammo-item": "556", "charges": 30 },
+          {
+            "item": "stanag30",
+            "ammo-item": "556",
+            "charges": 30
+          },
+          {
+            "item": "stanag30",
+            "ammo-item": "556",
+            "charges": 30
+          },
+          {
+            "item": "stanag30",
+            "ammo-item": "556",
+            "charges": 30
+          },
           { "group": "full_gasmask" }
         ]
       },
@@ -1781,7 +3389,12 @@
     "name": "Medical Resident",
     "description": "Fresh out of med school, you've got little in the way of practical experience and just a handful of first-aid supplies.  You just hope it will be enough if 'physician, heal thyself' turns out to be more literal than you expected.",
     "points": 2,
-    "skills": [ { "level": 5, "name": "firstaid" } ],
+    "skills": [
+      {
+        "level": 5,
+        "name": "firstaid"
+      }
+    ],
     "proficiencies": [
       "prof_wound_care",
       "prof_wound_care_expert",
@@ -1803,12 +3416,25 @@
           "glasses_safety",
           "wristwatch",
           "water_clean",
-          { "item": "bandages", "count": 3 },
-          { "item": "adhesive_bandages", "count": 10 },
+          {
+            "item": "bandages",
+            "count": 3
+          },
+          {
+            "item": "adhesive_bandages",
+            "count": 10
+          },
           "aspirin",
           "stethoscope"
         ],
-        "entries": [ { "item": "pants", "variant": "pants_blue" }, { "group": "charged_smart_phone" }, { "group": "full_1st_aid" } ]
+        "entries": [
+          {
+            "item": "pants",
+            "variant": "pants_blue"
+          },
+          { "group": "charged_smart_phone" },
+          { "group": "full_1st_aid" }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
@@ -1822,13 +3448,34 @@
     "description": "The boss always said he could rely on you to pull through on the tough jobs.  Shame he got himself smoked.  No problem; the world's always got a place for someone with your kind of talents.",
     "points": 4,
     "skills": [
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "unarmed" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "driving" }
+      {
+        "level": 3,
+        "name": "gun"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 3,
+        "name": "unarmed"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "driving"
+      }
     ],
     "items": {
       "both": {
@@ -1848,10 +3495,26 @@
         ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "glock_19", "ammo-item": "9mm", "container-item": "holster", "charges": 15 },
-          { "item": "glockmag", "ammo-item": "9mm", "charges": 15 },
-          { "item": "glockmag", "ammo-item": "9mm", "charges": 15 },
-          { "item": "lighter", "charges": 100 }
+          {
+            "item": "glock_19",
+            "ammo-item": "9mm",
+            "container-item": "holster",
+            "charges": 15
+          },
+          {
+            "item": "glockmag",
+            "ammo-item": "9mm",
+            "charges": 15
+          },
+          {
+            "item": "glockmag",
+            "ammo-item": "9mm",
+            "charges": 15
+          },
+          {
+            "item": "lighter",
+            "charges": 100
+          }
         ]
       },
       "male": [ "boxer_shorts", "gold_dental_grill" ],
@@ -1866,10 +3529,22 @@
     "description": "You had a boring, underpaid job watching cameras and patrolling hallways, but things have suddenly gotten a lot more dangerous.  You have some useful equipment, but you've never had any call to use it until now.",
     "points": 2,
     "skills": [
-      { "level": 2, "name": "gun" },
-      { "level": 2, "name": "pistol" },
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "bashing" }
+      {
+        "level": 2,
+        "name": "gun"
+      },
+      {
+        "level": 2,
+        "name": "pistol"
+      },
+      {
+        "level": 2,
+        "name": "melee"
+      },
+      {
+        "level": 2,
+        "name": "bashing"
+      }
     ],
     "items": {
       "both": {
@@ -1877,12 +3552,34 @@
         "entries": [
           { "group": "charged_smart_phone" },
           { "group": "charged_flashlight" },
-          { "item": "pants", "variant": "pants_urban" },
-          { "item": "soft_3a_vest", "variant": "security_armor_vest" },
-          { "item": "baton", "custom-flags": [ "auto_wield" ] },
-          { "item": "m9", "ammo-item": "9mm", "charges": 15, "container-item": "holster" },
-          { "item": "m9mag", "ammo-item": "9mm", "charges": 15 },
-          { "item": "m9mag", "ammo-item": "9mm", "charges": 15 }
+          {
+            "item": "pants",
+            "variant": "pants_urban"
+          },
+          {
+            "item": "soft_3a_vest",
+            "variant": "security_armor_vest"
+          },
+          {
+            "item": "baton",
+            "custom-flags": [ "auto_wield" ]
+          },
+          {
+            "item": "m9",
+            "ammo-item": "9mm",
+            "charges": 15,
+            "container-item": "holster"
+          },
+          {
+            "item": "m9mag",
+            "ammo-item": "9mm",
+            "charges": 15
+          },
+          {
+            "item": "m9mag",
+            "ammo-item": "9mm",
+            "charges": 15
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -1896,15 +3593,34 @@
     "description": "You used to mow lawns and trim hedges for the wealthy.  Contract work was getting scarce even before the zombies came, but now you've got nothing left except your tools and expertise.",
     "points": 1,
     "skills": [
-      { "level": 3, "name": "fabrication" },
-      { "level": 3, "name": "survival" },
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "cutting" }
+      {
+        "level": 3,
+        "name": "fabrication"
+      },
+      {
+        "level": 3,
+        "name": "survival"
+      },
+      {
+        "level": 2,
+        "name": "melee"
+      },
+      {
+        "level": 2,
+        "name": "cutting"
+      }
     ],
     "items": {
       "both": {
         "items": [ "tank_top", "jacket_windbreaker", "hat_ball", "gloves_work", "glasses_safety", "socks", "sneakers", "pants_cargo" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "g_shovel" }, { "item": "scabbard", "contents-item": "machete" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          { "item": "g_shovel" },
+          {
+            "item": "scabbard",
+            "contents-item": "machete"
+          }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
@@ -1917,7 +3633,20 @@
     "//": "They don't have the doctor's passive bonus to surgery.  Nursing assistants aren't required to hold a doctorate.",
     "description": "You went on providing in-home care for the elderly even as the whole world fell apart around you.  You can only pray that you don't see your former clients among the walking dead…",
     "points": 1,
-    "skills": [ { "level": 3, "name": "firstaid" }, { "level": 3, "name": "cooking" }, { "level": 3, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "cooking"
+      },
+      {
+        "level": 3,
+        "name": "speech"
+      }
+    ],
     "proficiencies": [ "prof_wound_care" ],
     "items": {
       "both": {
@@ -1928,16 +3657,28 @@
           "dress_shoes",
           "coat_lab",
           "water_clean",
-          { "item": "bandages", "count": 3 },
-          { "item": "adhesive_bandages", "count": 10 },
+          {
+            "item": "bandages",
+            "count": 3
+          },
+          {
+            "item": "adhesive_bandages",
+            "count": 10
+          },
           "aspirin",
           "stethoscope",
           "pudding"
         ],
         "entries": [
-          { "item": "pants", "variant": "pants_blue" },
+          {
+            "item": "pants",
+            "variant": "pants_blue"
+          },
           { "group": "charged_smart_phone" },
-          { "item": "mask_dust", "variant": "white_mask_dust" }
+          {
+            "item": "mask_dust",
+            "variant": "white_mask_dust"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -1967,13 +3708,34 @@
       "prof_gun_cleaning"
     ],
     "skills": [
-      { "level": 6, "name": "survival" },
-      { "level": 5, "name": "fabrication" },
-      { "level": 5, "name": "traps" },
-      { "level": 3, "name": "chemistry" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "cooking" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 6,
+        "name": "survival"
+      },
+      {
+        "level": 5,
+        "name": "fabrication"
+      },
+      {
+        "level": 5,
+        "name": "traps"
+      },
+      {
+        "level": 3,
+        "name": "chemistry"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "cooking"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -1992,9 +3754,18 @@
         "entries": [
           { "group": "charged_cell_phone" },
           { "group": "charged_flashlight" },
-          { "item": "lighter", "charges": 100 },
-          { "group": "knife_rambo_full", "container-item": "scabbard" },
-          { "item": "tshirt", "variant": "generic_tshirt" }
+          {
+            "item": "lighter",
+            "charges": 100
+          },
+          {
+            "group": "knife_rambo_full",
+            "container-item": "scabbard"
+          },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2023,12 +3794,31 @@
     "name": "Helicopter Pilot",
     "description": "You got your pilot's license and earned a living ferrying businessmen and tourists around.  The Cataclysm has grounded you for now, but the sky still calls to you…",
     "points": 4,
-    "skills": [ { "level": 6, "name": "driving" }, { "level": 3, "name": "mechanics" }, { "level": 2, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "driving"
+      },
+      {
+        "level": 3,
+        "name": "mechanics"
+      },
+      {
+        "level": 2,
+        "name": "speech"
+      }
+    ],
     "proficiencies": [ "prof_helicopter_pilot" ],
     "items": {
       "both": {
         "items": [ "pants_cargo", "socks", "polo_shirt", "boots", "wristwatch", "fancy_sunglasses" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "boy_shorts" ]
@@ -2042,28 +3832,71 @@
     "description": "You spent your career busting drug smugglers with your faithful canine companion.  Now the world has ended, and none of that matters anymore.  Your loyal dog is still at your side, though, ready to face the Cataclysm with you.",
     "points": 5,
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "bashing" },
-      { "level": 2, "name": "dodge" },
-      { "level": 2, "name": "survival" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "bashing"
+      },
+      {
+        "level": 2,
+        "name": "dodge"
+      },
+      {
+        "level": 2,
+        "name": "survival"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "traits": [ "PROF_POLICE" ],
     "proficiencies": [ "prof_spotting", "prof_gun_cleaning" ],
-    "pets": [ { "name": "mon_dog_gshepherd", "amount": 1 } ],
+    "pets": [
+      {
+        "name": "mon_dog_gshepherd",
+        "amount": 1
+      }
+    ],
     "items": {
       "both": {
         "items": [ "pants_army", "socks", "badge_deputy", "police_belt", "boots", "dog_whistle", "wristwatch", "dogfood_dry", "baton" ],
         "entries": [
           { "group": "charged_smart_phone" },
           { "group": "charged_two_way_radio" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "usp_45", "ammo-item": "45_acp", "charges": 12, "container-item": "holster" },
-          { "item": "legpouch_large", "contents-group": "army_mags_usp45" },
-          { "item": "kevlar_harness", "container-item": "runner_bag" },
-          { "item": "sheriffshirt", "variant": "sheriff" }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "usp_45",
+            "ammo-item": "45_acp",
+            "charges": 12,
+            "container-item": "holster"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_usp45"
+          },
+          {
+            "item": "kevlar_harness",
+            "container-item": "runner_bag"
+          },
+          {
+            "item": "sheriffshirt",
+            "variant": "sheriff"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2078,17 +3911,43 @@
     "description": "You have spent many long years forging a bond with your equine companion, from running down common thugs, to entertaining kids when you ride on by.  The cataclysm is upon you, but at least you have eachother.",
     "points": 5,
     "skills": [
-      { "level": 5, "name": "survival" },
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "bashing" },
-      { "level": 2, "name": "dodge" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 5,
+        "name": "survival"
+      },
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "bashing"
+      },
+      {
+        "level": 2,
+        "name": "dodge"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "traits": [ "PROF_POLICE" ],
     "proficiencies": [ "prof_spotting", "prof_gun_cleaning" ],
-    "pets": [ { "name": "mon_horse_police", "amount": 1 } ],
+    "pets": [
+      {
+        "name": "mon_horse_police",
+        "amount": 1
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -2106,9 +3965,18 @@
         "entries": [
           { "group": "charged_smart_phone" },
           { "group": "charged_two_way_radio" },
-          { "group": "holster_supp_usp9", "container-item": "XL_holster" },
-          { "item": "legpouch_large", "contents-group": "army_mags_usp9" },
-          { "item": "sheriffshirt", "variant": "sheriff" }
+          {
+            "group": "holster_supp_usp9",
+            "container-item": "XL_holster"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_usp9"
+          },
+          {
+            "item": "sheriffshirt",
+            "variant": "sheriff"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2121,13 +3989,29 @@
     "name": "Dog Lover",
     "description": "You spent your days running around with your faithful dogs by your side.  When the world ended, you grabbed your companions along with some of their things to protect them.  The zombies could be nearby, but at least your canine friends won't have to worry about the rain.",
     "points": 2,
-    "skills": [ { "level": 3, "name": "survival" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "survival"
+      }
+    ],
     "traits": [ "ANIMALEMPATH" ],
-    "pets": [ { "name": "mon_dog", "amount": 2 } ],
+    "pets": [
+      {
+        "name": "mon_dog",
+        "amount": 2
+      }
+    ],
     "items": {
       "both": {
         "items": [ "jeans", "longshirt", "socks", "sneakers", "water_clean", "wristwatch", "petpack", "pet_carrier" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "mbag", "contents-group": "dog_lover_bag" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "mbag",
+            "contents-group": "dog_lover_bag"
+          }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
@@ -2137,31 +4021,96 @@
   {
     "type": "profession",
     "id": "crazy_cat_lady",
-    "name": { "male": "Crazy Cat Dude", "female": "Crazy Cat Lady" },
+    "name": {
+      "male": "Crazy Cat Dude",
+      "female": "Crazy Cat Lady"
+    },
     "description": "Everyone is dead?  Oh well, it doesn't matter; it's not like you got along with people much anyway.  Your beloved cats are all the friends you need!",
     "points": 2,
-    "skills": [ { "level": 3, "name": "tailor" }, { "level": 3, "name": "survival" }, { "level": 3, "name": "cooking" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "tailor"
+      },
+      {
+        "level": 3,
+        "name": "survival"
+      },
+      {
+        "level": 3,
+        "name": "cooking"
+      }
+    ],
     "proficiencies": [ "prof_knitting", "prof_knitting_speed" ],
     "pets": [
-      { "name": "mon_cat", "amount": 5 },
-      { "name": "mon_cat_tabby", "amount": 4 },
-      { "name": "mon_cat_longhair", "amount": 3 },
-      { "name": "mon_cat_persian", "amount": 3 },
-      { "name": "mon_cat_siamese", "amount": 3 },
-      { "name": "mon_cat_calico", "amount": 2 },
-      { "name": "mon_cat_maine_coon", "amount": 2 },
-      { "name": "mon_cat_devon_rex", "amount": 2 },
-      { "name": "mon_cat_bengal", "amount": 1 },
-      { "name": "mon_cat_sphynx", "amount": 1 },
-      { "name": "mon_cat_chonker_kitten", "amount": 1 },
-      { "name": "mon_cat_longhair_kitten", "amount": 1 },
-      { "name": "mon_cat_calico_kitten", "amount": 1 },
-      { "name": "mon_cat_tabby_kitten", "amount": 1 }
+      {
+        "name": "mon_cat",
+        "amount": 5
+      },
+      {
+        "name": "mon_cat_tabby",
+        "amount": 4
+      },
+      {
+        "name": "mon_cat_longhair",
+        "amount": 3
+      },
+      {
+        "name": "mon_cat_persian",
+        "amount": 3
+      },
+      {
+        "name": "mon_cat_siamese",
+        "amount": 3
+      },
+      {
+        "name": "mon_cat_calico",
+        "amount": 2
+      },
+      {
+        "name": "mon_cat_maine_coon",
+        "amount": 2
+      },
+      {
+        "name": "mon_cat_devon_rex",
+        "amount": 2
+      },
+      {
+        "name": "mon_cat_bengal",
+        "amount": 1
+      },
+      {
+        "name": "mon_cat_sphynx",
+        "amount": 1
+      },
+      {
+        "name": "mon_cat_chonker_kitten",
+        "amount": 1
+      },
+      {
+        "name": "mon_cat_longhair_kitten",
+        "amount": 1
+      },
+      {
+        "name": "mon_cat_calico_kitten",
+        "amount": 1
+      },
+      {
+        "name": "mon_cat_tabby_kitten",
+        "amount": 1
+      }
     ],
     "items": {
       "both": {
         "items": [ "jeans", "longshirt", "socks", "sneakers", "knit_scarf", "pockknife", "water_clean", "wristwatch", "mbag" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_matches" }, { "item": "catfood_dry", "count": 10 } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          { "group": "charged_matches" },
+          {
+            "item": "catfood_dry",
+            "count": 10
+          }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
@@ -2175,12 +4124,30 @@
     "description": "Just a small-town deputy, you got the call and were ready to come to the rescue.  Soon it was you who needed rescuing, and you were lucky to escape with your life.  Who's going to respect your authority when the government this badge represents might not even exist anymore?",
     "points": 4,
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "bashing" },
-      { "level": 2, "name": "dodge" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "bashing"
+      },
+      {
+        "level": 2,
+        "name": "dodge"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "traits": [ "PROF_POLICE" ],
     "proficiencies": [ "prof_spotting", "prof_gun_cleaning" ],
@@ -2190,10 +4157,24 @@
         "entries": [
           { "group": "charged_smart_phone" },
           { "group": "charged_two_way_radio" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "usp_45", "ammo-item": "45_acp", "charges": 12, "container-item": "holster" },
-          { "item": "legpouch_large", "contents-group": "army_mags_usp45" },
-          { "item": "sheriffshirt", "variant": "sheriff" }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "usp_45",
+            "ammo-item": "45_acp",
+            "charges": 12,
+            "container-item": "holster"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_usp45"
+          },
+          {
+            "item": "sheriffshirt",
+            "variant": "sheriff"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2230,23 +4211,54 @@
           { "group": "charged_smart_phone" },
           { "group": "charged_two_way_radio" },
           { "group": "charged_ref_lighter" },
-          { "item": "pants", "variant": "pants_stone" },
+          {
+            "item": "pants",
+            "variant": "pants_stone"
+          },
           { "group": "speedloaders_s&w619_magnum" },
-          { "item": "sw_619", "ammo-item": "357mag_fmj", "charges": 7, "container-item": "holster" }
+          {
+            "item": "sw_619",
+            "ammo-item": "357mag_fmj",
+            "charges": 7,
+            "container-item": "holster"
+          }
         ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
     },
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "pistol" },
-      { "level": 1, "name": "melee" },
-      { "level": 1, "name": "bashing" },
-      { "level": 1, "name": "dodge" },
-      { "level": 1, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 1,
+        "name": "melee"
+      },
+      {
+        "level": 1,
+        "name": "bashing"
+      },
+      {
+        "level": 1,
+        "name": "dodge"
+      },
+      {
+        "level": 1,
+        "name": "swimming"
+      }
     ],
-    "addictions": [ { "intensity": 10, "type": "nicotine" } ]
+    "addictions": [
+      {
+        "intensity": 10,
+        "type": "nicotine"
+      }
+    ]
   },
   {
     "type": "profession",
@@ -2257,16 +4269,46 @@
     "points": 6,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 5, "name": "gun" },
-      { "level": 5, "name": "smg" },
-      { "level": 5, "name": "pistol" },
-      { "level": 4, "name": "shotgun" },
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "stabbing" },
-      { "level": 4, "name": "bashing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "throw" },
-      { "level": 3, "name": "swimming" }
+      {
+        "level": 5,
+        "name": "gun"
+      },
+      {
+        "level": 5,
+        "name": "smg"
+      },
+      {
+        "level": 5,
+        "name": "pistol"
+      },
+      {
+        "level": 4,
+        "name": "shotgun"
+      },
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "stabbing"
+      },
+      {
+        "level": 4,
+        "name": "bashing"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 3,
+        "name": "swimming"
+      }
     ],
     "traits": [ "PROF_SWAT" ],
     "items": {
@@ -2286,12 +4328,26 @@
         "entries": [
           { "group": "swat_ballistic_vest_pristine" },
           { "group": "charged_two_way_radio" },
-          { "item": "sheriffshirt", "variant": "swat_shirt" },
+          {
+            "item": "sheriffshirt",
+            "variant": "swat_shirt"
+          },
           { "group": "army_mags_mp5" },
           { "group": "army_mags_usp9" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "grenadebandolier", "contents-item": [ "flashbang", "flashbang" ] },
-          { "item": "usp_9mm", "ammo-item": "9mm", "charges": 15, "container-item": "holster" },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "grenadebandolier",
+            "contents-item": [ "flashbang", "flashbang" ]
+          },
+          {
+            "item": "usp_9mm",
+            "ammo-item": "9mm",
+            "charges": 15,
+            "container-item": "holster"
+          },
           {
             "item": "hk_mp5",
             "ammo-item": "9mm",
@@ -2312,16 +4368,46 @@
     "description": "As a member of the police force's most elite division, you were given special training and became an expert in close-quarters combat.  Unfortunately, the chain of command has broken down; your only mission now is to stay alive.",
     "points": 6,
     "skills": [
-      { "level": 5, "name": "gun" },
-      { "level": 5, "name": "shotgun" },
-      { "level": 5, "name": "pistol" },
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "bashing" },
-      { "level": 4, "name": "stabbing" },
-      { "level": 4, "name": "unarmed" },
-      { "level": 4, "name": "dodge" },
-      { "level": 3, "name": "throw" },
-      { "level": 3, "name": "swimming" }
+      {
+        "level": 5,
+        "name": "gun"
+      },
+      {
+        "level": 5,
+        "name": "shotgun"
+      },
+      {
+        "level": 5,
+        "name": "pistol"
+      },
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "bashing"
+      },
+      {
+        "level": 4,
+        "name": "stabbing"
+      },
+      {
+        "level": 4,
+        "name": "unarmed"
+      },
+      {
+        "level": 4,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 3,
+        "name": "swimming"
+      }
     ],
     "traits": [ "PROF_SWAT" ],
     "proficiencies": [ "prof_spotting", "prof_gun_cleaning" ],
@@ -2341,14 +4427,42 @@
         "entries": [
           { "group": "swat_ballistic_vest_pristine" },
           { "group": "charged_two_way_radio" },
-          { "item": "sheriffshirt", "variant": "swat_shirt" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "bandolier_shotgun", "contents-group": "bandolier_swat_cqc1" },
-          { "item": "bandolier_shotgun", "contents-group": "bandolier_swat_cqc2" },
-          { "item": "legpouch_large", "contents-group": "army_mags_usp9" },
-          { "item": "usp_9mm", "ammo-item": "9mmfmj", "charges": 15, "container-item": "holster" },
-          { "item": "baton-extended", "container-item": "police_belt" },
-          { "item": "ksg", "ammo-item": "shot_00", "charges": 7, "contents-item": [ "shoulder_strap" ] }
+          {
+            "item": "sheriffshirt",
+            "variant": "swat_shirt"
+          },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "bandolier_shotgun",
+            "contents-group": "bandolier_swat_cqc1"
+          },
+          {
+            "item": "bandolier_shotgun",
+            "contents-group": "bandolier_swat_cqc2"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_usp9"
+          },
+          {
+            "item": "usp_9mm",
+            "ammo-item": "9mmfmj",
+            "charges": 15,
+            "container-item": "holster"
+          },
+          {
+            "item": "baton-extended",
+            "container-item": "police_belt"
+          },
+          {
+            "item": "ksg",
+            "ammo-item": "shot_00",
+            "charges": 7,
+            "contents-item": [ "shoulder_strap" ]
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2364,14 +4478,38 @@
     "points": 6,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 7, "name": "gun" },
-      { "level": 7, "name": "rifle" },
-      { "level": 5, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "bashing" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 2, "name": "dodge" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 7,
+        "name": "gun"
+      },
+      {
+        "level": 7,
+        "name": "rifle"
+      },
+      {
+        "level": 5,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "bashing"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 2,
+        "name": "dodge"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "traits": [ "PROF_POLICE" ],
     "items": {
@@ -2390,13 +4528,35 @@
         ],
         "entries": [
           { "group": "charged_two_way_radio" },
-          { "item": "glasses_bal", "custom-flags": [ "no_auto_equip" ] },
+          {
+            "item": "glasses_bal",
+            "custom-flags": [ "no_auto_equip" ]
+          },
           { "group": "charged_powered_earmuffs" },
-          { "item": "usp_45", "ammo-item": "45_acp", "charges": 12, "container-item": "holster" },
-          { "item": "legpouch_large", "contents-group": "army_mags_usp45" },
-          { "item": "762_51", "charges": 20 },
-          { "item": "M24", "ammo-item": "762_51", "charges": 5, "contents-item": "shoulder_strap" },
-          { "item": "sheriffshirt", "variant": "sheriff" }
+          {
+            "item": "usp_45",
+            "ammo-item": "45_acp",
+            "charges": 12,
+            "container-item": "holster"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_usp45"
+          },
+          {
+            "item": "762_51",
+            "charges": 20
+          },
+          {
+            "item": "M24",
+            "ammo-item": "762_51",
+            "charges": 5,
+            "contents-item": "shoulder_strap"
+          },
+          {
+            "item": "sheriffshirt",
+            "variant": "sheriff"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2411,14 +4571,38 @@
     "description": "The riots were brutal, even before the dead rose and started to devour the living.  The line you were holding broke.  It was only through a bit of luck and a lot of head-bashing that you got away in one piece, and the worst is yet to come.",
     "points": 5,
     "skills": [
-      { "level": 5, "name": "melee" },
-      { "level": 4, "name": "bashing" },
-      { "level": 3, "name": "unarmed" },
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "launcher" },
-      { "level": 3, "name": "throw" },
-      { "level": 3, "name": "swimming" }
+      {
+        "level": 5,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "bashing"
+      },
+      {
+        "level": 3,
+        "name": "unarmed"
+      },
+      {
+        "level": 3,
+        "name": "gun"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "launcher"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 3,
+        "name": "swimming"
+      }
     ],
     "traits": [ "PROF_POLICE" ],
     "proficiencies": [ "prof_spotting", "prof_gun_cleaning" ],
@@ -2439,9 +4623,20 @@
         "entries": [
           { "group": "charged_two_way_radio" },
           { "group": "full_gasmask" },
-          { "item": "usp_45", "ammo-item": "45_acp", "charges": 12, "container-item": "holster" },
-          { "item": "legpouch_large", "contents-group": "army_mags_usp45" },
-          { "item": "tonfa", "container-item": "police_belt" },
+          {
+            "item": "usp_45",
+            "ammo-item": "45_acp",
+            "charges": 12,
+            "container-item": "holster"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_usp45"
+          },
+          {
+            "item": "tonfa",
+            "container-item": "police_belt"
+          },
           { "group": "charged_tazer" }
         ]
       },
@@ -2457,12 +4652,30 @@
     "description": "Just a small-town deputy, you got the call and were ready to ride to the rescue.  Soon it was you who needed rescuing, and you had to abandon your motorcycle to escape.  Who's going to respect your authority when the government this badge represents doesn't exist anymore?",
     "points": 4,
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "bashing" },
-      { "level": 2, "name": "dodge" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "bashing"
+      },
+      {
+        "level": 2,
+        "name": "dodge"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "traits": [ "PROF_POLICE" ],
     "proficiencies": [ "prof_spotting", "prof_gun_cleaning" ],
@@ -2478,16 +4691,36 @@
           "whistle",
           "wristwatch",
           "baton",
-          { "item": "leather_police_jacket", "variant": "leather_police_jacket" }
+          {
+            "item": "leather_police_jacket",
+            "variant": "leather_police_jacket"
+          }
         ],
         "entries": [
           { "group": "charged_smart_phone" },
           { "group": "charged_two_way_radio" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "gloves_leather", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "usp_45", "ammo-item": "45_acp", "charges": 12, "container-item": "holster" },
-          { "item": "legpouch_large", "contents-group": "army_mags_usp45" },
-          { "item": "sheriffshirt", "variant": "sheriff" }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "gloves_leather",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "usp_45",
+            "ammo-item": "45_acp",
+            "charges": 12,
+            "container-item": "holster"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_usp45"
+          },
+          {
+            "item": "sheriffshirt",
+            "variant": "sheriff"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2500,7 +4733,12 @@
     "name": "Used Car Salesman",
     "description": "They said you'd sell your own mother for a dollar.  How dare they!  You've been around the block a few times, and you'd charge way more than a dollar - and get it, too!",
     "points": 1,
-    "skills": [ { "level": 5, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 5,
+        "name": "speech"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "suit", "knit_scarf", "socks", "dress_shoes", "gold_watch", "money_strap_fifty" ],
@@ -2517,7 +4755,20 @@
     "description": "A great fan of the archers of old, but at the same time a follower of the latest trends in archery.  You always tried to keep up with the times, acquiring a takedown bow as well as several accessories to complement it.  You can only hope all the training you did with them can help you survive in this trying times.",
     "points": 4,
     "proficiencies": [ "prof_bow_basic", "prof_bow_expert" ],
-    "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "archery" }, { "level": 2, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "archery"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -2533,9 +4784,18 @@
         ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "rashguard", "variant": "black_rashguard_shirt" },
-          { "item": "takedown_recurbow", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "quiver_takedown_bow", "contents-group": "quiver_modern_archer" }
+          {
+            "item": "rashguard",
+            "variant": "black_rashguard_shirt"
+          },
+          {
+            "item": "takedown_recurbow",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "quiver_takedown_bow",
+            "contents-group": "quiver_modern_archer"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2550,7 +4810,20 @@
     "description": "Ever since you were a child you loved hunting, and quickly developed a talent for archery.  Why, if the world ended, there's nothing you'd want at your side more than your trusty bow.  So, when it did, you made sure to bring it along.",
     "points": 3,
     "proficiencies": [ "prof_bow_basic", "prof_bowyery" ],
-    "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "archery" }, { "level": 2, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "archery"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -2566,10 +4839,22 @@
         ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "compbow_low", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "quiver", "contents-group": "quiver_bow_hunter" },
-          { "item": "sheath", "contents-item": "knife_hunting" },
-          { "item": "tank_top", "variant": "tank_top_camo" }
+          {
+            "item": "compbow_low",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "quiver",
+            "contents-group": "quiver_bow_hunter"
+          },
+          {
+            "item": "sheath",
+            "contents-item": "knife_hunting"
+          },
+          {
+            "item": "tank_top",
+            "variant": "tank_top_camo"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2584,7 +4869,20 @@
     "description": "Ever since you were a child you loved hunting, and crossbow hunting was always your favorite.  Why, if the world ended, there's nothing you'd want at your side more than your trusty crossbow.  So, when it did, you made sure to bring it along, though most of your bolts were lost during the escape.",
     "points": 3,
     "proficiencies": [ "prof_bow_basic", "prof_gunsmithing_spring" ],
-    "skills": [ { "level": 4, "name": "rifle" }, { "level": 4, "name": "gun" }, { "level": 2, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "rifle"
+      },
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "knit_scarf", "socks", "boots_steel", "pants_cargo", "jacket_flannel", "hat_hunting", "wristwatch", "single_sling" ],
@@ -2597,9 +4895,18 @@
             "contents-item": "shoulder_strap",
             "custom-flags": [ "no_auto_equip" ]
           },
-          { "item": "quiver", "contents-group": "quiver_crossbow_hunter" },
-          { "item": "sheath", "contents-item": "knife_hunting" },
-          { "item": "tank_top", "variant": "tank_top_camo" }
+          {
+            "item": "quiver",
+            "contents-group": "quiver_crossbow_hunter"
+          },
+          {
+            "item": "sheath",
+            "contents-item": "knife_hunting"
+          },
+          {
+            "item": "tank_top",
+            "variant": "tank_top_camo"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2614,13 +4921,25 @@
     "description": "Ever since you were a child you loved hunting, and one year you got a shotgun for your birthday.  Why, if the world ended, there's nothing you'd want at your side more than your trusty shotgun.  So, when it did, you made sure to bring it along.",
     "points": 3,
     "proficiencies": [ "prof_gun_cleaning" ],
-    "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "shotgun" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "shotgun"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "knit_scarf", "socks", "boots_steel", "pants_cargo", "jacket_flannel", "hat_hunting", "wristwatch", "back_holster" ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
           {
             "item": "remington_870",
             "ammo-item": "shot_00",
@@ -2628,9 +4947,18 @@
             "contents-item": "shoulder_strap",
             "custom-flags": [ "no_auto_equip" ]
           },
-          { "item": "bandolier_shotgun", "contents-group": "bandolier_shotgun_hunter" },
-          { "item": "sheath", "contents-item": "knife_hunting" },
-          { "item": "tank_top", "variant": "tank_top_camo" }
+          {
+            "item": "bandolier_shotgun",
+            "contents-group": "bandolier_shotgun_hunter"
+          },
+          {
+            "item": "sheath",
+            "contents-item": "knife_hunting"
+          },
+          {
+            "item": "tank_top",
+            "variant": "tank_top_camo"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2645,13 +4973,25 @@
     "description": "Ever since you were a child you loved hunting, and you fancy yourself a crack shot.  Why, if the world ended, there's nothing you'd want at your side more than your trusty rifle.  So, when it did, you made sure to bring it along.",
     "points": 3,
     "proficiencies": [ "prof_gun_cleaning" ],
-    "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "rifle" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "rifle"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "knit_scarf", "socks", "boots_steel", "pants_cargo", "jacket_flannel", "hat_hunting", "wristwatch", "back_holster" ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
           {
             "item": "remington700_270",
             "ammo-item": "270win_jsp",
@@ -2659,9 +4999,18 @@
             "contents-item": "shoulder_strap",
             "custom-flags": [ "no_auto_equip" ]
           },
-          { "item": "bandolier_rifle", "contents-group": "bandolier_rifle_hunter" },
-          { "item": "sheath", "contents-item": "knife_hunting" },
-          { "item": "tank_top", "variant": "tank_top_camo" }
+          {
+            "item": "bandolier_rifle",
+            "contents-group": "bandolier_rifle_hunter"
+          },
+          {
+            "item": "sheath",
+            "contents-item": "knife_hunting"
+          },
+          {
+            "item": "tank_top",
+            "variant": "tank_top_camo"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2676,7 +5025,16 @@
     "description": "You always harbored a passion for hunting and a particular fondness for big-bore rifle calibers and affordable conversion kits.  Whether it was their cost-effective nature or the simple, testosterone-amplifying notion that you could retool your rifle to belt out .50-caliber bullets, you preferred them for your hunting trips.  Now, with your converted rifle in hand, you fancy that there isn't any game too large for you to take down.",
     "points": 3,
     "proficiencies": [ "prof_gun_cleaning" ],
-    "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "rifle" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "rifle"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -2692,7 +5050,10 @@
         ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
           {
             "item": "ar15_50",
             "ammo-item": "50beowulf_xtp",
@@ -2700,8 +5061,14 @@
             "contents-item": "shoulder_strap",
             "custom-flags": [ "no_auto_equip" ]
           },
-          { "item": "chestrig", "contents-group": "mags_50beowulf_ar15" },
-          { "item": "sheath", "contents-item": "knife_hunting" }
+          {
+            "item": "chestrig",
+            "contents-group": "mags_50beowulf_ar15"
+          },
+          {
+            "item": "sheath",
+            "contents-item": "knife_hunting"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2717,10 +5084,22 @@
     "points": 4,
     "proficiencies": [ "prof_driver" ],
     "skills": [
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "shotgun" },
-      { "level": 3, "name": "mechanics" },
-      { "level": 3, "name": "driving" }
+      {
+        "level": 3,
+        "name": "gun"
+      },
+      {
+        "level": 3,
+        "name": "shotgun"
+      },
+      {
+        "level": 3,
+        "name": "mechanics"
+      },
+      {
+        "level": 3,
+        "name": "driving"
+      }
     ],
     "vehicle": "extended_pickup",
     "items": {
@@ -2728,9 +5107,20 @@
         "items": [ "hoodie", "socks", "boots_steel", "jeans", "multitool", "jacket_flannel", "slingpack" ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "shot_00", "charges": 25 },
-          { "item": "beer", "count": 6 },
-          { "item": "remington_870", "ammo-item": "shot_00", "charges": 5, "contents-item": "shoulder_strap" }
+          {
+            "item": "shot_00",
+            "charges": 25
+          },
+          {
+            "item": "beer",
+            "count": 6
+          },
+          {
+            "item": "remington_870",
+            "ammo-item": "shot_00",
+            "charges": 5,
+            "contents-item": "shoulder_strap"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2740,7 +5130,10 @@
   {
     "type": "profession",
     "id": "construction_worker",
-    "name": { "male": "Handy Man", "female": "Handy Woman" },
+    "name": {
+      "male": "Handy Man",
+      "female": "Handy Woman"
+    },
     "description": "You used to work at a local hardware store, and you did plenty of home renovations yourself.  Now you look out at the horizon of a ruined world, and wonder - are your meager skills, and the few supplies you grabbed on the way out, sufficient to help rebuild?",
     "points": 3,
     "proficiencies": [
@@ -2751,15 +5144,34 @@
       "prof_carpentry_basic",
       "prof_appliance_repair"
     ],
-    "skills": [ { "level": 5, "name": "fabrication" }, { "level": 5, "name": "traps" } ],
+    "skills": [
+      {
+        "level": 5,
+        "name": "fabrication"
+      },
+      {
+        "level": 5,
+        "name": "traps"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "tank_top", "socks", "boots_steel", "pants", "multitool", "wristwatch" ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "nailgun", "ammo-item": "nail", "charges": 20 },
-          { "item": "nail", "charges": 180 },
-          { "item": "tool_belt", "contents-item": "hammer" }
+          {
+            "item": "nailgun",
+            "ammo-item": "nail",
+            "charges": 20
+          },
+          {
+            "item": "nail",
+            "charges": 180
+          },
+          {
+            "item": "tool_belt",
+            "contents-item": "hammer"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2773,7 +5185,16 @@
     "description": "You once ruled the road in your big rig.  When the riots hit, you hopped in and drove it to safety.  Now it's just you and your truck against the world.",
     "points": 4,
     "proficiencies": [ "prof_driver" ],
-    "skills": [ { "level": 6, "name": "driving" }, { "level": 3, "name": "mechanics" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "driving"
+      },
+      {
+        "level": 3,
+        "name": "mechanics"
+      }
+    ],
     "vehicle": "semi_truck_scenario",
     "items": {
       "both": {
@@ -2791,7 +5212,16 @@
     "description": "You love driving, and decided to start making some money doing it.  On your way to pick up a customer, a riot broke out around you.  You took a long detour to safety, only to find yourself somewhere unfamiliar.",
     "points": 3,
     "proficiencies": [ "prof_driver" ],
-    "skills": [ { "level": 5, "name": "driving" }, { "level": 2, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 5,
+        "name": "driving"
+      },
+      {
+        "level": 2,
+        "name": "speech"
+      }
+    ],
     "vehicle": "car",
     "items": {
       "both": {
@@ -2809,11 +5239,26 @@
     "description": "On your way to respond to an emergency call, you nearly drove straight into a riot in the city.  Turning off of the burning, debris-covered streets, you took a long detour only to find yourself lost.  That call will have to wait - you're in an emergency of your own now.",
     "points": 5,
     "skills": [
-      { "level": 6, "name": "firstaid" },
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "bashing" },
-      { "level": 4, "name": "swimming" },
-      { "level": 4, "name": "driving" }
+      {
+        "level": 6,
+        "name": "firstaid"
+      },
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "bashing"
+      },
+      {
+        "level": 4,
+        "name": "swimming"
+      },
+      {
+        "level": 4,
+        "name": "driving"
+      }
     ],
     "proficiencies": [
       "prof_wound_care",
@@ -2849,8 +5294,14 @@
         "entries": [
           { "group": "full_1st_aid" },
           { "group": "charged_smart_phone" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "halligan", "container-item": "fireman_belt" }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "halligan",
+            "container-item": "fireman_belt"
+          }
         ]
       }
     }
@@ -2863,10 +5314,22 @@
     "points": 3,
     "proficiencies": [ "prof_appliance_repair", "prof_driver" ],
     "skills": [
-      { "level": 4, "name": "mechanics" },
-      { "level": 4, "name": "electronics" },
-      { "level": 3, "name": "computer" },
-      { "level": 3, "name": "driving" }
+      {
+        "level": 4,
+        "name": "mechanics"
+      },
+      {
+        "level": 4,
+        "name": "electronics"
+      },
+      {
+        "level": 3,
+        "name": "computer"
+      },
+      {
+        "level": 3,
+        "name": "driving"
+      }
     ],
     "vehicle": "cube_van_cheap",
     "items": {
@@ -2884,7 +5347,10 @@
           "hammer",
           "hat_ball"
         ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_electrical_measuring" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          { "group": "charged_electrical_measuring" }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "panties", "bra" ]
@@ -2897,12 +5363,27 @@
     "description": "You made a living driving kids to and from school, a career choice you regretted almost every day.  None of the brats were at their normal stops, and the noise of your bus quickly attracted hordes of zombies.  You escaped, but now you've gotten lost.  At least you're getting a break from the hellish screams of children, though you're starting to hear new ones…",
     "points": 3,
     "proficiencies": [ "prof_driver" ],
-    "skills": [ { "level": 5, "name": "driving" }, { "level": 1, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 5,
+        "name": "driving"
+      },
+      {
+        "level": 1,
+        "name": "speech"
+      }
+    ],
     "vehicle": "schoolbus",
     "items": {
       "both": {
         "items": [ "sneakers", "socks", "jeans", "wristwatch", "jacket_light", "water_clean", "hat_ball" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "panties", "bra" ]
@@ -2916,13 +5397,34 @@
     "description": "An on-duty officer, you received the call and were ready to respond to the robbery.  It all went to shit, your backup got eaten, and you were lucky to escape with your life and patrol car.",
     "points": 5,
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "pistol" },
-      { "level": 4, "name": "driving" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "bashing" },
-      { "level": 2, "name": "dodge" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 4,
+        "name": "driving"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "bashing"
+      },
+      {
+        "level": 2,
+        "name": "dodge"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_driver" ],
     "vehicle": "policecar",
@@ -2933,10 +5435,24 @@
         "entries": [
           { "group": "charged_smart_phone" },
           { "group": "charged_two_way_radio" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "usp_45", "ammo-item": "45_acp", "charges": 12, "container-item": "holster" },
-          { "item": "legpouch_large", "contents-group": "army_mags_usp45" },
-          { "item": "sheriffshirt", "variant": "sheriff" }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "usp_45",
+            "ammo-item": "45_acp",
+            "charges": 12,
+            "container-item": "holster"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_usp45"
+          },
+          {
+            "item": "sheriffshirt",
+            "variant": "sheriff"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -2952,12 +5468,30 @@
     "points": 4,
     "proficiencies": [ "prof_driver" ],
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "rifle" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "fabrication" },
-      { "level": 3, "name": "mechanics" },
-      { "level": 3, "name": "driving" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "fabrication"
+      },
+      {
+        "level": 3,
+        "name": "mechanics"
+      },
+      {
+        "level": 3,
+        "name": "driving"
+      }
     ],
     "vehicle": "pickup_technical",
     "items": {
@@ -2980,12 +5514,34 @@
         ],
         "entries": [
           { "group": "charged_cell_phone" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
-          { "item": "m9", "ammo-item": "9mm", "charges": 15, "container-item": "holster" },
-          { "item": "chestrig", "contents-group": "army_mags_m4" },
-          { "item": "lighter", "charges": 100 },
-          { "item": "modular_ar15", "ammo-item": "223", "charges": 30, "contents-item": [ "shoulder_strap" ] }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
+          {
+            "item": "m9",
+            "ammo-item": "9mm",
+            "charges": 15,
+            "container-item": "holster"
+          },
+          {
+            "item": "chestrig",
+            "contents-group": "army_mags_m4"
+          },
+          {
+            "item": "lighter",
+            "charges": 100
+          },
+          {
+            "item": "modular_ar15",
+            "ammo-item": "223",
+            "charges": 30,
+            "contents-item": [ "shoulder_strap" ]
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -3001,13 +5557,34 @@
     "points": 5,
     "proficiencies": [ "prof_driver" ],
     "skills": [
-      { "level": 5, "name": "survival" },
-      { "level": 5, "name": "firstaid" },
-      { "level": 5, "name": "driving" },
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "fabrication" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 5,
+        "name": "survival"
+      },
+      {
+        "level": 5,
+        "name": "firstaid"
+      },
+      {
+        "level": 5,
+        "name": "driving"
+      },
+      {
+        "level": 3,
+        "name": "gun"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "fabrication"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "vehicle": "pickup",
     "items": {
@@ -3034,19 +5611,52 @@
           { "group": "charged_flashlight" },
           { "group": "charged_two_way_radio" },
           { "group": "full_1st_aid" },
-          { "item": "black_pen", "charges": 100 },
-          { "item": "coat_rain", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
+          {
+            "item": "black_pen",
+            "charges": 100
+          },
+          {
+            "item": "coat_rain",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
           { "item": "file" },
-          { "item": "legpouch_large", "contents-group": "ranger_mags" },
-          { "item": "lighter", "charges": 100 },
-          { "item": "p320_357sig", "ammo-item": "357sig_fmj", "charges": 13, "container-item": "holster" },
-          { "item": "paper", "charges": 20, "container-item": "leather_journal" },
-          { "item": "permanent_marker", "charges": 500 },
+          {
+            "item": "legpouch_large",
+            "contents-group": "ranger_mags"
+          },
+          {
+            "item": "lighter",
+            "charges": 100
+          },
+          {
+            "item": "p320_357sig",
+            "ammo-item": "357sig_fmj",
+            "charges": 13,
+            "container-item": "holster"
+          },
+          {
+            "item": "paper",
+            "charges": 20,
+            "container-item": "leather_journal"
+          },
+          {
+            "item": "permanent_marker",
+            "charges": 500
+          },
           { "item": "roadmap" },
-          { "item": "sm_extinguisher", "charges": 10 },
+          {
+            "item": "sm_extinguisher",
+            "charges": 10
+          },
           { "item": "trailmap" },
-          { "item": "sheriffshirt", "variant": "sheriff" }
+          {
+            "item": "sheriffshirt",
+            "variant": "sheriff"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -3060,15 +5670,33 @@
     "description": "You're a lumberjack, and you're okay.  You felled trees before the world ended, and you suspect the undead aren't nearly as tough.",
     "points": 2,
     "skills": [
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "bashing" },
-      { "level": 3, "name": "cutting" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "bashing"
+      },
+      {
+        "level": 3,
+        "name": "cutting"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
         "items": [ "jeans", "socks", "boots", "hat_hunting", "jacket_flannel", "knit_scarf", "vest", "wristwatch", "axe_ring" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "ax", "custom-flags": [ "auto_wield" ] } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "ax",
+            "custom-flags": [ "auto_wield" ]
+          }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "sports_bra", "boxer_shorts" ]
@@ -3080,12 +5708,23 @@
     "name": "Fast Food Cook",
     "description": "The diners at the fancy burger joint where you worked were even more irritable and unreasonable than usual today.  You showed them the meaning of fast food… by running for your life!",
     "points": 1,
-    "skills": [ { "level": 3, "name": "cooking" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "cooking"
+      }
+    ],
     "proficiencies": [ "prof_frying" ],
     "items": {
       "both": {
         "items": [ "pants", "sneakers", "socks", "knife_steak" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
@@ -3099,7 +5738,12 @@
     "description": "Small businesses often hired you for electrical work.  You were halfway through your latest job when the whole power grid went dead.",
     "points": 2,
     "proficiencies": [ "prof_elec_soldering", "prof_appliance_repair" ],
-    "skills": [ { "level": 6, "name": "electronics" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "electronics"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "jumpsuit", "socks", "boots", "tool_belt", "wristwatch", "mbag", "solder_wire" ],
@@ -3120,12 +5764,22 @@
     "name": "Computer Hacker",
     "description": "Caffeine pills and all-nighters in front of a computer screen made you an expert at writing and cracking code.  The power's gone out, and suddenly your elite skills seem significantly less useful.  At least there's no one stopping you from your dream of breaking into a military mainframe now.",
     "points": 2,
-    "skills": [ { "level": 6, "name": "computer" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "computer"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "pants", "tshirt_text", "socks", "sneakers", "mbag", "caffeine", "caff_gum", "memory_card", "usb_drive" ],
         "entries": [
-          { "item": "light_plus_battery_cell", "ammo-item": "battery", "charges": 150, "container-item": "portable_game" },
+          {
+            "item": "light_plus_battery_cell",
+            "ammo-item": "battery",
+            "charges": 150,
+            "container-item": "portable_game"
+          },
           { "group": "charged_smart_phone" },
           { "group": "charged_laptop" }
         ]
@@ -3140,11 +5794,22 @@
     "name": "Backpacker",
     "description": "For the past few years you've been traveling the world, sightseeing and living off your parents' trust fund.  You came home to find the world in ruins, and the only thing between you and death is the open road and your backpack.",
     "points": 1,
-    "skills": [ { "level": 3, "name": "survival" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "survival"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "backpack_hiking", "jeans", "boots_hiking", "knit_scarf", "socks", "wristwatch", "fun_survival" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "boy_shorts" ]
@@ -3156,11 +5821,26 @@
     "name": "Student",
     "description": "Just an average student, you find yourself facing a test you never studied for, and the stakes are a bit higher than geometry.  Maybe there'll be something useful in one of these books you've been lugging around all year.",
     "points": 0,
-    "skills": [ { "level": 2, "name": "chemistry" }, { "level": 2, "name": "computer" } ],
+    "skills": [
+      {
+        "level": 2,
+        "name": "chemistry"
+      },
+      {
+        "level": 2,
+        "name": "computer"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "pants", "socks", "sneakers", "ZSG", "backpack", "wristwatch", "textbook_speech", "story_book", "howto_computer" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "boy_shorts" ]
@@ -3175,7 +5855,17 @@
     "description": "You just stepped out of a nice, hot shower to find the world had ended.  You've got some soap, along with the most massively useful thing ever… a towel.",
     "points": -1,
     "flags": [ "NO_BONUS_ITEMS" ],
-    "items": { "both": { "items": [ "towel_wet" ], "entries": [ { "item": "soap", "custom-flags": [ "auto_wield" ] } ] } }
+    "items": {
+      "both": {
+        "items": [ "towel_wet" ],
+        "entries": [
+          {
+            "item": "soap",
+            "custom-flags": [ "auto_wield" ]
+          }
+        ]
+      }
+    }
   },
   {
     "type": "profession",
@@ -3184,7 +5874,16 @@
     "description": "You spent most of your life on a motorcycle, out on the open road with your club.  Now they're all dead.  Time to ride or die.",
     "points": 3,
     "proficiencies": [ "prof_driver" ],
-    "skills": [ { "level": 6, "name": "driving" }, { "level": 3, "name": "mechanics" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "driving"
+      },
+      {
+        "level": 3,
+        "name": "mechanics"
+      }
+    ],
     "vehicle": "motorcycle",
     "items": {
       "both": {
@@ -3200,8 +5899,14 @@
         ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "sheath", "contents-item": "knife_trench" },
-          { "item": "leg_bag", "variant": "black_leg_bag" }
+          {
+            "item": "sheath",
+            "contents-item": "knife_trench"
+          },
+          {
+            "item": "leg_bag",
+            "variant": "black_leg_bag"
+          }
         ]
       },
       "male": [ "boxer_shorts", "tank_top" ],
@@ -3214,9 +5919,17 @@
     "name": "Ballroom Dancer",
     "description": "Things got a little weird on your way to your weekly dance class.  Zombies don't seem to know how to dance, but you're not about to let them step on your toes.",
     "points": 0,
-    "skills": [ { "level": 3, "name": "dodge" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "dodge"
+      }
+    ],
     "items": {
-      "both": { "items": [ "socks", "knit_scarf", "dance_shoes" ], "entries": [ { "group": "charged_smart_phone" } ] },
+      "both": {
+        "items": [ "socks", "knit_scarf", "dance_shoes" ],
+        "entries": [ { "group": "charged_smart_phone" } ]
+      },
       "male": [ "briefs", "tux", "tourmaline_silver_cufflinks" ],
       "female": [ "bra", "panties", "dress", "purse", "tourmaline_silver_bracelet" ]
     },
@@ -3231,7 +5944,13 @@
     "items": {
       "both": {
         "items": [ "jeans", "socks", "sneakers", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
@@ -3246,7 +5965,11 @@
     "name": "Unwilling Mutant",
     "description": "You were a human guinea pig, used by laboratory technicians to understand the immense power of mutation.  You are determined to live on, if only to spite them for what they did to you.",
     "points": -1,
-    "items": { "both": [ "subsuit_xl" ], "male": [ "briefs" ], "female": [ "bra", "panties" ] },
+    "items": {
+      "both": [ "subsuit_xl" ],
+      "male": [ "briefs" ],
+      "female": [ "bra", "panties" ]
+    },
     "flags": [ "SCEN_ONLY" ],
     "age_lower": 16
   },
@@ -3256,7 +5979,16 @@
     "name": "Volunteer Mutant",
     "description": "Your dreams of becoming a mutant superhero through genetic alteration may have fallen a bit short, but the scientists say you're ready.  It's time for a field test.",
     "points": 2,
-    "skills": [ { "level": 4, "name": "chemistry" }, { "level": 4, "name": "electronics" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "chemistry"
+      },
+      {
+        "level": 4,
+        "name": "electronics"
+      }
+    ],
     "items": {
       "both": [ "dress_shirt", "pants", "socks", "boots", "knit_scarf", "coat_lab", "glasses_safety", "wristwatch" ],
       "male": [ "briefs" ],
@@ -3283,7 +6015,16 @@
     "name": "Trapper",
     "description": "You spent most of your life trapping with your father.  Both of you made a decent living selling your catches and running trapping tutorials.  Hopefully, your skills will come in useful against less conventional game.",
     "points": 3,
-    "skills": [ { "level": 6, "name": "traps" }, { "level": 4, "name": "survival" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "traps"
+      },
+      {
+        "level": 4,
+        "name": "survival"
+      }
+    ],
     "proficiencies": [ "prof_fibers", "prof_fibers_rope", "prof_traps", "prof_trapsetting" ],
     "items": {
       "both": {
@@ -3303,7 +6044,10 @@
         "entries": [
           { "group": "charged_smart_phone" },
           { "group": "charged_matches" },
-          { "item": "knife_hunting", "container-item": "sheath" }
+          {
+            "item": "knife_hunting",
+            "container-item": "sheath"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -3316,7 +6060,16 @@
     "name": "Blacksmith",
     "description": "You ran into trouble coming out of class at your community college's metalsmithing program, but despite the havoc you've managed to keep ahold of some of the equipment you were carrying.",
     "points": 2,
-    "skills": [ { "level": 6, "name": "fabrication" }, { "level": 2, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "fabrication"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
+    ],
     "proficiencies": [ "prof_metalworking", "prof_blacksmithing" ],
     "items": {
       "both": {
@@ -3336,7 +6089,13 @@
     "items": {
       "both": {
         "items": [ "clown_wig", "clown_suit", "clown_nose", "socks", "clownshoes", "airhorn" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "balloon", "count": 20 } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "balloon",
+            "count": 20
+          }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
@@ -3355,7 +6114,12 @@
     "items": {
       "both": {
         "items": [ "bondage_suit", "bondage_mask", "boots", "gloves_leather", "leather_belt" ],
-        "entries": [ { "group": "charged_matches", "custom-flags": [ "auto_wield" ] } ]
+        "entries": [
+          {
+            "group": "charged_matches",
+            "custom-flags": [ "auto_wield" ]
+          }
+        ]
       }
     },
     "missions": [ "MISSION_LOST_SUB" ]
@@ -3370,7 +6134,13 @@
     "items": {
       "both": {
         "items": [ "tobacco", "pipe_tobacco", "socks", "dress_shoes", "knit_scarf", "bellyband", "dentures" ],
-        "entries": [ { "group": "charged_ref_lighter" }, { "item": "cane", "custom-flags": [ "auto_wield" ] } ]
+        "entries": [
+          { "group": "charged_ref_lighter" },
+          {
+            "item": "cane",
+            "custom-flags": [ "auto_wield" ]
+          }
+        ]
       },
       "male": [ "briefs", "dress_shirt", "pants_checkered", "pocketwatch" ],
       "female": [ "panties", "bra", "dress", "fanny", "gold_watch" ]
@@ -3383,7 +6153,12 @@
     "name": "Otaku",
     "description": "After many late nights with friends watching anime and eating snacks, you decided to make the trip to the premier anime convention in the Northeast.  Now zombies are eating everyone, and even worse, the convention is cancelled!  At least you were ready in case your costume tore.",
     "points": 0,
-    "skills": [ { "level": 2, "name": "tailor" } ],
+    "skills": [
+      {
+        "level": 2,
+        "name": "tailor"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "shorts", "socks", "sneakers", "tank_top", "mbag", "mag_animecon", "cheeseburger" ],
@@ -3411,11 +6186,17 @@
   {
     "type": "profession",
     "id": "spouse",
-    "name": { "male": "Groom", "female": "Bride" },
+    "name": {
+      "male": "Groom",
+      "female": "Bride"
+    },
     "description": "The Cataclysm struck on the big day and you escaped with nothing but your wedding attire.  Cold feet?  You'd just like to keep your feet attached!",
     "points": -1,
     "items": {
-      "both": { "items": [ "ring_wedding" ], "entries": [ { "group": "charged_smart_phone" } ] },
+      "both": {
+        "items": [ "ring_wedding" ],
+        "entries": [ { "group": "charged_smart_phone" } ]
+      },
       "male": [ "tux", "socks", "dress_shoes", "briefs", "leather_belt", "tie_bow", "cufflinks_intricate" ],
       "female": [
         "veil_wedding",
@@ -3435,10 +6216,22 @@
   {
     "type": "profession",
     "id": "punkrockgirl",
-    "name": { "male": "Punk Rock Dude", "female": "Punk Rock Girl" },
+    "name": {
+      "male": "Punk Rock Dude",
+      "female": "Punk Rock Girl"
+    },
     "description": "All those wicked songs about the apocalypse have come to life.  Brutal!  Now that the system is dead, it's time to party among the bones of the world!",
     "points": 0,
-    "skills": [ { "level": 2, "name": "speech" }, { "level": 1, "name": "tailor" } ],
+    "skills": [
+      {
+        "level": 2,
+        "name": "speech"
+      },
+      {
+        "level": 1,
+        "name": "tailor"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "trenchcoat", "gloves_fingerless", "socks", "boots_combat", "weed", "tobacco", "rolling_paper", "wristwatch" ],
@@ -3446,8 +6239,14 @@
           { "group": "charged_smart_phone" },
           { "group": "charged_mp3" },
           { "group": "charged_ref_lighter" },
-          { "item": "onyx_silver_earring", "variant": "dark_earring" },
-          { "item": "onyx_silver_ring", "variant": "dark_ring" }
+          {
+            "item": "onyx_silver_earring",
+            "variant": "dark_earring"
+          },
+          {
+            "item": "onyx_silver_ring",
+            "variant": "dark_ring"
+          }
         ]
       },
       "male": [ "pants_cargo", "tank_top", "boxer_shorts" ],
@@ -3461,10 +6260,22 @@
     "description": "As a first responder, you were a direct witness to the gut-wrenching horrors of the apocalypse.  Separated from most of your equipment and your unit while on call, you were forced to fight your way to safety with little more than your trusty iron and your bunker gear to protect you.",
     "points": 3,
     "skills": [
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "bashing" },
-      { "level": 4, "name": "firstaid" },
-      { "level": 3, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "bashing"
+      },
+      {
+        "level": 4,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "swimming"
+      }
     ],
     "proficiencies": [ "prof_burn_care" ],
     "items": {
@@ -3483,8 +6294,14 @@
           "pocketwatch"
         ],
         "entries": [
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "halligan", "container-item": "fireman_belt" }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "halligan",
+            "container-item": "fireman_belt"
+          }
         ]
       }
     }
@@ -3492,14 +6309,26 @@
   {
     "type": "profession",
     "id": "skaboy",
-    "name": { "male": "Rude Boy", "female": "Rude Girl" },
+    "name": {
+      "male": "Rude Boy",
+      "female": "Rude Girl"
+    },
     "description": "Your ska band broke up after the drummer became a zombie.  Now you're alone in the Cataclysm with some cigarettes and your mp3 player.",
     "points": 0,
-    "skills": [ { "level": 3, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "speech"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "dress_shirt", "tie_skinny", "sunglasses", "pants", "socks", "dress_shoes", "rolling_paper", "tobacco", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_mp3" }, { "group": "charged_ref_lighter" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          { "group": "charged_mp3" },
+          { "group": "charged_ref_lighter" }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
@@ -3511,7 +6340,16 @@
     "name": "Mail Carrier",
     "description": "Neither snow nor rain nor heat nor gloom of night stays you from the swift completion of your appointed rounds, but nobody said anything about zombies.",
     "points": 0,
-    "skills": [ { "level": 3, "name": "driving" }, { "level": 2, "name": "dodge" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "driving"
+      },
+      {
+        "level": 2,
+        "name": "dodge"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -3527,9 +6365,18 @@
           "sneakers"
         ],
         "entries": [
-          { "item": "letter", "container-item": "envelope" },
-          { "item": "letter", "container-item": "envelope" },
-          { "item": "postcard", "container-item": "envelope" },
+          {
+            "item": "letter",
+            "container-item": "envelope"
+          },
+          {
+            "item": "letter",
+            "container-item": "envelope"
+          },
+          {
+            "item": "postcard",
+            "container-item": "envelope"
+          },
           { "group": "charged_smart_phone" }
         ]
       },
@@ -3544,10 +6391,22 @@
     "description": "Your trial was contentious, but ultimately you found yourself behind bars.  The Cataclysm has offered you a chance to escape, but freedom may come with a steep price.",
     "points": 0,
     "skills": [
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "stabbing" },
-      { "level": 2, "name": "unarmed" },
-      { "level": 2, "name": "traps" }
+      {
+        "level": 2,
+        "name": "melee"
+      },
+      {
+        "level": 2,
+        "name": "stabbing"
+      },
+      {
+        "level": 2,
+        "name": "unarmed"
+      },
+      {
+        "level": 2,
+        "name": "traps"
+      }
     ],
     "items": {
       "both": [ "striped_shirt", "striped_pants", "sneakers", "socks", "glass_shiv" ],
@@ -3561,7 +6420,20 @@
     "name": "Death Row Convict",
     "description": "You were a serial killer, ready to walk the green mile, but in a twist of fate you're one of the few still alive.  True death comes only from your hands, so you're in for a job.",
     "points": 1,
-    "skills": [ { "level": 3, "name": "melee" }, { "level": 3, "name": "stabbing" }, { "level": 2, "name": "unarmed" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 2,
+        "name": "unarmed"
+      }
+    ],
     "traits": [ "KILLER" ],
     "items": {
       "both": [ "striped_shirt", "striped_pants", "sneakers", "socks", "glass_shiv" ],
@@ -3576,18 +6448,36 @@
     "description": "You were given a target, a mission, but killing your mark seems to have become much more difficult now.  Your employer cut contact with you and now you have to make do with what you have.",
     "points": 2,
     "skills": [
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "stabbing" },
-      { "level": 3, "name": "unarmed" },
-      { "level": 3, "name": "dodge" }
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "stabbing"
+      },
+      {
+        "level": 3,
+        "name": "unarmed"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      }
     ],
     "traits": [ "PROF_ASSASSIN_CONVICT" ],
     "items": {
       "both": {
         "items": [ "striped_shirt", "striped_pants", "sneakers", "socks" ],
         "entries": [
-          { "item": "knife_combat", "container-item": "gartersheath1" },
-          { "item": "polaroid_photo", "container-item": "ankle_wallet_pouch" }
+          {
+            "item": "knife_combat",
+            "container-item": "gartersheath1"
+          },
+          {
+            "item": "polaroid_photo",
+            "container-item": "ankle_wallet_pouch"
+          }
         ]
       },
       "male": [ "briefs" ],
@@ -3601,7 +6491,16 @@
     "name": "Embezzler",
     "description": "You had a genius plan to skim fractions of cents out of your company's accounts.  This plan immediately failed and got you arrested.  They said you were too soft for prison, but guess what?  They're dead, and you're not.",
     "points": 0,
-    "skills": [ { "level": 4, "name": "speech" }, { "level": 3, "name": "computer" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "speech"
+      },
+      {
+        "level": 3,
+        "name": "computer"
+      }
+    ],
     "items": {
       "both": [ "striped_shirt", "striped_pants", "sneakers", "socks", "rock_sock" ],
       "male": [ "briefs" ],
@@ -3615,11 +6514,26 @@
     "name": "Meth Cook",
     "description": "You clawed your way out of poverty by selling products everyone wanted, and they had the nerve to put you in jail for it.  Too bad you can't sell drugs to zombies.",
     "points": 2,
-    "skills": [ { "level": 6, "name": "chemistry" }, { "level": 2, "name": "firstaid" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "chemistry"
+      },
+      {
+        "level": 2,
+        "name": "firstaid"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "striped_shirt", "striped_pants", "sneakers", "socks", "adderall" ],
-        "entries": [ { "item": "condom", "contents-item": "dayquil" }, { "group": "charged_matches" } ]
+        "entries": [
+          {
+            "item": "condom",
+            "contents-item": "dayquil"
+          },
+          { "group": "charged_matches" }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
@@ -3632,7 +6546,12 @@
     "name": "Political Prisoner",
     "description": "You did your best to expose what was going on in those labs, but they caught you and threw you in prison on trumped-up charges to silence you.  Clearly, they should have listened.",
     "points": 1,
-    "skills": [ { "level": 6, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "speech"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "striped_shirt", "striped_pants", "sneakers", "socks", "gum" ],
@@ -3646,12 +6565,29 @@
   {
     "type": "profession",
     "id": "convict_ratman",
-    "name": { "male": "Rat Prince", "female": "Rat Princess" },
+    "name": {
+      "male": "Rat Prince",
+      "female": "Rat Princess"
+    },
     "description": "You probably needed psychiatric help instead of a prison sentence.  At least your loyal subjects have agreed to hold the line as you make your daring escape.",
     "points": 3,
-    "skills": [ { "level": 4, "name": "survival" }, { "level": 2, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "survival"
+      },
+      {
+        "level": 2,
+        "name": "speech"
+      }
+    ],
     "traits": [ "ANIMALEMPATH" ],
-    "pets": [ { "name": "mon_black_rat", "amount": 13 } ],
+    "pets": [
+      {
+        "name": "mon_black_rat",
+        "amount": 13
+      }
+    ],
     "items": {
       "both": [ "striped_shirt", "striped_pants", "sneakers", "socks", "fried_seeds" ],
       "male": [ "briefs" ],
@@ -3666,7 +6602,16 @@
     "description": "This could be your lucky break.  Plenty of loot to be pilfered, and no cops to be seen.  Does it count as breaking and entering if everyone in town is undead?",
     "points": 2,
     "proficiencies": [ "prof_lockpicking" ],
-    "skills": [ { "level": 6, "name": "traps" }, { "level": 2, "name": "dodge" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "traps"
+      },
+      {
+        "level": 2,
+        "name": "dodge"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -3684,7 +6629,12 @@
           "stethoscope",
           "picklocks"
         ],
-        "entries": [ { "item": "pants", "variant": "pants_black_camo" } ]
+        "entries": [
+          {
+            "item": "pants",
+            "variant": "pants_black_camo"
+          }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
@@ -3696,7 +6646,12 @@
     "name": "Lawyer",
     "description": "The jury were in the palm of your hand, but after the defendant tried to eat your brain, you were forced to flee the courtroom in disgrace.  Now nobody seems to care about your objections.",
     "points": 1,
-    "skills": [ { "level": 6, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "speech"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -3723,11 +6678,22 @@
     "name": "Priest",
     "description": "Armageddon has come!  You did everything you could to protect your parish faithful, but it appears that prayers were not enough.  Now that they are all dead, you should probably find something more tangible to protect you.",
     "points": 0,
-    "skills": [ { "level": 3, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "speech"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "pants", "longshirt", "socks", "cassock", "dress_shoes", "holy_symbol", "holybook_bible1" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "holy_symbol", "variant": "catholic_necklace" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "holy_symbol",
+            "variant": "catholic_necklace"
+          }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
@@ -3739,7 +6705,16 @@
     "name": "Kannushi",
     "description": "You were one of the maintainers of a Shinto shrine, performing rituals and sacred tasks.  You preferred it when only the spirits of the dead inhabited your shrine, and not their rotting corpses.",
     "points": 0,
-    "skills": [ { "level": 3, "name": "fabrication" }, { "level": 3, "name": "tailor" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "fabrication"
+      },
+      {
+        "level": 3,
+        "name": "tailor"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "kariginu", "eboshi", "pants", "hakama", "tabi_dress", "geta", "holy_symbol", "holybook_kojiki" ],
@@ -3752,10 +6727,18 @@
   {
     "type": "profession",
     "id": "bhikkhu",
-    "name": { "male": "Bhikkhu", "female": "Bhikkhuni" },
+    "name": {
+      "male": "Bhikkhu",
+      "female": "Bhikkhuni"
+    },
     "description": "Your life was simple at the Vihara, doing household chores and meditating.  Your Sangha wanted to attain liberation from suffering, now their rotting corpses will suffer forever.",
     "points": 0,
-    "skills": [ { "level": 3, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "speech"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "antarvasa", "uttarasanga", "samghati", "flip_flops", "holy_symbol", "holybook_sutras" ],
@@ -3768,15 +6751,29 @@
   {
     "type": "profession",
     "id": "imam",
-    "name": { "male": "Imam", "female": "Mourchida" },
+    "name": {
+      "male": "Imam",
+      "female": "Mourchida"
+    },
     "description": "You spent much of your time prior to the apocalypse at the local mosque, studying the words of the Prophet and the Quran and guiding your community in prayer.  Back then they came from far and wide to listen to you; now they come to eat your brains.",
     "points": 0,
     "//": "No knife, fire, or decent storage/armor.  Skill points are countered.",
-    "skills": [ { "level": 3, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "speech"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "pants", "socks", "kufi", "thawb", "lowtops", "holybook_quran" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
@@ -3788,7 +6785,12 @@
     "name": "Rabbi",
     "description": "You were celebrating with your flock in the temple when the Cataclysm struck.  You sure could use a messiah right now!",
     "points": 0,
-    "skills": [ { "level": 3, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "speech"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -3815,11 +6817,26 @@
     "name": "Guru",
     "description": "You spent many years traveling through the world, becoming wise and learned.  Normally you can answer any question, but even you are not quite sure what to do about the ravenous undead.",
     "points": 1,
-    "skills": [ { "level": 5, "name": "speech" }, { "level": 3, "name": "survival" } ],
+    "skills": [
+      {
+        "level": 5,
+        "name": "speech"
+      },
+      {
+        "level": 3,
+        "name": "survival"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "jeans", "socks", "robe", "turban", "waterskin", "pockknife", "mbag", "leathersandals", "holy_symbol", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
@@ -3831,14 +6848,26 @@
     "name": "Traveling Preacher",
     "description": "You devoted your life to spreading the good word, always on the road, traveling from town to town.  Now everything has gone to hell, you can't host your daily podcast, and the undead don't seem particularly moved by your sermons.",
     "points": 1,
-    "skills": [ { "level": 4, "name": "speech" }, { "level": 4, "name": "driving" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "speech"
+      },
+      {
+        "level": 4,
+        "name": "driving"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "dress_shirt", "pants", "socks", "dress_shoes", "wristwatch", "backpack", "flyer", "flyer", "flyer", "holy_symbol" ],
         "entries": [
           { "group": "charged_smart_phone" },
           { "group": "charged_laptop" },
-          { "item": "holy_symbol", "variant": "general_necklace" }
+          {
+            "item": "holy_symbol",
+            "variant": "general_necklace"
+          }
         ]
       },
       "male": [ "briefs" ],
@@ -3851,7 +6880,16 @@
     "name": "Novice Martial Artist",
     "description": "You've decided today is the day to take your first lesson at the local dojo.  You'll be great at it, you're sure of it.",
     "points": 0,
-    "skills": [ { "level": 1, "name": "melee" }, { "level": 1, "name": "unarmed" } ],
+    "skills": [
+      {
+        "level": 1,
+        "name": "melee"
+      },
+      {
+        "level": 1,
+        "name": "unarmed"
+      }
+    ],
     "items": {
       "both": [ "karate_gi", "judo_belt_white", "mouthpiece", "socks_ankle", "sneakers" ],
       "male": [ "boxer_shorts" ],
@@ -3867,10 +6905,22 @@
     "points": 3,
     "traits": [ "PROF_MA_ORANGE" ],
     "skills": [
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "unarmed" },
-      { "level": 4, "name": "dodge" },
-      { "level": 3, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "unarmed"
+      },
+      {
+        "level": 4,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": [ "karate_gi", "judo_belt_orange", "mouthpiece", "socks_ankle", "sneakers" ],
@@ -3887,10 +6937,22 @@
     "points": 8,
     "traits": [ "PROF_MA_BLACK" ],
     "skills": [
-      { "level": 8, "name": "melee" },
-      { "level": 8, "name": "unarmed" },
-      { "level": 8, "name": "dodge" },
-      { "level": 5, "name": "swimming" }
+      {
+        "level": 8,
+        "name": "melee"
+      },
+      {
+        "level": 8,
+        "name": "unarmed"
+      },
+      {
+        "level": 8,
+        "name": "dodge"
+      },
+      {
+        "level": 5,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": [ "karate_gi", "judo_belt_black", "mouthpiece", "geta" ],
@@ -3901,10 +6963,22 @@
   {
     "type": "profession",
     "id": "pizzaboy",
-    "name": { "male": "Pizza Delivery Boy", "female": "Pizza Delivery Girl" },
+    "name": {
+      "male": "Pizza Delivery Boy",
+      "female": "Pizza Delivery Girl"
+    },
     "description": "You were delivering the last pizza of the night to the local cryogenics lab when hungry zombies attempted to make a meal out of you.  Fleeing for safety, you find yourself with only your wits and some leftover pizza.  And they didn't even leave a tip!",
     "points": 0,
-    "skills": [ { "level": 3, "name": "driving" }, { "level": 1, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "driving"
+      },
+      {
+        "level": 1,
+        "name": "speech"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -3919,7 +6993,13 @@
           "wristwatch",
           "mbag"
         ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "boy_shorts" ]
@@ -3932,11 +7012,26 @@
     "description": "Following a clue from your dead grandfather's journal, you made your way to a long-lost temple, but then the ground started to shake uncontrollably.  You had a bad feeling about that, so you got out of there quickly.",
     "points": 2,
     "skills": [
-      { "level": 4, "name": "survival" },
-      { "level": 2, "name": "gun" },
-      { "level": 2, "name": "pistol" },
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "bashing" }
+      {
+        "level": 4,
+        "name": "survival"
+      },
+      {
+        "level": 2,
+        "name": "gun"
+      },
+      {
+        "level": 2,
+        "name": "pistol"
+      },
+      {
+        "level": 2,
+        "name": "melee"
+      },
+      {
+        "level": 2,
+        "name": "bashing"
+      }
     ],
     "items": {
       "both": {
@@ -3957,7 +7052,12 @@
         "entries": [
           { "group": "charged_smart_phone" },
           { "group": "speedloaders_s&w619_special" },
-          { "item": "sw_619", "ammo-item": "38_special", "charges": 7, "container-item": "holster" }
+          {
+            "item": "sw_619",
+            "ammo-item": "38_special",
+            "charges": 7,
+            "container-item": "holster"
+          }
         ]
       },
       "male": [ "briefs" ],
@@ -3967,10 +7067,26 @@
   {
     "type": "profession",
     "id": "paperboy",
-    "name": { "male": "Paperboy", "female": "Papergirl" },
+    "name": {
+      "male": "Paperboy",
+      "female": "Papergirl"
+    },
     "description": "You set out this morning to deliver the news of the apocalypse.  The undead hordes don't seem to value the latest news, but at least your trusty bicycle is still in working order.",
     "points": 2,
-    "skills": [ { "level": 4, "name": "driving" }, { "level": 3, "name": "throw" }, { "level": 1, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "driving"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 1,
+        "name": "speech"
+      }
+    ],
     "proficiencies": [ "prof_athlete_basic", "prof_driver" ],
     "items": {
       "both": {
@@ -4006,10 +7122,22 @@
     "description": "A patch of soil, some water, and sunlight were all you ever needed; why should things be any different now?  With a handful of seeds and your trusty hoe, it's time to rebuild the Earth, one plant at a time.",
     "points": 1,
     "skills": [
-      { "level": 3, "name": "survival" },
-      { "level": 3, "name": "fabrication" },
-      { "level": 1, "name": "melee" },
-      { "level": 1, "name": "bashing" }
+      {
+        "level": 3,
+        "name": "survival"
+      },
+      {
+        "level": 3,
+        "name": "fabrication"
+      },
+      {
+        "level": 1,
+        "name": "melee"
+      },
+      {
+        "level": 1,
+        "name": "bashing"
+      }
     ],
     "items": {
       "both": {
@@ -4031,7 +7159,13 @@
           "seed_sugar_beet",
           "seed_tomato"
         ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
@@ -4045,13 +7179,34 @@
     "description": "The government activated your National Guard unit to deal with the growing epidemics.  Despite your best efforts, you were unable to form up before all communications ceased and you found yourself alone amongst the dead.",
     "points": 4,
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "rifle" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "bashing" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 2,
+        "name": "melee"
+      },
+      {
+        "level": 2,
+        "name": "bashing"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "proficiencies": [ "prof_wound_care", "prof_gun_cleaning" ],
     "items": {
@@ -4059,8 +7214,14 @@
         "items": [ "shorts", "socks", "lowtops", "wristwatch" ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "personal_gobag", "custom-flags": [ "FIT" ] },
-          { "item": "tshirt", "variant": "generic_tshirt" }
+          {
+            "item": "personal_gobag",
+            "custom-flags": [ "FIT" ]
+          },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -4076,20 +7237,62 @@
     "points": 8,
     "proficiencies": [ "prof_fibers", "prof_fibers_rope", "prof_knitting", "prof_closures" ],
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "rifle" },
-      { "level": 4, "name": "pistol" },
-      { "level": 4, "name": "shotgun" },
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "bashing" },
-      { "level": 4, "name": "cutting" },
-      { "level": 4, "name": "stabbing" },
-      { "level": 4, "name": "dodge" },
-      { "level": 4, "name": "fabrication" },
-      { "level": 4, "name": "mechanics" },
-      { "level": 4, "name": "tailor" },
-      { "level": 4, "name": "survival" },
-      { "level": 4, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "rifle"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 4,
+        "name": "shotgun"
+      },
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "bashing"
+      },
+      {
+        "level": 4,
+        "name": "cutting"
+      },
+      {
+        "level": 4,
+        "name": "stabbing"
+      },
+      {
+        "level": 4,
+        "name": "dodge"
+      },
+      {
+        "level": 4,
+        "name": "fabrication"
+      },
+      {
+        "level": 4,
+        "name": "mechanics"
+      },
+      {
+        "level": 4,
+        "name": "tailor"
+      },
+      {
+        "level": 4,
+        "name": "survival"
+      },
+      {
+        "level": 4,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -4105,9 +7308,19 @@
           "wristwatch"
         ],
         "entries": [
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "scar_h", "ammo-item": "762_51", "contents-item": "shoulder_strap" },
-          { "item": "katana", "container-item": "scabbard" }
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "scar_h",
+            "ammo-item": "762_51",
+            "contents-item": "shoulder_strap"
+          },
+          {
+            "item": "katana",
+            "container-item": "scabbard"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -4124,16 +7337,46 @@
     "points": 6,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "rifle" },
-      { "level": 4, "name": "pistol" },
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "stabbing" },
-      { "level": 4, "name": "dodge" },
-      { "level": 4, "name": "firstaid" },
-      { "level": 4, "name": "survival" },
-      { "level": 4, "name": "throw" },
-      { "level": 4, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "rifle"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "stabbing"
+      },
+      {
+        "level": 4,
+        "name": "dodge"
+      },
+      {
+        "level": 4,
+        "name": "firstaid"
+      },
+      {
+        "level": 4,
+        "name": "survival"
+      },
+      {
+        "level": 4,
+        "name": "throw"
+      },
+      {
+        "level": 4,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -4152,9 +7395,18 @@
           "mess_kit"
         ],
         "entries": [
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
           {
             "item": "modular_m4_carbine",
             "variant": "modular_m4a1",
@@ -4162,7 +7414,10 @@
             "contents-item": "shoulder_strap"
           },
           { "group": "charged_two_way_radio" },
-          { "item": "chestrig", "contents-group": "army_mags_m4" }
+          {
+            "item": "chestrig",
+            "contents-group": "army_mags_m4"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -4176,7 +7431,16 @@
     "name": "Mall Security",
     "description": "You spent dull nights guarding the local mall against teen hooligans and petty thieves.  Your job training didn't provide any terribly useful skills, but you do have your trusty stun gun, baton, and pocket knife.",
     "points": 0,
-    "skills": [ { "level": 2, "name": "melee" }, { "level": 2, "name": "bashing" } ],
+    "skills": [
+      {
+        "level": 2,
+        "name": "melee"
+      },
+      {
+        "level": 2,
+        "name": "bashing"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "socks", "boots", "longshirt", "holster", "pockknife", "wristwatch", "leather_belt" ],
@@ -4184,9 +7448,18 @@
           { "group": "charged_smart_phone" },
           { "group": "charged_flashlight" },
           { "group": "charged_tazer" },
-          { "item": "pants", "variant": "pants_urban" },
-          { "item": "stab_vest", "variant": "security_stab_vest" },
-          { "item": "baton", "custom-flags": [ "auto_wield" ] }
+          {
+            "item": "pants",
+            "variant": "pants_urban"
+          },
+          {
+            "item": "stab_vest",
+            "variant": "security_stab_vest"
+          },
+          {
+            "item": "baton",
+            "custom-flags": [ "auto_wield" ]
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -4201,17 +7474,50 @@
     "description": "Over long years of self-imposed exile in the wilderness, you have come to an understanding with Mother Nature.  The world as they knew it might have ended for your forsaken species, but you can hardly tell the difference.",
     "points": 6,
     "skills": [
-      { "level": 7, "name": "survival" },
-      { "level": 6, "name": "fabrication" },
-      { "level": 6, "name": "tailor" },
-      { "level": 5, "name": "gun" },
-      { "level": 5, "name": "archery" },
-      { "level": 4, "name": "chemistry" },
-      { "level": 4, "name": "cooking" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 2, "name": "dodge" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 7,
+        "name": "survival"
+      },
+      {
+        "level": 6,
+        "name": "fabrication"
+      },
+      {
+        "level": 6,
+        "name": "tailor"
+      },
+      {
+        "level": 5,
+        "name": "gun"
+      },
+      {
+        "level": 5,
+        "name": "archery"
+      },
+      {
+        "level": 4,
+        "name": "chemistry"
+      },
+      {
+        "level": 4,
+        "name": "cooking"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 2,
+        "name": "dodge"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "proficiencies": [
       "prof_bowyery",
@@ -4245,10 +7551,24 @@
           "fur_rollmat"
         ],
         "entries": [
-          { "item": "needle_bone", "ammo-item": "sinew", "charges": 200 },
-          { "item": "primitive_knife", "container-item": "sheath" },
-          { "item": "quiver", "contents-group": "quiver_naturalist" },
-          { "item": "fire_drill", "ammo-item": "notch", "charges": 24 }
+          {
+            "item": "needle_bone",
+            "ammo-item": "sinew",
+            "charges": 200
+          },
+          {
+            "item": "primitive_knife",
+            "container-item": "sheath"
+          },
+          {
+            "item": "quiver",
+            "contents-group": "quiver_naturalist"
+          },
+          {
+            "item": "fire_drill",
+            "ammo-item": "notch",
+            "charges": 24
+          }
         ]
       },
       "male": [ "chestwrap_fur", "loincloth_fur" ],
@@ -4261,7 +7581,16 @@
     "name": "Fisher",
     "description": "You spent most of your days fishing in the swamp, getting by quietly on your catch.  You found the buzzing of insects enjoyable, but recently they've gotten bigger and meaner.  Now their horrible noises have you spooked - you just hope the fish aren't as nasty.",
     "points": 2,
-    "skills": [ { "level": 5, "name": "survival" }, { "level": 2, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 5,
+        "name": "survival"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
+    ],
     "proficiencies": [ "prof_fibers" ],
     "items": {
       "both": {
@@ -4279,11 +7608,27 @@
         ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "fish_trap", "ammo-item": "fish_bait", "charges": 5 },
-          { "item": "fish_bait", "charges": 15 },
-          { "item": "lighter", "charges": 100 },
-          { "item": "knife_hunting", "container-item": "sheath" },
-          { "item": "fishing_rod_professional", "custom-flags": [ "auto_wield" ] }
+          {
+            "item": "fish_trap",
+            "ammo-item": "fish_bait",
+            "charges": 5
+          },
+          {
+            "item": "fish_bait",
+            "charges": 15
+          },
+          {
+            "item": "lighter",
+            "charges": 100
+          },
+          {
+            "item": "knife_hunting",
+            "container-item": "sheath"
+          },
+          {
+            "item": "fishing_rod_professional",
+            "custom-flags": [ "auto_wield" ]
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -4293,7 +7638,10 @@
   {
     "type": "profession",
     "id": "reenactor",
-    "name": { "male": "Historical Reenactor", "female": "Ahistorical Reenactor" },
+    "name": {
+      "male": "Historical Reenactor",
+      "female": "Ahistorical Reenactor"
+    },
     "description": {
       "male": "You were on your way to the Annual All New England Revolutionary War Living History exhibition when the end of the world permanently derailed your plans.",
       "female": "You were on your way to the Annual All New England Revolutionary War Living History exhibition when the end of the world made traditional gender roles obsolete."
@@ -4301,11 +7649,26 @@
     "points": 2,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_metalworking", "prof_gunsmithing_antique", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "rifle" },
-      { "level": 3, "name": "mechanics" },
-      { "level": 2, "name": "tailor" },
-      { "level": 2, "name": "cooking" }
+      {
+        "level": 3,
+        "name": "gun"
+      },
+      {
+        "level": 3,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "mechanics"
+      },
+      {
+        "level": 2,
+        "name": "tailor"
+      },
+      {
+        "level": 2,
+        "name": "cooking"
+      }
     ],
     "items": {
       "both": {
@@ -4327,11 +7690,28 @@
           "pipe_cleaner"
         ],
         "entries": [
-          { "item": "rifle_flintlock", "ammo-item": "flintlock_ammo", "charges": 1, "contents-item": "shoulder_strap" },
-          { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_reenactor" },
-          { "item": "flintlock_ammo", "charges": 15 },
-          { "item": "vinegar", "container-item": "bottle_plastic_small" },
-          { "item": "lamp_oil", "container-item": "bottle_plastic_small" },
+          {
+            "item": "rifle_flintlock",
+            "ammo-item": "flintlock_ammo",
+            "charges": 1,
+            "contents-item": "shoulder_strap"
+          },
+          {
+            "item": "flintlock_pouch",
+            "contents-group": "flintlock_pouch_reenactor"
+          },
+          {
+            "item": "flintlock_ammo",
+            "charges": 15
+          },
+          {
+            "item": "vinegar",
+            "container-item": "bottle_plastic_small"
+          },
+          {
+            "item": "lamp_oil",
+            "container-item": "bottle_plastic_small"
+          },
           { "group": "charged_smart_phone" },
           { "group": "charged_matches" }
         ]
@@ -4341,7 +7721,10 @@
   {
     "type": "profession",
     "id": "reenactor2",
-    "name": { "male": "Ahistorical Reenactor", "female": "Historical Reenactor" },
+    "name": {
+      "male": "Ahistorical Reenactor",
+      "female": "Historical Reenactor"
+    },
     "description": {
       "male": "You were on your way to the Annual All New England Revolutionary War Living History exhibition when the end of the world made traditional gender roles obsolete.",
       "female": "You were on your way to the Annual All New England Revolutionary War Living History exhibition when the end of the world permanently derailed your plans."
@@ -4349,10 +7732,22 @@
     "points": 2,
     "proficiencies": [ "prof_spinning", "prof_closures", "prof_knitting", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 4, "name": "tailor" },
-      { "level": 4, "name": "cooking" },
-      { "level": 2, "name": "gun" },
-      { "level": 2, "name": "rifle" }
+      {
+        "level": 4,
+        "name": "tailor"
+      },
+      {
+        "level": 4,
+        "name": "cooking"
+      },
+      {
+        "level": 2,
+        "name": "gun"
+      },
+      {
+        "level": 2,
+        "name": "rifle"
+      }
     ],
     "items": {
       "both": {
@@ -4374,8 +7769,15 @@
           "salt"
         ],
         "entries": [
-          { "item": "needle_wood", "ammo-item": "thread", "charges": 200 },
-          { "item": "oil_lamp", "charges": 750 },
+          {
+            "item": "needle_wood",
+            "ammo-item": "thread",
+            "charges": 200
+          },
+          {
+            "item": "oil_lamp",
+            "charges": 750
+          },
           { "group": "charged_smart_phone" },
           { "group": "charged_matches" }
         ]
@@ -4385,10 +7787,26 @@
   {
     "type": "profession",
     "id": "skaterkid",
-    "name": { "male": "Skater Boy (Rollerblades)", "female": "Skater Girl (Rollerblades)" },
+    "name": {
+      "male": "Skater Boy (Rollerblades)",
+      "female": "Skater Girl (Rollerblades)"
+    },
     "description": "You love to skate!  You've probably spent more time on a pair of blades than off.  Things have gotten pretty bad, but at least the grown-ups aren't telling you where you can't roll.",
     "points": 1,
-    "skills": [ { "level": 4, "name": "dodge" }, { "level": 3, "name": "driving" }, { "level": 2, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "driving"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
+    ],
     "traits": [ "PROF_SKATER" ],
     "proficiencies": [ "prof_athlete_basic" ],
     "items": {
@@ -4405,7 +7823,13 @@
           "wristwatch",
           "sports_drink"
         ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "boy_shorts" ]
@@ -4416,11 +7840,27 @@
   {
     "type": "profession",
     "id": "skaterkid_board",
-    "name": { "male": "Skater Boy (Skateboard)", "female": "Skater Girl (Skateboard)" },
+    "name": {
+      "male": "Skater Boy (Skateboard)",
+      "female": "Skater Girl (Skateboard)"
+    },
     "description": "You love to skate!  You've probably spent more time on a skateboard than off.  Things have gotten pretty bad, but at least the grown-ups aren't telling you where you can't roll.",
     "points": 1,
     "proficiencies": [ "prof_driver", "prof_athlete_basic" ],
-    "skills": [ { "level": 4, "name": "dodge" }, { "level": 3, "name": "driving" }, { "level": 2, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "driving"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
+    ],
     "traits": [ "PROF_SKATER" ],
     "items": {
       "both": {
@@ -4437,7 +7877,13 @@
           "wristwatch",
           "sports_drink"
         ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "boy_shorts" ]
@@ -4452,11 +7898,26 @@
     "description": "You never cared for grown-ups telling you what to do, so you ended up spending quite a few days in the principal's office.  Now, not needing grown-ups to tell you what to do is the only reason you're alive.  Man, you really should've played hooky today.",
     "points": 0,
     "skills": [
-      { "level": 1, "name": "gun" },
-      { "level": 1, "name": "archery" },
-      { "level": 1, "name": "melee" },
-      { "level": 1, "name": "unarmed" },
-      { "level": 1, "name": "dodge" }
+      {
+        "level": 1,
+        "name": "gun"
+      },
+      {
+        "level": 1,
+        "name": "archery"
+      },
+      {
+        "level": 1,
+        "name": "melee"
+      },
+      {
+        "level": 1,
+        "name": "unarmed"
+      },
+      {
+        "level": 1,
+        "name": "dodge"
+      }
     ],
     "items": {
       "both": {
@@ -4478,7 +7939,10 @@
         "entries": [
           { "group": "charged_smart_phone" },
           { "group": "charged_matches" },
-          { "item": "tshirt", "variant": "generic_tshirt" }
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
         ]
       },
       "male": [ "briefs" ],
@@ -4495,10 +7959,22 @@
     "description": "Your parents were crazy preppers who thought some \"Cataclysm\" was coming, and insisted on preparing you for it.  Turns out they were right.  You didn't get a chance to thank them.  The only thing you can do for them now is what they always hoped you would do in the dark days ahead: survive.",
     "points": 2,
     "skills": [
-      { "level": 3, "name": "fabrication" },
-      { "level": 3, "name": "survival" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "traps" }
+      {
+        "level": 3,
+        "name": "fabrication"
+      },
+      {
+        "level": 3,
+        "name": "survival"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "traps"
+      }
     ],
     "proficiencies": [ "prof_fibers", "prof_fibers_rope", "prof_lockpicking", "prof_gun_cleaning" ],
     "items": {
@@ -4521,7 +7997,10 @@
           { "group": "charged_cell_phone" },
           { "group": "full_1st_aid" },
           { "group": "charged_flashlight" },
-          { "item": "tshirt", "variant": "generic_tshirt" }
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
         ]
       },
       "male": [ "briefs" ],
@@ -4536,12 +8015,31 @@
     "name": "Dodgeball Player",
     "description": "In dodgeball, failing to dodge meant taking a ball to the head and being out of the game.  In the Cataclysm, it means getting eaten by monsters.  Don't slip up.",
     "points": 2,
-    "skills": [ { "level": 5, "name": "dodge" }, { "level": 4, "name": "throw" }, { "level": 3, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 5,
+        "name": "dodge"
+      },
+      {
+        "level": 4,
+        "name": "throw"
+      },
+      {
+        "level": 3,
+        "name": "swimming"
+      }
+    ],
     "proficiencies": [ "prof_athlete_basic" ],
     "items": {
       "both": {
         "items": [ "jacket_light", "jeans", "socks_ankle", "lowtops", "slingpack", "juice" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "boy_shorts" ]
@@ -4555,11 +8053,30 @@
     "name": "Science Club Member",
     "description": "The school never let your club play with the really fun chemicals, the kind that make things go boom, but there aren't any teachers around to enforce the rules anymore.",
     "points": 1,
-    "skills": [ { "level": 2, "name": "fabrication" }, { "level": 2, "name": "mechanics" }, { "level": 2, "name": "chemistry" } ],
+    "skills": [
+      {
+        "level": 2,
+        "name": "fabrication"
+      },
+      {
+        "level": 2,
+        "name": "mechanics"
+      },
+      {
+        "level": 2,
+        "name": "chemistry"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "jacket_light", "jeans", "socks", "sneakers", "knit_scarf", "backpack", "basic_chemistry", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "panties" ]
@@ -4573,7 +8090,16 @@
     "name": "A/V Club Member",
     "description": "You were a member of the school A/V club.  You're sure there's some way you can use your technical skills to help you stay alive.  You just haven't figured out how to make an awesome death ray yet.",
     "points": 1,
-    "skills": [ { "level": 3, "name": "electronics" }, { "level": 3, "name": "computer" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "electronics"
+      },
+      {
+        "level": 3,
+        "name": "computer"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -4601,11 +8127,22 @@
     "name": "Teacher",
     "description": "You've been teaching kids all your life, experiencing the joy and aggravation of imparting knowledge to young minds.  If zombies have any interest in education, they're not showing it.",
     "points": 1,
-    "skills": [ { "level": 4, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "speech"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "dress_shirt", "blazer", "pants", "socks", "dress_shoes", "tie_skinny", "tieclip", "poetry_book", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "permanent_marker", "charges": 500 } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "permanent_marker",
+            "charges": 500
+          }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
@@ -4617,13 +8154,23 @@
     "name": "Photojournalist",
     "description": "Covering the apocalypse up close could make your career, though finding a publisher seems more difficult a prospect than usual.  You managed to hold onto your camera - hopefully you can get some fantastic shots.",
     "points": 1,
-    "skills": [ { "level": 4, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "speech"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "pants", "dress_shirt", "blazer", "socks", "dress_shoes", "wristwatch", "camera_bag" ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "light_disposable_cell", "ammo-item": "battery", "charges": 300, "container-item": "camera_pro" }
+          {
+            "item": "light_disposable_cell",
+            "ammo-item": "battery",
+            "charges": 300,
+            "container-item": "camera_pro"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -4637,11 +8184,26 @@
     "description": "It was hard enough getting kids to run laps without having to worry about them trying to eat your brains.  Zombies won't even line up when you blow your whistle.",
     "points": 2,
     "skills": [
-      { "level": 3, "name": "swimming" },
-      { "level": 3, "name": "speech" },
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "bashing" },
-      { "level": 2, "name": "throw" }
+      {
+        "level": 3,
+        "name": "swimming"
+      },
+      {
+        "level": 3,
+        "name": "speech"
+      },
+      {
+        "level": 2,
+        "name": "melee"
+      },
+      {
+        "level": 2,
+        "name": "bashing"
+      },
+      {
+        "level": 2,
+        "name": "throw"
+      }
     ],
     "items": {
       "both": {
@@ -4658,7 +8220,16 @@
     "name": "Miner",
     "description": "You're a miner, not a minor!  Your canteen is dry, your jackhammer is out of gas, and you're on your last pair of batteries for your mining helmet…",
     "points": 1,
-    "skills": [ { "level": 2, "name": "mechanics" }, { "level": 2, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 2,
+        "name": "mechanics"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -4677,10 +8248,23 @@
           { "group": "charged_matches" },
           { "group": "full_gasmask" },
           { "group": "charged_smart_phone" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "jackhammer", "charges": 0 },
-          { "item": "light_minus_disposable_cell", "charges": 100 },
-          { "item": "light_minus_disposable_cell", "charges": 100, "container-item": "miner_hat" }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "jackhammer",
+            "charges": 0
+          },
+          {
+            "item": "light_minus_disposable_cell",
+            "charges": 100
+          },
+          {
+            "item": "light_minus_disposable_cell",
+            "charges": 100,
+            "container-item": "miner_hat"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -4692,17 +8276,42 @@
     "id": "demolition_expert",
     "name": "Demolition Expert",
     "description": "Before this all began, you were having the time of your life at your dream job: blowing stuff up.  The Cataclysm means you're finally allowed to do it full time.",
-    "skills": [ { "level": 4, "name": "fabrication" }, { "level": 3, "name": "chemistry" }, { "level": 3, "name": "throw" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "fabrication"
+      },
+      {
+        "level": 3,
+        "name": "chemistry"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      }
+    ],
     "points": 2,
     "items": {
       "both": {
         "items": [ "socks", "boots_steel", "gloves_work", "jumpsuit", "canteen", "tool_belt", "mbag", "briefcase", "wristwatch" ],
         "entries": [
-          { "item": "hat_hard", "variant": "yellow_hat_hard" },
+          {
+            "item": "hat_hard",
+            "variant": "yellow_hat_hard"
+          },
           { "group": "charged_matches" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "dynamite", "count": 8 },
-          { "item": "dynamite", "count": 4 },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "dynamite",
+            "count": 8
+          },
+          {
+            "item": "dynamite",
+            "count": 4
+          },
           { "group": "charged_smart_phone" }
         ]
       },
@@ -4713,15 +8322,33 @@
   {
     "type": "profession",
     "id": "parkour_practitioner",
-    "name": { "male": "Traceur", "female": "Traceuse" },
+    "name": {
+      "male": "Traceur",
+      "female": "Traceuse"
+    },
     "description": "You've practiced parkour for many years, and made the world your playground.  It wouldn't be a lie to say that running is your life.  Which is good, because now that the end has come, you're running FOR your life.",
     "points": 3,
     "proficiencies": [ "prof_parkour", "prof_athlete_basic" ],
-    "skills": [ { "level": 6, "name": "dodge" }, { "level": 4, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "dodge"
+      },
+      {
+        "level": 4,
+        "name": "swimming"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "hoodie", "pants_cargo", "socks_ankle", "sneakers", "runner_bag", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
+        ]
       },
       "male": [ "briefs" ],
       "female": [ "sports_bra", "boy_shorts" ]
@@ -4751,8 +8378,16 @@
         ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "light_disposable_cell", "ammo-item": "battery", "charges": 300, "container-item": "camera" },
-          { "item": "tshirt", "variant": "generic_tshirt" }
+          {
+            "item": "light_disposable_cell",
+            "ammo-item": "battery",
+            "charges": 300,
+            "container-item": "camera"
+          },
+          {
+            "item": "tshirt",
+            "variant": "generic_tshirt"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -4773,7 +8408,16 @@
     "description": "You were called in on your day off to feed the animals at the zoo.  For some reason, none of your coworkers bothered showing up for work today.",
     "points": 2,
     "traits": [ "ANIMALEMPATH" ],
-    "skills": [ { "level": 4, "name": "survival" }, { "level": 3, "name": "firstaid" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "survival"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -4799,11 +8443,26 @@
     "name": "Urban Samurai",
     "description": "You were always an inexplicable sight in town, with your funny hair and odd Japanese clothes.  Some claimed you were a visiting Shinto god.  Little of this concerned you, but last week the grocery service stopped coming and now the TV no longer turns on.  This displeases you.",
     "points": 0,
-    "skills": [ { "level": 1, "name": "melee" }, { "level": 1, "name": "cutting" } ],
+    "skills": [
+      {
+        "level": 1,
+        "name": "melee"
+      },
+      {
+        "level": 1,
+        "name": "cutting"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "haori", "kimono", "hakama", "loincloth", "tabi_dress", "geta", "bellywrap" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "bokken_inferior", "container-item": "scabbard" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "bokken_inferior",
+            "container-item": "scabbard"
+          }
+        ]
       },
       "female": [ "chestwrap" ]
     },
@@ -4816,10 +8475,22 @@
     "description": "Years of training prepared you for the competitive fencing circuit, but your latest tournament was cut short when zombies invaded the piste.  The referee was eaten, so you're not sure if the rules are still in play.",
     "points": 5,
     "skills": [
-      { "level": 6, "name": "melee" },
-      { "level": 6, "name": "stabbing" },
-      { "level": 6, "name": "dodge" },
-      { "level": 4, "name": "swimming" }
+      {
+        "level": 6,
+        "name": "melee"
+      },
+      {
+        "level": 6,
+        "name": "stabbing"
+      },
+      {
+        "level": 6,
+        "name": "dodge"
+      },
+      {
+        "level": 4,
+        "name": "swimming"
+      }
     ],
     "traits": [ "MARTIAL_FENCING" ],
     "items": {
@@ -4835,7 +8506,13 @@
           "fencing_epee",
           "duffelbag"
         ],
-        "entries": [ { "item": "fencing_mask", "custom-flags": [ "no_auto_equip" ] }, { "group": "charged_smart_phone" } ]
+        "entries": [
+          {
+            "item": "fencing_mask",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          { "group": "charged_smart_phone" }
+        ]
       },
       "female": [ "plastron_plastic" ]
     }
@@ -4846,12 +8523,20 @@
     "name": "Career Politician",
     "description": "You've spent your life appealing to the people, persuading many and promising much throughout your time in office.  Now that your voting base wants to eat you alive, winning hearts and minds just got that much harder.",
     "points": 2,
-    "skills": [ { "level": 8, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 8,
+        "name": "speech"
+      }
+    ],
     "traits": [ "LIAR" ],
     "items": {
       "both": {
         "items": [ "suit", "tieclip", "socks_wool", "dress_shoes", "gold_watch", "briefcase", "tie_skinny", "file", "cigar" ],
-        "entries": [ { "group": "charged_ref_lighter" }, { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "group": "charged_ref_lighter" },
+          { "group": "charged_smart_phone" }
+        ]
       },
       "male": [ "boxer_shorts", "opal_platinum_cufflinks" ],
       "female": [ "bra", "panties", "opal_platinum_earring" ]
@@ -4864,7 +8549,12 @@
     "name": "Rancher",
     "description": "Taking care of cows, horses, and other animals is your passion, but the ways things are going, this isn't going to be just another day at the ranch.",
     "points": 2,
-    "skills": [ { "level": 5, "name": "survival" } ],
+    "skills": [
+      {
+        "level": 5,
+        "name": "survival"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -4898,16 +8588,32 @@
     "description": "You've always worked just outside of the limelight, carrying and fixing the equipment and ensuring that the performers got what they needed.  The show must go on.",
     "points": 2,
     "skills": [
-      { "level": 3, "name": "fabrication" },
-      { "level": 3, "name": "mechanics" },
-      { "level": 3, "name": "electronics" },
-      { "level": 3, "name": "driving" }
+      {
+        "level": 3,
+        "name": "fabrication"
+      },
+      {
+        "level": 3,
+        "name": "mechanics"
+      },
+      {
+        "level": 3,
+        "name": "electronics"
+      },
+      {
+        "level": 3,
+        "name": "driving"
+      }
     ],
     "proficiencies": [ "prof_appliance_repair" ],
     "items": {
       "both": {
         "items": [ "jacket_jean", "tshirt_tour", "jeans", "socks", "boots_steel", "multitool", "wristwatch", "gloves_work", "mbag" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_matches" }, { "group": "charged_soldering_iron" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          { "group": "charged_matches" },
+          { "group": "charged_soldering_iron" }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "boy_shorts" ]
@@ -4919,7 +8625,12 @@
     "name": "Musician",
     "description": "You nailed your solo, but the audience erupted into screams instead of applause.  You weren't able to grab much during the panic, but at least you have your loaded six string on your back.",
     "points": 1,
-    "skills": [ { "level": 5, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 5,
+        "name": "speech"
+      }
+    ],
     "items": {
       "both": {
         "ammo": 100,
@@ -4939,7 +8650,13 @@
           "plectrum",
           "joint"
         ],
-        "entries": [ { "item": "towel", "custom-flags": [ "no_auto_equip" ] }, { "group": "charged_smart_phone" } ]
+        "entries": [
+          {
+            "item": "towel",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          { "group": "charged_smart_phone" }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "boy_shorts" ]
@@ -4968,11 +8685,26 @@
     "points": 4,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "pistol" },
-      { "level": 3, "name": "rifle" },
-      { "level": 3, "name": "shotgun" },
-      { "level": 2, "name": "survival" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "shotgun"
+      },
+      {
+        "level": 2,
+        "name": "survival"
+      }
     ],
     "items": {
       "both": {
@@ -4991,8 +8723,14 @@
         ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "whiskey", "container-item": "bottle_glass" },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "whiskey",
+            "container-item": "bottle_glass"
+          },
           {
             "item": "colt_saa",
             "ammo-item": "45colt_jhp",
@@ -5000,7 +8738,10 @@
             "container-item": "western_holster",
             "contents-group": "bandolier_ww_gunslinger"
           },
-          { "item": "sheriffshirt", "variant": "sheriff" }
+          {
+            "item": "sheriffshirt",
+            "variant": "sheriff"
+          }
         ]
       }
     }
@@ -5008,16 +8749,31 @@
   {
     "type": "profession",
     "id": "frat",
-    "name": { "male": "Frat Boy", "female": "Sorority Girl" },
+    "name": {
+      "male": "Frat Boy",
+      "female": "Sorority Girl"
+    },
     "description": "You were living the high life, spending your parents' money without a care in the world.  At one of your usual crazy parties, the guests became hungry for more than drugs and booze, but you still have a chance to use the last symbol of your luxurious life - your sports car - and get far away.",
     "points": 2,
     "proficiencies": [ "prof_driver" ],
-    "skills": [ { "level": 3, "name": "driving" }, { "level": 2, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "driving"
+      },
+      {
+        "level": 2,
+        "name": "speech"
+      }
+    ],
     "vehicle": "car_sports",
     "items": {
       "both": {
         "items": [ "gold_watch", "fancy_sunglasses", "water_mineral", "money_strap_twenty", "cig", "mag_porn" ],
-        "entries": [ { "group": "charged_ref_lighter" }, { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "group": "charged_ref_lighter" },
+          { "group": "charged_smart_phone" }
+        ]
       },
       "male": [ "boxer_shorts", "pants", "dress_shoes", "polo_shirt", "socks", "mag_dude" ],
       "female": [
@@ -5045,16 +8801,46 @@
     "points": 5,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "rifle" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "throw" },
-      { "level": 2, "name": "survival" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 2,
+        "name": "survival"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -5074,12 +8860,34 @@
         "entries": [
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "legpouch_large", "contents-group": "army_mags_m110" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
-          { "item": "m110a1", "ammo-item": "762_51", "charges": 20, "contents-item": [ "shoulder_strap" ] },
-          { "item": "m17", "ammo-item": "9mmfmj", "charges": 17, "container-item": "holster" },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_m110"
+          },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
+          {
+            "item": "m110a1",
+            "ammo-item": "762_51",
+            "charges": 20,
+            "contents-item": [ "shoulder_strap" ]
+          },
+          {
+            "item": "m17",
+            "ammo-item": "9mmfmj",
+            "charges": 17,
+            "container-item": "holster"
+          },
           { "group": "army_mags_m17" }
         ]
       },
@@ -5096,16 +8904,46 @@
     "points": 5,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "rifle" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "throw" },
-      { "level": 2, "name": "survival" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 2,
+        "name": "survival"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -5125,16 +8963,30 @@
         "entries": [
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
-          { "item": "water_clean", "container-item": "canteen" },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
           {
             "item": "m249",
             "ammo-item": "556",
             "charges": 200,
             "contents-item": [ "shoulder_strap", "holo_sight", "bipod" ]
           },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
-          { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
+          {
+            "item": "m17",
+            "ammo-item": "9mm",
+            "charges": 17,
+            "container-item": "holster"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -5150,17 +9002,50 @@
     "points": 4,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "launcher" },
-      { "level": 3, "name": "rifle" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "throw" },
-      { "level": 2, "name": "survival" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "launcher"
+      },
+      {
+        "level": 3,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 2,
+        "name": "survival"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -5180,17 +9065,34 @@
         "entries": [
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
-          { "item": "water_clean", "container-item": "canteen" },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
           {
             "item": "m320",
             "ammo-item": "40x46mm_m433",
             "charges": 1,
             "contents-item": [ "shoulder_strap", "holo_sight" ]
           },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "grenade_pouch", "contents-group": [ "army_grenades_40x46" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
-          { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "grenade_pouch",
+            "contents-group": [ "army_grenades_40x46" ]
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
+          {
+            "item": "m17",
+            "ammo-item": "9mm",
+            "charges": 17,
+            "container-item": "holster"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -5206,18 +9108,54 @@
     "points": 5,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "shotgun" },
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "bashing" },
-      { "level": 3, "name": "rifle" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "throw" },
-      { "level": 2, "name": "survival" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "shotgun"
+      },
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "bashing"
+      },
+      {
+        "level": 3,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 2,
+        "name": "survival"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -5240,13 +9178,38 @@
         "entries": [
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "mossberg_500", "ammo-item": "shot_00", "charges": 6, "contents-item": [ "shoulder_strap" ] },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "grenadebandolier", "contents-item": [ "flashbang", "flashbang" ] },
-          { "item": "bandolier_shotgun", "contents-group": "bandolier_swat_cqc1" },
-          { "item": "knife_combat", "container-item": "sheath" },
-          { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "mossberg_500",
+            "ammo-item": "shot_00",
+            "charges": 6,
+            "contents-item": [ "shoulder_strap" ]
+          },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "grenadebandolier",
+            "contents-item": [ "flashbang", "flashbang" ]
+          },
+          {
+            "item": "bandolier_shotgun",
+            "contents-group": "bandolier_swat_cqc1"
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
+          {
+            "item": "m17",
+            "ammo-item": "9mm",
+            "charges": 17,
+            "container-item": "holster"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -5262,16 +9225,46 @@
     "points": 5,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 5, "name": "gun" },
-      { "level": 5, "name": "rifle" },
-      { "level": 4, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "throw" },
-      { "level": 2, "name": "survival" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 5,
+        "name": "gun"
+      },
+      {
+        "level": 5,
+        "name": "rifle"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 2,
+        "name": "survival"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -5293,17 +9286,34 @@
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
           { "group": "army_mags_m2010" },
-          { "item": "water_clean", "container-item": "canteen" },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
           {
             "item": "m2010",
             "ammo-item": "300_winmag",
             "charges": 5,
             "contents-item": [ "shoulder_strap", "rifle_scope" ]
           },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
-          { "item": "m17", "ammo-item": "9mmfmj", "container-item": "holster", "charges": 17 },
-          { "item": "legpouch_large", "contents-group": "army_mags_m17" }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
+          {
+            "item": "m17",
+            "ammo-item": "9mmfmj",
+            "container-item": "holster",
+            "charges": 17
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_m17"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -5319,19 +9329,58 @@
     "points": 7,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_elec_soldering", "prof_appliance_repair", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 7, "name": "computer" },
-      { "level": 6, "name": "electronics" },
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "smg" },
-      { "level": 4, "name": "pistol" },
-      { "level": 3, "name": "rifle" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 3, "name": "throw" },
-      { "level": 2, "name": "survival" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 7,
+        "name": "computer"
+      },
+      {
+        "level": 6,
+        "name": "electronics"
+      },
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "smg"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 2,
+        "name": "survival"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -5353,17 +9402,32 @@
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
           { "group": "army_mags_mp7" },
-          { "item": "water_clean", "container-item": "canteen" },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
           {
             "item": "hk_mp7",
             "ammo-item": "46mm",
             "charges": 20,
             "contents-item": [ "shoulder_strap", "holo_sight", "suppressor" ]
           },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
-          { "item": "XL_holster", "contents-group": "holster_supp_MEU" },
-          { "item": "legpouch_large", "contents-group": "army_mags_1911" }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
+          {
+            "item": "XL_holster",
+            "contents-group": "holster_supp_MEU"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_1911"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -5378,16 +9442,46 @@
     "points": 5,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "pistol" },
-      { "level": 4, "name": "speech" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 2, "name": "throw" },
-      { "level": 2, "name": "survival" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 4,
+        "name": "speech"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 2,
+        "name": "throw"
+      },
+      {
+        "level": 2,
+        "name": "survival"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
@@ -5406,10 +9500,19 @@
         ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "holster", "contents-group": "holster_supp_57" },
+          {
+            "item": "holster",
+            "contents-group": "holster_supp_57"
+          },
           { "item": "suppressor" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "legpouch_large", "contents-group": "army_mags_57" }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_57"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -5424,16 +9527,46 @@
     "description": "You got to see things fall apart from the sky, transporting soldiers and survivors from one holdout to the next.  You knew it was only a matter of time before the horrors patrolling the skies shot you down.",
     "points": 5,
     "skills": [
-      { "level": 7, "name": "driving" },
-      { "level": 4, "name": "mechanics" },
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "firstaid" },
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "stabbing" },
-      { "level": 2, "name": "dodge" },
-      { "level": 2, "name": "throw" },
-      { "level": 1, "name": "swimming" }
+      {
+        "level": 7,
+        "name": "driving"
+      },
+      {
+        "level": 4,
+        "name": "mechanics"
+      },
+      {
+        "level": 3,
+        "name": "gun"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 2,
+        "name": "melee"
+      },
+      {
+        "level": 2,
+        "name": "stabbing"
+      },
+      {
+        "level": 2,
+        "name": "dodge"
+      },
+      {
+        "level": 2,
+        "name": "throw"
+      },
+      {
+        "level": 1,
+        "name": "swimming"
+      }
     ],
     "proficiencies": [ "prof_helicopter_pilot", "prof_spotting", "prof_gun_cleaning" ],
     "items": {
@@ -5443,7 +9576,11 @@
           "boots_combat",
           "wristwatch",
           "gloves_tactical",
-          { "item": "flight_helmet", "ammo-item": "light_plus_battery_cell", "charges": 150 },
+          {
+            "item": "flight_helmet",
+            "ammo-item": "light_plus_battery_cell",
+            "charges": 150
+          },
           "mil_flight_suit",
           "chestrig",
           "webbing_belt",
@@ -5452,12 +9589,32 @@
         "entries": [
           { "group": "charged_matches" },
           { "group": "charged_flashlight" },
-          { "item": "handflare", "count": 2, "charges": 200 },
+          {
+            "item": "handflare",
+            "count": 2,
+            "charges": 200
+          },
           { "item": "whistle" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "m17", "ammo-item": "9mm", "container-item": "holster", "charges": 17 },
-          { "item": "p320mag_17rd_9x19mm", "ammo-item": "9mm", "charges": 17 },
-          { "item": "p320mag_17rd_9x19mm", "ammo-item": "9mm", "charges": 17 }
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "m17",
+            "ammo-item": "9mm",
+            "container-item": "holster",
+            "charges": 17
+          },
+          {
+            "item": "p320mag_17rd_9x19mm",
+            "ammo-item": "9mm",
+            "charges": 17
+          },
+          {
+            "item": "p320mag_17rd_9x19mm",
+            "ammo-item": "9mm",
+            "charges": 17
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -5472,7 +9629,20 @@
     "name": "EMT",
     "description": "You were responding to a call with your partner before you got separated.  Now all you have is your trusty ambulance, ready to transport patients through the apocalypse.",
     "points": 3,
-    "skills": [ { "level": 5, "name": "firstaid" }, { "level": 4, "name": "driving" }, { "level": 2, "name": "mechanics" } ],
+    "skills": [
+      {
+        "level": 5,
+        "name": "firstaid"
+      },
+      {
+        "level": 4,
+        "name": "driving"
+      },
+      {
+        "level": 2,
+        "name": "mechanics"
+      }
+    ],
     "proficiencies": [ "prof_wound_care", "prof_intro_biology", "prof_physiology", "prof_burn_care", "prof_driver" ],
     "traits": [ "PROF_MED" ],
     "vehicle": "ambulance",
@@ -5486,9 +9656,15 @@
           "multitool",
           "wristwatch",
           "boots",
-          { "item": "aspirin", "count": 5 },
+          {
+            "item": "aspirin",
+            "count": 5
+          },
           "adrenaline_injector",
-          { "item": "adhesive_bandages", "count": 8 }
+          {
+            "item": "adhesive_bandages",
+            "count": 8
+          }
         ],
         "entries": [ { "group": "charged_smart_phone" } ]
       },
@@ -5502,7 +9678,20 @@
     "name": "Paramedic",
     "description": "You were separated from your partner while out on a call.  You managed to hang onto some medical supplies, but it's looking like the only life that needs saving now is yours.",
     "points": 3,
-    "skills": [ { "level": 6, "name": "firstaid" }, { "level": 3, "name": "driving" }, { "level": 1, "name": "mechanics" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "firstaid"
+      },
+      {
+        "level": 3,
+        "name": "driving"
+      },
+      {
+        "level": 1,
+        "name": "mechanics"
+      }
+    ],
     "proficiencies": [
       "prof_wound_care",
       "prof_wound_care_expert",
@@ -5521,7 +9710,10 @@
           "wristwatch",
           "boots",
           "mbag",
-          { "item": "bandages", "count": 3 },
+          {
+            "item": "bandages",
+            "count": 3
+          },
           "stethoscope",
           "scissors",
           "syringe",
@@ -5531,8 +9723,14 @@
         "entries": [
           { "group": "charged_smart_phone" },
           { "group": "full_1st_aid" },
-          { "item": "pants", "variant": "pants_blue" },
-          { "item": "mask_dust", "variant": "white_mask_dust" }
+          {
+            "item": "pants",
+            "variant": "pants_blue"
+          },
+          {
+            "item": "mask_dust",
+            "variant": "white_mask_dust"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -5547,16 +9745,46 @@
     "description": "You were on the front lines when everything happened, patching up the wounded and providing support.  But they wouldn't stop coming.  Now you're on your own.",
     "points": 5,
     "skills": [
-      { "level": 6, "name": "firstaid" },
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "rifle" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "stabbing" },
-      { "level": 3, "name": "dodge" },
-      { "level": 3, "name": "throw" },
-      { "level": 2, "name": "survival" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 6,
+        "name": "firstaid"
+      },
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "stabbing"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "throw"
+      },
+      {
+        "level": 2,
+        "name": "survival"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "traits": [ "PROF_MED" ],
     "proficiencies": [
@@ -5582,7 +9810,10 @@
           "boots_combat",
           "wristwatch",
           "thermometer",
-          { "item": "bandages", "count": 3 },
+          {
+            "item": "bandages",
+            "count": 3
+          },
           "scalpel",
           "syringe",
           "morphine",
@@ -5596,12 +9827,31 @@
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
           { "group": "full_ifak" },
-          { "item": "water_clean", "container-item": "canteen" },
-          { "item": "legpouch_large", "contents-group": "army_mags_m4" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "mask_dust", "variant": "camo_mask_dust", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "stethoscope", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
+          {
+            "item": "water_clean",
+            "container-item": "canteen"
+          },
+          {
+            "item": "legpouch_large",
+            "contents-group": "army_mags_m4"
+          },
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "mask_dust",
+            "variant": "camo_mask_dust",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "stethoscope",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
           {
             "item": "modular_m4_carbine",
             "variant": "modular_m4a1",
@@ -5621,7 +9871,16 @@
     "name": "Relief Volunteer",
     "description": "You were a member of a nonprofit organization dedicated to helping out where help was needed.  When the riots happened, you were eager to lend a hand.  But you had to cut your plans short when everyone was less interested in handouts, and more interested in eating you.",
     "points": 1,
-    "skills": [ { "level": 3, "name": "firstaid" }, { "level": 1, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "firstaid"
+      },
+      {
+        "level": 1,
+        "name": "speech"
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -5630,8 +9889,14 @@
           "socks",
           "sneakers",
           "mbag",
-          { "item": "adhesive_bandages", "count": 10 },
-          { "item": "bandages", "count": 3 },
+          {
+            "item": "adhesive_bandages",
+            "count": 10
+          },
+          {
+            "item": "bandages",
+            "count": 3
+          },
           "water_clean",
           "water_clean",
           "water_clean",
@@ -5648,11 +9913,19 @@
   {
     "type": "profession",
     "id": "super_biker",
-    "name": { "male": "Speed King", "female": "Speed Queen" },
+    "name": {
+      "male": "Speed King",
+      "female": "Speed Queen"
+    },
     "description": "You used to rule the roads before they were filled with wrecks, undead, and unspeakable horrors.  At least there's no speed limits in the apocalypse!",
     "points": 4,
     "proficiencies": [ "prof_driver" ],
-    "skills": [ { "level": 8, "name": "driving" } ],
+    "skills": [
+      {
+        "level": 8,
+        "name": "driving"
+      }
+    ],
     "vehicle": "superbike",
     "items": {
       "both": {
@@ -5676,7 +9949,12 @@
     "name": "Hazmat Unit",
     "description": "You were deployed to autopsy one of the rioters showing feral behavior before being put down.  When they got back up, you knew this was out of your pay grade.",
     "points": 4,
-    "skills": [ { "level": 6, "name": "firstaid" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "firstaid"
+      }
+    ],
     "proficiencies": [
       "prof_wound_care",
       "prof_wound_care_expert",
@@ -5689,7 +9967,14 @@
     "items": {
       "both": {
         "items": [ "jumpsuit", "hazmat_suit", "socks", "gloves_medical", "wristwatch", "glasses_safety", "scalpel" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "mask_filter", "ammo-item": "gasfilter_sm", "charges": 100 } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "mask_filter",
+            "ammo-item": "gasfilter_sm",
+            "charges": 100
+          }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
@@ -5702,18 +9987,38 @@
     "description": "You were about to make your biggest sale yet, but when you met the buyer he tried to bite you.  To top it off, it seems that this wasn't some sort of bad trip, as the whole town tried going for your throat too.",
     "points": 2,
     "skills": [
-      { "level": 4, "name": "speech" },
-      { "level": 2, "name": "melee" },
-      { "level": 2, "name": "stabbing" },
-      { "level": 2, "name": "unarmed" },
-      { "level": 1, "name": "chemistry" }
+      {
+        "level": 4,
+        "name": "speech"
+      },
+      {
+        "level": 2,
+        "name": "melee"
+      },
+      {
+        "level": 2,
+        "name": "stabbing"
+      },
+      {
+        "level": 2,
+        "name": "unarmed"
+      },
+      {
+        "level": 1,
+        "name": "chemistry"
+      }
     ],
     "items": {
       "both": {
         "items": [ "hoodie", "jeans", "mbag", "socks", "sneakers", "bandana", "gloves_medical", "switchblade" ],
         "entries": [
           { "group": "charged_cell_phone" },
-          { "item": "crack", "count": 25, "container-item": "null", "entry-wrapper": "bag_zipper" }
+          {
+            "item": "crack",
+            "count": 25,
+            "container-item": "null",
+            "entry-wrapper": "bag_zipper"
+          }
         ]
       },
       "male": [ "briefs" ],
@@ -5728,13 +10033,34 @@
     "description": "Born into poverty, you joined one of the organized crime families to make a living.  There, you quickly made it to the top and became the boss.  The government was building a RICO case against you, but doomsday arrived first.  Your crew is gone, but your past life has prepared you for a world where violence is common currency.",
     "points": 5,
     "skills": [
-      { "level": 6, "name": "speech" },
-      { "level": 4, "name": "gun" },
-      { "level": 4, "name": "pistol" },
-      { "level": 3, "name": "smg" },
-      { "level": 3, "name": "melee" },
-      { "level": 3, "name": "unarmed" },
-      { "level": 3, "name": "dodge" }
+      {
+        "level": 6,
+        "name": "speech"
+      },
+      {
+        "level": 4,
+        "name": "gun"
+      },
+      {
+        "level": 4,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "smg"
+      },
+      {
+        "level": 3,
+        "name": "melee"
+      },
+      {
+        "level": 3,
+        "name": "unarmed"
+      },
+      {
+        "level": 3,
+        "name": "dodge"
+      }
     ],
     "items": {
       "both": {
@@ -5750,10 +10076,28 @@
         ],
         "entries": [
           { "group": "charged_cell_phone" },
-          { "item": "cigar", "entry-wrapper": "case_cigar", "container-item": "null", "count": 2 },
-          { "item": "deagle_44", "ammo-item": "44fmj", "container-item": "holster", "charges": 8 },
-          { "item": "deaglemag", "ammo-item": "44fmj", "charges": 8, "count": 2 },
-          { "item": "knuckle_brass", "container-item": "tux" }
+          {
+            "item": "cigar",
+            "entry-wrapper": "case_cigar",
+            "container-item": "null",
+            "count": 2
+          },
+          {
+            "item": "deagle_44",
+            "ammo-item": "44fmj",
+            "container-item": "holster",
+            "charges": 8
+          },
+          {
+            "item": "deaglemag",
+            "ammo-item": "44fmj",
+            "charges": 8,
+            "count": 2
+          },
+          {
+            "item": "knuckle_brass",
+            "container-item": "tux"
+          }
         ]
       },
       "male": [ "boxer_shorts", "diamond_gold_cufflinks" ],
@@ -5769,7 +10113,20 @@
     "name": "Paranormal Investigator",
     "description": "You were dismissed from your position as a parapsychology professor at the local university and started your own business as a paranormal investigator.  Your former colleagues didn't approve of your research, but it looks like it's paying off now.",
     "points": 1,
-    "skills": [ { "level": 3, "name": "electronics" }, { "level": 2, "name": "chemistry" }, { "level": 2, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "electronics"
+      },
+      {
+        "level": 2,
+        "name": "chemistry"
+      },
+      {
+        "level": 2,
+        "name": "speech"
+      }
+    ],
     "traits": [ "SPIRITUAL" ],
     "proficiencies": [ "prof_electromagnetics" ],
     "items": {
@@ -5784,9 +10141,24 @@
             "charges": 50,
             "container-item": "rad_monitor"
           },
-          { "item": "light_battery_cell", "ammo-item": "battery", "charges": 100, "container-item": "radio" },
-          { "item": "light_battery_cell", "ammo-item": "battery", "charges": 100, "container-item": "camera_pro" },
-          { "item": "light_battery_cell", "ammo-item": "battery", "charges": 100, "container-item": "emf_detector" }
+          {
+            "item": "light_battery_cell",
+            "ammo-item": "battery",
+            "charges": 100,
+            "container-item": "radio"
+          },
+          {
+            "item": "light_battery_cell",
+            "ammo-item": "battery",
+            "charges": 100,
+            "container-item": "camera_pro"
+          },
+          {
+            "item": "light_battery_cell",
+            "ammo-item": "battery",
+            "charges": 100,
+            "container-item": "emf_detector"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -5799,11 +10171,19 @@
     "name": "Bird Watcher",
     "description": "You were at your favorite park looking at the robins when the Cataclysm struck.  Now all you have are your binoculars and a lot of trivia about local birds to share with any survivors you may find.",
     "points": 1,
-    "skills": [ { "level": 3, "name": "survival" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "survival"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "jeans", "longshirt", "socks", "sneakers", "mbag", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "binoculars" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          { "item": "binoculars" }
+        ]
       },
       "male": [ "boxer_shorts" ],
       "female": [ "bra", "panties" ]
@@ -5819,7 +10199,11 @@
       "both": {
         "items": [ "xedra_enviro_suit", "socks", "union_suit" ],
         "entries": [
-          { "item": "mask_gas", "ammo-item": "gasfilter_med", "charges": 100 },
+          {
+            "item": "mask_gas",
+            "ammo-item": "gasfilter_med",
+            "charges": 100
+          },
           {
             "item": "light_minus_battery_cell",
             "ammo-item": "battery",
@@ -5832,7 +10216,10 @@
             "charges": 20,
             "container-item": "broken_dimensional_anchor"
           },
-          { "item": "xedra_seismograph", "custom-flags": [ "auto_wield" ] }
+          {
+            "item": "xedra_seismograph",
+            "custom-flags": [ "auto_wield" ]
+          }
         ]
       }
     },
@@ -5842,22 +10229,46 @@
   {
     "type": "profession",
     "id": "ninja",
-    "name": { "male": "Ninja", "female": "Kunoichi" },
+    "name": {
+      "male": "Ninja",
+      "female": "Kunoichi"
+    },
     "description": "You are obsessed with the techniques and aesthetics of the ninja, so you practiced your movements, dressed all in black, and spent big bucks to acquire some tools of the trade.  Some may question your historical authenticity, but you're perfectly happy living out your fantasy regardless.",
     "points": 5,
     "skills": [
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "cutting" },
-      { "level": 4, "name": "dodge" },
-      { "level": 4, "name": "throw" },
-      { "level": 2, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "cutting"
+      },
+      {
+        "level": 4,
+        "name": "dodge"
+      },
+      {
+        "level": 4,
+        "name": "throw"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      }
     ],
     "items": {
       "both": {
         "items": [ "hood_ninja", "jacket_ninja", "trousers_ninja", "tabi_dress", "geta", "gloves_wraps", "bellywrap" ],
         "entries": [
-          { "item": "katana", "container-item": "scabbard" },
-          { "item": "grenadebandolier", "contents-group": "ninja_grenade_pouch" }
+          {
+            "item": "katana",
+            "container-item": "scabbard"
+          },
+          {
+            "item": "grenadebandolier",
+            "contents-group": "ninja_grenade_pouch"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -5872,11 +10283,29 @@
     "name": "Cheerleader",
     "description": "Your last cheerleader routine ended abruptly after your partners switched sides to the undead team.  Let's hope your quick reflexes and flexibility help you to find new members for the squad.",
     "points": 1,
-    "skills": [ { "level": 3, "name": "dodge" }, { "level": 3, "name": "swimming" }, { "level": 3, "name": "speech" } ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "dodge"
+      },
+      {
+        "level": 3,
+        "name": "swimming"
+      },
+      {
+        "level": 3,
+        "name": "speech"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "pom_poms", "socks_ankle", "sneakers" ],
-        "entries": [ { "item": "tank_top", "variant": "tank_top_cheerleader" } ]
+        "entries": [
+          {
+            "item": "tank_top",
+            "variant": "tank_top_cheerleader"
+          }
+        ]
       },
       "male": [ "briefs", "shorts", "tank_top" ],
       "female": [ "sports_bra", "panties", "cheerleader_skirt" ]
@@ -5894,18 +10323,42 @@
     "items": {
       "both": {
         "items": [ "american_flag", "socks", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "mask_dust", "variant": "flag_mask_dust" } ]
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "mask_dust",
+            "variant": "flag_mask_dust"
+          }
+        ]
       },
       "male": {
         "items": [ "flag_shirt", "sneakers" ],
-        "entries": [ { "item": "flag_swimsuit", "variant": "flag_swimsuit" }, { "item": "pants", "variant": "pants_flag" } ]
+        "entries": [
+          {
+            "item": "flag_swimsuit",
+            "variant": "flag_swimsuit"
+          },
+          {
+            "item": "pants",
+            "variant": "pants_flag"
+          }
+        ]
       },
       "female": {
         "items": [ "flag_jumpsuit" ],
         "entries": [
-          { "item": "bikini_top", "variant": "flag_bikini_top" },
-          { "item": "bikini_bottom", "variant": "flag_bikini_bottom" },
-          { "item": "heels", "variant": "heels_flag" }
+          {
+            "item": "bikini_top",
+            "variant": "flag_bikini_top"
+          },
+          {
+            "item": "bikini_bottom",
+            "variant": "flag_bikini_bottom"
+          },
+          {
+            "item": "heels",
+            "variant": "heels_flag"
+          }
         ]
       }
     }
@@ -5917,25 +10370,69 @@
     "description": "Does the American dream still exist?  Well, recent events have put that to the test.  Does it still proudly live in your beating heart?  Yes.  Yes, it does.  A patriot to the bitter end, you’ve readied yourself to go toe to toe with the Cataclysm that would seek to do harm to your darling USA.  That is to say, you grabbed your gun… and nothing more.  God bless America, soldier.",
     "points": 2,
     "skills": [
-      { "level": 3, "name": "gun" },
-      { "level": 2, "name": "rifle" },
-      { "level": 2, "name": "pistol" },
-      { "level": 2, "name": "shotgun" }
+      {
+        "level": 3,
+        "name": "gun"
+      },
+      {
+        "level": 2,
+        "name": "rifle"
+      },
+      {
+        "level": 2,
+        "name": "pistol"
+      },
+      {
+        "level": 2,
+        "name": "shotgun"
+      }
     ],
     "items": {
       "both": {
         "items": [ "american_flag", "slippers" ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "mask_dust", "variant": "flag_mask_dust" },
-          { "item": "chestrig", "variant": "flag_chestrig", "contents-group": "mags_ruger_arr" },
-          { "item": "cowboy_hat", "variant": "flag_cowboy_hat" },
-          { "item": "leg_bag", "variant": "flag_leg_bag" },
-          { "item": "ruger_arr", "ammo-item": "450_ftx", "charges": 3, "contents-item": "shoulder_strap" }
+          {
+            "item": "mask_dust",
+            "variant": "flag_mask_dust"
+          },
+          {
+            "item": "chestrig",
+            "variant": "flag_chestrig",
+            "contents-group": "mags_ruger_arr"
+          },
+          {
+            "item": "cowboy_hat",
+            "variant": "flag_cowboy_hat"
+          },
+          {
+            "item": "leg_bag",
+            "variant": "flag_leg_bag"
+          },
+          {
+            "item": "ruger_arr",
+            "ammo-item": "450_ftx",
+            "charges": 3,
+            "contents-item": "shoulder_strap"
+          }
         ]
       },
-      "male": { "entries": [ { "item": "boxer_shorts", "variant": "flag_boxer_shorts" } ] },
-      "female": { "entries": [ { "item": "boy_shorts", "variant": "flag_boy_shorts" } ] }
+      "male": {
+        "entries": [
+          {
+            "item": "boxer_shorts",
+            "variant": "flag_boxer_shorts"
+          }
+        ]
+      },
+      "female": {
+        "entries": [
+          {
+            "item": "boy_shorts",
+            "variant": "flag_boy_shorts"
+          }
+        ]
+      }
     }
   },
   {
@@ -5946,13 +10443,33 @@
     "points": 3,
     "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
     "skills": [
-      { "level": 4, "name": "survival" },
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "pistol" },
-      { "level": 3, "name": "driving" },
-      { "level": 1, "name": "swimming" }
+      {
+        "level": 4,
+        "name": "survival"
+      },
+      {
+        "level": 3,
+        "name": "gun"
+      },
+      {
+        "level": 3,
+        "name": "pistol"
+      },
+      {
+        "level": 3,
+        "name": "driving"
+      },
+      {
+        "level": 1,
+        "name": "swimming"
+      }
     ],
-    "pets": [ { "name": "mon_horse", "amount": 1 } ],
+    "pets": [
+      {
+        "name": "mon_horse",
+        "amount": 1
+      }
+    ],
     "items": {
       "both": {
         "items": [
@@ -5975,9 +10492,19 @@
         ],
         "entries": [
           { "group": "charged_smart_phone" },
-          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "sw_619", "ammo-item": "357mag_jhp", "charges": 7 },
-          { "item": "western_holster", "contents-group": "bandolier_cowboy" }
+          {
+            "item": "ear_plugs",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "sw_619",
+            "ammo-item": "357mag_jhp",
+            "charges": 7
+          },
+          {
+            "item": "western_holster",
+            "contents-group": "bandolier_cowboy"
+          }
         ]
       },
       "male": [ "boxer_shorts" ],
@@ -5990,23 +10517,58 @@
     "name": "Tourist Swimmer",
     "description": "You were looking forward to a nice, relaxing day at the beach.  You had to run when some lunatics tried to rip your head off and play beach volleyball with it, but at least you managed to grab your bag on the way out.",
     "points": 0,
-    "skills": [ { "level": 2, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 2,
+        "name": "swimming"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "sunglasses", "straw_hat", "dive_bag", "beach_volleyball" ],
         "entries": [
-          { "item": "waterproof_smart_phone_case", "variant": "black_smart_phone_case", "contents-group": "charged_smart_phone" },
-          { "item": "towel", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "flip_flops", "custom-flags": [ "no_auto_equip" ] }
+          {
+            "item": "waterproof_smart_phone_case",
+            "variant": "black_smart_phone_case",
+            "contents-group": "charged_smart_phone"
+          },
+          {
+            "item": "towel",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "flip_flops",
+            "custom-flags": [ "no_auto_equip" ]
+          }
         ]
       },
-      "male": { "items": [ "trunks", "swim_briefs" ], "entries": [ { "item": "tank_top", "custom-flags": [ "no_auto_equip" ] } ] },
+      "male": {
+        "items": [ "trunks", "swim_briefs" ],
+        "entries": [
+          {
+            "item": "tank_top",
+            "custom-flags": [ "no_auto_equip" ]
+          }
+        ]
+      },
       "female": {
         "entries": [
-          { "item": "bikini_top", "variant": "tropical_bikini_top" },
-          { "item": "bikini_bottom", "variant": "tropical_bikini_bottom" },
-          { "item": "halter_top", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "skirt", "custom-flags": [ "no_auto_equip" ] }
+          {
+            "item": "bikini_top",
+            "variant": "tropical_bikini_top"
+          },
+          {
+            "item": "bikini_bottom",
+            "variant": "tropical_bikini_bottom"
+          },
+          {
+            "item": "halter_top",
+            "custom-flags": [ "no_auto_equip" ]
+          },
+          {
+            "item": "skirt",
+            "custom-flags": [ "no_auto_equip" ]
+          }
         ]
       }
     }
@@ -6017,12 +10579,28 @@
     "name": "Professional Swimmer",
     "description": "After much practice you were sure the next competition would be your big break, but your rivals started killing each other and you had to escape with only your competition gear on you.  Will your athleticism alone be enough to keep you alive?",
     "points": 2,
-    "skills": [ { "level": 6, "name": "swimming" }, { "level": 2, "name": "dodge" } ],
+    "skills": [
+      {
+        "level": 6,
+        "name": "swimming"
+      },
+      {
+        "level": 2,
+        "name": "dodge"
+      }
+    ],
     "traits": [ "OUTDOORSMAN" ],
     "items": {
       "both": [ "goggles_swim", "swim_cap" ],
       "male": [ "speedo" ],
-      "female": { "entries": [ { "item": "flag_swimsuit", "variant": "generic_swimsuit" } ] }
+      "female": {
+        "entries": [
+          {
+            "item": "flag_swimsuit",
+            "variant": "generic_swimsuit"
+          }
+        ]
+      }
     },
     "proficiencies": [ "prof_athlete_basic" ]
   },
@@ -6033,7 +10611,16 @@
     "description": "You went to ride the waves, but the waves ended up riding you instead when a putrid hand appeared from underwater and grabbed you by the ankle.  You had to ditch your surfboard in favor of a kickboard, and now you'll fight every day to stay ahead of the wave of the undead.",
     "points": 1,
     "flags": [ "NO_BONUS_ITEMS" ],
-    "skills": [ { "level": 4, "name": "dodge" }, { "level": 4, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "dodge"
+      },
+      {
+        "level": 4,
+        "name": "swimming"
+      }
+    ],
     "traits": [ "OUTDOORSMAN" ],
     "items": {
       "both": [ "swimming_kickboard" ],
@@ -6047,13 +10634,37 @@
     "name": "Lifeguard",
     "description": "Your job was to safeguard the lives of everyone at the beach, but when the swimmers started drowning each other, you knew the situation was out of your hands.",
     "points": 2,
-    "skills": [ { "level": 4, "name": "firstaid" }, { "level": 4, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "firstaid"
+      },
+      {
+        "level": 4,
+        "name": "swimming"
+      }
+    ],
     "traits": [ "OUTDOORSMAN" ],
     "proficiencies": [ "prof_wound_care" ],
     "items": {
       "both": [ "whistle", "sunglasses", "diving_watch" ],
-      "male": { "items": [ "trunks", "swim_briefs" ], "entries": [ { "item": "rashguard", "variant": "lifeguard_rashguard_shirt" } ] },
-      "female": { "entries": [ { "item": "flag_swimsuit", "variant": "lifeguard_swimsuit" } ] }
+      "male": {
+        "items": [ "trunks", "swim_briefs" ],
+        "entries": [
+          {
+            "item": "rashguard",
+            "variant": "lifeguard_rashguard_shirt"
+          }
+        ]
+      },
+      "female": {
+        "entries": [
+          {
+            "item": "flag_swimsuit",
+            "variant": "lifeguard_swimsuit"
+          }
+        ]
+      }
     }
   },
   {
@@ -6062,12 +10673,23 @@
     "name": "Diver",
     "description": "You were exploring below the waves close to shore when you noticed something weird on the nearby beach, you decided to swim away when you heard the screams.",
     "points": 2,
-    "skills": [ { "level": 5, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 5,
+        "name": "swimming"
+      }
+    ],
     "traits": [ "OUTDOORSMAN" ],
     "items": {
       "both": {
         "items": [ "wetsuit", "wetsuit_hood", "wetsuit_booties", "wetsuit_gloves", "diving_watch", "diveknife" ],
-        "entries": [ { "item": "rebreather", "ammo-item": "rebreather_filter", "charges": 20 } ]
+        "entries": [
+          {
+            "item": "rebreather",
+            "ammo-item": "rebreather_filter",
+            "charges": 20
+          }
+        ]
       }
     }
   },
@@ -6078,14 +10700,29 @@
     "description": "You were the captain of your small ship, making a living by ferrying divers and tourists across the waves.  The last excursion went bad after your passengers tried to mutiny, but you managed to escape.  Will you ever sail the open ocean again?",
     "points": 3,
     "proficiencies": [ "prof_boat_pilot" ],
-    "skills": [ { "level": 4, "name": "driving" }, { "level": 3, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "driving"
+      },
+      {
+        "level": 3,
+        "name": "swimming"
+      }
+    ],
     "traits": [ "OUTDOORSMAN" ],
     "items": {
       "both": {
         "items": [ "trunks", "bastsandals", "dive_bag", "wristwatch", "flotation_vest", "hand_pump", "folded_inflatable_boat" ],
         "entries": [
-          { "item": "rashguard", "variant": "tropical_rashguard_shirt" },
-          { "item": "hat_ball", "variant": "generic_hatball" },
+          {
+            "item": "rashguard",
+            "variant": "tropical_rashguard_shirt"
+          },
+          {
+            "item": "hat_ball",
+            "variant": "generic_hatball"
+          },
           {
             "item": "waterproof_smart_phone_case",
             "variant": "black_smart_phone_case",
@@ -6096,8 +10733,14 @@
       "male": [ "swim_briefs" ],
       "female": {
         "entries": [
-          { "item": "bikini_top", "variant": "tropical_bikini_top" },
-          { "item": "bikini_bottom", "variant": "tropical_bikini_bottom" }
+          {
+            "item": "bikini_top",
+            "variant": "tropical_bikini_top"
+          },
+          {
+            "item": "bikini_bottom",
+            "variant": "tropical_bikini_bottom"
+          }
         ]
       }
     }
@@ -6105,18 +10748,42 @@
   {
     "type": "profession",
     "id": "hitman",
-    "name": { "male": "Hitman", "female": "Hitwoman" },
+    "name": {
+      "male": "Hitman",
+      "female": "Hitwoman"
+    },
     "requirement": "achievement_kill_100_monsters",
     "description": "You were the best undercover agent they had, with a mission so vital that you had to take it even with the riots going on.  Your target seems to have turned feral as well as your contact, you are all alone now.",
     "points": 6,
     "skills": [
-      { "level": 5, "name": "gun" },
-      { "level": 5, "name": "pistol" },
-      { "level": 4, "name": "melee" },
-      { "level": 4, "name": "stabbing" },
-      { "level": 4, "name": "unarmed" },
-      { "level": 4, "name": "dodge" },
-      { "level": 4, "name": "speech" }
+      {
+        "level": 5,
+        "name": "gun"
+      },
+      {
+        "level": 5,
+        "name": "pistol"
+      },
+      {
+        "level": 4,
+        "name": "melee"
+      },
+      {
+        "level": 4,
+        "name": "stabbing"
+      },
+      {
+        "level": 4,
+        "name": "unarmed"
+      },
+      {
+        "level": 4,
+        "name": "dodge"
+      },
+      {
+        "level": 4,
+        "name": "speech"
+      }
     ],
     "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_wp_syn_armored" ],
     "items": {
@@ -6132,8 +10799,17 @@
         ],
         "entries": [
           { "group": "charged_cell_phone" },
-          { "item": "glock_29", "ammo-item": "10mm_fmj", "charges": 15 },
-          { "item": "glock_20mag", "ammo-item": "10mm_fmj", "charges": 15, "container-item": "bbholster" }
+          {
+            "item": "glock_29",
+            "ammo-item": "10mm_fmj",
+            "charges": 15
+          },
+          {
+            "item": "glock_20mag",
+            "ammo-item": "10mm_fmj",
+            "charges": 15,
+            "container-item": "bbholster"
+          }
         ]
       },
       "male": [
@@ -6172,11 +10848,26 @@
     "description": "You were the best undercover agent they had, with a mission so vital that you had to take it even with the riots going on.  Your target seems to have turned feral as well as your contact, you are all alone now.",
     "points": 6,
     "skills": [
-      { "level": 6, "name": "throw" },
-      { "level": 5, "name": "melee" },
-      { "level": 5, "name": "stabbing" },
-      { "level": 5, "name": "dodge" },
-      { "level": 4, "name": "speech" }
+      {
+        "level": 6,
+        "name": "throw"
+      },
+      {
+        "level": 5,
+        "name": "melee"
+      },
+      {
+        "level": 5,
+        "name": "stabbing"
+      },
+      {
+        "level": 5,
+        "name": "dodge"
+      },
+      {
+        "level": 4,
+        "name": "speech"
+      }
     ],
     "proficiencies": [ "prof_spotting", "prof_wp_syn_armored" ],
     "items": {
@@ -6184,8 +10875,14 @@
         "items": [ "fancy_sunglasses", "platinum_watch", "knit_scarf_loose", "gloves_liner", "polaroid_photo", "switchblade" ],
         "entries": [
           { "group": "charged_cell_phone" },
-          { "item": "knife_combat", "container-item": "gartersheath1" },
-          { "item": "leg_sheath6", "contents-group": "leg_sheath6_throwing_knives" }
+          {
+            "item": "knife_combat",
+            "container-item": "gartersheath1"
+          },
+          {
+            "item": "leg_sheath6",
+            "contents-group": "leg_sheath6_throwing_knives"
+          }
         ]
       },
       "male": [
@@ -6223,12 +10920,30 @@
     "description": "You've been through hell once before.  Hopefully those weekend range trips have kept your skills sharp.",
     "points": 4,
     "skills": [
-      { "level": 3, "name": "gun" },
-      { "level": 3, "name": "rifle" },
-      { "level": 2, "name": "pistol" },
-      { "level": 2, "name": "firstaid" },
-      { "level": 2, "name": "throw" },
-      { "level": 1, "name": "survival" }
+      {
+        "level": 3,
+        "name": "gun"
+      },
+      {
+        "level": 3,
+        "name": "rifle"
+      },
+      {
+        "level": 2,
+        "name": "pistol"
+      },
+      {
+        "level": 2,
+        "name": "firstaid"
+      },
+      {
+        "level": 2,
+        "name": "throw"
+      },
+      {
+        "level": 1,
+        "name": "survival"
+      }
     ],
     "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_gun_cleaning" ],
     "items": {
@@ -6245,12 +10960,29 @@
           "beret"
         ],
         "entries": [
-          { "item": "pants", "variant": "pants_british_khaki" },
-          { "item": "cane", "custom-flags": [ "auto_wield" ] },
+          {
+            "item": "pants",
+            "variant": "pants_british_khaki"
+          },
+          {
+            "item": "cane",
+            "custom-flags": [ "auto_wield" ]
+          },
           { "group": "charged_ref_lighter" },
-          { "item": "chestrig", "contents-group": "army_mags_m14" },
-          { "item": "knife_combat", "container-item": "sheath" },
-          { "item": "m1a", "ammo-item": "762_51", "charges": 20, "contents-item": [ "shoulder_strap" ] }
+          {
+            "item": "chestrig",
+            "contents-group": "army_mags_m14"
+          },
+          {
+            "item": "knife_combat",
+            "container-item": "sheath"
+          },
+          {
+            "item": "m1a",
+            "ammo-item": "762_51",
+            "charges": 20,
+            "contents-item": [ "shoulder_strap" ]
+          }
         ]
       },
       "male": [ "briefs" ],
@@ -6264,7 +10996,16 @@
     "name": "Urban Explorer",
     "description": "You've always admired the beauty of urban desolation, and were ready for your next excursion when the end of the world hit.  You suppose that pretty much every building could be considered abandoned now.",
     "points": 2,
-    "skills": [ { "level": 4, "name": "traps" }, { "level": 3, "name": "swimming" } ],
+    "skills": [
+      {
+        "level": 4,
+        "name": "traps"
+      },
+      {
+        "level": 3,
+        "name": "swimming"
+      }
+    ],
     "proficiencies": [ "prof_lockpicking" ],
     "items": {
       "both": {
@@ -6282,8 +11023,16 @@
           "urbexmap"
         ],
         "entries": [
-          { "group": "charged_smart_phone", "container-item": "pants" },
-          { "item": "light_disposable_cell", "ammo-item": "battery", "charges": 300, "container-item": "camera_pro" },
+          {
+            "group": "charged_smart_phone",
+            "container-item": "pants"
+          },
+          {
+            "item": "light_disposable_cell",
+            "ammo-item": "battery",
+            "charges": 300,
+            "container-item": "camera_pro"
+          },
           {
             "item": "light_disposable_cell",
             "ammo-item": "battery",
@@ -6304,23 +11053,93 @@
     "description": "You felt years of your life being sapped away, slaving at your computer as you subsisted on a daily pot of coffee, microwave burritos and an endless supply of crumpled paper to toss.  Perhaps the Cataclysm is a refreshing change of pace…",
     "points": 0,
     "skills": [
-      { "level": 2, "name": "computer" },
-      { "level": 2, "name": "cooking" },
-      { "level": 2, "name": "throw" },
-      { "level": 2, "name": "speech" }
+      {
+        "level": 2,
+        "name": "computer"
+      },
+      {
+        "level": 2,
+        "name": "cooking"
+      },
+      {
+        "level": 2,
+        "name": "throw"
+      },
+      {
+        "level": 2,
+        "name": "speech"
+      }
     ],
-    "addictions": [ { "intensity": 10, "type": "caffeine" } ],
+    "addictions": [
+      {
+        "intensity": 10,
+        "type": "caffeine"
+      }
+    ],
     "items": {
       "both": {
         "items": [ "dress_shirt", "undershirt", "pants", "socks", "tie_clipon", "dress_shoes" ],
         "entries": [
           { "group": "charged_smart_phone" },
           { "group": "charged_penblack" },
-          { "item": "coffee", "container-item": "coffeepot" }
+          {
+            "item": "coffee",
+            "container-item": "coffeepot"
+          }
         ]
       },
       "male": [ "briefs" ],
       "female": [ "panties", "bra" ]
     }
+  },
+  {
+    "type": "profession",
+    "id": "rv_hunter",
+    "name": "RV Hunter",
+    "description": "Ever since you were a child you loved hunting and traveling; so when you scraped enough money, you bought yourself an old rv, a gun, and hit the road.  You've been all over the country, hunting for good game.  Unfortunately the country is all over this time, and even more unfortunately you've lost your ol' reliable in the chaos.  Now you gotta find a new reliable.",
+    "points": 4,
+	"proficiencies": [ "prof_driver", "prof_basic_engines" ],
+    "skills": [
+      {
+        "level": 3,
+        "name": "rifle"
+      },
+      {
+        "level": 3,
+        "name": "gun"
+      },
+      {
+        "level": 2,
+        "name": "swimming"
+      },
+	  {
+		"level": 4,
+		"name": "driving"
+	  },
+	  {
+		"level": 4,
+		"name": "mechanics"
+	  }
+    ],
+	"vehicle": "rv",
+    "items": {
+      "both": {
+        "items": [ "knit_scarf", "socks", "boots_steel", "pants_cargo", "jacket_flannel", "hat_hunting", "wristwatch", "back_holster" ],
+        "entries": [
+          { "group": "charged_smart_phone" },
+          {
+            "item": "sheath",
+            "contents-item": "knife_hunting"
+          },
+          {
+            "item": "tank_top",
+            "variant": "tank_top_camo"
+          }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "sports_bra", "boxer_shorts" ]
+    },
+    "missions": [ "MISSION_HUNTER" ]
   }
 ]


### PR DESCRIPTION
#### Summary

Content "Add three new professions"

#### Purpose of change

Adds three new professions that I think may be interesting, and branches the priest profession to three different instances: protestant, catholic and orthodox. Adds items if need be.

#### Describe the solution

The New Professions:

RV hunter: Self explanatory. Adds a rifle hunter (at least skill wise) with an RV, that lost their gun to balance the advantage. Will add a mission to find a new gun. Basic engine and driving proficiencies. I'm also thinking of adding the nomad trait. A good start for deathmobile enthusiasts.

Heist Driver: A cheesy Drive reference, but also adds a vehicle and combat focused start which is kinda lacking outside military professions imo. High vehicles and mechanics skill, moderate unarmed and melee skill and/or gun skills. Spawns with muscle car. Thinking of adding the gosling jacket lol

Prostitute: Alright this one is kinda vulgar but makes sense. I don't know if it is legal in New England but US in general have decent amount of sex workers to my knowledge. It is a social skill only skill start without the benefits of the religious professions. Maybe give a switchblade for defensive purposes.

And branch the priest profession into two others: Our current priest starts with the King James bible and a catholic symbol for some reason and idk if this is intentional. This aims to create seperate Catholic and Protestant(unitarian? whatever) priests. New England has appearently one of the highest catholic demographics os this makes sense, and fixes the current priest to be less offensive(?) and more realistic.

#### Describe alternatives you've considered

Rethink or don't add the new professions (pls don't take my Drive reference away ): )

#### Testing

In Progress

#### Additional context

Waiting for devs to review this because two of these are kinda absurd