### PR TITLE
Jeweler profession

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3355,6 +3355,23 @@
     }
   },
   {
+	"type": "profession",
+	"id": "jeweller",
+	"name": "Jeweller",
+	"description": "You were an independent artisan, who made gorgeous rings and pendants for the people who afforded your services.  You doubt the market for your work has faired well after the end of the world, but perhaps your proficiency with fine tools and metals will come in handy somehow.",
+	"points": 2,
+	"skills": [ { "level": 6, "name": "fabrication" }, { "level": 2, "name": "swimming" } ],
+	"proficiencies": [ "prof_metalworking", "prof_redsmithing", "prof_fine_metalsmithing", "prof_gem_setting" ],
+	"items": {
+		"both": {
+			"items": [ "jeans", "socks", "boots", "longshirt", "wristwatch", "apron_leather", "chisel" ],
+			"entries": [ { "group": "charged_smart_phone" } ]
+		},
+		"male": [ "briefs" ],
+		"female": [ "bra", "panties" ]
+	}
+  },
+  {
     "type": "profession",
     "id": "clown",
     "name": "Clown",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3356,8 +3356,8 @@
   },
   {
     "type": "profession",
-    "id": "jeweller",
-    "name": "Jeweller",
+    "id": "jeweler",
+    "name": "Jeweler",
     "description": "You were an independent artisan, who made gorgeous rings and pendants for the people who afforded your services.  You doubt the market for your work has faired well after the end of the world, but perhaps your proficiency with fine tools and metals will come in handy somehow.",
     "points": 2,
     "skills": [ { "level": 6, "name": "fabrication" }, { "level": 2, "name": "swimming" } ],

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3355,21 +3355,21 @@
     }
   },
   {
-	"type": "profession",
-	"id": "jeweller",
-	"name": "Jeweller",
-	"description": "You were an independent artisan, who made gorgeous rings and pendants for the people who afforded your services.  You doubt the market for your work has faired well after the end of the world, but perhaps your proficiency with fine tools and metals will come in handy somehow.",
-	"points": 2,
-	"skills": [ { "level": 6, "name": "fabrication" }, { "level": 2, "name": "swimming" } ],
-	"proficiencies": [ "prof_metalworking", "prof_redsmithing", "prof_fine_metalsmithing", "prof_gem_setting" ],
-	"items": {
-		"both": {
-			"items": [ "jeans", "socks", "boots", "longshirt", "wristwatch", "apron_leather", "chisel" ],
-			"entries": [ { "group": "charged_smart_phone" } ]
-		},
-		"male": [ "briefs" ],
-		"female": [ "bra", "panties" ]
-	}
+    "type": "profession",
+    "id": "jeweller",
+    "name": "Jeweller",
+    "description": "You were an independent artisan, who made gorgeous rings and pendants for the people who afforded your services.  You doubt the market for your work has faired well after the end of the world, but perhaps your proficiency with fine tools and metals will come in handy somehow.",
+    "points": 2,
+    "skills": [ { "level": 6, "name": "fabrication" }, { "level": 2, "name": "swimming" } ],
+    "proficiencies": [ "prof_metalworking", "prof_redsmithing", "prof_fine_metalsmithing", "prof_gem_setting" ],
+    "items": {
+      "both": {
+        "items": [ "jeans", "socks", "boots", "longshirt", "wristwatch", "apron_leather", "chisel" ],
+        "entries": [ { "group": "charged_smart_phone" } ]
+      },
+      "male": [ "briefs" ],
+      "female": [ "bra", "panties" ]
+    }
   },
   {
     "type": "profession",


### PR DESCRIPTION
#### Summary
Content "Adds a jeweler as a new starting profession"

#### Purpose of change

More options for characters. This profession could be considered A sidepath to the blacksmith profession, trading the useful blacksmithing proficiency for several, lesser used and more specific proficiencies.

#### Describe the solution

Adds the jeweler as a profession, which starts with fabrication 6 and a metalworking chisel. The proficiencies they start with are Metalworking, Fine Metalsmithing, Redsmithing and Gem Setting (Redsmithing is required by Gem setting, which requires metalworking.) 

#### Describe alternatives you've considered

removing some of the proficiencies they start with or not adding them altogether. I'm also open to changing the description bc I think it could use work..

#### Additional context

Gem Setting currently does nothing, I hope this gets fixed in the future.
