### PR TITLE
Fix wrong maybe-uninitialized

### DIFF
--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2834,7 +2834,7 @@ void armor_portion_data::deserialize( const JsonObject &jo )
     optional( jo, false, "coverage", coverage, 0 );
 
     // load a breathability override
-    breathability_rating temp_enum;
+    breathability_rating temp_enum = breathability_rating::last;
     optional( jo, false, "breathability", temp_enum, breathability_rating::last );
     if( temp_enum != breathability_rating::last ) {
         breathability = material_type::breathability_to_rating( temp_enum );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
My compiler was warning me about this, and while the compiler is obviously wrong, it costs nothing to "fix" it.
```
src/item_factory.cpp: In member function ‘void armor_portion_data::deserialize(const JsonObject&)’:
src/item_factory.cpp:2840:63: error: ‘temp_enum’ may be used uninitialized [-Werror=maybe-uninitialized]
 2840 |         breathability = material_type::breathability_to_rating( temp_enum );
      |                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
src/item_factory.cpp:2837:26: note: ‘temp_enum’ was declared here
 2837 |     breathability_rating temp_enum;
      |                          ^~~~~~~~~
```
