### PR TITLE
Characters with Infection Immune trait no longer need to sterilize bionics prior to installation

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -3782,7 +3782,7 @@
     "id": "INFIMMUNE",
     "name": { "str": "Infection Immune" },
     "points": 3,
-    "description": "Your bloodstream has developed antibiotic properties.  Your wounds will never become infected.",
+    "description": "Your bloodstream has developed antibiotic properties.  Your wounds will never become infected.  You will also be able to install non-sterile CBMs.",
     "prereqs": [ "DISRESISTANT", "DISIMMUNE" ],
     "prereqs2": [ "INFRESIST" ],
     "category": [ "MEDICAL" ],

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -162,6 +162,7 @@ static const json_character_flag json_flag_BIONIC_POWER_SOURCE( "BIONIC_POWER_SO
 static const json_character_flag json_flag_BIONIC_TOGGLED( "BIONIC_TOGGLED" );
 static const json_character_flag json_flag_BIONIC_WEAPON( "BIONIC_WEAPON" );
 static const json_character_flag json_flag_ENHANCED_VISION( "ENHANCED_VISION" );
+static const json_character_flag json_flag_INFECTION_IMMUNE( "INFECTION_IMMUNE" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
 
 static const material_id fuel_type_metabolism( "metabolism" );
@@ -2336,7 +2337,7 @@ ret_val<void> Character::is_installable( const item *it, const bool by_autodoc )
         const std::string msg = by_autodoc ? _( "/!\\ CBM is highly contaminated. /!\\" ) :
                                 _( "CBM is filthy." );
         return ret_val<void>::make_failure( msg );
-    } else if( it->has_flag( flag_NO_STERILE ) ) {
+    } else if( it->has_flag( flag_NO_STERILE ) && !has_flag( json_flag_INFECTION_IMMUNE ) ) {
         const std::string msg = by_autodoc ?
                                 // NOLINTNEXTLINE(cata-text-style): single space after the period for symmetry
                                 _( "/!\\ CBM is not sterile. /!\\ Please use autoclave to sterilize." ) :

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -133,6 +133,8 @@ static const itype_id itype_power_cord( "power_cord" );
 static const itype_id itype_stock_none( "stock_none" );
 static const itype_id itype_syringe( "syringe" );
 
+static const json_character_flag json_flag_INFECTION_IMMUNE( "INFECTION_IMMUNE" );
+
 static const mon_flag_str_id mon_flag_INTERIOR_AMMO( "INTERIOR_AMMO" );
 
 static const proficiency_id proficiency_prof_traps( "prof_traps" );
@@ -4116,7 +4118,7 @@ ret_val<void> install_bionic_actor::can_use( const Character &p, const item &it,
             return ret_val<void>::make_failure( _( "You can't self-install this CBM." ) );
         } else  if( it.has_flag( flag_FILTHY ) ) {
             return ret_val<void>::make_failure( _( "You can't install a filthy CBM!" ) );
-        } else if( it.has_flag( flag_NO_STERILE ) ) {
+        } else if( it.has_flag( flag_NO_STERILE ) && !p.has_flag( json_flag_INFECTION_IMMUNE ) ) {
             return ret_val<void>::make_failure( _( "This CBM is not sterile, you can't install it." ) );
         } else if( it.has_fault( fault_bionic_salvaged ) ) {
             return ret_val<void>::make_failure(


### PR DESCRIPTION
#### Summary
Features "Characters with Infection Immune trait no longer need to sterilize bionics prior to installation"

#### Purpose of change
Characters with Infection Immune trait are, well, immune to infections, including those which can transmit via installation of non-sterile bionics. This change feels plausible and make trait in question more valuable.

#### Describe the solution
Ported https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/pull/60 and https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/pull/67:
- Added check for the trait in `Character::is_installable` and `install_bionic_actor::can_use` functions.
- Updated trait's description.

#### Describe alternatives you've considered
- Characters with Disease Immune should gain this advantage too? On the other hand, "disease" in this context only relates to viral diseases like common cold and flu, and I'm not sure whether we should take other viral pathogens into consideration since we don't simulate them.
- Permit installing not only non-sterile bionics, but also filthy ones?

#### Testing
Got Infection Immune trait. Got non-sterile bionic. Found autodoc. Tried to install the bionic. Success.

#### Additional context
None.