### PR TITLE
Make it obvious when TCL badges are destroyed or not

### DIFF
--- a/data/json/furniture_and_terrain/terrain-mechanisms.json
+++ b/data/json/furniture_and_terrain/terrain-mechanisms.json
@@ -400,7 +400,7 @@
     "type": "terrain",
     "id": "t_card_science_visitor",
     "name": "Facility entrance card reader",
-    "description": "A smartcard reader.  It sports the stylized symbol of an atom inside a flask that is universally known to indicate SCIENCE.  You could swipe a visitor's pass near it to unlock the gates.",
+    "description": "A smartcard reader.  It sports the stylized symbol of an atom inside a flask that is universally known to indicate SCIENCE.  You could insert a visitor's pass into it to unlock the gates.",
     "//": "Entrance card for a lab.  Low security access.",
     "symbol": "6",
     "color": "cyan",
@@ -415,7 +415,7 @@
       "radius": 3,
       "terrain_changes": { "t_door_metal_locked": "t_door_metal_c" },
       "query": true,
-      "query_msg": "Are you sure you want to open this door?",
+      "query_msg": "Are you sure you want to open this door? It looks like you might not get the card back.",
       "success_msg": "You opened the door!",
       "redundant_msg": "The door is already open."
     }
@@ -524,7 +524,7 @@
     "type": "terrain",
     "id": "t_card_science_transport_1",
     "name": "Freight hauler access card reader",
-    "description": "A smartcard reader.  It sports the stylized symbol of an atom and a truck.  You could swipe a transporter's badge near it to unlock the gates.",
+    "description": "A smartcard reader.  It sports the stylized symbol of an atom and a truck.  You could insert a transporter's badge into it to unlock the gates.",
     "//": "Entrance card for a lab.  Low security access.",
     "symbol": "6",
     "color": "cyan",
@@ -539,7 +539,7 @@
       "radius": 7,
       "terrain_changes": { "t_door_metal_locked": "t_thconc_floor" },
       "query": true,
-      "query_msg": "Are you sure you want to open this gate?",
+      "query_msg": "Are you sure you want to open this gate? It looks like you might not get the card back.",
       "success_msg": "You opened the gate!",
       "redundant_msg": "The gate is already open."
     }

--- a/data/json/furniture_and_terrain/terrain-mechanisms.json
+++ b/data/json/furniture_and_terrain/terrain-mechanisms.json
@@ -400,7 +400,7 @@
     "type": "terrain",
     "id": "t_card_science_visitor",
     "name": "Facility entrance card reader",
-    "description": "A smartcard reader.  It sports the stylized symbol of an atom inside a flask that is universally known to indicate SCIENCE.  You could insert a visitor's pass into it to unlock the gates.",
+    "description": "A smartcard reader.  It sports the stylized symbol of an atom inside a flask that is universally known to indicate SCIENCE.  You could swipe a visitor's pass near it to unlock the gates.",
     "//": "Entrance card for a lab.  Low security access.",
     "symbol": "6",
     "color": "cyan",
@@ -409,13 +409,13 @@
     "examine_action": {
       "type": "cardreader",
       "flags": [ "SCIENCE_CARD_VISITOR" ],
-      "consume_card": true,
+      "consume_card": false,
       "allow_hacking": true,
       "despawn_monsters": true,
       "radius": 3,
       "terrain_changes": { "t_door_metal_locked": "t_door_metal_c" },
       "query": true,
-      "query_msg": "Are you sure you want to open this door? It looks like you might not get the card back.",
+      "query_msg": "Are you sure you want to open this door?",
       "success_msg": "You opened the door!",
       "redundant_msg": "The door is already open."
     }
@@ -524,7 +524,7 @@
     "type": "terrain",
     "id": "t_card_science_transport_1",
     "name": "Freight hauler access card reader",
-    "description": "A smartcard reader.  It sports the stylized symbol of an atom and a truck.  You could insert a transporter's badge into it to unlock the gates.",
+    "description": "A smartcard reader.  It sports the stylized symbol of an atom and a truck.  You could swipe a transporter's badge near it to unlock the gates.",
     "//": "Entrance card for a lab.  Low security access.",
     "symbol": "6",
     "color": "cyan",
@@ -533,13 +533,13 @@
     "examine_action": {
       "type": "cardreader",
       "flags": [ "SCIENCE_CARD_TRANSPORT_1" ],
-      "consume_card": true,
+      "consume_card": false,
       "allow_hacking": false,
       "despawn_monsters": false,
       "radius": 7,
       "terrain_changes": { "t_door_metal_locked": "t_thconc_floor" },
       "query": true,
-      "query_msg": "Are you sure you want to open this gate? It looks like you might not get the card back.",
+      "query_msg": "Are you sure you want to open this gate?",
       "success_msg": "You opened the gate!",
       "redundant_msg": "The gate is already open."
     }

--- a/data/json/items/id_cards.json
+++ b/data/json/items/id_cards.json
@@ -55,7 +55,7 @@
     "copy-from": "card_plastic_abstract",
     "color": "blue",
     "name": { "str": "visitor's pass", "str_pl": "visitor's passes" },
-    "description": "A visitor's pass to some sort of facility.  The reverse side describes the protocol for using it; this could grant one-time access at a card reader, if you can find one.  It also lists the addresses of nearby facilities; activate it to add their locations to your map.",
+    "description": "A visitor's pass to some sort of facility.  The reverse side describes the protocol for using it; this could grant access at a card reader, if you can find one.  It also lists the addresses of nearby facilities; activate it to add their locations to your map.",
     "price": 60000,
     "extend": { "flags": [ "SCIENCE_CARD_VISITOR" ] },
     "price_postapoc": 250,
@@ -117,7 +117,7 @@
     "symbol": ",",
     "copy-from": "id_science",
     "name": { "str": "transport freight employee badge" },
-    "description": "An employee badge for a freight hauler.  The reverse side describes the protocol for using it; this could grant one-time access to a transport freight card reader.  It also lists the addresses of nearby facilities; activate it to add their locations to your map.",
+    "description": "An employee badge for a freight hauler.  The reverse side describes the protocol for using it; this could grant access at transport freight card readers.  It also lists the addresses of nearby facilities; activate it to add their locations to your map.",
     "flags": [ "SCIENCE_CARD_TRANSPORT_1", "CREDIT_CARD_SHAPED" ],
     "use_action": {
       "type": "reveal_map",


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Make it obvious when TCL badges are destroyed or not"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* ~~Updates the TCL card readers that have `consume_card: true` so that it is a bit more obvious to the player that the card itself will be consumed (destroyed).~~
* ~~Updates all card readers that actually consume (destroy) the card so that the player know what will happen.~~
* Edit: Updates the TCL card readers that previously had `consume_card: true` so they now instead are  `consume_card: false`, to make them not consume (destroy) the card. This makes them work like the other colored TCL card readers.


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Story time:
* First time I visited TCL, I had a few visitor's badges with me.
* So I opened all doors I could find in the outer yard.
* This, unknownst to me, consumed (destroyed) all visitor's badges that I had with me.
* Then I encountered another card reader that also required a `visitor's pass`, but lo and behold I had none!
* That taught me that TCL cards are consumed (destroyed) when used.
* So I slowly realized that these TCL doors are a puzzle in itself, and thinking to myself that it's difficult choice on where you choose to use your TCL badges.
* So, because of these first few doors that consumed (destroyed) some of the badges, I had the feeling that all doors would consume (destroy) the corresponding card.
* My playstyle was therefore to open as few doors as possible, to not consume what I perceived was precious cards.

This commit therefore suggests that we make it obvious to the player when the card will be:
* kept (not consumed): using the phrasing `swipe the card`
* consumed (destroyed): using the phrasing `insert the card`

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* Another option would be to rename `visitor's badge` into something like `one-time use visitor's badge`.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
