### PR TITLE
view recipe: fix nested and or more results

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -3424,7 +3424,7 @@ class Character : public Creature, public visitable
          * @param goto_recipe the recipe to display initially. A null recipe_id opens the default crafting screen.
          */
         void craft( const std::optional<tripoint> &loc = std::nullopt,
-                    const recipe_id &goto_recipe = recipe_id() );
+                    const recipe_id &goto_recipe = recipe_id(), const std::string &filterstring = "" );
         void recraft( const std::optional<tripoint> &loc = std::nullopt );
         void long_craft( const std::optional<tripoint> &loc = std::nullopt,
                          const recipe_id &goto_recipe = recipe_id() );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -352,10 +352,11 @@ bool Character::has_morale_to_craft() const
     return get_morale_level() >= -50;
 }
 
-void Character::craft( const std::optional<tripoint> &loc, const recipe_id &goto_recipe )
+void Character::craft( const std::optional<tripoint> &loc, const recipe_id &goto_recipe,
+                       const std::string &filterstring )
 {
     int batch_size = 0;
-    const recipe *rec = select_crafting_recipe( batch_size, goto_recipe, *this );
+    const recipe *rec = select_crafting_recipe( batch_size, goto_recipe, *this, filterstring );
     if( rec ) {
         std::string reason;
         if( is_npc() && !rec->npc_can_craft( reason ) ) {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1125,7 +1125,7 @@ static bool selection_ok( const std::vector<const recipe *> &list, const int cur
 }
 
 const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto_recipe,
-                                      Character &crafter )
+                                      Character &crafter, std::string filterstring )
 {
     recipe_result_info_cache result_info( crafter );
     recipe_info_cache r_info_cache;
@@ -1246,7 +1246,6 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
 
     const inventory &crafting_inv = crafter.crafting_inventory();
     const std::vector<npc *> helpers = crafter.get_crafting_helpers();
-    std::string filterstring;
 
     const recipe_subset &available_recipes = crafter.get_available_recipes( crafting_inv,
             &helpers );

--- a/src/crafting_gui.h
+++ b/src/crafting_gui.h
@@ -13,7 +13,7 @@ class JsonObject;
 class recipe;
 
 const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto_recipe,
-                                      Character &crafter );
+                                      Character &crafter, std::string filterstring = "" );
 
 void load_recipe_category( const JsonObject &jsobj );
 void reset_recipe_categories();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "view recipe: fix nested and or more results"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #68080

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
If the item is an in-progress crafting recipe, behave as before this PR.

Otherwise, search if the item is a byproduct on top of just the result of a recipe.
The colouring of "View recipe" has been changed accordingly, see #52685
If it is a byproduct & the player can craft: hint:good
If it is a byproduct & the player cannot craft: hint:iffy
Else hint:cannot

Then, if the player can craft, open the crafting menu with the filter set to "r: &lt;item name&gt;".

Open it as usual:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/2815c0e3-1c54-45c1-80af-9c20a49cff25)
Example long string:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/688cdf09-8b2c-49b1-9a18-df41a62310fd)

Example buttermilk:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/2f605041-d089-40fc-b356-0456a1460fe7)
When pressing `f`ilter you can see the filter that has been passed
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/7528195a-1cb8-4a50-b493-9091df1ad171)


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Make a function for deciding if a recipe exists and if Character can make it, as it is used at two places and the code is identical.
The return would be pair<bool, bool> (recipe_exists, character_can_craft). or enum or int expressing the options.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
View recipes of lye, long string, and 2-by-sword.
View them with a character that knows the recipes and a character that doesn't.
Try to view a recipe of a matchbook, that doesn't have one.


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
