### PR TITLE
Validation for damage type id's

### DIFF
--- a/data/json/monster_weakpoints/turret_weakpoints.json
+++ b/data/json/monster_weakpoints/turret_weakpoints.json
@@ -10,7 +10,7 @@
         "coverage": 15,
         "difficulty": { "melee": 4, "ranged": 6 },
         "coverage_mult": { "bash": 0.5 },
-        "armor_mult": { "point": 0.5, "cut": 1.1 },
+        "armor_mult": { "stab": 0.5, "cut": 1.1 },
         "effects": [
           {
             "effect": "stunned",
@@ -56,7 +56,7 @@
         "name": "the weapon",
         "coverage": 20,
         "difficulty": { "melee": 4, "ranged": 5 },
-        "armor_mult": { "bash": 0.5, "point": 0.5, "cut": 0.75 },
+        "armor_mult": { "bash": 0.5, "stab": 0.5, "cut": 0.75 },
         "effects": [
           {
             "effect": "stunned",
@@ -78,7 +78,7 @@
         "name": "the shaft",
         "coverage": 30,
         "difficulty": { "melee": 1, "ranged": 6 },
-        "armor_mult": { "broad": 0.75, "stab": 1.5 }
+        "armor_mult": { "bash": 0.75, "stab": 1.5 }
       }
     ]
   },

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -582,6 +582,13 @@ void bionic_data::check_bionic_consistency()
         if( !item::type_is_defined( bio.itype() ) && !bio.included ) {
             debugmsg( "Bionic %s has no defined item version", bio.id.c_str() );
         }
+        for( const std::pair<const bodypart_str_id, resistances> &bprot : bio.protec ) {
+            for( const std::pair<const damage_type_id, float> &dt : bprot.second.resist_vals ) {
+                if( !dt.first.is_valid() ) {
+                    debugmsg( "Invalid protection type \"%s\" for bionic %s", dt.first.c_str(), bio.id.c_str() );
+                }
+            }
+        }
     }
 }
 

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -546,6 +546,18 @@ void body_part_type::check() const
         }
     }
 
+    for( const std::pair<const damage_type_id, float> &dt : armor.resist_vals ) {
+        if( !dt.first.is_valid() ) {
+            debugmsg( "Invalid armor type \"%s\" for body part %s", dt.first.c_str(), id.c_str() );
+        }
+    }
+
+    for( const damage_unit &dt : damage.damage_units ) {
+        if( !dt.type.is_valid() ) {
+            debugmsg( "Invalid unarmed_damage type \"%s\" for body part %s", dt.type.c_str(), id.c_str() );
+        }
+    }
+
     // Check that connected_to leads eventually to the root bodypart (currently always head),
     // without any loops
     std::unordered_set<bodypart_str_id> visited = { id };

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2041,6 +2041,12 @@ void Item_factory::check_definitions() const
             }
         }
 
+        for( const std::pair<const damage_type_id, float> &dt : type->melee ) {
+            if( !dt.first.is_valid() ) {
+                msg += string_format( "Invalid melee damage type \"%s\".\n", dt.first.c_str() );
+            }
+        }
+
         if( !type->can_have_charges() && type->charges_default() > 0 ) {
             msg += "charges defined but can not have any\n";
         } else if( type->comestible && type->can_have_charges() && type->charges_default() <= 0 ) {

--- a/src/material.cpp
+++ b/src/material.cpp
@@ -176,6 +176,12 @@ void material_type::check() const
                   id.str() );
     }
 
+    for( const auto &dt : _resistances.resist_vals ) {
+        if( !dt.first.is_valid() ) {
+            debugmsg( "Invalid resistance type \"%s\" for material %s", dt.first.c_str(), id.c_str() );
+        }
+    }
+
     for( const damage_type &dt : damage_type::get_all() ) {
         bool type_defined =
             std::find( _res_was_loaded.begin(), _res_was_loaded.end(),  dt.id ) != _res_was_loaded.end();

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1667,6 +1667,27 @@ void MonsterGenerator::check_monster_definitions() const
                           mon.biosig_item.c_str(), mon.id.c_str() );
             }
         }
+
+        for( const std::pair<const damage_type_id, float> &dt : mon.armor.resist_vals ) {
+            if( !dt.first.is_valid() ) {
+                debugmsg( "Invalid armor type \"%s\" for monster %s", dt.first.c_str(), mon.id.c_str() );
+            }
+        }
+
+        for( const std::pair<const std::string, mtype_special_attack> &spatk : mon.special_attacks ) {
+            const melee_actor *atk = dynamic_cast<const melee_actor *>( &*spatk.second );
+            if( !atk ) {
+                continue;
+            }
+            for( const damage_unit &dt : atk->damage_max_instance.damage_units ) {
+                if( !dt.type.is_valid() ) {
+                    debugmsg( "Invalid monster attack damage type \"%s\" for monster %s", dt.type.c_str(),
+                              mon.id.c_str() );
+                }
+            }
+        }
+
+        mon.weakpoints.check();
     }
 }
 

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -793,6 +793,29 @@ void mutation_branch::check_consistency()
             }
         }
 
+        for( const std::pair<const bodypart_str_id, resistances> &ma : mdata.armor ) {
+            for( const std::pair<const damage_type_id, float> &dt : ma.second.resist_vals ) {
+                if( !dt.first.is_valid() ) {
+                    debugmsg( "Invalid armor type \"%s\" for mutation %s", dt.first.c_str(), mdata.id.c_str() );
+                }
+            }
+        }
+
+        for( const mut_attack &atk : mdata.attacks_granted ) {
+            for( const damage_unit &dt : atk.base_damage.damage_units ) {
+                if( !dt.type.is_valid() ) {
+                    debugmsg( "Invalid base_damage type \"%s\" for a mutation attack in mutation %s", dt.type.c_str(),
+                              mdata.id.c_str() );
+                }
+            }
+            for( const damage_unit &dt : atk.strength_damage.damage_units ) {
+                if( !dt.type.is_valid() ) {
+                    debugmsg( "Invalid strength_damage type \"%s\" for a mutation attack in mutation %s",
+                              dt.type.c_str(), mdata.id.c_str() );
+                }
+            }
+        }
+
         // We need to display active mutations in the UI.
         if( mdata.activated && !mdata.player_display ) {
             debugmsg( "mutation %s is not displayed but set as active" );

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -932,6 +932,12 @@ void vpart_info::check() const
     if( base_item->pockets.size() > 4 ) {
         debugmsg( "Error: vehicle parts assume only one pocket.  Multiple pockets unsupported" );
     }
+    for( const auto &dt : damage_reduction ) {
+        if( !dt.first.is_valid() ) {
+            debugmsg( "Invalid damage_reduction type \"%s\" for vehicle part %s", dt.first.c_str(),
+                      id.c_str() );
+        }
+    }
 }
 
 void vehicles::parts::reset()

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -440,6 +440,30 @@ void weakpoint::load( const JsonObject &jo )
     }
 }
 
+void weakpoint::check() const
+{
+    for( const std::pair<const damage_type_id, float> &dt : armor_mult ) {
+        if( !dt.first.is_valid() ) {
+            debugmsg( "Invalid armor_mult type \"%s\" for weakpoint %s", dt.first.c_str(), id );
+        }
+    }
+    for( const std::pair<const damage_type_id, float> &dt : armor_penalty ) {
+        if( !dt.first.is_valid() ) {
+            debugmsg( "Invalid armor_penalty type \"%s\" for weakpoint %s", dt.first.c_str(), id );
+        }
+    }
+    for( const std::pair<const damage_type_id, float> &dt : damage_mult ) {
+        if( !dt.first.is_valid() ) {
+            debugmsg( "Invalid damage_mult type \"%s\" for weakpoint %s", dt.first.c_str(), id );
+        }
+    }
+    for( const std::pair<const damage_type_id, float> &dt : crit_mult ) {
+        if( !dt.first.is_valid() ) {
+            debugmsg( "Invalid crit_mult type \"%s\" for weakpoint %s", dt.first.c_str(), id );
+        }
+    }
+}
+
 std::string weakpoint::get_name() const
 {
     return name.translated();
@@ -575,6 +599,13 @@ void weakpoints::load( const JsonArray &ja )
     []( const weakpoint & a, const weakpoint & b ) {
         return a.coverage < b.coverage;
     } );
+}
+
+void weakpoints::check() const
+{
+    for( const weakpoint &w : weakpoint_list ) {
+        w.check();
+    }
 }
 
 void weakpoints::finalize()

--- a/src/weakpoint.h
+++ b/src/weakpoint.h
@@ -151,6 +151,7 @@ struct weakpoint {
     // Return the change of the creature hitting the weakpoint.
     float hit_chance( const weakpoint_attack &attack ) const;
     void load( const JsonObject &jo );
+    void check() const;
 };
 
 struct weakpoints {
@@ -172,6 +173,7 @@ struct weakpoints {
     void load( const JsonArray &ja );
     void remove( const JsonArray &ja );
     void finalize();
+    void check() const;
 
     /********************* weakpoint_set handling ****************************/
     // load standalone JSON type


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Often enough, someone will use an invalid damage type id and will not notice until the game triggers an error during gameplay (ex: [using "pierce" instead of "stab"](https://github.com/CleverRaven/Cataclysm-DDA/pull/67677/commits/10877f98cafd81f30ef03d49be93f39e65280618)). This is not caught by the tests or the loading checks, since these id's are only dereferenced much later only when they're used.

#### Describe the solution
Add some validation checks for objects that reference damage types to make sure the id's are valid.

#### Describe alternatives you've considered

#### Testing
Loaded with all mods in the test binary to discover invalid id's:
```
build-scripts/get_all_mods.py | xargs -I '{}' -d '\n' ./tests/cata_test --user-dir=all_modded --mods='{}' '~*'
```

#### Additional context
