### PR TITLE
Rebalance gunsmith ammo conversion

### DIFF
--- a/data/json/items/ammo/762.json
+++ b/data/json/items/ammo/762.json
@@ -8,7 +8,7 @@
     "volume": "113 ml",
     "longest_side": "56 mm",
     "price": 120,
-    "price_postapoc": 900,
+    "price_postapoc": 800,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
     "material": [ "steel", "brass", "lead", "powder" ],
     "symbol": "=",
@@ -62,7 +62,7 @@
     "//": "Entirely provisional.  Could someone design a better wound ballistics system?",
     "description": "7.62x39mm M67 ammunition with a 123gr bullet.  The inadequate terminal ballistics of the M43 round led to the development of the M67 round in Yugoslavia in the 1960s.  It destabilizes much faster than M43 after hitting a target, leading to greater damage.",
     "price": 150,
-    "price_postapoc": 6800,
+    "price_postapoc": 800,
     "relative": { "damage": { "damage_type": "bullet", "amount": 4, "armor_penetration": 2 } }
   },
   {

--- a/data/json/npcs/isolated_road/isolated_road_jay_convert.json
+++ b/data/json/npcs/isolated_road/isolated_road_jay_convert.json
@@ -312,7 +312,7 @@
               { "case": 300, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "240" ] } },
               { "case": 545, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "240" ] } },
               { "case": 556, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "360" ] } },
-              { "case": 76251, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "90" ] } }
+              { "case": 76251, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "180" ] } }
             ]
           }
         },
@@ -324,7 +324,7 @@
               { "case": 300, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "240" ] } },
               { "case": 545, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "240" ] } },
               { "case": 556, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "360" ] } },
-              { "case": 76239, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "90" ] } }
+              { "case": 76239, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "180" ] } }
             ]
           }
         }

--- a/data/json/npcs/isolated_road/isolated_road_jay_convert.json
+++ b/data/json/npcs/isolated_road/isolated_road_jay_convert.json
@@ -273,10 +273,10 @@
           "effect": {
             "switch": { "math": [ "u_number_artisans_gunsmith_ammo_to" ] },
             "cases": [
-              { "case": 545, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "140" ] } },
-              { "case": 556, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "100" ] } },
-              { "case": 76239, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "120" ] } },
-              { "case": 76251, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "60" ] } }
+              { "case": 545, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "180" ] } },
+              { "case": 556, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "270" ] } },
+              { "case": 76239, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "135" ] } },
+              { "case": 76251, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "135" ] } }
             ]
           }
         },
@@ -285,10 +285,10 @@
           "effect": {
             "switch": { "math": [ "u_number_artisans_gunsmith_ammo_to" ] },
             "cases": [
-              { "case": 300, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "220" ] } },
-              { "case": 556, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "140" ] } },
-              { "case": 76239, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "160" ] } },
-              { "case": 76251, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "80" ] } }
+              { "case": 300, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "180" ] } },
+              { "case": 556, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "270" ] } },
+              { "case": 76239, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "135" ] } },
+              { "case": 76251, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "135" ] } }
             ]
           }
         },
@@ -297,10 +297,10 @@
           "effect": {
             "switch": { "math": [ "u_number_artisans_gunsmith_ammo_to" ] },
             "cases": [
-              { "case": 300, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "280" ] } },
-              { "case": 545, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "240" ] } },
-              { "case": 76239, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "200" ] } },
-              { "case": 76251, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "120" ] } }
+              { "case": 300, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "120" ] } },
+              { "case": 545, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "120" ] } },
+              { "case": 76239, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "90" ] } },
+              { "case": 76251, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "90" ] } }
             ]
           }
         },
@@ -309,10 +309,10 @@
           "effect": {
             "switch": { "math": [ "u_number_artisans_gunsmith_ammo_to" ] },
             "cases": [
-              { "case": 300, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "260" ] } },
-              { "case": 545, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "220" ] } },
-              { "case": 556, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "160" ] } },
-              { "case": 76251, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "100" ] } }
+              { "case": 300, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "240" ] } },
+              { "case": 545, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "240" ] } },
+              { "case": 556, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "360" ] } },
+              { "case": 76251, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "90" ] } }
             ]
           }
         },
@@ -321,10 +321,10 @@
           "effect": {
             "switch": { "math": [ "u_number_artisans_gunsmith_ammo_to" ] },
             "cases": [
-              { "case": 300, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "440" ] } },
-              { "case": 545, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "360" ] } },
-              { "case": 556, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "280" ] } },
-              { "case": 76239, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "320" ] } }
+              { "case": 300, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "240" ] } },
+              { "case": 545, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "240" ] } },
+              { "case": 556, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "360" ] } },
+              { "case": 76239, "effect": { "math": [ "u_number_artisans_gunsmith_ammo_convert_coeff", "=", "90" ] } }
             ]
           }
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Rebalance the price of 7.62x39mm and the gunsmith ammo conversion ratio"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #68061
1. The `price_postapoc` of 7.62x39mm M67 is 6800, which is too high and raises another problem.
2. The player can exchange 5.56 M855 for 7.62 M67 at a ratio of about 1:1 in bullet bank, which maybe breaks the economic system in the game. Because the conversion ratio of bullets is not set according to the barter value.


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Adjust the `price_postapoc` of 7.62x39mm to 800, which is the same as 7.62x51mm M80.
2. Rebalance the ammo conversion ratio of bullets according to their barter value.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

- The price of different ammo (￠) 

|  ammo / property   | 5.45x39mm | 5.56mm M855 | .300 AAC | 7.62x39mm M67 | 7.62x51mm M80 | 7.62x39mm M67 (before) |
|:------------------:|:---------:|:-----------:|:------------:|:-------------:|:-------------:|:----------------------:|
|`price_postapoc` |    900    |     900     |     1500     |      800      |      800      |          6800          |
|     `stack_size`     |    30     |     47      |      47      |      20       |      20       |           20           |
|  barter value   |    30     |    19.2     |     31.9     |      40       |      40       |          340           |

- Before  (the conversion result per 200 rounds)

| Conversion | 5.45 | 5.56 | .300 | 7.62x39 | 7.62x51 |
|:----------------:|:----:|:----:|:----:|:-------:|:-------:|
|       5.45       |  -   | 140  | 220  |   160   |   80    |
|       5.56       | 240  |  -   | 280  |   200   |   120   |
|       .300       | 140  | 100  |  -   |   120   |   60    |
|     7.62x39      | 220  | 160  | 260  |    -    |   100   |
|     7.62x51      | 360  | 280  | 440  |   320   |    -    |

- After  (the conversion result per 200 rounds)

| Conversion | 5.45 | 5.56 | .300 | 7.62x39 | 7.62x51 |
|:--------------:|:----:|:----:|:----:|:-------:|:-------:|
|      5.45      |  -   | 270  | 180  |   135   |   135   |
|      5.56      | 120  |  -   | 120  |   90    |   90    |
|      .300      | 180  | 270  |  -   |   135   |   135   |
|    7.62x39     | 240  | 360  | 240  |    -    |   180    |
|    7.62x51     | 240  | 360  | 240  |   180    |    -    |

#### Describe alternatives you've considered

- Just replace 7.62x39mm M67 with 7.62x39mm 57-N-231 in the ammo conversion.

- Adjust the prices of other ammunition appropriately.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Change the corresponding file, enter the game test, everything is fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
