### PR TITLE
Add BIOLOGICALPROOF flag to biological damage immunity, apply it to robots and Nether emanations

### DIFF
--- a/data/json/damage_types.json
+++ b/data/json/damage_types.json
@@ -167,7 +167,7 @@
     "physical": false,
     "magic_color": "white",
     "name": "cold",
-    "immune_flags": { "character": [ "COLD_IMMUNE" ] }
+    "immune_flags": { "character": [ "COLD_IMMUNE" ], "monster": [ "COLDPROOF" ] }
   },
   {
     "id": "cold",
@@ -187,7 +187,7 @@
     "physical": false,
     "magic_color": "green",
     "name": "biological",
-    "immune_flags": { "character": [ "BIO_IMMUNE" ] },
+    "immune_flags": { "character": [ "BIO_IMMUNE" ], "monster": [ "BIOLOGICALPROOF" ] },
     "no_resist": true
   },
   {

--- a/data/json/damage_types.json
+++ b/data/json/damage_types.json
@@ -167,7 +167,7 @@
     "physical": false,
     "magic_color": "white",
     "name": "cold",
-    "immune_flags": { "character": [ "COLD_IMMUNE" ], "monster": [ "COLDPROOF" ] }
+    "immune_flags": { "character": [ "COLD_IMMUNE" ] }
   },
   {
     "id": "cold",

--- a/data/json/monsters/drones.json
+++ b/data/json/monsters/drones.json
@@ -14,7 +14,7 @@
     "morale": 100,
     "luminance": 5,
     "death_function": { "message": "The %s's interior compartment sizzles with destructive energy.", "corpse_type": "BROKEN" },
-    "flags": [ "SEES", "FLIES", "NOHEAD", "ELECTRONIC", "NO_BREATHE", "INTERIOR_AMMO", "STUN_IMMUNE", "PACIFIST" ]
+    "flags": [ "SEES", "FLIES", "NOHEAD", "ELECTRONIC", "NO_BREATHE", "BIOLOGICALPROOF", "INTERIOR_AMMO", "STUN_IMMUNE", "PACIFIST" ]
   },
   {
     "id": "mon_EMP_hack",
@@ -170,6 +170,7 @@
       "FLIES",
       "NOHEAD",
       "ELECTRONIC",
+      "BIOLOGICALPROOF",
       "NO_BREATHE",
       "INTERIOR_AMMO",
       "PATH_AVOID_DANGER_1",

--- a/data/json/monsters/monster_flags.json
+++ b/data/json/monsters/monster_flags.json
@@ -195,6 +195,11 @@
     "//": "Immune to cold damage"
   },
   {
+    "id": "BIOLOGICALPROOF",
+    "type": "monster_flag",
+    "//": "Immune to biological damage"
+  },
+  {
     "id": "COMBAT_MOUNT",
     "type": "monster_flag",
     "//": "Mount has better chance to ignore hostile monster fear"

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1058,7 +1058,18 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
     "harvest": "exempt",
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s melts away." },
-    "flags": [ "HEARS", "GOODHEARING", "STUMBLES", "NOHEAD", "HARDTOSHOOT", "FLIES", "PLASTIC", "NO_BREATHE", "NOGIB" ]
+    "flags": [
+      "HEARS",
+      "GOODHEARING",
+      "STUMBLES",
+      "BIOLOGICALPROOF",
+      "NOHEAD",
+      "HARDTOSHOOT",
+      "FLIES",
+      "PLASTIC",
+      "NO_BREATHE",
+      "NOGIB"
+    ]
   },
   {
     "id": "mon_shifting_mass",
@@ -1085,7 +1096,7 @@
       }
     ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s fades away." },
-    "flags": [ "FLIES", "NO_BREATHE", "SEES", "HEARS" ]
+    "flags": [ "FLIES", "NO_BREATHE", "SEES", "BIOLOGICALPROOF", "HEARS" ]
   },
   {
     "id": "mon_impossible_shape",
@@ -1112,7 +1123,7 @@
       }
     ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s fades away." },
-    "flags": [ "FLIES", "NO_BREATHE", "SEES", "RANGED_ATTACKER", "IMMOBILE" ]
+    "flags": [ "FLIES", "NO_BREATHE", "SEES", "BIOLOGICALPROOF", "RANGED_ATTACKER", "IMMOBILE" ]
   },
   {
     "id": "mon_absence",
@@ -1139,7 +1150,7 @@
       }
     ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s returns to normal levels of empty." },
-    "flags": [ "FLIES", "NO_BREATHE", "SEES", "RANGED_ATTACKER", "IMMOBILE" ]
+    "flags": [ "FLIES", "NO_BREATHE", "SEES", "BIOLOGICALPROOF", "RANGED_ATTACKER", "IMMOBILE" ]
   },
   {
     "id": "mon_giant_appendage",
@@ -1162,7 +1173,7 @@
     "melee_dice_sides": 5,
     "melee_damage": [ { "damage_type": "cut", "amount": 14 } ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s is pulled back through the closing portal." },
-    "flags": [ "FLIES", "NO_BREATHE", "STUMBLES" ]
+    "flags": [ "FLIES", "NO_BREATHE", "BIOLOGICALPROOF", "STUMBLES" ]
   },
   {
     "id": "mon_memory",
@@ -1186,7 +1197,7 @@
     "grab_strength": 20,
     "special_attacks": [ { "id": "grab", "cooldown": 2 }, [ "PARROT", 4 ] ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s begins to cry as it disappears." },
-    "flags": [ "NO_BREATHE", "GRABS", "PUSH_MON", "GROUP_BASH" ]
+    "flags": [ "NO_BREATHE", "GRABS", "BIOLOGICALPROOF", "PUSH_MON", "GROUP_BASH" ]
   },
   {
     "id": "mon_swarm_structure",
@@ -1212,7 +1223,7 @@
       }
     ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "Your memory can't decide whether the %s was even there in the first place." },
-    "flags": [ "IMMOBILE", "NO_BREATHE", "SEES", "HEARS", "RANGED_ATTACKER" ],
+    "flags": [ "IMMOBILE", "NO_BREATHE", "BIOLOGICALPROOF", "SEES", "HEARS", "RANGED_ATTACKER" ],
     "armor": { "bash": 5, "cut": 5, "bullet": 5 }
   },
   {
@@ -1240,7 +1251,7 @@
       }
     ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "Your memory can't decide whether the %s was even there in the first place." },
-    "flags": [ "FLIES", "NO_BREATHE", "SEES", "HEARS", "RANGED_ATTACKER" ]
+    "flags": [ "FLIES", "NO_BREATHE", "BIOLOGICALPROOF", "SEES", "HEARS", "RANGED_ATTACKER" ]
   },
   {
     "id": "mon_archunk_weak",
@@ -1274,7 +1285,7 @@
       "message": "The material stabilizes and reforms itself into a small chunk of unknown composition."
     },
     "death_drops": "ps_artifact_weak",
-    "flags": [ "COLDPROOF", "SEES", "HEARS", "NO_BREATHE", "STUN_IMMUNE", "NOHEAD", "ACIDPROOF" ],
+    "flags": [ "COLDPROOF", "SEES", "HEARS", "BIOLOGICALPROOF", "NO_BREATHE", "STUN_IMMUNE", "NOHEAD", "ACIDPROOF" ],
     "armor": { "bash": 20, "cut": 20, "stab": 20, "heat": 20, "bullet": 20, "electric": 20 }
   },
   {
@@ -1334,7 +1345,7 @@
         "cooldown": 5
       }
     ],
-    "flags": [ "SEES", "HEARS", "NO_BREATHE", "PUSH_MON", "ALWAYS_VISIBLE", "ALWAYS_SEES_YOU" ]
+    "flags": [ "SEES", "HEARS", "BIOLOGICALPROOF", "NO_BREATHE", "PUSH_MON", "ALWAYS_VISIBLE", "ALWAYS_SEES_YOU" ]
   },
   {
     "id": "mon_twisted_reflection",
@@ -1415,7 +1426,7 @@
       "corpse_type": "NO_CORPSE",
       "message": "Your shadow seemingly becomes normal again."
     },
-    "flags": [ "SEES", "HEARS", "NO_BREATHE" ]
+    "flags": [ "SEES", "HEARS", "BIOLOGICALPROOF", "NO_BREATHE" ]
   },
   {
     "id": "mon_hallucinator",
@@ -1444,6 +1455,7 @@
       "ACIDPROOF",
       "CAN_OPEN_DOORS",
       "FIREPROOF",
+      "BIOLOGICALPROOF",
       "LOUDMOVES",
       "SLUDGEPROOF",
       "SMELLS",
@@ -1476,7 +1488,7 @@
       }
     ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s fades away." },
-    "flags": [ "SEES", "HEARS", "NO_BREATHE", "PUSH_MON", "ALWAYS_VISIBLE", "ALWAYS_SEES_YOU" ]
+    "flags": [ "SEES", "HEARS", "NO_BREATHE", "BIOLOGICALPROOF", "PUSH_MON", "ALWAYS_VISIBLE", "ALWAYS_SEES_YOU" ]
   },
   {
     "id": "mon_sloth",
@@ -1493,7 +1505,7 @@
       }
     ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "The %s fades away." },
-    "flags": [ "SEES", "HEARS", "NO_BREATHE", "PUSH_MON", "ALWAYS_VISIBLE", "ALWAYS_SEES_YOU" ]
+    "flags": [ "SEES", "HEARS", "NO_BREATHE", "BIOLOGICALPROOF", "PUSH_MON", "ALWAYS_VISIBLE", "ALWAYS_SEES_YOU" ]
   },
   {
     "id": "mon_hanging_roper",

--- a/data/json/monsters/robofac_robots.json
+++ b/data/json/monsters/robofac_robots.json
@@ -29,7 +29,7 @@
     "special_when_hit": [ "RETURN_FIRE", 100 ],
     "death_drops": {  },
     "death_function": { "corpse_type": "BROKEN" },
-    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE", "STUN_IMMUNE" ],
+    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "BIOLOGICALPROOF", "IMMOBILE", "NO_BREATHE", "STUN_IMMUNE" ],
     "armor": { "bash": 2, "cut": 5, "bullet": 2 }
   },
   {
@@ -65,6 +65,7 @@
       "FLIES",
       "ELECTRONIC",
       "COLDPROOF",
+      "BIOLOGICALPROOF",
       "NO_BREATHE",
       "NOHEAD",
       "HEARS",
@@ -123,7 +124,17 @@
     ],
     "death_drops": { "groups": [ [ "robots", 4 ], [ "skitterbot", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
-    "flags": [ "SEES", "HEARS", "GOODHEARING", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "PATH_AVOID_DANGER_1", "STUN_IMMUNE" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "GOODHEARING",
+      "ELECTRONIC",
+      "COLDPROOF",
+      "BIOLOGICALPROOF",
+      "NO_BREATHE",
+      "PATH_AVOID_DANGER_1",
+      "STUN_IMMUNE"
+    ],
     "armor": { "bash": 12, "cut": 12, "bullet": 10, "electric": 5 }
   }
 ]

--- a/data/json/monsters/turrets.json
+++ b/data/json/monsters/turrets.json
@@ -43,7 +43,7 @@
     "special_when_hit": [ "RETURN_FIRE", 100 ],
     "death_drops": {  },
     "death_function": { "corpse_type": "BROKEN" },
-    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE", "DROPS_AMMO" ],
+    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "BIOLOGICALPROOF", "COLDPROOF", "IMMOBILE", "NO_BREATHE", "DROPS_AMMO" ],
     "armor": { "bash": 10, "cut": 16, "bullet": 13, "stab": 16 }
   },
   {
@@ -74,7 +74,7 @@
       "message": "As the final light is destroyed, it erupts in a blinding flare!",
       "corpse_type": "NO_CORPSE"
     },
-    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE", "PRIORITIZE_TARGETS" ],
+    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "BIOLOGICALPROOF", "IMMOBILE", "NO_BREATHE", "PRIORITIZE_TARGETS" ],
     "armor": { "bash": 14, "cut": 16, "bullet": 13, "stab": 16 }
   },
   {
@@ -127,6 +127,7 @@
       "SEES",
       "NOHEAD",
       "ELECTRONIC",
+      "BIOLOGICALPROOF",
       "COLDPROOF",
       "IMMOBILE",
       "NO_BREATHE",
@@ -186,6 +187,7 @@
       "SEES",
       "NOHEAD",
       "ELECTRONIC",
+      "BIOLOGICALPROOF",
       "COLDPROOF",
       "IMMOBILE",
       "NO_BREATHE",
@@ -245,6 +247,7 @@
       "SEES",
       "NOHEAD",
       "ELECTRONIC",
+      "BIOLOGICALPROOF",
       "COLDPROOF",
       "IMMOBILE",
       "NO_BREATHE",
@@ -301,7 +304,17 @@
     ],
     "death_drops": {  },
     "death_function": { "corpse_type": "BROKEN" },
-    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "COLDPROOF", "IMMOBILE", "NO_BREATHE", "DROPS_AMMO", "ID_CARD_DESPAWN" ],
+    "flags": [
+      "SEES",
+      "NOHEAD",
+      "ELECTRONIC",
+      "COLDPROOF",
+      "BIOLOGICALPROOF",
+      "IMMOBILE",
+      "NO_BREATHE",
+      "DROPS_AMMO",
+      "ID_CARD_DESPAWN"
+    ],
     "armor": { "bash": 14, "cut": 16, "bullet": 13, "stab": 16 }
   },
   {
@@ -328,7 +341,7 @@
     "special_attacks": [ [ "SPEAKER", 10 ] ],
     "death_function": { "corpse_type": "BROKEN" },
     "death_drops": { "groups": [ [ "turret_speaker", 1 ] ] },
-    "flags": [ "SEES", "NOHEAD", "ELECTRONIC", "IMMOBILE", "NO_BREATHE" ],
+    "flags": [ "SEES", "NOHEAD", "BIOLOGICALPROOF", "ELECTRONIC", "IMMOBILE", "NO_BREATHE" ],
     "armor": { "bash": 14, "cut": 16, "bullet": 14, "stab": 16 }
   },
   {
@@ -377,7 +390,17 @@
     "special_when_hit": [ "RETURN_FIRE", 100 ],
     "death_drops": { "subtype": "collection", "groups": [ [ "robots", 80 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
-    "flags": [ "SEES", "HEARS", "GOODHEARING", "NOHEAD", "IMMOBILE", "NO_BREATHE", "PRIORITIZE_TARGETS", "INTERIOR_AMMO" ],
+    "flags": [
+      "SEES",
+      "HEARS",
+      "GOODHEARING",
+      "NOHEAD",
+      "BIOLOGICALPROOF",
+      "IMMOBILE",
+      "NO_BREATHE",
+      "PRIORITIZE_TARGETS",
+      "INTERIOR_AMMO"
+    ],
     "armor": { "bash": 24, "bullet": 24, "cut": 26, "stab": 26 }
   },
   {

--- a/data/json/monsters/utility_bot.json
+++ b/data/json/monsters/utility_bot.json
@@ -24,6 +24,7 @@
     "flags": [
       "SEES",
       "ELECTRONIC",
+      "BIOLOGICALPROOF",
       "COLDPROOF",
       "NO_BREATHE",
       "FIREPROOF",
@@ -62,6 +63,7 @@
       "SEES",
       "ELECTRONIC",
       "COLDPROOF",
+      "BIOLOGICALPROOF",
       "NO_BREATHE",
       "FIREPROOF",
       "PUSH_MON",
@@ -101,6 +103,7 @@
       "HEARS",
       "BASHES",
       "ELECTRONIC",
+      "BIOLOGICALPROOF",
       "COLDPROOF",
       "NO_BREATHE",
       "PRIORITIZE_TARGETS",
@@ -133,7 +136,17 @@
     "revert_to_itype": "bot_molebot",
     "death_drops": { "groups": [ [ "robots", 4 ], [ "molebot", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
-    "flags": [ "HEARS", "GOODHEARING", "DIGS", "NO_BREATHE", "ELECTRONIC", "COLDPROOF", "PATH_AVOID_DANGER_1", "STUN_IMMUNE" ],
+    "flags": [
+      "HEARS",
+      "GOODHEARING",
+      "DIGS",
+      "NO_BREATHE",
+      "BIOLOGICALPROOF",
+      "ELECTRONIC",
+      "COLDPROOF",
+      "PATH_AVOID_DANGER_1",
+      "STUN_IMMUNE"
+    ],
     "armor": { "cut": 12, "bullet": 10 }
   },
   {
@@ -161,7 +174,18 @@
     "special_attacks": [ [ "ASSIST", 30 ], [ "CHECK_UP", 120 ] ],
     "death_drops": { "groups": [ [ "robots", 4 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
-    "flags": [ "SEES", "ELECTRONIC", "COLDPROOF", "NO_BREATHE", "FIREPROOF", "PUSH_MON", "HEARS", "PACIFIST", "STUN_IMMUNE" ],
+    "flags": [
+      "SEES",
+      "ELECTRONIC",
+      "COLDPROOF",
+      "NO_BREATHE",
+      "BIOLOGICALPROOF",
+      "FIREPROOF",
+      "PUSH_MON",
+      "HEARS",
+      "PACIFIST",
+      "STUN_IMMUNE"
+    ],
     "armor": { "bash": 8, "cut": 10, "bullet": 8 }
   },
   {
@@ -196,6 +220,7 @@
       "SEES",
       "ELECTRONIC",
       "COLDPROOF",
+      "BIOLOGICALPROOF",
       "NO_BREATHE",
       "FIREPROOF",
       "PUSH_MON",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Add BIOLOGICALPROOF flag to biological damage immunity"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Robots etc are supposed to be immune to biological damage (which requires having biology), but they currently are not. I was testing a spell I added that did biological damage and was able to murder several manhacks with it just fine.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the BIOLOGICALPROOF monster flag and set it as the immune flag for the biological damage type. Apply the flag to all robots and all Nether emanations (portal storm monsters). I did not apply it to any other monsters at this time. 

I did not use NO_BREATHE here because the thing I'm doing requires having a distinction--zombies should be immune to gas and smoke (NO_BREATHE) but they should not be immune to having their flesh rotted off by magic (BIOLOGICALPROOF)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Robots are now immune to biological damage.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
