### PR TITLE
Fix identical omts spawning over themselves

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -2889,10 +2889,16 @@ void overmap::ter_set( const tripoint_om_omt &p, const oter_id &id )
 
     oter_id &val = layer[p.z() + OVERMAP_DEPTH].terrain[p.xy()];
     if( id->has_flag( oter_flags::requires_predecessor ) ) {
-        const oter_type_id id_type = id->get_type_id();
         // Stops linear fallback_predecessor maps (roads etc) spawning over themselves
-        if( !( id_type->is_linear() && id_type == val->get_type_id() ) ) {
-            predecessors_[p].push_back( val );
+        std::vector<oter_id> &om_predecessors = predecessors_[p];
+        if( om_predecessors.empty() || !val->is_linear() ) {
+            om_predecessors.push_back( val );
+        } else {
+            // Collapse and keep the last linear oter of matching type
+            oter_id &last_predecessor = om_predecessors.back();
+            if( last_predecessor->get_type_id() == val->get_type_id() ) {
+                last_predecessor = val;
+            }
         }
     }
     val = id;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix overload of zeds and vehicles with older saves"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Possibly fixes #67837. One fix led to another bug, which leads to this fix. There's a migration safety issue in mapgen where old saves serialized 'bad data' that was resolved at runtime. The runtime fixup was removed, but the saves were not migrated. This is an attempt to implement that save migration.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I don't really know the exact terminology, but the laymans answer is things like roads were running mapgen 'over themselves' repeatedly. This resulted in things like dozen car pileups and hundreds of zeds in cities. The patch that introduced this (#67773) implemented logic at worldgen? mapgen? time which prevents these redundant roads being added to a 'predecessors' list. I ported that logic into the savegame deserializer to try to handle this at load time so older saves migrate forward successfully. The only thing I'm unsure of is the base condition of zero to 1 predecessors, but I'm assuming that *any* predecessor should be allowed compared to a base case of I'm guessing null terrain?
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Created a save in a game compiled just prior to #67773. Debug map revealed and teleported to a city extremely far away. No problem.
Loaded that save on ##67773. Teleported to the same tile. Hundreds of zeds.
![before](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/64962e1f-e70e-4eea-b491-dd89cd053295)

Applied my fix. Teleported to the tile. Not hundreds of zeds.

![after](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/f2c54ecc-2aff-416b-bc09-1fa3f1a1042b)

Roads don't have infinite predecessors anymore. A before comparison:

![current_bad](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/587f036f-3cc1-4407-afab-d3bd6e6d2cb1)

Created a new world. Inspected 4 way intersections in cities. Saw there are still some that have a manhole omt as a predecessor. Manholes appear to not be linear, and adding the LINEAR flag is apparently mutually exclusive with NO_ROTATE, so that's not going to change. I don't know if this means city intersections have a higher chance of double spawns of somethings or not.
![after](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/36f233a6-b6e4-4c25-bdf0-6ee93b0c039b)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

0.G didn't have this redundant manhole under crossroad stuff. But JSONizing roads is radically different than what was before. No clue how to get there.

![og_manhole](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/f903cf87-e080-4fad-b5bc-08c256d35af7)

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
