### PR TITLE
Martial arts docs update

### DIFF
--- a/data/json/martialarts_fictional.json
+++ b/data/json/martialarts_fictional.json
@@ -568,7 +568,6 @@
     "crit_tec": true,
     "stun_dur": 2,
     "knockback_dist": 3,
-    "powerful_knockback": true,
     "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 2.0 } ],
     "messages": [ "Your Stinger Kick sends %s flying", "<npcname>'s Stinger Kick sends %s flying" ],
     "attack_vectors": [ "FOOT" ]

--- a/data/mods/MMA/techniques.json
+++ b/data/mods/MMA/techniques.json
@@ -493,7 +493,6 @@
     "condition_desc": "* Only works on a <info>non-downed</info> target of <info>similar or smaller</info> size, may fail on enemies grabbing you",
     "down_dur": 2,
     "knockback_dist": 4,
-    "powerful_knockback": true,
     "weighting": 2,
     "mult_bonuses": [
       { "stat": "damage", "type": "bash", "scale": 1.5 },

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -4008,7 +4008,7 @@ Alternately, every item (book, tool, armor, even food) can be used as a gunmod i
 "revert_msg": "The torch fades out.", // Message, that would be printed, when revert_to is used
 "sub": "hotplate",         // optional; this tool has the same functions as another tool
 "variables": {
-  "vehicle_name": "Wheelchair",         // this tool is a foldable vehicle, that could bypass the default foldability rules; this is the id of vehicle to unfold
+  "vehicle_name": "Wheelchair",         // this tool is a foldable vehicle, that could bypass the default foldability rules; this is the name of the vehicle that would be unfolded 
   "folded_parts": "folded_parts_syntax" // this is the parts that this vehice has -it uses it's own syntax, different from `"type": "vehicle"`, so better to read the examples in `unfoldable.json`
 }
 ```

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -2971,6 +2971,7 @@ Unless specified as optional, the following fields are mandatory for parts with 
                               // To be a fuel an item needs to be made of only one material,
                               // this material has to produce energy, *ie* have a `data_fuel` entry,
                               // and it needs to have consumable charges.
+"displacement": 280           // engine displacement, meaasured in cubic centimeters (cm3)
 ```
 
 #### The following optional fields are specific to WHEELs.
@@ -2983,6 +2984,8 @@ Unless specified as optional, the following fields are mandatory for parts with 
 "rolling_resistance": 1.0,    // The "squishiness" of the wheel, per SAE standards.  Wheel rolling
                               // resistance increases vehicle drag linearly as vehicle weight
                               // and speed increase.
+"diameter": 8,                // diameter of wheel (in inches)
+"width": 4,                   // width of the wheel (in inches)
 ```
 
 `wheel_terrain_modifiers` field provides a way to modify wheel traction according to the flags set on terrain tile under each wheel.
@@ -3178,6 +3181,9 @@ Weakpoints only match if they share the same id, so it's important to define the
 "price_postapoc": "1 USD",                       // Same as price but represent value post cataclysm. Can use string "cent" "USD" or "kUSD".
 "stackable": true,                           // This item can be stacked together, similarly to `charges`
 "degradation_multiplier": 0.8,               // Controls how quickly an item degrades when taking damage. 0 = no degradation. Defaults to 1.0.
+"solar_efficiency": 0.3,                     // Efficiency of solar energy conversion for solarpacks; require SOLARPACK_ON to generate electricity; default 0
+"source_monster": "mon_child",               // This item is corpse of this monster (so it has weight and volume of this monster), and revive into this monster; require COPRSE flag
+"thrown_damage": [ { "damage_type": "bash", "amount": 15 } ], // Damage, that would be dealt when you throw this item; lack of this field fall back to use melee damage, including player's str bonus applied to melee attack
 "material": [                                // Material types, can be as many as you want.  See materials.json for possible options
   { "type": "cotton", "portion": 9 },        // type indicates the material's ID, portion indicates proportionally how much of the item is composed of that material
   { "type": "plastic" }                      // portion can be omitted and will default to 1. In this case, the item is 90% cotton and 10% plastic.
@@ -3591,11 +3597,22 @@ Books can be defined like this:
                       // additional some book specific entries:
 "max_level" : 5,      // Maximum skill level this book will train to
 "intelligence" : 11,  // Intelligence required to read this book without penalty
-"time" : "35 m",          // Time a single read session takes. An integer will be read in minutes or a time string can be used.
+"time" : "35 m",      // Time a single read session takes. An integer will be read in minutes or a time string can be used.
 "fun" : -2,           // Morale bonus/penalty for reading
 "skill" : "computer", // Skill raised
 "chapters" : 4,       // Number of chapters (for fun only books), each reading "consumes" a chapter. Books with no chapters left are less fun (because the content is already known to the character).
-"required_level" : 2  // Minimum skill level required to learn
+"required_level" : 2,  // Minimum skill level required to learn
+"martial_art": "style_mma", // Martial art learned from this book; incompatible with `skill`
+"proficiencies": [    // Having this book mitigate lack of proficiency, required for crafting 
+  { 
+    "proficiency": "prof_fermenting", // id of proficiency
+    "time_factor": 0.1,               // slowdown for using this book proficiency - slowdown from lack of proficiency is multiplied on this value, so for `0.75`, if recipe adds 10 hours for lack of proficiency,  with book it would be [ 10 * ( 1 - 0.75 ) = ] 2.5 hours; multiple books stacks, but in logarithmic way, meaning having more books of the same proficiency is better than having one book, but never would be better than learning the proficiency
+    "fail_factor": 0.25               // works same as `time_factor`
+  },
+  { "proficiency": "prof_brewing", "time_factor": 0.25, "fail_factor": 0.5 },
+  { "proficiency": "prof_winemaking", "time_factor": 0.1, "fail_factor": 0.25 }
+],
+
 ```
 It is possible to omit the `max_level` field if the book you're creating contains only recipes and it's not supposed to level up any skill. In this case the `skill` field will just refer to the skill required to learn the recipes.
 
@@ -3988,7 +4005,12 @@ Alternately, every item (book, tool, armor, even food) can be used as a gunmod i
 "rand_charges": [10, 15, 25], // Randomize the charges when spawned. This example has a 50% chance of rng(10, 15) charges and a 50% chance of rng(15, 25). (The endpoints are included.)
 "power_draw": "50 mW",          // Energy consumption per second
 "revert_to": "torch_done", // Transforms into item when charges are expended
+"revert_msg": "The torch fades out.", // Message, that would be printed, when revert_to is used
 "sub": "hotplate",         // optional; this tool has the same functions as another tool
+"variables": {
+  "vehicle_name": "Wheelchair",         // this tool is a foldable vehicle, that could bypass the default foldability rules; this is the id of vehicle to unfold
+  "folded_parts": "folded_parts_syntax" // this is the parts that this vehice has -it uses it's own syntax, different from `"type": "vehicle"`, so better to read the examples in `unfoldable.json`
+}
 ```
 
 
@@ -4018,7 +4040,7 @@ Currently only vats can only accept and produce liquid items.
 ```C++
 "brewable" : {
     "time": 3600, // A time duration: how long the fermentation will take.
-    "result": { "beer": 1, "yeast": 10 } // Ids with a multiplier for the amount of results per charge of the brewable items.
+    "results": { "beer": 1, "yeast": 10 } // Ids with a multiplier for the amount of results per charge of the brewable items.
 }
 ```
 
@@ -4206,7 +4228,8 @@ The contents of use_action fields can either be a string indicating a built-in f
     "fields_produced" : {"cracksmoke" : 2}, // Fields to produce, mostly used for smoke.
     "charges_needed" : { "fire" : 1 }, // Charges to use in the process of consuming the drug.
     "tools_needed" : { "apparatus" : -1 }, // Tool needed to use the drug.
-    "moves": 50 // Number of moves required in the process, default value is 100.
+    "moves": 50, // Number of moves required in the process, default value is 100.
+    "vitamins": [ [ "mutagen_alpha", 225 ], [ "mutagen", 125 ] ] // what and how much vitamin is given by this drug
 },
 "use_action": {
     "type": "place_monster", // place a turret / manhack / whatever monster on the map
@@ -4365,6 +4388,7 @@ The contents of use_action fields can either be a string indicating a built-in f
     "head_power" : 7,       // How much hp to restore when healing head? If unset, defaults to 0.8 * limb_power.
     "torso_power" : 15,     // How much hp to restore when healing torso? If unset, defaults to 1.5 * limb_power.
     "bleed" : 4,            // How many bleed effect intensity levels can be reduced by it. Base value.
+    "disinfectant_power": 4,// quality of disinfection - antiseptic is 4, alcohol wipe is 2; float
     "bite" : 0.95,          // Chance to remove bite effect.
     "infect" : 0.1,         // Chance to remove infected effect.
     "move_cost" : 250,      // Cost in moves to use the item.
@@ -4433,7 +4457,19 @@ The contents of use_action fields can either be a string indicating a built-in f
 }
 ```
 
-  ### Tick Actions
+### Drop Actions
+
+Similar to use_action, this drop_actions would be triggered when you throw the item
+
+```c++
+"drop_action": {                  
+  "type": "emit_actor",           // allow to emit a specific field when thrown
+  "emits": [ "emit_acid_drop" ],  // id of emit to spread
+  "scale_qty": true               // if true, throwing more than one charge of item with emit_actor increases the size of emission
+  }
+```
+
+### Tick Actions
 
 `"tick_action"` of active tools is executed once on every turn. This action can be any use action or iuse but some of them may not work properly when not executed by player.
 

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3182,7 +3182,7 @@ Weakpoints only match if they share the same id, so it's important to define the
 "stackable": true,                           // This item can be stacked together, similarly to `charges`
 "degradation_multiplier": 0.8,               // Controls how quickly an item degrades when taking damage. 0 = no degradation. Defaults to 1.0.
 "solar_efficiency": 0.3,                     // Efficiency of solar energy conversion for solarpacks; require SOLARPACK_ON to generate electricity; default 0
-"source_monster": "mon_child",               // This item is corpse of this monster (so it has weight and volume of this monster), and revive into this monster; require COPRSE flag
+"source_monster": "mon_zombie",               // This item is corpse of this monster (so it has weight and volume of this monster), and revive into this monster; require COPRSE flag
 "thrown_damage": [ { "damage_type": "bash", "amount": 15 } ], // Damage, that would be dealt when you throw this item; lack of this field fall back to use melee damage, including player's str bonus applied to melee attack
 "material": [                                // Material types, can be as many as you want.  See materials.json for possible options
   { "type": "cotton", "portion": 9 },        // type indicates the material's ID, portion indicates proportionally how much of the item is composed of that material

--- a/doc/MARTIALART_JSON.md
+++ b/doc/MARTIALART_JSON.md
@@ -2,7 +2,7 @@
 
 ### Martial arts
 
-```JSON
+```C++
 {
   "type": "martial_art",
   "id": "style_debug",        // Unique ID. Must be one continuous word,
@@ -12,15 +12,22 @@
   "initiate": [ "You stand ready.", "%s stands ready." ],     // Message shown when player or NPC chooses this art
   "autolearn": [ [ "unarmed", "2" ] ],     // A list of skill requirements that if met, automatically teach the player the martial art
   "teachable": true,          // Whether it's possible to teach this style between characters
+  "allow_all_weapons": true,             // This martial art works always, no matter what weapon you equip (including no weapon)
+  "force_unarmed": true,                 // You never use equipped item to make attacks with this martial art, and will use only your fist, legs or another limbs you have
+  "prevent_weapon_blocking": true,       // You never block using weapon with this martial art
+  "strictly_melee": true,                // This martial art can be used only with some weapon, no way to use it with bare hands
+  "arm_block_with_bio_armor_arms": true, // Using this martial art, you can block damage using Arms Alloy Plating CBM
+  "leg_block_with_bio_armor_legs": true, // Using this martial art, you can block damage using Legs Alloy Plating CBM
+  "autolearn": [ [ "melee", 1 ] ], // This martial art is autolearned once you reach this level in specific skill or skills
+  "primary_skill": "bashing", // The difficulty and effectiveness of this martial art scales from this skill; unarmed by default
   "learn_difficulty": 5,      // Difficulty to learn a style from book based on "primary skill"
                               // Total chance to learn a style from a single read of the book is equal to one in (10 + learn_difficulty - primary_skill)
   "arm_block": 99,            // Unarmed skill level at which arm blocking is unlocked
   "leg_block": 99,            // Unarmed skill level at which arm blocking is unlocked
   "nonstandard_block": 99,    // Unarmed skill level at which blocking with "nonstandard" mutated limbs is unlocked
-  "static_buffs": [           // List of buffs that are automatically applied every turn
+  "static_buffs": [           // List of buffs that are automatically applied every turn; this syntax is applied for every field with `_buffs` in it's name
     {
-      "id": "debug_elem_resist",
-      "heat_arm_per": 1.0
+      "id": "debug_elem_resist" // for detals of syntax see Buffs
     }
   ],
   "onmove_buffs": [],         // List of buffs that are automatically applied on movement
@@ -62,10 +69,13 @@
 {
   "id": "tec_debug_arpen",    // Unique ID. Must be one continuous word
   "name": "phasing strike",   // In-game name displayed
+  "attack_vectors": [ "WEAPON", "HAND" ] // What attack vector would be used for this technique; this field is order dependend, meaning in this example the game will try to use WEAPON first, and, if not possible, reject it and will use HAND instead; For more info see Attack vectors below
+  "attack_vectors_random": [ "FOOT", "HEAD", "TORSO", "HEAD", "HEAD" ] // same as attack_vectors, but has no priority, and pick random vector from the list; it is used only if all choises from attack_vectors are rejected
   "unarmed_allowed": true,    // Can an unarmed character use this technique
   "unarmed_weapons_allowed": true,    // Does this technique require the character to be actually unarmed or does it allow unarmed weapons
   "weapon_categories_allowed": [ "BLADES", "KNIVES" ], // Restrict technique to only these categories of weapons. If omitted, all weapon categories are allowed.
   "melee_allowed": true,      // Means that ANY melee weapon can be used, NOT just the martial art's weapons
+  "powerful_knockback": true, //
   "skill_requirements": [ { "name": "melee", "level": 3 } ],     // Skills and their minimum levels required to use this technique. Can be any skill.
   "weapon_damage_requirements": [ { "type": "bash", "min": 5 } ],     // Minimum weapon damage required to use this technique. Can be any damage type.
   "required_buffs_any": [ "eskrima_hit_buff" ],    // This technique requires any of the named buffs to be active
@@ -81,7 +91,7 @@
   "attack_override": false,   // This technique replaces the base attack it triggered on, nulling damage and movecost (instead using the tech's flat_bonuses), and counts as unarmed for the purposes of skill training and special melee effects
   "condition": "u_is_outside",// Optional (array of) dialog conditions the attack requires to trigger.  Failing these will disqualify the tech from being selected
   "condition_desc": "Needs X",// Description string describing the conditions of this attack (since dialog conditions can't be automatically evaluated)       
-  "repeat_min": 1,            // Technique's damage and any added effects are repeated rng( repeat_min, repeat_max) times. The target's armor and the effect's chances are applied for each repeat.
+  "repeat_min": 1,            // Technique's damage and any added effects are repeated rng(repeat_min, repeat_max) times. The target's armor and the effect's chances are applied for each repeat.
   "repeat_max": 1,
   "knockback_dist": 1,        // Distance target is knocked back
   "knockback_spread": 1,      // The knockback may not send the target straight back
@@ -109,6 +119,30 @@
 }
 ```
 
+### Attack vectors
+
+Attack vector is a way for game to separate which techniques could be used by character, and which could not - it would be odd to see player is unable to kick because their arm is broken
+
+List of attack vectors is currently hardcoded, and contain:
+
+- `HAND` - Any technique that hits with any part of the hand (backhand, jab, hammer fist). Can be used as long as at least one hand/arm limb is not broken.
+- `FINGERS` - Any technique that hits with the fingers (eye gouge, spearhand). Can be used as long as at least one hand/arm limb is not broken.
+- `PALM` - Any technique that hits with the palm of the hand(palm strike). Can be used as long as at least one hand/arm limb is not broken.
+- `HAND_BACK` - Any technique that hits with the back of the hand(backfist, backhand slap). Can be used as long as at least one hand/arm limb is not broken.
+- `WRIST` - Any technique that hits with the wrist (crane strike). Can be used as long as at least one hand/arm limb is not broken.
+- `ARM` - Any technique that hits with the arm itself (clothesline). Can be used as long as at least one hand/arm limb is not broken.
+- `ELBOW` - Any technique that hits with an elbow (elbow strike). Can be used as long as at least one hand/arm limb is not broken.
+- `SHOULDER` - Any technique that hits with the upper part of the arm (shoulder check). Can be used as long as at least one hand/arm limb is not broken.
+- `FOOT` - Any technique that hits with any part of the foot (roundhouse kick, foot stomp, heel drop). Can be used only if both legs are not broken. You need one functional leg to perform the attack and another functional leg to balance on.
+- `LOWER_LEG` - Any technique that hits with shin (Muay Thai kicks). Can be used only if both legs are not broken. You need one functional leg to perform the attack and another functional leg to balance on.
+- `KNEE` - Any technique that hits with the knee (knee bash). Can be used only if both legs are not broken. You need one functional leg to perform the attack and another functional leg to balance on.
+- `HIP` - Any technique that hits with the hips or buttocks (Peach Bomber, R. Mika's Flying Peach). Can be used only if both legs are not broken. You need one functional leg to perform the attack and another functional leg to balance on.
+- `TORSO` - Any technique that hits with the center mass of the user's body (flying body splash, throwing yourself at an enemy). Can always be used because if your Torso is broken, you are dead.  // Shouldn't it requre both legs? can't really use a whole body if legs are broken, no way to deliver the momentum ain't it?
+- `HEAD` - Any technique that hits with the user's head such as a headbutt. Can always be used because if your Head is broken, you are dead.
+- `WEAPON` - Any technique the requires a held item to perform (see any weapon style). Can be used if the user is holding a valid style weapon for their martial art and at least one hand/arm is not broken.
+- `THROW` - Any technique that forcefully moves an opponent (judo throws, suplex). Can be used only if both hands/arms are not broken.
+- `GRAPPLE` - Any technique that maintains contact with an opponent and squeezes (chock, headlock), bends (Krav Maga's Arm Breaker), or twists (arm twist) some part of the opponent. Can be used only if both hands/arms are not broken.
+
 ### Tech effects
 ```JSON
 "tech_effects": [
@@ -129,13 +163,15 @@
 ```JSON
 {
   "id": "debug_elem_resist",         // Unique ID. Must be one continuous word
-  "name": "Elemental Resistance",    // In-game name displayed
-  "description": "You are a walking tank!\n\nBash armor increased by 100% of Strength, Cut armor increased by 100% of Dexterity, Electricic armor increased by 100% of Intelligence, and Fire armor increased by 100% of Perception", // In-game description
+  "name": "Elemental Resistance",    // In-game name displayed, would be shown in character menu
+  "description": "You are a walking tank!\n\nBash armor increased by 100% of Strength, Cut armor increased by 100% of Dexterity, Electricic armor increased by 100% of Intelligence, and Fire armor increased by 100% of Perception", // In-game description, would be shown in character menu
   "buff_duration": 2,                // Duration in turns that this buff lasts
   "persists": false,                 // Allow buff to remain when changing to a new style
-  "unarmed_allowed": true,           // Can this buff be applied to an unarmed character
-  "unarmed_allowed": false,          // Can this buff be applied to an armed character
+  "unarmed_allowed": true,           // Effect is applied when you have no weapon equipped
+  "melee_allowed": true,             // Effect is applied when you have some melee weapon equipped
   "unarmed_weapons_allowed": true,   // Does this buff require the character to be actually unarmed. If true, allows unarmed weapons (brass knuckles, punch daggers)
+  "strictly_unarmed": true,          // Effect is applied only when you have no weapon whatsoever, even unarmed weapon
+  "wall_adjacent": true,            // Effect is applied when you stand near the wall
   "weapon_categories_allowed": [ "BLADES", "KNIVES" ], // Restrict buff to only these categories of weapons. If omitted, all weapon categories are allowed.
   "max_stacks": 8,                   // Maximum number of stacks on the buff. Buff bonuses are multiplied by current buff intensity
   "bonus_blocks": 1,                 // Extra blocks per turn

--- a/doc/MARTIALART_JSON.md
+++ b/doc/MARTIALART_JSON.md
@@ -65,7 +65,7 @@
 
 ### Techniques
 
-```JSON
+```C++
 {
   "id": "tec_debug_arpen",    // Unique ID. Must be one continuous word
   "name": "phasing strike",   // In-game name displayed
@@ -144,7 +144,7 @@ List of attack vectors is currently hardcoded, and contain:
 - `GRAPPLE` - Any technique that maintains contact with an opponent and squeezes (chock, headlock), bends (Krav Maga's Arm Breaker), or twists (arm twist) some part of the opponent. Can be used only if both hands/arms are not broken.
 
 ### Tech effects
-```JSON
+```C++
 "tech_effects": [
   {
     "id": "eff_expl",    // Unique ID. Must be one continuous word
@@ -160,7 +160,7 @@ List of attack vectors is currently hardcoded, and contain:
 
 ### Buffs
 
-```JSON
+```C++
 {
   "id": "debug_elem_resist",         // Unique ID. Must be one continuous word
   "name": "Elemental Resistance",    // In-game name displayed, would be shown in character menu
@@ -185,7 +185,7 @@ List of attack vectors is currently hardcoded, and contain:
 
 The bonuses arrays contain any number of bonus entries like this:
 
-```JSON
+```C++
 {
   "stat": "damage",
   "type": "bash",

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -242,7 +242,6 @@ void ma_technique::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "stun_dur", stun_dur, 0 );
     optional( jo, was_loaded, "knockback_dist", knockback_dist, 0 );
     optional( jo, was_loaded, "knockback_spread", knockback_spread, 0 );
-    optional( jo, was_loaded, "powerful_knockback", powerful_knockback, false );
     optional( jo, was_loaded, "knockback_follow", knockback_follow, false );
 
     optional( jo, was_loaded, "aoe", aoe, "" );
@@ -827,7 +826,6 @@ ma_technique::ma_technique()
     stun_dur = 0;
     knockback_dist = 0;
     knockback_spread = 0; // adding randomness to knockback, like tec_throw
-    powerful_knockback = false;
     knockback_follow = false; // player follows the knocked-back party into their former tile
 
     // offensive
@@ -1874,10 +1872,6 @@ std::string ma_technique::get_description() const
     if( wall_adjacent ) {
         dump += _( "* Will only activate while <info>near</info> to a <info>wall</info>" ) +
                 std::string( "\n" );
-    }
-
-    if( powerful_knockback ) {
-        dump += _( "* Causes extra damage on <info>knockback collision</info>." ) + std::string( "\n" );
     }
 
     if( dodge_counter ) {

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -164,7 +164,6 @@ class ma_technique
         int stun_dur = 0;
         int knockback_dist = 0;
         float knockback_spread = 0.0f;  // adding randomness to knockback, like tec_throw
-        bool powerful_knockback = false;
         std::string aoe;                // corresponds to an aoe shape, defaults to just the target
         bool knockback_follow = false;  // Character follows the knocked-back party into their former tile
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1823,7 +1823,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
             }
         }
 
-        if( technique.stun_dur > 0 && !technique.powerful_knockback ) {
+        if( technique.stun_dur > 0 ) {
             t.add_effect( effect_stunned, rng( 1_turns, time_duration::from_turns( technique.stun_dur ) ) );
         }
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Another documentation stuff
Adress #67783
#### Describe the solution
Documented some fields
The reason it's a separate PR is because i found and confirmed that `powerful_knockback` has no back up in code - it was introduced in #34407:

https://github.com/CleverRaven/Cataclysm-DDA/pull/34407/files#diff-2cd8dac3d0903ca1ee60a47c28e09bcb56290214bc8d1fe5cf4afaed108b9d92R1333

to change the way the game calculate said knockback to be similar with vehicle collision, and deal additional damage when pushed enemy collides with another critter or wall; However the code that made it possible was (accidentally, i believe) removed few days later, in #34483:

https://github.com/CleverRaven/Cataclysm-DDA/pull/34483/files#diff-2cd8dac3d0903ca1ee60a47c28e09bcb56290214bc8d1fe5cf4afaed108b9d92L1332

I need someone to confirm, that i am correct, and that i didn't remove anything important accidentally

#### Additional context
Accidentally checked it out from #68390, so it has some side commits also