### PR TITLE
Fix Free Merchants Broker price calculation of non charge based item

### DIFF
--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1743,6 +1743,25 @@ static int parse_mod( const dialogue &d, const std::string &attribute, const int
             factor );
 }
 
+static int total_price( const talker &seller, const itype_id &item_type )
+{
+    int price = 0;
+    item tmp( item_type );
+
+    if( tmp.count_by_charges() ) {
+        tmp.charges =  seller.charges_of( item_type );
+        price = tmp.price( true );
+    } else {
+        std::vector<const item *> items = seller.const_items_with( [&item_type]( const item & e ) {
+            return item_type == e.type->get_id();
+        } );
+        for( const item *it : items ) {
+            price += it->price( true );
+        }
+    }
+    return price;
+}
+
 int talk_trial::calc_chance( dialogue &d ) const
 {
     if( d.actor( false )->has_trait( trait_DEBUG_MIND_CONTROL ) ) {
@@ -1964,13 +1983,11 @@ void parse_tags( std::string &phrase, const Character &u, const Character &me, c
             item tmp( item_type );
             phrase.replace( fa, l, format_money( tmp.price( true ) ) );
         } else if( tag == "<topic_item_my_total_price>" ) {
-            item tmp( item_type );
-            tmp.charges = me.charges_of( item_type );
-            phrase.replace( fa, l, format_money( tmp.price( true ) ) );
+            int price = total_price( *get_talker_for( me ), item_type );
+            phrase.replace( fa, l, format_money( price ) );
         } else if( tag == "<topic_item_your_total_price>" ) {
-            item tmp( item_type );
-            tmp.charges = u.charges_of( item_type );
-            phrase.replace( fa, l, format_money( tmp.price( true ) ) );
+            int price = total_price( *get_talker_for( u ), item_type );
+            phrase.replace( fa, l, format_money( price ) );
         } else if( tag == "<interval>" ) {
             const npc *guy = dynamic_cast<const npc *>( &me );
             phrase.replace( fa, l, guy->get_restock_interval() );
@@ -3547,7 +3564,7 @@ void talk_effect_fun_t::set_bulk_trade_accept( const JsonObject &jo, const std::
         tmp.charges = seller_has;
         if( is_trade ) {
             const int npc_debt = d.actor( true )->debt();
-            int price = tmp.price( true ) * ( is_npc ? -1 : 1 ) + npc_debt;
+            int price = total_price( *seller, d.cur_item ) * ( is_npc ? -1 : 1 ) + npc_debt;
             if( d.actor( true )->get_faction() && !d.actor( true )->get_faction()->currency.is_empty() ) {
                 const itype_id &pay_in = d.actor( true )->get_faction()->currency;
                 item pay( pay_in );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix Free Merchants Broker price calculation of non charge based item"

#### Purpose of change
Address #67882.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing
100 pieces of dried fruit can be sold for $100, not $1.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13540013/eb269a8c-6211-4b8d-a556-c61e9f2242c4)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13540013/b2f7c6e3-100c-47d3-9b43-a7242c24e12e)

#### Additional context
