### PR TITLE
Almost all weapon techniques now require melee skill.

### DIFF
--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -143,6 +143,7 @@
     "id": "RAPID",
     "name": "Rapid Strike",
     "melee_allowed": true,
+    "skill_requirements": [ { "name": "melee", "level": 3 } ],
     "mult_bonuses": [
       { "stat": "movecost", "scale": 0.5 },
       { "stat": "damage", "type": "bash", "scale": 0.66 },
@@ -150,7 +151,7 @@
       { "stat": "damage", "type": "stab", "scale": 0.66 }
     ],
     "messages": [ "You quickly strike %s!", "<npcname> quickly strikes %s!" ],
-    "description": "50% moves, 66% damage",
+    "description": "50% moves, 66% damage, min 3 melee",
     "attack_vectors": [ "WEAPON" ]
   },
   {

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -3189,6 +3189,21 @@
   },
   {
     "type": "technique",
+    "id": "RAPID_TEST",
+    "name": "Rapid Strike Test",
+    "melee_allowed": true,
+    "mult_bonuses": [
+      { "stat": "movecost", "scale": 0.5 },
+      { "stat": "damage", "type": "bash", "scale": 0.66 },
+      { "stat": "damage", "type": "cut", "scale": 0.66 },
+      { "stat": "damage", "type": "stab", "scale": 0.66 }
+    ],
+    "messages": [ "You quickly strike %s!", "<npcname> quickly strikes %s!" ],
+    "description": "50% moves, 66% damage",
+    "attack_vectors": [ "WEAPON" ]
+  },
+  {
+    "type": "technique",
     "id": "tec_debug_slow",
     "name": "slow strike",
     "unarmed_allowed": true,

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -35,10 +35,11 @@
   {
     "type": "technique",
     "id": "DEF_DISARM",
-    "name": "disarm",
+    "name": "Disarm",
     "melee_allowed": true,
     "disarms": true,
-    "description": "Unwield target's weapon",
+    "skill_requirements": [ { "name": "melee", "level": 4 } ],
+    "description": "Unwield target's weapon, min 4 melee",
     "attack_vectors": [ "HAND" ]
   },
   {
@@ -91,6 +92,7 @@
     "name": "Brutal Strike",
     "melee_allowed": true,
     "crit_tec": true,
+    "skill_requirements": [ { "name": "melee", "level": 2 } ],
     "stun_dur": 1,
     "knockback_dist": 1,
     "//condition": "Basic size filtering, if the target is grabbing you contested roll of strength vs grab strength",
@@ -135,7 +137,7 @@
     },
     "condition_desc": "* Only works on a <info>non-stunned mundane</info> target of <info>similar or smaller</info> size, may fail on enemies grabbing you",
     "messages": [ "You send %s reeling!", "<npcname> sends %s reeling!" ],
-    "description": "Stun 1 turn, knockback 1 tile, crit only",
+    "description": "Stun 1 turn, knockback 1 tile, crit only, min 2 melee",
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -143,7 +145,7 @@
     "id": "RAPID",
     "name": "Rapid Strike",
     "melee_allowed": true,
-    "skill_requirements": [ { "name": "melee", "level": 3 } ],
+    "skill_requirements": [ { "name": "melee", "level": 2 } ],
     "mult_bonuses": [
       { "stat": "movecost", "scale": 0.5 },
       { "stat": "damage", "type": "bash", "scale": 0.66 },
@@ -151,7 +153,7 @@
       { "stat": "damage", "type": "stab", "scale": 0.66 }
     ],
     "messages": [ "You quickly strike %s!", "<npcname> quickly strikes %s!" ],
-    "description": "50% moves, 66% damage, min 3 melee",
+    "description": "50% moves, 66% damage, min 2 melee",
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -174,6 +176,7 @@
     "id": "WRAP",
     "name": "Wrap Attack",
     "melee_allowed": true,
+    "skill_requirements": [ { "name": "melee", "level": 4 } ],
     "//condition": "Similar size, no wrapping tiny or very nonstandard targets",
     "condition": {
       "and": [
@@ -187,7 +190,7 @@
     "condition_desc": "* Only works on a target of <info>similar size</info> with limbs to catch",
     "stun_dur": 2,
     "messages": [ "You wrap up %s!", "<npcname> wraps up %s!" ],
-    "description": "Stun 2 turns",
+    "description": "Stun 2 turns, min 4 melee",
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -195,6 +198,7 @@
     "id": "SWEEP",
     "name": "Sweep Attack",
     "melee_allowed": true,
+    "skill_requirements": [ { "name": "melee", "level": 3 } ],
     "//condition": "Humanoids of similar size and no flying",
     "condition": {
       "and": [
@@ -208,7 +212,7 @@
     "condition_desc": "* Only works on a <info>non-downed humanoid</info> target of <info>similar or smaller</info> size incapable of flight",
     "down_dur": 2,
     "messages": [ "You sweep %s!", "<npcname> sweeps %s!" ],
-    "description": "Down 2 turns",
+    "description": "Down 2 turns, min 3 melee",
     "attack_vectors": [ "WEAPON" ]
   },
   {

--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -3771,7 +3771,7 @@
       "install_time": "5 s"
     },
     "min_skills": [ [ "weapon", 2 ], [ "melee", 1 ] ],
-    "techniques": [ "RAPID" ],
+    "techniques": [ "RAPID_TEST" ],
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 19 ] ],
     "thrown_damage": [ { "damage_type": "stab", "amount": 14 } ],
     "flags": [ "DURABLE_MELEE", "SHEATH_KNIFE", "NPC_THROWN", "ALLOWS_BODY_BLOCK", "NO_SALVAGE" ],

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -297,8 +297,8 @@ TEST_CASE( "EOC_combat_mutator_test", "[eoc]" )
     REQUIRE( globvars.get_global_value( "npctalk_var_key2" ).empty() );
     REQUIRE( globvars.get_global_value( "npctalk_var_key3" ).empty() );
     CHECK( effect_on_condition_EOC_combat_mutator_test->activate( d ) );
-    CHECK( globvars.get_global_value( "npctalk_var_key1" ) == "RAPID" );
-    CHECK( globvars.get_global_value( "npctalk_var_key2" ) == "Rapid Strike" );
+    CHECK( globvars.get_global_value( "npctalk_var_key1" ) == "RAPID_TEST" );
+    CHECK( globvars.get_global_value( "npctalk_var_key2" ) == "Rapid Strike Test" );
     CHECK( globvars.get_global_value( "npctalk_var_key3" ) == "50% moves, 66% damage" );
 }
 

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -707,9 +707,9 @@ TEST_CASE( "techniques_when_wielded", "[iteminfo][weapon][techniques]" )
            "--\n"
            "<color_c_white>Techniques when wielded</color>:"
            " <color_c_light_blue>Brutal Strike</color>:"
-           " <color_c_cyan>Stun 1 turn, knockback 1 tile, crit only</color> <color_c_cyan>* Only works on a <color_c_cyan>non-stunned mundane</color> target of <color_c_cyan>similar or smaller</color> size, may fail on enemies grabbing you</color>,"
+           " <color_c_cyan>Stun 1 turn, knockback 1 tile, crit only, min 2 melee</color> <color_c_cyan>* Only works on a <color_c_cyan>non-stunned mundane</color> target of <color_c_cyan>similar or smaller</color> size, may fail on enemies grabbing you</color>,"
            " <color_c_light_blue>Sweep Attack</color>:"
-           " <color_c_cyan>Down 2 turns</color> <color_c_cyan>* Only works on a <color_c_cyan>non-downed humanoid</color> target of <color_c_cyan>similar or smaller</color> size incapable of flight</color>, and"
+           " <color_c_cyan>Down 2 turns, min 3 melee</color> <color_c_cyan>* Only works on a <color_c_cyan>non-downed humanoid</color> target of <color_c_cyan>similar or smaller</color> size incapable of flight</color>, and"
            " <color_c_light_blue>Block</color>:"
            " <color_c_cyan>Medium blocking ability</color> <color_c_cyan></color>\n" );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Most weapon techniques require some melee skill now"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Quite a lot of weapons had techniques inherent to them, which was fine, but a lot of those techniques were quite specialized or required some substantial skill to pull off. Yet, 0 skill characters who've never fought in their life could pull most of them off reliably, even though low- or no-skill characters should basically be doing little more than swinging for the fences.

#### Describe the solution

Most weapon techs now require some level of melee skill from 2 to 4. Rapid and Brutal Strike require 2 skill minimum, Sweep Attack requires 3, and Wrap (for the steel chain) and Disarm require 4. Numbers were chosen in a hierarchy of what I personally figure to be simplest to most complex.

Also capitalized Disarm in line with all the other technique names being capitalized.

#### Describe alternatives you've considered

The numbers could be fiddled with into infinity, who's to say 2-4 is the ideal? But it tracks with other techniques and martial arts. Brutal Strike could be argued to be the only one that might not need a requirement; there might not be much skilled involved in Hit Very Hard, but we can say the requirement is just your ability to land the hit square in a way that does cause a knockback.

#### Testing

Game runs with changes and techs only proc with the required melee level.

#### Additional context

This will likely make the extreme early game (day 1) harder since now you can't reliably sweep-lock zombies with a pipe mace or the like (although sweep in particular has some other issues), so whether further changes will be needed to even out the meta shift is something to be seen going forward. At least the predominant early strategy of spear-kiting is unaffected.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
