### PR TITLE
Bugfix: Prevent segfault when scrolling options

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3475,10 +3475,10 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
         };
         for( int i = 0; i < static_cast<int>( page_items.size() ); i++ ) {
             if( is_visible( i ) ) {
-                visible_items.push_back( i );
                 if( i == iCurrentLine ) {
                     curr_line_visible = static_cast<int>( visible_items.size() );
                 }
+                visible_items.push_back( i );
             }
         }
 


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent segfault when scrolling options"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Prevents segfault when scrolling list of options when "Centered menu scrolling" is set to `false`.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Fixes #67666

How to reproduce the issue being fixed:
1. Main menu -> Settings -> Options -> Interface
2. Expand all headers (lines with `+`) so that the list of options is more than what can be displayed on one screen
3. Under "QOL options", change "Centered menu scrolling" to `false`.
4. Move cursor down so that it should wrap around to the top of the list
5. Segfault

The issue before was:
* `curr_line_visible` is supposed to contain the index of the currently selected options item.
* However, it was previously assigned to the value of `visible_items.size()` **after** an item had been added to `visible_items`
* This made `curr_line_visible` be 1-indexed (counting starts at 1). This is the root cause of the problem.
* The value of `curr_line_visible` is passed into `calcStartPos` as the parameter named `iCurrentLine`.
* `calcStartPos` assumes that `iCurrentLine` is 0-indexed (counting starts at 0).

With this suggested change, the list of options now correctly scrolls to the top of the list when displaying more lines than can fit on screen and having "Centered menu scrolling" set to `false`. The actual change is that `curr_line_visible` is now 0-indexed.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Performed steps above to try to reproduce the issue. With this suggested change, the game does not segfault.
* Performed steps mentioned in #67666 .
* Scrolling the list of options and wrapping around at top / bottom also works when having "Centered menu scrolling" set to `true`, which is the default.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
