### PR TITLE
Fix duplicate OMTs, take two

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -2887,21 +2887,38 @@ void overmap::ter_set( const tripoint_om_omt &p, const oter_id &id )
         return;
     }
 
-    oter_id &val = layer[p.z() + OVERMAP_DEPTH].terrain[p.xy()];
+    oter_id &current_oter = layer[p.z() + OVERMAP_DEPTH].terrain[p.xy()];
+    const oter_type_str_id &current_type_id = current_oter->get_type_id();
+    const oter_type_str_id &incoming_type_id = id->get_type_id();
+    const bool current_type_same = current_type_id == incoming_type_id;
+
+    // Mapgen refinement can push multiple different roads over each other.
+    // Roads require a predecessor. A road pushed over a road might cause a
+    // road to be a predecessor to another road. That causes too many spawns
+    // to happen. So when pushing a predecessor, if the predecessor to-be-pushed
+    // is linear and the previous predecessor is linear, overwrite it.
+    // This way only the 'last' rotation/variation generated is kept.
     if( id->has_flag( oter_flags::requires_predecessor ) ) {
-        // Stops linear fallback_predecessor maps (roads etc) spawning over themselves
         std::vector<oter_id> &om_predecessors = predecessors_[p];
-        if( om_predecessors.empty() || !val->is_linear() ) {
-            om_predecessors.push_back( val );
-        } else {
-            // Collapse and keep the last linear oter of matching type
+        if( om_predecessors.empty() || ( !current_oter->is_linear() && !current_type_same ) ) {
+            // If we need a predecessor, we must have a predecessor no matter what.
+            // Or, if the oter to-be-pushed is not linear, push it only if the incoming oter is different.
+            om_predecessors.push_back( current_oter );
+        } else if( !current_type_same ) {
+            // Current oter is linear, incoming oter is different from current.
+            // If the last predecessor is the same type as the current type, overwrite.
+            // Else push the current type.
             oter_id &last_predecessor = om_predecessors.back();
-            if( last_predecessor->get_type_id() == val->get_type_id() ) {
-                last_predecessor = val;
+            if( last_predecessor->get_type_id() == current_type_id ) {
+                last_predecessor = current_oter;
+            } else {
+                om_predecessors.push_back( current_oter );
             }
         }
+        // We had a predecessor, and it was the same type as the incoming one
+        // Don't push another copy.
     }
-    val = id;
+    current_oter = id;
 }
 
 const oter_id &overmap::ter( const tripoint_om_omt &p ) const

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -659,30 +659,57 @@ void overmap::unserialize( const JsonObject &jsobj )
         } else if( name == "predecessors" ) {
             std::vector<std::pair<tripoint_om_omt, std::vector<oter_id>>> flattened_predecessors;
             om_member.read( flattened_predecessors, true );
-            std::vector<oter_id> deduped_predecessors;
-            for( std::pair<tripoint_om_omt, std::vector<oter_id>> &p : flattened_predecessors ) {
-                // TODO remove after 0.H release.
-                // JSONizing roads caused some bad mapgen data to get saved to disk. Repeated redundant linear
-                // type omts were all saved. The new logic only pushes a linear predecessor if the predecessors
-                // list is empty or the incoming omt is not linear. Fixup bad saves to conform.
-                deduped_predecessors.reserve( p.second.size() );
-                for( const oter_id &id : p.second ) {
-                    if( deduped_predecessors.empty() || !id->is_linear() ) {
-                        deduped_predecessors.push_back( id );
-                    } else {
-                        oter_id &last_predecessor = deduped_predecessors.back();
-                        if( last_predecessor->get_type_id() == id->get_type_id() ) {
-                            last_predecessor = id;
-                        } else {
-                            deduped_predecessors.push_back( id );
+            std::vector<oter_id> om_predecessors;
+
+            for( auto& [p, serialized_predecessors] : flattened_predecessors ) {
+                if( !serialized_predecessors.empty() ) {
+                    // TODO remove after 0.H release.
+                    // JSONizing roads caused some bad mapgen data to get saved to disk. Fixup bad saves to conform.
+                    // The logic to do this is to emulate setting overmap::set_ter repeatedly. The difference is the
+                    // 'original' terrain is lost, all we have is a chain of predecessors.
+                    // This doesn't matter for the sake of deduplicating predecessors.
+                    //
+                    // Mapgen refinement can push multiple different roads over each other.
+                    // Roads require a predecessor. A road pushed over a road might cause a
+                    // road to be a predecessor to another road. That causes too many spawns
+                    // to happen. So when pushing a predecessor, if the predecessor to-be-pushed
+                    // is linear and the previous predecessor is linear, overwrite it.
+                    // This way only the 'last' rotation/variation generated is kept.
+                    om_predecessors.reserve( serialized_predecessors.size() );
+                    oter_id current_oter;
+                    auto local_set_ter = [&]( oter_id & id ) {
+                        const oter_type_str_id &current_type_id = current_oter->get_type_id();
+                        const oter_type_str_id &incoming_type_id = id->get_type_id();
+                        const bool current_type_same = current_type_id == incoming_type_id;
+                        if( om_predecessors.empty() || ( !current_oter->is_linear() && !current_type_same ) ) {
+                            // If we need a predecessor, we must have a predecessor no matter what.
+                            // Or, if the oter to-be-pushed is not linear, push it only if the incoming oter is different.
+                            om_predecessors.push_back( current_oter );
+                        } else if( !current_type_same ) {
+                            // Current oter is linear, incoming oter is different from current.
+                            // If the last predecessor is the same type as the current type, overwrite.
+                            // Else push the current type.
+                            oter_id &last_predecessor = om_predecessors.back();
+                            if( last_predecessor->get_type_id() == current_type_id ) {
+                                last_predecessor = current_oter;
+                            } else {
+                                om_predecessors.push_back( current_oter );
+                            }
                         }
+                        current_oter = id;
+                    };
+
+                    current_oter = serialized_predecessors.front();
+                    for( size_t i = 1; i < serialized_predecessors.size(); ++i ) {
+                        local_set_ter( serialized_predecessors[i] );
                     }
+                    local_set_ter( layer[p.z() + OVERMAP_DEPTH].terrain[p.xy()] );
                 }
-                predecessors_.insert_or_assign( p.first, std::move( deduped_predecessors ) );
+                predecessors_.insert_or_assign( p, std::move( om_predecessors ) );
 
                 // Reuse allocations because it's a good habit.
-                deduped_predecessors = std::move( p.second );
-                deduped_predecessors.clear();
+                om_predecessors = std::move( serialized_predecessors );
+                om_predecessors.clear();
             }
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Followup to #68324. I wasn't happy with the solution and felt it deserved more documentation. I also realize I missed an else clause during world generation which could have affected what omts spawn over others (if you have sequential linear OMTs of different types). I'm not sure this is actually a case that happens but in theory there could be a linear omt that requires a predecessor and that predecessor itself could be linear (I dunno) so we should allow stacking those.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Redo the logic with extra wextra comments. Make the mapgen logic and savegame deserialization logic use almost literally exactly the same code. I could've factored it into a helper function maybe but the way it would possibly mutate local or non-local state made me a bit wary to do so. I could still try though. I want to get this in front of eyes sooner though.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded the old save from #67837 and validated the deserialize logic works. Created a new save in the same build, crossroads still have manholes sometimes.

You can still get 4 way streets over manholes over 4 way streets. Not sure if this means those intersections are susceptible to extra spawning, but the one I found did not seem over full.
![road_over_manhole_over_road](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/26dcf383-7760-40f9-9227-4bd0486e0c0b)

Roads still overwrite trails correctly (presuming trails are linear and roads are linear, this means my safety net for linear-over-linear is working). 
![road_over_trail](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/09ad769c-2d39-4da9-9f88-f2682df837db)

And extra special verification that savegame recover works. This save had 7 duplicate omts serialized. It only pushes the one halfway through the list.
![verified_recovery](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/62c1e31c-5bf7-4889-b8e7-ab0c76dbd8a1)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
