### PR TITLE
Some mask cartridge fix

### DIFF
--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -695,7 +695,7 @@
       [ "gloves_medical", 5 ],
       [ "mask_dust", 5 ],
       { "item": "mask_filter", "prob": 5, "charges": [ 0, 100 ] },
-      [ "gasfilter_s", 5 ],
+      { "item": "gasfilter_sm", "prob": 5, "charges": [ 0, 100 ] },
       [ "glasses_safety", 5 ],
       { "item": "UPS_OFF", "prob": 3, "charges": [ 0, 1000 ] },
       [ "microscope", 5 ],

--- a/data/json/items/magazine/filter.json
+++ b/data/json/items/magazine/filter.json
@@ -3,7 +3,7 @@
     "id": "gasfilter_sm",
     "type": "MAGAZINE",
     "category": "tool_magazine",
-    "name": { "str": "gas mask cartridge" },
+    "name": { "str": "filter mask cartridge" },
     "description": "A small-sized, replaceable filter cartridge for an air filtration mask.",
     "weight": "2 g",
     "volume": "250 ml",

--- a/data/mods/DinoMod/mapgen/map_extras/mass_grave.json
+++ b/data/mods/DinoMod/mapgen/map_extras/mass_grave.json
@@ -98,7 +98,7 @@
         { "item": "stanag30", "repeat": [ 0, 2 ], "x": [ 2, 22 ], "y": [ 18, 23 ] },
         { "item": "mask_gas", "repeat": [ 0, 3 ], "x": [ 2, 5 ], "y": 20 },
         { "item": "pure_meth", "repeat": [ 1, 6 ], "x": 10, "y": [ 20, 22 ] },
-        { "item": "gasfilter_m", "repeat": [ 5, 8 ], "x": 10, "y": [ 20, 22 ] }
+        { "item": "gasfilter_med", "repeat": [ 5, 8 ], "x": 10, "y": [ 20, 22 ] }
       ],
       "place_monsters": [
         { "monster": "GROUP_DINOSAUR_ZOMBIE", "density": 1, "x": [ 1, 22 ], "y": [ 1, 22 ] },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I suppose "gasfilter_s", "gasfilter_m" are should be replaced to "gasfilter_sm", "gasfilter_med".

#### Describe the solution
- Fix Item name of "gasfilter_sm" ("filter mask cartridge" is probably correct)
- Fix lab item spawn.
- [Dino mod]Fix Mass Grave item spawn.

#### Describe alternatives you've considered

#### Testing

#### Additional context