### PR TITLE
Insert new response to more suitable place for the exist topic

### DIFF
--- a/data/mods/Xedra_Evolved/npc/draco_dune.json
+++ b/data/mods/Xedra_Evolved/npc/draco_dune.json
@@ -2,6 +2,7 @@
   {
     "id": "TALK_REFUGEE_Draco_1a",
     "type": "talk_topic",
+    "insert_before_standard_exits": true,
     "responses": [ { "text": "Have you seen anything that could help me?", "topic": "TALK_REFUGEE_Draco_changeling_breadcrumb" } ]
   },
   {

--- a/data/mods/Xedra_Evolved/npc/mr_lapin.json
+++ b/data/mods/Xedra_Evolved/npc/mr_lapin.json
@@ -2,6 +2,7 @@
   {
     "id": "TALK_WARRENER",
     "type": "talk_topic",
+    "insert_before_standard_exits": true,
     "responses": [ { "text": "What can you tell me about Xedra?", "topic": "TALK_WARRENER_XEDRA" } ]
   },
   {

--- a/data/mods/Xedra_Evolved/npc/rubik.json
+++ b/data/mods/Xedra_Evolved/npc/rubik.json
@@ -2,6 +2,7 @@
   {
     "id": "TALK_EXODII_MERCHANT_Talk",
     "type": "talk_topic",
+    "insert_before_standard_exits": true,
     "responses": [
       { "text": "What can you tell me about Xedra?", "topic": "TALK_EXODII_MERCHANT_XEDRA" },
       { "text": "What can you tell me about these faeries?", "topic": "TALK_EXODII_MERCHANT_FAE" },

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -395,6 +395,17 @@ Format:
 #### `type`
 Must always be there and must always be `"talk_topic"`.
 
+#### `"insert_before_standard_exits"`
+For mod usage to insert dialogue above the `TALK_DONE` and `TALK_NONE` lines. Defaults to false.
+```json
+  {
+    "id": "TALK_REFUGEE_Draco_1a",
+    "type": "talk_topic",
+    "insert_before_standard_exits": true,
+    "responses": [ { "text": "Have you seen anything that could help me?", "topic": "TALK_REFUGEE_Draco_changeling_breadcrumb" } ]
+  }
+```
+
 #### `id`
 The topic id can be one of the built-in topics or a new id. However, if several talk topics *in json* have the same id, the last topic definition will override the previous ones.
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6058,8 +6058,25 @@ void json_talk_topic::load( const JsonObject &jo )
             }
         }
     }
-    for( JsonObject response : jo.get_array( "responses" ) ) {
-        responses.emplace_back( response );
+    bool insert_above_bottom = false;
+    if( jo.has_bool( "insert_above_bottom" ) ) {
+        insert_above_bottom = jo.get_bool( "insert_above_bottom" );
+    }
+    if ( !insert_above_bottom || responses.empty() ) {
+        for( JsonObject response : jo.get_array( "responses" ) ) {
+            responses.emplace_back( response );
+        }
+    } else {
+        int dec_count = 0;
+        if ( responses.size() >= 1 && responses[ responses.size() - 1].get_actual_response().success.next_topic.id == "TALK_DONE" ) {
+            dec_count = 1;
+        }
+        if ( responses.size() >= 2 && responses[ responses.size() - 2].get_actual_response().success.next_topic.id == "TALK_NONE" ) {
+            dec_count = 2;
+        }
+        for( JsonObject response : jo.get_array( "responses" ) ) {
+            responses.emplace( responses.end() - dec_count, response );
+        }
     }
     if( jo.has_object( "repeat_responses" ) ) {
         repeat_responses.emplace_back( jo.get_object( "repeat_responses" ) );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6062,16 +6062,18 @@ void json_talk_topic::load( const JsonObject &jo )
     if( jo.has_bool( "insert_above_bottom" ) ) {
         insert_above_bottom = jo.get_bool( "insert_above_bottom" );
     }
-    if ( !insert_above_bottom || responses.empty() ) {
+    if( !insert_above_bottom || responses.empty() ) {
         for( JsonObject response : jo.get_array( "responses" ) ) {
             responses.emplace_back( response );
         }
     } else {
         int dec_count = 0;
-        if ( responses.size() >= 1 && responses[ responses.size() - 1].get_actual_response().success.next_topic.id == "TALK_DONE" ) {
+        if( responses.size() >= 1 &&
+            responses[ responses.size() - 1].get_actual_response().success.next_topic.id == "TALK_DONE" ) {
             dec_count = 1;
         }
-        if ( responses.size() >= 2 && responses[ responses.size() - 2].get_actual_response().success.next_topic.id == "TALK_NONE" ) {
+        if( responses.size() >= 2 &&
+            responses[ responses.size() - 2].get_actual_response().success.next_topic.id == "TALK_NONE" ) {
             dec_count = 2;
         }
         for( JsonObject response : jo.get_array( "responses" ) ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -6059,8 +6059,8 @@ void json_talk_topic::load( const JsonObject &jo )
         }
     }
     bool insert_above_bottom = false;
-    if( jo.has_bool( "insert_above_bottom" ) ) {
-        insert_above_bottom = jo.get_bool( "insert_above_bottom" );
+    if( jo.has_bool( "insert_before_standard_exits" ) ) {
+        insert_above_bottom = jo.get_bool( "insert_before_standard_exits" );
     }
     if( !insert_above_bottom || responses.empty() ) {
         for( JsonObject response : jo.get_array( "responses" ) ) {
@@ -6068,8 +6068,8 @@ void json_talk_topic::load( const JsonObject &jo )
         }
     } else {
         int dec_count = 0;
-        if( responses.size() >= 1 &&
-            responses[ responses.size() - 1].get_actual_response().success.next_topic.id == "TALK_DONE" ) {
+        if( !responses.empty() &&
+            responses.back().get_actual_response().success.next_topic.id == "TALK_DONE" ) {
             dec_count = 1;
         }
         if( responses.size() >= 2 &&
@@ -6287,3 +6287,4 @@ const json_talk_topic *get_talk_topic( const std::string &id )
     }
     return &it->second;
 }
+


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "talk_topic option for insert new responses at the suitable place to existing topic"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
For modding. If we want to add a new response to the existent talk topic for a conversation with a follower.
```
  {
    "id": "TALK_ALLY_SOCIAL",
    "type": "talk_topic",
    "responses": [
      { "text": "What do you think of our current situation?", "topic": "TALK_ASK_CURRENT_SITUATION" }
    ]
  },
```
The response(s) I added is placed at the end.
![20230917a](https://github.com/CleverRaven/Cataclysm-DDA/assets/109350502/3d2c8100-4735-49e3-baa5-3a4ddfbe5ed2)

I would prefer that it be placed above [d] (i.e., above `TALK_NONE` [d] and `TAKL_DONE` [e] ). This is because I think it is better that the response to return to the topic(`TALK_NONE`) and the response to end the conversation(`TALK_DONE`) basically be placed at the end of responses, for playability.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I have set up new field named `insert_before_standard_exits` on the `talk_topic` and to create a process that will place the response above `TALK_NONE` and `TALK_DONE` (if they exist and are placed at bottom in responses) when this is turned on.

```
  {
    "id": "TALK_ALLY_SOCIAL",
    "type": "talk_topic",
    "insert_before_standard_exits": true,
    "responses": [
      { "text": "What do you think of our current situation?", "topic": "TALK_ASK_CURRENT_SITUATION" }
    ]
  },
```
Then, 
![20230917b](https://github.com/CleverRaven/Cataclysm-DDA/assets/109350502/37aaaf51-b570-491e-9234-0f44bcaba746)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I tried to see if I could get the desired behavior with the existing features, but as far as I could research, it was not possible, so I added a new function.
**If such a thing is already possible with the existing features, please let me know.** I will gladly withdraw it.

I don't think this is an important feature at all for the common player.
But I think it might be helpful if the creator of a mod that extends an existing system has a nervous disposition that will not tolerate `TALK_NONE` and `TALK_DONE` not being placed at the end of responses, like me.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
In-game testing was completed and no problems.
It will not work unless explicitly turned on in the field, so it is not expected to affect existing play in any way.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I have a bit free time these days, so made this as part of the maintenance of my virtual machine for C++ program development.

Yes, I think there are still some terrible codes, so please correct it if you find appropriate ones.
~~`if ( responses.size() >= 1 && responses[ responses.size() - 1]}`~~
`if ( responses.size() >= 2 && responses[ responses.size() - 2]}`

~~Also, the field name `"insert_above_bottom"` is not good. Alternative are welcome.~~
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
