### PR TITLE
Bugfix: Prevent segfault for npc get_restock_interval

### DIFF
--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2041,8 +2041,9 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             int price = total_price( u, item_type );
             phrase.replace( fa, l, format_money( price ) );
         } else if( tag == "<interval>" ) {
-            const npc *guy = dynamic_cast<const npc *>( &me );
-            phrase.replace( fa, l, guy->get_restock_interval() );
+            const npc *guy = dynamic_cast<const npc *>( me_chr );
+            std::string restock_interval = guy ? guy->get_restock_interval() : _( "a few days" );
+            phrase.replace( fa, l, restock_interval );
         } else if( tag.find( "<u_val:" ) != std::string::npos ) {
             //adding a user variable to the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -32,6 +32,20 @@ class talker_character_const: public talker_cloner<talker_character_const>
         }
         ~talker_character_const() override = default;
 
+        // underlying element accessor functions
+        Character *get_character() override {
+            return nullptr;
+        }
+        const Character *get_character() const override {
+            return me_chr_const;
+        }
+        Creature *get_creature() override {
+            return nullptr;
+        }
+        const Creature *get_creature() const override {
+            return me_chr_const;
+        }
+
         // identity and location
         std::string disp_name() const override;
         std::string get_name() const override;


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent segfault when asking the scrap trader when they'll restock"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Fixes #68346 .
* Prevents segfault that previously happened when choosing the talk option "Find anything good?" when talking to scrap trader.


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Previous problem was caused by:
* `const npc *guy` was `nullptr`
* This was in turn caused by `talker::get_character` returning `nullptr`
* The reason for that `nullptr` was that `const talker &u` was of type `talker_character`, created from `get_talker_for( const Creature &me )` in `creature.cpp`
* `talker_character` previously did not override `get_character`, so it used the default impl from `talker` which always returns `nullptr`.

Therefore, this commit updates `talker_character` so that `get_character` returns a valid pointer.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* Could also have updated all callers to use instances of `talker` instead of `Character`, but that could possibly affect other functionality.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

* Tested the savegame and steps from #68346 . 

![bugfix-segfault-get_restock_interval](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/6628b76a-226e-4057-bb4c-392ef7a1a2e2)


#### Additional context

This code was recently changed in #68244 where the types of `me` was changed from `Character` to `talker`, possibly causing the `nullptr`.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
