### PR TITLE
Normal SD cards don't give secret recipes

### DIFF
--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -2273,7 +2273,8 @@
       "recipes_chance": 1.0,
       "recipes_amount": 3,
       "recipes_categories": [ "CC_CHEM" ],
-      "recipes_level_min": 6
+      "recipes_level_min": 6,
+      "secret_recipes": true
     },
     "pocket_data": [  ]
   },

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3826,7 +3826,8 @@ Memory card information can be defined on any GENERIC item by adding an object n
   "recipes_amount": 5,                 // contains between 1 and 5 new recipes
   "recipes_level_min": 4,              // recipes will have at least level 4
   "recipes_level_max": 8,              // recipes will have at most level 8
-  "recipes_categories": [ "CC_FOOD" ]  // recipes from CC_FOOD category
+  "recipes_categories": [ "CC_FOOD" ], // (Optional) Array, defaults `CC_FOOD`. Memory card can contain recipes from any of these categories.
+  "secret_recipes": true               // (Optional) Boolean, default false. If true, can contain recipes with the `SECRET` flag.
 }
 ```
 

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1040,7 +1040,8 @@ void data_handling_activity_actor::do_turn( player_activity &act, Character &p )
         for( const auto& [rid, r] : recipe_dict ) {
             if( r.never_learn || r.obsolete || mmd->recipes_categories.count( r.category ) == 0 ||
                 saved_recipes.count( rid ) ||
-                r.difficulty > mmd->recipes_level_max || r.difficulty < mmd->recipes_level_min ) {
+                r.difficulty > mmd->recipes_level_max || r.difficulty < mmd->recipes_level_min ||
+                ( r.has_flag( "SECRET" ) && !mmd->secret_recipes ) ) {
                 continue;
             }
             candidates.emplace( rid );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2562,6 +2562,9 @@ static void load_memory_card_data( memory_card_info &mcd, const JsonObject &jo )
     } else {
         mcd.recipes_categories = { "CC_FOOD" };
     }
+    if( jo.has_member( "secret_recipes" ) ) {
+        mcd.secret_recipes = jo.get_bool( "secret_recipes" );
+    }
 }
 
 void islot_ammo::load( const JsonObject &jo )

--- a/src/itype.h
+++ b/src/itype.h
@@ -1123,6 +1123,7 @@ struct memory_card_info {
     int recipes_level_min;
     int recipes_level_max;
     std::set<std::string> recipes_categories;
+    bool secret_recipes;
 };
 
 struct itype {


### PR DESCRIPTION
#### Summary
Balance "Normal SD cards don't give secret recipes"

#### Purpose of change
You could get exodii recipes from normal SD cards. Obviously, this doesn't make any sense.

#### Describe the solution
Add a new member to the memory card struct: `secret_recipes` (default false boolean). If the recipe has the `SECRET` flag, and the memory card does not have `secret_recipes` then the recipe is skipped as a possible option.

The exodii recipes already have the `SECRET` flag so no further edits were needed.

#### Describe alternatives you've considered


#### Testing
Compiled with my changes, banged some memory cards into a smartphone. Confirmed I could still get mutagen recipes with xedra cards. Confirmed that removing the `secret_recipes` boolean did not allow `SECRET` recipes (no mutagens etc).

#### Additional context