### PR TITLE
Ki Strike now works with worn equipment

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1241,7 +1241,7 @@ static void roll_melee_damage_internal( const Character &u, const damage_type_id
 
     // FIXME: Hardcoded damage type effects (bash)
     if( dt == damage_bash ) {
-        if( u.has_trait( trait_KI_STRIKE ) && unarmed && weap.is_null() ) {
+        if( u.has_trait( trait_KI_STRIKE ) && unarmed ) {
             // Pure unarmed doubles the bonuses from unarmed skill
             skill *= 2;
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Ki Strike now works with worn equipment"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Ki Strike now works with worn equipment when using a technique with the appropriate attack vector. 

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
This simple change fixes a bug that was causing Ki Strike to not give its bonus damage if the player was wearing something in the location used by an attack vector. For example, punching while wearing gloves wouldn't get extra damage from Ki Strike. As it stands now, as long as your hands are free (not holding anything) you will get bonus damage from Ki Strike.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Ki Strike was made before Attack Vectors were added to the game and due to the way the code is written, Attack Vectors treats the worn item as a "weapon" which was disabling Ki Strike. Some might argue that things like worn claws shouldn't benefit from Ki Strike but due to the way the game is coded, ANYTHING worn will disable Ki Strike including things like a baseball cap, shoes, and even socks. Ultimately, Ki Strike is in the MMA mod where balance isn't a big of a concern. And even it if was, Unarmed styles are still MUCH lower in damage than Melee styles even with Ki Strike and strong worn equipment.

