### PR TITLE
Allow metal wreckage to be used for cutting

### DIFF
--- a/data/json/furniture_and_terrain/furniture-terrains.json
+++ b/data/json/furniture_and_terrain/furniture-terrains.json
@@ -851,6 +851,7 @@
     "move_cost_mod": 6,
     "max_volume": "750 L",
     "required_str": -1,
+    "crafting_pseudo_item": "fake_sharp_metal_wreckage",
     "flags": [
       "TRANSPARENT",
       "UNSTABLE",

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -97,6 +97,13 @@
     "qualities": [ [ "BUTCHER", 8 ], [ "CUT", 1 ] ]
   },
   {
+    "id": "fake_sharp_metal_wreckage",
+    "copy-from": "fake_item",
+    "type": "TOOL",
+    "name": { "str": "sharp piece of wreckage" },
+    "qualities": [ [ "CUT", 1 ] ]
+  },
+  {
     "id": "boulder_anvil",
     "type": "TOOL",
     "copy-from": "fake_item",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Allow metal wreckage to be used for cutting"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Allow the sharp edges of metal wreckage to be used for cutting. Only lowest level of cutting is provided, on par with eg. stone axe head. This is mostly useful in an emergency situation, eg. the helicopter crash start.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add CUT 1 to metal wreckage via pseudo tool.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I considered also adding very low negative butchering quality, but except for extremely small animals this is not going to be doable since the tool itself can't be maneuvered. We can't represent the size distinction so that's a no go.

Also considered adding wood sawing 1 but came to the same conclusion, the tool not being movable makes it unusable for things we use wood sawing 1 for.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawn metal wreckage, see it provides cutting 1.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
