### PR TITLE
Fix overflow when using cash card charges

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10727,7 +10727,8 @@ int item::ammo_consume( int qty, const tripoint &pos, Character *carrier )
 
     // Modded tools can consume UPS/bionic energy instead of ammo.
     // Guns handle energy in energy_consume()
-    if( carrier != nullptr && type->tool ) {
+    if( carrier != nullptr && type->tool &&
+        ( has_flag( flag_USE_UPS ) || has_flag( flag_USES_BIONIC_POWER ) ) ) {
         units::energy wanted_energy = units::from_kilojoule( qty );
 
         if( has_flag( flag_USE_UPS ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix overflow when using cash card charges"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #67279 

#### Describe the solution

Got hit by the bug described in #67279 today. An overflow happens in `ammo_consume` when using more than 2147 charges of a cash card (`from_kilojoule` internally scales by 1,000,000 to convert to mJ, so it hits the limit rather quickly): 

https://github.com/CleverRaven/Cataclysm-DDA/blob/0997bfcc9474823f8ff766d57de5d4fec4f22f55/src/item.cpp#L10730-L10746

This is then converted back to a quantity and subtracted, leaving only 2147 charges to be subtracted from the next cash card.

Clearly this branch should not even be hit by cash cards. I've added the proper flag checks, which fixes the issue.

#### Describe alternatives you've considered

None

#### Testing

Tested ATM deposits with more than one cash card in character's inventory. Depositing the full amount of all cash cards fully removes all charges. Lower amounts properly drain successive cards until the requested amount has been reached.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
