### PR TITLE
Option to ignore items in usage zones (i.e. firewood, auto-eat, etc)

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2052,7 +2052,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
             bool ignore_contents = false;
 
             for( zone_data const *zone : zones ) {
-                firewood_options const &options = dynamic_cast<const firewood_options &>( zone->get_options() );
+                ignorable_options const &options = dynamic_cast<const ignorable_options &>( zone->get_options() );
                 ignore_contents |= options.get_ignore_contents();
             }
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2046,10 +2046,21 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                 return;
             }
 
-            // skip tiles in IGNORE zone and tiles on fire
-            // (to prevent taking out wood off the lit brazier)
+            std::vector<zone_data const *> const zones = mgr.get_zones_at( src, zone_type_SOURCE_FIREWOOD,
+                                                                           _fac_id( you ) );
+
+            bool ignore_contents = false;
+
+            for( zone_data const *zone : zones ) {
+                firewood_options const &options = dynamic_cast<const firewood_options &>( zone->get_options() );
+                ignore_contents |= options.get_ignore_contents();
+            }
+
+            // skip tiles in IGNORE zone or with ignore option,
+            // tiles on fire (to prevent taking out wood off the lit brazier)
             // and inaccessible furniture, like filled charcoal kiln
             if( mgr.has( zone_type_LOOT_IGNORE, src, _fac_id( you ) ) ||
+                ignore_contents ||
                 here.get_field( src_loc, fd_fire ) != nullptr ||
                 !here.can_put_items_ter_furn( src_loc ) ) {
                 continue;
@@ -2179,6 +2190,8 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                 mgr.custom_loot_has( src, &thisitem, zone_type_LOOT_CUSTOM, _fac_id( you ) ) ) {
                 continue;
             }
+
+            //insert ignore firewood source here
 
             const std::unordered_set<tripoint_abs_ms> dest_set =
                 mgr.get_near( id, abspos, ACTIVITY_SEARCH_DISTANCE, &thisitem, _fac_id( you ) );

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2054,7 +2054,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                 // add zones using mgr.get_zones_at
                 for( zone_data const *zone : mgr.get_zones_at( src, zone_type, _fac_id( you ) ) ) {
                     ignorable_options const &options = dynamic_cast<const ignorable_options &>( zone->get_options() );
-                    if ( options.get_ignore_contents() ) {
+                    if( options.get_ignore_contents() ) {
                         ignore_contents = true;
                         break;
                     }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2046,15 +2046,24 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                 return;
             }
 
-            std::vector<zone_data const *> const zones = mgr.get_zones_at( src, zone_type_SOURCE_FIREWOOD,
-                                                                           _fac_id( you ) );
-
+            std::vector<zone_data const *> zones;
             bool ignore_contents = false;
 
-            for( zone_data const *zone : zones ) {
-                ignorable_options const &options = dynamic_cast<const ignorable_options &>( zone->get_options() );
-                ignore_contents |= options.get_ignore_contents();
+            // check ignorable zones for ignore_contents enabled
+            for( const auto &zone_type : ignorable_zone_types ) {
+                // add zones using mgr.get_zones_at
+                for( zone_data const *zone : mgr.get_zones_at( src, zone_type, _fac_id( you ) ) ) {
+                    ignorable_options const &options = dynamic_cast<const ignorable_options &>( zone->get_options() );
+                    if ( options.get_ignore_contents() ) {
+                        ignore_contents = true;
+                        break;
+                    }
+                }
+                if( ignore_contents ) {
+                    break;
+                }
             }
+
 
             // skip tiles in IGNORE zone or with ignore option,
             // tiles on fire (to prevent taking out wood off the lit brazier)

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -81,12 +81,11 @@ static const zone_type_id zone_type_VEHICLE_REPAIR( "VEHICLE_REPAIR" );
 static const zone_type_id zone_type_zone_disassemble( "zone_disassemble" );
 static const zone_type_id zone_type_zone_unload_all( "zone_unload_all" );
 
-const std::vector<zone_type_id> ignorable_zone_types =
-        {
-        zone_type_AUTO_EAT,
-        zone_type_AUTO_DRINK,
-        zone_type_SOURCE_FIREWOOD
-        };
+const std::vector<zone_type_id> ignorable_zone_types = {
+    zone_type_AUTO_EAT,
+    zone_type_AUTO_DRINK,
+    zone_type_SOURCE_FIREWOOD
+};
 
 zone_manager::zone_manager()
 {
@@ -212,7 +211,8 @@ shared_ptr_fast<zone_options> zone_options::create( const zone_type_id &type )
         return make_shared_fast<loot_options>();
     } else if( type == zone_type_zone_unload_all ) {
         return make_shared_fast<unload_options>();
-    } else if(std::find(ignorable_zone_types.begin(), ignorable_zone_types.end(), type) != ignorable_zone_types.end()) {
+    } else if( std::find( ignorable_zone_types.begin(), ignorable_zone_types.end(),
+                          type ) != ignorable_zone_types.end() ) {
         return make_shared_fast<ignorable_options>();
     }
 
@@ -229,7 +229,8 @@ bool zone_options::is_valid( const zone_type_id &type, const zone_options &optio
         return dynamic_cast<const loot_options *>( &options ) != nullptr;
     } else if( type == zone_type_zone_unload_all ) {
         return dynamic_cast<const unload_options *>( &options ) != nullptr;
-    } else if(std::find(ignorable_zone_types.begin(), ignorable_zone_types.end(), type) != ignorable_zone_types.end()) {
+    } else if( std::find( ignorable_zone_types.begin(), ignorable_zone_types.end(),
+                          type ) != ignorable_zone_types.end() ) {
         return dynamic_cast<const ignorable_options *>( &options ) != nullptr;
     }
 

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -84,7 +84,8 @@ static const zone_type_id zone_type_zone_unload_all( "zone_unload_all" );
 const std::vector<zone_type_id> ignorable_zone_types = {
     zone_type_AUTO_EAT,
     zone_type_AUTO_DRINK,
-    zone_type_SOURCE_FIREWOOD
+    zone_type_SOURCE_FIREWOOD,
+    zone_type_zone_disassemble
 };
 
 zone_manager::zone_manager()

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -465,7 +465,7 @@ std::string unload_options::get_zone_name_suggestion() const
 std::vector<std::pair<std::string, std::string>> blueprint_options::get_descriptions() const
 {
     std::vector<std::pair<std::string, std::string>> options =
-            std::vector<std::pair<std::string, std::string>>();
+                std::vector<std::pair<std::string, std::string>>();
     options.emplace_back( _( "Construct: " ),
                           group ? group->name() : _( "No Construction" ) );
 
@@ -493,8 +493,8 @@ std::vector<std::pair<std::string, std::string>> plot_options::get_descriptions(
 {
     auto options = std::vector<std::pair<std::string, std::string>>();
     options.emplace_back(
-            _( "Plant seed: " ),
-            !seed.is_empty() ? item::nname( itype_id( seed ) ) : _( "No seed" ) );
+        _( "Plant seed: " ),
+        !seed.is_empty() ? item::nname( itype_id( seed ) ) : _( "No seed" ) );
 
     return options;
 }

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -220,6 +220,9 @@ class firewood_options : public zone_options
         query_firewood_result query_firewood();
 
     public:
+        bool get_ignore_contents() const {
+            return ignore_contents;
+        }
         bool has_options() const override {
             return true;
         }

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -206,18 +206,18 @@ class blueprint_options : public zone_options, public mark_option
         void deserialize( const JsonObject &jo_zone ) override;
 };
 
-class firewood_options : public zone_options
+class ignorable_options : public zone_options
 {
     private:
         bool ignore_contents;
 
-        enum query_firewood_result {
+        enum query_ignorable_result {
             canceled,
             successful,
             changed,
         };
 
-        query_firewood_result query_firewood();
+        query_ignorable_result query_ignorable();
 
     public:
         bool get_ignore_contents() const {
@@ -229,8 +229,6 @@ class firewood_options : public zone_options
 
         bool query_at_creation() override;
         bool query() override;
-
-        std::string get_zone_name_suggestion() const override;
 
         std::vector<std::pair<std::string, std::string>> get_descriptions() const override;
 

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -206,6 +206,36 @@ class blueprint_options : public zone_options, public mark_option
         void deserialize( const JsonObject &jo_zone ) override;
 };
 
+class firewood_options : public zone_options
+{
+    private:
+        bool ignore_contents;
+
+        enum query_firewood_result {
+            canceled,
+            successful,
+            changed,
+        };
+
+        query_firewood_result query_firewood();
+
+    public:
+        bool has_options() const override {
+            return true;
+        }
+
+        bool query_at_creation() override;
+        bool query() override;
+
+        std::string get_zone_name_suggestion() const override;
+
+        std::vector<std::pair<std::string, std::string>> get_descriptions() const override;
+
+        void serialize( JsonOut &json ) const override;
+        void deserialize( const JsonObject &jo_zone ) override;
+
+};
+
 class loot_options : public zone_options, public mark_option
 {
     private:

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -37,6 +37,8 @@ const std::string type_fac_hash_str = "__FAC__";
 //Generic activity: maximum search distance for zones, constructions, etc.
 constexpr int ACTIVITY_SEARCH_DISTANCE = 60;
 
+extern const std::vector<zone_type_id> ignorable_zone_types;
+
 class zone_type
 {
     private:


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Option to ignore zone contents in usage oriented zones"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Zones such as Source: Firewood, Auto Eat/Drink, and Disassembly rely on players to manually sort items in to these zones, and it is usually undesirable to accidentally have the items sorted when covered by a blanket unsorted zone in a home area. Currently, mitigating this requires adding ignore zones to separately to accompany each zone. This change adds an option to ignore the zone contents when placing the zone.
#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

This change adds an "ignorable_zone_types" variable that contains the zone designations for zones that should give users the option to ignore the zone's contents. Currently this contains Auto Eat/Drink, Source: Firewood, and Disassemble. Zones in this list will prompt the player with a yes/no dialog on zone creation whether they'd like to ignore the zone's contents or not. This option is checked during item sorting, adding a condition along side the current ignore zone and tile on fire logic.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Creating an ignore zone with the same footprint as the intended zone at creation time. This provides a number of complications, including the need to modify multiple zones later and adding unnecessary bulk to what is often an already long list of zones.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Create zones with ignore option enabled, confirm sort action skips tiles. Disable ignore option in zones, confirm sort action acts on tiles as intended.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
