### PR TITLE
🧗‍♀️ Rebalance & expand climbing down with ropes, ladders, vehicles, downspouts & mutations

### DIFF
--- a/data/json/climbing.json
+++ b/data/json/climbing.json
@@ -223,6 +223,19 @@
   },
   {
     "type": "climbing_aid",
+    "id": "ability_INSECT_ARMS_OK",
+    "//": "Four insectoid arms makes climbing quite easy.",
+    "copy-from": "generic_superpower",
+    "down": {
+      "menu_text": "Crawl down using all your arms.",
+      "confirm_text": "Crawl down?",
+      "msg_after": "You crawl down using all your arms.",
+      "max_height": 2
+    },
+    "condition": { "type": "trait", "flag": "INSECT_ARMS_OK" }
+  },
+  {
+    "type": "climbing_aid",
     "id": "ability_VINES2",
     "//": "Vines 2-3 gives the option to leave a vine behind or not.  This is VINES2, keeping.",
     "copy-from": "generic_superpower",

--- a/data/json/climbing.json
+++ b/data/json/climbing.json
@@ -28,9 +28,95 @@
   },
   {
     "type": "climbing_aid",
+    "abstract": "generic_improvised",
+    "//": "TEMPLATE: terrain that helps a little with climbing but is still risky (eg, downspouts)",
+    "slip_chance_mod": -5,
+    "down": { "menu_text": "Climb down.", "confirm_text": "Climb down %s?" },
+    "condition": { "type": "special", "flag": "abstract" }
+  },
+  {
+    "type": "climbing_aid",
+    "abstract": "generic_rappel",
+    "//": "TEMPLATE: Rope used to rappel.  Much safer than a bare ledge, but should be strenuous.",
+    "slip_chance_mod": -12,
+    "down": {
+      "menu_text": "Rappel down.",
+      "confirm_text": "Rappel down?",
+      "msg_before": "You grasp the rope firmly and rappel down."
+    },
+    "condition": { "type": "special", "flag": "abstract" }
+  },
+  {
+    "type": "climbing_aid",
+    "abstract": "generic_stepladder",
+    "//": "TEMPLATE: Stepladders, not the bolted-down kind.  Very safe and easy unless you're reckless.",
+    "slip_chance_mod": -20,
+    "down": {
+      "menu_text": "Climb down with this stepladder.",
+      "confirm_text": "Climb down the ladder?",
+      "msg_after": "You climb down the ladder."
+    },
+    "condition": { "type": "special", "flag": "abstract" }
+  },
+  {
+    "type": "climbing_aid",
+    "abstract": "generic_half_z_level",
+    "//": "TEMPLATE: Immobile things about half a Z-level (~5 feet) tall.  Extremely safe but strenuous.",
+    "slip_chance_mod": -40,
+    "down": { "menu_text": "Clamber down.", "confirm_text": "Clamber down?", "msg_after": "You clamber down.", "max_height": 1 },
+    "condition": { "type": "special", "flag": "abstract" }
+  },
+  {
+    "type": "climbing_aid",
+    "abstract": "generic_superpower",
+    "//": "Template for powerful mutations that make climbing almost completely safe.  Be sure to customize text.",
+    "slip_chance_mod": -100,
+    "down": {
+      "menu_text": "Use your talents to climb down.",
+      "confirm_text": "Use your talents to climb down?",
+      "msg_after": "You descend effortlessly.",
+      "max_height": 1
+    },
+    "condition": { "type": "special", "flag": "abstract" }
+  },
+  {
+    "type": "climbing_aid",
+    "id": "vehicle",
+    "//": "Currently this applies to any part of any vehicle.  Trickier than most climbing.",
+    "slip_chance_mod": -8,
+    "down": {
+      "menu_text": "Climb down onto the vehicle here.",
+      "confirm_text": "Climb down onto the vehicle?",
+      "msg_after": "You climb down onto the vehicle.",
+      "max_height": 1
+    },
+    "condition": { "type": "veh", "flag": "INITIAL_PART" }
+  },
+  {
+    "type": "climbing_aid",
+    "id": "furn_CLIMBABLE",
+    "//": "eg: fences, downspouts",
+    "copy-from": "generic_improvised",
+    "down": { "menu_text": "Climb down %s here.", "confirm_text": "Climb down %s?", "msg_after": "You climb down." },
+    "condition": { "type": "ter_furn", "flag": "CLIMBABLE" }
+  },
+  {
+    "type": "climbing_aid",
+    "id": "furn_CLIMB_SIMPLE",
+    "//": "eg: sandbag walls, earthbag walls.  Flag is for furniture where climbing 'never fails'.",
+    "copy-from": "generic_half_z_level",
+    "down": {
+      "menu_text": "Clamber down onto %s here.",
+      "confirm_text": "Clamber down onto %s?",
+      "msg_after": "You clamber down onto %s."
+    },
+    "condition": { "type": "ter_furn", "flag": "CLIMB_SIMPLE" }
+  },
+  {
+    "type": "climbing_aid",
     "id": "furn_LADDER",
     "//": "currently applies to placeable stepladders, not constructed stair-like ladders",
-    "slip_chance_mod": -1000,
+    "copy-from": "generic_stepladder",
     "down": {
       "menu_text": "Climb down %s here.",
       "confirm_text": "Climb down %s?",
@@ -41,15 +127,61 @@
   },
   {
     "type": "climbing_aid",
-    "id": "item_grapnel",
-    "//": "deploy a grappling hook from inventory.  Already-placed hooks are not helpful at this time...",
-    "slip_chance_mod": -1000,
+    "id": "item_stepladder",
+    "//": "We can generalize the grappling hook mechanism to portable ladders, so why not?",
+    "copy-from": "generic_stepladder",
     "down": {
-      "menu_text": "Attach your grappling hook to climb down.",
+      "menu_text": "Place your wooden stepladder below and climb down.",
+      "menu_cant": "Can't place your stepladder (needs open space one story below).",
+      "menu_hotkey": "l",
+      "confirm_text": "Climb down with your stepladder?",
+      "msg_after": "You lower the ladder into place and climb down.",
+      "//": "This removes a stepladder from inventory and places it on the ground below.",
+      "max_height": 1,
+      "allow_remaining_height": false,
+      "deploy_furn": "f_ladder",
+      "easy_climb_back_up": 1
+    },
+    "condition": { "type": "item", "flag": "stepladder", "uses": 1 }
+  },
+  {
+    "type": "climbing_aid",
+    "id": "item_aluminum_stepladder",
+    "//": "Variant of the wooden stepladder.",
+    "copy-from": "item_stepladder",
+    "down": {
+      "menu_text": "Place your aluminum stepladder below and climb down.",
+      "menu_cant": "Can't place your stepladder (needs open space one story below).",
+      "menu_hotkey": "l",
+      "confirm_text": "Climb down with your stepladder?",
+      "deploy_furn": "f_aluminum_stepladder"
+    },
+    "condition": { "type": "item", "flag": "aluminum_stepladder", "uses": 1 }
+  },
+  {
+    "type": "climbing_aid",
+    "id": "furn_ROPE",
+    "//": "currently based on DIFFICULT_Z flag, but a ROPE flag would be appropriate in the future.",
+    "copy-from": "generic_rappel",
+    "down": {
+      "menu_text": "Rappel down with the %s here.",
+      "confirm_text": "Rappel down with the %s?",
+      "msg_before": "You grasp the rope firmly and rappel down.",
+      "max_height": 1
+    },
+    "condition": { "type": "ter_furn", "flag": "DIFFICULT_Z" }
+  },
+  {
+    "type": "climbing_aid",
+    "id": "item_grapnel",
+    "//": "deploy a grappling hook from inventory.  Already-placed hooks instead use furn_ROPE.",
+    "copy-from": "generic_rappel",
+    "down": {
+      "menu_text": "Attach your grappling hook and rappel down.",
       "menu_cant": "Can't attach your grappling hook (something is in the way).",
       "menu_hotkey": "g",
-      "confirm_text": "Use your grappling hook to climb down?",
-      "msg_before": "You tie the rope around your waist and begin to climb down.",
+      "confirm_text": "Use your grappling hook to rappel down?",
+      "msg_before": "You tie the rope around your waist and begin to rappel down.",
       "//": "Grappling hook is 30 ft (ie, 2 levels) but we don't currently have proper furniture for that.",
       "max_height": 1,
       "deploy_furn": "f_rope_up",
@@ -61,7 +193,7 @@
     "type": "climbing_aid",
     "id": "ability_WALL_CLING",
     "//": "Allows players to safely climb up/down or hold position against a wall.",
-    "slip_chance_mod": -1000,
+    "copy-from": "generic_superpower",
     "down": {
       "menu_text": "Crawl down the wall with your sticky pads.",
       "confirm_text": "Crawl down the wall?",
@@ -75,7 +207,7 @@
     "type": "climbing_aid",
     "id": "ability_WEB_RAPPEL",
     "//": "Extremely safe descent regardless of height by spinning webs.",
-    "slip_chance_mod": -1000,
+    "copy-from": "generic_superpower",
     "down": {
       "menu_text": "Spin your webs to descend.",
       "menu_cant": "Can't spin your webs (something is in the way).",
@@ -88,5 +220,67 @@
       "easy_climb_back_up": 999
     },
     "condition": { "type": "trait", "flag": "WEB_RAPPEL" }
+  },
+  {
+    "type": "climbing_aid",
+    "id": "ability_VINES2",
+    "//": "Vines 2-3 gives the option to leave a vine behind or not.  This is VINES2, keeping.",
+    "copy-from": "generic_superpower",
+    "down": {
+      "menu_text": "Climb down using your vines.",
+      "confirm_text": "Use your vines to descend?",
+      "msg_after": "You gingerly descend using your vines.",
+      "max_height": 1
+    },
+    "condition": { "type": "trait", "flag": "VINES2" }
+  },
+  {
+    "type": "climbing_aid",
+    "id": "ability_VINES2_deploy",
+    "//": "Vines 2-3 gives the option to leave a vine behind or not.  This is VINES2, detaching.",
+    "copy-from": "generic_superpower",
+    "down": {
+      "menu_text": "Detach a vine so you can climb back up (<color_yellow>this will hurt</color>).",
+      "menu_cant": "Can't detach a vine (something is in the way).",
+      "menu_hotkey": "v",
+      "confirm_text": "Detach a vine to descend?",
+      "msg_after": "You descend on your vines, though leaving a part of you behind stings.",
+      "max_height": 1,
+      "cost": { "pain": 5, "damage": 5, "kcal": 87, "thirst": 10 },
+      "deploy_furn": "f_vine_up",
+      "easy_climb_back_up": 1
+    },
+    "condition": { "type": "trait", "flag": "VINES2" }
+  },
+  {
+    "type": "climbing_aid",
+    "id": "ability_VINES3",
+    "//": "Vines 2-3 gives the option to leave a vine behind or not.  This is VINES3, keeping.",
+    "copy-from": "generic_superpower",
+    "down": {
+      "menu_text": "Climb down using your vines.",
+      "confirm_text": "Use your vines to descend?",
+      "msg_after": "You effortlessly descend using your vines.",
+      "max_height": 1
+    },
+    "condition": { "type": "trait", "flag": "VINES3" }
+  },
+  {
+    "type": "climbing_aid",
+    "id": "ability_VINES3_deploy",
+    "//": "Vines 2-3 gives the option to leave a vine behind or not.  This is VINES3, detaching.",
+    "copy-from": "generic_superpower",
+    "down": {
+      "menu_text": "Detach a vine so you can climb back up (this is harmless).",
+      "menu_cant": "Can't detach a vine (something is in the way).",
+      "menu_hotkey": "v",
+      "confirm_text": "Detach a vine to descend?",
+      "msg_after": "You effortlessly lower yourself and leave a vine rooted for future use.",
+      "max_height": 1,
+      "cost": { "kcal": 87, "thirst": 10 },
+      "deploy_furn": "f_vine_up",
+      "easy_climb_back_up": 1
+    },
+    "condition": { "type": "trait", "flag": "VINES3" }
   }
 ]

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -1587,6 +1587,27 @@
   },
   {
     "type": "furniture",
+    "id": "f_vine_up",
+    "name": "vine leading up",
+    "looks_like": "t_rope_up",
+    "description": "A thick vine is rigidly anchored to something above you.  It looks quite alive.  You could climb up or tear it down.",
+    "symbol": "<",
+    "color": "light_green",
+    "move_cost_mod": 1,
+    "required_str": -1,
+    "flags": [ "CLIMBABLE", "TRANSPARENT", "SEEN_FROM_ABOVE", "ALLOW_ON_OPEN_AIR", "DIFFICULT_Z" ],
+    "examine_action": "deployed_furniture",
+    "deployed_item": "vine_30",
+    "bash": {
+      "str_min": 1,
+      "str_max": 10,
+      "sound": "rrrrip!",
+      "sound_fail": "twang.",
+      "items": [ { "item": "vine_6", "count": [ 2, 5 ] } ]
+    }
+  },
+  {
+    "type": "furniture",
     "id": "f_web_up",
     "name": "web leading up",
     "looks_like": "fd_web",

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -216,6 +216,7 @@ static const character_modifier_id character_modifier_slip_prevent_mod( "slip_pr
 
 static const climbing_aid_id climbing_aid_ability_WALL_CLING( "ability_WALL_CLING" );
 static const climbing_aid_id climbing_aid_default( "default" );
+static const climbing_aid_id climbing_aid_furn_CLIMBABLE( "furn_CLIMBABLE" );
 
 static const damage_type_id damage_acid( "acid" );
 static const damage_type_id damage_bash( "bash" );
@@ -11797,7 +11798,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
         } else {
             // TODO: Make it an extended action
             climbing = true;
-            climbing_aid = climbing_aid_default;
+            climbing_aid = climbing_aid_furn_CLIMBABLE;
             u.set_activity_level( EXTRA_EXERCISE );
             move_cost = cost == 0 ? 1000 : cost + 500;
 

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -117,7 +117,6 @@ static const bionic_id bio_painkiller( "bio_painkiller" );
 
 static const character_modifier_id character_modifier_obstacle_climb_mod( "obstacle_climb_mod" );
 
-static const climbing_aid_id climbing_aid_default( "default" );
 static const climbing_aid_id climbing_aid_furn_CLIMBABLE( "furn_CLIMBABLE" );
 
 static const efftype_id effect_antibiotic( "antibiotic" );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -118,6 +118,7 @@ static const bionic_id bio_painkiller( "bio_painkiller" );
 static const character_modifier_id character_modifier_obstacle_climb_mod( "obstacle_climb_mod" );
 
 static const climbing_aid_id climbing_aid_default( "default" );
+static const climbing_aid_id climbing_aid_furn_CLIMBABLE( "furn_CLIMBABLE" );
 
 static const efftype_id effect_antibiotic( "antibiotic" );
 static const efftype_id effect_bite( "bite" );
@@ -1518,7 +1519,7 @@ void iexamine::chainfence( Character &you, const tripoint &examp )
         move_cost = 100;
     } else {
         move_cost = you.has_trait( trait_BADKNEES ) ? 800 : 400;
-        if( g->slip_down( game::climb_maneuver::over_obstacle, climbing_aid_default ) ) {
+        if( g->slip_down( game::climb_maneuver::over_obstacle, climbing_aid_furn_CLIMBABLE ) ) {
             you.moves -= move_cost;
             return;
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Rebalance & expand climbing down with ropes, ladders, vehicles, downspouts & bug/plant mutations."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Currently some methods of climbing are quite risky while others are absolutely safe and the nature of these differences can be counterintuitive.  Ladders and held grappling hooks are foolproof while a lot of other climbable things do nothing to help you descend.  Certain mutations and tools are only usable in the specific situation where downstairs don't have matching upstairs.  This can be chalked up to a previously untamed labyrinth of conditionals and special cases, where functions like `slip_down` didn't have enough context to factor in abilities and terrain.

I've written three contributions building a UX and tech foundation for this expansion and rebalance:

* https://github.com/CleverRaven/Cataclysm-DDA/pull/68120 (ie, get a sense of falling risk)
* https://github.com/CleverRaven/Cataclysm-DDA/pull/68150 (ie, climb by walking into a ledge)
* https://github.com/CleverRaven/Cataclysm-DDA/pull/68265 (adds a JSON system for climbing aids)

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Various `climbing_aid`s have been added for things that should reasonably be possible.  These and existing climbing aids have been organized into six categories of differing safety with differing `slip_chance_mod` affecting the chance to fall and get hurt when climbing down from a ledge.

* 🆕 -> New stuff (didn't help with climbing down before).
* 👹 -> Nerfed stuff (was absolutely risk-free before).

| Category                           | `slip_chance_mod` | Climbing Aids                                                |
| ---------------------------------- | ----------------- | ------------------------------------------------------------ |
| Improvised                         | -5%               | 🆕 `CLIMBABLE` below (eg, downspouts, fences)                         |
| Vehicles                           | -8%               | 🆕 Any vehicle                                                |
| Rapelling                          | -12%              | 👹 Place a grappling hook<br />🆕 `DIFFICULT_Z` below (eg, placed grappling hook) |
| Stepladders                        | -20%              | 👹 `LADDER` below<br />🆕 Place stepladder from inventory |
| Half-Story Drop<br />Solid Footing | -40%              | 🆕 `CLIMB_SIMPLE` below (eg, sandbag barrier)                   |
| Climbing<br />"Superpowers"        | -100%             | 👹 "Web Diver" Mutation (allows multi-story descent)<br />👹 "Wall Cling" Trait (from debug tail)<br />🆕 Vines Mutation (levels 2 and 3, with detach option)<br />🆕 Insect Arms (allows 1- or 2-story descent) |

`slip_chance_mod` offsets the normal chance to fail at certain climbing maneuvers, which is typically around 8-12% but can be much higher if the player is wet, hurt, heavily burdened or *especially* if they're low on stamina.  For players in good climbing condition, the new modifier can reduce slip_chance below 0%.  If it reaches -5% or less, the safety prompt will say "perfectly safe" or even be bypassed completely.

The "nerfed" climbing methods are still quite safe in most situations.  On the other hand, a particularly luckless player could be so overburdened, weakened, wet and low on stamina that even that -100% modifier doesn't protect them.

I added a new furniture item "vine leading up" as part of implementing vines for this contribution.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

* **Give downspout a zero `slip_chance_mod` and give ledges a positive `slip_chance_mod`**, so that improvised climbing aids like downspouts and fences are no safer than before.
* **Let grappling hooks and stepladders remain foolproof**.
* **Rappelling with regular ropes**.  This would require more legwork to require something to tie to and make ropes only retrievable from above.
* **Allow two-story descent with grappling hooks**.  They *are* described as 30 feet long, and I laid some C++ groundwork for this, but it would require new furniture gimmicks to represent the top and bottom of the grappling hook.

Some things that are probably out of scope because they need more extensive C++ work:

* **Make JSON rules for climbing up too**.  Those rules are currently hardcoded into `vertical_move`.
* **Treat stairs / building ladders as climbing aids**.  Those are currently hardcoded into `vertical_move`.  Not sure if slipping on stairs should be added to the game, even if it's extremely unlikely.
* **Allow "alley climbing" as a way to descend**.  See `map::climb_difficulty`).
* **Don't freefall at the end of a partial climb-down**.  Right now most methods can be used to climb down one story from a multi-story ledge, but the player just falls afterwards.  When rapelling, the player could stop at the end of the rope instead of being forced to let go and fall.  This could create interesting tactics like jumping through a second-story window from the roof!  But we would need new furniture flags to make it happen.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
- Tested various ledges on a 2-story building.
- Tested with both types of stepladders including placing stepladders.
- Tested with downspouts.
- Tested with grappling hook, pre-placed and in inventory.
- Tested with varying levels of stamina, torso encumbrance & weight, and two-handed item wielding.
- Limited testing with vines and webs mutations in previous iterations of this PR.

**I welcome any help testing this with mutations**, as I haven't played enough CDDA to be familiar with them.  The previous implementation seemed buggy but I did my best to replicate the way it worked while greatly tidying up the code.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

This is what the new "walk into a ledge" menu looks like with all "deployable" climbing aids (web, vine detach, ladder, grapple)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13224671/86d416cb-2d38-47aa-ac87-e4da965d74e4)

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
