### PR TITLE
[Magiclysm] Everburning Torch rebalancing

### DIFF
--- a/data/mods/Magiclysm/furniture.json
+++ b/data/mods/Magiclysm/furniture.json
@@ -342,7 +342,7 @@
     "color": "red",
     "move_cost_mod": 2,
     "required_str": 12,
-    "light_emitted": 240,
+    "light_emitted": 120,
     "flags": [ "TRANSPARENT", "EASY_DECONSTRUCT" ],
     "deconstruct": { "items": [ { "item": "everburning_torch_candelabra", "count": 1 } ] },
     "bash": {

--- a/data/mods/Magiclysm/items/enchanted_misc.json
+++ b/data/mods/Magiclysm/items/enchanted_misc.json
@@ -104,7 +104,7 @@
     ],
     "techniques": [ "WBLOCK_1" ],
     "sub": "fire",
-    "extend": { "flags": [ "FIRE", "LIGHT_240", "FLAMING", "TRADER_AVOID", "WATER_EXTINGUISH" ] }
+    "extend": { "flags": [ "FIRE", "LIGHT_60", "FLAMING", "TRADER_AVOID", "WATER_EXTINGUISH" ] }
   },
   {
     "name": { "str": "endless flask" },

--- a/data/mods/Magiclysm/vehicleparts/vehicle_parts.json
+++ b/data/mods/Magiclysm/vehicleparts/vehicle_parts.json
@@ -53,7 +53,7 @@
     "color": "red",
     "broken_color": "blue",
     "durability": 20,
-    "bonus": 240,
+    "bonus": 60,
     "damage_modifier": 10,
     "breaks_into": [
       { "item": "splinter", "count": [ 2, 8 ] },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Everburning Torch rebalancing"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I was very surprised when I looked at the everburning torch and saw it was set at LIGHT_240, which is more than the standing lamp's "bonus": 200.  It seemed pretty weird to me that a magical torch should give off more light than an electric lamp, especially with Magiclysm's premise that technology is often more convenient and sometimes better than magic, and when I looked up the source for everburning torch (D&D), it said that

> This otherwise normal torch has a [continual flame](https://www.dandwiki.com/wiki/SRD:Continual_Flame) spell cast upon it. An everburning torch clearly illuminates a 20-foot radius and provides shadowy illumination out to a 40-foot radius.

And if you look up a torch it says

> A torch burns for 1 hour, clearly illuminating a 20-foot radius and providing shadowy illumination out to a 40- foot radius. 

So, an everburning torch is a torch that burns forever but illuminates the same area, and we already have a light value for torches.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change the everburning torch so it matches the torch's light value (LIGHT_60). Do the same to the everburning sconce and change the everburning candelabra to LIGHT_120
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Light values are reflected in game.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
I was going to try to make a dropped everburning torch start fires but it doesn't look like actual torches do that either: 
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/d4eea27e-fe0f-4897-be7a-d881055f383f)


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
