### PR TITLE
Creatures don't (mostly) react to things under vehicles.

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10686,7 +10686,8 @@ point game::place_player( const tripoint &dest_loc, bool quick )
             }
         }
     }
-    if( m.has_flag( ter_furn_flag::TFLAG_UNSTABLE, dest_loc ) && !u.is_mounted() ) {
+    if( m.has_flag( ter_furn_flag::TFLAG_UNSTABLE, dest_loc ) &&
+        !u.is_mounted() && !m.has_vehicle_floor( dest_loc ) ) {
         u.add_effect( effect_bouldering, 1_turns, true );
     } else if( u.has_effect( effect_bouldering ) ) {
         u.remove_effect( effect_bouldering );

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -9962,7 +9962,7 @@ void map::update_pathfinding_cache( int zlev ) const
                     }
 
                     if( ( !tile.get_trap_t().is_benign() || !terrain.trap.obj().is_benign() ) &&
-                          !here.has_vehicle_floor( p ) ) {
+                        !here.has_vehicle_floor( p ) ) {
                         cur_value |= PF_TRAP;
                     }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -2646,6 +2646,17 @@ bool map::has_floor_or_support( const tripoint &p ) const
     return !valid_move( p, below, false, true );
 }
 
+bool map::has_vehicle_floor( const tripoint &p ) const
+{
+    const tripoint_bub_ms p_bub( p );
+    return has_vehicle_floor( p_bub );
+}
+bool map::has_vehicle_floor( const tripoint_bub_ms &p ) const
+{
+    return veh_at( p ).part_with_feature( "BOARDABLE", false ) ||
+           veh_at( p ).part_with_feature( "OBSTACLE", false );
+}
+
 void map::drop_everything( const tripoint &p )
 {
     if( has_floor_or_water( p ) ) {
@@ -9924,6 +9935,7 @@ void map::update_pathfinding_cache( int zlev ) const
                     const ter_t &terrain = tile.get_ter_t();
                     const furn_t &furniture = tile.get_furn_t();
                     const field &field = tile.get_field();
+                    const map &here = get_map();
                     int part;
                     const vehicle *veh = veh_at_internal( p, part );
 
@@ -9949,7 +9961,8 @@ void map::update_pathfinding_cache( int zlev ) const
                         }
                     }
 
-                    if( !tile.get_trap_t().is_benign() || !terrain.trap.obj().is_benign() ) {
+                    if( ( !tile.get_trap_t().is_benign() || !terrain.trap.obj().is_benign() ) &&
+                          !here.has_vehicle_floor( p ) ) {
                         cur_value |= PF_TRAP;
                     }
 
@@ -9960,7 +9973,7 @@ void map::update_pathfinding_cache( int zlev ) const
                         cur_value |= PF_UPDOWN;
                     }
 
-                    if( terrain.has_flag( ter_furn_flag::TFLAG_SHARP ) ) {
+                    if( terrain.has_flag( ter_furn_flag::TFLAG_SHARP ) && !here.has_vehicle_floor( p ) ) {
                         cur_value |= PF_SHARP;
                     }
 

--- a/src/map.h
+++ b/src/map.h
@@ -1670,6 +1670,8 @@ class map
         /** Does this tile support vehicles and furniture above it */
         bool supports_above( const tripoint &p ) const;
         bool has_floor_or_support( const tripoint &p ) const;
+        bool has_vehicle_floor( const tripoint &p ) const;
+        bool has_vehicle_floor( const tripoint_bub_ms &p ) const;
 
         /**
          * Handles map objects of given type (not creatures) falling down.

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -173,8 +173,10 @@ bool monster::will_move_to( const tripoint &p ) const
         }
     }
 
-    if( ( !can_submerge() && !flies() ) && here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, p ) ) {
-        return false;
+    if( !here.has_vehicle_floor( p ) ) {
+        if( ( !can_submerge() && !flies() ) && here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, p ) ) {
+            return false;
+        }
     }
 
     if( digs() && !here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, p ) &&
@@ -230,32 +232,33 @@ bool monster::know_danger_at( const tripoint &p ) const
     // before hitting simple or complex but this is more explicit
     if( avoid_fire || avoid_fall || avoid_simple || avoid_complex ) {
         const ter_id target = here.ter( p );
-
-        // Don't enter lava if we have any concept of heat being bad
-        if( avoid_fire && target == t_lava ) {
-            return false;
-        }
-
-        if( avoid_fall ) {
-            // Don't throw ourselves off cliffs if we have a concept of falling
-            if( !here.has_floor_or_water( p ) && !flies() ) {
+        if( !here.has_vehicle_floor( p ) ) {
+            // Don't enter lava if we have any concept of heat being bad
+            if( avoid_fire && target == t_lava ) {
                 return false;
             }
 
-            // Don't enter open pits ever unless tiny, can fly or climb well
-            if( !( type->size == creature_size::tiny || can_climb() ) &&
-                ( target == t_pit || target == t_pit_spiked || target == t_pit_glass ) ) {
-                return false;
-            }
-        }
+            if( avoid_fall ) {
+                // Don't throw ourselves off cliffs if we have a concept of falling
+                if( !here.has_floor_or_water( p ) && !flies() ) {
+                    return false;
+                }
 
-        // Some things are only avoided if we're not attacking
-        if( attitude( &get_player_character() ) != MATT_ATTACK ) {
-            // Sharp terrain is ignored while attacking
-            if( avoid_simple && here.has_flag( ter_furn_flag::TFLAG_SHARP, p ) &&
-                !( type->size == creature_size::tiny || flies() ||
-                   get_armor_type( damage_cut, bodypart_id( "torso" ) ) >= 10 ) ) {
-                return false;
+                // Don't enter open pits ever unless tiny, can fly or climb well
+                if( !( type->size == creature_size::tiny || can_climb() ) &&
+                    ( target == t_pit || target == t_pit_spiked || target == t_pit_glass ) ) {
+                    return false;
+                }
+            }
+
+            // Some things are only avoided if we're not attacking
+            if( attitude( &get_player_character() ) != MATT_ATTACK ) {
+                // Sharp terrain is ignored while attacking
+                if( avoid_simple && here.has_flag( ter_furn_flag::TFLAG_SHARP, p ) &&
+                    !( type->size == creature_size::tiny || flies() ||
+                       get_armor_type( damage_cut, bodypart_id( "torso" ) ) >= 10 ) ) {
+                    return false;
+                }
             }
         }
 
@@ -267,10 +270,12 @@ bool monster::know_danger_at( const tripoint &p ) const
             if( is_dangerous_fields( target_field ) ) {
                 return false;
             }
-            // Don't step on any traps (if we can see)
-            const trap &target_trap = here.tr_at( p );
-            if( has_flag( mon_flag_SEES ) && !target_trap.is_benign() && here.has_floor_or_water( p ) ) {
-                return false;
+            if( !here.has_vehicle_floor( p ) ) {
+                // Don't step on any traps (if we can see)
+                const trap &target_trap = here.tr_at( p );
+                if( has_flag( mon_flag_SEES ) && !target_trap.is_benign() && here.has_floor_or_water( p ) ) {
+                    return false;
+                }
             }
         }
 
@@ -913,7 +918,7 @@ void monster::move()
     nursebot_operate( dragged_foe );
 
     // The monster can sometimes hang in air due to last fall being blocked
-    if( !flies() && here.has_flag( ter_furn_flag::TFLAG_NO_FLOOR, pos() ) ) {
+    if( !flies() && !here.has_floor_or_water( pos() ) && !here.has_vehicle_floor( pos_bub() ) ) {
         here.creature_on_trap( *this, false );
         if( is_dead() ) {
             return;
@@ -1897,20 +1902,8 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
         return true;
     }
 
-    if( type->size != creature_size::tiny && on_ground ) {
-        const int sharp_damage = rng( 1, 10 );
-        const int rough_damage = rng( 1, 2 );
-        if( here.has_flag( ter_furn_flag::TFLAG_SHARP, pos() ) && !one_in( 4 ) &&
-            get_armor_type( damage_cut, bodypart_id( "torso" ) ) < sharp_damage && get_hp() > sharp_damage ) {
-            apply_damage( nullptr, bodypart_id( "torso" ), sharp_damage );
-        }
-        if( here.has_flag( ter_furn_flag::TFLAG_ROUGH, pos() ) && one_in( 6 ) &&
-            get_armor_type( damage_cut, bodypart_id( "torso" ) ) < rough_damage && get_hp() > rough_damage ) {
-            apply_damage( nullptr, bodypart_id( "torso" ), rough_damage );
-        }
-    }
-
-    if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, destination ) && on_ground ) {
+    if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, destination ) &&
+        on_ground && !here.has_vehicle_floor( p ) ) {
         add_effect( effect_bouldering, 1_turns, true );
     } else if( has_effect( effect_bouldering ) ) {
         remove_effect( effect_bouldering );
@@ -1922,9 +1915,23 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
         remove_effect( effect_no_sight );
     }
 
-    here.creature_on_trap( *this );
-    if( is_dead() ) {
-        return true;
+    if( !here.has_vehicle_floor( p ) ) {
+        if( type->size != creature_size::tiny && on_ground ) {
+            const int sharp_damage = rng( 1, 10 );
+            const int rough_damage = rng( 1, 2 );
+            if( here.has_flag( ter_furn_flag::TFLAG_SHARP, pos() ) && !one_in( 4 ) &&
+                get_armor_type( damage_cut, bodypart_id( "torso" ) ) < sharp_damage && get_hp() > sharp_damage ) {
+                apply_damage( nullptr, bodypart_id( "torso" ), sharp_damage );
+            }
+            if( here.has_flag( ter_furn_flag::TFLAG_ROUGH, pos() ) && one_in( 6 ) &&
+                get_armor_type( damage_cut, bodypart_id( "torso" ) ) < rough_damage && get_hp() > rough_damage ) {
+                apply_damage( nullptr, bodypart_id( "torso" ), rough_damage );
+            }
+        }
+        here.creature_on_trap( *this );
+        if( is_dead() ) {
+            return true;
+        }
     }
     if( !will_be_water && ( digs() || can_dig() ) ) {
         underwater = here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, pos() );

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1903,7 +1903,7 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
     }
 
     if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, destination ) &&
-        on_ground && !here.has_vehicle_floor( p ) ) {
+        on_ground && !here.has_vehicle_floor( destination ) ) {
         add_effect( effect_bouldering, 1_turns, true );
     } else if( has_effect( effect_bouldering ) ) {
         remove_effect( effect_bouldering );
@@ -1915,7 +1915,7 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
         remove_effect( effect_no_sight );
     }
 
-    if( !here.has_vehicle_floor( p ) ) {
+    if( !here.has_vehicle_floor( destination ) ) {
         if( type->size != creature_size::tiny && on_ground ) {
             const int sharp_damage = rng( 1, 10 );
             const int rough_damage = rng( 1, 2 );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3246,7 +3246,8 @@ void npc::on_load()
 
     map &here = get_map();
     // for spawned npcs
-    if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub() ) && !here.has_vehicle_floor( pos_bub() ) ) {
+    if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub() ) &&
+        !here.has_vehicle_floor( pos_bub() ) ) {
         add_effect( effect_bouldering, 1_turns,  true );
     } else if( has_effect( effect_bouldering ) ) {
         remove_effect( effect_bouldering );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3246,7 +3246,7 @@ void npc::on_load()
 
     map &here = get_map();
     // for spawned npcs
-    if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos() ) ) {
+    if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub() ) && !here.has_vehicle_floor( pos_bub() ) ) {
         add_effect( effect_bouldering, 1_turns,  true );
     } else if( has_effect( effect_bouldering ) ) {
         remove_effect( effect_bouldering );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2547,7 +2547,7 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
                 here.creature_on_trap( *mounted_creature );
             }
         }
-        if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos() ) ) {
+        if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub() ) && !here.has_vehicle_floor( pos_bub() ) ) {
             add_effect( effect_bouldering, 1_turns, true );
         } else if( has_effect( effect_bouldering ) ) {
             remove_effect( effect_bouldering );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2547,7 +2547,8 @@ void npc::move_to( const tripoint &pt, bool no_bashing, std::set<tripoint> *nomo
                 here.creature_on_trap( *mounted_creature );
             }
         }
-        if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub() ) && !here.has_vehicle_floor( pos_bub() ) ) {
+        if( here.has_flag( ter_furn_flag::TFLAG_UNSTABLE, pos_bub() ) &&
+            !here.has_vehicle_floor( pos_bub() ) ) {
             add_effect( effect_bouldering, 1_turns, true );
         } else if( has_effect( effect_bouldering ) ) {
             remove_effect( effect_bouldering );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Creatures above vehicles react to various objects under the vehicle. (For example, dogs will stop moving when they see deep water under it.)
I improve it.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Vehicle parts with "BOARDABLE" or "OBSTACLE" are assumed to have a floor, and the objects under them will be ignored if necessary.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Instead of using "BOARDABLE" or "OBSTACLE", add the "FLOOR" flag and use it.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I confirmed that followings didn't react and no damage.
- deep pit
- deep water
- lava
- open air
- terrains with  "ROUGH" or "SHARP" or "UNSTABLE"
- traps
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
