### PR TITLE
Fix a minor issue in the tied-up fridge and tied-up freezer crafting recipe

### DIFF
--- a/data/json/recipes/other/vehicle.json
+++ b/data/json/recipes/other/vehicle.json
@@ -194,7 +194,7 @@
     "time": "30 s",
     "autolearn": true,
     "reversible": true,
-    "components": [ [ [ "fridge", 1 ] ], [ [ "rope_30", 1 ], [ "rope_30", 5 ] ] ]
+    "components": [ [ [ "fridge", 1 ] ], [ [ "rope_30", 1 ], [ "rope_6", 5 ] ] ]
   },
   {
     "type": "recipe",
@@ -205,6 +205,6 @@
     "time": "30 s",
     "autolearn": true,
     "reversible": true,
-    "components": [ [ [ "freezer", 1 ] ], [ [ "rope_30", 1 ], [ "rope_30", 5 ] ] ]
+    "components": [ [ [ "freezer", 1 ] ], [ [ "rope_30", 1 ], [ "rope_6", 5 ] ] ]
   }
 ]


### PR DESCRIPTION


#### Summary
Bugfixes "Fix the tied-up fridge/freezer reciper where one of the components is 5 long ropes instead of 5 short ropes"

#### Purpose of change

When i was looking for the recipe of the tied up freezer in the hhg, i noticed it list one of the components as "5 long ropes". looking at its json proper, it is 5 long ropes. I feel like this should be 5 short ropes so this fixes it.

#### Describe the solution

Change the 5 rope component from `rope_30` to `rope_6`

#### Describe alternatives you've considered

Letting it be, considering it doesnt shows up in game.

#### Testing

Before
![Screenshot_2023-09-20_17-41-19_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/78019001/1e897801-2ba1-4f4d-9ad3-5acd128632c9)

After
![Screenshot_2023-09-20_17-52-24_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/78019001/f3dea48e-be88-4276-8dc3-dd0eb715343b)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
