### PR TITLE
Monsters care about item theft

### DIFF
--- a/data/json/npcs/factions.json
+++ b/data/json/npcs/factions.json
@@ -869,6 +869,7 @@
     "likes_u": 30,
     "respects_u": 30,
     "known_by_u": false,
+    "mon_faction": "exodii",
     "size": 100,
     "power": 100,
     "food_supply": 115200,

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -122,6 +122,8 @@ class avatar : public Character
 
         mfaction_id get_monster_faction() const override;
 
+        void witness_thievery( item * ) override {}
+
         std::string get_save_id() const {
             return save_id.empty() ? name : save_id;
         }

--- a/src/creature.h
+++ b/src/creature.h
@@ -294,6 +294,9 @@ class Creature : public viewer
             return nullptr;
         }
         virtual mfaction_id get_monster_faction() const = 0;
+
+        // Witness and respond to theft of faction items
+        virtual void witness_thievery( item *it ) = 0;
         /** return the direction the creature is facing, for sdl horizontal flip **/
         FacingDirection facing = FacingDirection::RIGHT;
         /** Returns true for non-real Creatures used temporarily; i.e. fake NPC's used for turret fire. */

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1949,6 +1949,23 @@ bool item::is_owned_by( const Character &c, bool available_to_take ) const
     return c.get_faction()->id == get_owner();
 }
 
+bool item::is_owned_by( const monster &m, bool available_to_take ) const
+{
+    // owner.is_null() implies faction_id( "no_faction" ) which shouldn't happen, or no owner at all.
+    // either way, certain situations this means the thing is available to take.
+    // in other scenarios we actually really want to check for id == id, even for no_faction
+    if( get_owner().is_null() ) {
+        return available_to_take;
+    }
+    for( const std::pair<const faction_id, faction> &fact : g->faction_manager_ptr->all() ) {
+        if( fact.second.mon_faction != m.faction.id() ) {
+            continue;
+        }
+        return fact.first == get_owner();
+    }
+    return false;
+}
+
 bool item::is_old_owner( const Character &c, bool available_to_take ) const
 {
     if( get_old_owner().is_null() ) {
@@ -6309,26 +6326,37 @@ void item::handle_pickup_ownership( Character &c )
     if( is_owned_by( c ) ) {
         return;
     }
-    Character &player_character = get_player_character();
     // Add ownership to item if unowned
     if( owner.is_null() ) {
         set_owner( c );
     } else {
         if( !is_owned_by( c ) && c.is_avatar() ) {
-            std::vector<npc *> witnesses;
-            for( npc &elem : g->all_npcs() ) {
-                if( rl_dist( elem.pos(), player_character.pos() ) < MAX_VIEW_DISTANCE &&
-                    elem.get_faction() && is_owned_by( elem ) && elem.sees( player_character.pos() ) ) {
-                    elem.say( "<witnessed_thievery>", 7 );
-                    npc *npc_to_add = &elem;
-                    witnesses.push_back( npc_to_add );
+            const auto sees_stealing = [&c, this]( const Creature & cr ) {
+                const npc *const as_npc = cr.as_npc();
+                const monster *const as_monster = cr.as_monster();
+                bool owned_by = false;
+                if( as_npc ) {
+                    owned_by = is_owned_by( *as_npc );
+                } else if( as_monster ) {
+                    owned_by = is_owned_by( *as_monster );
                 }
-            }
+                return &cr != &c && owned_by && rl_dist( cr.pos(), c.pos() ) < MAX_VIEW_DISTANCE &&
+                       cr.sees( c.pos() );
+            };
+            std::vector<Creature *> witnesses = g->get_creatures_if( sees_stealing );
+            /*
+                for( &elem : witness ) {
+                        elem.say( "<witnessed_thievery>", 7 );
+                        npc *npc_to_add = &elem;
+                        witnesses.push_back( npc_to_add );
+                }
+            */
             if( !witnesses.empty() ) {
                 set_old_owner( get_owner() );
                 bool guard_chosen = false;
-                for( npc *elem : witnesses ) {
-                    if( elem->myclass == NC_BOUNTY_HUNTER ) {
+                for( Creature *witness : witnesses ) {
+                    npc *const elem = witness->as_npc();
+                    if( elem && elem->myclass == NC_BOUNTY_HUNTER ) {
                         guard_chosen = true;
                         elem->witness_thievery( &*this );
                         break;

--- a/src/item.h
+++ b/src/item.h
@@ -2741,6 +2741,7 @@ class item : public visitable
         faction_id get_owner() const;
         faction_id get_old_owner() const;
         bool is_owned_by( const Character &c, bool available_to_take = false ) const;
+        bool is_owned_by( const monster &m, bool available_to_take = false ) const;
         bool is_old_owner( const Character &c, bool available_to_take = false ) const;
         std::string get_old_owner_name() const;
         std::string get_owner_name() const;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1362,6 +1362,23 @@ Creature *monster::attack_target()
     return target;
 }
 
+void monster::witness_thievery( item *it )
+{
+    add_msg( m_bad, _( "%1$s saw the %2$s being stolen!" ), get_name(), it->tname() );
+    std::vector<npc *> friends;
+    for( npc &guy : g->all_npcs() ) {
+        if( guy.get_faction() && guy.get_faction()->mon_faction == faction.id() ) {
+            friends.push_back( &guy );
+        }
+    }
+    if( friends.empty() ) {
+        aggro_character = true;
+        anger = 100;
+        return;
+    }
+    random_entry( friends )->witness_thievery( it );
+}
+
 bool monster::is_fleeing( Character &u ) const
 {
     if( effect_cache[FLEEING] ) {

--- a/src/monster.h
+++ b/src/monster.h
@@ -131,6 +131,7 @@ class monster : public Creature
         int get_hp_max() const override;
         int hp_percentage() const override;
         int get_eff_per() const override;
+        void witness_thievery( item *it ) override;
 
         float get_mountable_weight_ratio() const;
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -1064,7 +1064,7 @@ class npc : public Character
         void handle_sound( sounds::sound_t priority, const std::string &description,
                            int heard_volume, const tripoint &spos );
 
-        void witness_thievery( item *it );
+        void witness_thievery( item *it ) override;
 
         /* shift() works much like monster::shift(), and is called when the player moves
          * from one submap to an adjacent submap.  It updates our position (shifting by


### PR DESCRIPTION
#### Summary
Features "Monsters affiliated with factions will watch for theft of faction items"

#### Purpose of change
Only the NPCs in the exodii will care when you steal items. That's wrong, and easily exploitable.

#### Describe the solution
Make monsters who witness theft, who are in the monster faction associated with the faction that the item was stolen from, either alert nearby NPCs who are in the faction that an item was stolen, or if there are no nearby NPCs, become hostile.

#### Describe alternatives you've considered
Don't have them go hostile? The NPC alerting is kind of magic to start with.

#### Testing
Steal stuff in the exodii castle, Rubik talks to me about all the stuff I've been stealing.
Kill the NPCs in the exodii castle, when a exodii worker or quad witnesses me stealing, they become hostile.

#### Additional context
This needs some more work, but as it is works as a proof of concept.
