### PR TITLE
Fix furniture & vehicle map memory refresh

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1855,10 +1855,6 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     //Memorize everything the character just saw even if it wasn't displayed.
     for( int mem_y = min_visible.y; mem_y <= max_visible.y; mem_y++ ) {
         for( int mem_x = min_visible.x; mem_x <= max_visible.x; mem_x++ ) {
-            const point colrow = player_to_tile( { mem_x, mem_y } );
-            if( top_any_tile_range.contains( colrow ) ) {
-                continue;
-            }
             const tripoint p( mem_x, mem_y, center.z );
             lit_level lighting = ch.visibility_cache[p.x][p.y];
             // `apply_vision_effects` does not memorize anything so we only need
@@ -1877,6 +1873,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             //bypass cache check in case we learn something new about the terrain's connections
             draw_terrain( p, lighting, height_3d, invisible, true );
             if( here.memory_cache_dec_is_dirty( p ) ) {
+                you.memorize_clear_decoration( here.getglobal( p ), "" );
                 draw_furniture( p, lighting, height_3d, invisible, true );
                 draw_trap( p, lighting, height_3d, invisible, true );
                 draw_part_con( p, lighting, height_3d, invisible, true );

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1855,6 +1855,10 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     //Memorize everything the character just saw even if it wasn't displayed.
     for( int mem_y = min_visible.y; mem_y <= max_visible.y; mem_y++ ) {
         for( int mem_x = min_visible.x; mem_x <= max_visible.x; mem_x++ ) {
+            const point colrow = player_to_tile( { mem_x, mem_y } );
+            if( is_isometric() && top_any_tile_range.contains( colrow ) ) {
+                continue;
+            }
             const tripoint p( mem_x, mem_y, center.z );
             lit_level lighting = ch.visibility_cache[p.x][p.y];
             // `apply_vision_effects` does not memorize anything so we only need


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix furniture & vehicle map memory refresh"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

There have been a number of cases where player map memory becomes out of sync with the actual map state, but does not update correctly even after the player sees the updated tile. I have experienced this with NPCs deconstructing things out of sight, and had cases where vehicles leave ghosted parts in memory, usually during creative acts of destruction. 
#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

The root cause of this issue is two-fold: 1/ A change to parts of the draw code relating to isometric mode removed an is_isometric check, causing memory updates to be skipped under certain circumstances, and 2/ The code to update player memory on tile flagged with dirty decorator memory did not first remove decorators before updating the memory, allowing for ghost entries to remain.
#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Loathe entering my home base when I've allowed NPCs to deconstruct things outside of my watchful gaze.
#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

1. Set construction zone for deconstruction of furniture outside of line of sight.
2. Order NPC to deconstruct furniture
3. Observe message about deconstruction, memory of unseen area remains the same
4. Visit area, move back out of line of sight
5. Observe updated memory with properly removed furniture and in-progress deconstruction decorators.
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

To date, this has been addressed with workarounds for specific cases (such as dragging items with blocked vision, #66327 ). While better than the alternative of a trail of dragged furniture stuck in memory, it's removal of things from memory while un-sighted does not accurately represent the players knowledge of the world state around them.

A lot of exiting placement and removal functions (i.e. construction, deconstruction, traps, etc) check specifically on player line of sight for updating memory state. In the future it may be worth considering the exact nature of how this knowledge is gained or lost, particularly as NPCs become for functionally relevant to game play.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
