### PR TITLE
Bugfix: Re-scroll list of options when toggling header

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3826,6 +3826,7 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
                 case ItemType::GroupHeader: {
                     bool &state = groups_state[curr_item.data];
                     state = !state;
+                    recalc_startpos = true;
                     break;
                 }
                 case ItemType::BlankLine: {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -2245,6 +2245,8 @@ void calcStartPos( int &iStartPos, const int iCurrentLine, const int iContentHei
             iStartPos = iCurrentLine;
         } else if( iCurrentLine >= iStartPos + iContentHeight ) {
             iStartPos = 1 + iCurrentLine - iContentHeight;
+        } else if( iStartPos + iContentHeight > iNumEntries ) {
+            iStartPos = iNumEntries - iContentHeight;
         }
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Re-scroll list of options when toggling header"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Prevents issue where toggling (expanding/minimizing) a header in the list of options would cause old entries to be displayed

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Issue being resolved can be reproduced by:
* Main menu -> Settings -> Options
* Expand all headers so that the list of options displays more items than can fit on screen.
* For example, in "Interface" tab, expand all headers such as "QOL Options" and "Mouse control options" so that the scrollbar is visible.
* Close "QOL options" so that the header is no longer displayed with `-` but instead is displayed as `+`.
* The bottom of the list now displays old entries that should not be visible.

![options-displays-old-items](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/0148fd67-3371-4e9e-a99c-e514f7075057)

The suggested change is to cause the list of options to re-scroll when toggling each header, by setting `recalc_startpos=true`. In the case of  "Centered menu scrolling" having been set to `false`, this also means that `calcStartPos` now needs to handle the case that `iStartPos` is positioned too far down, which is fixed in this suggested change.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* With this suggested change, the list of options will now re-scroll when toggling a header, so that the bottom of the screen displays the bottom options-item. Another option would be to not re-scroll the list of options but instead display blank lines at the bottom of the list. 

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Expanding all options headers so that the list of options exceeds what can be displayed on one screen. Closing/opening each header now does not cause old entries to be displayed at the bottom.
* Setting  "Centered menu scrolling" to `false` also works as expected.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
