### PR TITLE
[MoM] Set limited duration for zombie null psi-nullification field

### DIFF
--- a/data/mods/MindOverMatter/effects/effects_penalty.json
+++ b/data/mods/MindOverMatter/effects/effects_penalty.json
@@ -191,11 +191,41 @@
   {
     "type": "effect_type",
     "id": "effect_psi_null",
-    "name": [ "Nullified" ],
-    "desc": [ "You can't use your powers." ],
+    "name": [
+      "Nullified",
+      "Nullified",
+      "Nullified",
+      "Nullified",
+      "Nullified",
+      "Nullified",
+      "Nullified",
+      "Nullified",
+      "Nullified",
+      "Nullified"
+    ],
+    "desc": [
+      "You can't use your powers.",
+      "You can't use your powers.",
+      "You can't use your powers.",
+      "You can't use your powers.",
+      "You can't use your powers.",
+      "You can't use your powers.",
+      "You can't use your powers.",
+      "You can't use your powers.",
+      "You can't use your powers.",
+      "You can't use your powers."
+    ],
     "apply_message": "You feel a dull pain behind your eyes and a terrible sense of loss.",
     "remove_message": "You have a sudden sense of regaining something you had lost.",
-    "flags": [ "NO_SPELLCASTING" ]
+    "flags": [ "NO_SPELLCASTING" ],
+    "rating": "bad",
+    "max_duration": "1 minutes",
+    "show_intensity": false,
+    "max_intensity": 10,
+    "int_decay_step": -1,
+    "int_add_val": 2,
+    "int_decay_tick": 1,
+    "int_decay_remove": true
   },
   {
     "type": "effect_type",
@@ -250,6 +280,7 @@
       "effect_vitakin_purge_rads_sideeffects",
       "effect_vita_super_heal"
     ],
+    "max_duration": "24 hours",
     "flags": [ "NO_SPELLCASTING" ]
   },
   {

--- a/data/mods/MindOverMatter/effects/effects_penalty.json
+++ b/data/mods/MindOverMatter/effects/effects_penalty.json
@@ -222,7 +222,7 @@
     "max_duration": "1 minutes",
     "show_intensity": false,
     "max_intensity": 10,
-    "int_decay_step": -1,
+    "int_decay_step": -2,
     "int_add_val": 2,
     "int_decay_tick": 1,
     "int_decay_remove": true

--- a/data/mods/MindOverMatter/fields.json
+++ b/data/mods/MindOverMatter/fields.json
@@ -114,7 +114,7 @@
           {
             "effect_id": "effect_psi_null",
             "body_part": "mouth",
-            "intensity": 1,
+            "intensity": 10,
             "min_duration": "100 seconds",
             "max_duration": "350 seconds",
             "immune_inside_vehicle": false


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Set limited duration for zombie null psi-nullification field"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Default effect duration of 365 days strikes again!
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Implement an intensity and effect decay for the nullified field around zombie nulls.  Now it should last a maximum of 5 seconds after killing them or leaving their presence. 

Once there's an option to remove more than one field at once, I can put in a death spell that deletes the remaining nullification field as well.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

No more 20-minute-long lack of spells if you spend too long fighting a null
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
The Nether-void still has an uncapped duration from its neutralizing attack.  This is intended. 

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
