### PR TITLE
[Object Creator] Add checks to spell properties to prevent crash

### DIFF
--- a/object_creator/spell_window.cpp
+++ b/object_creator/spell_window.cpp
@@ -395,7 +395,7 @@ creator::spell_window::spell_window( QWidget *parent, Qt::WindowFlags flags )
     base_energy_cost_box.setMinimum( 0 );
     QObject::connect( &base_energy_cost_box, &QSpinBox::textChanged,
     [&]() {
-        void base_energy_cost_box_textchanged();
+        base_energy_cost_box_textchanged();
     } );
 
     energy_increment_box.setToolTip( QString(
@@ -1012,7 +1012,7 @@ void creator::spell_window::final_casting_time_box_textchanged()
 void creator::spell_window::base_energy_cost_box_textchanged()
 {
     editable_spell.base_energy_cost.min.dbl_val = base_energy_cost_box.value();
-    if(editable_spell.energy_increment.min.dbl_val.has_value()) {
+    if( editable_spell.energy_increment.min.dbl_val.has_value() ) {
         if( editable_spell.energy_increment.min.dbl_val.value() > 0.0f ) {
             final_energy_cost_box.setValue( std::max( final_energy_cost_box.value(),
                                             static_cast<int>( editable_spell.base_energy_cost.min.dbl_val.value() ) ) );
@@ -1051,9 +1051,11 @@ void creator::spell_window::min_damage_box_textchanged()
     editable_spell.min_damage.min.dbl_val = min_damage_box.value();
     if(editable_spell.damage_increment.min.dbl_val.has_value()) {
         if( editable_spell.damage_increment.min.dbl_val.value() > 0.0f ) {
-            max_damage_box.setValue( std::max( max_damage_box.value(), static_cast<int>( editable_spell.min_damage.min.dbl_val.value() ) ) );
+            max_damage_box.setValue( std::max( max_damage_box.value(), 
+                                        static_cast<int>( editable_spell.min_damage.min.dbl_val.value() ) ) );
         } else if( editable_spell.damage_increment.min.dbl_val.value() < 0.0f ) {
-            max_damage_box.setValue( std::min( max_damage_box.value(), static_cast<int>( editable_spell.min_damage.min.dbl_val.value() ) ) );
+            max_damage_box.setValue( std::min( max_damage_box.value(), 
+                                        static_cast<int>( editable_spell.min_damage.min.dbl_val.value() ) ) );
         } else {
             max_damage_box.setValue( editable_spell.min_damage.min.dbl_val.value() );
         }
@@ -1062,10 +1064,16 @@ void creator::spell_window::min_damage_box_textchanged()
     write_json();
 }
 
+/*
+* This enforces rules applied to the energy cost increment values
+* If the energy cost increment is positive, the max energy cost should be greater than the min energy cost
+* If the energy cost increment is negative, the max energy cost should be less than the min energy cost
+* If the energy cost increment is 0, the max energy cost should be equal to the min energy cost
+*/
 void creator::spell_window::final_energy_cost_box_textchanged()
 {
     editable_spell.final_energy_cost.min.dbl_val = final_energy_cost_box.value();
-    if(editable_spell.energy_increment.min.dbl_val.has_value()) {
+    if( editable_spell.energy_increment.min.dbl_val.has_value() ) {
         if( editable_spell.energy_increment.min.dbl_val.value() > 0.0f) {
             base_energy_cost_box.setValue( std::min( base_energy_cost_box.value(),
                                         static_cast<int>( editable_spell.final_energy_cost.min.dbl_val.value() ) ) );
@@ -1206,10 +1214,19 @@ void creator::spell_window::populate_fields()
 
 
             base_energy_cost_box.setValue( sp_t.base_energy_cost.min.dbl_val.value() );
+            energy_increment_box.setValue( sp_t.energy_increment.min.dbl_val.value() );
             final_energy_cost_box.setValue( sp_t.final_energy_cost.min.dbl_val.value() );
-            min_range_box.setValue( sp_t.min_range.min.dbl_val.value() );
+            if(sp_t.min_range.min.is_constant()) {
+                min_range_box.setValue( sp_t.min_range.min.dbl_val.value() );
+            } else {
+                min_range_box.setValue( 0 );
+            }
             range_increment_box.setValue( sp_t.range_increment.min.dbl_val.value() );
-            max_range_box.setValue( sp_t.max_range.min.dbl_val.value() );
+            if(sp_t.max_range.min.is_constant()) {
+                max_range_box.setValue( sp_t.max_range.min.dbl_val.value() );
+            } else {
+                max_range_box.setValue( 0 );
+            }
             
             if(sp_t.min_damage.min.is_constant()) {
                 min_damage_box.setValue( sp_t.min_damage.min.dbl_val.value() );
@@ -1222,13 +1239,17 @@ void creator::spell_window::populate_fields()
             } else {
                 max_damage_box.setValue( 0 );
             }
-            if(sp_t.min_aoe.min.dbl_val.has_value()) {
+            if(sp_t.min_aoe.min.is_constant()) {
                 min_aoe_box.setValue( sp_t.min_aoe.min.dbl_val.value() );
             } else {
                 min_aoe_box.setValue( 0 );
             }
             aoe_increment_box.setValue( sp_t.aoe_increment.min.dbl_val.value() );
-            max_aoe_box.setValue( sp_t.max_aoe.min.dbl_val.value() );
+            if(sp_t.max_aoe.min.is_constant()) {
+                max_aoe_box.setValue( sp_t.max_aoe.min.dbl_val.value() );
+            } else {
+                max_aoe_box.setValue( 0 );
+            }
             min_dot_box.setValue( sp_t.min_dot.min.dbl_val.value() );
             dot_increment_box.setValue( sp_t.dot_increment.min.dbl_val.value() );
             max_dot_box.setValue( sp_t.max_dot.min.dbl_val.value() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Add checks to spell property widgets to prevent crash"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Prevent a crash to the application when a spell like `druid_summon_brambles_arc` is selected
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Prevent inserting anything into the spell property widget if the json contains a math function, like in 
https://github.com/CleverRaven/Cataclysm-DDA/blob/575aa13f52bd474ae3767e63fc7857e0756883b5/data/mods/Magiclysm/Spells/druid.json#L924

Now you can't really edit the min_range of that spell using the object creator, that will have to be implemented in a different PR. Right now I am only trying to keep it from crashing.

Also fixed a bug where the base_energy_cost wouldn't update when it changed
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Adding a widget that allows the user to add a math function instead of a number but since the math function comes in a few different fromats, it requires a more in-depth consideration
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Opened in on Linux and Windows and scrolled trough the spell list with the magiclysm mod loaded.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
