### PR TITLE
Select default bodypart when applying bandage

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -1224,6 +1224,11 @@ void uilist::settext( const std::string &str )
     text = str;
 }
 
+void uilist::set_selected( int index )
+{
+    selected = std::clamp( index, 0, static_cast<int>( entries.size() - 1 ) );
+}
+
 struct pointmenu_cb::impl_t {
     const std::vector< tripoint > &points;
     int last; // to suppress redrawing

--- a/src/ui.h
+++ b/src/ui.h
@@ -515,6 +515,8 @@ class uilist // NOLINT(cata-xy)
         input_event ret_evt;
         int ret = 0;
         int selected = 0;
+
+        void set_selected( int index );
 };
 
 /**


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Select default bodypart when applying bandage"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Makes the default selected bodypart in the "apply bandage"-ui be the bodypart that is the most damaged.
* If the bodypart has a bandage with the same power as the bandage being applied, another bodypart is selected.
* In particular: if there's only one bodypart that needs tending, it will now be the default selected one.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

* When populating the selectable bodyparts, keep track of
    * whether the bodypart can be healed further with the item that is currently being applied: `bool gives_improvement`
    * which bodypart is hurt the most, by percentage: `float default_selection_hp_percent` 
* When presenting the ui for selecting bodypart, default to the bodypart that both "can be healed further" and has the lowest hp percentage.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* There may be lots of ways to select a more optimal bodypart to heal first, such as:
    * Prioritizing bleeding bodyparts over other parts that may be more hurt but require long-term healing
    * Prioritizing bites when using a disinfectant
* So there are cases where selecting another more "optimal" default bp would be preferable, but this also means that the logic would be more complicated, which might be unintuitive to the player.
* There's also a minor information leakage here: two bodyparts might show the same `||\..`-bars, but the player does not know which one is actually more hurt than the other since the bars show the same. With this suggested change, the bandaging ui will reveal that since the most hurt part will be the default one even if the bars are the same.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* I got hurt in all bodyparts. Applied bandages one after eachother. The first time the bandaging-ui shows, the most damaged bodypart is pre-selected. The second time, the next-most damaged bp is selected. And so on, until all parts have been bandaged.
* It might not be obvious, but it's possible to `/`-search in the bandaging ui to search for a bodypart to heal. This still works even if the default selection is something else.
* Tested bandages, disinfectant and stopping bleeding.

![tis-but-a-scratch](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/f3d2955e-6449-4fcd-9297-e4906796a2f3)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
