### PR TITLE
Sound-triggered traps

### DIFF
--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -1155,5 +1155,17 @@
     "name": "portal dungeon next level",
     "copy-from": "trap_base",
     "effect_str": "EOC_PORTAL_STORM_DUNGEON_NEXT_LEVEL"
-  }
+  }, 
+  {
+	"type": "trap",
+	"id": "tr_noisetest",
+	"name": "noise test trap",
+	"color": "light_cyan",
+	"symbol": "_",
+		"visibility": 0,
+		"avoidance": 8,
+		"difficulty": 0,
+	"action": "sound_detect",
+		"sound_threshold": 5
+}
 ]

--- a/data/json/traps.json
+++ b/data/json/traps.json
@@ -1155,17 +1155,17 @@
     "name": "portal dungeon next level",
     "copy-from": "trap_base",
     "effect_str": "EOC_PORTAL_STORM_DUNGEON_NEXT_LEVEL"
-  }, 
+  },
   {
-	"type": "trap",
-	"id": "tr_noisetest",
-	"name": "noise test trap",
-	"color": "light_cyan",
-	"symbol": "_",
-		"visibility": 0,
-		"avoidance": 8,
-		"difficulty": 0,
-	"action": "sound_detect",
-		"sound_threshold": 5
-}
+    "type": "trap",
+    "id": "tr_noisetest",
+    "name": "noise test trap",
+    "color": "light_cyan",
+    "symbol": "_",
+    "visibility": 0,
+    "avoidance": 8,
+    "difficulty": 0,
+    "action": "sound_detect",
+    "sound_threshold": 5
+  }
 ]

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -2773,7 +2773,8 @@ See [MUTATIONS.md](MUTATIONS.md)
       "spawn_items": [ "beartrap" ]
     },
     "trigger_message_u": "A bear trap closes on your foot!", // This message will be printed when player steps on a trap
-    "trigger_message_npc": "A bear trap closes on <npcname>'s foot!" // This message will be printed when NPC or monster steps on a trap
+    "trigger_message_npc": "A bear trap closes on <npcname>'s foot!", // This message will be printed when NPC or monster steps on a trap
+    "sound_threshold": 5 // Optional. Minimum volume of sound that will trigger this trap. Defaults to 0 (Will not trigger from sound).
 ```
 
 ### Vehicle Groups

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -37,6 +37,7 @@
 #include "safemode_ui.h"
 #include "string_formatter.h"
 #include "translations.h"
+#include "trap.h"
 #include "type_id.h"
 #include "uistate.h"
 #include "units.h"
@@ -479,6 +480,16 @@ void sounds::process_sounds()
             if( vol * 2 > dist ) {
                 // Exclude monsters that certainly won't hear the sound
                 critter.hear_sound( source, vol, dist, this_centroid.provocative );
+            }
+        }
+        // Trigger sound-triggered traps
+        for( const trap *trapType : trap::get_sound_triggered_traps() ) {
+            for( tripoint tp : get_map().trap_locations( trapType->id ) ) {
+                const int dist = sound_distance( source, tp );
+                trap tr = get_map().tr_at( tp );
+                if( tr.triggered_by_sound( vol, dist ) ) {
+                    tr.trigger( tp );
+                }
             }
         }
     }

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -484,9 +484,9 @@ void sounds::process_sounds()
         }
         // Trigger sound-triggered traps
         for( const trap *trapType : trap::get_sound_triggered_traps() ) {
-            for( tripoint tp : get_map().trap_locations( trapType->id ) ) {
+            for( const tripoint &tp : get_map().trap_locations( trapType->id ) ) {
                 const int dist = sound_distance( source, tp );
-                trap tr = get_map().tr_at( tp );
+                const trap &tr = get_map().tr_at( tp );
                 if( tr.triggered_by_sound( vol, dist ) ) {
                     tr.trigger( tp );
                 }

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -115,6 +115,13 @@ const std::vector<const trap *> &trap::get_funnels()
     return funnel_traps;
 }
 
+static std::vector<const trap *> sound_triggered_traps;
+
+const std::vector<const trap *> &trap::get_sound_triggered_traps()
+{
+    return sound_triggered_traps;
+}
+
 size_t trap::count()
 {
     return trap_factory.size();
@@ -164,6 +171,7 @@ void trap::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "floor_bedding_warmth", floor_bedding_warmth, 0 );
     optional( jo, was_loaded, "spell_data", spell_data );
     assign( jo, "trigger_weight", trigger_weight );
+    optional( jo, was_loaded, "sound_threshold", sound_threshold );
     for( const JsonValue entry : jo.get_array( "drops" ) ) {
         itype_id item_type;
         int quantity = 0;
@@ -226,6 +234,7 @@ update_mapgen_id trap::map_regen_target() const
 void trap::reset()
 {
     funnel_traps.clear();
+    sound_triggered_traps.clear();
     trap_factory.reset();
 }
 
@@ -307,6 +316,14 @@ bool trap::can_see( const tripoint &pos, const Character &p ) const
     return visibility < 0 || p.knows_trap( pos );
 }
 
+void trap::trigger( const tripoint &pos ) const
+{
+    if( is_null() ) {
+        return;
+    }
+    act( pos, nullptr, nullptr );
+}
+
 void trap::trigger( const tripoint &pos, Creature &creature ) const
 {
     return trigger( pos, &creature, nullptr );
@@ -346,6 +363,17 @@ bool trap::triggered_by_item( const item &itm ) const
 bool trap::is_funnel() const
 {
     return !is_null() && funnel_radius_mm > 0;
+}
+
+bool trap::has_sound_trigger() const
+{
+    return !is_null() && sound_threshold > 0;
+}
+
+bool trap::triggered_by_sound( const int vol, const int dist )
+{
+    const int volume = vol - dist;
+    return !is_null() && volume >= sound_threshold;
 }
 
 void trap::on_disarmed( map &m, const tripoint &p ) const
@@ -395,6 +423,9 @@ void trap::finalize()
         t.loadid = t.id.id();
         if( t.is_funnel() ) {
             funnel_traps.push_back( &t );
+        }
+        if( t.has_sound_trigger() ) {
+            sound_triggered_traps.push_back( &t );
         }
     }
 

--- a/src/trap.cpp
+++ b/src/trap.cpp
@@ -370,7 +370,7 @@ bool trap::has_sound_trigger() const
     return !is_null() && sound_threshold > 0;
 }
 
-bool trap::triggered_by_sound( const int vol, const int dist )
+bool trap::triggered_by_sound( int vol, int dist ) const
 {
     const int volume = vol - dist;
     return !is_null() && volume >= sound_threshold;

--- a/src/trap.h
+++ b/src/trap.h
@@ -343,7 +343,7 @@ struct trap {
          */
         bool has_sound_trigger() const;
         static const std::vector<const trap *> &get_sound_triggered_traps();
-        bool triggered_by_sound( const int vol, const int dist );
+        bool triggered_by_sound( int vol, int dist ) const;
 
         /*@{*/
         /**

--- a/src/trap.h
+++ b/src/trap.h
@@ -65,6 +65,7 @@ bool map_regen( const tripoint &p, Creature *c, item *i );
 bool drain( const tripoint &p, Creature *c, item *i );
 bool snake( const tripoint &p, Creature *c, item *i );
 bool cast_spell( const tripoint &p, Creature *critter, item * );
+bool sound_detect( const tripoint &p, Creature *, item * );
 } // namespace trapfunc
 
 struct vehicle_handle_trap_data {
@@ -151,6 +152,10 @@ struct trap {
          * If an item with this weight or more is thrown onto the trap, it triggers.
          */
         units::mass trigger_weight = 500_gram;
+        /**
+         * If a sound of at least this volume reaches the trap, it triggers.
+         */
+        int sound_threshold = 0;
         int funnel_radius_mm = 0;
         // For disassembly?
         std::vector<std::tuple<itype_id, int, int>> components;
@@ -284,6 +289,8 @@ struct trap {
         void trigger( const tripoint &pos, item &item ) const;
         /*@}*/
 
+        void trigger( const tripoint &pos ) const;
+
         /**
          * If the given item is throw onto the trap, does it trigger the trap?
          */
@@ -330,6 +337,13 @@ struct trap {
          */
         static const std::vector<const trap *> &get_funnels();
         /*@}*/
+
+        /*
+         * Can the trap be triggered by sounds?
+         */
+        bool has_sound_trigger() const;
+        static const std::vector<const trap *> &get_sound_triggered_traps();
+        bool triggered_by_sound( const int vol, const int dist );
 
         /*@{*/
         /**

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1576,6 +1576,16 @@ bool trapfunc::snake( const tripoint &p, Creature *, item * )
 }
 
 /**
+ * Made to test sound-triggered traps.
+ * Warning: generating a sound can trigger sound-triggered traps.
+ */
+bool trapfunc::sound_detect( const tripoint &p, Creature *, item * )
+{
+    sounds::sound( p, 10, sounds::sound_t::alert, _( "Sound Detected!" ), false, "misc" );
+    return true;
+}
+
+/**
  * Takes the name of a trap function and returns a function pointer to it.
  * @param function_name The name of the trapfunc function to find.
  * @return A function object with a pointer to the matched function,
@@ -1618,7 +1628,8 @@ const trap_function &trap_function_from_string( const std::string &function_name
             { "map_regen", trapfunc::map_regen },
             { "drain", trapfunc::drain },
             { "spell", trapfunc::cast_spell },
-            { "snake", trapfunc::snake }
+            { "snake", trapfunc::snake },
+            { "sound_detect", trapfunc::sound_detect }
         }
     };
 


### PR DESCRIPTION
Sound-triggered traps. Add traps to sound processing, add sound_threshold json key for traps, and add a test noise-triggered trap.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Sound-triggered traps"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Create the possibility to have things happen from sounds. One step towards the possibility of dormant zombies #65305
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The map now stores types of traps that have a sound trigger. When processing sounds, we iterate over these traps, similar to creatures. Sound trigger can be added to traps with the json key "sound_threshold", which defines the minimum volume of noise that will trigger the trap.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Add items to sound processing, so corpses can be used for dormant zombies. This seems like a potentially large performance hit and large amount of code work.
Pass the sound to the trap act function, so traps can do things like repeat the sound louder or only trigger for speech. This may be a potential future PR, but I wanted to get the basic functionality working.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Start a new game. Add the test trap. Yelling triggered the trap. Walking near it sometimes triggered the trap. The noise from the trap triggering sometimes triggered the trap.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
The new noise trigger is an addition to the standard enter-same-tile trigger. It does not remove the standard trigger.
If a triggered trap makes a noise it can trigger other noise-triggered traps, including itself!

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
