### PR TITLE
Bugfix: AIM: insert items into container in corpse

### DIFF
--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -260,8 +260,8 @@ void advanced_inventory_pane::add_items_from_area( advanced_inv_area &square,
                     if( it->is_corpse() ) {
                         for( item *loot : it->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
                             if( !is_filtered( *loot ) ) {
-                                advanced_inv_listitem aim_item( item_location( loc_cursor, loot ), 0, 1, square.id,
-                                                                is_in_vehicle );
+                                advanced_inv_listitem aim_item( item_location( item_location( loc_cursor, it ), loot ),
+                                                                0, 1, square.id, is_in_vehicle );
                                 square.volume += aim_item.volume;
                                 square.weight += aim_item.weight;
                                 items.push_back( aim_item );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "AIM: Prevent segfault when inserting items into container in corpse"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Fixes #67949 .
* Prevents segfault in AIM when inserting items into a toplevel container that is carried by a corpse.
* How to reproduce issue being resolved:
	1. Stand adjacent to corpse
	2. Corpse is wearing "French maid clothes" (or some other container)
	3. Enter AIM, have "all" on left and "inventory" on right
	4. Navigate to "French maid clothes" on left and press `c` to open it as container
	5. Switch to right AIM pane and navigate to an item in your inventory, for example "matchbook"
	6. Press enter to move "matchbook" into "French maid clothes"
	7. Segfault

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

* Thanks to @andrei8l for pointing out the problem in https://github.com/CleverRaven/Cataclysm-DDA/issues/67949#issuecomment-1698805883
* The location for `advanced_inv_listitem aim_item` previously pointed to a container located at `loc_cursor`. But this location is the location of the corpse.
* Therefore, this suggested change is to switch the containers relative location:
	* `item_location( loc_cursor, loot )` (before): would mean that the container is placed on the same location as the corpse
	* `item_location( loc_cursor, it )` (used by this change): is the corpse (`it`) represented as a container
	* `item_location( item_location( loc_cursor, it ), loot )` (used by this change) is then the container `loot` inside (the corpse represented as a container)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Doing the steps in #67949 no longer causes segfault
* Tested moving items from player inventory into inventory of corpse.
* Tested moving items from player inventory into containers in inventory of corpse.
* Tested moving items from player inventory into containers inside other containers in inventory of corpse.
* Tested moving items from player inventory into containers inside containers inside other containers in inventory of corpse.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
