### PR TITLE
[DONE] Visitable flood fill

### DIFF
--- a/src/creature.h
+++ b/src/creature.h
@@ -742,8 +742,20 @@ class Creature : public viewer
         virtual bool uncanny_dodge() {
             return false;
         }
+        void set_reachable_zone( int zone ) {
+            reachable_zone = zone;
+        }
+        int get_reachable_zone() const {
+            return reachable_zone;
+        }
 
     private:
+        /** This number establishes a partition of zones on the map that have shared
+         * reachability/visibility. In short, if you aren't in the same zone as some other monster,
+         * you can ignore them since you won't be able to reach them by any combination of
+         * regular movement and vision. **/
+        int reachable_zone = 0;
+
         /** The creature's position in absolute coordinates */
         tripoint_abs_ms location;
     protected:

--- a/src/flood_fill.h
+++ b/src/flood_fill.h
@@ -50,6 +50,163 @@ std::vector<Point> point_flood_fill_4_connected( const Point &starting_point,
 
     return filled_points;
 }
+
+struct span {
+    span() : startX( 0 ), endX( 0 ), y( 0 ), dy( 0 ), z( 0 ),
+        dz( 0 ) {}
+    span( uint8_t p_startX, uint8_t p_endX, uint8_t p_y, int8_t p_dy, int8_t p_z,
+          int8_t p_dz ) : startX( p_startX ), endX( p_endX ), y( p_y ), dy( p_dy ), z( p_z ),
+        dz( p_dz ) {}
+
+    uint8_t startX;
+    uint8_t endX;
+    uint8_t y;
+    int8_t dy;
+    int8_t z;
+    int8_t dz;
+};
+
+inline void add_span( std::vector<span> &spans, int startX, int endX,
+                      int y, int dy, int z, int dz )
+{
+    const int clamped_z = clamp<int8_t>( z, -OVERMAP_DEPTH, OVERMAP_HEIGHT );
+    spans.emplace_back( std::max( startX, 0 ), std::min( endX, MAPSIZE_X - 1 ),
+                        clamp( y, 0, MAPSIZE_Y - 1 ), dy, clamped_z, dz );
+}
+
+
+template<typename UnaryPredicate, typename UnaryVisitor>
+void flood_fill_visit_10_connected( const tripoint_bub_ms &starting_point, UnaryPredicate predicate,
+                                    UnaryVisitor visitor )
+{
+    std::array<std::array<std::bitset<MAPSIZE_Y>, MAPSIZE_X>, OVERMAP_LAYERS> visited;
+    std::array<std::array<std::bitset<MAPSIZE_Y>, MAPSIZE_X>, OVERMAP_LAYERS> visited_vertically;
+    std::array<std::vector<span>, OVERMAP_LAYERS> spans_to_process;
+    int current_z = starting_point.z();
+    add_span( spans_to_process[current_z + OVERMAP_DEPTH], starting_point.x(), starting_point.x(),
+              starting_point.y(), 1, starting_point.z(), 0 );
+    add_span( spans_to_process[current_z + OVERMAP_DEPTH], starting_point.x(), starting_point.x(),
+              starting_point.y() - 1, -1, starting_point.z(), 0 );
+    auto check = [&predicate, &visited]( const tripoint_bub_ms loc, int dir ) {
+        return loc.z() >= -OVERMAP_DEPTH && loc.z() <= OVERMAP_HEIGHT &&
+               loc.y() >= 0 && loc.y() < MAPSIZE_Y &&
+               loc.x() >= 0 && loc.x() < MAPSIZE_X &&
+               !visited[loc.z() + OVERMAP_DEPTH][loc.y()][loc.x()] && predicate( loc, dir );
+    };
+    auto check_vertical = [&predicate, &visited_vertically]( const tripoint_bub_ms loc,
+    int dir ) {
+        return loc.z() >= -OVERMAP_DEPTH && loc.z() <= OVERMAP_HEIGHT &&
+               loc.y() >= 0 && loc.y() < MAPSIZE_Y &&
+               loc.x() >= 0 && loc.x() < MAPSIZE_X &&
+               !visited_vertically[loc.z() + OVERMAP_DEPTH][loc.y()][loc.x()] && predicate( loc, dir );
+    };
+    while( true ) {
+        struct span current_span;
+        if( !spans_to_process[current_z + OVERMAP_DEPTH].empty() ) {
+            current_span = spans_to_process[current_z + OVERMAP_DEPTH].back();
+            spans_to_process[current_z + OVERMAP_DEPTH].pop_back();
+        } else {
+            for( current_z = OVERMAP_HEIGHT; current_z >= -OVERMAP_DEPTH; current_z-- ) {
+                if( !spans_to_process[current_z + OVERMAP_DEPTH].empty() ) {
+                    current_span = spans_to_process[current_z + OVERMAP_DEPTH].back();
+                    spans_to_process[current_z + OVERMAP_DEPTH].pop_back();
+                    break;
+                }
+            }
+            if( current_z < -OVERMAP_DEPTH ) {
+                break;
+            }
+        }
+        tripoint_bub_ms current_point{ static_cast<int>( current_span.startX ), static_cast <int>( current_span.y ), static_cast<int>( current_span.z ) };
+        // Special handling for spans with a vertical offset.
+        if( current_span.dz != 0 ) {
+            bool span_found = false;
+            struct span new_span {
+                current_span.startX, current_span.endX, current_span.y, current_span.dy, current_span.z, 0
+            };
+            // Iterate over tiles in the span, adding to new span as long as check passes.
+            while( current_point.x() <= current_span.endX ) {
+                if( check_vertical( current_point, current_span.dz ) ) {
+                    span_found = true;
+                    new_span.endX = current_point.x();
+                    visited_vertically[current_point.z() + OVERMAP_DEPTH][current_point.y()].set( current_point.x() );
+                } else {
+                    if( span_found ) {
+                        add_span( spans_to_process[current_z + OVERMAP_DEPTH], new_span.startX, new_span.endX,
+                                  new_span.y, 1, current_point.z(), 0 );
+                        add_span( spans_to_process[current_z + OVERMAP_DEPTH], new_span.startX, new_span.endX,
+                                  new_span.y - 1, -1, current_point.z(), 0 );
+                    }
+                    new_span.startX = current_point.x() + 1;
+                    span_found = false;
+                }
+                current_point.x()++;
+            }
+            if( span_found ) {
+                add_span( spans_to_process[current_z + OVERMAP_DEPTH], new_span.startX, new_span.endX,
+                          new_span.y, 1, current_point.z(), 0 );
+                add_span( spans_to_process[current_z + OVERMAP_DEPTH], new_span.startX, new_span.endX,
+                          new_span.y - 1, -1, current_point.z(), 0 );
+            }
+            continue;
+        }
+
+        // Scan to the left of the leftmost point in the current span.
+        if( check( current_point, 0 ) ) {
+            // This decrements before visiting because the next loop will visit the current value of startX
+            current_point.x()--;
+            while( check( current_point, 0 ) ) {
+                visitor( current_point );
+                visited[current_point.z() + OVERMAP_DEPTH][current_point.y()].set( current_point.x() );
+                current_point.x()--;
+            }
+            current_point.x()++;
+            // If we found visitable tiles to the left of the span, emit a new span going in the other y direction to go around corners.
+            if( current_point.x() < current_span.startX ) {
+                add_span( spans_to_process[current_z + OVERMAP_DEPTH], current_point.x() - 1,
+                          current_span.startX - 1, current_span.y - current_span.dy, -current_span.dy,
+                          current_point.z(), 0 );
+            }
+        }
+        int furthestX = current_point.x();
+        current_point.x() = current_span.startX;
+        // Scan the span itself, running off the edge to the right if possible.
+        while( current_point.x() <= current_span.endX ) {
+            while( check( current_point, 0 ) ) {
+                visitor( current_point );
+                visited[current_point.z() + OVERMAP_DEPTH][current_point.y()].set( current_point.x() );
+                current_point.x()++;
+            }
+            // If we have made any progress in the above loops, emit a span going in our initial y direction as well as in both vertical directions.
+            if( current_point.x() > furthestX ) {
+                add_span( spans_to_process[current_z + OVERMAP_DEPTH], furthestX - 1, current_point.x(),
+                          current_span.y + current_span.dy, current_span.dy,
+                          current_span.z, 0 );
+                if( current_z + 1 < OVERMAP_HEIGHT ) {
+                    add_span( spans_to_process[current_z + OVERMAP_DEPTH + 1], furthestX, current_point.x() - 1,
+                              current_span.y, 0, current_span.z + 1, 1 );
+                }
+                if( current_z - 1 >= -OVERMAP_DEPTH ) {
+                    add_span( spans_to_process[current_z + OVERMAP_DEPTH - 1], furthestX, current_point.x() - 1,
+                              current_span.y, 0, current_span.z - 1, -1 );
+                }
+            }
+            // If we found visitable tiles to the right of the span, emit a new span going in the other y direction to go around corners.
+            if( current_point.x() - 1 > current_span.endX ) {
+                add_span( spans_to_process[current_z + OVERMAP_DEPTH], current_span.endX + 1, current_point.x(),
+                          current_span.y - current_span.dy, -current_span.dy, current_span.z, 0 );
+            }
+            // This is pointing to a tile that faied the predicate, so advance to the next tile.
+            current_point.x()++;
+            // Scan past any unvisitable tiles up to the end of the current span.
+            while( current_point.x() < current_span.endX && !predicate( current_point, 0 ) ) {
+                current_point.x()++;
+            }
+            // We either found a new visitable tile or ran off the end of the span, record our new scan start point regardless.
+            furthestX = current_point.x();
+        }
+    }
+}
 } // namespace ff
 
 #endif // CATA_SRC_FLOOD_FILL_H

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -646,6 +646,11 @@ bool map::is_transparent( const tripoint &p ) const
     return light_transparency( p ) > LIGHT_TRANSPARENCY_SOLID;
 }
 
+bool map::is_transparent_wo_fields( const tripoint &p ) const
+{
+    return get_cache_ref( p.z ).transparent_cache_wo_fields[p.x][p.y] > LIGHT_TRANSPARENCY_SOLID;
+}
+
 float map::light_transparency( const tripoint &p ) const
 {
     return get_cache_ref( p.z ).transparency_cache[p.x][p.y];

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -241,6 +241,7 @@ void map::set_transparency_cache_dirty( const tripoint &p, bool field )
         if( !field ) {
             get_cache( smp.z ).r_hor_cache->invalidate( p.xy() );
             get_cache( smp.z ).r_up_cache->invalidate( p.xy() );
+            set_visitable_zones_cache_dirty();
         }
     }
 }
@@ -1774,6 +1775,7 @@ bool map::furn_set( const tripoint &p, const furn_id &new_furniture, const bool 
             ter_furn_flag::TFLAG_NO_FLOOR ) ) {
         set_floor_cache_dirty( p.z );
         set_seen_cache_dirty( p );
+        set_visitable_zones_cache_dirty();
     }
 
     if( old_f.has_flag( ter_furn_flag::TFLAG_SUN_ROOF_ABOVE ) != new_f.has_flag(
@@ -1788,6 +1790,9 @@ bool map::furn_set( const tripoint &p, const furn_id &new_furniture, const bool 
         player_character.memorize_clear_decoration( getglobal( p ), "f_" );
     }
 
+    if( ( old_f.movecost < 0 ) != ( new_f.movecost < 0 ) ) {
+        set_visitable_zones_cache_dirty();
+    }
     // TODO: Limit to changes that affect move cost, traps and stairs
     set_pathfinding_cache_dirty( p.z );
 
@@ -2232,6 +2237,9 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_crea
         player_character.memorize_clear_decoration( getglobal( p ), "t_" );
     }
 
+    if( ( old_t.movecost == 0 ) != ( new_t.movecost == 0 ) ) {
+        set_visitable_zones_cache_dirty();
+    }
     // TODO: Limit to changes that affect move cost, traps and stairs
     set_pathfinding_cache_dirty( p.z );
 

--- a/src/map.h
+++ b/src/map.h
@@ -349,6 +349,12 @@ class map
         void set_outside_cache_dirty( int zlev );
         void set_floor_cache_dirty( int zlev );
         void set_pathfinding_cache_dirty( int zlev );
+        void set_visitable_zones_cache_dirty( bool dirty = true ) {
+            visitable_cache_dirty = dirty;
+        };
+        bool get_visitable_zones_cache_dirty() const {
+            return visitable_cache_dirty;
+        };
         /*@}*/
 
         void invalidate_map_cache( int zlev );
@@ -1753,6 +1759,7 @@ class map
          * Returns whether the tile at `p` is transparent(you can look past it).
          */
         bool is_transparent( const tripoint &p ) const;
+        bool is_transparent_wo_fields( const tripoint &p ) const;
         // End of light/transparency
 
         /**
@@ -2221,6 +2228,13 @@ class map
         // this is set for maps loaded in bounds of the main map (g->m)
         bool _main_requires_cleanup = false;
         std::optional<bool> _main_cleanup_override = std::nullopt;
+
+        // Tracks the dirtiness of the visitable zones cache, but that cache does not live here,
+        // it is distributed among the active monsters. This must be flipped when
+        // persistent visibility from terrain or furniture changes
+        // (this excludes vehicles and fields) or when persistent traversability changes,
+        // which means walls and floors.
+        bool visitable_cache_dirty = false;
 
     public:
         void queue_main_cleanup();

--- a/tests/visitable_zone_test.cpp
+++ b/tests/visitable_zone_test.cpp
@@ -1,0 +1,179 @@
+#include "cata_catch.h"
+#include "map.h"
+#include "map_helpers.h"
+#include "map_iterator.h"
+#include "monster.h"
+#include "rng.h"
+
+#include <vector>
+
+// The area of the whole map from two below to one above ground level.
+static const tripoint p1( 0, 0, -2 );
+static const tripoint p2( ( MAPSIZE *SEEX ) - 1, ( MAPSIZE *SEEY ) - 1, 1 );
+
+struct structure {
+    structure( const tripoint &origin, const tripoint &dimensions, const std::string &name ) :
+        area( origin, origin + dimensions ), name_( name ) {};
+    bool contains( const tripoint &p ) const {
+        return area.contains( p );
+    }
+    inclusive_cuboid<tripoint> area;
+    std::string name_;
+};
+
+static void place_structures( const std::vector<structure> &spawn_areas,
+                              std::vector<std::vector<tripoint>> &interior_areas,
+                              std::vector<tripoint> &outside_area,
+                              std::vector<tripoint> &rooftop_area )
+{
+    map &here = get_map();
+    for( const tripoint &p : here.points_in_rectangle( p1, p2 ) ) {
+        bool found = false;
+        for( unsigned int i = 0; i < spawn_areas.size(); ++i ) {
+            // Indexing so these can pair up with interior_areas.
+            const structure &spawn_area = spawn_areas[i];
+            if( spawn_area.contains( p ) ) {
+                found = true;
+                // Uppermost level (if any) gets a roof covering the whole footprint.
+                if( spawn_area.area.p_max.z != spawn_area.area.p_min.z && p.z == spawn_area.area.p_max.z ) {
+                    rooftop_area.emplace_back( p );
+                    here.ter_set( p, ter_id( "t_flat_roof" ) );
+                    break;
+                }
+                inclusive_cuboid<tripoint> interior{
+                    rectangle{
+                        spawn_area.area.p_min.xy() + point_south_east,
+                        spawn_area.area.p_max.xy() - point_south_east
+                    },
+                    spawn_area.area.p_min.z, spawn_area.area.p_min.z
+                };
+                if( interior.contains( p ) ) {
+                    here.ter_set( p, ter_id( "t_floor" ) );
+                    interior_areas[i].emplace_back( p );
+                } else {
+                    here.ter_set( p, ter_id( "t_concrete_wall" ) );
+                }
+                break;
+            }
+        }
+        if( !found && p.z == 0 ) {
+            outside_area.push_back( p );
+        }
+    }
+}
+
+// Just make all the buildings the same size.
+static constexpr int building_width = 7;
+static constexpr int building_height = 1;
+static constexpr tripoint building_offset{ building_width, building_width, building_height };
+static constexpr tripoint cave_offset{ building_width, building_width, 0 };
+
+TEST_CASE( "visitable_zone_surface_test" )
+{
+    map &here = get_map();
+    clear_map();
+
+    std::string mon_type = "mon_zombie";
+    std::vector<monster *> monsters;
+    // All of these origins must be building_width + 3 away from each other.
+    // Surface building locations.
+    const tripoint enclosed_building{ 30, 30, 0 };
+    const tripoint closed_door = enclosed_building + tripoint_east * 2;
+    // Surface building with a door.
+    const tripoint door_building{ 40, 30, 0 };
+    const tripoint open_door = door_building + tripoint_east * 2;
+    // Surface building with a window.
+    const tripoint window_building{ 50, 30, 0 };
+    const tripoint window = window_building + tripoint_south * 2;
+    // Underground room.
+    const tripoint underground_room{ 60, 30, -1 };
+    // Underground room.
+    const tripoint underground_stairs_room{ 70, 30, -1 };
+    const tripoint underground_stairs_up = underground_stairs_room + tripoint_south_east * 3;
+    const tripoint underground_stairs_down = underground_stairs_up + tripoint_above;
+    // Elevated building with stairs to the surface.
+    const tripoint stilts_building{ 80, 30, 1 };
+    const tripoint stilts_stairs_down = stilts_building + tripoint_south_east * 3;
+    const tripoint stilts_stairs_up = stilts_stairs_down + tripoint_below;
+
+    std::vector<structure> spawn_locations = {{
+            { enclosed_building, building_offset, "closed door building" },
+            { door_building, building_offset, "open door building" },
+            { window_building, building_offset, "window building" },
+            { underground_room, cave_offset, "cave" },
+            { underground_stairs_room, cave_offset, "cave with stairs" },
+            { stilts_building, building_offset, "building on stilts" }
+        }
+    };
+    std::vector<std::vector<tripoint>> interior_areas( spawn_locations.size() );
+    std::vector<tripoint> outside_area;
+    std::vector<tripoint> rooftop_area;
+    place_structures( spawn_locations, interior_areas, outside_area, rooftop_area );
+    here.ter_set( closed_door, ter_id( "t_door_c" ) );
+    here.ter_set( open_door, ter_id( "t_door_o" ) );
+    here.ter_set( window, ter_id( "t_window" ) );
+    here.ter_set( underground_stairs_up, ter_id( "t_wood_stairs_up" ) );
+    here.ter_set( underground_stairs_down, ter_id( "t_wood_stairs_down" ) );
+    here.ter_set( stilts_stairs_up, ter_id( "t_wood_stairs_up" ) );
+    here.ter_set( stilts_stairs_down, ter_id( "t_wood_stairs_down" ) );
+
+    // Reset all the map caches after editing the map.
+    for( int i = OVERMAP_HEIGHT; i >= -OVERMAP_DEPTH; --i ) {
+        here.invalidate_map_cache( i );
+        here.build_map_cache( i, true );
+    }
+
+    // Some spot checks of our map edits.
+    REQUIRE( !here.passable( enclosed_building + point_east ) );
+    REQUIRE( !here.passable( door_building + point_south ) );
+    REQUIRE( !here.is_transparent_wo_fields( enclosed_building + point_east ) );
+    REQUIRE( !here.is_transparent_wo_fields( door_building + point_south ) );
+
+    REQUIRE( here.passable( open_door ) );
+    REQUIRE( here.is_transparent_wo_fields( open_door ) );
+
+    REQUIRE( !here.passable( closed_door ) );
+    REQUIRE( !here.is_transparent_wo_fields( closed_door ) );
+
+    REQUIRE( !here.passable( window ) );
+    REQUIRE( here.is_transparent_wo_fields( window ) );
+
+    for( std::vector<tripoint> &area : interior_areas ) {
+        for( const int &choice : rng_sequence( 2, 0, area.size() - 1 ) ) {
+            monster &mon = spawn_test_monster( mon_type, area[choice] );
+            monsters.push_back( &mon );
+        }
+    }
+    for( const int &choice : rng_sequence( 5, 0, outside_area.size() - 1 ) ) {
+        monster &mon = spawn_test_monster( mon_type, outside_area[choice] );
+        monsters.push_back( &mon );
+    }
+    for( const int &choice : rng_sequence( 5, 0, rooftop_area.size() - 1 ) ) {
+        monster &mon = spawn_test_monster( mon_type, rooftop_area[choice] );
+        monsters.push_back( &mon );
+    }
+    std::set<int> zones;
+    for( monster *mon : monsters ) {
+        mon->plan();
+        zones.insert( mon->get_reachable_zone() );
+    }
+    for( monster *mon : monsters ) {
+        tripoint mpos = mon->pos();
+        std::vector<structure>::iterator it =
+            find_if( spawn_locations.begin(), spawn_locations.end(),
+        [mon]( structure & a_structure ) {
+            return a_structure.contains( mon->pos() );
+        } );
+        std::string spawn_site = "outside";
+        if( mpos.z >= 1 ) {
+            spawn_site = "rooftop";
+        } else if( it != spawn_locations.end() ) {
+            spawn_site = it->name_;
+        }
+        CAPTURE( spawn_site );
+        CAPTURE( mon->pos() );
+        CAPTURE( mon->get_reachable_zone() );
+        CHECK( mon->get_reachable_zone() != 0 );
+        CHECK( zones.size() == 3 );
+    }
+}


### PR DESCRIPTION
#### Summary
Performance "Precalculate visitable zones to optimize inter-monster aggression checks"

#### Purpose of change
When there are a large number of monsters of opposing factions in the reality bubble, the checks for vision etc between them can get expensive, especially when we are trying to run the simulation forward quickly when e.g. crafting, waiting, or sleeping.

#### Describe the solution
This adds a concept I'm calling a "visitable region" and calculates it for each monster. The core idea is it performs a flood-fill across every tile that a monster *might* be able to traverse OR see. The reason to make it so permissive is so that it is a proper partition of the game space, every monster is in exactly one zone, so at monster AI calculation time all the monster needs to do is compare its zone number with an opposing monster's zone number to determine if there is any possibility of them interacting.
For the same reason, it looks at terrain-based transparency, ignoring things like field effects which change frequently and invalidate the map.
In principle, this map would only need to be re-calculated once every 24 turns or so when the player triggers a map shift, and almost never when the player is not moving.

#### Describe alternatives you've considered
As a type of cache, there's always an option to do nothing, but inter-monster agression performance is a pretty hard nut to crack.

#### Testing
So far I've been focusing on whether the system is even a net win and whether it's doing the appropriate work. I have added some debug statements that summarize the extent of the zones that are produced and they look like they are the appropriate sizes.
This really needs some unit tests with some different scenarios in it to demonstrate that the flood filling is working as intended.

#### Additional Context
This is based on pathfinding caching algorithms, but the main difference is uninioning traversibility with vision such that the cache remains stable and handles all different movement/vision modes.

#### Known Issues
This is currently a net negative as the flood fill is quite slow and I don't have any invalidation-based caching in place yet.  I've been focusing on making the flood-fill itself reasonably performant first before messing with caching.
There are also some potentially large optimizations I might be able to add to further optimize it.
1. Invalidation based caching might be all that is needed since it should run very infrequently, almost never when the player isn't moving. It invalidates on map shift, when the passability state of a tile changes, and when field-oblivious transparency changes. I did a quick test of this by generating the cache once and removing the invalidation logic and it results in eliminating about 10% of total overhead in a pathological case of waiting above an uncleared lab.
2. This is likely to have noticeably bad overhead when moving quickly, e.g. auto-drive. If so it might be mitigable by only performing a flood fill if the player stays in the same location for several turns.
3. Searching for monsters to mark is a pretty dominant operation, as it flood fills it searches for monsters and the negative case where there's no monster present is eating us alive. We could stick a bitset in front of the find operation in creature_at<>() and potentially save a ton of hashing.
4. All the uniform above-ground submaps could be handled specially and most likely cut overhead in half.