### PR TITLE
An alternate sidebar

### DIFF
--- a/data/json/ui/sidebar-thick-cleaner.json
+++ b/data/json/ui/sidebar-thick-cleaner.json
@@ -39,7 +39,8 @@
       "weary_rest_layout",
       "needs_layout_cleaner"
     ]
-  },  {
+  },
+  {
     "id": "more_graphs_layout",
     "type": "widget",
     "style": "layout",

--- a/data/json/ui/sidebar-thick-cleaner.json
+++ b/data/json/ui/sidebar-thick-cleaner.json
@@ -47,9 +47,9 @@
     "id": "more_graphs_layout",
     "type": "widget",
     "style": "layout",
-    "label": "Extra bodygraphs",
+    "label": "Extra body graphs",
     "arrange": "columns",
-    "description": "Three <color_yellow>small bodygraphs</color> for status, encumbrance and temperature.",
+    "description": "Three <color_yellow>small body graphs</color> for status, encumbrance and temperature.",
     "widgets": [ "more_body_graph_status", "more_body_graph_temp", "more_body_graph_encumb" ],
     "flags": [ "W_DISABLED_BY_DEFAULT" ]
   },
@@ -153,7 +153,7 @@
     "type": "widget",
     "style": "layout",
     "label": "Body + More Graphs",
-    "description": "A large <color_yellow>health display</color> and health bars, as well as three <color_yellow>small bodygraphs</color> for status, encumbrance and temperature.",
+    "description": "A large <color_yellow>health display</color> and health bars, as well as three <color_yellow>small body graphs</color> for status, encumbrance and temperature.",
     "arrange": "minimum_columns",
     "widgets": [ "thick_body_graph", "thick_rs_column_more_graphs" ]
   },
@@ -162,6 +162,7 @@
     "type": "widget",
     "style": "sidebar",
     "label": "thick-cleaner",
+    "description": "An alternate thick sidebar. Restart required if using the extra body graphs.",
     "separator": ": ",
     "padding": 2,
     "width": 66,

--- a/data/json/ui/sidebar-thick-cleaner.json
+++ b/data/json/ui/sidebar-thick-cleaner.json
@@ -22,11 +22,7 @@
     "style": "layout",
     "label": "stacked",
     "arrange": "rows",
-    "widgets": [
-      "ll_limbs_layout",
-      "spacer",
-      "more_graphs_layout"
-    ]
+    "widgets": [ "ll_limbs_layout", "spacer", "more_graphs_layout" ]
   },
   {
     "id": "thick_rs_column_cleaner_2",

--- a/data/json/ui/sidebar-thick-cleaner.json
+++ b/data/json/ui/sidebar-thick-cleaner.json
@@ -1,0 +1,185 @@
+[
+  {
+    "id": "thick_rs_column_cleaner",
+    "type": "widget",
+    "style": "layout",
+    "label": "stacked",
+    "arrange": "rows",
+    "widgets": [
+      "ll_limbs_layout",
+      "spacer",
+      "ll_stats_layout",
+      "sound_mood_focus_layout",
+      "spacer",
+      "stamina_speed_layout_full",
+      "weary_rest_layout",
+      "needs_layout_cleaner"
+    ]
+  },
+  {
+    "id": "thick_rs_column_more_graphs",
+    "type": "widget",
+    "style": "layout",
+    "label": "stacked",
+    "arrange": "rows",
+    "widgets": [
+      "ll_limbs_layout",
+      "spacer",
+      "more_graphs_layout"
+    ]
+  },
+  {
+    "id": "thick_rs_column_cleaner_2",
+    "type": "widget",
+    "style": "layout",
+    "label": "Status displays",
+    "description": "All sorts of <color_yellow>bars</color> and <color_yellow>numbers</color> about the player's status, 'not too little, not too much'.",
+    "arrange": "rows",
+    "widgets": [
+      "ll_stats_layout",
+      "sound_mood_focus_layout",
+      "spacer",
+      "stamina_speed_layout_full",
+      "weary_rest_layout",
+      "needs_layout_cleaner"
+    ]
+  },  {
+    "id": "more_graphs_layout",
+    "type": "widget",
+    "style": "layout",
+    "label": "Extra bodygraphs",
+    "arrange": "columns",
+    "description": "Three <color_yellow>small bodygraphs</color> for status, encumbrance and temperature.",
+    "widgets": [ "more_body_graph_status", "more_body_graph_temp", "more_body_graph_encumb" ],
+    "flags": [ "W_DISABLED_BY_DEFAULT" ]
+  },
+  {
+    "id": "more_body_graph_status",
+    "type": "widget",
+    "style": "layout",
+    "arrange": "rows",
+    "widgets": [ "more_body_graph_status_text", "structured_body_graph_status_layout" ]
+  },
+  {
+    "id": "more_body_graph_temp",
+    "type": "widget",
+    "style": "layout",
+    "arrange": "rows",
+    "widgets": [ "more_body_graph_temp_text", "structured_body_graph_temp_layout" ]
+  },
+  {
+    "id": "more_body_graph_encumb",
+    "type": "widget",
+    "style": "layout",
+    "arrange": "rows",
+    "widgets": [ "more_body_graph_encumb_text", "structured_body_graph_encumb_layout" ]
+  },
+  {
+    "id": "spacer",
+    "type": "widget",
+    "style": "text",
+    "string": "",
+    "flags": [ "W_LABEL_NONE" ]
+  },
+  {
+    "id": "more_body_graph_status_text",
+    "type": "widget",
+    "style": "text",
+    "string": " Status",
+    "flags": [ "W_LABEL_NONE" ]
+  },
+  {
+    "id": "more_body_graph_temp_text",
+    "type": "widget",
+    "style": "text",
+    "string": "Temperature",
+    "flags": [ "W_LABEL_NONE" ]
+  },
+  {
+    "id": "more_body_graph_encumb_text",
+    "type": "widget",
+    "style": "text",
+    "string": "Encumbrance",
+    "flags": [ "W_LABEL_NONE" ]
+  },
+  {
+    "id": "stamina_speed_layout_full",
+    "type": "widget",
+    "style": "layout",
+    "arrange": "columns",
+    "widgets": [ "stamina_graph", "speed_num" ]
+  },
+  {
+    "id": "weary_rest_layout",
+    "type": "widget",
+    "style": "layout",
+    "arrange": "columns",
+    "widgets": [ "weariness_desc", "fatigue_desc_label" ]
+  },
+  {
+    "id": "needs_layout_cleaner",
+    "type": "widget",
+    "style": "layout",
+    "label": "Needs",
+    "arrange": "rows",
+    "widgets": [ "pain_heat_layout", "thirst_hunger_label" ]
+  },
+  {
+    "id": "pain_heat_layout",
+    "type": "widget",
+    "style": "layout",
+    "arrange": "columns",
+    "widgets": [ "pain_desc_label", "body_temp_desc_label" ]
+  },
+  {
+    "id": "thirst_hunger_label",
+    "type": "widget",
+    "style": "layout",
+    "arrange": "columns",
+    "widgets": [ "thirst_desc_label", "hunger_desc_label" ]
+  },
+  {
+    "id": "thick_side_by_side_cleaner",
+    "type": "widget",
+    "style": "layout",
+    "label": "Body + Details",
+    "arrange": "minimum_columns",
+    "description": "A large <color_yellow>health display</color> and details about the <color_yellow>player's status</color>, with the principle of 'not too little, not too much'.",
+    "widgets": [ "thick_body_graph", "thick_rs_column_cleaner" ],
+    "flags": [ "W_DISABLED_BY_DEFAULT" ]
+  },
+  {
+    "id": "thick_side_by_side_more_graphs",
+    "type": "widget",
+    "style": "layout",
+    "label": "Body + More Graphs",
+    "description": "A large <color_yellow>health display</color> and health bars, as well as three <color_yellow>small bodygraphs</color> for status, encumbrance and temperature.",
+    "arrange": "minimum_columns",
+    "widgets": [ "thick_body_graph", "thick_rs_column_more_graphs" ]
+  },
+  {
+    "id": "my_labels_sidebar_cleaner",
+    "type": "widget",
+    "style": "sidebar",
+    "label": "thick-cleaner",
+    "separator": ": ",
+    "padding": 2,
+    "width": 66,
+    "widgets": [
+      "thick_side_by_side_cleaner",
+      "more_graphs_layout",
+      "thick_side_by_side_more_graphs",
+      "thick_rs_column_cleaner_2",
+      "separator",
+      "thick_side_by_side_2",
+      "lcla_weapon_layout",
+      "structured_style_ma_buffs_layout",
+      "separator_disabled",
+      "structured_mana_layout",
+      "vehicle_acf_label_layout_columns",
+      "sundial_label_layout",
+      "separator_disabled",
+      "compass_all_layout"
+    ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "An alternate thick sidebar was added."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There was not a lot of choice when it comes to thick sidebars.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
It's a new sidebar.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I tested that it doesn't produce errors currently. There is an issue with the (optional) extra body graphs not being laid out properly on the first run, though. They seems to start working properly when you restart the game.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Originally posted [here](https://www.reddit.com/r/cataclysmdda/comments/16ccb5s/alternative_thick_sidebar/), with a screenshot of how it's supposed to look. Those extra body graphs should work correctly when restarting the game, and there's a note about that in the description until a more proper fix is made.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
