### PR TITLE
Change Grim Reapers Scythe

### DIFF
--- a/data/json/items/tool/landscaping.json
+++ b/data/json/items/tool/landscaping.json
@@ -168,17 +168,16 @@
     "color": "light_gray",
     "name": { "str": "grim reaper's scythe" },
     "description": "A long, crooked tool used to reap souls, with a skull engraved in its blade.  Let the harvest begin.",
-    "weight": "2721 g",
+    "weight": "1685 g",
     "volume": "3550 ml",
     "longest_side": "150 cm",
     "price": 3000,
-    "price_postapoc": 10,
+    "price_postapoc": 5,
     "to_hit": { "grip": "solid", "length": "long", "surface": "any", "balance": "uneven" },
     "material": [ "plastic" ],
-    "techniques": [ "WIDE", "BRUTAL" ],
-    "flags": [ "NONCONDUCTIVE", "FRAGILE_MELEE", "POLEARM", "SHEATH_SPEAR", "REACH_ATTACK", "ALWAYS_TWOHAND" ],
+    "flags": [ "NONCONDUCTIVE", "FRAGILE_MELEE", "POLEARM", "SHEATH_SPEAR", "REACH_ATTACK" ],
     "weapon_category": [ "HOOKING_WEAPONRY", "POLEARMS" ],
-    "melee_damage": { "bash": 7 }
+    "melee_damage": { "bash": 2 }
   },
   {
     "id": "shovel",

--- a/data/json/items/tool/landscaping.json
+++ b/data/json/items/tool/landscaping.json
@@ -168,7 +168,7 @@
     "color": "light_gray",
     "name": { "str": "grim reaper's scythe" },
     "description": "A long, crooked tool used to reap souls, with a skull engraved in its blade.  Let the harvest begin.",
-    "weight": "1685 g",
+    "weight": "1160 g",
     "volume": "3550 ml",
     "longest_side": "150 cm",
     "price": 3000,

--- a/data/json/items/tool/landscaping.json
+++ b/data/json/items/tool/landscaping.json
@@ -168,7 +168,7 @@
     "color": "light_gray",
     "name": { "str": "grim reaper's scythe" },
     "description": "A long, crooked tool used to reap souls, with a skull engraved in its blade.  Let the harvest begin.",
-    "weight": "1160 g",
+    "weight": "586 g",
     "volume": "3550 ml",
     "longest_side": "150 cm",
     "price": 3000,

--- a/data/mods/TEST_DATA/known_bad_density.json
+++ b/data/mods/TEST_DATA/known_bad_density.json
@@ -774,8 +774,7 @@
       "rocuronium",
       "alumentum",
       "rebreather_filler_ko2",
-      "rebreather_filler_soda_lime",
-      "scythe_toy"
+      "rebreather_filler_soda_lime"
     ]
   }
 ]

--- a/data/mods/TEST_DATA/known_bad_density.json
+++ b/data/mods/TEST_DATA/known_bad_density.json
@@ -774,7 +774,8 @@
       "rocuronium",
       "alumentum",
       "rebreather_filler_ko2",
-      "rebreather_filler_soda_lime"
+      "rebreather_filler_soda_lime",
+      "scythe_toy"
     ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Adjust Grim Reaper Scythe"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

A solid plastic toy is a luxury most people wouldn't have. So this PR changes it to be hollow. Didn't want to do the math of 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Removes techniques and nerfs damage, but reduced weight. Did some garbage math. Assumed the volume was a cylinder with 2.5mm wall thickness, giving 2932.75 cm^3 of empty space. Is it perfect? No. Did I have to do a bunch of math to try to find out what the actual volume would be? No. Should I have just searched up a toy and get its weight from the product page? Probably. Also adds it to the known bad density json, don't know if that was needed or not
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Forcing kids to grow up and use real scythes as toys.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Why not?
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
