### PR TITLE
fireweed and more mostly decorative flora

### DIFF
--- a/data/json/furniture_and_terrain/furniture-flora.json
+++ b/data/json/furniture_and_terrain/furniture-flora.json
@@ -422,7 +422,10 @@
     "required_str": -1,
     "flags": [ "TRANSPARENT", "TINY", "FLOWER", "FLAMMABLE_ASH", "NOCOLLIDE", "ORGANIC" ],
     "examine_action": "harvest_furn_nectar",
-    "harvest_by_season": [ { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_spring_harv" }, { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_harv" } ],
+    "harvest_by_season": [
+      { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_spring_harv" },
+      { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_harv" }
+    ],
     "bash": {
       "str_min": 2,
       "str_max": 6,
@@ -443,7 +446,10 @@
     "move_cost_mod": 0,
     "flags": [ "TRANSPARENT", "TINY", "FLOWER", "FLAMMABLE_ASH", "NOCOLLIDE", "ORGANIC" ],
     "examine_action": "harvest_furn_nectar",
-    "harvest_by_season": [ { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_spring_harv" }, { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_harv" } ],
+    "harvest_by_season": [
+      { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_spring_harv" },
+      { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_harv" }
+    ],
     "bash": {
       "str_min": 2,
       "str_max": 6,

--- a/data/json/furniture_and_terrain/furniture-flora.json
+++ b/data/json/furniture_and_terrain/furniture-flora.json
@@ -121,7 +121,7 @@
     "required_str": -1,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
     "examine_action": "harvest_furn_nectar",
-    "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "tulip_harv" } ],
+    "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "generic_flower_harv" } ],
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
   },
   {
@@ -168,7 +168,7 @@
     "required_str": -1,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
     "examine_action": "harvest_furn_nectar",
-    "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "black_eyed_susan_harv" } ],
+    "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "generic_flower_harv" } ],
     "//": "Add flower and bud spawns once useful.",
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
   },
@@ -184,7 +184,7 @@
     "required_str": -1,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
     "examine_action": "harvest_furn_nectar",
-    "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "lily_harv" } ],
+    "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "generic_flower_harv" } ],
     "//": "Add flower and bud spawns once useful.",
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
   },
@@ -245,7 +245,7 @@
     "required_str": -1,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
     "examine_action": "harvest_furn",
-    "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "lilypad_harv" } ],
+    "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "generic_flower_harv" } ],
     "bash": { "str_min": 2, "str_max": 6, "sound": "crunch.", "sound_fail": "whish." }
   },
   {
@@ -354,7 +354,6 @@
     "looks_like": "f_lily",
     "color": [ "brown_green", "green", "red", "brown" ],
     "move_cost_mod": 1,
-    "coverage": 20,
     "required_str": -1,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
     "examine_action": "harvest_furn_nectar",
@@ -377,7 +376,6 @@
     "//": "green all year long",
     "color": "green",
     "move_cost_mod": 1,
-    "coverage": 20,
     "required_str": -1,
     "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "FLOWER" ],
     "examine_action": "harvest_furn_nectar",
@@ -401,7 +399,7 @@
     "move_cost_mod": 3,
     "coverage": 70,
     "required_str": -1,
-    "flags": [ "TRANSPARENT", "TINY", "FLAMMABLE_ASH", "NOCOLLIDE", "ORGANIC" ],
+    "flags": [ "TRANSPARENT", "SHORT", "SHRUB", "FLAMMABLE_ASH", "NOCOLLIDE", "ORGANIC" ],
     "examine_action": "harvest_furn_nectar",
     "harvest_by_season": [ { "seasons": [ "spring" ], "id": "japanese_knotweed_harv" } ],
     "bash": {
@@ -410,6 +408,109 @@
       "sound": "crunch.",
       "sound_fail": "whish.",
       "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] }, { "item": "leaves", "count": [ 2, 4 ] } ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_fireweed",
+    "name": "fireweed",
+    "description": "Vibrant purple, it tends to be the first to appear after fires, hence its name.",
+    "symbol": ",",
+    "looks_like": "f_dahlia",
+    "move_cost_mod": 0,
+    "color": [ "brown_green", "magenta", "magenta", "brown" ],
+    "required_str": -1,
+    "flags": [ "TRANSPARENT", "TINY", "FLOWER", "FLAMMABLE_ASH", "NOCOLLIDE", "ORGANIC" ],
+    "examine_action": "harvest_furn_nectar",
+    "harvest_by_season": [ { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_spring_harv" }, { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_harv" } ],
+    "bash": {
+      "str_min": 2,
+      "str_max": 6,
+      "sound": "crunch.",
+      "sound_fail": "whish.",
+      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] }, { "item": "leaves", "count": [ 2, 4 ] } ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_selfheal",
+    "name": "common selfheal",
+    "description": "A small purple flower.  It got its name due to its usage in traditional medicine.",
+    "symbol": ",",
+    "looks_like": "f_dahlia",
+    "color": [ "brown_green", "magenta", "magenta", "brown" ],
+    "required_str": -1,
+    "move_cost_mod": 0,
+    "flags": [ "TRANSPARENT", "TINY", "FLOWER", "FLAMMABLE_ASH", "NOCOLLIDE", "ORGANIC" ],
+    "examine_action": "harvest_furn_nectar",
+    "harvest_by_season": [ { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_spring_harv" }, { "seasons": [ "summer", "autumn" ], "id": "generic_edible_flower_harv" } ],
+    "bash": {
+      "str_min": 2,
+      "str_max": 6,
+      "sound": "crunch.",
+      "sound_fail": "whish.",
+      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] }, { "item": "leaves", "count": [ 2, 4 ] } ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_dogbane",
+    "name": "spreading dogbane",
+    "description": "It is not only toxic to dogs when eaten by them.  Humans and many other animals are affected, too.  Its fibers sure are worth salvaging though.  Despite its name, it is not actually spreading fast.",
+    "symbol": ",",
+    "looks_like": "f_chamomile",
+    "color": [ "brown_green", "green", "green", "brown" ],
+    "required_str": -1,
+    "move_cost_mod": 0,
+    "flags": [ "TRANSPARENT", "SHORT", "SHRUB", "FLAMMABLE_ASH", "NOCOLLIDE", "ORGANIC" ],
+    "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "dogbane_harv" } ],
+    "bash": {
+      "str_min": 2,
+      "str_max": 6,
+      "sound": "crunch.",
+      "sound_fail": "whish.",
+      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] }, { "item": "leaves", "count": [ 2, 4 ] } ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_thistle",
+    "name": "thistle",
+    "looks_like": "f_burdock",
+    "description": "A prickly and invasive small plant.",
+    "symbol": ",",
+    "color": [ "brown_green", "green", "green", "brown" ],
+    "required_str": -1,
+    "move_cost_mod": 0,
+    "flags": [ "TRANSPARENT", "TINY", "FLOWER", "FLAMMABLE_ASH", "NOCOLLIDE", "ORGANIC" ],
+    "examine_action": "harvest_furn_nectar",
+    "harvest_by_season": [ { "seasons": [ "spring", "summer", "autumn" ], "id": "thistle_harv" } ],
+    "bash": {
+      "str_min": 2,
+      "str_max": 6,
+      "sound": "crunch.",
+      "sound_fail": "whish.",
+      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
+    }
+  },
+  {
+    "type": "furniture",
+    "id": "f_purple_loosestrife",
+    "name": "purple loosestrife",
+    "looks_like": "f_dahlia",
+    "description": "A pretty violet flower that likes water.  Unfortunately it is invasive and does not benefit the environment.",
+    "symbol": ",",
+    "color": [ "brown_green", "magenta", "magenta", "brown" ],
+    "required_str": -1,
+    "move_cost_mod": 0,
+    "flags": [ "TRANSPARENT", "SHORT", "FLOWER", "FLAMMABLE_ASH", "NOCOLLIDE", "ORGANIC" ],
+    "examine_action": "harvest_furn_nectar",
+    "bash": {
+      "str_min": 2,
+      "str_max": 6,
+      "sound": "crunch.",
+      "sound_fail": "whish.",
+      "items": [ { "item": "withered", "prob": 50, "count": [ 1, 2 ] } ]
     }
   },
   {

--- a/data/json/harvest.json
+++ b/data/json/harvest.json
@@ -10,6 +10,11 @@
     "entries": [  ]
   },
   {
+    "id": "generic_flower_harv",
+    "type": "harvest",
+    "entries": [ { "drop": "withered", "base_num": [ 1, 2 ] }, { "drop": "seed_flower", "base_num": [ 1, 2 ] } ]
+  },
+  {
     "id": "dandelion_harv",
     "type": "harvest",
     "entries": [ { "drop": "raw_dandelion", "base_num": [ 1, 4 ] } ]
@@ -22,7 +27,12 @@
   {
     "id": "burdock_summer_harv",
     "type": "harvest",
-    "entries": [ { "drop": "raw_burdock", "base_num": [ 1, 4 ] }, { "drop": "burdock_stalk", "base_num": [ 1, 4 ] } ]
+    "entries": [ { "drop": "raw_burdock", "base_num": [ 1, 4 ] }, { "drop": "plant_stalk", "base_num": [ 1, 4 ] } ]
+  },
+  {
+    "id": "thistle_harv",
+    "type": "harvest",
+    "entries": [ { "drop": "plant_stalk", "base_num": [ 1, 2 ] } ]
   },
   {
     "id": "salsify_harv",
@@ -66,11 +76,6 @@
     "entries": [ { "drop": "chamomile", "base_num": [ 4, 8 ] } ]
   },
   {
-    "id": "tulip_harv",
-    "type": "harvest",
-    "entries": [ { "drop": "withered", "base_num": [ 1, 2 ] }, { "drop": "seed_flower", "base_num": [ 1, 2 ] } ]
-  },
-  {
     "id": "spurge_harv",
     "type": "harvest",
     "entries": [
@@ -80,24 +85,9 @@
     ]
   },
   {
-    "id": "black_eyed_susan_harv",
-    "type": "harvest",
-    "entries": [ { "drop": "withered", "base_num": [ 1, 2 ] }, { "drop": "seed_flower", "base_num": [ 1, 2 ] } ]
-  },
-  {
-    "id": "lily_harv",
-    "type": "harvest",
-    "entries": [ { "drop": "withered", "base_num": [ 1, 2 ] }, { "drop": "seed_flower", "base_num": [ 1, 2 ] } ]
-  },
-  {
     "id": "sunflower_harv",
     "type": "harvest",
     "entries": [ { "drop": "sunflower" } ]
-  },
-  {
-    "id": "lilypad_harv",
-    "type": "harvest",
-    "entries": [ { "drop": "withered", "base_num": [ 1, 2 ] } ]
   },
   {
     "id": "cattails_winter_harv",
@@ -122,7 +112,7 @@
   {
     "id": "chicory_harv",
     "type": "harvest",
-    "entries": [ { "drop": "chicory_raw", "base_num": [ 1, 2 ] } ]
+    "entries": [ { "drop": "chicory_raw", "base_num": [ 1, 2 ] }, { "drop": "chicory_leaves", "base_num": [ 1, 5 ] } ]
   },
   {
     "id": "datura_harv",
@@ -335,6 +325,29 @@
     "id": "young_leaves_harv",
     "type": "harvest",
     "entries": [ { "drop": "young_leaves", "base_num": [ 2, 5 ], "scale_num": [ 0, 1 ] } ]
+  },
+  {
+    "id": "generic_edible_flower_spring_harv",
+    "type": "harvest",
+    "entries": [
+      { "drop": "young_leaves", "base_num": [ 2, 5 ], "scale_num": [ 0, 1 ] },
+      { "drop": "withered", "base_num": [ 1, 2 ], "scale_num": [ 0, 1 ] },
+      { "drop": "plant_stalk", "base_num": [ 0, 1 ] },
+      { "drop": "plant_fibre", "base_num": [ 0, 2 ], "scale_num": [ 0, 1 ] }
+    ]
+  },
+  {
+    "id": "generic_edible_flower_harv",
+    "type": "harvest",
+    "entries": [
+      { "drop": "withered", "base_num": [ 1, 2 ], "scale_num": [ 0, 1 ] },
+      { "drop": "plant_fibre", "base_num": [ 0, 2 ], "scale_num": [ 0, 1 ] }
+    ]
+  },
+  {
+    "id": "dogbane_harv",
+    "type": "harvest",
+    "entries": [ { "drop": "dogbane", "base_num": [ 1, 3 ], "scale_num": [ 0, 1 ] } ]
   },
   {
     "id": "japanese_knotweed_harv",

--- a/data/json/itemgroups/Agriculture_Forage_Excavation/forage.json
+++ b/data/json/itemgroups/Agriculture_Forage_Excavation/forage.json
@@ -5,6 +5,7 @@
     "subtype": "distribution",
     "entries": [
       { "item": "young_leaves", "prob": 50, "count-min": 1, "count-max": 4 },
+      { "item": "plant_stalk", "prob": 20, "count-min": 1, "count-max": 3 },
       { "group": "any_wild_egg", "prob": 15, "count-min": 2, "count-max": 5 },
       { "item": "groundnut", "prob": 5, "count-min": 1, "count-max": 8 },
       { "item": "egg_reptile", "prob": 5, "count-min": 2, "count-max": 5 },
@@ -29,6 +30,7 @@
     "subtype": "distribution",
     "entries": [
       { "item": "mayapple", "prob": 10, "count-min": 1, "count-max": 3 },
+      { "item": "plant_stalk", "prob": 10, "count-min": 1, "count-max": 3 },
       { "item": "groundnut", "prob": 3, "count-min": 1, "count-max": 6 },
       { "group": "forage_mushroom", "prob": 25 },
       { "group": "any_wild_egg", "prob": 5, "count-min": 2, "count-max": 5 },
@@ -52,6 +54,7 @@
     "subtype": "distribution",
     "entries": [
       { "item": "mayapple", "prob": 8, "count-min": 1, "count-max": 2 },
+      { "item": "plant_stalk", "prob": 5, "count-min": 1, "count-max": 3 },
       { "item": "groundnut", "prob": 2, "count-min": 1, "count-max": 9 },
       { "group": "forage_mushroom", "prob": 50 },
       { "item": "wild_herbs", "prob": 10, "count": 20 },

--- a/data/json/items/comestibles/raw_veggy.json
+++ b/data/json/items/comestibles/raw_veggy.json
@@ -238,9 +238,9 @@
   },
   {
     "type": "COMESTIBLE",
-    "id": "burdock_stalk",
-    "name": { "str": "burdock stalk" },
-    "description": "A stiff, green stalk from a burdock plant.  It is starchy and fibrous, but it would be much better if you cooked it.",
+    "id": "plant_stalk",
+    "name": { "str": "plant stalk" },
+    "description": "A stiff, green stalk from a plant.  It is starchy and fibrous, but it would be much better if you cooked it.",
     "copy-from": "cattail_stalk"
   },
   {
@@ -1011,13 +1011,23 @@
     "comestible_type": "FOOD",
     "symbol": "%",
     "calories": 18,
-    "description": "Some young leaves from miscellaneous plants.  They're tender enough to eat, but not very tasty raw.",
-    "price": 40,
+    "description": "Some young leaves from miscellaneous plants.  They're tender enough to eat, but not very tasty on their own.",
+    "price": 0,
     "price_postapoc": 10,
     "material": [ "veggy" ],
     "volume": "45 ml",
-    "fun": -5,
+    "fun": -2,
     "vitamins": [ [ "vitC", 1 ] ]
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "chicory_leaves",
+    "name": { "str_sp": "handful of chicory greens" },
+    "copy-from": "young_leaves",
+    "description": "Some chicory greens.  They are quite bitter but high in vitamins.",
+    "price_postapoc": 20,
+    "fun": -8,
+    "vitamins": [ [ "vitC", 6 ], [ "iron", 1 ], [ "calcium", 2 ] ]
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/mapgen/isherwood_farms/dairy_farm_isherwood.json
+++ b/data/json/mapgen/isherwood_farms/dairy_farm_isherwood.json
@@ -163,9 +163,7 @@
         ".": [ "t_grass", "t_grass", "t_dirt", "t_dirt", "t_dirt" ],
         "f": "t_splitrail_fencegate_c"
       },
-      "furniture": {
-        ".": [ [ "f_null", 29 ], [ "f_thistle", 1 ] ]
-      },
+      "furniture": { ".": [ [ "f_null", 29 ], [ "f_thistle", 1 ] ] },
       "place_item": [
         { "item": "cattlefodder", "x": 37, "y": 15, "amount": [ 0, 4 ] },
         { "item": "cattlefodder", "x": 38, "y": 6, "amount": [ 0, 4 ] },
@@ -528,9 +526,7 @@
         ".$............................................$."
       ],
       "terrain": { "$": "t_splitrail_fence", ".": [ "t_grass", "t_grass", "t_dirt", "t_dirt", "t_dirt" ] },
-      "furniture": {
-        ".": [ [ "f_null", 29 ], [ "f_thistle", 1 ] ]
-      },
+      "furniture": { ".": [ [ "f_null", 29 ], [ "f_thistle", 1 ] ] },
       "place_monsters": [
         { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 10 ], "y": [ 1, 9 ], "density": 0.5 },
         { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 12 ], "y": [ 1, 12 ], "density": 0.5 },

--- a/data/json/mapgen/isherwood_farms/dairy_farm_isherwood.json
+++ b/data/json/mapgen/isherwood_farms/dairy_farm_isherwood.json
@@ -163,6 +163,9 @@
         ".": [ "t_grass", "t_grass", "t_dirt", "t_dirt", "t_dirt" ],
         "f": "t_splitrail_fencegate_c"
       },
+      "furniture": {
+        ".": [ [ "f_null", 29 ], [ "f_thistle", 1 ] ]
+      },
       "place_item": [
         { "item": "cattlefodder", "x": 37, "y": 15, "amount": [ 0, 4 ] },
         { "item": "cattlefodder", "x": 38, "y": 6, "amount": [ 0, 4 ] },
@@ -292,6 +295,8 @@
         "h": "f_chair",
         "U": "f_55gal_firebarrel",
         "b": "f_bench",
+        ".": [ [ "f_null", 29 ], [ "f_thistle", 1 ] ],
+        ",": [ [ "f_null", 29 ], [ "f_thistle", 1 ] ],
         "x": "f_bench",
         "M": [ "f_crate_c", "f_cardboard_box" ]
       }
@@ -523,6 +528,9 @@
         ".$............................................$."
       ],
       "terrain": { "$": "t_splitrail_fence", ".": [ "t_grass", "t_grass", "t_dirt", "t_dirt", "t_dirt" ] },
+      "furniture": {
+        ".": [ [ "f_null", 29 ], [ "f_thistle", 1 ] ]
+      },
       "place_monsters": [
         { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 10 ], "y": [ 1, 9 ], "density": 0.5 },
         { "monster": "GROUP_COWS_DAIRY", "x": [ 1, 12 ], "y": [ 1, 12 ], "density": 0.5 },

--- a/data/json/mapgen_palettes/farm_dairy.json
+++ b/data/json/mapgen_palettes/farm_dairy.json
@@ -24,9 +24,6 @@
       ".": [ [ "t_region_groundcover", 2 ], [ "t_region_soil", 3 ] ],
       ",": [ [ "t_region_groundcover", 2 ], [ "t_region_soil", 3 ] ]
     },
-    "furniture": {
-      ".": [ [ "f_null", 29 ], [ "f_thistle", 1 ] ],
-      ",": [ [ "f_null", 29 ], [ "f_thistle", 1 ] ]
-    }
+    "furniture": { ".": [ [ "f_null", 29 ], [ "f_thistle", 1 ] ], ",": [ [ "f_null", 29 ], [ "f_thistle", 1 ] ] }
   }
 ]

--- a/data/json/mapgen_palettes/farm_dairy.json
+++ b/data/json/mapgen_palettes/farm_dairy.json
@@ -23,6 +23,10 @@
       },
       ".": [ [ "t_region_groundcover", 2 ], [ "t_region_soil", 3 ] ],
       ",": [ [ "t_region_groundcover", 2 ], [ "t_region_soil", 3 ] ]
+    },
+    "furniture": {
+      ".": [ [ "f_null", 29 ], [ "f_thistle", 1 ] ],
+      ",": [ [ "f_null", 29 ], [ "f_thistle", 1 ] ]
     }
   }
 ]

--- a/data/json/mapgen_palettes/ranch_camp.json
+++ b/data/json/mapgen_palettes/ranch_camp.json
@@ -65,6 +65,7 @@
       "E": "f_bookcase",
       "L": "f_locker",
       "O": "f_oven",
+      ".": [ [ "f_null", 39 ], [ "f_thistle", 1 ] ],
       "S": "f_sink",
       "Y": "f_sofa",
       "Z": "f_crate_o",

--- a/data/json/obsoletion/migration_items.json
+++ b/data/json/obsoletion/migration_items.json
@@ -223,5 +223,10 @@
     "type": "MIGRATION",
     "replace": "sword_sheets_welded_large",
     "variant": "sword_sheets_bolted_large"
+  },
+  {
+    "id": "burdock_stalk",
+    "type": "MIGRATION",
+    "replace": "plant_stalk"
   }
 ]

--- a/data/json/obsoletion/obsolete_items.json
+++ b/data/json/obsoletion/obsolete_items.json
@@ -1163,5 +1163,12 @@
     "dispersion": 50,
     "recoil": 350,
     "effects": [ "COOKOFF", "NEVER_MISFIRES" ]
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "burdock_stalk",
+    "name": { "str": "burdock stalk" },
+    "description": "A stiff, green stalk from a burdock plant.  It is starchy and fibrous, but it would be much better if you cooked it.",
+    "copy-from": "cattail_stalk"
   }
 ]

--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -5096,6 +5096,7 @@
         [ "garlic_clove", 1 ],
         [ "wild_garlic", 1 ],
         [ "young_leaves", 2 ],
+        [ "chicory_leaves", 2 ],
         [ "onion", 1 ]
       ],
       [ [ "cheese_standard", 1, "LIST" ], [ "veggy_green", 1, "LIST" ] ],
@@ -5128,6 +5129,7 @@
         [ "garlic_clove", 1 ],
         [ "wild_garlic", 1 ],
         [ "young_leaves", 2 ],
+        [ "chicory_leaves", 2 ],
         [ "onion", 1 ]
       ],
       [ [ "cheese_standard", 1, "LIST" ], [ "veggy_green", 1, "LIST" ] ],
@@ -6504,6 +6506,7 @@
         [ "irradiated_tomato", 1 ],
         [ "tomato", 1 ],
         [ "young_leaves", 2 ],
+        [ "chicory_leaves", 2 ],
         [ "lettuce", 1 ],
         [ "irradiated_lettuce", 1 ]
       ],
@@ -6542,7 +6545,7 @@
       [ [ "pickle", 1 ], [ "veggy_pickled", 1 ], [ "sauerkraut", 1 ] ],
       [ [ "irradiated_onion", 1 ], [ "onion", 1 ] ],
       [ [ "can_tomato", 1 ], [ "irradiated_tomato", 1 ], [ "tomato", 1 ] ],
-      [ [ "young_leaves", 2 ], [ "lettuce", 1 ], [ "irradiated_lettuce", 1 ] ],
+      [ [ "young_leaves", 2 ], [ "chicory_leaves", 2 ], [ "lettuce", 1 ], [ "irradiated_lettuce", 1 ] ],
       [ [ "ketchup", 1 ], [ "barbecue_sauce", 1 ] ],
       [ [ "mustard", 1 ], [ "honey_mustard", 1 ] ],
       [ [ "horseradish", 1 ], [ "mayonnaise", 1 ] ]
@@ -6571,6 +6574,7 @@
         [ "irradiated_tomato", 1 ],
         [ "tomato", 1 ],
         [ "young_leaves", 2 ],
+        [ "chicory_leaves", 2 ],
         [ "lettuce", 1 ],
         [ "irradiated_lettuce", 1 ]
       ],
@@ -6609,6 +6613,7 @@
         [ "irradiated_tomato", 1 ],
         [ "tomato", 1 ],
         [ "young_leaves", 2 ],
+        [ "chicory_leaves", 2 ],
         [ "lettuce", 1 ],
         [ "irradiated_lettuce", 1 ]
       ],
@@ -6649,6 +6654,7 @@
         [ "irradiated_tomato", 1 ],
         [ "tomato", 1 ],
         [ "young_leaves", 2 ],
+        [ "chicory_leaves", 2 ],
         [ "lettuce", 1 ],
         [ "irradiated_lettuce", 1 ]
       ],
@@ -6768,6 +6774,7 @@
         [ "can_tomato", 1 ],
         [ "dandelion_cooked", 1 ],
         [ "young_leaves", 2 ],
+        [ "chicory_leaves", 2 ],
         [ "burdock_cooked", 1 ]
       ],
       [
@@ -6850,6 +6857,7 @@
         [ "can_tomato", 1 ],
         [ "dandelion_cooked", 1 ],
         [ "young_leaves", 2 ],
+        [ "chicory_leaves", 2 ],
         [ "burdock_cooked", 1 ]
       ],
       [
@@ -6946,6 +6954,7 @@
         [ "tomato", 1 ],
         [ "lettuce", 1 ],
         [ "young_leaves", 2 ],
+        [ "chicory_leaves", 2 ],
         [ "irradiated_lettuce", 1 ]
       ],
       [
@@ -6988,6 +6997,7 @@
         [ "irradiated_tomato", 1 ],
         [ "tomato", 1 ],
         [ "young_leaves", 2 ],
+        [ "chicory_leaves", 2 ],
         [ "lettuce", 1 ],
         [ "irradiated_lettuce", 1 ]
       ],
@@ -7306,7 +7316,7 @@
     "components": [
       [ [ "bread_sandwich", 2, "LIST" ] ],
       [ [ "bacon", 1 ] ],
-      [ [ "lettuce", 1 ], [ "irradiated_lettuce", 1 ], [ "young_leaves", 2 ] ],
+      [ [ "lettuce", 1 ], [ "irradiated_lettuce", 1 ], [ "young_leaves", 2 ], [ "chicory_leaves", 2 ] ],
       [ [ "can_tomato", 1 ], [ "irradiated_tomato", 1 ], [ "tomato", 1 ], [ "tomato_cut", 1 ] ]
     ],
     "charges": 2
@@ -7324,7 +7334,7 @@
     "components": [
       [ [ "bread_sandwich_wheat_free", 2, "LIST" ] ],
       [ [ "bacon", 1 ] ],
-      [ [ "lettuce", 1 ], [ "irradiated_lettuce", 1 ], [ "young_leaves", 2 ] ],
+      [ [ "lettuce", 1 ], [ "irradiated_lettuce", 1 ], [ "young_leaves", 2 ], [ "chicory_leaves", 2 ] ],
       [ [ "can_tomato", 1 ], [ "irradiated_tomato", 1 ], [ "tomato", 1 ] ]
     ],
     "charges": 2
@@ -7882,6 +7892,7 @@
         [ "fiddlehead_boiled", 2 ],
         [ "fiddlehead_sauteed", 2 ],
         [ "young_leaves", 4 ],
+        [ "chicory_leaves", 4 ],
         [ "sauerkraut", 2 ],
         [ "grape_leaves", 2 ],
         [ "irradiated_cabbage", 2 ],
@@ -8164,6 +8175,7 @@
         [ "can_tomato", 1 ],
         [ "dandelion_cooked", 1 ],
         [ "young_leaves", 2 ],
+        [ "chicory_leaves", 2 ],
         [ "wild_garlic", 1 ],
         [ "burdock_cooked", 1 ]
       ]
@@ -8232,6 +8244,7 @@
         [ "can_tomato", 1 ],
         [ "dandelion_cooked", 1 ],
         [ "young_leaves", 2 ],
+        [ "chicory_leaves", 2 ],
         [ "wild_garlic", 1 ],
         [ "burdock_cooked", 1 ]
       ]
@@ -8301,6 +8314,7 @@
         [ "can_tomato", 1 ],
         [ "dandelion_cooked", 1 ],
         [ "young_leaves", 2 ],
+        [ "chicory_leaves", 2 ],
         [ "wild_garlic", 1 ],
         [ "burdock_cooked", 1 ]
       ]
@@ -8370,6 +8384,7 @@
         [ "can_tomato", 1 ],
         [ "dandelion_cooked", 1 ],
         [ "young_leaves", 2 ],
+        [ "chicory_leaves", 2 ],
         [ "wild_garlic", 1 ],
         [ "burdock_cooked", 1 ]
       ]

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -202,6 +202,7 @@
           "f_black_eyed_susan": 3,
           "f_bluebell": 2,
           "f_maianthemum_stellatum": 2,
+          "f_fireweed": 1,
           "f_flower_spurge": 1,
           "f_dahlia": 1,
           "f_salsify": 1,
@@ -209,13 +210,15 @@
           "f_sunflower": 1
         },
         "f_region_weed": {
-          "f_chamomile": 400,
+          "f_thistle": 400,
+          "f_dandelion": 400,
+          "f_burdock": 400,
+          "f_chamomile": 300,
           "f_carrot_wild": 300,
           "f_salsify": 300,
           "f_datura": 300,
           "f_japanese_knotweed": 300,
           "f_bluebell": 200,
-          "f_burdock": 100,
           "f_dahlia": 100,
           "f_lily": 100,
           "f_sunflower": 100,
@@ -228,6 +231,7 @@
           "f_carrot_wild": 300,
           "f_salsify": 300,
           "f_datura": 300,
+          "f_thistle": 300,
           "f_japanese_knotweed": 200,
           "f_dahlia": 200,
           "f_maianthemum_stellatum": 200,
@@ -236,9 +240,12 @@
           "f_flower_tulip": 100,
           "f_mustard": 100,
           "f_sunflower": 100,
+          "f_fireweed": 100,
+          "f_selfheal": 100,
           "f_jerusalem_artichoke": 100,
           "f_lily": 100,
-          "f_chicory": 100
+          "f_chicory": 100,
+          "f_dogbane": 30
         },
         "f_region_forest": {
           "f_burdock": 2000,
@@ -252,7 +259,8 @@
           "f_dahlia": 200,
           "f_mutpoppy": 100,
           "f_maianthemum_stellatum": 100,
-          "f_wintergreen": 100
+          "f_wintergreen": 100,
+          "f_dogbane": 80
         },
         "f_region_forest_dense": {
           "f_burdock": 2000,
@@ -260,10 +268,11 @@
           "f_lily": 500,
           "f_wild_sarsaparilla": 400,
           "f_salsify": 300,
-          "f_wintergreen": 200
+          "f_wintergreen": 200,
+          "f_dogbane": 100
         },
-        "f_region_forest_water": { "f_burdock": 4, "f_japanese_knotweed": 2, "f_lily": 1 },
-        "f_region_water_plant": { "f_cattails": 15, "f_wild_rice": 1, "f_lilypad": 1, "f_lotus": 5 }
+        "f_region_forest_water": { "f_burdock": 4, "f_purple_loosestrife": 3, "f_japanese_knotweed": 2, "f_lily": 1 },
+        "f_region_water_plant": { "f_cattails": 15, "f_purple_loosestrife": 10, "f_wild_rice": 1, "f_lilypad": 1, "f_lotus": 5 }
       }
     },
     "river_scale": 1.0,

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -4596,7 +4596,7 @@ Array of dictionaries defining possible items produced on butchering and their l
 For every `type` other then those with "dissect_only" (see below) the following entries scale the results:
     `base_num` value should be an array with two elements in which the first defines the minimum number of the corresponding item produced and the second defines the maximum number.
     `scale_num` value should be an array with two elements, increasing the minimum and maximum drop numbers respectively by element value * survival skill.
-    `max` upper limit after `bas_num` and `scale_num` are calculated using
+    `max` upper limit after `base_num` and `scale_num` are calculated using
     `mass_ratio` value is a multiplier of how much of the monster's weight comprises the associated item. to conserve mass, keep between 0 and 1 combined with all drops. This overrides `base_num`, `scale_num` and `max`
 
 For `type`s with "dissect_only" (see below), the following entries can scale the results:

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -1399,9 +1399,9 @@ static void burned_ground_parser( map &m, const tripoint &loc )
         } else {
             m.ter_set( loc, ter_t_dirt );
             if( one_in( 4 ) ) {
-              m.furn_set( loc, f_ash );
+                m.furn_set( loc, f_ash );
             } else {
-              m.furn_set( loc, furn_id( "f_fireweed" ));
+                m.furn_set( loc, furn_id( "f_fireweed" ) );
             }
             m.spawn_item( loc, itype_ash, 1, rng( 10, 1000 ) );
         }

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -1398,7 +1398,11 @@ static void burned_ground_parser( map &m, const tripoint &loc )
             m.ter_set( loc, ter_t_tree_dead );
         } else {
             m.ter_set( loc, ter_t_dirt );
-            m.furn_set( loc, f_ash );
+            if( one_in( 4 ) ) {
+              m.furn_set( loc, f_ash );
+            } else {
+              m.furn_set( loc, furn_id( "f_fireweed" ));
+            }
             m.spawn_item( loc, itype_ash, 1, rng( 10, 1000 ) );
         }
         // everything else is destroyed, ash is added
@@ -1519,6 +1523,7 @@ static bool mx_reed( map &m, const tripoint &abs_sub )
     weighted_int_list<furn_id> vegetation;
     vegetation.add( f_cattails, 15 );
     vegetation.add( f_lotus, 5 );
+    vegetation.add( furn_id( "f_purple_loosestrife" ), 1 );
     vegetation.add( f_lilypad, 1 );
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "decorative flora additions"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Expanding Massachusetts flora we have ingame.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Due to lack of time and knowledge to unhardcode map extras, I had to add the entries in the C++ directly.

- New flora:
  - Fireweed
    - One of the first plants to flower after a fire, hence its name. [Go Botany](https://gobotany.nativeplanttrust.org/species/chamerion/angustifolium/)
    - Added into the burned ground map extra.
  - Thistle
    - Invasive. Because livestock avoids it, it thrives in pastures. [Go Botany](https://gobotany.nativeplanttrust.org/species/cirsium/vulgare/)
    - For this reason, I made it abundant in livestock pens.
  - Common selfheal/Heal-all
    - Although used extensively in traditional medicine its benefits remain too esoteric to be used by proper medicine. [Study about its theoretical uses](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9261270/) [Go Botany](https://gobotany.nativeplanttrust.org/species/prunella/vulgaris/) [Wikipedia](https://en.wikipedia.org/wiki/Prunella_vulgaris#Uses)
  - Purple loosestrife
    - A bad invasive plant which can reproduce rapidly in real life but does not ingame for several reasons. [Go Botany](https://gobotany.nativeplanttrust.org/species/lythrum/salicaria/)
  - Spreading dogbane
    - Used to be only able to be foraged, now it grows in the wilds, too. [Go Botany](https://gobotany.nativeplanttrust.org/species/apocynum/androsaemifolium/)

Other changes:
- Chicory drops chicory leaves now, too. More nutritious but also a higher morale penalty because those are bitter as heck. Data taken from https://fdc.nal.usda.gov/fdc-app.html#/food-details/169992/nutrients
- Removed several harvest entries and replaced them with a generic one, which some of the new additions use, too. Reduces file size and makes things overall simpler.
- Renamed burdock stalks to plant stalks. We do not need 3 types of plant stalks only differing in name.
- Fixed a typo in the docs I noticed while working on all this.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Applied JSON changes locally. I could not test the C++ stuff just yet. It is simple stuff so if the tests run I might just leave it at that.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Additional sources I used:
- https://birdwatchinghq.com/wildflowers-in-massachusetts/
- https://uswildflowers.com/wfquery.php?State=MA
- https://wildlifeinformer.com/wildflowers-in-massachusetts/ which also list those notorious bluebells and lilies.

For the future and out of scope for right now: Look at bluebells. The pretty bluebells appearing in Spring (https://en.wikipedia.org/wiki/Hyacinthoides_non-scripta) you can see in Europe do not appear to be terribly native. However, there are three species to consider:
- https://gobotany.nativeplanttrust.org/species/campanula/rapunculoides/
- https://gobotany.nativeplanttrust.org/species/campanula/aparinoides/
- https://gobotany.nativeplanttrust.org/species/campanula/rotundifolia/
- And one i could not find on Go Botany: https://en.wikipedia.org/wiki/Campanula_americana

All seem edible and the first one, known as Rapunzel, can even be cultivated it looks like.

Someone also recommended me the New England Forests channel on youtube, https://www.youtube.com/@NewEnglandForests.
When I have time and motivation I'll look through this gem. Since I live far away from New England it will help me to further grasp its ecology.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
