### PR TITLE
Bugfix: AIM: Display correct truncation of container names

### DIFF
--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -795,8 +795,7 @@ void advanced_inventory::redraw_pane( side p )
     const advanced_inv_area &sq = same_as_dragged ? squares[AIM_DRAGGED] : square;
     bool car = square.can_store_in_vehicle() && panes[p].in_vehicle() && sq.id != AIM_DRAGGED;
     std::string name = utf8_truncate( car ? sq.veh->name : sq.name, width );
-    std::string desc = utf8_truncate( pane.container ? pane.container->tname( 1, false ) :
-                                      sq.desc[car], width );
+    std::string desc = pane.container ? pane.container->tname( 1, false ) : sq.desc[car];
     // starts at offset 2, plus space between the header and the text
     width -= 2 + 1;
     trim_and_print( w, point( 2, 1 ), width, active ? c_green  : c_light_gray, name );


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "AIM: Display correct truncation of container names"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Prevent string truncation inside `<color>` tags of container names in AIM
* Fixes #67456 .
* For example, instead of displaying `plastic bottle (sealed) > <color` before, this commit will display `plastic bottle (sealed) > clean water (frozen...`


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Before:

![aim-truncated-container-names-before](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/f7a6392d-187e-4eda-8cd5-e14b7a1df99b)


#### Describe the solution

* Truncation to AIM width is still performed by `trim_and_print` anyway, so there should be little need to also use `utf8_truncate`.
* This commit therefore simply removes the call to `utf8_truncate` for container descriptions.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

After:

![aim-truncated-container-names-after](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/c8e84aa6-619c-46d3-8b41-06647f48feef)

Truncation of terrain names also works with this change:
![aim-truncated-container-names-terrain](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/27ce4858-2fb3-40cf-a0d3-429d04b59af0)

Truncation of vehicle part names also works with this change:
![aim-truncated-container-names-vehicle](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/04078a28-3975-4819-8859-6accb0942285)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
