### PR TITLE
Isolation Protocol: Better Danger Clock

### DIFF
--- a/data/mods/Isolation-Protocol/EOC/danger_clock_eoc.json
+++ b/data/mods/Isolation-Protocol/EOC/danger_clock_eoc.json
@@ -2,20 +2,17 @@
   {
     "type": "effect_on_condition",
     "id": "ISO_DANGER_CLOCK",
-    "recurrence": "80 minutes",
+    "recurrence": "3 minutes",
     "global": true,
-    "condition": { "not": { "u_is_on_terrain": "t_grass" } },
-    "effect": [
-      { "u_adjust_var": "ISO_DANGER", "type": "counter", "context": "ISO", "adjustment": 1 },
-      { "u_adjust_var": "ISO_CURRENT_LEVEL_DANGER", "type": "counter", "context": "ISO", "adjustment": 1 }
-    ]
+    "condition": { "not": { "or": [ { "u_at_om_location": "iso_hallway_safe" }, { "u_at_om_location": "iso_elevator_safe" } ] } },
+    "effect": [ { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", "++" ] }, { "math": [ "u_ISO_DANGER", "++" ] } ]
   },
   {
     "type": "effect_on_condition",
     "id": "ISO_DANGER_LEVEL_SPAWNER",
     "recurrence": "5 minutes",
     "global": true,
-    "condition": { "u_compare_var": "ISO_CURRENT_LEVEL_DANGER", "type": "counter", "context": "ISO", "op": ">=", "value": 17 },
+    "condition": { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", ">=", "20" ] },
     "effect": [
       {
         "u_spawn_monster": "mon_hound_tindalos",
@@ -30,18 +27,7 @@
       "run_eocs": [
         {
           "id": "ISO_CURRENT_LEVEL_DANGER_medium",
-          "condition": {
-            "and": [
-              { "x_in_y_chance": { "x": 1, "y": 10 } },
-              {
-                "u_compare_var": "ISO_CURRENT_LEVEL_DANGER",
-                "type": "counter",
-                "context": "ISO",
-                "op": ">=",
-                "value": 16
-              }
-            ]
-          },
+          "condition": { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", ">=", "15" ] },
           "effect": [
             {
               "u_spawn_monster": "mon_darkman",
@@ -56,18 +42,7 @@
             "run_eocs": [
               {
                 "id": "ISO_CURRENT_LEVEL_DANGER_low",
-                "condition": {
-                  "and": [
-                    { "x_in_y_chance": { "x": 1, "y": 5 } },
-                    {
-                      "u_compare_var": "ISO_CURRENT_LEVEL_DANGER",
-                      "type": "counter",
-                      "context": "ISO",
-                      "op": ">=",
-                      "value": 15
-                    }
-                  ]
-                },
+                "condition": { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", ">=", "10" ] },
                 "effect": [
                   {
                     "u_spawn_monster": "mon_shadow",

--- a/data/mods/Isolation-Protocol/EOC/elevator_eoc.json
+++ b/data/mods/Isolation-Protocol/EOC/elevator_eoc.json
@@ -1,0 +1,52 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ISO_ADD_TRAIT",
+    "eoc_type": "EVENT",
+    "required_event": "game_begin",
+    "condition": { "and": [ { "not": { "u_has_trait": "iso_trait" } } ] },
+    "effect": [ { "u_add_trait": "iso_trait" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ISO_ELEVATOR",
+    "effect": [
+      { "math": [ "ISO_CURRENT_LEVEL", "++" ] },
+      { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", "=", "0" ] },
+      { "run_eocs": [ "EOC_ISO_DECIDE_LEVEL" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ISO_DECIDE_LEVEL",
+    "condition": { "math": [ "ISO_CURRENT_LEVEL % SAFEPOINT_INTERVAL", "==", "0" ] },
+    "effect": [ { "run_eocs": [ "EOC_ISO_MICROLAB_SAFE_TP" ] } ],
+    "false_effect": [ { "run_eocs": [ "EOC_ISO_MICROLAB_TP" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ISO_MICROLAB_TP",
+    "effect": [
+      {
+        "u_location_variable": { "global_val": "new_map" },
+        "target_params": { "om_terrain": "iso_elevator", "z": -1, "random": true, "cant_see": true, "search_range": 180 },
+        "terrain": "t_elevator",
+        "target_max_radius": 30
+      },
+      { "u_teleport": { "global_val": "new_map" }, "force": true }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ISO_MICROLAB_SAFE_TP",
+    "effect": [
+      {
+        "u_location_variable": { "global_val": "new_map" },
+        "target_params": { "om_terrain": "iso_elevator_safe", "z": -1, "random": true, "cant_see": true, "search_range": 180 },
+        "terrain": "t_elevator",
+        "target_max_radius": 30
+      },
+      { "u_teleport": { "global_val": "new_map" }, "force": true }
+    ]
+  }
+]

--- a/data/mods/Isolation-Protocol/EOC/elevator_eoc.json
+++ b/data/mods/Isolation-Protocol/EOC/elevator_eoc.json
@@ -13,6 +13,7 @@
     "effect": [
       { "math": [ "ISO_CURRENT_LEVEL", "++" ] },
       { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", "=", "0" ] },
+      { "u_message": "The elevator starts moving before you can touch the panel.", "popup": true },
       { "run_eocs": [ "EOC_ISO_DECIDE_LEVEL" ] }
     ]
   },

--- a/data/mods/Isolation-Protocol/EOC/scenario_init.json
+++ b/data/mods/Isolation-Protocol/EOC/scenario_init.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "scenario_fractal_facility",
+    "eoc_type": "SCENARIO_SPECIFIC",
+    "effect": [ { "math": [ "SAFEPOINT_INTERVAL", "=", "5" ] }, { "math": [ "ISO_CURRENT_LEVEL", "=", "1" ] } ]
+  }
+]

--- a/data/mods/Isolation-Protocol/Map/levels/safe_level.json
+++ b/data/mods/Isolation-Protocol/Map/levels/safe_level.json
@@ -1,0 +1,16 @@
+[
+  {
+    "type": "overmap_special",
+    "id": "iso_safe_map",
+    "overmaps": [
+      { "point": [ 0, 0, -1 ], "overmap": "iso_elevator_safe_north" },
+      { "point": [ 0, -1, -1 ], "overmap": "iso_hallway_safe_north" },
+      { "point": [ 0, -2, -1 ], "overmap": "iso_next_level_elevator_south" }
+    ],
+    "locations": [ "iso_nether" ],
+    "flags": [ "ISO_MAP" ],
+    "city_distance": [ 0, 30 ],
+    "city_sizes": [ 0, 16 ],
+    "occurrences": [ 4, 4 ]
+  }
+]

--- a/data/mods/Isolation-Protocol/Map/mapgen/elevator.json
+++ b/data/mods/Isolation-Protocol/Map/mapgen/elevator.json
@@ -17,6 +17,12 @@
   },
   {
     "type": "mapgen",
+    "om_terrain": "iso_elevator_safe",
+    "method": "json",
+    "object": { "fill_ter": "t_strconc_floor", "place_nested": [ { "chunks": [ "iso_elevator" ], "x": 0, "y": 0 } ] }
+  },
+  {
+    "type": "mapgen",
     "om_terrain": "iso_next_level_elevator",
     "method": "json",
     "object": { "fill_ter": "t_strconc_floor", "place_nested": [ { "chunks": [ "iso_elevator_next" ], "x": 0, "y": 0 } ] }

--- a/data/mods/Isolation-Protocol/Map/mapgen/hallway.json
+++ b/data/mods/Isolation-Protocol/Map/mapgen/hallway.json
@@ -13,5 +13,60 @@
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
       ]
     }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": "iso_hallway_safe",
+    "object": {
+      "fill_ter": "t_strconc_floor",
+      "place_nested": [
+        { "chunks": [ "microlab_generic_hallway_safe_tile" ], "x": 0, "y": 0 },
+        { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 0, "neighbors": { "north_west": "microlab" } },
+        { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 0, "neighbors": { "north_east": "microlab" } },
+        { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
+        { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
+      ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "nested_mapgen_id": "microlab_generic_hallway_safe_tile",
+    "method": "json",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "|####| YY    A YY |####|",
+        "|####||55||SS||55||####|",
+        "|####|YPPY||||YPPY|####|",
+        "|#|||||55||||||55|||||#|",
+        "|#|b@@|  b bb b  |@@b|#|",
+        "|#|b  5YYb bb bYY5  b|#|",
+        "|#|b@@|   ms A   |@@b|#|",
+        "|#|||||          |||||#|",
+        "|#|iY PPPPPPPPPPPP Yi|#|",
+        "|#|iY PPPPPPPPPPPP Yi|#|",
+        "|#||| PP ====== PP |||#|",
+        "|#|Y2 PPY=XXXX=YPP |;|#|",
+        "|#|;| PPY=XXXX=YPP 2Y|#|",
+        "|#||| PP ====== PP |||#|",
+        "|#|úY PPPPPPPPPPPP Yú|#|",
+        "|#|úY PPPPPPPPPPPP Yú|#|",
+        "|#||||| A   s    |||||#|",
+        "|#|b@@|    m    A|@@b|#|",
+        "|#|b  5YYb bb bYY5  b|#|",
+        "|#|b@@|  b bb b  |@@b|#|",
+        "|#|||||55||||||55|||||#|",
+        "|####|Y  Y||||Y  Y|####|",
+        "|####||55||SS||55||####|",
+        "|||||| YY      YY ||||||"
+      ],
+      "palettes": [ "microlab" ],
+      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red", "5": "t_door_metal_c" },
+      "furniture": { "A": "f_xedra_antenna" },
+      "item": { "m": { "item": "xedra_microphone", "chance": 90 }, "s": { "item": "xedra_seismograph", "chance": 90 } },
+      "items": { "ú": { "item": "SUS_evac_shelter_locker_used", "chance": 95 } },
+      "signs": { "S": { "signage": "\nNRE-SAFEPOINT\nStatus: ACTIVE" } }
+    }
   }
 ]

--- a/data/mods/Isolation-Protocol/Map/overmap.json
+++ b/data/mods/Isolation-Protocol/Map/overmap.json
@@ -1,7 +1,7 @@
 [
   {
     "type": "overmap_terrain",
-    "id": [ "iso_first_elevator", "iso_elevator", "iso_next_level_elevator" ],
+    "id": [ "iso_first_elevator", "iso_elevator", "iso_elevator_safe", "iso_next_level_elevator" ],
     "name": "lab elevator",
     "color": "light_red",
     "sym": "L",
@@ -15,5 +15,14 @@
     "color": "light_red",
     "see_cost": 5,
     "flags": [ "RISK_HIGH" ]
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "iso_hallway_safe" ],
+    "name": "lab safepoint",
+    "sym": "L",
+    "color": "light_red",
+    "see_cost": 5,
+    "flags": [ "SOURCE_SAFETY" ]
   }
 ]

--- a/data/mods/Isolation-Protocol/Player/enchantments.json
+++ b/data/mods/Isolation-Protocol/Player/enchantments.json
@@ -3,6 +3,14 @@
     "type": "enchantment",
     "id": "iso_ranged_adjust",
     "condition": "ALWAYS",
-    "values": [ { "value": "RANGED_DAMAGE", "multiply": 0.75 } ]
+    "values": [ { "value": "RANGED_DAMAGE", "multiply": -0.25 } ]
+  },
+  {
+    "type": "enchantment",
+    "id": "iso_ench_deliverator",
+    "condition": "ALWAYS",
+    "name": { "str": "The Deliverator" },
+    "description": "Always on the clock.",
+    "values": [ { "value": "SPEED", "add": { "math": [ "u_ISO_CURRENT_LEVEL_DANGER" ] } } ]
   }
 ]

--- a/data/mods/Isolation-Protocol/Player/perks.json
+++ b/data/mods/Isolation-Protocol/Player/perks.json
@@ -1,0 +1,21 @@
+[
+  {
+    "type": "mutation_type",
+    "id": "iso_perk"
+  },
+  {
+    "type": "mutation_type",
+    "id": "iso_start_perk"
+  },
+  {
+    "type": "mutation",
+    "id": "iso_deliverator",
+    "name": { "str": "The Deliverator" },
+    "points": 0,
+    "description": "Every night you brave the highway, life-bound to a single promise: \"Your pie in thirty minutes or you can have it free.\"  People can respect that.  You are a role model.  A hero to the hungry.\n\nYou gain +1 quickness for each level of the nether hazard clock.",
+    "category": [ "iso_start_perk" ],
+    "enchantments": [ "iso_ench_deliverator" ],
+    "purifiable": false,
+    "valid": false
+  }
+]

--- a/data/mods/Isolation-Protocol/Player/perks.json
+++ b/data/mods/Isolation-Protocol/Player/perks.json
@@ -12,7 +12,7 @@
     "id": "iso_deliverator",
     "name": { "str": "The Deliverator" },
     "points": 0,
-    "description": "Every night you brave the highway, life-bound to a single promise: \"Your pie in thirty minutes or you can have it free.\"  People can respect that.  You are a role model.  A hero to the hungry.\n\nYou gain +1 quickness for each level of the nether hazard clock.",
+    "description": "Every night you brave the highway, life-bound to a single promise: \"Your pie in thirty minutes or you can have it free.\"  People can respect that.  You are a role model.  A hero to the hungry.\n\nYou gain +1 quickness for each level of normality distortion.",
     "category": [ "iso_start_perk" ],
     "enchantments": [ "iso_ench_deliverator" ],
     "purifiable": false,

--- a/data/mods/Isolation-Protocol/Player/profession.json
+++ b/data/mods/Isolation-Protocol/Player/profession.json
@@ -5,7 +5,7 @@
     "name": { "male": "Pizza Delivery Boy", "female": "Pizza Delivery Girl" },
     "description": "A late night delivery to a lonely building, a cry for help from under the elevator, and a terrible conspiracy.  You are not drunk enough for this.",
     "points": 1,
-    "traits": [ "iso_trait" ],
+    "traits": [ "iso_trait", "iso_deliverator" ],
     "skills": [
       { "level": 3, "name": "driving" },
       { "level": 1, "name": "speech" },

--- a/data/mods/Isolation-Protocol/furniture.json
+++ b/data/mods/Isolation-Protocol/furniture.json
@@ -10,24 +10,6 @@
     "coverage": 50,
     "roof": "t_flat_roof",
     "flags": [ "NOITEM", "INDOORS" ],
-    "examine_action": {
-      "type": "effect_on_condition",
-      "effect_on_conditions": [
-        {
-          "id": "EOC_ISO_ELEVATOR",
-          "effect": [
-            {
-              "u_location_variable": { "global_val": "new_map" },
-              "target_params": { "om_terrain": "iso_elevator", "z": -1, "random": true, "cant_see": true, "search_range": 180 },
-              "x_adjust": 13,
-              "y_adjust": 9
-            },
-            { "u_message": "The elevator starts moving before you can touch the panel.", "popup": true },
-            { "u_teleport": { "global_val": "new_map" }, "force": true },
-            { "u_add_var": "ISO_CURRENT_LEVEL_DANGER", "type": "counter", "context": "ISO", "value": "0" }
-          ]
-        }
-      ]
-    }
+    "examine_action": { "type": "effect_on_condition", "effect_on_conditions": [ "EOC_ISO_ELEVATOR" ] }
   }
 ]

--- a/data/mods/Isolation-Protocol/scenarios.json
+++ b/data/mods/Isolation-Protocol/scenarios.json
@@ -8,6 +8,8 @@
     "allowed_locs": [ "iso_entry_setpiece" ],
     "professions": [ "iso_deliveryboy", "iso_cop", "iso_paramedic", "iso_hacker" ],
     "flags": [ "LONE_START" ],
-    "start_name": "Facility Lobby"
+    "start_name": "Facility Lobby",
+    "forbidden_traits": [ "ROBUST", "XS", "XXXL", "CHAOTIC_BAD", "QUICK", "NOMAD", "WAYFARER", "NYCTOPHOBIA" ],
+    "eoc": [ "scenario_fractal_facility" ]
   }
 ]

--- a/data/mods/Isolation-Protocol/ui.json
+++ b/data/mods/Isolation-Protocol/ui.json
@@ -47,7 +47,7 @@
         "condition": { "or": [ { "u_at_om_location": "iso_hallway_safe" }, { "u_at_om_location": "iso_elevator_safe" } ] }
       },
       {
-        "id": "near_death",
+        "id": "ok",
         "text": "Deteriorating",
         "color": "light_gray",
         "condition": {
@@ -61,7 +61,7 @@
         }
       },
       {
-        "id": "near_death",
+        "id": "wrong",
         "text": "Distorted",
         "color": "dark_gray",
         "condition": {
@@ -69,7 +69,7 @@
         }
       },
       {
-        "id": "starving",
+        "id": "bad",
         "text": "Unstable",
         "color": "magenta",
         "condition": {
@@ -77,7 +77,7 @@
         }
       },
       {
-        "id": "hungry",
+        "id": "vbad",
         "text": "Unraveling",
         "color": "pink",
         "condition": { "and": [ { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", ">=", "20" ] } ] }

--- a/data/mods/Isolation-Protocol/ui.json
+++ b/data/mods/Isolation-Protocol/ui.json
@@ -1,0 +1,87 @@
+[
+  {
+    "//": "Extend with the danger widget",
+    "copy-from": "legacy_classic_sidebar",
+    "type": "widget",
+    "id": "legacy_classic_sidebar",
+    "extend": { "widgets": [ "iso_danger" ] }
+  },
+  {
+    "//": "Extend with the danger widget",
+    "copy-from": "legacy_compact_sidebar",
+    "type": "widget",
+    "id": "legacy_compact_sidebar",
+    "extend": { "widgets": [ "iso_danger" ] }
+  },
+  {
+    "//": "Extend with the danger widget",
+    "copy-from": "legacy_labels_narrow_sidebar",
+    "type": "widget",
+    "id": "legacy_labels_narrow_sidebar",
+    "extend": { "widgets": [ "iso_danger" ] }
+  },
+  {
+    "//": "Extend with the danger widget",
+    "copy-from": "legacy_labels_sidebar",
+    "type": "widget",
+    "id": "legacy_labels_sidebar",
+    "extend": { "widgets": [ "iso_danger" ] }
+  },
+  {
+    "//": "Extend with the danger widget",
+    "copy-from": "structured_sidebar",
+    "type": "widget",
+    "id": "structured_sidebar",
+    "extend": { "widgets": [ "iso_danger" ] }
+  },
+  {
+    "id": "iso_danger",
+    "type": "widget",
+    "label": "Location normality",
+    "style": "text",
+    "clauses": [
+      {
+        "id": "safe",
+        "text": "Stable",
+        "color": "light_green",
+        "condition": { "or": [ { "u_at_om_location": "iso_hallway_safe" }, { "u_at_om_location": "iso_elevator_safe" } ] }
+      },
+      {
+        "id": "near_death",
+        "text": "Deteriorating",
+        "color": "light_gray",
+        "condition": {
+          "and": [
+            { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", ">=00g", "0" ] },
+            { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", "<", "10" ] },
+            {
+              "not": { "or": [ { "u_at_om_location": "iso_hallway_safe" }, { "u_at_om_location": "iso_elevator_safe" } ] }
+            }
+          ]
+        }
+      },
+      {
+        "id": "near_death",
+        "text": "Distorted",
+        "color": "dark_gray",
+        "condition": {
+          "and": [ { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", ">=", "10" ] }, { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", "<", "15" ] } ]
+        }
+      },
+      {
+        "id": "starving",
+        "text": "Unstable",
+        "color": "magenta",
+        "condition": {
+          "and": [ { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", ">=", "15" ] }, { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", "<", "20" ] } ]
+        }
+      },
+      {
+        "id": "hungry",
+        "text": "Unraveling",
+        "color": "pink",
+        "condition": { "and": [ { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", ">=", "20" ] } ] }
+      }
+    ]
+  }
+]

--- a/data/mods/Isolation-Protocol/ui.json
+++ b/data/mods/Isolation-Protocol/ui.json
@@ -52,7 +52,7 @@
         "color": "light_gray",
         "condition": {
           "and": [
-            { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", ">=00g", "0" ] },
+            { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", ">=", "0" ] },
             { "math": [ "u_ISO_CURRENT_LEVEL_DANGER", "<", "10" ] },
             {
               "not": { "or": [ { "u_at_om_location": "iso_hallway_safe" }, { "u_at_om_location": "iso_elevator_safe" } ] }


### PR DESCRIPTION
#### Summary
Mods "Isolation Protocol: Improve the Danger Clock"

#### Purpose of change
The danger clock serves the important function of actually pushing the player forward and not letting them patiently and safely clear the lab levels. It however needs some flexibility to let you engage with time consuming game systems that aren't combat related.

So some sort of compromise is needed.

#### Describe the solution
Reworked the danger clock so it ticks up much faster in lab levels, but also implemented shelter style levels where the player is free to sleep, craft objects or otherwise train and recuperate.  I added an UI widget to properly communicate the danger clock mechanic
and clearly distinguish the safe level from the rest. These levels spawn every 5 normal levels in the fractal facility scenario

Additionally I added the class perk for the Pizza Delivery guy.
Since they are a generalist class the start with: "The Deliverator" perk, which increases player quickness as reality deteriorates. Technicaly its uncapped but surviving past the point where the perk grants +20 speed is pretty hard.

#### Testing
Crawled the dungeon for a bit
