### PR TITLE
Deconstructing a water heater yields a 100L tank instead of 60L

### DIFF
--- a/data/json/furniture_and_terrain/furniture-plumbing.json
+++ b/data/json/furniture_and_terrain/furniture-plumbing.json
@@ -114,7 +114,7 @@
     "flags": [ "CONTAINER", "PLACE_ITEM", "LIQUIDCONT", "NOITEM", "SEALED", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
     "//": "keg_capacity assumed to be from model XE36S06ST45U0 water heater <https://images.thdstatic.com/catalog/pdfImages/2d/2d7ed116-1a8c-439d-b7fe-a62a0a98f806.pdf>",
     "examine_action": "keg",
-    "keg_capacity": 105,
+    "keg_capacity": 400,
     "deconstruct": { "items": [ { "item": "household_water_heater", "count": 1 } ] },
     "bash": {
       "str_min": 18,

--- a/data/json/furniture_and_terrain/furniture-plumbing.json
+++ b/data/json/furniture_and_terrain/furniture-plumbing.json
@@ -112,8 +112,9 @@
     "coverage": 55,
     "required_str": -1,
     "flags": [ "CONTAINER", "PLACE_ITEM", "LIQUIDCONT", "NOITEM", "SEALED", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
+    "//": "keg_capacity assumed to be from model XE36S06ST45U0 water heater <https://images.thdstatic.com/catalog/pdfImages/2d/2d7ed116-1a8c-439d-b7fe-a62a0a98f806.pdf>",
     "examine_action": "keg",
-    "keg_capacity": 240,
+    "keg_capacity": 105,
     "deconstruct": { "items": [ { "item": "household_water_heater", "count": 1 } ] },
     "bash": {
       "str_min": 18,

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -1271,6 +1271,7 @@
     "price": 0,
     "price_postapoc": 10,
     "material": [ "steel" ],
+    "//": "weight and volume assumed to be from model XE36S06ST45U0 water heater <https://images.thdstatic.com/catalog/pdfImages/2d/2d7ed116-1a8c-439d-b7fe-a62a0a98f806.pdf>",
     "weight": "54431 g",
     "volume": "240 L",
     "to_hit": -5,

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -4183,8 +4183,9 @@
       [ [ "thermostat", 1 ] ],
       [ [ "water_faucet", 1 ] ],
       [ [ "pipe_fittings", 6 ] ],
-      [ [ "metal_tank", 1 ] ]
-    ]
+      [ [ "30gal_drum", 1 ] ]
+    ],
+    "//": "drum assumed to be from model XE36S06ST45U0 water heater <https://images.thdstatic.com/catalog/pdfImages/2d/2d7ed116-1a8c-439d-b7fe-a62a0a98f806.pdf>"
   },
   {
     "result": "television",


### PR DESCRIPTION
#### Summary
Balance "Deconstructing a water heater yields a 100L tank instead of 60L (plus the usual bits and bobs)."

#### Purpose of change

Fixes #68316

#### Describe the solution

I did a quick search for water heaters on the website of the nearest home improvement store and found that the Rheem model XE36S06ST45U0 is a good match for the stats of the existing household_water_heater item at 240L exterior volume and 54kg mass. See
<https://images.thdstatic.com/catalog/pdfImages/2d/2d7ed116-1a8c-439d-b7fe-a62a0a98f806.pdf> for published dimensions.

As this water heater has an internal capacity of 36 US gallons (136L), I changed the deconstruction recipe to yield a 100L tank instead of the 60L it used to be. I also changed the keg_capacity of the heater to match.

#### Describe alternatives you've considered

I originally intended to use the 200L `55gal_drum` for this change, primarily because I myself have a 50–gallon heater. However, I noticed that this didn’t leave a lot of room for insulation, and went looking for specifications on real water heaters.

Of course, this size of water heater is intended for use in small apartments; larger houses would have larger heaters (up to 100 gallons even). I’m resisting the temptation to add another size or two just on general principle, but I note that mansions do exist.

#### Testing

I tested this by disassembling a water heater and noting that I got a 100L tank as intended. Later I noticed that the keg_capacity was off; turns out that it's in cups not liters.

#### Additional context

![Screenshot 2023-09-27 at 15-54-19 2d7ed116-1a8c-439d-b7fe-a62a0a98f806 pdf](https://github.com/CleverRaven/Cataclysm-DDA/assets/228849/7adb9194-1095-4745-9a29-ca2aa0b27c42)

![Screenshot from 2023-09-27 15-51-58](https://github.com/CleverRaven/Cataclysm-DDA/assets/228849/0bcce927-845a-4488-bba6-0b095fff720d)
