### PR TITLE
Add EOC condition: weapon category 

### DIFF
--- a/data/json/npcs/TALK_TEST.json
+++ b/data/json/npcs/TALK_TEST.json
@@ -598,6 +598,24 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_TEST_ITEM_WIELDED",
+    "dynamic_line": "This is a test conversation that shouldn't appear in the game.",
+    "responses": [
+      { "text": "This is a basic test response.", "topic": "TALK_DONE" },
+      {
+        "text": "This is a u_has_wielded_with_weapon_category LONG_SWORDS test response.",
+        "topic": "TALK_DONE",
+        "condition": { "u_has_wielded_with_weapon_category": "LONG_SWORDS" }
+      },
+      {
+        "text": "This is a u_has_wielded_with_weapon_category KNIVES test response.",
+        "topic": "TALK_DONE",
+        "condition": { "u_has_wielded_with_weapon_category": "KNIVES" }
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_TEST_VARS",
     "dynamic_line": "This is a test conversation that shouldn't appear in the game.",
     "responses": [

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -730,6 +730,22 @@ check do you wield something with `WHIP` flag
 { "u_has_wielded_with_flag": "WHIP" }
 ```
 
+### `u_has_wielded_with_weapon_category`, `npc_has_wielded_with_weapon_category`
+- type: string or [variable object](##variable-object)
+- return true if alpha or beta talker wield something with specific weapon category
+
+#### Valid talkers:
+
+| Avatar | Character | NPC | Monster |  Furniture | Item |
+| ------ | --------- | --------- | ---- | ------- | --- | 
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+
+#### Examples
+check do you wield something with `LONG_SWORDS` weapon category
+```json
+{ "u_has_wielded_with_weapon_category": "LONG_SWORDS" }
+```
+
 ### `u_can_see`, `npc_can_see`
 - type: simple string
 - return true if alpha or beta talker can see (not blind)

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -3114,6 +3114,16 @@ void conditional_t::set_has_wielded_with_flag( const JsonObject &jo, const std::
     };
 }
 
+void conditional_t::set_has_wielded_with_weapon_category( const JsonObject &jo,
+        const std::string &member,
+        bool is_npc )
+{
+    str_or_var flag = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [flag, is_npc]( dialogue const & d ) {
+        return d.actor( is_npc )->wielded_with_flag( flag_id( flag.evaluate( d ) ) );
+    };
+}
+
 void conditional_t::set_can_see( bool is_npc )
 {
     condition = [is_npc]( dialogue const & d ) {
@@ -3419,6 +3429,10 @@ conditional_t::conditional_t( const JsonObject &jo )
         set_has_wielded_with_flag( jo, "u_has_wielded_with_flag" );
     } else if( jo.has_member( "npc_has_wielded_with_flag" ) ) {
         set_has_wielded_with_flag( jo, "npc_has_wielded_with_flag", is_npc );
+    } else if( jo.has_member( "u_has_wielded_with_weapon_category" ) ) {
+        set_has_wielded_with_weapon_category( jo, "u_has_wielded_with_weapon_category" );
+    } else if( jo.has_member( "npc_has_wielded_with_weapon_category" ) ) {
+        set_has_wielded_with_weapon_category( jo, "npc_has_wielded_with_weapon_category", is_npc );
     } else if( jo.has_member( "u_is_on_terrain" ) ) {
         set_is_on_terrain( jo, "u_is_on_terrain" );
     } else if( jo.has_member( "npc_is_on_terrain" ) ) {

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -3118,9 +3118,9 @@ void conditional_t::set_has_wielded_with_weapon_category( const JsonObject &jo,
         const std::string &member,
         bool is_npc )
 {
-    str_or_var flag = get_str_or_var( jo.get_member( member ), member, true );
-    condition = [flag, is_npc]( dialogue const & d ) {
-        return d.actor( is_npc )->wielded_with_flag( flag_id( flag.evaluate( d ) ) );
+    str_or_var w_cat = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [w_cat, is_npc]( dialogue const & d ) {
+        return d.actor( is_npc )->wielded_with_weapon_category( weapon_category_id( w_cat.evaluate( d ) ) );
     };
 }
 

--- a/src/condition.h
+++ b/src/condition.h
@@ -50,7 +50,7 @@ const std::unordered_set<std::string> complex_conds = { {
         "u_has_skill", "npc_has_skill", "u_know_recipe", "u_compare_var", "npc_compare_var",
         "u_compare_time_since_var", "npc_compare_time_since_var", "is_weather", "mod_is_loaded", "one_in_chance", "x_in_y_chance",
         "u_is_height", "npc_is_height", "math",
-        "u_has_worn_with_flag", "npc_has_worn_with_flag", "u_has_wielded_with_flag", "npc_has_wielded_with_flag",
+        "u_has_worn_with_flag", "npc_has_worn_with_flag", "u_has_wielded_with_flag", "npc_has_wielded_with_flag", "u_has_wielded_with_weapon_category", "npc_has_wielded_with_weapon_category",
         "u_has_pain", "npc_has_pain", "u_has_power", "npc_has_power", "u_has_focus", "npc_has_focus", "u_has_morale",
         "npc_has_morale", "u_is_on_terrain", "npc_is_on_terrain", "u_is_on_terrain_with_flag", "npc_is_on_terrain_with_flag", "u_is_in_field", "npc_is_in_field", "compare_int",
         "compare_string", "roll_contested", "compare_num", "u_has_martial_art", "npc_has_martial_art", "get_condition", "get_game_option"

--- a/src/condition.h
+++ b/src/condition.h
@@ -140,6 +140,8 @@ struct conditional_t {
         void set_has_worn_with_flag( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_has_wielded_with_flag( const JsonObject &jo, const std::string &member,
                                         bool is_npc = false );
+        void set_has_wielded_with_weapon_category( const JsonObject &jo, const std::string &member,
+                bool is_npc = false );
         void set_is_wearing( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_has_item( const JsonObject &jo, const std::string &member, bool is_npc = false );
         void set_has_items( const JsonObject &jo, std::string_view member, bool is_npc = false );

--- a/src/talker.h
+++ b/src/talker.h
@@ -555,6 +555,9 @@ class talker
         virtual bool wielded_with_flag( const flag_id & ) const {
             return false;
         }
+        virtual bool wielded_with_weapon_category( const weapon_category_id & ) const {
+            return false;
+        }
         virtual bool has_item_with_flag( const flag_id & ) const {
             return false;
         }

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -4,6 +4,7 @@
 #include "character_martial_arts.h"
 #include "effect.h"
 #include "item.h"
+#include "itype.h"
 #include "magic.h"
 #include "npc.h"
 #include "npctalk.h"
@@ -663,6 +664,12 @@ bool talker_character_const::worn_with_flag( const flag_id &flag, const bodypart
 bool talker_character_const::wielded_with_flag( const flag_id &flag ) const
 {
     return me_chr_const->get_wielded_item() && me_chr_const->get_wielded_item()->has_flag( flag );
+}
+
+bool talker_character_const::wielded_with_weapon_category( const weapon_category_id &w_cat ) const
+{
+    return me_chr_const->get_wielded_item() &&
+           me_chr_const->get_wielded_item()->typeId()->weapon_category.count( w_cat ) > 0;
 }
 
 bool talker_character_const::has_item_with_flag( const flag_id &flag ) const

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -145,6 +145,7 @@ class talker_character_const: public talker_cloner<talker_character_const>
 
         bool worn_with_flag( const flag_id &flag, const bodypart_id &bp ) const override;
         bool wielded_with_flag( const flag_id &flag ) const override;
+        bool wielded_with_weapon_category( const weapon_category_id &w_cat ) const override;
         bool has_item_with_flag( const flag_id &flag ) const override;
         int item_rads( const flag_id &flag, aggregate_type agg_func ) const override;
 

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -53,6 +53,7 @@ static const item_category_id item_category_manual( "manual" );
 static const itype_id itype_beer( "beer" );
 static const itype_id itype_bottle_glass( "bottle_glass" );
 static const itype_id itype_dnd_handbook( "dnd_handbook" );
+static const itype_id itype_knife_butcher( "knife_butcher" );
 static const itype_id itype_manual_speech( "manual_speech" );
 
 static const mtype_id mon_zombie_bio_op( "mon_zombie_bio_op" );
@@ -787,6 +788,15 @@ TEST_CASE( "npc_talk_items", "[npc_talk]" )
     CHECK( d.responses[6].text == "This is a repeated item beer, bottle_glass test response" );
     CHECK( d.responses[6].success.next_topic.item_type == itype_beer );
     CHECK( d.responses[7].text == "This is a basic test response." );
+
+    d.add_topic( "TALK_TEST_ITEM_WIELDED" );
+    item_location loc = player_character.i_add( item( itype_knife_butcher ) );
+    CHECK( player_character.wield( *loc ) );
+    gen_response_lines( d, 2 );
+    CHECK( d.responses[0].text == "This is a basic test response." );
+    CHECK( d.responses[1].text ==
+           "This is a u_has_wielded_with_weapon_category KNIVES test response." );
+    player_character.i_rem( &*player_character.get_wielded_item() );
 
     // test sell and consume
     d.add_topic( "TALK_TEST_EFFECTS" );


### PR DESCRIPTION
#### Summary
Features "Add EOC condition: weapon category"

#### Purpose of change
There is no way to know what type of weapon player has.

#### Describe the solution
Add new condition "has_wielded_with_weapon_category"

#### Describe alternatives you've considered
As the number of functions that retrieve item information has increased, it may be better to provide wrapper function rather than preparing individual functions.
Something like:
```
{ "u_has_wielded_with": { "weapon_category": "SHORT_SWORDS" } }
```

#### Testing
See TALK_TEST_ITEM_WIELDED
wield butcher knife
{ "u_has_wielded_with_weapon_category": "KNIVES" } => true
{ "u_has_wielded_with_weapon_category": "LONG_SWORDS" } => false

#### Additional context
