### PR TITLE
XE Addiction snippets

### DIFF
--- a/data/mods/Xedra_Evolved/addiction_eocs.json
+++ b/data/mods/Xedra_Evolved/addiction_eocs.json
@@ -33,12 +33,10 @@
         "id": "EOC_LOTUS_ADDICTION_SNIPPET_TYPE",
         "condition": { "not": { "u_has_effect": "sleep" } },
         "effect": [
-          { "u_message": "lotus_addiction", "snippet": true, "type": "warning" },
-          { "u_add_morale": "morale_craving_blood", "bonus": -5, "max_bonus": -30 }
+          { "u_message": "lotus_addiction", "snippet": true, "type": "warning" }
         ],
         "false_effect": [
-          { "u_message": "lotus_addiction_dream", "snippet": true, "type": "warning" },
-          { "u_add_morale": "morale_craving_blood", "bonus": -5, "max_bonus": -30 }
+          { "u_message": "lotus_addiction_dream", "snippet": true, "type": "warning" }
         ]
 
       }

--- a/data/mods/Xedra_Evolved/addiction_eocs.json
+++ b/data/mods/Xedra_Evolved/addiction_eocs.json
@@ -6,41 +6,41 @@
       "compare_num": [ { "rand": 2000 }, "<=", { "u_val": "addiction_intensity", "addiction": "blood", "mod": { "val": 2000, "step": 20 } } ]
     },
     "effect": [
-      { "run_eocs": {
-        "id": "EOC_BLOOD_ADDICTION_SNIPPET_TYPE",
-        "condition": { "not": { "u_has_effect": "sleep" } },
-        "effect": [
-          { "u_message": "blood_addiction", "snippet": true, "type": "warning" },
-          { "u_add_morale": "morale_craving_blood", "bonus": -5, "max_bonus": -30 }
-        ],
-        "false_effect": [
-          { "u_message": "blood_addiction_dream", "snippet": true, "type": "warning" },
-          { "u_add_morale": "morale_craving_blood", "bonus": -5, "max_bonus": -30 }
-        ]
-
+      {
+        "run_eocs": {
+          "id": "EOC_BLOOD_ADDICTION_SNIPPET_TYPE",
+          "condition": { "not": { "u_has_effect": "sleep" } },
+          "effect": [
+            { "u_message": "blood_addiction", "snippet": true, "type": "warning" },
+            { "u_add_morale": "morale_craving_blood", "bonus": -5, "max_bonus": -30 }
+          ],
+          "false_effect": [
+            { "u_message": "blood_addiction_dream", "snippet": true, "type": "warning" },
+            { "u_add_morale": "morale_craving_blood", "bonus": -5, "max_bonus": -30 }
+          ]
+        }
       }
-    }
     ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_LOTUS_ADDICTION",
     "condition": {
-      "compare_num": [ { "rand": 800 }, "<=", { "u_val": "addiction_intensity", "addiction": "lotus_blossom", "mod": { "val": 800, "step": 20 } } ]
+      "compare_num": [
+        { "rand": 800 },
+        "<=",
+        { "u_val": "addiction_intensity", "addiction": "lotus_blossom", "mod": { "val": 800, "step": 20 } }
+      ]
     },
     "effect": [
-      { "run_eocs": {
-        "id": "EOC_LOTUS_ADDICTION_SNIPPET_TYPE",
-        "condition": { "not": { "u_has_effect": "sleep" } },
-        "effect": [
-          { "u_message": "lotus_addiction", "snippet": true, "type": "warning" }
-        ],
-        "false_effect": [
-          { "u_message": "lotus_addiction_dream", "snippet": true, "type": "warning" }
-        ]
-
+      {
+        "run_eocs": {
+          "id": "EOC_LOTUS_ADDICTION_SNIPPET_TYPE",
+          "condition": { "not": { "u_has_effect": "sleep" } },
+          "effect": [ { "u_message": "lotus_addiction", "snippet": true, "type": "warning" } ],
+          "false_effect": [ { "u_message": "lotus_addiction_dream", "snippet": true, "type": "warning" } ]
+        }
       }
-    }
     ]
   }
 ]

--- a/data/mods/Xedra_Evolved/addiction_eocs.json
+++ b/data/mods/Xedra_Evolved/addiction_eocs.json
@@ -6,56 +6,43 @@
       "compare_num": [ { "rand": 2000 }, "<=", { "u_val": "addiction_intensity", "addiction": "blood", "mod": { "val": 2000, "step": 20 } } ]
     },
     "effect": [
-      { "u_message": "You want some blood.", "type": "warning" },
-      { "u_add_morale": "morale_craving_blood", "bonus": -5, "max_bonus": -30 },
-      {
-        "run_eocs": [
-          {
-            "id": "EOC_BLOOD_ADDICTION_EFFECTS",
-            "condition": {
-              "and": [
-                {
-                  "compare_num": [
-                    { "u_val": "vitamin", "name": "human_blood_vitamin" },
-                    ">",
-                    { "u_val": "addiction_intensity", "addiction": "blood", "mod": -10 }
-                  ]
-                },
-                { "compare_num": [ { "rand": 10 }, "<", { "u_val": "addiction_intensity", "addiction": "blood" } ] }
-              ]
-            },
-            "effect": {
-              "weighted_list_eocs": [ [ "EOC_BLOOD_ADDICTION_SHAKES", { "const": 10 } ], [ "EOC_BLOOD_ADDICTION_BLIND", { "const": 10 } ] ]
-            }
-          },
-          {
-            "id": "EOC_BLOOD_ADDICTION_BLIND",
-            "condition": {
-              "and": [
-                { "compare_num": [ { "u_val": "addiction_intensity", "addiction": "blood" }, ">=", { "const": 8 } ] },
-                { "compare_num": [ { "rand": 392 }, "<", { "u_val": "addiction_intensity", "addiction": "blood" } ] }
-              ]
-            },
-            "effect": [
-              { "u_message": "Your vision goes black as blood fills your thoughts!", "type": "bad" },
-              { "u_add_effect": "blind", "duration": "2 minutes" }
-            ]
-          },
-          {
-            "id": "EOC_BLOOD_ADDICTION_SHAKES",
-            "condition": {
-              "and": [
-                { "compare_num": [ { "u_val": "addiction_intensity", "addiction": "blood" }, ">=", { "const": 8 } ] },
-                { "compare_num": [ { "rand": 392 }, "<", { "u_val": "addiction_intensity", "addiction": "blood" } ] }
-              ]
-            },
-            "effect": [
-              { "u_message": "Your hands clench uncontrollably as you think about how much you need blood now!", "type": "bad" },
-              { "u_add_effect": "shakes", "duration": "2 minutes" }
-            ]
-          }
+      { "run_eocs": {
+        "id": "EOC_BLOOD_ADDICTION_SNIPPET_TYPE",
+        "condition": { "not": { "u_has_effect": "sleep" } },
+        "effect": [
+          { "u_message": "blood_addiction", "snippet": true, "type": "warning" },
+          { "u_add_morale": "morale_craving_blood", "bonus": -5, "max_bonus": -30 }
+        ],
+        "false_effect": [
+          { "u_message": "blood_addiction_dream", "snippet": true, "type": "warning" },
+          { "u_add_morale": "morale_craving_blood", "bonus": -5, "max_bonus": -30 }
         ]
+
       }
+    }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LOTUS_ADDICTION",
+    "condition": {
+      "compare_num": [ { "rand": 800 }, "<=", { "u_val": "addiction_intensity", "addiction": "lotus_blossom", "mod": { "val": 800, "step": 20 } } ]
+    },
+    "effect": [
+      { "run_eocs": {
+        "id": "EOC_LOTUS_ADDICTION_SNIPPET_TYPE",
+        "condition": { "not": { "u_has_effect": "sleep" } },
+        "effect": [
+          { "u_message": "lotus_addiction", "snippet": true, "type": "warning" },
+          { "u_add_morale": "morale_craving_blood", "bonus": -5, "max_bonus": -30 }
+        ],
+        "false_effect": [
+          { "u_message": "lotus_addiction_dream", "snippet": true, "type": "warning" },
+          { "u_add_morale": "morale_craving_blood", "bonus": -5, "max_bonus": -30 }
+        ]
+
+      }
+    }
     ]
   }
 ]

--- a/data/mods/Xedra_Evolved/addictions.json
+++ b/data/mods/Xedra_Evolved/addictions.json
@@ -12,7 +12,7 @@
     "id": "lotus_blossom",
     "name": "Lotus Eater",
     "type_name": "lotus_eater",
-    "description": "You ate the lotus, you experienced the universe.  You washed the pain away.  ",
+    "description": "You ate the lotus, you experienced the universe.  You washed the pain away.",
     "craving_morale": "morale_craving_lotus_blossom",
     "effect_on_condition": "EOC_LOTUS_ADDICTION"
   }

--- a/data/mods/Xedra_Evolved/addictions.json
+++ b/data/mods/Xedra_Evolved/addictions.json
@@ -6,5 +6,14 @@
     "type_name": "blood_hunger",
     "description": "You suffer from a quite unnatural thirst for the blood of your fellow man.  Unfortunately, the supply has shrunk by about 99% from a few months ago.",
     "effect_on_condition": "EOC_BLOOD_ADDICTION"
+  },
+  {
+    "type": "addiction_type",
+    "id": "lotus_blossom",
+    "name": "Lotus Eater",
+    "type_name": "lotus_eater",
+    "description": "You ate the lotus, you experienced the universe.  You washed the pain away.  ",
+    "craving_morale": "morale_craving_lotus_blossom",
+    "effect_on_condition": "EOC_LOTUS_ADDICTION"
   }
 ]

--- a/data/mods/Xedra_Evolved/items/drugs.json
+++ b/data/mods/Xedra_Evolved/items/drugs.json
@@ -35,6 +35,8 @@
     "stim": -20,
     "fun": 45,
     "flags": [ "NO_INGEST", "EDIBLE_FROZEN" ],
+    "addiction_type": "lotus_blossom",
+    "addiction_potential": 40,
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You eat the purple lotus blossom.",

--- a/data/mods/Xedra_Evolved/morale_types.json
+++ b/data/mods/Xedra_Evolved/morale_types.json
@@ -4,7 +4,7 @@
     "type": "morale_type",
     "text": "Ate dreamdross"
   },
-    {
+  {
     "id": "morale_craving_lotus_blossom",
     "type": "morale_type",
     "text": "A hum at the edge of your thoughts."

--- a/data/mods/Xedra_Evolved/morale_types.json
+++ b/data/mods/Xedra_Evolved/morale_types.json
@@ -3,5 +3,10 @@
     "id": "morale_ate_dross",
     "type": "morale_type",
     "text": "Ate dreamdross"
+  },
+    {
+    "id": "morale_craving_lotus_blossom",
+    "type": "morale_type",
+    "text": "A hum at the edge of your thoughts."
   }
 ]

--- a/data/mods/Xedra_Evolved/snippets/addiction_snippets.json
+++ b/data/mods/Xedra_Evolved/snippets/addiction_snippets.json
@@ -12,9 +12,18 @@
     "type": "snippet",
     "category": "blood_addiction_dream",
     "text": [
-      { "id": "blood_addiction_dream_1", "text": "You dream of sneaking into a home through an open window late at night.  Walking through the darkened hallways, unerringly finding your way to a bedroom.  You stand at the foot of the bed staring down at the person sleeping in it.  Are they a man, woman or child?  You can't tell, all you know is they are filled with blood and you need it." },
-      { "id": "blood_addiction_dream_2", "text": "In your dream, an early evening storm begins with you outside.  You feel the rain hitting you but it is thicker than water, more viscous.  You smell it first, before you look at your hands and realize the rain is blood.  You lean your head back and open your mouth wide to the rain falling into it." },
-      { "id": "blood_addiction_dream_3", "text": "You float above a house late at night watching someone enter through an open window.  You blink and you are now in a bedroom seeing a disturbing scene.  Someone who's face is shadowed where you can't see them is standing over a person lying on the bed.  You startle when you realize that you are the person lying on the bed.  You scream helplessly as the shadowed person bites into sleeping you's throat and blood sprays across the room.  You wake as your struggles slow and lessen." }
+      {
+        "id": "blood_addiction_dream_1",
+        "text": "You dream of sneaking into a home through an open window late at night.  Walking through the darkened hallways, unerringly finding your way to a bedroom.  You stand at the foot of the bed staring down at the person sleeping in it.  Are they a man, woman or child?  You can't tell, all you know is they are filled with blood and you need it."
+      },
+      {
+        "id": "blood_addiction_dream_2",
+        "text": "In your dream, an early evening storm begins with you outside.  You feel the rain hitting you but it is thicker than water, more viscous.  You smell it first, before you look at your hands and realize the rain is blood.  You lean your head back and open your mouth wide to the rain falling into it."
+      },
+      {
+        "id": "blood_addiction_dream_3",
+        "text": "You float above a house late at night watching someone enter through an open window.  You blink and you are now in a bedroom seeing a disturbing scene.  Someone who's face is shadowed where you can't see them is standing over a person lying on the bed.  You startle when you realize that you are the person lying on the bed.  You scream helplessly as the shadowed person bites into sleeping you's throat and blood sprays across the room.  You wake as your struggles slow and lessen."
+      }
     ]
   },
   {
@@ -22,17 +31,32 @@
     "category": "lotus_addiction",
     "text": [
       { "id": "lotus_addiction_1", "text": "You are sure you saw movement at the edge of your vision." },
-      { "id": "lotus_addiction_2", "text": "The hair on the back of your neck rises as you hear a voice you remember from just out of sight." },
-      { "id": "lotus_addiction_3", "text": "Your eye twitches on it's own for several minutes.  From the top corner near your temple down into the cheek." }
+      {
+        "id": "lotus_addiction_2",
+        "text": "The hair on the back of your neck rises as you hear a voice you remember from just out of sight."
+      },
+      {
+        "id": "lotus_addiction_3",
+        "text": "Your eye twitches on it's own for several minutes.  From the top corner near your temple down into the cheek."
+      }
     ]
   },
   {
     "type": "snippet",
     "category": "lotus_addiction_dream",
     "text": [
-      { "id": "lotus_addiction_dream_1", "text": "You dream about watching tv, it's a documentary about some bioweapon that got loose in Newfoundland.  A doctor is talking about how containment failed and health campaigns failed to eradicate it.  You recognize the voice, it's your voice.  As the credits play you see listed '<full_name> M.D.'  This seems worrying." },
-      { "id": "lotus_addiction_dream_2", "text": "You dream of walking down a long hallway with no definite beginning or end, portraits and mirrors alternate on the sides of the hallway.  Slowly you have a sneaking suspicion that your reflections aren't quite reflecting you.  Sometimes you spot out of the corner of your eyes distorted features, a mouth full of sharp teeth, different hair styles and colors, even horns.  Each time you turn and look though it's just your own reflection looking back at you.  You try one last time to catch your reflection and while you are staring into its eyes, you see the pupils track towards the portrait reflected behind you.  You turn your eyes to focus on the portrait reflection and there you are climbing out of the portrait mouth agape, full of too many needle sharp teeth, you quickly focus back at your reflection in the mirror and see only clear glass.  Before you can turn you feel a sharp pain in your shoulder." },
-      { "id": "lotus_addiction_dream_3", "text": "You lounge in sunny glades, eating lotus blossoms while others frolick through the breeze.  You wake feeling calmer than normal and go back to less pleasant sleep." }
+      {
+        "id": "lotus_addiction_dream_1",
+        "text": "You dream about watching tv, it's a documentary about some bioweapon that got loose in Newfoundland.  A doctor is talking about how containment failed and health campaigns failed to eradicate it.  You recognize the voice, it's your voice.  As the credits play you see listed '<full_name> M.D.'  This seems worrying."
+      },
+      {
+        "id": "lotus_addiction_dream_2",
+        "text": "You dream of walking down a long hallway with no definite beginning or end, portraits and mirrors alternate on the sides of the hallway.  Slowly you have a sneaking suspicion that your reflections aren't quite reflecting you.  Sometimes you spot out of the corner of your eyes distorted features, a mouth full of sharp teeth, different hair styles and colors, even horns.  Each time you turn and look though it's just your own reflection looking back at you.  You try one last time to catch your reflection and while you are staring into its eyes, you see the pupils track towards the portrait reflected behind you.  You turn your eyes to focus on the portrait reflection and there you are climbing out of the portrait mouth agape, full of too many needle sharp teeth, you quickly focus back at your reflection in the mirror and see only clear glass.  Before you can turn you feel a sharp pain in your shoulder."
+      },
+      {
+        "id": "lotus_addiction_dream_3",
+        "text": "You lounge in sunny glades, eating lotus blossoms while others frolick through the breeze.  You wake feeling calmer than normal and go back to less pleasant sleep."
+      }
     ]
   }
 ]

--- a/data/mods/Xedra_Evolved/snippets/addiction_snippets.json
+++ b/data/mods/Xedra_Evolved/snippets/addiction_snippets.json
@@ -1,0 +1,38 @@
+[
+  {
+    "type": "snippet",
+    "category": "blood_addiction",
+    "text": [
+      { "id": "blood_addiction_1", "text": "You need blood to survive." },
+      { "id": "blood_addiction_2", "text": "A blood spattered charnel room flashes in front of your eyes." },
+      { "id": "blood_addiction_3", "text": "You lick your teeth thinking about blood." }
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "blood_addiction_dream",
+    "text": [
+      { "id": "blood_addiction_dream_1", "text": "You dream of sneaking into a home through an open window late at night.  Walking through the darkened hallways, unerringly finding your way to a bedroom.  You stand at the foot of the bed staring down at the person sleeping in it.  Are they a man, woman or child?  You can't tell, all you know is they are filled with blood and you need it." },
+      { "id": "blood_addiction_dream_2", "text": "In your dream, an early evening storm begins with you outside.  You feel the rain hitting you but it is thicker than water, more viscous.  You smell it first, before you look at your hands and realize the rain is blood.  You lean your head back and open your mouth wide to the rain falling into it." },
+      { "id": "blood_addiction_dream_3", "text": "You float above a house late at night watching someone enter through an open window.  You blink and you are now in a bedroom seeing a disturbing scene.  Someone who's face is shadowed where you can't see them is standing over a person lying on the bed.  You startle when you realize that you are the person lying on the bed.  You scream helplessly as the shadowed person bites into sleeping you's throat and blood sprays across the room.  You wake as your struggles slow and lessen." }
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "lotus_addiction",
+    "text": [
+      { "id": "lotus_addiction_1", "text": "You are sure you saw movement at the edge of your vision." },
+      { "id": "lotus_addiction_2", "text": "The hair on the back of your neck rises as you hear a voice you remember from just out of sight." },
+      { "id": "lotus_addiction_3", "text": "Your eye twitches on it's own for several minutes.  From the top corner near your temple down into the cheek." }
+    ]
+  },
+  {
+    "type": "snippet",
+    "category": "lotus_addiction_dream",
+    "text": [
+      { "id": "lotus_addiction_dream_1", "text": "You dream about watching tv, it's a documentary about some bioweapon that got loose in Newfoundland.  A doctor is talking about how containment failed and health campaigns failed to eradicate it.  You recognize the voice, it's your voice.  As the credits play you see listed '<full_name> M.D.'  This seems worrying." },
+      { "id": "lotus_addiction_dream_2", "text": "You dream of walking down a long hallway with no definite beginning or end, portraits and mirrors alternate on the sides of the hallway.  Slowly you have a sneaking suspicion that your reflections aren't quite reflecting you.  Sometimes you spot out of the corner of your eyes distorted features, a mouth full of sharp teeth, different hair styles and colors, even horns.  Each time you turn and look though it's just your own reflection looking back at you.  You try one last time to catch your reflection and while you are staring into its eyes, you see the pupils track towards the portrait reflected behind you.  You turn your eyes to focus on the portrait reflection and there you are climbing out of the portrait mouth agape, full of too many needle sharp teeth, you quickly focus back at your reflection in the mirror and see only clear glass.  Before you can turn you feel a sharp pain in your shoulder." },
+      { "id": "lotus_addiction_dream_3", "text": "You lounge in sunny glades, eating lotus blossoms while others frolick through the breeze.  You wake feeling calmer than normal and go back to less pleasant sleep." }
+    ]
+  }
+]

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -543,7 +543,7 @@ Here's a quick summary of what each of the JSON files contain, broken down by fo
 | `scent_types.json`            | type of scent available
 | `scores.json`                 | scores
 | `skills.json`                 | skill descriptions and ID's
-| `snippets.json`               | flier/poster descriptions
+| `snippets.json`               | flier/poster/monster speech/dream/etc descriptions
 | `species.json`                | monster species
 | `speed_descripton.json`       | monster speed description
 | `speech.json`                 | monster vocalizations


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Addiction snippets for Xedra Evolved"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adds addiction dreams for blood and dreams and snippets and addiction type for lotus blossums.  
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds a bunch of snippets and the json to make them work.   Adds an eoc to power it and adjusts an older eoc.  Doesn't give any penalties to gaining Lotus Blossom addiction just weird dreams and paranoia.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Giving poor morale effects to wanting more lotus blossom.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
