### PR TITLE
Accessible item insert menu

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2482,6 +2482,13 @@
   },
   {
     "type": "keybinding",
+    "name": "Insert item",
+    "category": "DEFAULTMODE",
+    "id": "insert",
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
+  },
+  {
+    "type": "keybinding",
     "name": "Unload item",
     "category": "DEFAULTMODE",
     "id": "unload",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -237,6 +237,8 @@ std::string action_ident( action_id act )
             return "reload_weapon";
         case ACTION_RELOAD_WIELDED:
             return "reload_wielded";
+        case ACTION_INSERT_ITEM:
+            return "insert";
         case ACTION_UNLOAD:
             return "unload";
         case ACTION_MEND:
@@ -889,6 +891,7 @@ action_id handle_action_menu()
             // Everything below here can be accessed through
             // the inventory screen, so it's sorted to the
             // end of the list.
+            REGISTER_ACTION( ACTION_INSERT_ITEM );
             REGISTER_ACTION( ACTION_UNLOAD_CONTAINER );
             REGISTER_ACTION( ACTION_DROP );
             REGISTER_ACTION( ACTION_COMPARE );

--- a/src/action.h
+++ b/src/action.h
@@ -182,6 +182,8 @@ enum action_id : int {
     ACTION_SELECT_FIRE_MODE,
     /** Cast a spell (only if any spells are known) */
     ACTION_CAST_SPELL,
+    /** Open the insert-item menu */
+    ACTION_INSERT_ITEM,
     /** Unload container in a given direction */
     ACTION_UNLOAD_CONTAINER,
     /** Open the drop-item menu */

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2482,6 +2482,7 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "reload_item" );
     ctxt.register_action( "reload_weapon" );
     ctxt.register_action( "reload_wielded" );
+    ctxt.register_action( "insert" );
     ctxt.register_action( "unload" );
     ctxt.register_action( "throw" );
     ctxt.register_action( "fire" );
@@ -9077,6 +9078,20 @@ game::vmenu_ret game::list_monsters( const std::vector<Creature *> &monster_list
     u.view_offset = stored_view_offset;
 
     return game::vmenu_ret::QUIT;
+}
+
+void game::insert_item()
+{
+    item_location item_loc = inv_map_splice( [&]( const item_location & it ) {
+        return it->is_container() && !it->is_corpse() && rate_action_insert( u, it ) == hint_rating::good;
+    }, _( "Insert item" ), 1, _( "You have no container to insert items." ) );
+
+    if( !item_loc ) {
+        add_msg( _( "Never mind." ) );
+        return;
+    }
+
+    game_menus::inv::insert_items( u, item_loc );
 }
 
 void game::unload_container()

--- a/src/game.h
+++ b/src/game.h
@@ -889,6 +889,7 @@ class game
         // Pick up items from all nearby tiles
         void pickup_all();
 
+        void insert_item(); // Insert items to container  'v'
         void unload_container(); // Unload a container w/ direction  'd'
         void drop_in_direction( const tripoint &pnt ); // Drop w/ direction  'D'
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -2414,6 +2414,10 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
             }
             break;
 
+        case ACTION_INSERT_ITEM:
+            insert_item();
+            break;
+
         case ACTION_UNLOAD_CONTAINER:
             // You CAN drop things to your own tile while in the shell.
             unload_container();


### PR DESCRIPTION
#### Summary
Interface "Accessible item insert menu"

#### Purpose of change
In today's systems that have to manage countless items, it is very important that the feature to explicitly store items in specific containers.
However, the current item insertion menu can only be accessed from the inventory menu, which is very inconvenient.

#### Describe the solution
Adds a shortcut key to instantly call the item insertion menu.

#### Describe alternatives you've considered

#### Testing
Game begin, press "v" key, then the item insertion menu opens. I verified that I can indeed insert items.

#### Additional context
Keys that can be used for shortcuts are limited. I assigned the extra "v" key, but is it better to use a different key?

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13540013/f739428d-309b-4ce5-ad1f-7c4e494458b9)
