### PR TITLE
Bulk loading/unloading items into container saves time cost

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <iterator>
 #include <list>
 #include <map>
 #include <new>
@@ -4134,13 +4135,36 @@ std::unique_ptr<activity_actor> move_furniture_activity_actor::deserialize( Json
     return actor.clone();
 }
 
-static int item_move_cost( Character &who, item_location &item )
+static int item_move_cost( Character &who, item_location &item, bool bulk_cost )
 {
-    // Cost to take an item from a container or map
-    const int obtain_cost = item.obtain_cost( who );
-    // Cost to move an item to a container, vehicle or the ground
-    const int move_cost = Pickup::cost_to_move_item( who, *item );
-    return obtain_cost + move_cost;
+    if( !bulk_cost ) {
+        // Cost to take an item from a container or map
+        const int obtain_cost = item.obtain_cost( who );
+        // Cost to move an item to a container, vehicle or the ground
+        const int move_cost = Pickup::cost_to_move_item( who, *item );
+        return obtain_cost + move_cost;
+    } else {
+        // Pure cost to handling item excluding overhead.
+        return std::max( who.item_handling_cost( *item, true, 0, -1, true ), 1 );
+    }
+}
+
+static bool is_bulk_load( const item_location &lhs, const item_location &rhs )
+{
+    if( lhs.where() == rhs.where() && lhs->stacks_with( *rhs ) ) {
+        switch( lhs.where() ) {
+            case item_location::type::container:
+                return lhs.parent_item() == rhs.parent_item();
+                break;
+            case item_location::type::map:
+            case item_location::type::vehicle:
+                return lhs.position() == rhs.position();
+                break;
+            default:
+                break;
+        }
+    }
+    return false;
 }
 
 void insert_item_activity_actor::start( player_activity &act, Character &who )
@@ -4152,7 +4176,7 @@ void insert_item_activity_actor::start( player_activity &act, Character &who )
 
     all_pockets_rigid = holster->all_pockets_rigid();
 
-    const int total_moves = item_move_cost( who, items.front().first );
+    const int total_moves = item_move_cost( who, items.front().first, false );
     act.moves_left = total_moves;
     act.moves_total = total_moves;
 }
@@ -4160,9 +4184,15 @@ void insert_item_activity_actor::start( player_activity &act, Character &who )
 void insert_item_activity_actor::finish( player_activity &act, Character &who )
 {
     bool success = false;
+    bool bulk_load = false;
     drop_location &holstered_item = items.front();
     if( holstered_item.first ) {
         item &it = *holstered_item.first;
+        // Check if next is bulk load before moving item.
+        auto itr = std::next( items.begin() );
+        if( itr != items.end() && itr->first ) {
+            bulk_load = is_bulk_load( holstered_item.first, itr->first );
+        }
         if( !it.count_by_charges() ) {
             if( holster->can_contain_directly( it ).success() &&
                 holster.parents_can_contain_recursive( &it ) ) {
@@ -4226,7 +4256,7 @@ void insert_item_activity_actor::finish( player_activity &act, Character &who )
     }
 
     // Restart the activity
-    const int total_moves = item_move_cost( who, items.front().first );
+    const int total_moves = item_move_cost( who, items.front().first, bulk_load );
     act.moves_left = total_moves;
     act.moves_total = total_moves;
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7038,7 +7038,7 @@ bool Character::consume_charges( item &used, int qty )
 }
 
 int Character::item_handling_cost( const item &it, bool penalties, int base_cost,
-                                   int charges_in_it ) const
+                                   int charges_in_it, bool bulk_cost ) const
 {
     int mv = base_cost;
     if( penalties ) {
@@ -7060,17 +7060,20 @@ int Character::item_handling_cost( const item &it, bool penalties, int base_cost
         mv *= pen;
     }
 
-    // For single handed items use the least encumbered hand
-    if( it.is_two_handed( *this ) ) {
-        for( const bodypart_id &part : get_all_body_parts_of_type( body_part_type::type::hand ) ) {
-            mv += encumb( part );
+    // The following is considered as overhead and is not included in the cost when handling multiple items at once.
+    if( !bulk_cost ) {
+        // For single handed items use the least encumbered hand
+        if( it.is_two_handed( *this ) ) {
+            for( const bodypart_id &part : get_all_body_parts_of_type( body_part_type::type::hand ) ) {
+                mv += encumb( part );
+            }
+        } else {
+            int min_encumb = INT_MAX;
+            for( const bodypart_id &part : get_all_body_parts_of_type( body_part_type::type::hand ) ) {
+                min_encumb = std::min( min_encumb, encumb( part ) );
+            }
+            mv += min_encumb;
         }
-    } else {
-        int min_encumb = INT_MAX;
-        for( const bodypart_id &part : get_all_body_parts_of_type( body_part_type::type::hand ) ) {
-            min_encumb = std::min( min_encumb, encumb( part ) );
-        }
-        mv += min_encumb;
     }
 
     return std::max( mv, 0 );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10999,6 +10999,7 @@ bool Character::unload( item_location &loc, bool bypass_activity )
         }
 
         int moves = 0;
+        item *prev_contained = nullptr;
 
         for( item_pocket::pocket_type ptype : {
                  item_pocket::pocket_type::CONTAINER,
@@ -11007,7 +11008,12 @@ bool Character::unload( item_location &loc, bool bypass_activity )
              } ) {
 
             for( item *contained : it.all_items_top( ptype, true ) ) {
-                moves += this->item_handling_cost( *contained );
+                if( prev_contained && prev_contained->stacks_with( *contained ) ) {
+                    moves += std::max( this->item_handling_cost( *contained, true, 0, -1, true ), 1 );
+                } else {
+                    moves += this->item_handling_cost( *contained );
+                }
+                prev_contained = contained;
             }
 
         }

--- a/src/character.h
+++ b/src/character.h
@@ -1907,10 +1907,11 @@ class Character : public Creature, public visitable
          * @param penalties Whether item volume and temporary effects (e.g. GRABBED, DOWNED) should be considered.
          * @param base_cost Cost due to storage type.
          * @param charges_in_it the amount of charges to be handled (default is whole)
+         * @param bulk_cost Calculate costs excluding overhead, such as when loading and unloading items in bulk (default is false)
          * @return cost in moves ranging from 0 to MAX_HANDLING_COST
          */
         int item_handling_cost( const item &it, bool penalties = true,
-                                int base_cost = INVENTORY_HANDLING_PENALTY, int charges_in_it = -1 ) const;
+                                int base_cost = INVENTORY_HANDLING_PENALTY, int charges_in_it = -1, bool bulk_cost = false ) const;
 
         /**
          * Calculate (but do not deduct) the number of moves required when storing an item in a container


### PR DESCRIPTION
#### Summary
Balance "Bulk loading/unloading  items into container saves time cost"

#### Purpose of change
We had been looking for various opinions here regarding the time cost of handling large quantities of items. (https://github.com/CleverRaven/Cataclysm-DDA/pull/68004)
There were various opinions, but I think there is no particular disagreement with the opinion that it saves time by putting items in bulk when putting them in a specific container.
Picking up sand from a sand pile can be thought of as scooping sand with a cardboard box or plastic bag.

#### Describe the solution
Currently, the cost to load one item is as follows. (item_move_cost() in activity_actor.cpp)

cost = obtain_cost + move_cost

Both obtain_cost and move_cost includes overhead cost of reaching the item, such as the time it takes to walk to adjacent tiles.
I think this overhead is unnecessary for the second and subsequent items, so that is applied only once in new formula.
The cost to load excluding overhead is set as follows based on volume penalty of item_handling_cost() in character.cpp.

cost = min( 200, item_volume / 20_ml )

This is applied unloading too.

#### Describe alternatives you've considered
There are various ways of thinking about how to calculate costs.
- Apply formula suggested in https://github.com/CleverRaven/Cataclysm-DDA/issues/67385
- Same cost as liquid. (~666ml/s)

#### Testing
spawn items, press "v" and load items into backpack from floor.

Consumed time(1000 salts)
Before: 21:40
After: 00:11

Consumed time(100 apples)
Before: 2:21
After: 00:12

press "U" and unload items from backpack into another backpack.

Consumed time(1000 salts)
Before: 16:40
After: 00:11

Consumed time(100 apples)
Before: 1:51
After: 00:12

I feel that the time it takes to load apples is a little short, but I think it is not far from reality.

#### Additional context
This only applies to explicitly storing items in a specific container. (v key) Does not apply to normal item picking up process. (g key)
I think a different approach is needed to save time on the generic process of picking up items.
There may be some people think it's strange that you can pick up powdered items without leaving them behind, but I don't think that's something that should be discussed in this PR.