### PR TITLE
Fixed uncommon stream_mutable generation failure

### DIFF
--- a/data/mods/innawood/overmap/overmap_mutable/stream_mutable.json
+++ b/data/mods/innawood/overmap/overmap_mutable/stream_mutable.json
@@ -23,7 +23,7 @@
       "stream_end_bend_wn": { "overmap": "stream_end_north", "south": "stream_to_east" },
       "stream_end_bend_ws": { "overmap": "stream_end_south", "north": "stream_to_east" }
     },
-    "root": "stream_body",
+    "root": "stream_end_n",
     "phases": [
       [
         { "overmap": "stream_body", "weight": 100 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixed stream_mutable generation failure"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

As noted in #67192 there was a rare chance for the stream mutable to fail to generate causing a long error message. This PR aims to resolve this.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

I found that it was possible for the stream to generate in a ring and intersect with it's own mapgen causing an error. This was possible because when it started generating it had two open sides; this PR changes the root generation to an end point making it impossible for two unresolved sections to meet.

I believe this also has the side effect of resolving a problem in the original PR ( #67065 ) where you were unable to spawn multiple streams in the same overmap chunk without a high risk of errors.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Removing streams or leaving the error open.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I'm unfamiliar with the automated tests, so I'd implore somebody to run some to double check this change. For my own testing, I manually spawned thousands of streams by upping the spawn quantity and got no errors.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
