### PR TITLE
[MoM] Remove FEAR_PARALYZE from telepathic monsters

### DIFF
--- a/data/mods/MindOverMatter/monsters/feral_lab_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_lab_psychics.json
@@ -72,8 +72,7 @@
         "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
         "miss_msg_npc": "%s stares at <npcname> but nothing happens!"
       },
-      [ "PULL_METAL_WEAPON", 8 ],
-      [ "FEAR_PARALYZE", 10 ]
+      [ "PULL_METAL_WEAPON", 8 ]
     ],
     "flags": [
       "SEES",

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -782,8 +782,7 @@
         "spell_data": { "id": "telepathic_confusion_monster", "min_level": 3 },
         "cooldown": 10,
         "monster_message": "A roar fills %3$s's mind and the world is blotted out!"
-      },
-      [ "FEAR_PARALYZE", 15 ]
+      }
     ],
     "flags": [
       "SEES",
@@ -850,8 +849,7 @@
         "spell_data": { "id": "telepathic_blast_monster", "min_level": 2 },
         "cooldown": 10,
         "monster_message": "%1$s stares at %3$s!"
-      },
-      [ "FEAR_PARALYZE", 10 ]
+      }
     ],
     "flags": [
       "SEES",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Remove FEAR_PARALYZE from telepathic monsters"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

When I first made the telepathic ferals, I added FEAR_PARALYZE because it seemed in-theme.  But now that an actual system for telepathic attacks, telepathic damage, and resisting same exists, FEAR_PARALYZE as a hardcoded attack is out of place.  It bypasses all of that so there's no obvious way to defend against it.

I'll probably replicate the effects with a power that can be defended against using normal psionic methods.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove the attack from feral telepaths.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
