### PR TITLE
[Object Creator] Instead of calling exit(), reset and signal the default handler

### DIFF
--- a/object_creator/creator_main.cpp
+++ b/object_creator/creator_main.cpp
@@ -23,6 +23,13 @@
 #include <QtWidgets/qsplashscreen.h>
 #include <QtGui/qpainter.h>
 
+//Required by the sigaction function in the exit_handler
+#if defined(_WIN32)
+#include "platform_win.h"
+#else
+#include <csignal>
+#endif
+
 #ifdef _WIN32
 #include <QtCore/QtPlugin>
 Q_IMPORT_PLUGIN( QWindowsIntegrationPlugin );
@@ -46,7 +53,20 @@ void exit_handler( int s )
 
         catacurses::endwin();
 
-        exit( exit_status );
+    // As suggested by https://github.com/CleverRaven/Cataclysm-DDA/pull/67893
+    #if !defined(_WIN32)
+        if( s == 2 ) {
+            struct sigaction sigIntHandler;
+            sigIntHandler.sa_handler = SIG_DFL;
+            sigemptyset( &sigIntHandler.sa_mask );
+            sigIntHandler.sa_flags = 0;
+            sigaction( SIGINT, &sigIntHandler, nullptr );
+            kill( getpid(), s );
+        } else
+    #endif
+        {
+            exit( exit_status );
+        }
     }
     inp_mngr.set_timeout( old_timeout );
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix signal handler: call to exit() in Object Creator"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
As suggested in #67893
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Copy-pasted the solution offered in #67893
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not implementing it
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
On Linux:
- Open Object Creator using the terminal
- Observe it launches
- Press CTRL+C to terminate the application. Unlike in #67893, no confirmation screen pops up since there is no game gui visible

On Windows:
- Open Object Creator.
- Close Object Creator using the x on top.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
If there is a better way to test it let me know, I'm not even sure what this is supposed to fix.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
