### PR TITLE
Fix alder_bark density

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -3794,7 +3794,7 @@
     "price": 0,
     "price_postapoc": 10,
     "material": [ "wood" ],
-    "weight": "323 g",
+    "weight": "200 g",
     "volume": "250 ml",
     "to_hit": 1,
     "melee_damage": { "bash": 4 }

--- a/data/mods/TEST_DATA/known_bad_density.json
+++ b/data/mods/TEST_DATA/known_bad_density.json
@@ -518,7 +518,6 @@
       "bread_garlic",
       "feces_manure",
       "ammo_satchel_leather",
-      "alder_bark",
       "recipe_maiar",
       "disassembly",
       "toothbrush_electric",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Follow up #67975, fixes `dryad_bark` density error, that fail all test..
#### Describe the solution
..by fixing the `alder_bark` density, that it copies-from
#### Describe alternatives you've considered
adding `dryad_bark` to known_bad_density