### PR TITLE
Undine healing fix.

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesian_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesian_mutations.json
@@ -169,7 +169,7 @@
       "NOHEAL"
     ],
     "can_heal_with": [ "cerulean_poultice" ],
-    "description": "You are literally made of water.",
+    "description": "You are born of the deep waters.",
     "anger_relations": [ [ "UNDINE", -20 ], [ "SALAMANDER", 20 ] ],
     "allowed_category": [ "UNDINE" ],
     "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesian_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesian_mutations.json
@@ -168,8 +168,8 @@
       "SLOWHEALER3",
       "NOHEAL"
     ],
-    "can_only_heal_with": [ "cerulean_poultice" ],
-    "description": "You are literally made of earth and stone.",
+    "can_heal_with": [ "cerulean_poultice" ],
+    "description": "You are literally made of water.",
     "anger_relations": [ [ "UNDINE", -20 ], [ "SALAMANDER", 20 ] ],
     "allowed_category": [ "UNDINE" ],
     "no_cbm_on_bp": [ "torso", "head", "eyes", "mouth", "arm_l", "arm_r", "hand_l", "hand_r", "leg_l", "leg_r", "foot_l", "foot_r" ]


### PR DESCRIPTION
Fixes up the issue of Undine start being unable to use regular medicines and drugs.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Undine healing fix"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes the strings to allow Undine the ability to use regular medicines like other Elemental Birth starts.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fix tiny string with can_heal_with
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Works fine, and no more infected waterkin.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
During my current playthrough I noticed that as a Undine I was unable to use any healing items or drugs unless it was 'specifically' Cerulean Poultices which is for Undine Mutation line. This has lead to a whole goofy adventure which forced me to soak up and stay in the nearby river in the hopes of my water-healing ability to clear away bites and infected wounds.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
