### PR TITLE
Show insertion failure reasons in Insert menu and AIM

### DIFF
--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -3639,7 +3639,9 @@
         "watertight": true,
         "open_container": true,
         "max_contains_volume": "250 ml",
-        "max_contains_weight": "1 kg"
+        "max_contains_weight": "1 kg",
+        "//": "sealed_data is here so the container can be sealed to avoid spilling",
+        "sealed_data": { "spoil_multiplier": 1.0 }
       }
     ]
   },

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1423,7 +1423,7 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
     recalc = true;
     cata_assert( amount_to_move > 0 );
     if( to_vehicle && sitem->items.front()->is_bucket_nonempty() &&
-        !query_yn( _( "!!The %s would spill if stored there. Remove its contents first?" ),
+        !query_yn( _( "The %s would spill if stored there.  Remove its contents first?" ),
                    sitem->items.front()->tname() ) ) {
         return false;
     }

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1345,7 +1345,7 @@ void advanced_inventory::start_activity(
             && panes[dest].container.where() != item_location::type::map
             && !player_character.is_wielding( *panes[dest].container ) ) {
 
-            popup_getkey( _( "The %s would spill unless it's on the ground or wielded." ),
+            popup_getkey( _( "The %s would spill if opened up; it must be on the ground or wielded." ),
                           panes[dest].container->type_name() );
             return;
         }

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1422,6 +1422,11 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
     // but are potentially at a different place).
     recalc = true;
     cata_assert( amount_to_move > 0 );
+    if( to_vehicle && sitem->items.front()->is_bucket_nonempty() &&
+        !query_yn( _( "!!The %s would spill if stored there. Remove its contents first?" ),
+            sitem->items.front()->tname() ) ) {
+        return false;
+    }
     if( srcarea == AIM_CONTAINER && destarea == AIM_INVENTORY &&
         spane.container.held_by( player_character ) ) {
         popup_getkey( _( "The %s is already in your inventory." ), sitem->items.front()->tname() );

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1915,46 +1915,6 @@ bool advanced_inventory::query_destination( aim_location &def )
     return false;
 }
 
-bool advanced_inventory::move_content( item &src_container, item &dest_container )
-{
-    if( !src_container.is_container() ) {
-        popup( _( "Source must be a container." ) );
-        return false;
-    }
-    if( src_container.is_container_empty() ) {
-        popup( _( "Source container is empty." ) );
-        return false;
-    }
-
-    item &src_contents = src_container.legacy_front();
-
-    if( !src_contents.made_of( phase_id::LIQUID ) ) {
-        popup( _( "You can unload only liquids into the target container." ) );
-        return false;
-    }
-
-    std::string err;
-    // TODO: Allow buckets here, but require them to be on the ground or wielded
-    const int amount = std::min( src_contents.charges,
-                                 dest_container.get_remaining_capacity_for_liquid( src_contents, false, &err ) );
-    if( !err.empty() ) {
-        popup( err );
-        return false;
-    }
-    dest_container.fill_with( src_contents, amount );
-    src_contents.charges -= amount;
-    src_container.contained_where( src_contents )->on_contents_changed();
-    src_container.on_contents_changed();
-    get_avatar().flag_encumbrance();
-
-    uistate.adv_inv_container_content_type = dest_container.legacy_front().typeId();
-    if( src_contents.charges <= 0 ) {
-        src_container.clear_items();
-    }
-
-    return true;
-}
-
 bool advanced_inventory::query_charges( aim_location destarea, const advanced_inv_listitem &sitem,
                                         const std::string &action, int &amount )
 {

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -1424,7 +1424,7 @@ bool advanced_inventory::action_move_item( advanced_inv_listitem *sitem,
     cata_assert( amount_to_move > 0 );
     if( to_vehicle && sitem->items.front()->is_bucket_nonempty() &&
         !query_yn( _( "!!The %s would spill if stored there. Remove its contents first?" ),
-            sitem->items.front()->tname() ) ) {
+                   sitem->items.front()->tname() ) ) {
         return false;
     }
     if( srcarea == AIM_CONTAINER && destarea == AIM_INVENTORY &&

--- a/src/advanced_inv.h
+++ b/src/advanced_inv.h
@@ -190,12 +190,6 @@ class advanced_inventory
          */
         bool query_destination( aim_location &def );
         /**
-         * Move content of source container into destination container (destination pane = AIM_CONTAINER)
-         * @param src_container Source container
-         * @param dest_container Destination container
-         */
-        bool move_content( item &src_container, item &dest_container );
-        /**
          * Setup how many items/charges (if counted by charges) should be moved.
          * @param destarea Where to move to. This must not be AIM_ALL.
          * @param sitem The source item, it must contain a valid reference to an item!

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5918,7 +5918,7 @@ bool Character::pour_into( item_location &container, item &liquid, bool ignore_s
     std::string err;
     int max_remaining_capacity = container->get_remaining_capacity_for_liquid( liquid, *this, &err );
     int amount = container->all_pockets_rigid() ? max_remaining_capacity :
-                 std::min( max_remaining_capacity, container.max_charges_by_parent_recursive( liquid ) );
+                 std::min( max_remaining_capacity, container.max_charges_by_parent_recursive( liquid ).value() );
 
     if( !err.empty() ) {
         if( !container->has_item_with( [&liquid]( const item & it ) {

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2355,7 +2355,7 @@ void outfit::pickup_stash( const item &newit, int &remaining_charges, bool ignor
         if( remaining_charges == 0 ) {
             break;
         }
-        if( i.can_contain_partial( newit ) ) {
+        if( i.can_contain_partial( newit ).success() ) {
             const int used_charges =
                 i.fill_with( newit, remaining_charges, false, false, ignore_pkt_settings );
             remaining_charges -= used_charges;
@@ -2437,7 +2437,7 @@ void outfit::add_stash( Character &guy, const item &newit, int &remaining_charge
         // Crawl First : wielded item
         item_location carried_item = guy.get_wielded_item();
         if( carried_item && !carried_item->has_pocket_type( item_pocket::pocket_type::MAGAZINE ) &&
-            carried_item->can_contain_partial( newit ) ) {
+            carried_item->can_contain_partial( newit ).success() ) {
             int used_charges = carried_item->fill_with( newit, remaining_charges, false, false, false );
             remaining_charges -= used_charges;
         }
@@ -2474,8 +2474,8 @@ void outfit::add_stash( Character &guy, const item &newit, int &remaining_charge
             const item_location parent_data = pocket_data_ptr.parent;
 
             if( parent_data.has_parent() ) {
-                if( parent_data.parents_can_contain_recursive( &temp_it ) ) {
-                    max_contain_value = parent_data.max_charges_by_parent_recursive( temp_it );
+                if( parent_data.parents_can_contain_recursive( &temp_it ).success() ) {
+                    max_contain_value = parent_data.max_charges_by_parent_recursive( temp_it ).value();
                 } else {
                     max_contain_value = 0;
                 }

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -239,8 +239,8 @@ item_location Character::try_add( item it, int &copies_remaining, const item *av
         if( !temp_it.is_null() ) {
             const int pocket_max_copies = pocket.second->remaining_capacity_for_item( temp_it );
             const int parent_max_copies = !pocket.first.has_parent() ? INT_MAX :
-                                          !pocket.first.parents_can_contain_recursive( &temp_it ) ? 0 :
-                                          pocket.first.max_charges_by_parent_recursive( temp_it );
+                                          !pocket.first.parents_can_contain_recursive( &temp_it ).success() ? 0 :
+                                          pocket.first.max_charges_by_parent_recursive( temp_it ).value();
             max_copies = std::min( { copies_remaining, pocket_max_copies, parent_max_copies } );
         } else {
             max_copies = copies_remaining;

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -554,6 +554,11 @@ void Character::drop( const drop_locations &what, const tripoint &target,
     const tripoint placement = target - pos();
     std::vector<drop_or_stash_item_info> items;
     for( drop_location item_pair : what ) {
+        if( is_avatar() && item_pair.first->is_bucket_nonempty() &&
+            !query_yn( _( "The %s would spill if stored there. Remove its contents first?" ),
+                       item_pair.first->tname() ) ) {
+            continue;
+        }
         if( can_drop( *item_pair.first ).success() ) {
             items.emplace_back( item_pair.first, item_pair.second );
         }

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -249,6 +249,11 @@ item_location Character::try_add( item it, int &copies_remaining, const item *av
         std::vector<item *>newits;
         pocket.second->add( it, max_copies, newits );
 
+        if( newits.empty() ) {
+            // Failed to insert into best pocket - break out to prevent infinite loop.
+            break;
+        }
+
         // Give invlet to the first item created.
         if( !first_item_added ) {
             first_item_added = item_location( pocket.first, newits.front() );

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -555,7 +555,7 @@ void Character::drop( const drop_locations &what, const tripoint &target,
     std::vector<drop_or_stash_item_info> items;
     for( drop_location item_pair : what ) {
         if( is_avatar() && item_pair.first->is_bucket_nonempty() &&
-            !query_yn( _( "The %s would spill if stored there. Remove its contents first?" ),
+            !query_yn( _( "The %s would spill if stored there.  Remove its contents first?" ),
                        item_pair.first->tname() ) ) {
             continue;
         }

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -837,7 +837,7 @@ bool inventory_holster_preset::is_shown( const item_location &contained ) const
     if( contained->is_bucket_nonempty() ) {
         return false;
     }
-    if( !holster.parents_can_contain_recursive( &item_copy ) ) {
+    if( !holster.parents_can_contain_recursive( &item_copy ).success() ) {
         return false;
     }
     return true;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9978,7 +9978,7 @@ ret_val<void> item::can_contain( const item &it, int &copies_remaining, const bo
                          this == parent_it.get_item() ) ) {
         // does the set of all sets contain itself?
         // or does this already contain it?
-        return ret_val<void>::make_failure();
+        return ret_val<void>::make_failure( "can't put a container into itself" );
     }
     if( nested && !this->is_container() ) {
         return ret_val<void>::make_failure();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10026,27 +10026,27 @@ ret_val<void> item::can_contain( const item &it, int &copies_remaining, const bo
            contents.can_contain( it, copies_remaining, ignore_pkt_settings, remaining_parent_volume );
 }
 
-bool item::can_contain( const itype &tp ) const
+ret_val<void> item::can_contain( const itype &tp ) const
 {
-    return can_contain( item( &tp ) ).success();
+    return can_contain( item( &tp ) );
 }
 
-bool item::can_contain_partial( const item &it ) const
+ret_val<void> item::can_contain_partial( const item &it ) const
 {
     item i_copy = it;
     if( i_copy.count_by_charges() ) {
         i_copy.charges = 1;
     }
-    return can_contain( i_copy ).success();
+    return can_contain( i_copy );
 }
 
-bool item::can_contain_partial_directly( const item &it ) const
+ret_val<void> item::can_contain_partial_directly( const item &it ) const
 {
     item i_copy = it;
     if( i_copy.count_by_charges() ) {
         i_copy.charges = 1;
     }
-    return can_contain( i_copy, false, false, true, item_location(), 10000000_ml, false ).success();
+    return can_contain( i_copy, false, false, true, item_location(), 10000000_ml, false );
 }
 
 std::pair<item_location, item_pocket *> item::best_pocket( const item &it, item_location &this_loc,
@@ -11787,7 +11787,7 @@ int item::get_remaining_capacity_for_liquid( const item &liquid, bool allow_buck
 
     int remaining_capacity = 0;
 
-    if( can_contain_partial( liquid ) ) {
+    if( can_contain_partial( liquid ).success() ) {
         if( !contents.can_contain_liquid( allow_bucket ) ) {
             return error( string_format( _( "That %s must be on the ground or held to hold contents!" ),
                                          tname() ) );

--- a/src/item.h
+++ b/src/item.h
@@ -1652,10 +1652,10 @@ class item : public visitable
                                    const item_location &parent_it = item_location(),
                                    units::volume remaining_parent_volume = 10000000_ml,
                                    bool allow_nested = true ) const;
-        bool can_contain( const itype &tp ) const;
-        bool can_contain_partial( const item &it ) const;
+        ret_val<void> can_contain( const itype &tp ) const;
+        ret_val<void> can_contain_partial( const item &it ) const;
         ret_val<void> can_contain_directly( const item &it ) const;
-        bool can_contain_partial_directly( const item &it ) const;
+        ret_val<void> can_contain_partial_directly( const item &it ) const;
         /*@}*/
         std::pair<item_location, item_pocket *> best_pocket( const item &it, item_location &this_loc,
                 const item *avoid = nullptr, bool allow_sealed = false, bool ignore_settings = false,

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -124,7 +124,8 @@ static void put_into_container(
     item ctr( *container_type, birthday );
     Item_spawn_data::ItemList excess;
     for( auto it = items.end() - num_items; it != items.end(); ++it ) {
-        if( ctr.can_contain_directly( *it ).success() ) {
+        ret_val<void> ret = ctr.can_contain_directly( *it );
+        if( ret.success() ) {
             const item_pocket::pocket_type pk_type = guess_pocket_for( ctr, *it );
             ctr.put_in( *it, pk_type );
         } else if( ctr.is_corpse() ) {
@@ -133,11 +134,11 @@ static void put_into_container(
         } else {
             switch( on_overflow ) {
                 case Item_spawn_data::overflow_behaviour::none:
-                    debugmsg( "item %s does not fit in container %s when spawning item group %s.  "
+                    debugmsg( "item %s could not be put in container %s when spawning item group %s: %s.  "
                               "This can be resolved either by changing the container or contents "
                               "to ensure that they fit, or by specifying an overflow behaviour via "
                               "\"on_overflow\" on the item group.",
-                              it->typeId().str(), container_type->str(), context );
+                              it->typeId().str(), container_type->str(), context, ret.str() );
                     break;
                 case Item_spawn_data::overflow_behaviour::spill:
                     excess.push_back( *it );

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -884,11 +884,11 @@ ret_val<void> item_location::parents_can_contain_recursive( item *it ) const
         it_length = it_length * std::cbrt( current_pocket_data->volume_multiplier );
 
         if( it_weight > parent_pocket->remaining_weight() ) {
-            return ret_val<void>::make_failure( _( "item is too heavy for one of the pockets" ) );
+            return ret_val<void>::make_failure( _( "item is too heavy for a parent pocket" ) );
         } else if( it_volume > parent_pocket->remaining_volume() ) {
-            return ret_val<void>::make_failure( _( "item is too big for one of the pockets" ) );
+            return ret_val<void>::make_failure( _( "item is too big for a parent pocket" ) );
         } else if( it_length > parent_pocket->get_pocket_data()->max_item_length ) {
-            return ret_val<void>::make_failure( _( "item is too long for one of the pockets" ) );
+            return ret_val<void>::make_failure( _( "item is too long for a parent pocket" ) );
         }
 
         //Move up one level of containers
@@ -948,11 +948,11 @@ ret_val<int> item_location::max_charges_by_parent_recursive( const item &it ) co
 
     int charges_weight = it.charges_per_weight( max_weight, true );
     if( charges_weight == 0 ) {
-        return ret_val<int>::make_failure( 0, _( "item is too heavy for one of the pockets" ) );
+        return ret_val<int>::make_failure( 0, _( "item is too heavy for a parent pocket" ) );
     }
     int charges_volume = it.charges_per_volume( max_volume, true );
     if( charges_volume == 0 ) {
-        return ret_val<int>::make_failure( 0, _( "item is too big for one of the pockets" ) );
+        return ret_val<int>::make_failure( 0, _( "item is too big for a parent pocket" ) );
     }
 
     return ret_val<int>::make_success( std::min( charges_weight, charges_volume ) );

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -19,6 +19,7 @@ class map_cursor;
 class vehicle_cursor;
 class talker;
 struct tripoint;
+template<typename T> class ret_val;
 
 /**
  * A lightweight handle to an item independent of it's location
@@ -139,8 +140,8 @@ class item_location
         **/
         bool protected_from_liquids() const;
 
-        bool parents_can_contain_recursive( item *it ) const;
-        int max_charges_by_parent_recursive( const item &it ) const;
+        ret_val<void> parents_can_contain_recursive( item *it ) const;
+        ret_val<int> max_charges_by_parent_recursive( const item &it ) const;
 
         /**
          * Returns whether another item is eventually contained by this item

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1356,7 +1356,7 @@ ret_val<item_pocket::contain_code> item_pocket::is_compatible( const item &it ) 
     if( !data->ammo_restriction.empty() ) {
         if( !it.is_ammo() ) {
             return ret_val<item_pocket::contain_code>::make_failure(
-                       contain_code::ERR_AMMO, _( "item is not an ammo" ) );
+                       contain_code::ERR_AMMO, _( "item is not ammunition" ) );
         }
 
         const auto ammo_restriction_iter = data->ammo_restriction.find( it.ammo_type() );
@@ -1389,7 +1389,7 @@ ret_val<item_pocket::contain_code> item_pocket::is_compatible( const item &it ) 
         !it.is_frozen_liquid() && data->max_item_volume &&
         !charges_per_volume_recursive( *data->max_item_volume, it ) ) {
         return ret_val<item_pocket::contain_code>::make_failure(
-                   contain_code::ERR_TOO_BIG, _( "item too big" ) );
+                   contain_code::ERR_TOO_BIG, _( "item is too big" ) );
     }
     if( it.length() > data->max_item_length ) {
         return ret_val<item_pocket::contain_code>::make_failure(
@@ -1488,7 +1488,7 @@ ret_val<item_pocket::contain_code> item_pocket::_can_contain( const item &it,
         }
         if( it.volume() > volume_capacity() ) {
             return ret_val<item_pocket::contain_code>::make_failure(
-                       contain_code::ERR_TOO_BIG, _( "item too big" ) );
+                       contain_code::ERR_TOO_BIG, _( "item is too big" ) );
         }
         return ret_val<item_pocket::contain_code>::make_success();
     }
@@ -1557,7 +1557,7 @@ ret_val<item_pocket::contain_code> item_pocket::_can_contain( const item &it,
     units::volume volume = it.volume();
     if( volume > volume_capacity() ) {
         return ret_val<item_pocket::contain_code>::make_failure(
-                   contain_code::ERR_TOO_BIG, _( "item too big" ) );
+                   contain_code::ERR_TOO_BIG, _( "item is too big" ) );
     }
 
     int fallback_capacity = it.count_by_charges() ? it.charges : copies_remaining;

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -54,21 +54,21 @@ class item_pocket
             ERR_MOD,
             // trying to put a liquid into a non-watertight container
             ERR_LIQUID,
-            // trying to put a gas in a non-airtight container
+            // trying to put a gas into a non-airtight container
             ERR_GAS,
-            // trying to put an item that wouldn't fit if the container were empty
+            // trying to store an item that wouldn't fit even if the container were empty
             ERR_TOO_BIG,
-            // trying to put an item that wouldn't fit if the container were empty
+            // trying to store an item that would be too heavy even if the container were empty
             ERR_TOO_HEAVY,
-            // trying to put an item that wouldn't fit if the container were empty
+            // trying to store an item that's below the minimum size or length
             ERR_TOO_SMALL,
-            // pocket doesn't have sufficient space left
+            // pocket doesn't have sufficient volume capacity left
             ERR_NO_SPACE,
-            // pocket doesn't have sufficient weight left
+            // pocket doesn't have sufficient weight capacity left
             ERR_CANNOT_SUPPORT,
-            // requires a flag
+            // requires a flag the item doesn't have
             ERR_FLAG,
-            // requires item be a specific ammotype
+            // requires the item to be a specific ammotype
             ERR_AMMO
         };
 

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -99,9 +99,13 @@ static pickup_answer handle_problematic_pickup( const item &it, const std::strin
 
     amenu.text = explain;
 
+    item empty_it( it );
+    empty_it.get_contents().clear_items();
+    bool can_pickup = u.can_stash( empty_it ) && u.can_pickWeight( empty_it );
+
     if( it.is_bucket_nonempty() ) {
         amenu.addentry( WIELD, true, 'w', _( "Wield %s" ), it.display_name() );
-        amenu.addentry( SPILL, u.can_stash( it ), 's', _( "Spill contents of %s, then pick up %s" ),
+        amenu.addentry( SPILL, can_pickup, 's', _( "Spill contents of %s, then pick up %s" ),
                         it.tname(), it.display_name() );
     }
 
@@ -218,10 +222,6 @@ static bool pick_one_up( item_location &loc, int quantity, bool &got_water, bool
         got_water = true;
     } else if( newit.made_of_from_type( phase_id::GAS ) ) {
         got_gas = true;
-    } else if( !player_character.can_pickWeight_partial( newit, false ) ||
-               !player_character.can_stash_partial( newit, false ) ) {
-        option = CANCEL;
-        stash_successful = false;
     } else if( newit.is_bucket_nonempty() ) {
         if( !autopickup ) {
             const std::string &explain = string_format( _( "Can't stash %s while it's not empty" ),
@@ -231,6 +231,10 @@ static bool pick_one_up( item_location &loc, int quantity, bool &got_water, bool
         } else {
             option = CANCEL;
         }
+    } else if( !player_character.can_pickWeight_partial( newit, false ) ||
+               !player_character.can_stash_partial( newit, false ) ) {
+        option = CANCEL;
+        stash_successful = false;
     } else {
         option = STASH;
     }

--- a/tests/battery_mod_test.cpp
+++ b/tests/battery_mod_test.cpp
@@ -279,15 +279,15 @@ TEST_CASE( "battery_and_tool_properties", "[battery][tool][properties]" )
         }
 
         SECTION( "has compatible magazines" ) {
-            CHECK( flashlight.can_contain( *itype_light_battery_cell ) );
-            CHECK( flashlight.can_contain( *itype_light_disposable_cell ) );
-            CHECK( flashlight.can_contain( *itype_light_plus_battery_cell ) );
-            CHECK( flashlight.can_contain( *itype_light_atomic_battery_cell ) );
+            CHECK( flashlight.can_contain( *itype_light_battery_cell ).success() );
+            CHECK( flashlight.can_contain( *itype_light_disposable_cell ).success() );
+            CHECK( flashlight.can_contain( *itype_light_plus_battery_cell ).success() );
+            CHECK( flashlight.can_contain( *itype_light_atomic_battery_cell ).success() );
         }
 
         SECTION( "Does not fit medium or large magazines" ) {
-            CHECK_FALSE( flashlight.can_contain( *itype_medium_battery_cell ) );
-            CHECK_FALSE( flashlight.can_contain( *itype_heavy_plus_battery_cell ) );
+            CHECK_FALSE( flashlight.can_contain( *itype_medium_battery_cell ).success() );
+            CHECK_FALSE( flashlight.can_contain( *itype_heavy_plus_battery_cell ).success() );
         }
 
         SECTION( "has a default magazine" ) {

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -52,8 +52,8 @@ Item_spawn_data_wallet_science_stylish_full( "wallet_science_stylish_full" );
 static const item_group_id Item_spawn_data_wallet_stylish_full( "wallet_stylish_full" );
 
 static const itype_id itype_test_backpack( "test_backpack" );
-static const itype_id itype_test_socks( "test_socks" );
 static const itype_id itype_test_jug_plastic( "test_jug_plastic" );
+static const itype_id itype_test_socks( "test_socks" );
 static const itype_id
 itype_test_watertight_open_sealed_container_1L( "test_watertight_open_sealed_container_1L" );
 

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -53,6 +53,7 @@ static const item_group_id Item_spawn_data_wallet_stylish_full( "wallet_stylish_
 
 static const itype_id itype_test_backpack( "test_backpack" );
 static const itype_id itype_test_socks( "test_socks" );
+static const itype_id itype_test_jug_plastic( "test_jug_plastic" );
 static const itype_id
 itype_test_watertight_open_sealed_container_1L( "test_watertight_open_sealed_container_1L" );
 
@@ -1017,7 +1018,7 @@ TEST_CASE( "sealed_containers", "[pocket][seal]" )
     }
 
     GIVEN( "non-sealable jug" ) {
-        item jug( "test_jug_plastic" );
+        item jug( itype_test_jug_plastic );
 
         // Ensure it has exactly one contained pocket, and get that pocket for testing
         std::vector<item_pocket *>jug_pockets = jug.get_all_contained_pockets();
@@ -1649,7 +1650,7 @@ TEST_CASE( "character_best_pocket", "[pocket][character][best]" )
     WHEN( "wearing a container with a nested rigid container" ) {
         item socks( itype_test_socks );
         item backpack( itype_test_backpack );
-        item container( itype_test_watertight_open_sealed_container_1L );
+        item container( itype_test_jug_plastic );
         item filler( "test_rag" );
 
         // wear the backpack item.
@@ -1699,7 +1700,7 @@ TEST_CASE( "character_best_pocket", "[pocket][character][best]" )
     WHEN( "wearing a container with a nested rigid container which should be avoided" ) {
         item socks( itype_test_socks );
         item backpack( itype_test_backpack );
-        item container( itype_test_watertight_open_sealed_container_1L );
+        item container( itype_test_jug_plastic );
 
         // wear the backpack item.
         REQUIRE( dummy.wear_item( backpack ) );
@@ -2244,7 +2245,7 @@ TEST_CASE( "multipocket_liquid_transfer_test", "[pocket][item][liquid]" )
     map &m = get_map();
     Character &u = get_player_character();
     item water( "water" );
-    item cont_jug( "test_jug_plastic" );
+    item cont_jug( itype_test_jug_plastic );
     item cont_suit( "test_robofac_armor_rig" );
 
     // Place a container at the character's feet

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -296,7 +296,7 @@ TEST_CASE( "max_item_volume", "[pocket][max_item_volume]" )
         }
         THEN( "it cannot contain solid items larger than the opening" ) {
             REQUIRE_FALSE( rock.is_soft() );
-            expect_cannot_contain( pocket_jug, rock, "item too big",
+            expect_cannot_contain( pocket_jug, rock, "item is too big",
                                    item_pocket::contain_code::ERR_TOO_BIG );
         }
     }
@@ -404,7 +404,7 @@ TEST_CASE( "magazine_with_ammo_restriction", "[pocket][magazine][ammo_restrictio
 
             THEN( "it cannot contain items that are not ammo" ) {
                 item rag( "test_rag" );
-                expect_cannot_contain( pocket_mag, rag, "item is not an ammo",
+                expect_cannot_contain( pocket_mag, rag, "item is not ammunition",
                                        item_pocket::contain_code::ERR_AMMO );
             }
         }
@@ -542,12 +542,12 @@ TEST_CASE( "pocket_with_item_flag_restriction", "[pocket][flag_restriction]" )
                 REQUIRE( axe.volume() > data_belt.max_contains_volume() );
 
                 THEN( "pocket cannot contain it, because it is too big" ) {
-                    expect_cannot_contain( pocket_belt, axe, "item too big",
+                    expect_cannot_contain( pocket_belt, axe, "item is too big",
                                            item_pocket::contain_code::ERR_TOO_BIG );
                 }
 
                 THEN( "item cannot be inserted into the pocket" ) {
-                    expect_cannot_insert( pocket_belt, axe, "item too big",
+                    expect_cannot_insert( pocket_belt, axe, "item is too big",
                                           item_pocket::contain_code::ERR_TOO_BIG );
                 }
             }
@@ -631,12 +631,12 @@ TEST_CASE( "holster_can_contain_one_fitting_item", "[pocket][holster]" )
         item_pocket pocket_holster( &data_holster );
 
         THEN( "it cannot contain the item, because it is too big" ) {
-            expect_cannot_contain( pocket_holster, glock, "item too big",
+            expect_cannot_contain( pocket_holster, glock, "item is too big",
                                    item_pocket::contain_code::ERR_TOO_BIG );
         }
 
         THEN( "item cannot be successfully inserted" ) {
-            expect_cannot_insert( pocket_holster, glock, "item too big",
+            expect_cannot_insert( pocket_holster, glock, "item is too big",
                                   item_pocket::contain_code::ERR_TOO_BIG );
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Show insertion failure reasons in Insert menu and AIM"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
`can_contain` provides detailed reasons why an item can't be inserted into a pocket, but they aren't actually used in player-facing messages. Failing to insert with the AIM shows an unhelpful "Could not put X into Y, aborting.", and the insert menu simply hides invalid items entirely, which can confuse players who are unsure why items aren't showing up.

Fixes #67967.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make many functions that call `can_contain` maintain its error string, and adding it to error messages in `insert_item_activity_actor`, `inventory_holster_preset`, and `put_into_container`. The insert menu no longer hides invalid items, showing why items can't be inserted.

There are also a few miscellaneous open-container-related changes:

- Plastic beverage bags didn't start sealed, which meant the MRE item group was spawning opened beverage bags inside containers.
- The `character_best_pocket` test was using open containers which can't accept contents while inside a backpack so it wasn't actually passing the test in the correct way.
- Attempting to stash a filled bucket will only check the lone bucket's vol & weight, since you'd have to spill its contents to stash it anyway.
- Trying to put a bucket into vehicle cargo with the drop action or AIM will ask the player if they want to remove the contents, rather than just quietly doing it.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Containers with a variety of different pocket types, like backpacks, could have all those different pockets fail for different reasons, but will show only a single reason. I tried showing "+X others" for this, but it felt like it was just more confusing so I scrapped it.

I originally made bucket stashing a more general failure, which is what led to those bucket changes, but it was feeling like too big of a change so I toned it down. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
All tests green locally. Ensured it still works to insert items both via menu and the AIM.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/6759778/de92804a-3f2d-4574-af8e-bcfd73db1473)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
