### PR TITLE
Compare recipe result with inventory item

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -758,6 +758,13 @@
   },
   {
     "type": "keybinding",
+    "id": "COMPARE",
+    "category": "CRAFTING",
+    "name": "Compare recipe to item in inventory",
+    "bindings": [ { "input_method": "keyboard_char", "key": "I" }, { "input_method": "keyboard_code", "key": "i", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
     "id": "LEVEL_UP",
     "name": "Go up",
     "bindings": [

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -24,8 +24,10 @@
 #include "debug.h"
 #include "display.h"
 #include "flag.h"
+#include "game_inventory.h"
 #include "input.h"
 #include "inventory.h"
+#include "inventory_ui.h"
 #include "item.h"
 #include "item_factory.h"
 #include "itype.h"
@@ -101,6 +103,8 @@ static std::string peek_related_recipe( const recipe *current, const recipe_subs
 static int related_menu_fill( uilist &rmenu,
                               const std::vector<std::pair<itype_id, std::string>> &related_recipes,
                               const recipe_subset &available );
+static item get_recipe_result_item( const recipe &rec, Character &crafter );
+static void compare_recipe_with_item( const item &recipe_item, Character &crafter );
 
 static std::string get_cat_unprefixed( const std::string_view prefixed_name )
 {
@@ -567,6 +571,7 @@ static input_context make_crafting_context( bool highlight_unread_recipes )
     ctxt.register_action( "SELECT" );
     ctxt.register_action( "SCROLL_UP" );
     ctxt.register_action( "SCROLL_DOWN" );
+    ctxt.register_action( "COMPARE" );
     if( highlight_unread_recipes ) {
         ctxt.register_action( "TOGGLE_RECIPE_UNREAD" );
         ctxt.register_action( "MARK_ALL_RECIPES_READ" );
@@ -680,6 +685,30 @@ void recipe_result_info_cache::get_item_header( item &dummy_item, const int quan
     }
 }
 
+static item get_recipe_result_item( const recipe &rec, Character &crafter )
+{
+    item dummy_result = item( rec.result(), calendar::turn, item::default_charges_tag{} );
+    if( !rec.variant().empty() ) {
+        dummy_result.set_itype_variant( rec.variant() );
+    }
+    //Check if recipe result is a clothing item that can be properly fitted
+    if( dummy_result.has_flag( flag_VARSIZE ) && !dummy_result.has_flag( flag_FIT ) ) {
+        //Check if it can actually fit.  If so, list the fitted info
+        item::sizing general_fit = dummy_result.get_sizing( crafter );
+        if( general_fit == item::sizing::small_sized_small_char ||
+            general_fit == item::sizing::human_sized_human_char ||
+            general_fit == item::sizing::big_sized_big_char ||
+            general_fit == item::sizing::ignore ) {
+            dummy_result.set_flag( flag_FIT );
+        }
+    }
+    if( dummy_result.count_by_charges() ) {
+        dummy_result.charges = 1;
+    }
+    dummy_result.set_var( "recipe_exemplar", rec.ident().str() );
+    return dummy_result;
+}
+
 item_info_data recipe_result_info_cache::get_result_data( const recipe *rec, const int batch_size,
         int &scroll_pos, const catacurses::window &window )
 {
@@ -710,31 +739,13 @@ item_info_data recipe_result_info_cache::get_result_data( const recipe *rec, con
     std::vector<iteminfo> details_info;
 
     //Make a temporary item for the result.  NOTE: If the result would normally be in a container, this is not.
-    item dummy_result = item( rec->result(), calendar::turn, item::default_charges_tag{} );
+    item dummy_result = get_recipe_result_item( *rec, crafter );
     std::string result_description;
     if( dummy_result.is_null() ) {
         result_description = rec->description.translated();
     }
-    if( !rec->variant().empty() ) {
-        dummy_result.set_itype_variant( rec->variant() );
-    }
-    //Check if recipe result is a clothing item that can be properly fitted
-    if( dummy_result.has_flag( flag_VARSIZE ) && !dummy_result.has_flag( flag_FIT ) ) {
-        //Check if it can actually fit.  If so, list the fitted info
-        item::sizing general_fit = dummy_result.get_sizing( crafter );
-        if( general_fit == item::sizing::small_sized_small_char ||
-            general_fit == item::sizing::human_sized_human_char ||
-            general_fit == item::sizing::big_sized_big_char ||
-            general_fit == item::sizing::ignore ) {
-            dummy_result.set_flag( flag_FIT );
-        }
-    }
     bool result_uses_charges = dummy_result.count_by_charges();
     int const makes_amount = rec->makes_amount();
-    if( result_uses_charges ) {
-        dummy_result.charges = 1;
-    }
-    dummy_result.set_var( "recipe_exemplar", rec->ident().str() );
     item dummy_container;
 
     //Several terms are used repeatedly in headers/descriptions, list them here for a single entry/translation point
@@ -1954,6 +1965,9 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
                 recalc = true;
                 recalc_unread = highlight_unread_recipes;
             }
+        } else if( action == "COMPARE" && selection_ok( current, line, false ) ) {
+            const item recipe_result = get_recipe_result_item( *current[line], crafter );
+            compare_recipe_with_item( recipe_result, crafter );
         } else if( action == "HELP_KEYBINDINGS" ) {
             // Regenerate keybinding tips
             ui.mark_resize();
@@ -2091,6 +2105,28 @@ int related_menu_fill( uilist &rmenu,
     }
 
     return np_last;
+}
+
+static void compare_recipe_with_item( const item &recipe_item, Character &crafter )
+{
+    inventory_pick_selector inv_s( crafter );
+
+    inv_s.add_character_items( crafter );
+    inv_s.set_title( _( "Compare" ) );
+    inv_s.set_hint( _( "Select item to compare with." ) );
+
+    if( inv_s.empty() ) {
+        popup( std::string( _( "There are no items to compare." ) ), PF_GET_KEY );
+        return;
+    }
+
+    do {
+        const item_location to_compare = inv_s.execute();
+        if( !to_compare ) {
+            break;
+        }
+        game_menus::inv::compare_items( recipe_item, *to_compare );
+    } while( true );
 }
 
 static bool query_is_yes( const std::string_view query )


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Compare recipe result with inventory item"

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Adds ability to press `I` (capital i) when in `&` crafting screen to compare the result of a recipe with an item from the inventory.
* Use case: "Would this new thing be better than what I have now?"

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

* Uses `I` keybinding, which is the same keybind as the regular "compare two items".
* Moves code from `recipe_result_info_cache::get_result_data` into new function `get_recipe_result_item` so that the comparison can use the correct (fitting) variant of clothing items.
* Reuses existing code in `inventory_pick_selector` for picking an items from inventory to compare to.
* Reuses existing code in `game_menus::inv::compare_items` to show the comparison.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* We might also want to compare recipes not only to items in inventory but also to adjacent items.
* Might also be interesting to compare two recipes to each other, but that might need a totally different ui.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Compared some recipes to items in inventory
* Immediately cancelling the popup that asks for which item to compare: works.
* Pressing `I` when on a nested crafting category: prompts for selecting a recipe
* Pressing `I` when completely naked and no items in inventory: shows a popup stating that.

![compare-recipe-to-item-1](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/93876012-fb7b-4fba-8ca7-dabe06aad041)

![compare-recipe-to-item-2](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/d6dbd713-159e-4929-91e0-f21b57e9b308)

![compare-recipe-to-item-3](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/ed5c6d21-2366-4b5c-95f9-31793ffdafd7)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
