### PR TITLE
Updated Alloy Reference Manual

### DIFF
--- a/data/json/itemgroups/books.json
+++ b/data/json/itemgroups/books.json
@@ -153,7 +153,8 @@
       { "item": "book_icef", "prob": 8 },
       { "item": "book_pneumatics", "prob": 8 },
       { "item": "carpentry_book", "prob": 5 },
-      { "item": "theater_props", "prob": 2 }
+      { "item": "theater_props", "prob": 2 },
+      { "item": "alloy_book", "prob": 12 }
     ]
   },
   {
@@ -431,7 +432,8 @@
       { "item": "reference_fabrication1", "prob": 6 },
       { "item": "reference_firstaid1", "prob": 2 },
       { "item": "reference_firstaid2", "prob": 1 },
-      { "item": "textbook_toxicology", "prob": 2 }
+      { "item": "textbook_toxicology", "prob": 2 },
+      { "item": "alloy_book", "prob": 5 }
     ]
   },
   {
@@ -542,7 +544,8 @@
       { "group": "manuals", "prob": 1 },
       { "item": "textbook_arthropod", "prob": 5 },
       { "item": "book_pneumatics", "prob": 8 },
-      { "item": "textbook_botany", "prob": 5 }
+      { "item": "textbook_botany", "prob": 5 },
+      { "item": "alloy_book", "prob": 8 }
     ]
   },
   {

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -1179,7 +1179,7 @@
     "difficulty": 5,
     "time": "4 h",
     "batch_time_factors": [ 90, 2 ],
-    "book_learn": [ [ "reference_fabrication1", 5 ], [ "welding_book", 5 ] ],
+    "book_learn": [ [ "reference_fabrication1", 5 ], [ "welding_book", 5 ], [ "alloy_book", 5 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
     "tools": [ [ [ "metalworking_tongs", -1 ] ], [ [ "metal_tank", -1 ] ], [ [ "forge", 500 ] ] ],
     "components": [ [ [ "steel_lump", 1 ], [ "steel_chunk", 4 ], [ "scrap", 20 ] ], [ [ "coal_lump", 64 ], [ "charcoal", 40 ] ] ]

--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -1194,7 +1194,7 @@
     "difficulty": 5,
     "time": "6 h",
     "batch_time_factors": [ 90, 2 ],
-    "book_learn": [ [ "reference_fabrication1", 5 ], [ "welding_book", 5 ] ],
+    "book_learn": [ [ "reference_fabrication1", 5 ], [ "welding_book", 5 ], [ "alloy_book", 5 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
     "tools": [ [ [ "metalworking_tongs", -1 ] ], [ [ "metal_tank", -1 ] ], [ [ "forge", 500 ] ] ],
     "components": [ [ [ "steel_lump", 1 ], [ "steel_chunk", 4 ], [ "scrap", 20 ] ], [ [ "coal_lump", 77 ], [ "charcoal", 48 ] ] ]
@@ -1209,7 +1209,7 @@
     "difficulty": 5,
     "time": "7 h",
     "batch_time_factors": [ 90, 2 ],
-    "book_learn": [ [ "reference_fabrication1", 5 ], [ "welding_book", 5 ] ],
+    "book_learn": [ [ "reference_fabrication1", 5 ], [ "welding_book", 5 ], [ "alloy_book", 5 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
     "tools": [ [ [ "metalworking_tongs", -1 ] ], [ [ "metal_tank", -1 ] ], [ [ "forge", 500 ] ] ],
     "components": [ [ [ "steel_lump", 1 ], [ "steel_chunk", 4 ], [ "scrap", 20 ] ], [ [ "coal_lump", 90 ], [ "charcoal", 68 ] ] ]
@@ -1225,7 +1225,7 @@
     "difficulty": 5,
     "time": "3 h",
     "batch_time_factors": [ 90, 2 ],
-    "book_learn": [ [ "reference_fabrication1", 5 ], [ "welding_book", 5 ] ],
+    "book_learn": [ [ "reference_fabrication1", 5 ], [ "welding_book", 5 ], [ "alloy_book", 5 ] ],
     "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
     "tools": [ [ [ "metalworking_tongs", -1 ] ], [ [ "metal_tank", -1 ] ], [ [ "forge", 200 ] ] ],
     "components": [


### PR DESCRIPTION
#### Summary
Content "new Alloy Reference Manual contains recipes for steel grades + spawns more often"

#### Purpose of change

I watched TheMurderUnicorn's recent video and he said he doesn't like how the book added in #67864 only has one recipe. Turns out Karol intended to add recipes for the different lumps of steel, but just didn't do it.
While I was doing this I noticed its spawnrate was really obscure and low, so I added it to some more itemgroups. 

#### Describe the solution

`steel_lump`, `lc_steel_lump`, `mc_steel_lump`, and `hc_steel_lump` all have the new book added to their `book_learn` line. I also added the new book to the itemgroups `hardware_books`, `textbooks`, and `lab_bookshelves`.

#### Testing

Haven't tested its spawns

I noticed a titanium/titanium alloy related PR in the works, Maybe some recipes from that could be added to here once it's done cooking
