### PR TITLE
Bugfix: Prevent empty subject in 'but do no damage' msgs when dealing no damage

### DIFF
--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2569,7 +2569,7 @@ std::string melee_message( const ma_technique &tec, Character &p,
     };
 
     int total_dam = 0;
-    std::pair<damage_type_id, int> dominant_type = { damage_type_id::NULL_ID(), 0 };
+    std::pair<damage_type_id, int> dominant_type = { damage_bash, 0 };
     for( const damage_type &dt : damage_type::get_all() ) {
         if( dt.melee_only ) {
             int dmg = ddi.type_damage( dt.id );


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent empty subject in 'but do no damage' msgs when dealing no damage"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Addresses one part of #67290 .
* Fixes an issue where hitting an enemy without doing damage would show ` but do no damage` (sic) without the `You hit the zombie`-part.
* The issue before was:
	* The method `melee_message` tries to determine which damage type does the most damage
	* But if the attack does `0` damage on all damage types, it would select `damage_type_id::NULL_ID` as the type of damage being dealt.
	* This meant that the code that determines whether to display `You poke the zombie`, `You cut the zombie` or `You hit the zombie` picked none of them, thus displaying the broken attack messages.


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

* This change defaults to bashing damage if none of the other damage types deals any damage, so that the message displayed will be `You hit the zombie`+` but do no damage`
* Bashing damage was the previous choice before this code was refactored in https://github.com/CleverRaven/Cataclysm-DDA/commit/6141f7651e48740ecb26a7462282cf313250bbec#diff-2cd8dac3d0903ca1ee60a47c28e09bcb56290214bc8d1fe5cf4afaed108b9d92R2532-L2715

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* Another option would be to pick a random damage type

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Before:
![bugfix-empty-monstername-when-hitting-no-damage-before](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/803d704e-5e30-41f4-b648-372919411a47)

After:
![bugfix-empty-monstername-when-hitting-no-damage-after](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/cdc55540-67bf-4dec-b2aa-8389b6597fbc)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
