### PR TITLE
Bugfix: Do not path NPCs into wall lights

### DIFF
--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -601,7 +601,7 @@
     "color": "white",
     "broken_color": "blue",
     "durability": 20,
-    "description": "A floor lamp that provides illumination when turned on.",
+    "description": "A wall-mounted lamp that provides illumination when turned on.",
     "epower": "-10 W",
     "bonus": 200,
     "damage_modifier": 10,
@@ -611,7 +611,7 @@
       { "item": "steel_chunk", "count": [ 0, 2 ] },
       { "item": "scrap", "count": [ 1, 2 ] }
     ],
-    "flags": [ "WALL_MOUNTED", "HALF_CIRCLE_LIGHT", "APPLIANCE", "ENABLED_DRAINS_EPOWER", "CTRL_ELECTRONIC" ],
+    "flags": [ "WALL_MOUNTED", "HALF_CIRCLE_LIGHT", "APPLIANCE", "ENABLED_DRAINS_EPOWER", "CTRL_ELECTRONIC", "OBSTACLE" ],
     "requirements": { "removal": { "time": "6 m" } },
     "variants": [ { "symbols": "*", "symbols_broken": "-" } ]
   },


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Do not path NPCs into wall lights"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Fixes #67553 .
* Prevents NPCs from selecting a walk path into wall-mounted lamps `ap_wall_light`.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

* The issue before was that even tough the NPC was set to follow the player, it did not proceed beyond the wall lamp. 
* The cause of the issue before was that:
	* The wall lamp is considered an appliance, and thus a *vehicle*.
	* `map::route` in `pathinding.cpp` would then consider the square with the wall lamp as a vehicle, and select the pathfinding weight according to that.
	* Since the wall lamp did not have flag `obstacle`, `map::route` would get `part=-1` and then consider it a walkable square, and rank it as a zero-cost square to path into.
* This change therefore adds the flag `OBSTACLE` to wall lights, to make the pathfinder also consider such appliances as being non-free to path into.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* Considered changing the pathfinder code to also take into account vehicle parts that are placed at the same square as impassable terrain.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Tested the save from #67553 . The NPC now correctly follows the player.
* Also checked for other appliances that might have the same problem, by searching for flag `WALL_MOUNTED`. The only other such appliance is "wall wiring", and that appliance already has the `OBSTACLE` flag, and it does not cause any pathfinding issues.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
