### PR TITLE
[Magiclysm] Make goblins myopic in light 

### DIFF
--- a/data/mods/Magiclysm/mutations/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/fantasy_species.json
@@ -252,6 +252,12 @@
   },
   {
     "type": "mutation",
+    "id": "NIGHTVISION3",
+    "copy-from": "NIGHTVISION3",
+    "extend": { "category": [ "SPECIES_DWARF", "SPECIES_GOBLIN" ] }
+  },
+  {
+    "type": "mutation",
     "id": "SMELLY",
     "copy-from": "SMELLY",
     "extend": { "category": [ "SPECIES_DWARF" ] }

--- a/data/mods/Magiclysm/mutations/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/fantasy_species.json
@@ -503,6 +503,7 @@
     "description": "Your people have always had an easier time operating at night, away from the hated light of the sun.",
     "mixed_effect": true,
     "valid": false,
+    "flags": [ "MYOPIC_IN_LIGHT" ],
     "category": [ "SPECIES_GOBLIN" ],
     "threshreq": [ "THRESH_SPECIES_GOBLIN" ],
     "enchantments": [

--- a/data/mods/Magiclysm/traits/fantasy_species.json
+++ b/data/mods/Magiclysm/traits/fantasy_species.json
@@ -36,7 +36,7 @@
     "traits": [
       "THRESH_SPECIES_DWARF",
       "DARKSIGHT",
-      "NIGHTVISION",
+      "NIGHTVISION2",
       "DWARVEN_BUILD",
       "PAINRESIST",
       "INFRESIST",
@@ -66,7 +66,7 @@
       "DARKSIGHT",
       "GOBLIN_BUILD",
       "GOBLIN_TEETH",
-      "NIGHTVISION2",
+      "NIGHTVISION3",
       "SAPROVORE",
       "SNOUT",
       "NAILS",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Make goblins myopic in light"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I forgot about the MYOPIC_IN_LIGHT flag when I made the goblin traits, but it makes perfect sense for a nocturnal species to have. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the MYOPIC_IN_LIGHT flag to the NOCTURNAL trait. Also give goblins Full Night Vision and dwarves High Night Vision.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Daytime:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/f9763f25-a9bd-41fe-8046-1a3efb358b2d)

Nighttime:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/010752ec-f774-4ce9-ab52-52fe41d8e808)



<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
