### PR TITLE
Fix item group error with magiclysm + defense mode enabled

### DIFF
--- a/data/mods/Defense_Mode/npcs.json
+++ b/data/mods/Defense_Mode/npcs.json
@@ -184,7 +184,7 @@
       { "group": "preserved_food", "prob": 70 },
       { "group": "pet_food", "prob": 70 },
       { "group": "condiments", "prob": 70 },
-      { "group": "trader_guns&ammo", "prob": 70, "charges": 30 },
+      { "group": "trader_guns&ammo", "prob": 70 },
       { "group": "hardware", "prob": 70 },
       { "group": "defense_caravan_melee", "prob": 70 },
       { "group": "defense_caravan_ranged", "prob": 70, "charges": 30 },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

I don't know if it's a complete fix, but it addresses #67927.
I'm also not sure if it's a good fix, see alternatives section.

#### Describe the solution

Remove charges modifier from a group entry, which seems to cause conflicts with other (sub-)entries from within that group.

#### Describe alternatives you've considered

https://github.com/CleverRaven/Cataclysm-DDA/blob/e3eddedf3eb16328197b82cc2dd3b17619ed1026/src/item_group.cpp#L571-L580

I think the real issue might lie in this. The same code for guns instead of tools treats both magazines and items with magazine wells the same and just calls `ammo_set` on them instead of manually inserting a magazine. But I can't really test if this breaks anything (and then fix potentially resulting issues) currently.

#### Testing

Run tests with `--rng-seed 1696217676 '~*' --mods=dda,stats_through_kills,standard_combat_test,defense_mode,magiclysm,no_fungal_growth,blazeindustries,megafauna,ruralbiome,railroads,package_bionic_professions,Tamable_Wildlife,extra_mut_scens,sees_player_hitbutton,Mythos-Creatures,StatsThroughSkills,mindovermatter,my_sweet_cataclysm,generic_guns,speedydex,translate_dialogue,personal_portal_storms,alt_map_key,tropicata,cbm_slots,MMA,sees_player_retro,crazy_cataclysm,deadly_bites,no_npc_food,xedra_evolved,DinoMod,no_hope,Only_Wildlife,bombastic_perks` before and after the change.
(Just enabling defense_mode and magiclysm might be enough, but no idea if that messes with the rng in some way.)

#### Additional context

It actually still fails with the above seed with this fix, but with a different error: `[get_part_id] Could not find equivalent bodypart id mouth in Tom 'Tom' Tom's body`.