### PR TITLE
Don't Lose default background when chosing a profession

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -4533,6 +4533,7 @@ void reset_scenario( avatar &u, const scenario *scen )
     }
 
     u.hobbies.clear();
+    u.add_default_background();
     u.clear_mutations();
     u.recalc_hp();
     u.empty_skills();

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -684,11 +684,9 @@ bool avatar::create( character_type type, const std::string &tempname )
         pool = pool_type::MULTI_POOL;
     }
 
-    bool default_backgrounds = false;
     switch( type ) {
         case character_type::CUSTOM:
             randomize_cosmetics();
-            default_backgrounds = true;
             break;
         case character_type::RANDOM:
             //random scenario, default name if exist
@@ -718,9 +716,8 @@ bool avatar::create( character_type type, const std::string &tempname )
             break;
     }
 
-    if( default_backgrounds )
-        //to check which starts add the basic adult backgrounds
-    {
+    // Don't apply the default backgrounds on a template
+    if( type != character_type::TEMPLATE ) {
         add_default_background();
     }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
#### Purpose of change

Fixes #68006
Overrides #68013 with a different solution
Fix losing default backgrounds when chosing a profession

#### Describe the solution

Only skip default background for templates but not for other character creation mods
Keep default background when resetting hobbies so that setting a profession doesn't immedialty erase default background

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Make a template without background > load it > no background
- Make a character with other method > chose a profession > backgrounds still there

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
