### PR TITLE
Switch crafter in crafting menu to and from an ally

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -3481,6 +3481,11 @@ class Character : public Creature, public visitable
         bool can_continue_craft( item &craft, const requirement_data &continue_reqs );
         /** Return nearby Characters ready and willing to help with crafting. */
         std::vector<Character *> get_crafting_helpers() const;
+        /**
+         * Return group of ally characters sharing knowledge of crafting.
+         * Unlike get_crafting_helpers, includes the caller and sleeping Characters.
+         */
+        std::vector<Character *> get_crafting_group() const;
         int get_num_crafting_helpers( int max ) const;
         /**
          * Handle skill gain for player and followers during crafting.

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -356,15 +356,16 @@ void Character::craft( const std::optional<tripoint> &loc, const recipe_id &goto
                        const std::string &filterstring )
 {
     int batch_size = 0;
-    const recipe *rec = select_crafting_recipe( batch_size, goto_recipe, this, filterstring );
+    const auto [crafter, rec] = select_crafter_and_crafting_recipe( batch_size, goto_recipe, this,
+                                filterstring );
     if( rec ) {
         std::string reason;
         if( is_npc() && !rec->npc_can_craft( reason ) ) {
             add_msg( m_info, reason );
             return;
         }
-        if( crafting_allowed( *this, *rec ) ) {
-            make_craft( rec->ident(), batch_size, loc );
+        if( crafting_allowed( *crafter, *rec ) ) {
+            crafter->make_craft( rec->ident(), batch_size, loc );
         }
     }
 }
@@ -381,10 +382,10 @@ void Character::recraft( const std::optional<tripoint> &loc )
 void Character::long_craft( const std::optional<tripoint> &loc, const recipe_id &goto_recipe )
 {
     int batch_size = 0;
-    const recipe *rec = select_crafting_recipe( batch_size, goto_recipe, this );
+    const auto [crafter, rec] = select_crafter_and_crafting_recipe( batch_size, goto_recipe, this );
     if( rec ) {
-        if( crafting_allowed( *this, *rec ) ) {
-            make_all_craft( rec->ident(), batch_size, loc );
+        if( crafting_allowed( *crafter, *rec ) ) {
+            crafter->make_all_craft( rec->ident(), batch_size, loc );
         }
     }
 }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -559,7 +559,7 @@ bool Character::can_make( const recipe *r, int batch_size ) const
 {
     const inventory &crafting_inv = crafting_inventory();
 
-    if( !has_recipe( r, crafting_inv, get_crafting_helpers() ) ) {
+    if( !has_recipe( r, crafting_inv, get_crafting_group() ) ) {
         return false;
     }
 
@@ -2978,6 +2978,15 @@ std::vector<Character *> Character::get_crafting_helpers() const
                && guy.is_npc()
                && !guy.in_sleep_state()
                && guy.is_obeying( *this )
+               && rl_dist( guy.pos(), pos() ) < PICKUP_RANGE
+               && get_map().clear_path( pos(), guy.pos(), PICKUP_RANGE, 1, 100 );
+    } );
+}
+
+std::vector<Character *> Character::get_crafting_group() const
+{
+    return g->get_characters_if( [this]( const Character & guy ) {
+        return guy.is_ally( *this )
                && rl_dist( guy.pos(), pos() ) < PICKUP_RANGE
                && get_map().clear_path( pos(), guy.pos(), PICKUP_RANGE, 1, 100 );
     } );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -356,7 +356,7 @@ void Character::craft( const std::optional<tripoint> &loc, const recipe_id &goto
                        const std::string &filterstring )
 {
     int batch_size = 0;
-    const recipe *rec = select_crafting_recipe( batch_size, goto_recipe, *this, filterstring );
+    const recipe *rec = select_crafting_recipe( batch_size, goto_recipe, this, filterstring );
     if( rec ) {
         std::string reason;
         if( is_npc() && !rec->npc_can_craft( reason ) ) {
@@ -381,7 +381,7 @@ void Character::recraft( const std::optional<tripoint> &loc )
 void Character::long_craft( const std::optional<tripoint> &loc, const recipe_id &goto_recipe )
 {
     int batch_size = 0;
-    const recipe *rec = select_crafting_recipe( batch_size, goto_recipe, *this );
+    const recipe *rec = select_crafting_recipe( batch_size, goto_recipe, this );
     if( rec ) {
         if( crafting_allowed( *this, *rec ) ) {
             make_all_craft( rec->ident(), batch_size, loc );

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -602,7 +602,8 @@ const inventory &Character::crafting_inventory( const tripoint &src_pos, int rad
         && moves == crafting_cache.moves
         && radius == crafting_cache.radius
         && calendar::turn == crafting_cache.time
-        && inv_pos == crafting_cache.position ) {
+        && inv_pos == crafting_cache.position
+      ) {
         return *crafting_cache.crafting_inventory;
     }
     crafting_cache.crafting_inventory->clear();
@@ -2972,9 +2973,12 @@ std::vector<Character *> Character::get_crafting_helpers() const
 {
     return g->get_characters_if( [this]( const Character & guy ) {
         // NPCs can help craft if awake, taking orders, within pickup range and have clear path
-        return getID() != guy.getID() && guy.is_npc() && !guy.in_sleep_state() && guy.is_obeying( *this ) &&
-               rl_dist( guy.pos(), pos() ) < PICKUP_RANGE &&
-               get_map().clear_path( pos(), guy.pos(), PICKUP_RANGE, 1, 100 );
+        return getID() != guy.getID()
+               && guy.is_npc()
+               && !guy.in_sleep_state()
+               && guy.is_obeying( *this )
+               && rl_dist( guy.pos(), pos() ) < PICKUP_RANGE
+               && get_map().clear_path( pos(), guy.pos(), PICKUP_RANGE, 1, 100 );
     } );
 }
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1143,9 +1143,9 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
 {
     recipe_result_info_cache result_info( crafter );
     recipe_info_cache r_info_cache;
-    int recipe_info_scroll = 0;
-    int item_info_scroll = 0;
-    int item_info_scroll_popup = 0;
+    int line_recipe_info = 0;
+    int line_item_info = 0;
+    int line_item_info_popup = 0;
     const int headHeight = 3;
     const int subHeadHeight = 2;
 
@@ -1428,20 +1428,17 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
                                                    recp, avail, crafter, qry_comps, batch_size, fold_width, color );
 
             const int total_lines = info.size();
-            recipe_info_scroll = clamp( recipe_info_scroll, 0, total_lines - dataLines );
-            for( int i = recipe_info_scroll;
-                 i < std::min( recipe_info_scroll + dataLines, total_lines );
-                 ++i ) {
+            line_recipe_info = clamp( line_recipe_info, 0, total_lines - dataLines );
+            for( int i = line_recipe_info; i < std::min( line_recipe_info + dataLines, total_lines ); ++i ) {
                 nc_color dummy = color;
-                print_colored_text( w_data, point( xpos, i - recipe_info_scroll ),
-                                    dummy, color, info[i] );
+                print_colored_text( w_data, point( xpos, i - line_recipe_info ), dummy, color, info[i] );
             }
 
             if( total_lines > dataLines ) {
                 scrollbar()
                 .offset_x( xpos + fold_width + 1 )
                 .content_size( total_lines )
-                .viewport_pos( recipe_info_scroll )
+                .viewport_pos( line_recipe_info )
                 .viewport_size( dataLines )
                 .apply( w_data );
             }
@@ -1474,7 +1471,7 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
                             w_iteminfo ) ).apply( w_iteminfo );
                 wnoutrefresh( w_iteminfo );
             } else {
-                item_info_data data = result_info.get_result_data( cur_recipe, batch_size, item_info_scroll,
+                item_info_data data = result_info.get_result_data( cur_recipe, batch_size, line_item_info,
                                       w_iteminfo );
                 data.without_getch = true;
                 data.without_border = true;
@@ -1686,13 +1683,13 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
                 }
             }
         } else if( action == "SCROLL_RECIPE_INFO_UP" ) {
-            recipe_info_scroll -= dataLines;
+            line_recipe_info -= dataLines;
         } else if( action == "SCROLL_UP" && mouse_in_recipe ) {
-            --recipe_info_scroll;
+            --line_recipe_info;
         } else if( action == "SCROLL_RECIPE_INFO_DOWN" ) {
-            recipe_info_scroll += dataLines;
+            line_recipe_info += dataLines;
         } else if( action == "SCROLL_DOWN" && mouse_in_recipe ) {
-            ++recipe_info_scroll;
+            ++line_recipe_info;
         } else if( action == "LEFT" || ( action == "SCROLL_UP" && mouse_in_window( coord, w_subhead ) ) ) {
             if( batch || !filterstring.empty() ) {
                 continue;
@@ -1704,13 +1701,13 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
                      subtab.cur() != "CSC_ALL" ? subtab.cur() : "" ) );
             recalc = true;
         } else if( action == "SCROLL_ITEM_INFO_UP" ) {
-            item_info_scroll -= scroll_item_info_lines;
+            line_item_info -= scroll_item_info_lines;
         } else if( action == "SCROLL_UP" && mouse_in_window( coord, w_iteminfo ) ) {
-            --item_info_scroll;
+            --line_item_info;
         } else if( action == "SCROLL_ITEM_INFO_DOWN" ) {
-            item_info_scroll += scroll_item_info_lines;
+            line_item_info += scroll_item_info_lines;
         } else if( action == "SCROLL_DOWN" && mouse_in_window( coord, w_iteminfo ) ) {
-            ++item_info_scroll;
+            ++line_item_info;
         } else if( action == "PREV_TAB" || ( action == "SCROLL_UP" &&
                                              mouse_in_window( coord, w_head_tabs ) ) ) {
             tab.prev();
@@ -1780,7 +1777,7 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
             recalc_unread = highlight_unread_recipes;
             ui.invalidate_ui();
 
-            item_info_data data = result_info.get_result_data( current[line], 1, item_info_scroll_popup,
+            item_info_data data = result_info.get_result_data( current[line], 1, line_item_info_popup,
                                   w_iteminfo );
             data.handle_scrolling = true;
             draw_item_info( []() -> catacurses::window {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1361,25 +1361,9 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
         mvwputch( w_data, point( width - 1, dataHeight - 1 ), BORDER_COLOR, LINE_XOOX ); // _|
 
         const int max_recipe_name_width = 27;
-        int recmin = 0;
-        int recmax = current.size();
-        int istart = 0;
-        int iend = 0;
-        if( recmax > dataLines ) {
-            if( line <= recmin + dataHalfLines ) {
-                istart = recmin;
-                iend = recmin + dataLines;
-            } else if( line >= recmax - dataHalfLines ) {
-                istart = recmax - dataLines;
-                iend = recmax;
-            } else {
-                istart = line - dataHalfLines;
-                iend = line - dataHalfLines + dataLines;
-            }
-        } else {
-            istart = 0;
-            iend = std::min<int>( current.size(), dataHeight + 1 );
-        }
+        const int recmax = current.size();
+        // pair<int, int>
+        const auto& [istart, iend] = subindex_around_cursor( recmax, dataLines, line );
         list_map.clear();
         for( int i = istart; i < iend; ++i ) {
             if( i >= static_cast<int>( indent.size() ) || indent[i] < 0 ) {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -1138,11 +1138,11 @@ static bool selection_ok( const std::vector<const recipe *> &list, const int cur
     return false;
 }
 
-const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto_recipe,
-                                      Character *crafter, std::string filterstring )
+std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &batch_size_out,
+        const recipe_id &goto_recipe, Character *crafter, std::string filterstring )
 {
     if( crafter == nullptr ) {
-        return nullptr;
+        return {nullptr, nullptr};
     }
     recipe_result_info_cache result_info( *crafter );
     recipe_info_cache r_info_cache;
@@ -1965,7 +1965,7 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
         }
     } while( !done );
 
-    return chosen;
+    return { crafter, chosen };
 }
 
 std::string peek_related_recipe( const recipe *current, const recipe_subset &available,

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -420,12 +420,14 @@ static std::vector<std::string> recipe_info(
                   "recipe <color_yellow>may appear to be craftable "
                   "when it is not</color>.\n" );
     }
-    if( !can_craft_this && avail.apparently_craftable && !recp.is_nested() ) {
-        oss << _( "<color_red>Cannot be crafted because the same item is needed "
-                  "for multiple components</color>\n" );
-    }
     std::string reason;
-    if( !can_craft_this && avail.crafter.is_npc() && !recp.npc_can_craft( reason ) ) {
+    bool npc_cant = avail.crafter.is_npc() && !recp.npc_can_craft( reason );
+    if( !can_craft_this && avail.apparently_craftable && !recp.is_nested() && !npc_cant ) {
+        oss << _( "<color_red>Cannot be crafted because the same item is needed "
+                  "for multiple components.</color>\n" );
+    }
+
+    if( !can_craft_this && npc_cant ) {
         oss << colorize( reason, c_red ) << "\n";
     }
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -196,7 +196,7 @@ struct availability {
                                craft_flags::start_only );
             would_use_favorite = !req.can_make_with_inventory( inv, no_favorite_filter, batch_size,
                                  craft_flags::start_only );
-            would_not_benefit = r->is_practice() && cannot_gain_skill_or_prof( crafter, *r );
+            useless_practice = r->is_practice() && cannot_gain_skill_or_prof( crafter, *r );
             is_nested_category = r->is_nested();
             const requirement_data &simple_req = r->simple_requirements();
             apparently_craftable = ( !r->is_practice() || has_all_skills ) && has_proficiencies &&
@@ -212,7 +212,7 @@ struct availability {
         bool can_craft;
         bool would_use_rotten;
         bool would_use_favorite;
-        bool would_not_benefit;
+        bool useless_practice;
         bool apparently_craftable;
         bool has_proficiencies;
         bool has_all_skills;
@@ -260,7 +260,7 @@ struct availability {
                 return h_dark_gray;
             } else if( is_nested_category ) {
                 return h_light_blue;
-            }  else if( would_use_rotten || would_not_benefit ) {
+            }  else if( would_use_rotten || useless_practice ) {
                 return has_all_skills ? h_brown : h_red;
             } else if( would_use_favorite ) {
                 return has_all_skills ? h_pink : h_red;
@@ -276,7 +276,7 @@ struct availability {
                 return c_dark_gray;
             } else if( is_nested_category ) {
                 return c_light_blue;
-            } else if( would_use_rotten || would_not_benefit ) {
+            } else if( would_use_rotten || useless_practice ) {
                 return has_all_skills || ignore_missing_skills ? c_brown : c_red;
             } else if( would_use_favorite ) {
                 return has_all_skills ? c_pink : c_red;

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -117,8 +117,9 @@ void load_recipe_category( const JsonObject &jsobj )
         jsobj.throw_error( "Crafting category id has to be prefixed with 'CC_'" );
     }
 
-    if( !is_hidden &&
-        std::find( craft_cat_list.begin(), craft_cat_list.end(), category ) == craft_cat_list.end() ) {
+    if( !is_hidden
+        && std::find( craft_cat_list.begin(), craft_cat_list.end(), category ) == craft_cat_list.end()
+      ) {
         craft_cat_list.push_back( category );
     }
 
@@ -713,8 +714,11 @@ item_info_data recipe_result_info_cache::get_result_data( const recipe *rec, con
         /* If the recipe has not changed, return the cached version in info.
            Unfortunately, the separator lines are baked into info at a specific width, so if the terminal width
            has changed, the info needs to be regenerated */
-        if( rec == last_recipe && rec != nullptr && TERMX == last_terminal_width &&
-            batch_size == cached_batch_size ) {
+        if( rec == last_recipe
+            && rec != nullptr
+            && TERMX == last_terminal_width
+            && batch_size == cached_batch_size
+          ) {
             item_info_data data( "", "", info, {}, scroll_pos );
             return data;
         }
@@ -843,7 +847,8 @@ static const std::vector<std::string> &cached_recipe_info( recipe_info_cache &in
         info_cache.qry_comps != qry_comps ||
         info_cache.batch_size != batch_size ||
         info_cache.fold_width != fold_width ||
-        lang_version != detail::get_current_language_version() ) {
+        lang_version != detail::get_current_language_version()
+      ) {
         info_cache.recp = &recp;
         info_cache.qry_comps = qry_comps;
         info_cache.batch_size = batch_size;
@@ -1021,8 +1026,9 @@ static void recursively_expance_recipes( std::vector<const recipe *> &current,
     std::vector<const recipe *> tmp;
     for( const recipe_id &nested : current[i]->nested_category_data ) {
 
-        if( available_recipes.contains( &nested.obj() ) &&
-            hidden_recipes.find( nested ) == hidden_recipes.end() ) {
+        if( available_recipes.contains( &nested.obj() )
+            && hidden_recipes.find( nested ) == hidden_recipes.end()
+          ) {
             // only do this if we can actually craft the recipe
             tmp.push_back( &nested.obj() );
             indent.insert( indent.begin() + i + 1, indent[i] + 2 );
@@ -1071,8 +1077,9 @@ static void expand_recipes( std::vector<const recipe *> &current,
 {
     //TODO Make this more effecient
     for( size_t i = 0; i < current.size(); ++i ) {
-        if( current[i]->is_nested() &&
-            uistate.expanded_recipes.find( current[i]->ident() ) != uistate.expanded_recipes.end() ) {
+        if( current[i]->is_nested()
+            && uistate.expanded_recipes.find( current[i]->ident() ) != uistate.expanded_recipes.end()
+          ) {
             // add all the recipes from the nests
             recursively_expance_recipes( current, indent, availability_cache, i, crafter,
                                          unread_recipes_first, highlight_unread_recipes, available_recipes, hidden_recipes );
@@ -1431,8 +1438,11 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
             }
 
             if( total_lines > dataLines ) {
-                scrollbar().offset_x( xpos + fold_width + 1 ).content_size( total_lines )
-                .viewport_pos( recipe_info_scroll ).viewport_size( dataLines )
+                scrollbar()
+                .offset_x( xpos + fold_width + 1 )
+                .content_size( total_lines )
+                .viewport_pos( recipe_info_scroll )
+                .viewport_size( dataLines )
                 .apply( w_data );
             }
         }
@@ -1442,7 +1452,8 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
         .offset_y( 0 )
         .content_size( recmax )
         .viewport_pos( istart )
-        .viewport_size( dataLines ).apply( w_data );
+        .viewport_size( dataLines )
+        .apply( w_data );
 
         wnoutrefresh( w_data );
 
@@ -1480,8 +1491,7 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
             // When we switch tabs, redraw the header
             recalc = false;
             const recipe *prev_rcp = nullptr;
-            if( keepline && line >= 0
-                && static_cast<size_t>( line ) < current.size() ) {
+            if( keepline && line >= 0 && static_cast<size_t>( line ) < current.size() ) {
                 prev_rcp = current[line];
             }
 

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -436,18 +436,18 @@ static std::vector<std::string> recipe_info(
     if( disp_prof_msg && time_maluses < max_time_malus && skill_maluses < max_skill_malus ) {
         oss << string_format( _( "<color_green>This recipe will be %.2fx faster than normal, "
                                  "and your effective skill will be %.2f levels higher than normal, because of "
-                                 "the proficiencies you have.</color>\n" ),
+                                 "the proficiencies the crafter has.</color>\n" ),
                               max_time_malus / time_maluses, max_skill_malus - skill_maluses );
     } else if( disp_prof_msg && time_maluses < max_time_malus ) {
         oss << string_format( _( "<color_green>This recipe will be %.2fx faster than normal, "
-                                 "because of the proficiencies you have.</color>\n" ), max_time_malus / time_maluses );
+                                 "because of the proficiencies the crafter has.</color>\n" ), max_time_malus / time_maluses );
     } else if( disp_prof_msg && skill_maluses < max_skill_malus ) {
         oss << string_format(
                 _( "<color_green>Your effective skill will be %.2f levels higher than normal, "
-                   "because of the proficiencies you have.</color>\n" ), max_skill_malus - skill_maluses );
+                   "because of the proficiencies the crafter has.</color>\n" ), max_skill_malus - skill_maluses );
     }
     if( !can_craft_this && !avail.has_proficiencies ) {
-        oss << _( "<color_red>Cannot be crafted because you lack"
+        oss << _( "<color_red>Cannot be crafted because the crafter lacs"
                   " the required proficiencies.</color>\n" );
     }
 
@@ -523,7 +523,7 @@ static std::string practice_recipe_description( const recipe &recp,
         const int player_skill_level = crafter.get_all_skills().get_skill_level( recp.skill_used );
         if( player_skill_level < recp.practice_data->min_difficulty ) {
             std::string txt = string_format(
-                                  _( "You do not possess the minimum <color_cyan>%s</color> skill level required to practice this." ),
+                                  _( "The crafter does not possess the minimum <color_cyan>%s</color> skill level required to practice this." ),
                                   recp.skill_used->name() );
             txt = string_format( "<color_red>%s</color>", txt );
             oss << txt << "\n";
@@ -1761,7 +1761,7 @@ const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto
         } else if( action == "CONFIRM" ) {
             if( available.empty() || ( !available[line].can_craft && !current[line]->is_nested() ) ) {
                 query_popup()
-                .message( "%s", _( "You can't do that!" ) )
+                .message( "%s", _( "Crafter can't craft that!" ) )
                 .option( "QUIT" )
                 .query();
             } else if( current[line]->is_nested() ) {

--- a/src/crafting_gui.cpp
+++ b/src/crafting_gui.cpp
@@ -2212,23 +2212,26 @@ static std::map<size_t, inclusive_rectangle<point>> draw_recipe_tabs( const cata
             break;
         }
         case FILTERED: {
-            mvwhline( w, point( 0, getmaxy( w ) - 1 ), LINE_OXOX, getmaxx( w ) - 1 );
-            mvwputch( w, point( 0, getmaxy( w ) - 1 ), BORDER_COLOR, LINE_OXXO ); // |^
-            const std::string tab_name = _( "Searched" );
+            mvwhline( w, point( 0, getmaxy( w ) - 1 ), LINE_OXOX, getmaxx( w ) - 1 );  // ─
+            mvwputch( w, point( 0, getmaxy( w ) - 1 ), BORDER_COLOR, LINE_OXXO );  // ┌
+            std::string tab_name = _( "Searched" );
+            if( filtered_unread ) {
+                tab_name += " ";  // space for green "+"
+            }
             draw_tab( w, 2, tab_name, true );
             if( filtered_unread ) {
-                mvwprintz( w, point( 3 + utf8_width( tab_name ), 1 ), c_light_green, "⁺" );
+                mvwprintz( w, point( 2 + utf8_width( tab_name ), 1 ), c_light_green, "⁺" );
             }
             break;
         }
         case BATCH:
-            mvwhline( w, point( 0, getmaxy( w ) - 1 ), LINE_OXOX, getmaxx( w ) - 1 );
-            mvwputch( w, point( 0, getmaxy( w ) - 1 ), BORDER_COLOR, LINE_OXXO ); // |^
+            mvwhline( w, point( 0, getmaxy( w ) - 1 ), LINE_OXOX, getmaxx( w ) - 1 );  // ─
+            mvwputch( w, point( 0, getmaxy( w ) - 1 ), BORDER_COLOR, LINE_OXXO );  // ┌
             draw_tab( w, 2, _( "Batch" ), true );
             break;
     }
-    //draw_tabs will produce a border ending with // ^| but that's inappropriate here, so clean it up
-    mvwputch( w, point( getmaxx( w ) - 1, 2 ), BORDER_COLOR, LINE_OXOX ); //_
+    //draw_tabs will produce a border ending with ┐ but that's inappropriate here, so clean it up
+    mvwputch( w, point( getmaxx( w ) - 1, 2 ), BORDER_COLOR, LINE_OXOX );  // ─
     wnoutrefresh( w );
     return tab_map;
 }

--- a/src/crafting_gui.h
+++ b/src/crafting_gui.h
@@ -13,7 +13,7 @@ class JsonObject;
 class recipe;
 
 const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto_recipe,
-                                      Character &crafter, std::string filterstring = "" );
+                                      Character *crafter, std::string filterstring = "" );
 
 void load_recipe_category( const JsonObject &jsobj );
 void reset_recipe_categories();

--- a/src/crafting_gui.h
+++ b/src/crafting_gui.h
@@ -12,8 +12,16 @@ class Character;
 class JsonObject;
 class recipe;
 
-const recipe *select_crafting_recipe( int &batch_size_out, const recipe_id &goto_recipe,
-                                      Character *crafter, std::string filterstring = "" );
+/**
+ * Open crafting menu where user selects who will craft what (the crafter & the recipe).
+ *
+ * @param crafter: who opened the menu - the initial crafter
+ * @param filterstring: initial filter to execute
+ *
+ * Return: if recipe * is not nullptr, then Character * is not nullptr either.
+ */
+std::pair<Character *, const recipe *> select_crafter_and_crafting_recipe( int &batch_size_out,
+        const recipe_id &goto_recipe, Character *crafter, std::string filterstring = "" );
 
 void load_recipe_category( const JsonObject &jsobj );
 void reset_recipe_categories();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1815,7 +1815,7 @@ static hint_rating rate_action_disassemble( avatar &you, const item &it )
 static hint_rating rate_action_view_recipe( avatar &you, const item &it )
 {
     const inventory &inven = you.crafting_inventory();
-    const std::vector<Character *> helpers = you.get_crafting_helpers();
+    const std::vector<Character *> helpers = you.get_crafting_group();
     if( it.is_craft() ) {
         const recipe &craft_recipe = it.get_making();
         if( craft_recipe.is_null() || !craft_recipe.ident().is_valid() ) {

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -6733,7 +6733,7 @@ void iexamine::workbench_internal( Character &you, const tripoint &examp,
                 }
                 const recipe &rec = selected_craft->get_making();
                 const inventory &inv = you.crafting_inventory();
-                if( !you.has_recipe( &rec, inv, you.get_crafting_helpers() ) ) {
+                if( !you.has_recipe( &rec, inv, you.get_crafting_group() ) ) {
                     you.add_msg_player_or_npc(
                         _( "You don't know the recipe for the %s and can't continue crafting." ),
                         _( "<npcname> doesn't know the recipe for the %s and can't continue crafting." ),

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8583,7 +8583,7 @@ std::optional<int> iuse::craft( Character *p, item *it, const tripoint & )
     }
     const recipe &rec = it->get_making();
     const inventory &inv = p->crafting_inventory();
-    if( !p->has_recipe( &rec, inv, p->get_crafting_helpers() ) ) {
+    if( !p->has_recipe( &rec, inv, p->get_crafting_group() ) ) {
         p->add_msg_player_or_npc(
             _( "You don't know the recipe for the %s and can't continue crafting." ),
             _( "<npcname> doesn't know the recipe for the %s and can't continue crafting." ),

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2481,8 +2481,7 @@ bool npc::is_walking_with() const
 
 bool npc::is_obeying( const Character &p ) const
 {
-    return ( p.is_avatar() && is_walking_with() && is_player_ally() ) ||
-           ( is_ally( p ) && is_stationary( true ) );
+    return is_ally( p ) && ( ( p.is_avatar() && is_walking_with() ) || is_stationary( true ) );
 }
 
 bool npc::is_following() const

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1566,12 +1566,12 @@ std::map<size_t, inclusive_rectangle<point>> draw_tabs( const catacurses::window
     std::map<size_t, inclusive_rectangle<point>> tab_map;
 
     int width = getmaxx( w );
-    for( int i = 0; i < width; i++ ) {
-        mvwputch( w, point( i, 2 ), BORDER_COLOR, LINE_OXOX ); // -
+    for( int i = 1; i < width - 1; i++ ) {
+        mvwputch( w, point( i, 2 ), BORDER_COLOR, LINE_OXOX );  // ─
     }
 
-    mvwputch( w, point( 0, 2 ), BORDER_COLOR, LINE_OXXO ); // |^
-    mvwputch( w, point( width - 1, 2 ), BORDER_COLOR, LINE_OOXX ); // ^|
+    mvwputch( w, point( 0, 2 ), BORDER_COLOR, LINE_OXXO );  // ┌
+    mvwputch( w, point( width - 1, 2 ), BORDER_COLOR, LINE_OOXX );  // ┐
 
     const int tab_step = 3;
     int x = 2;

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -41,6 +41,7 @@
 #include "string_formatter.h"
 #include "string_input_popup.h"
 #include "translations.h"
+#include "ui.h"
 #include "ui_manager.h"
 #include "units.h"
 #include "units_utility.h"
@@ -115,26 +116,6 @@ static std::vector<std::pair<bodypart_id, bool>> list_and_combine_bps( const Cha
         }
     }
     return bps;
-}
-
-static std::pair<int, int> subindex_around_cursor(
-    const int num_entries, const int available_space, const int cursor_pos, const bool focused )
-/**
- * Return indexes [start, end) that should be displayed from list long `num_entries`,
- * given that cursor is at position `cursor_pos` and we have `available_space` spaces.
- *
- * Example:
- * num_entries = 6, available_space = 3, cursor_pos = 2, focused = true;
- * so choose 3 from indexes [0, 1, 2, 3, 4, 5]
- * return {1, 4}
- */
-{
-    if( !focused || num_entries <= available_space ) {
-        return { 0, std::min( available_space, num_entries ) };
-    }
-    int slice_start = std::min( std::max( 0, cursor_pos - available_space / 2 ),
-                                num_entries - available_space );
-    return {slice_start, slice_start + available_space };
 }
 
 void Character::print_encumbrance( ui_adaptor &ui, const catacurses::window &win,

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -75,7 +75,7 @@ time_duration recipe::batch_duration( const Character &guy, int batch, float mul
 
 static bool helpers_have_proficiencies( const Character &guy, const proficiency_id &prof )
 {
-    for( Character *helper : guy.get_crafting_helpers() ) {
+    for( Character *helper : guy.get_crafting_group() ) {
         if( helper->has_proficiency( prof ) ) {
             return true;
         }
@@ -1023,7 +1023,7 @@ std::vector<proficiency_id> recipe::used_proficiencies() const
 static float get_aided_proficiency_level( const Character &crafter, const proficiency_id &prof )
 {
     float max_prof = crafter.get_proficiency_practice( prof );
-    for( const Character *helper : crafter.get_crafting_helpers() ) {
+    for( const Character *helper : crafter.get_crafting_group() ) {
         max_prof = std::max( max_prof, helper->get_proficiency_practice( prof ) );
     }
     return max_prof;

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1304,11 +1304,11 @@ std::function<bool( const item & )> recipe::get_component_filter(
 bool recipe::npc_can_craft( std::string &reason ) const
 {
     if( is_practice() ) {
-        reason = _( "Ordering practice to NPC is not implemented yet." );
+        reason = _( "Ordering NPC to practice is not implemented yet." );
         return false;
     }
     if( result()->phase != phase_id::SOLID ) {
-        reason = _( "Ordering no solid item to NPC is not implemented yet." );
+        reason = _( "Ordering NPC to craft non-solid item is not implemented yet." );
         return false;
     }
     for( const auto& [bp, _] : get_byproducts() ) {

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1307,12 +1307,10 @@ bool recipe::npc_can_craft( std::string &reason ) const
         reason = _( "Ordering no solid item to NPC is not implemented yet." );
         return false;
     }
-    if( !get_byproducts().empty() ) {
-        for( const std::pair<const itype_id, int> &bp : get_byproducts() ) {
-            if( bp.first->phase != phase_id::SOLID ) {
-                reason = _( "Ordering no solid item to NPC is not implemented yet." );
-                return false;
-            }
+    for( const auto& [bp, _] : get_byproducts() ) {
+        if( bp->phase != phase_id::SOLID ) {
+            reason = _( "Ordering NPC to craft non-solid item is not implemented yet." );
+            return false;
         }
     }
     return true;

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1137,7 +1137,7 @@ float recipe::exertion_level() const
 }
 
 // Format a vector of std::pair<skill_id, int> for the crafting menu.
-// skill colored green (or yellow if beyond characters skill)
+// skill colored green, yellow or red according to character skill
 // with the skill level (player / difficulty)
 static std::string required_skills_as_string( const std::vector<std::pair<skill_id, int>> &skills,
         const Character &c )
@@ -1148,7 +1148,14 @@ static std::string required_skills_as_string( const std::vector<std::pair<skill_
     return enumerate_as_string( skills,
     [&]( const std::pair<skill_id, int> &skill ) {
         const int player_skill = c.get_skill_level( skill.first );
-        std::string difficulty_color = skill.second > player_skill ? "yellow" : "green";
+        std::string difficulty_color;
+        if( skill.second <= player_skill ) {
+            difficulty_color = "green";
+        } else if( static_cast<int>( skill.second * 0.8 ) <= player_skill ) {
+            difficulty_color = "yellow";
+        } else {
+            difficulty_color = "red";
+        }
         return string_format( "<color_cyan>%s</color> <color_%s>(%d/%d)</color>", skill.first->name(),
                               difficulty_color, player_skill, skill.second );
     } );

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -1031,8 +1031,10 @@ static float get_aided_proficiency_level( const Character &crafter, const profic
 
 static float proficiency_time_malus( const Character &crafter, const recipe_proficiency &prof )
 {
-    if( !crafter.has_proficiency( prof.id ) &&
-        !helpers_have_proficiencies( crafter, prof.id ) && prof.time_multiplier > 1.0f ) {
+    if( !crafter.has_proficiency( prof.id )
+        && !helpers_have_proficiencies( crafter, prof.id )
+        && prof.time_multiplier > 1.0f
+      ) {
         double malus = prof.time_multiplier - 1.0;
         malus *= 1.0 - crafter.crafting_inventory().get_book_proficiency_bonuses().time_factor( prof.id );
         double pl = get_aided_proficiency_level( crafter, prof.id );
@@ -1064,8 +1066,10 @@ float recipe::max_proficiency_time_maluses( const Character & ) const
 
 static float proficiency_skill_malus( const Character &crafter, const recipe_proficiency &prof )
 {
-    if( !crafter.has_proficiency( prof.id ) &&
-        !helpers_have_proficiencies( crafter, prof.id ) && prof.skill_penalty > 0.f ) {
+    if( !crafter.has_proficiency( prof.id )
+        && !helpers_have_proficiencies( crafter, prof.id )
+        && prof.skill_penalty > 0.f
+      ) {
         double malus =  prof.skill_penalty;
         malus *= 1.0 - crafter.crafting_inventory().get_book_proficiency_bonuses().fail_factor( prof.id );
         double pl = get_aided_proficiency_level( crafter, prof.id );

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1389,3 +1389,14 @@ bool navigate_ui_list( const std::string &action, V &val, int page_delta, S size
     }
     return true;
 }
+
+std::pair<int, int> subindex_around_cursor( int num_entries, int available_space, int cursor_pos,
+        bool focused )
+{
+    if( !focused || num_entries <= available_space ) {
+        return { 0, std::min( available_space, num_entries ) };
+    }
+    int slice_start = std::min( std::max( 0, cursor_pos - available_space / 2 ),
+                                num_entries - available_space );
+    return {slice_start, slice_start + available_space };
+}

--- a/src/ui.h
+++ b/src/ui.h
@@ -667,4 +667,19 @@ inc_clamp( T val, I inc, T size )
 template<typename V, typename S>
 bool navigate_ui_list( const std::string &action, V &val, int page_delta, S size, bool wrap );
 
+/**
+ * Return indexes [start, end) that should be displayed from list long `num_entries`,
+ * given that cursor is at position `cursor_pos` and we have `available_space` spaces.
+ *
+ * @param focused: if false, behave as if cursor_pos = 0,
+ * useful when other menu is displayed and this should show the beggining
+ *
+ * Example:
+ * num_entries = 6, available_space = 3, cursor_pos = 2, focused = true;
+ * so choose 3 from indexes [0, 1, 2, 3, 4, 5]
+ * return {1, 4}
+ */
+std::pair<int, int> subindex_around_cursor( int num_entries, int available_space, int cursor_pos,
+        bool focused = true );
+
 #endif // CATA_SRC_UI_H

--- a/src/ui.h
+++ b/src/ui.h
@@ -14,6 +14,7 @@
 #include <utility>
 #include <vector>
 
+#include "cata_assert.h"
 #include "color.h"
 #include "cuboid_rectangle.h"
 #include "cursesdef.h"
@@ -527,6 +528,46 @@ class uilist // NOLINT(cata-xy)
         int selected = 0;
 
         void set_selected( int index );
+};
+
+/**
+ *  Hack ui list to behave as a multi column menu
+ */
+class uimenu
+{
+    public:
+        explicit uimenu( int columns ) {
+            cata_assert( columns >= 1 );
+            col_count = columns;
+        }
+        /**
+        * @param retval return value of this option when selected during menu query
+        * @param enable is entry enabled. disabled entries will be grayed out and won't be selectable
+        * @param col_content each string will be displayed on the entry's respective column
+        */
+        void addentry( int retval, bool enabled, const std::vector<std::string> &col_content );
+        void set_selected( int index );
+        void set_title( const std::string &title );
+        int query();
+
+    private:
+        /**
+         * Called in query to calculate sizes for multiple columns.
+         */
+        void finalize_addentries();
+        struct col {
+            col( int i_retval, bool i_enabled, const std::vector<std::string> &i_col_content ) :
+                retval( i_retval ), enabled( i_enabled ), col_content( i_col_content )
+            {};
+            int retval;
+            bool enabled;
+            const std::vector<std::string> col_content;
+        };
+        std::vector<col> cols;
+        uilist menu;
+        int col_count;
+
+        int suggest_width = 74;  // 80 (for min size) - 6 (for edges)
 };
 
 /**

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -33,7 +33,7 @@ affordability
 affordably
 afterbirth
 aftereffect
-aftereffects 
+aftereffects
 afterglow
 afterimage
 afterlife
@@ -637,6 +637,7 @@ coverplate
 crablike
 cracklins
 craftable
+crafter
 craftsfolk
 craftswoman
 craftwork
@@ -3000,7 +3001,7 @@ teshuvah
 testbed
 tetradrachm
 tetrahedron
-thaumaturge 
+thaumaturge
 thaumaturgical
 thawb
 themm


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Switch crafter in crafting menu to and from an ally"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

### Purpose of change
Resolves #66163
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/eefa2e34-f9ad-4612-8d5c-35feffc01653)


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

### Describe the solution
- [x] Depends on #68666
- [x] Crafting group*.
- [x] Menu for switching crafters of crafting group. Listing all allies. Including those who cannot craft right now with an explanation of why it is so.
- [x] REMOVE TEMPORARY: Cycle through crafters with keybinding - includes those who should not be selectable (asleep, crafting, ...).
- [x] REMOVE TEMPORARY: List members of the crafting group at the top of detail.
- [x] List the crafter at the top of detail.
- [x] Show all recipes the crafting group knows.
- [x] Allow crafting only recipes you should be able to (like before - so don't introduce a bug).
- [x] Mark recipes (in the left column) beyond crafters' understanding. With light red (unused so far). Categories with magenta (unused so far), but I wanted purple (doesn't exist). ~With a new colour? Or strike them? - don't know how Suggestions welcome!~
- [x] In recipe detail, if a recipe is beyond understanding, colour skill requirement with red (eg. fabrication `<red>4/8</red>`). Also, add the text: `<color_red>Cannot be crafted because the crafter is not skilled enough to understand the recipe.</color>`.
- [ ] The above marks secondary skills as red too, should revert to yellow?
- [x] fix: NPC cannot be told a recipe they don't know by the player - this was in crafting from a conversation with NPC, `iuse.cpp`, and `iexamine.cpp`. Solved by separating `crafting_group()` (allies nearby) from `crafting_helpers()` (willing, awake, etc. who will help with batch crafting etc.)
- [x] fix: On non-memorized recipes, if it is both written in a book and known by an ally, only `Written in` was shown, now `Known by` is also shown.
- [x] Improve some text.
- [x] Characters provide crafting recipes and proficiencies even when sleeping (preventing optimal non-fun gameplay of waking everyone up before crafting and letting them fall asleep immediately after choosing a recipe). They still don't learn if asleep.
- [x] Don't duplicate code if not necessary (get_available_recipes, has_recipe).
- [x] fix: `Searched+` tab overlapped
- [x] fix: "Cannot be crafted because the same item is needed for multiple components" triggered for NPCs that cannot craft or practice this.

*__Crafting group__: on each opening of the crafting menu (be it with keybinding `&` or through conversation with allied NPC), the crafter finds nearby allies forming a `crafting_group` of which they are a part. The group shares their knowledge and you can switch between crafters, the default crafter is who it was before this PR. Recipes of all participants are shown, so switching crafters is more seamless. Recipes beyond the crafters' knowledge are marked as uncraftable.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

The default keybinding for choosing a crafter is `c`, it could be `&`, then pressing `&&` would open the crafting menu and in that the choose crafter menu.

I consider `uimenu`'s implementation temporary, but the public interface might as well be final.

### Testing

1. Have a friendly NPC who knows next to nothing.
2. Through the debug menu, obtain all recipes and get all skills to 10 for yourself.
3. Open the crafting menu `&` and switch between you and the NPC `c` (new keybinding) as you browse the crafting menu.
4. Observe that NPC cannot craft recipes that they shouldn't be able to (cannot craft recipe whose `floor(recipe.primary_skill_requirement * 0.8) > guy.skill`). If you press enter, it says `Crafter cannot craft that!`.
5. Observe that recipes have `Known by You` (this is a bugfix).
6. Select a recipe and start crafting.
7. Observe that the selected crafter is crafting the recipe (even if somebody else opened the crafting menu).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

### Additional context

Allies cannot use items from each other's inventories. #68182 Somebody please implement it :)

Now, switching between characters will shuffle recipes dramatically, as some become (un)craftable, it would be solved by implementing the aforementioned.

You can tell NPC to craft a crossbow trap out of their crossbow. I hope this is in line. This PR didn't change that behaviour but I noticed it thanks to it.

Switching between characters filters by `filterstring` again (notably slow with prompts like `d:close to`), but it shouldn't as the list of recipes is the same, since crafting_group couldn't have changed.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
