### PR TITLE
Fix segfault when finishing fermentation

### DIFF
--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -3646,12 +3646,14 @@ void iexamine::fvat_full( Character &you, const tripoint &examp )
 
         if( query_yn( _( "Finish brewing?" ) ) ) {
             const std::map<itype_id, int> results = brew_i.brewing_results();
+            const int count = brew_i.count();
+            const time_point birthday = brew_i.birthday();
 
             here.i_clear( examp );
             for( const std::pair<const itype_id, int> &result : results ) {
-                int amount = result.second * brew_i.count();
+                int amount = result.second * count;
                 // TODO: Different age based on settings
-                item booze( result.first, brew_i.birthday() );
+                item booze( result.first, birthday );
                 if( result.first->phase == phase_id::LIQUID ) {
                     booze.charges = amount;
                     here.add_item( examp, booze );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix segfault when finishing fermentation"

#### Purpose of change

#67538 uses `brew_i.count()`, but this is done after the item is removed (`here.i_clear( examp );`). This causes a segfault as the `type` pointer is invalidated by the removal.

Fixes #67937.
Fixes #68181.

#### Describe the solution

Don't use `brew_i` after `i_clear`, put the necessary data in local vars.

#### Describe alternatives you've considered

None

#### Testing

Tested finishing fermentation with the attached saves from each of the linked issues. Both work properly now.