### PR TITLE
Adds priority parameter for special placement

### DIFF
--- a/doc/OVERMAP.md
+++ b/doc/OVERMAP.md
@@ -389,7 +389,7 @@ original intersection.
 | `city_distance` | Min/max distance from a city edge that the special may be placed. Use -1 for unbounded.               |
 | `city_sizes`    | Min/max city size for a city that the special may be placed near. Use -1 for unbounded.               |
 | `occurrences`   | Min/max number of occurrences when placing the special. If UNIQUE flag is set, becomes X of Y chance. |
-| `priority`      | (default = 0) The generation process is executed in the order of specials with the highest value.     |
+| `priority`      | **Warning: Do not use this unnecessarily.** The generation process is executed in the order of specials with the highest value. Can be used when maps are difficult to generate. (large maps, maps that are or require dependencies etc) It is **strongly recommended** to set it to 1 (HIGH priority) or -1 (LOW priority) if used. (default = 0) |
 | `flags`         | See `Overmap specials` in [JSON_FLAGS.md](JSON_FLAGS.md).                                             |
 | `rotate`        | Whether the special can rotate. True if not specified.                                                |
 
@@ -430,7 +430,6 @@ Depending on the subtype, there are further relevant fields:
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 3, 12 ],
     "occurrences": [ 0, 5 ],
-    "priority": 0,
     "flags": [ "CLASSIC" ],
     "rotate" : true
   }

--- a/doc/OVERMAP.md
+++ b/doc/OVERMAP.md
@@ -430,6 +430,7 @@ Depending on the subtype, there are further relevant fields:
     "city_distance": [ 10, -1 ],
     "city_sizes": [ 3, 12 ],
     "occurrences": [ 0, 5 ],
+    "priority": 0,
     "flags": [ "CLASSIC" ],
     "rotate" : true
   }

--- a/doc/OVERMAP.md
+++ b/doc/OVERMAP.md
@@ -389,6 +389,7 @@ original intersection.
 | `city_distance` | Min/max distance from a city edge that the special may be placed. Use -1 for unbounded.               |
 | `city_sizes`    | Min/max city size for a city that the special may be placed near. Use -1 for unbounded.               |
 | `occurrences`   | Min/max number of occurrences when placing the special. If UNIQUE flag is set, becomes X of Y chance. |
+| `priority`      | (default = 0) The generation process is executed in the order of specials with the highest value.     |
 | `flags`         | See `Overmap specials` in [JSON_FLAGS.md](JSON_FLAGS.md).                                             |
 | `rotate`        | Whether the special can rotate. True if not specified.                                                |
 

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -537,6 +537,9 @@ class overmap_special
             return flags_;
         }
         bool has_flag( const std::string & ) const;
+        int get_priority() const {
+            return priority_;
+        }
         int longest_side() const;
         std::vector<overmap_special_terrain> preview_terrains() const;
         std::vector<overmap_special_locations> required_locations() const;
@@ -578,6 +581,7 @@ class overmap_special
         bool rotatable_ = true;
         overmap_special_spawns monster_spawns_;
         cata::flat_set<std::string> flags_;
+        int priority_ = 0;
 
         // These locations are the default values if ones are not specified for the individual OMTs.
         cata::flat_set<string_id<overmap_location>> default_locations_;

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6298,8 +6298,8 @@ bool overmap::place_special_attempt(
 
     std::shuffle( enabled_specials.begin(), enabled_specials.end(), rng_get_engine() );
     std::set<int> priorities;
-    for( auto iter = enabled_specials.begin(); iter != enabled_specials.end(); ++iter ) {
-        priorities.emplace( iter->special_details->get_priority() );
+    for( const overmap_special_placement &os : enabled_specials ) {
+        priorities.emplace( os.special_details->get_priority() );
     }
     for( auto pri_iter = priorities.rbegin(); pri_iter != priorities.rend(); ++pri_iter ) {
         for( auto iter = enabled_specials.begin(); iter != enabled_specials.end(); ++iter ) {


### PR DESCRIPTION
#### Summary
Features "Adds priority parameter for special placement"

#### Purpose of change
In special placement, some large facilities may be placed abnormally far from the player's starting point due to a low success rate of creation.
Currently, the order of generation for facilities is random, but I think this problem can be alleviated to some extent by giving them priority.

#### Describe the solution
reimplement #67723
Priority can be set for special placement. (int value, default = 0).
Generation will be determined in order of priority.

#### Describe alternatives you've considered

#### Testing
Although random elements are involved in map generation, I thought it would be possible to check the effectiveness by measuring the distance from the initial point to the refugee center.
Each survey was conducted 10 times.

refugee center: priority = 0
Mean: 206
Median: 196
Min: 83
Max: 390

refugee center: priority = 1
Mean: 104
Median: 87.5
Min: 17
Max: 326

refugee center: priority = -1 (Failed: 2/10)
Mean: 340
Median: 264
Min: 32
Max: 943

#### Additional context
