### PR TITLE
Make eoc melee test stop failing for the wrong reason

### DIFF
--- a/tests/melee_test.cpp
+++ b/tests/melee_test.cpp
@@ -365,14 +365,18 @@ static void check_eocs_from_test_fire( const std::string &mon_id )
     REQUIRE( mon.get_value( "npctalk_var_general_dmg_type_test_test_fire" ).empty() );
     item firesword( "test_fire_sword" );
     dude.set_wielded_item( firesword );
-    while( !dude.melee_attack( mon, false ) ) {}
+    for( int i = 0; i < 1000; ++i ) {
+        if( dude.melee_attack( mon, false ) && !dude.get_value( "npctalk_var_test_bp" ).empty() ) {
+            break;
+        }
+    }
+    CHECK( !dude.get_value( "npctalk_var_test_bp" ).empty() );
     if( mon.get_value( "npctalk_var_general_dmg_type_test_test_fire" ) == "target" ) {
         REQUIRE( dude.get_value( "npctalk_var_general_dmg_type_test_test_fire" ) == "source" );
     }
 
     eoc_total_dmg = std::round( std::stod(
                                     dude.get_value( "npctalk_var_test_damage_taken" ) ) );
-    REQUIRE( !dude.get_value( "npctalk_var_test_bp" ).empty() );
 
     Messages::clear_messages();
     CHECK( eoc_total_dmg == firesword.damage_melee( damage_test_fire ) );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Spurious test failures are spuriously rage inducing.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
When the melee attack misses, the eoc doesn't fire, the damage value isn't set, std::stod is passed an empty string, it throws an exception, babies cry. Make the test get 1000 tries to actually successfully hit the monster once before bailing out, by testing the eoc condition fires, because it sets a particular var to a value that is not empty (which is what was failing the test before).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
CI. Ran the test locally and it passed.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
