### PR TITLE
Minor misc JSON edits

### DIFF
--- a/data/json/items/comestibles/drink.json
+++ b/data/json/items/comestibles/drink.json
@@ -82,7 +82,7 @@
     "healthy": -1,
     "addiction_potential": 8,
     "calories": 35,
-    "description": "This serving of coffee has been created using an atomic coffee pot's FULL NUCLEAR brewing cycle.  Every possible microgram of caffeine and flavor has been carefully extracted for your enjoyment, using the power of the atom.",
+    "description": "This serving of coffee has twice as much coffee as black coffee, as well as some caffeine pills and sugar for good measure.  You didn't plan to sleep this week anyway, right?",
     "price": 300,
     "price_postapoc": 100,
     "flags": [ "EATEN_HOT", "NO_AUTO_CONSUME" ],

--- a/data/json/items/vehicle/cargo.json
+++ b/data/json/items/vehicle/cargo.json
@@ -136,7 +136,8 @@
     "name": { "str": "animal locker" },
     "description": "A locker used to contain animals safely during transportation if installed properly.  There is room for animal food and other animal care goods.  It is meant to hold medium or smaller animals for transport.  Use it on a suitable animal to capture, use it on an empty tile to release.",
     "weight": "10000 g",
-    "volume": "31250 ml"
+    "volume": "31250 ml",
+    "properties": [ [ "creature_size_capacity", "MEDIUM" ] ]
   },
   {
     "id": "stowed_fridge",

--- a/data/json/items/vehicle/cargo.json
+++ b/data/json/items/vehicle/cargo.json
@@ -137,7 +137,7 @@
     "description": "A locker used to contain animals safely during transportation if installed properly.  There is room for animal food and other animal care goods.  It is meant to hold medium or smaller animals for transport.  Use it on a suitable animal to capture, use it on an empty tile to release.",
     "weight": "10000 g",
     "volume": "31250 ml",
-    "properties": [ [ "creature_size_capacity", "MEDIUM" ] ]
+    "properties": { "creature_size_capacity": "MEDIUM" }
   },
   {
     "id": "stowed_fridge",

--- a/data/json/recipes/ammo/weldgas.json
+++ b/data/json/recipes/ammo/weldgas.json
@@ -174,7 +174,7 @@
     "autolearn": true,
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "ANVIL", "level": 1 } ],
     "tools": [ [ [ "metalworking_tongs", -1 ] ], [ [ "forge", 250 ], [ "oxy_torch", 50 ] ], [ [ "wire_draw_machine", 120 ] ] ],
-    "proficiencies": [ { "proficiency": "prof_metalworking" } ],
+    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_wiremaking" } ],
     "components": [ [ [ "material_aluminium_ingot", 3 ], [ "scrap_aluminum", 11 ] ] ]
   },
   {

--- a/data/json/recipes/other/parts.json
+++ b/data/json/recipes/other/parts.json
@@ -487,7 +487,7 @@
     "autolearn": true,
     "charges": 182,
     "qualities": [ { "id": "ANVIL", "level": 1 }, { "id": "HAMMER", "level": 2 } ],
-    "proficiencies": [ { "proficiency": "prof_metalworking" } ],
+    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_wiremaking" } ],
     "//": "Requires annealing 4 times from the copper rod.",
     "tools": [
       [ [ "metalworking_tongs", -1 ] ],

--- a/data/json/recipes/recipe_medsandchemicals.json
+++ b/data/json/recipes/recipe_medsandchemicals.json
@@ -566,20 +566,6 @@
   },
   {
     "type": "recipe",
-    "activity_level": "NO_EXERCISE",
-    "result": "canister_goo",
-    "category": "CC_CHEM",
-    "subcategory": "CSC_CHEM_CHEMICALS",
-    "skill_used": "fabrication",
-    "difficulty": 2,
-    "time": "5 m",
-    "autolearn": true,
-    "//": "'stick the blob globs in a can and seal it' does not seem hugely challenging",
-    "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "components": [ [ [ "canister_empty", 1 ] ], [ [ "slime_scrap", 10 ] ] ]
-  },
-  {
-    "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "iodine",
     "category": "CC_CHEM",

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -731,7 +731,11 @@
     "result_mult": 6,
     "autolearn": true,
     "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 } ],
-    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
+    "proficiencies": [
+      { "proficiency": "prof_metalworking" },
+      { "proficiency": "prof_blacksmithing" },
+      { "proficiency": "prof_wiremaking" }
+    ],
     "tools": [
       [ [ "metalworking_tongs", -1 ] ],
       [ [ "hotcut", -1 ] ],
@@ -768,7 +772,11 @@
     "result_mult": 6,
     "autolearn": true,
     "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 } ],
-    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
+    "proficiencies": [
+      { "proficiency": "prof_metalworking" },
+      { "proficiency": "prof_blacksmithing" },
+      { "proficiency": "prof_wiremaking" }
+    ],
     "tools": [
       [ [ "metalworking_tongs", -1 ] ],
       [ [ "hotcut", -1 ] ],
@@ -805,7 +813,11 @@
     "result_mult": 6,
     "autolearn": true,
     "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 } ],
-    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
+    "proficiencies": [
+      { "proficiency": "prof_metalworking" },
+      { "proficiency": "prof_blacksmithing" },
+      { "proficiency": "prof_wiremaking" }
+    ],
     "tools": [
       [ [ "metalworking_tongs", -1 ] ],
       [ [ "hotcut", -1 ] ],
@@ -842,7 +854,11 @@
     "result_mult": 6,
     "autolearn": true,
     "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 } ],
-    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
+    "proficiencies": [
+      { "proficiency": "prof_metalworking" },
+      { "proficiency": "prof_blacksmithing" },
+      { "proficiency": "prof_wiremaking" }
+    ],
     "tools": [
       [ [ "metalworking_tongs", -1 ] ],
       [ [ "hotcut", -1 ] ],
@@ -880,7 +896,11 @@
     "autolearn": true,
     "qualities": [ { "id": "ANVIL", "level": 3 }, { "id": "HAMMER", "level": 3 } ],
     "using": [ [ "carbon", 1 ] ],
-    "proficiencies": [ { "proficiency": "prof_metalworking" }, { "proficiency": "prof_blacksmithing" } ],
+    "proficiencies": [
+      { "proficiency": "prof_metalworking" },
+      { "proficiency": "prof_blacksmithing" },
+      { "proficiency": "prof_wiremaking" }
+    ],
     "tools": [
       [ [ "metalworking_tongs", -1 ] ],
       [ [ "hotcut", -1 ] ],
@@ -925,7 +945,8 @@
     "proficiencies": [
       { "proficiency": "prof_metalworking" },
       { "proficiency": "prof_blacksmithing" },
-      { "proficiency": "prof_quenching", "skill_penalty": 1 }
+      { "proficiency": "prof_quenching", "skill_penalty": 1 },
+      { "proficiency": "prof_wiremaking" }
     ],
     "tools": [
       [ [ "metalworking_tongs", -1 ] ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Changed the animal locker to hold medium creatures instead of huge, as per its description. As it stands, it was just a smaller livestock carrier with the same functionality which extended to the vehicle part too
- Changed the description of atomic coffee to reflect the mild lore change it had gotten lately and it's new recipe
- Removed the goo canister recipe - fabrication two and a screwdriver to fabricate your own friendly slimes makes no sense. The item is cool, but it should not be craftable by the player
- Added the wire-making proficiency to all recipes using the wire draw machine (except for the welding wire, because it doesn't seem to actually make new wire?)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I briefly considered removing the goo canister altogether, but I like it. It probably shouldn't spawn friendly slimes, either, but eh, I didn't feel like being a villain today. Besides, it's a cool little surprise to find ingame.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
