### PR TITLE
Merchants will tell when they will restock

### DIFF
--- a/data/json/npcs/cabin_chemist/chemist_npc.json
+++ b/data/json/npcs/cabin_chemist/chemist_npc.json
@@ -74,8 +74,8 @@
   {
     "type": "talk_topic",
     "id": "TALK_NPC_CABIN_CHEMIST_ASK_INTERVAL",
-    "dynamic_line": "Unfortunately, I'm still gathering resources and cooking new stuff. Maybe ask again after <interval>.",
-    "responses": [ { "text": "Alright. thanks nonetheless.", "topic": "TALK_NPC_CABIN_CHEMIST_INTRO" } ]
+    "dynamic_line": "Unfortunately, I'm still gathering resources and cooking new stuff.  Maybe ask again after <interval>.",
+    "responses": [ { "text": "Alright.  thanks nonetheless.", "topic": "TALK_NPC_CABIN_CHEMIST_INTRO" } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/cabin_chemist/chemist_npc.json
+++ b/data/json/npcs/cabin_chemist/chemist_npc.json
@@ -56,6 +56,7 @@
     "responses": [
       { "text": "Who are you?", "topic": "TALK_NPC_CABIN_CHEMIST_STORY" },
       { "text": "What is this place?", "topic": "TALK_NPC_CABIN_CHEMIST_HOME" },
+      { "text": "Brewed anything new lately?", "topic": "TALK_NPC_CABIN_CHEMIST_ASK_INTERVAL" },
       { "text": "Care to trade?", "topic": "TALK_NPC_CABIN_CHEMIST_INTRO", "effect": "start_trade" },
       {
         "text": "I'd like to buy in bulk.",

--- a/data/json/npcs/cabin_chemist/chemist_npc.json
+++ b/data/json/npcs/cabin_chemist/chemist_npc.json
@@ -72,6 +72,12 @@
   },
   {
     "type": "talk_topic",
+    "id": "TALK_NPC_CABIN_CHEMIST_ASK_INTERVAL",
+    "dynamic_line": "Unfortunately, I'm still gathering resources and cooking new stuff. Maybe ask again after <interval>.",
+    "responses": [ { "text": "Alright. thanks nonetheless.", "topic": "TALK_NPC_CABIN_CHEMIST_INTRO" } ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_NPC_CABIN_CHEMIST_STORY",
     "dynamic_line": "I used to be a chemist.  Well, I am a chemist.  I've been living out here in the wilderness for a little while now since <the_cataclysm>.  Even brought some of my equipment, though unfortunately missing some of the more sensitive and expensive stuff.  I found a couple useful things here in the cupboards, but other than that, entirely empty.  So, I moved in.",
     "responses": [ { "text": "Hmm.", "topic": "TALK_NONE" } ]

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -338,7 +338,7 @@
     "id": "TALK_EXODII_MERCHANT_AskedRestock",
     "type": "talk_topic",
     "dynamic_line": [ "HEH, ye c'nnae get enough o' ol' Rubik's merchandise, eh?.  Sure as 'ell, come back in <interval>." ],
-	"//~": "HEH, you can't get enough of old Rubik's merchandise, eh? Sure as hell, come back in <interval>.",
+    "//~": "HEH, you can't get enough of old Rubik's merchandise, eh? Sure as hell, come back in <interval>.",
     "responses": [
       { "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
       { "text": "Well, thanks.  I'd better be going.  Bye.", "topic": "TALK_DONE" }

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -338,7 +338,8 @@
     "id": "TALK_EXODII_MERCHANT_AskedRestock",
     "type": "talk_topic",
     "dynamic_line": [ "HEH, ye c'nnae get enough o' ol' Rubik's merchandise, eh?.  Sure as 'ell, come back in <interval>." ],
-    "response": [
+	"//~": "HEH, you can't get enough of old Rubik's merchandise, eh? Sure as hell, come back in <interval>.",
+    "responses": [
       { "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
       { "text": "Well, thanks.  I'd better be going.  Bye.", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -278,7 +278,7 @@
         "text": "You seem to have a bunch of blueprints.  Can you tell me more about those?",
         "topic": "TALK_EXODII_MERCHANT_Stock_Nomad"
       },
-	  { "text": "Have you anything more back there?", "topic": "TALK_EXODII_MERCHANT_AskedRestock" },
+      { "text": "Have you anything more back there?", "topic": "TALK_EXODII_MERCHANT_AskedRestock" },
       { "text": "What was it you were saying before?", "topic": "TALK_NONE" },
       { "text": "Well, I'd better be going.  Bye.", "topic": "TALK_DONE" }
     ]

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -278,6 +278,7 @@
         "text": "You seem to have a bunch of blueprints.  Can you tell me more about those?",
         "topic": "TALK_EXODII_MERCHANT_Stock_Nomad"
       },
+	  { "text": "Have you anything more back there?", "topic": "TALK_EXODII_MERCHANT_AskedRestock" },
       { "text": "What was it you were saying before?", "topic": "TALK_NONE" },
       { "text": "Well, I'd better be going.  Bye.", "topic": "TALK_DONE" }
     ]
@@ -332,6 +333,15 @@
       { "text": "What was it you were saying before?", "topic": "TALK_NONE" },
       { "text": "Well, I'd better be going.  Bye.", "topic": "TALK_DONE" }
     ]
+  },
+  {
+	"id": "TALK_EXODII_MERCHANT_AskedRestock",
+	"type": "talk_topic",
+	"dynamic_line": [ "HEH, ye c'nnae get enough o' ol' Rubik's merchandise, eh?.  Sure as 'ell, come back in <interval>." ],
+	"response": [
+	{ "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
+	{ "text": "Well, thanks.  I'd better be going.  Bye.", "topic": "TALK_DONE" }
+	]
   },
   {
     "id": "TALK_EXODII_MERCHANT_Talk",

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -335,13 +335,13 @@
     ]
   },
   {
-	"id": "TALK_EXODII_MERCHANT_AskedRestock",
-	"type": "talk_topic",
-	"dynamic_line": [ "HEH, ye c'nnae get enough o' ol' Rubik's merchandise, eh?.  Sure as 'ell, come back in <interval>." ],
-	"response": [
-	{ "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
-	{ "text": "Well, thanks.  I'd better be going.  Bye.", "topic": "TALK_DONE" }
-	]
+    "id": "TALK_EXODII_MERCHANT_AskedRestock",
+    "type": "talk_topic",
+    "dynamic_line": [ "HEH, ye c'nnae get enough o' ol' Rubik's merchandise, eh?.  Sure as 'ell, come back in <interval>." ],
+    "response": [
+      { "text": "Can we talk about something else?", "topic": "TALK_EXODII_MERCHANT_Talk" },
+      { "text": "Well, thanks.  I'd better be going.  Bye.", "topic": "TALK_DONE" }
+    ]
   },
   {
     "id": "TALK_EXODII_MERCHANT_Talk",

--- a/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
+++ b/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
@@ -122,7 +122,7 @@
   },
   {
     "id": "TALK_GODCO_Kostas_Interval",
-    "type": "talk_ropic",
+    "type": "talk_topic",
     "dynamic_line": [
       "I'm afraid I haven't gone out there for a while, maybe come back in <interval>.  These are all I have, care to take a look?.",
       "Sorry these are all I have.  However I'll be back from my next run in <interval>.  Care to take a look in the meanwhile?"

--- a/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
+++ b/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
@@ -128,7 +128,7 @@
       "Sorry these are all I have.  However I'll be back from my next run in <interval>.  Care to take a look in the meanwhile?"
     ],
     "responses": [
-      { "text": "Alright, I'll take a look.", "effec": "start_trade", "Topic": "TALK_GODCO_Kostas_1" },
+      { "text": "Alright, I'll take a look.", "effect": "start_trade", "topic": "TALK_GODCO_Kostas_1" },
       { "text": "Alright, thanks for informing me. Bye!", "topic": "TALK_DONE" }
     ]
   },

--- a/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
+++ b/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
@@ -131,7 +131,7 @@
       { "text": "Alright, I'll take a look.", "effec": "start_trade", "Topic": "TALK_GODCO_Kostas_1" },
       { "text": "Alright, thanks for iinforming me. Bye!", "topic": "TALK_DONE" }
     ]
-  }
+  },
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Kostas_2",

--- a/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
+++ b/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
@@ -129,7 +129,7 @@
     ],
     "responses": [
       { "text": "Alright, I'll take a look.", "effec": "start_trade", "Topic": "TALK_GODCO_Kostas_1" },
-      { "text": "Alright, thanks for iinforming me. Bye!", "topic": "TALK_DONE" }
+      { "text": "Alright, thanks for informing me. Bye!", "topic": "TALK_DONE" }
     ]
   },
   {

--- a/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
+++ b/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
@@ -102,6 +102,7 @@
         "effect": "start_trade",
         "topic": "TALK_GODCO_Kostas_2"
       },
+      { "text": "Hey Kostas, find something interesting lately?", "topic": "TALK_GODCO_Kostas_Interval" },
       {
         "text": "Hey, Kostas.  I can't stay to talk.",
         "condition": { "not": { "u_has_var": "godco_notalk_to_u", "type": "dialogue", "context": "godco", "value": "yes" } },
@@ -119,6 +120,18 @@
       }
     ]
   },
+  {
+    "id": "TALK_GODCO_Kostas_Interval",
+    "type": "talk_ropic",
+    "dynamic_line": [
+      "I'm afraid I haven't gone out there for a while, maybe come back in <interval>.  These are all I have, care to take a look?.",
+      "Sorry these are all I have.  However I'll be back from my next run in <interval>.  Care to take a look in the meanwhile?"
+    ],
+    "responses": [
+      { "text": "Alright, I'll take a look.", "effec": "start_trade", "Topic": "TALK_GODCO_Kostas_1" },
+      { "text": "Alright, thanks for iinforming me. Bye!" "topic": "TALK_DONE" }
+    ]
+  }
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Kostas_2",

--- a/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
+++ b/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
@@ -129,7 +129,7 @@
     ],
     "responses": [
       { "text": "Alright, I'll take a look.", "effec": "start_trade", "Topic": "TALK_GODCO_Kostas_1" },
-      { "text": "Alright, thanks for iinforming me. Bye!" "topic": "TALK_DONE" }
+      { "text": "Alright, thanks for iinforming me. Bye!", "topic": "TALK_DONE" }
     ]
   }
   {

--- a/data/json/npcs/godco/visitors/TALK_CARAVAN_MERCHANT_PREDATORY.json
+++ b/data/json/npcs/godco/visitors/TALK_CARAVAN_MERCHANT_PREDATORY.json
@@ -81,10 +81,17 @@
         "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_Trade",
         "effect": "start_trade"
       },
+      { "text": "You got anything else?", "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_askinterval" },
       { "text": "Your prices seem awfully high.", "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_Price" },
       { "text": "Thanks.  What were we talking about before?", "topic": "TALK_NONE" },
       { "text": "Thanks for that.  I'd better go.", "topic": "TALK_DONE" }
     ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_CARAVAN_MERCHANT_PREDATORY_askinterval",
+    "dynamic_line": "Well, not right now.  Try again after around <interval>.",
+    "responses": [ { "text": "Okay. About other things…", "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_2" } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/godco/visitors/TALK_CARAVAN_MERCHANT_PREDATORY.json
+++ b/data/json/npcs/godco/visitors/TALK_CARAVAN_MERCHANT_PREDATORY.json
@@ -91,7 +91,7 @@
     "type": "talk_topic",
     "id": "TALK_CARAVAN_MERCHANT_PREDATORY_askinterval",
     "dynamic_line": "Well, not right now.  Try again after around <interval>.",
-    "responses": [ { "text": "Okay. About other things…", "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_2" } ]
+    "responses": [ { "text": "Okay.  About other things…", "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_2" } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
@@ -154,12 +154,19 @@
         "topic": "TALK_ISHERWOOD_CLAIRE",
         "condition": { "not": { "u_is_wearing": "badge_marshal" } }
       },
+      { "text": "Hey, when would more of this stuff be ready?", "topic": "TALK_ISHERWOOD_CLAIRE_RESTOCK" },
       {
         "text": "I'd better get going.",
         "topic": "TALK_DONE",
         "condition": { "not": { "u_is_wearing": "badge_marshal" } }
       }
     ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ISHERWOOD_CLAIRE_RESTOCK",
+    "dynamic_line": "Around <interval>.",
+    "responses": [ { "text": "Alright then, bye.", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/isherwood_farm/NPC_Eddie_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Eddie_Isherwood.json
@@ -102,12 +102,19 @@
         "effect": "start_trade",
         "condition": { "not": { "u_is_wearing": "badge_marshal" } }
       },
+      { "text": "When will your cows produce again?", "topic": "TALK_ISHERWOOD_EDDIE_RESTOCK" },
       {
         "text": "I'd better get going.",
         "topic": "TALK_DONE",
         "condition": { "not": { "u_is_wearing": "badge_marshal" } }
       }
     ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ISHERWOOD_EDDIE_RESTOCK",
+    "dynamic_line": "If the cows don't get anything nasty it should be around <interval>.",
+    "responses": [ { "text": "Cheers, bye.", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/isherwood_farm/NPC_Jack_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Jack_Isherwood.json
@@ -199,12 +199,19 @@
         "effect": "start_trade",
         "condition": { "not": { "u_is_wearing": "badge_marshal" } }
       },
+      { "text": "Hey, when would more of this stuff be ready?", "topic": "TALK_ISHERWOOD_JACK_RESTOCK" },
       {
         "text": "I'd better get going.",
         "topic": "TALK_DONE",
         "condition": { "not": { "u_is_wearing": "badge_marshal" } }
       }
     ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_ISHERWOOD_JACK_RESTOCK",
+    "dynamic_line": "Around <interval>.",
+    "responses": [ { "text": "Alright then, bye.", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
@@ -221,7 +221,7 @@
         "effect": "start_trade"
       },
       {
-        "text": "Interesting. When would be the next batch of merchandise ready?",
+        "text": "Interesting.  When would be the next batch of merchandise ready?",
         "topic": "TALK_BLACKSMITH_RESTOCK"
       },
       {
@@ -236,7 +236,7 @@
     "id": "TALK_BLACKSMITH_RESTOCK",
     "type": "talk_topic",
     "dynamic_line": "With how the things are goin'? <interval>.",
-    "responses": [ { "text": "I'll leave you to your work then. Bye.", "topic": "TALK_DONE" } ]
+    "responses": [ { "text": "I'll leave you to your work then.  Bye.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_BLACKSMITH_ABOUT",

--- a/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
@@ -220,6 +220,7 @@
         "topic": "TALK_BLACKSMITH_SERVICES",
         "effect": "start_trade"
       },
+      { "text": "Interesting. When would be the next batch of merchandise ready?", "topic": "TALK_BLACKSMITH_RESTOCK" },
       {
         "text": "I heard you might want some metal…",
         "topic": "TALK_BLACKSMITH_DEAL_NEGOTIATE",
@@ -227,6 +228,12 @@
       },
       { "text": "I have to go.", "topic": "TALK_DONE" }
     ]
+  },
+  {
+    "id": "TALK_BLACKSMITH_RESTOCK",
+    "type": "talk_topic",
+    "dynamic_line": "With how the things are goin'? <interval>.",
+    "responses": [ { "text": "I'll leave you to your work then. Bye.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_BLACKSMITH_ABOUT",

--- a/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
@@ -220,7 +220,10 @@
         "topic": "TALK_BLACKSMITH_SERVICES",
         "effect": "start_trade"
       },
-      { "text": "Interesting. When would be the next batch of merchandise ready?", "topic": "TALK_BLACKSMITH_RESTOCK" },
+      {
+        "text": "Interesting. When would be the next batch of merchandise ready?",
+        "topic": "TALK_BLACKSMITH_RESTOCK"
+      },
       {
         "text": "I heard you might want some metal…",
         "topic": "TALK_BLACKSMITH_DEAL_NEGOTIATE",

--- a/data/json/npcs/isolated_road/isolated_road_jay_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_jay_dialogue.json
@@ -148,8 +148,15 @@
         "topic": "TALK_MISSION_LIST"
       },
       { "text": "Let's trade.", "topic": "TALK_GUNSMITH_SERVICES", "effect": "start_trade" },
+      { "text": "How's the 'printing' thing going?", "topic": "TALK_GUNSMITH_RESTOCK" },
       { "text": "I have to go.", "topic": "TALK_DONE" }
     ]
+  },
+  {
+    "id": "TALK_GUNSMITH_RESTOCK",
+    "type": "talk_topic",
+    "dynamic_line": "Next series of currency gotta be ready in around <interval>, fresh off the print!",
+    "responses": [ { "text": "I'll make sure to take a look. Bye.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_GUNSMITH_SHOP_ABOUT",

--- a/data/json/npcs/isolated_road/isolated_road_jay_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_jay_dialogue.json
@@ -156,7 +156,7 @@
     "id": "TALK_GUNSMITH_RESTOCK",
     "type": "talk_topic",
     "dynamic_line": "Next series of currency gotta be ready in around <interval>, fresh off the print!",
-    "responses": [ { "text": "I'll make sure to take a look. Bye.", "topic": "TALK_DONE" } ]
+    "responses": [ { "text": "I'll make sure to take a look.  Bye.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_GUNSMITH_SHOP_ABOUT",

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -47,7 +47,7 @@
     "responses": [
       { "text": "About other things…", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" },
       { "text": "Let's trade.", "topic": "TALK_FREE_MERCHANTS_MERCHANT_DoneTrading", "effect": "start_trade" },
-	  { "text": "When will you have new stuff in stock?", "topic": "TALK_FREE_MERCHANTS_MERCHANT_AskedRestock" },
+      { "text": "When will you have new stuff in stock?", "topic": "TALK_FREE_MERCHANTS_MERCHANT_AskedRestock" },
       { "text": "That's all for now.  Take care.", "topic": "TALK_DONE" }
     ]
   },

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -43,7 +43,7 @@
   {
     "id": "TALK_FREE_MERCHANTS_MERCHANT_DoneTrading",
     "type": "talk_topic",
-    "dynamic_line": [ "Come back in <interval>. I may have something you're interested in. " ],
+    "dynamic_line": [ "Come back in <interval>.  I may have something you're interested in." ],
     "responses": [
       { "text": "About other things…", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" },
       { "text": "Let's trade.", "topic": "TALK_FREE_MERCHANTS_MERCHANT_DoneTrading", "effect": "start_trade" },

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -52,13 +52,16 @@
     ]
   },
   {
-	"id": "TALK_FREE_MERCHANTS_MERCHANT_AskedRestock",
-	"type": "talk_topic",
-	"dynamic_line": [ "Next shipment should arrive in around <interval>.", "Stick around for <interval>, there will surely be something you'd like." ],
-	"responses": [
-	{ "text": "Actually, I wanted to ask...", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" },
-	{ "text": "Thanks, I will make sure to check back.  Farewell.", "topic": "TALK_DONE" }
-	]
+    "id": "TALK_FREE_MERCHANTS_MERCHANT_AskedRestock",
+    "type": "talk_topic",
+    "dynamic_line": [
+      "Next shipment should arrive in around <interval>.",
+      "Stick around for <interval>, there will surely be something you'd like."
+    ],
+    "responses": [
+      { "text": "Actually, I wanted to ask...", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" },
+      { "text": "Thanks, I will make sure to check back.  Farewell.", "topic": "TALK_DONE" }
+    ]
   },
   {
     "id": "TALK_FREE_MERCHANTS_MERCHANT_Intro",

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -59,7 +59,7 @@
       "Stick around for <interval>, there will surely be something you'd like."
     ],
     "responses": [
-      { "text": "Actually, I wanted to ask...", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" },
+      { "text": "Actually, I wanted to ask…", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" },
       { "text": "Thanks, I will make sure to check back.  Farewell.", "topic": "TALK_DONE" }
     ]
   },

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -43,12 +43,22 @@
   {
     "id": "TALK_FREE_MERCHANTS_MERCHANT_DoneTrading",
     "type": "talk_topic",
-    "dynamic_line": [ "Come back in <interval>.  I may have something you're interested in." ],
+    "dynamic_line": [ "Hope it helps.", "Give me second to write that down… okay, done.", "You know where to find me." ],
     "responses": [
       { "text": "About other things…", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" },
       { "text": "Let's trade.", "topic": "TALK_FREE_MERCHANTS_MERCHANT_DoneTrading", "effect": "start_trade" },
+	  { "text": "When will you have new stuff in stock?", "topic": "TALK_FREE_MERCHANTS_MERCHANT_AskedRestock" },
       { "text": "That's all for now.  Take care.", "topic": "TALK_DONE" }
     ]
+  },
+  {
+	"id": "TALK_FREE_MERCHANTS_MERCHANT_AskedRestock",
+	"type": "talk_topic",
+	"dynamic_line": [ "Next shipment should arrive in around <interval>.", "Stick around for <interval>, there will surely be something you'd like." ],
+	"responses": [
+	{ "text": "Actually, I wanted to ask...", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" },
+	{ "text": "Thanks, I will make sure to check back.  Farewell.", "topic": "TALK_DONE" }
+	]
   },
   {
     "id": "TALK_FREE_MERCHANTS_MERCHANT_Intro",

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -43,7 +43,7 @@
   {
     "id": "TALK_FREE_MERCHANTS_MERCHANT_DoneTrading",
     "type": "talk_topic",
-    "dynamic_line": [ "Hope it helps.", "Give me second to write that down… okay, done.", "You know where to find me." ],
+    "dynamic_line": [ "Come back in <interval>. I may have something you're interested in. " ],
     "responses": [
       { "text": "About other things…", "topic": "TALK_FREE_MERCHANTS_MERCHANT_Talk" },
       { "text": "Let's trade.", "topic": "TALK_FREE_MERCHANTS_MERCHANT_DoneTrading", "effect": "start_trade" },

--- a/data/json/npcs/robofac/ROBOFAC_SURFACE_FREEMERCHANT.json
+++ b/data/json/npcs/robofac/ROBOFAC_SURFACE_FREEMERCHANT.json
@@ -100,6 +100,7 @@
     },
     "responses": [
       { "text": "Let's trade.", "effect": "start_trade", "topic": "TALK_ROBOFAC_FREE_MERCHANT" },
+      { "text": "When is the next shipment?", "topic": "TALK_ROBOFAC_FREE_MERCHANT_INTERVAL" },
       { "text": "What are you doing here?", "topic": "TALK_ROBOFAC_FREE_MERCHANT_DOING" },
       { "text": "Well, bye.", "topic": "TALK_DONE" }
     ]
@@ -113,5 +114,11 @@
       "no": "We have been supplying this lab here with food from a few hunting and farming communities nearby.  The roads are tough and dangerous, but it makes good money, and beats scavenging the cities for scraps."
     },
     "responses": [ { "text": "Keep safe, then.", "topic": "TALK_ROBOFAC_FREE_MERCHANT" } ]
+  },
+  {
+    "id": "TALK_ROBOFAC_FREE_MERCHANT_INTERVAL",
+    "type": "talk_topic",
+    "dynamic_line": "Around <interval>, if the caravan doesn't run into trouble.",
+    "responses": [ { "text": "Thanks for the info, bye.", "topic": "TALK_DONE" } ]
   }
 ]

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -283,6 +283,7 @@
     "responses": [
       { "text": "Let's discuss contracts.", "topic": "TALK_ROBOFAC_INTERCOM_CONTRACTS" },
       { "text": "Let's trade.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES", "effect": "start_trade" },
+	   { "text": "Is there anything fancier you can sell?", "topic": "TALK_ROBOFAC_INTERCOM_ASK_INTERVAL" },
       {
         "text": "Let's discuss prototypes.",
         "condition": { "u_has_var": "u_hub_prototypes", "type": "dialogue", "context": "intercom", "value": "yes" },
@@ -805,5 +806,11 @@
       "sentinel": "told_about_prototype"
     },
     "responses": [ { "text": "Right.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
-  }
+   },
+   {
+	 "id": "TALK_ROBOFAC_INTERCOM_ASK_INTERVAL",
+	 "type": "talk_topic"
+	 "dynamic_line": [ "We have no other disposable equipment right now.  You'll have to come back in <interval>.", "No. Come back in <interval>." ],
+     "responses": [ { "text": "Right…", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
+   }
 ]

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -809,7 +809,7 @@
    },
    {
 	 "id": "TALK_ROBOFAC_INTERCOM_ASK_INTERVAL",
-	 "type": "talk_topic"
+	 "type": "talk_topic",
 	 "dynamic_line": [ "We have no other disposable equipment right now.  You'll have to come back in <interval>.", "No. Come back in <interval>." ],
      "responses": [ { "text": "Right…", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
    }

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -806,11 +806,14 @@
       "sentinel": "told_about_prototype"
     },
     "responses": [ { "text": "Right.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
-   },
-   {
-	 "id": "TALK_ROBOFAC_INTERCOM_ASK_INTERVAL",
-	 "type": "talk_topic",
-	 "dynamic_line": [ "We have no other disposable equipment right now.  You'll have to come back in <interval>.", "No. Come back in <interval>." ],
-     "responses": [ { "text": "Right…", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
-   }
+  },
+  {
+    "id": "TALK_ROBOFAC_INTERCOM_ASK_INTERVAL",
+    "type": "talk_topic",
+    "dynamic_line": [
+      "We have no other disposable equipment right now.  You'll have to come back in <interval>.",
+      "No. Come back in <interval>."
+    ],
+    "responses": [ { "text": "Right…", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES" } ]
+  }
 ]

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -283,7 +283,7 @@
     "responses": [
       { "text": "Let's discuss contracts.", "topic": "TALK_ROBOFAC_INTERCOM_CONTRACTS" },
       { "text": "Let's trade.", "topic": "TALK_ROBOFAC_INTERCOM_SERVICES", "effect": "start_trade" },
-	   { "text": "Is there anything fancier you can sell?", "topic": "TALK_ROBOFAC_INTERCOM_ASK_INTERVAL" },
+      { "text": "Is there anything fancier you can sell?", "topic": "TALK_ROBOFAC_INTERCOM_ASK_INTERVAL" },
       {
         "text": "Let's discuss prototypes.",
         "condition": { "u_has_var": "u_hub_prototypes", "type": "dialogue", "context": "intercom", "value": "yes" },

--- a/data/json/npcs/scrap_trader/scrap_trader.json
+++ b/data/json/npcs/scrap_trader/scrap_trader.json
@@ -282,7 +282,7 @@
   {
     "id": "TALK_SCRAP_TRADER_ASK_INTERVAL",
     "type": "talk_topic",
-    "dynamic_line": "Nope, although I have a really good claim by the river. Gonna go fetch them soon, be right back in <interval>.",
+    "dynamic_line": "Nope, although I have a really good claim by the river.  Gonna go fetch them soon, be right back in <interval>.",
     "responses": [ { "text": "Well, good luck.", "topic": "TALK_NPC_SCRAP_TRADER" } ]
   }
 ]

--- a/data/json/npcs/scrap_trader/scrap_trader.json
+++ b/data/json/npcs/scrap_trader/scrap_trader.json
@@ -275,7 +275,14 @@
     "dynamic_line": [ "Anything else you need?" ],
     "responses": [
       { "text": "No, that's all.", "topic": "TALK_DONE" },
+      { "text": "Find anything good?", "topic": "TALK_SCRAP_TRADER_ASK_INTERVAL" },
       { "text": "Can I have another look?", "topic": "TALK_SCRAP_TRADER_BULK_SELL_END", "effect": "start_trade" }
     ]
+  },
+  {
+    "id": "TALK_SCRAP_TRADER_ASK_INTERVAL",
+    "type": "talk_topic",
+    "dynamic_line": "Nope, although I have a really good claim by the river. Gonna go fetch them soon, be right back in <interval>.",
+    "responses": [ { "text": "Well, good luck.", "topic": "TALK_NPC_SCRAP_TRADER" } ]
   }
 ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_scavenger.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_scavenger.json
@@ -35,8 +35,15 @@
       { "text": "What is your job here?", "topic": "TALK_RANCH_SCAVENGER_1_JOB" },
       { "text": "Do you need any help?", "topic": "TALK_RANCH_SCAVENGER_1_HIRE" },
       { "text": "Let's see what you've managed to find.", "topic": "TALK_RANCH_SCAVENGER_1", "effect": "start_trade" },
+      { "text": "Any lucky find?", "topic": "TALK_RANCH_SCAVENGER_ASK_RESTOCK" },
       { "text": "I've got to go…", "topic": "TALK_DONE" }
     ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_RANCH_SCAVENGER_ASK_RESTOCK",
+    "dynamic_line": "Nope, current run hasn't returned yet.  Come back in <interval>.  You might find something you like.",
+    "responses": [ { "text": "Alright, thanks.", "topic": "TALK_RANCH_SCAVENGER_1" } ]
   },
   {
     "type": "talk_topic",

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -354,6 +354,7 @@ Field | Used for...
 `<topic_item_price>` | referenced item unit price
 `<topic_item_my_total_price>` | TODO Add
 `<topic_item_your_total_price>` | TODO Add
+`<interval>` | displays the time remaining until restock
 `<u_val:VAR>` | The user variable VAR
 `<npc_val:VAR>` | The npc variable VAR
 `<context_val:VAR>` | The context variable VAR

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2178,7 +2178,7 @@ void npc::shop_restock()
 std::string npc::get_interval( const npc &guy ) const
 {
     time_duration const restock_remaining =
-        calendar::turn - restock;
+        restock - calendar::turn;
     std::string restock_rem = to_string( restock_remaining );
     return restock_rem;
 }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2175,7 +2175,7 @@ void npc::shop_restock()
     distribute_items_to_npc_zones( ret, *this );
 }
 
-std::string npc::get_interval() const
+std::string npc::get_restock_interval() const
 {
     time_duration const restock_remaining =
         restock - calendar::turn;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2175,6 +2175,14 @@ void npc::shop_restock()
     distribute_items_to_npc_zones( ret, *this );
 }
 
+std::string npc::get_interval( const npc &guy ) const
+{
+    time_duration const restock_remaining =
+        calendar::turn - restock;
+    std::string restock_rem = to_string( restock_remaining );
+    return restock_rem;
+}
+
 bool npc::is_shopkeeper() const
 {
     return !is_player_ally() && !myclass->get_shopkeeper_items().empty();

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2175,7 +2175,7 @@ void npc::shop_restock()
     distribute_items_to_npc_zones( ret, *this );
 }
 
-std::string npc::get_interval( const npc &guy ) const
+std::string npc::get_interval() const
 {
     time_duration const restock_remaining =
         restock - calendar::turn;

--- a/src/npc.h
+++ b/src/npc.h
@@ -922,6 +922,7 @@ class npc : public Character
 
         // Re-roll the inventory of a shopkeeper
         void shop_restock();
+        std::string get_interval( const npc &guy ) const;
         bool is_shopkeeper() const;
         // Use and assessment of items
         // The minimum value to want to pick up an item

--- a/src/npc.h
+++ b/src/npc.h
@@ -922,7 +922,7 @@ class npc : public Character
 
         // Re-roll the inventory of a shopkeeper
         void shop_restock();
-        std::string get_interval() const;
+        std::string get_restock_interval() const;
         bool is_shopkeeper() const;
         // Use and assessment of items
         // The minimum value to want to pick up an item

--- a/src/npc.h
+++ b/src/npc.h
@@ -922,7 +922,7 @@ class npc : public Character
 
         // Re-roll the inventory of a shopkeeper
         void shop_restock();
-        std::string get_interval( const npc &guy ) const;
+        std::string get_interval() const;
         bool is_shopkeeper() const;
         // Use and assessment of items
         // The minimum value to want to pick up an item

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1971,9 +1971,9 @@ void parse_tags( std::string &phrase, const Character &u, const Character &me, c
             item tmp( item_type );
             tmp.charges = u.charges_of( item_type );
             phrase.replace( fa, l, format_money( tmp.price( true ) ) );
-        } else if (tag == "<interval>") {
-            const npc *guy = dynamic_cast<const npc*>(&me);
-            phrase.replace(fa, l, guy->get_interval( *guy ));
+        } else if( tag == "<interval>" ) {
+            const npc *guy = dynamic_cast<const npc *>( &me );
+            phrase.replace( fa, l, guy->get_interval( *guy ) );
         } else if( tag.find( "<u_val:" ) != std::string::npos ) {
             //adding a user variable to the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1971,6 +1971,9 @@ void parse_tags( std::string &phrase, const Character &u, const Character &me, c
             item tmp( item_type );
             tmp.charges = u.charges_of( item_type );
             phrase.replace( fa, l, format_money( tmp.price( true ) ) );
+        } else if (tag == "<interval>") {
+            const npc *guy = dynamic_cast<const npc*>(&me);
+            phrase.replace(fa, l, guy->get_interval( *guy ));
         } else if( tag.find( "<u_val:" ) != std::string::npos ) {
             //adding a user variable to the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1973,7 +1973,7 @@ void parse_tags( std::string &phrase, const Character &u, const Character &me, c
             phrase.replace( fa, l, format_money( tmp.price( true ) ) );
         } else if( tag == "<interval>" ) {
             const npc *guy = dynamic_cast<const npc *>( &me );
-            phrase.replace( fa, l, guy->get_interval() );
+            phrase.replace( fa, l, guy->get_restock_interval() );
         } else if( tag.find( "<u_val:" ) != std::string::npos ) {
             //adding a user variable to the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1973,7 +1973,7 @@ void parse_tags( std::string &phrase, const Character &u, const Character &me, c
             phrase.replace( fa, l, format_money( tmp.price( true ) ) );
         } else if( tag == "<interval>" ) {
             const npc *guy = dynamic_cast<const npc *>( &me );
-            phrase.replace( fa, l, guy->get_interval( *guy ) );
+            phrase.replace( fa, l, guy->get_interval() );
         } else if( tag.find( "<u_val:" ) != std::string::npos ) {
             //adding a user variable to the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );


### PR DESCRIPTION
#### Summary
Features "Merchants will tell when they will restock"

#### Purpose of change
Adressses #68132. Checking on merchants can be exhausting especially if there is a long distance between you and the merchant. This aims to communicate to the player when the merchants restock.

#### Describe the solution
I created a new parse_tag snippet called <\interval> that gives you the remaining time before they restock. This can be used like "Stick around for <\interval>, a new shipment is on the way" or yada yada.

As of publishing this it is very half baked and gives you a dumb value in negative few thousand seconds, but I aim to make it so that specific time durations will give player different outputs that sounds more daily like, i.E: between 3 or 5 days will be "a few days", under a day will be "soon" etc. Or simply fix it to say a more comprehensible value like "x days x hours"

I put this out in WIP beacuse I wanted to know what everyone thinks

#### Describe alternatives you've considered
cut my heart into a thousand pieces, this is my last resort

Uhh I mean any alternative is welcome; like I said, it is extremely half-baked rn

#### Testing

Replaced Smokes' after trade dialogue with "Come back in <\interval>. I may have something you're interested in. " It worked but put back something like - 435345435 seconds. Working on it as stated above.

#### Additional context
My C++ is extremely undergrad so any feedback is very welcome 
