### PR TITLE
More quick setup debug functions

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -2753,10 +2753,13 @@ int Character::get_free_bionics_slots( const bodypart_id &bp ) const
     return get_total_bionics_slots( bp ) - get_used_bionics_slots( bp );
 }
 
-bionic_uid Character::add_bionic( const bionic_id &b, bionic_uid parent_uid )
+bionic_uid Character::add_bionic( const bionic_id &b, bionic_uid parent_uid,
+                                  bool suppress_debug )
 {
     if( has_bionic( b ) && !b->dupes_allowed ) {
-        debugmsg( "Tried to install bionic %s that is already installed!", b.c_str() );
+        if( !suppress_debug ) {
+            debugmsg( "Tried to install bionic %s that is already installed!", b.c_str() );
+        }
         return 0;
     }
 
@@ -2775,7 +2778,7 @@ bionic_uid Character::add_bionic( const bionic_id &b, bionic_uid parent_uid )
     }
 
     for( const bionic_id &inc_bid : b->included_bionics ) {
-        add_bionic( inc_bid, bio_uid );
+        add_bionic( inc_bid, bio_uid, suppress_debug );
     }
 
     for( const std::pair<const spell_id, int> &spell_pair : b->learned_spells ) {

--- a/src/character.h
+++ b/src/character.h
@@ -1688,7 +1688,7 @@ class Character : public Creature, public visitable
         /** Removes a bionic from my_bionics[] */
         void remove_bionic( const bionic &bio );
         /** Adds a bionic to my_bionics[] */
-        bionic_uid add_bionic( const bionic_id &b, bionic_uid parent_uid = 0 );
+        bionic_uid add_bionic( const bionic_id &b, bionic_uid parent_uid = 0, bool suppress_debug = false );
         /**Calculate skill bonus from tiles in radius*/
         float env_surgery_bonus( int radius ) const;
         /** Calculate skill for (un)installing bionics */

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -3596,7 +3596,7 @@ void debug()
         case debug_menu_index::SIX_MILLION_DOLLAR_SURVIVOR: {
             Character &u = get_avatar();
             for( bionic_data bionic : bionic_data::get_all() ) {
-                u.add_bionic( bionic.id );
+                u.add_bionic( bionic.id, 0, true );
             }
             break;
         }

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -31,6 +31,7 @@
 #include "achievement.h"
 #include "action.h"
 #include "avatar.h"
+#include "bionics.h"
 #include "bodypart.h"
 #include "calendar.h"
 #include "calendar_ui.h"
@@ -98,6 +99,7 @@
 #include "recipe_dictionary.h"
 #include "relic.h"
 #include "rng.h"
+#include "skill.h"
 #include "sounds.h"
 #include "stomach.h"
 #include "string_formatter.h"
@@ -247,6 +249,9 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::EXPORT_FOLLOWER: return "EXPORT_FOLLOWER";
         case debug_menu::debug_menu_index::EXPORT_SELF: return "EXPORT_SELF";
 		case debug_menu::debug_menu_index::QUICK_SETUP: return "QUICK_SETUP";
+		case debug_menu::debug_menu_index::TOGGLE_SETUP_MUTATION: return "TOGGLE_SETUP_MUTATION";
+		case debug_menu::debug_menu_index::NORMALIZE_BODY_STAT: return "NORMALIZE_BODY_STAT";
+		case debug_menu::debug_menu_index::SIX_MILLION_DOLLAR_SURVIVOR: return "SIX_MILLION_DOLLAR_SURVIVOR";
         // *INDENT-ON*
         case debug_menu::debug_menu_index::last:
             break;
@@ -588,6 +593,9 @@ static int quick_setup_uilist()
 {
     const std::vector<uilist_entry> uilist_initializer = {
         { uilist_entry( debug_menu_index::QUICK_SETUP, true, 'Q', _( "Quick setup…" ) ) },
+        { uilist_entry( debug_menu_index::TOGGLE_SETUP_MUTATION, true, 't', _( "Toggle debug mutations" ) ) },
+        { uilist_entry( debug_menu_index::NORMALIZE_BODY_STAT, true, 'n', _( "Normalize body stats" ) ) },
+        { uilist_entry( debug_menu_index::SIX_MILLION_DOLLAR_SURVIVOR, true, 'B', _( "Install ALL bionics" ) ) },
     };
 
     return uilist( _( "Quick setup…" ), uilist_initializer );
@@ -2697,6 +2705,18 @@ void debug()
 
     get_event_bus().send<event_type::uses_debug_menu>( *action );
 
+    // Used for quick setup, constructed outside the switches to reduce duplicate code
+    std::vector<trait_id> setup_traits;
+    setup_traits.emplace_back( trait_DEBUG_BIONICS );
+    setup_traits.emplace_back( trait_DEBUG_CLAIRVOYANCE );
+    setup_traits.emplace_back( trait_DEBUG_CLOAK );
+    setup_traits.emplace_back( trait_DEBUG_HS );
+    setup_traits.emplace_back( trait_DEBUG_LS );
+    setup_traits.emplace_back( trait_DEBUG_MANA );
+    setup_traits.emplace_back( trait_DEBUG_NODMG );
+    setup_traits.emplace_back( trait_DEBUG_NOTEMP );
+    setup_traits.emplace_back( trait_DEBUG_SPEED );
+
     avatar &player_character = get_avatar();
     map &here = get_map();
     switch( *action ) {
@@ -3515,16 +3535,6 @@ void debug()
         }
 
         case debug_menu_index::QUICK_SETUP: {
-            std::vector<trait_id> setup_traits;
-            setup_traits.emplace_back( trait_DEBUG_BIONICS );
-            setup_traits.emplace_back( trait_DEBUG_CLAIRVOYANCE );
-            setup_traits.emplace_back( trait_DEBUG_CLOAK );
-            setup_traits.emplace_back( trait_DEBUG_HS );
-            setup_traits.emplace_back( trait_DEBUG_LS );
-            setup_traits.emplace_back( trait_DEBUG_MANA );
-            setup_traits.emplace_back( trait_DEBUG_NODMG );
-            setup_traits.emplace_back( trait_DEBUG_NOTEMP );
-            setup_traits.emplace_back( trait_DEBUG_SPEED );
             Character &u = get_avatar();
             u.clear_bionics();
             u.clear_effects();
@@ -3533,17 +3543,61 @@ void debug()
             u.clear_vitamins();
             u.set_all_parts_hp_to_max();
             u.set_fatigue( 0 );
+            u.set_focus( 100 );
             u.set_hunger( 0 );
+            // Specifically only adds mutations instead of toggling them.
             u.set_mutations( setup_traits );
             u.set_pain( 0 );
-            // Ideally, delete all held and worn items? (Then add debug backpack as worn item?)
-            // u.remove_items_with();
+            // Drop all items
+            u.remove_weapon();
+            for( const item_location loc : u.top_items_loc() ) {
+                u.drop( loc, u.pos() );
+            }
+            item backpack( "debug_backpack" );
+            u.wear_item( backpack );
             u.set_rad( 0 );
-            // This would require a lot more declarations or a bunch more code, so no skill levels being set (for now)
-            // u.set_skill_level(skill_archery, 10);
+            for( const std::pair<const skill_id, SkillLevel> &pair : u.get_all_skills() ) {
+                u.set_skill_level( pair.first, 10 );
+            }
             u.set_sleep_deprivation( 0 );
+            u.set_stamina( u.get_stamina_max() );
             u.set_stored_kcal( u.get_healthy_kcal() );
             u.set_thirst( 0 );
+            break;
+        }
+
+        case debug_menu_index::TOGGLE_SETUP_MUTATION: {
+            Character &u = get_avatar();
+            for( trait_id &trait : setup_traits ) {
+                u.toggle_trait( trait );
+            }
+            break;
+        }
+
+        case debug_menu_index::NORMALIZE_BODY_STAT: {
+            Character &u = get_avatar();
+            // Maybe separate this out into a function so it isn't duplicated from quick setup?
+            u.clear_effects();
+            u.clear_morale();
+            u.clear_vitamins();
+            u.set_all_parts_hp_to_max();
+            u.set_fatigue( 0 );
+            u.set_focus( 100 );
+            u.set_hunger( 0 );
+            u.set_pain( 0 );
+            u.set_rad( 0 );
+            u.set_sleep_deprivation( 0 );
+            u.set_stamina( u.get_stamina_max() );
+            u.set_stored_kcal( u.get_healthy_kcal() );
+            u.set_thirst( 0 );
+            break;
+        }
+
+        case debug_menu_index::SIX_MILLION_DOLLAR_SURVIVOR: {
+            Character &u = get_avatar();
+            for( bionic_data bionic : bionic_data::get_all() ) {
+                u.add_bionic( bionic.id );
+            }
             break;
         }
 

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2664,6 +2664,24 @@ static cata_path prepare_export_dir_and_find_unused_name( const std::string &cha
     return ret;
 }
 
+static void normalize_body()
+{
+    Character &u = get_avatar();
+    u.clear_effects();
+    u.clear_morale();
+    u.clear_vitamins();
+    u.set_all_parts_hp_to_max();
+    u.set_fatigue( 0 );
+    u.set_focus( 100 );
+    u.set_hunger( 0 );
+    u.set_pain( 0 );
+    u.set_rad( 0 );
+    u.set_sleep_deprivation( 0 );
+    u.set_stamina( u.get_stamina_max() );
+    u.set_stored_kcal( u.get_healthy_kcal() );
+    u.set_thirst( 0 );
+}
+
 void debug()
 {
     bool debug_menu_has_hotkey = hotkey_for_action( ACTION_DEBUG,
@@ -3536,33 +3554,16 @@ void debug()
 
         case debug_menu_index::QUICK_SETUP: {
             Character &u = get_avatar();
-            u.clear_bionics();
-            u.clear_effects();
-            u.clear_morale();
-            u.clear_mutations();
-            u.clear_vitamins();
-            u.set_all_parts_hp_to_max();
-            u.set_fatigue( 0 );
-            u.set_focus( 100 );
-            u.set_hunger( 0 );
+            normalize_body();
             // Specifically only adds mutations instead of toggling them.
             u.set_mutations( setup_traits );
-            u.set_pain( 0 );
-            // Drop all items
             u.remove_weapon();
-            for( const item_location loc : u.top_items_loc() ) {
-                u.drop( loc, u.pos() );
-            }
+            u.clear_worn();
             item backpack( "debug_backpack" );
             u.wear_item( backpack );
-            u.set_rad( 0 );
             for( const std::pair<const skill_id, SkillLevel> &pair : u.get_all_skills() ) {
                 u.set_skill_level( pair.first, 10 );
             }
-            u.set_sleep_deprivation( 0 );
-            u.set_stamina( u.get_stamina_max() );
-            u.set_stored_kcal( u.get_healthy_kcal() );
-            u.set_thirst( 0 );
             break;
         }
 
@@ -3575,29 +3576,17 @@ void debug()
         }
 
         case debug_menu_index::NORMALIZE_BODY_STAT: {
-            Character &u = get_avatar();
-            // Maybe separate this out into a function so it isn't duplicated from quick setup?
-            u.clear_effects();
-            u.clear_morale();
-            u.clear_vitamins();
-            u.set_all_parts_hp_to_max();
-            u.set_fatigue( 0 );
-            u.set_focus( 100 );
-            u.set_hunger( 0 );
-            u.set_pain( 0 );
-            u.set_rad( 0 );
-            u.set_sleep_deprivation( 0 );
-            u.set_stamina( u.get_stamina_max() );
-            u.set_stored_kcal( u.get_healthy_kcal() );
-            u.set_thirst( 0 );
+            normalize_body();
             break;
         }
 
         case debug_menu_index::SIX_MILLION_DOLLAR_SURVIVOR: {
             Character &u = get_avatar();
-            for( bionic_data bionic : bionic_data::get_all() ) {
+            for( const bionic_data &bionic : bionic_data::get_all() ) {
                 u.add_bionic( bionic.id, 0, true );
             }
+            // Prevent synthetic lungs/etc from instantly suffocating you. This is bad for testing!
+            u.set_power_level( 2500_kJ );
             break;
         }
 

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -102,6 +102,9 @@ enum class debug_menu_index : int {
     EXPORT_FOLLOWER,
     EXPORT_SELF,
     QUICK_SETUP,
+    TOGGLE_SETUP_MUTATION,
+    NORMALIZE_BODY_STAT,
+    SIX_MILLION_DOLLAR_SURVIVOR,
     last
 };
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The debug menu can take a lot of keypresses and waffling to do simple things that you will want to do *a lot* when debugging.

#### Describe the solution
Make it even easier for anyone that needs to test content by adding new debug functions.

-Touch up the quick setup option (now covers focus, stamina, adds all skills to 10, and strips gear/provides debug backpack )

-New function to **toggle** the most useful debug mutations. Turn them on or turn them off, all at once, without affecting anything else!

-New option to normalize body stats (e.g. sets hp/stamina/focus to max, reduces hunger/thirst/rads to 0, etc)

-New option to install one of every bionic (instead of having to quick setup/add bionic installation and then spawn each and every bionic you need to test and manually activate them)

#### Describe alternatives you've considered
I thought about adding a function for learning all spells, but there's *so many spells* it might be patently useless?

#### Testing
All bionics being installed in just a few keypresses:
https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/f2877ed6-e18e-42af-a271-f7582a48fed4

#### Additional context
The skill and bionic parts loop through **all** skills and **all** bionics so they should be future-proofed against any removals/additions, and should work regardless of what mods may be loaded.