### PR TITLE
Make long stick long

### DIFF
--- a/data/json/items/resources/wood.json
+++ b/data/json/items/resources/wood.json
@@ -48,7 +48,7 @@
     "weight": "1500 g",
     "volume": "2500 ml",
     "longest_side": "130 cm",
-    "to_hit": -1,
+    "to_hit": { "grip": "solid", "length": "long", "surface": "any", "balance": "neutral" },
     "category": "spare_parts",
     "melee_damage": { "bash": 14 }
   },
@@ -61,12 +61,12 @@
     "description": "A straight section of wood, about eight feet long and a couple of inches in diameter.  Makes a decent melee weapon, and can be broken into shorter pieces for crafting.",
     "material": [ "wood" ],
     "techniques": [ "WBLOCK_1" ],
-    "flags": [ "TRADER_AVOID", "FIREWOOD" ],
+    "flags": [ "TRADER_AVOID", "FIREWOOD", "REACH_ATTACK" ],
     "weight": "3000 g",
     "volume": "5000 ml",
     "longest_side": "260 cm",
     "looks_like": "stick",
-    "to_hit": -1,
+    "to_hit": { "grip": "solid", "length": "long", "surface": "any", "balance": "uneven" },
     "use_action": [ "BREAK_STICK" ],
     "category": "spare_parts",
     "melee_damage": { "bash": 18 }

--- a/data/mods/TEST_DATA/expected_dps_data/two_handed_clubs_hammers_dps.json
+++ b/data/mods/TEST_DATA/expected_dps_data/two_handed_clubs_hammers_dps.json
@@ -2,6 +2,6 @@
   {
     "type": "test_data",
     "//": "expected value ideally around 28",
-    "expected_dps": { "warhammer": 35.77, "hammer_sledge": 20.0, "halligan": 16.5, "stick_long": 6.0 }
+    "expected_dps": { "warhammer": 35.77, "hammer_sledge": 20.0, "halligan": 16.5, "stick_long": 8.0 }
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Give long stick reach"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Long stick is long. 2.6 meters long. Almost a full meter longer than most spears long. Yet it didn't have reach attack. (Also, both the stick and long stick still had manually-input to-hit values)

#### Describe the solution

Give the poor long stick REACH_ATTACK so you can bonk people from another tile away. Also updated the stick and long stick's to-hit values to the modern standard. Both have solid grip, any angle, and long reach. Stick has "neutral" balance and the long stick has "uneven" balance.

#### Describe alternatives you've considered

None

#### Testing

Game do indeed load and sticks are sticky.

#### Additional context

The to-hit changes are actually a decent buff; the regular stick is now at +1 while the long stick is at 0. Before, they were both at -1. They kinda needed the buff anyway due to their slow speed, though.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
