### PR TITLE
Context menu when bumping into things  (examine, deconstruct, pickup)

### DIFF
--- a/data/json/zones.json
+++ b/data/json/zones.json
@@ -24,5 +24,12 @@
     "name": "Loot: Unload Everything",
     "can_be_personal": true,
     "description": "Any containers in this zone you don't otherwise sort will have their contents dumped out and placed on the same tile.  This includes corpses, magazines, and magazine wells."
+  },
+  {
+    "id": "BUMP_INTERACT",
+    "type": "LOOT_ZONE",
+    "name": "Bump to Interact",
+    "can_be_personal": true,
+    "description": "You can examine, access or deconstruct furniture in this zone by walking into it.  This includes workbenches, lockers and appliances.  Disabled when safe mode is off."
   }
 ]

--- a/src/avatar_action.cpp
+++ b/src/avatar_action.cpp
@@ -60,9 +60,9 @@
 
 class gun_mode;
 
-static const construction_str_id construction_constr_deconstruct( "constr_deconstruct" );
 static const construction_str_id construction_constr_deconstruct_simple
     = construction_str_id( "constr_deconstruct_simple" );
+static const construction_str_id construction_constr_deconstruct( "constr_deconstruct" );
 
 static const efftype_id effect_amigara( "amigara" );
 static const efftype_id effect_glowing( "glowing" );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1488,6 +1488,17 @@ void options_manager::add_options_general()
     add_option_group( "general", Group( "auto_feat_opts", to_translation( "Auto Features Options" ),
                                         to_translation( "Options regarding auto features." ) ),
     [&]( const std::string & page_id ) {
+        add( "BUMP_TO_INTERACT", page_id, to_translation( "Bump to Interact" ),
+             to_translation( "Enables a pop-up menu when walking into a tile that can be examined, accessed or deconstructed.  This is disabled when safe mode is off.  It can be enabled for specific tiles by placing a \"Bump to Interact\" zone." ),
+        {
+            { "off", to_translation( "options", "Disabled" ) },
+            { "impassable", to_translation( "Impassable Tiles" ) },
+            { "selective", to_translation( "Useful Furniture" ) },
+            { "furniture", to_translation( "Most Furniture" ) },
+            // TODO maybe add "all" / "wherever possible" option.
+        }, "impassable"
+           );
+
         add( "AUTO_FEATURES", page_id, to_translation( "Additional auto features" ),
              to_translation( "If true, enables configured auto features below.  Disabled as long as any enemy monster is seen." ),
              false


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Configurable 'Bump to Interact' menu when walking into certain furniture or terrain in safe mode."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Previously I added a multiple-choice context prompt when walking into ledges:  #68150.  This was more intuitive and convenient than what was previously there, presenting players with a list of useful interactions when bumping into an otherwise dangerous/impassable ledge.  It works by forwarding to the `e`xamine action.

This left me curious if a similar bump-to-interact menu would be useful for other things — primarily in a base management context.  Bumping into solar panels, refrigerators and workbenches would be just a bit nicer than reaching for the `e` key every time and might be a boon to accessibility and mobile gameplay.  I decided to experiment.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
When the player bumps into an impassable tile (other than an unlocked door) a menu may appear with applicable options from this list:

* Access items in
* Examine
* Deconstruct

If the only option would be 'move onto' or 'access items', it is picked automatically.  Here's a refrigerator:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13224671/9a5c6bd5-3d67-47e3-9609-c6e997de7be4)

There is also a new type of personal zone that can enable bump-interact for *all* movement-hampering tiles in a designated area.  This could be useful for the player's base, friendly camps and other safehouses.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13224671/8c9b2917-70dc-41ff-a546-4b86281ffb63)

A new "Auto Features" menu setting controls which tiles it may apply to, outside of designated zones:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13224671/c31be400-5e26-40c6-af15-9f100f1d1e6b)

- Disabled
- Impassable Tiles (eg, fridge, water heater, water purifier) — default!
- Useful Furniture (eg, workbench, countertops)
- Most furniture (ie, anything that hampers movement and is deconstructible/examinable/contains things)

Bump-interact only applies to furniture or terrain that blocks or hampers movement, and only when safe mode is on.  It never applies to NPCs or auto-move.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

* Add a menu option to suppress bump-interaction for a little while (ie, in combat).  Safe mode fills this role.
* Only show the menu when the tile has a terrain/furniture flag, eg: `BUMP_INTERACT` or more specific `BUMP_EXAMINE`/`BUMP_PICKUP`/`BUMP_DECONSTRUCT`.
* Only show the menu (for passable tiles) if there are no hostiles in sight.

Other miscellaneous changes that might be useful:

* Automatically choose the "pickup" option when the only other interaction is non-simple deconstruction (eg, lockers).
* Move the new code to `iexamine.cpp`.
* Find some way to fold examine sub-options into the bump menu (eg, to avoid two consecutive menus when bump-examining a solar panel)

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

* Tested with safe mode on and off.
* Tried bumping refrigerators, chairs, cupboards.
* Tested taking down a chair.
* Tested connecting a fridge to the grid.
* Tested grid-connected appliance (**does not work for vehicles at this time**)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Impassable stuff:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13224671/0bdb8feb-4df0-4f24-bf32-b91dd87c6547)

Passable stuff (potentially problematic):
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13224671/d302039f-704d-4105-8f31-d3f0f7f1df90)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13224671/7dcc0970-2bb1-4923-a81c-4ae39249790e)


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
