### PR TITLE
Add ignored_monster_species spell parameter

### DIFF
--- a/data/mods/MindOverMatter/powers/telepathy.json
+++ b/data/mods/MindOverMatter/powers/telepathy.json
@@ -377,7 +377,8 @@
     "energy_increment": -250,
     "base_casting_time": 120,
     "final_casting_time": 75,
-    "casting_time_increment": -3.5
+    "casting_time_increment": -3.5,
+    "ignored_monster_species": [ "ZOMBIE", "ROBOT", "NETHER", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME" ]
   },
   {
     "id": "telepathic_network",

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -242,6 +242,7 @@ Field group | Description | Example
 `sound_type`, `sound_description`, `sound_ambient`, `sound_id`, `sound_variant` | Respond for the sound that play when you use the spell. `sound_type` is one of `background`, `weather`, `music`, `movement`, `speech`, `activity`, `destructive_activity`, `alarm`, `combat`, `alert`, `order`; `sound_description` respond for the message in log, as "You hear %s" ("an explosion" by default); `sound_ambient` whether or not this is treated as an ambient sound | "sound_type": "combat", <bp>"sound_description": "a whoosh", <bp>"sound_ambient": true, <bp>"sound_id": "misc", <bp>"sound_variant": "shockwave", 
 `targeted_monster_ids` | You can target only `monster_id` | "targeted_monster_ids": [ "mon_hologram" ],
 `targeted_monster_species` | You can target only picked species (for list see data/json/species.json) | "targeted_monster_species": [ "ROBOT", "CYBORG" ],
+`ignored_monster_species` | The opposite of targeted_monster_species: you can target everything except picked species (for list see data/json/species.json) | "targeted_monster_species": [ "ROBOT", "CYBORG" ],
 
 ### Spell Flags
 

--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -242,7 +242,7 @@ Field group | Description | Example
 `sound_type`, `sound_description`, `sound_ambient`, `sound_id`, `sound_variant` | Respond for the sound that play when you use the spell. `sound_type` is one of `background`, `weather`, `music`, `movement`, `speech`, `activity`, `destructive_activity`, `alarm`, `combat`, `alert`, `order`; `sound_description` respond for the message in log, as "You hear %s" ("an explosion" by default); `sound_ambient` whether or not this is treated as an ambient sound | "sound_type": "combat", <bp>"sound_description": "a whoosh", <bp>"sound_ambient": true, <bp>"sound_id": "misc", <bp>"sound_variant": "shockwave", 
 `targeted_monster_ids` | You can target only `monster_id` | "targeted_monster_ids": [ "mon_hologram" ],
 `targeted_monster_species` | You can target only picked species (for list see data/json/species.json) | "targeted_monster_species": [ "ROBOT", "CYBORG" ],
-`ignored_monster_species` | The opposite of targeted_monster_species: you can target everything except picked species (for list see data/json/species.json) | "targeted_monster_species": [ "ROBOT", "CYBORG" ],
+`ignored_monster_species` | The opposite of targeted_monster_species: you can target everything except picked species (for list see data/json/species.json) | "ignored_monster_species": [ "ZOMBIE", "NETHER" ],
 
 ### Spell Flags
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -486,7 +486,7 @@ void spell_type::serialize( JsonOut &json ) const
     json.member( "sound_variant", sound_variant, sound_variant_default );
     json.member( "targeted_monster_ids", targeted_monster_ids, std::set<mtype_id> {} );
     json.member( "targeted_monster_species", targeted_species_ids, std::set<species_id> {} );
-    json.member( "ignored_monster_species", ignored_species_ids, std::set<species_id> {});
+    json.member( "ignored_monster_species", ignored_species_ids, std::set<species_id> {} );
     json.member( "extra_effects", additional_spells, std::vector<fake_spell> {} );
     if( !affected_bps.none() ) {
         json.member( "affected_body_parts", affected_bps );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -297,6 +297,13 @@ void spell_type::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "targeted_monster_species", targeted_species_ids,
               targeted_monster_species_reader );
 
+    const auto ignored_monster_species_reader = string_id_reader<::species_type>{};
+    optional(jo, was_loaded, "ignored_monster_species", ignored_species_ids,
+        ignored_monster_species_reader);
+
+
+
+
     const auto trigger_reader = enum_flags_reader<spell_target> { "valid_targets" };
     mandatory( jo, was_loaded, "valid_targets", valid_targets, trigger_reader );
 
@@ -479,6 +486,7 @@ void spell_type::serialize( JsonOut &json ) const
     json.member( "sound_variant", sound_variant, sound_variant_default );
     json.member( "targeted_monster_ids", targeted_monster_ids, std::set<mtype_id> {} );
     json.member( "targeted_monster_species", targeted_species_ids, std::set<species_id> {} );
+    json.member( "ignored_monster_species", ignored_species_ids, std::set<species_id> {});
     json.member( "extra_effects", additional_spells, std::vector<fake_spell> {} );
     if( !affected_bps.none() ) {
         json.member( "affected_body_parts", affected_bps );
@@ -1408,6 +1416,7 @@ bool spell::is_valid_target( const Creature &caster, const tripoint &p ) const
         valid = valid || ( is_valid_target( spell_target::self ) && p == caster.pos() );
         valid = valid && target_by_monster_id( p );
         valid = valid && target_by_species_id( p );
+        valid = valid && ignore_by_species_id( p );
     } else {
         valid = is_valid_target( spell_target::ground );
     }
@@ -1443,6 +1452,25 @@ bool spell::target_by_species_id( const tripoint &p ) const
     }
     return valid;
 }
+
+bool spell::ignore_by_species_id(const tripoint& p) const
+{
+    if (type->ignored_species_ids.empty()) {
+        return true;
+    }
+    bool valid = true;
+    if (monster* const target = get_creature_tracker().creature_at<monster>(p)) {
+        for (const species_id& spid : type->ignored_species_ids) {
+            if (target->type->in_species(spid)) {
+                valid = false;
+            }
+        }
+    }
+    return valid;
+}
+
+
+
 
 std::string spell::description() const
 {
@@ -1599,6 +1627,22 @@ std::string spell::list_targeted_species_names() const
     all_valid_species_names.erase( std::unique( all_valid_species_names.begin(),
                                    all_valid_species_names.end() ), all_valid_species_names.end() );
     std::string ret = enumerate_as_string( all_valid_species_names );
+    return ret;
+}
+
+std::string spell::list_ignored_species_names() const
+{
+    if (type->ignored_species_ids.empty()) {
+        return "";
+    }
+    std::vector<std::string> all_valid_species_names;
+    for (const species_id& species_id : type->ignored_species_ids) {
+        all_valid_species_names.emplace_back(species_id.str());
+    }
+    //remove repeat names
+    all_valid_species_names.erase(std::unique(all_valid_species_names.begin(),
+        all_valid_species_names.end()), all_valid_species_names.end());
+    std::string ret = enumerate_as_string(all_valid_species_names);
     return ret;
 }
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1459,9 +1459,9 @@ bool spell::ignore_by_species_id( const tripoint &p ) const
         return true;
     }
     bool valid = true;
-    if (monster* const target = get_creature_tracker().creature_at<monster>(p)) {
-        for (const species_id& spid : type->ignored_species_ids) {
-            if (target->type->in_species(spid)) {
+    if( monster *const target = get_creature_tracker().creature_at<monster>( p ) ) {
+        for( const species_id &spid : type->ignored_species_ids ) {
+            if( target->type->in_species( spid ) ) {
                 valid = false;
             }
         }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1640,9 +1640,9 @@ std::string spell::list_ignored_species_names() const
         all_valid_species_names.emplace_back( species_id.str() );
     }
     //remove repeat names
-    all_valid_species_names.erase(std::unique(all_valid_species_names.begin(),
-        all_valid_species_names.end()), all_valid_species_names.end());
-    std::string ret = enumerate_as_string(all_valid_species_names);
+    all_valid_species_names.erase( std::unique( all_valid_species_names.begin(),
+                                   all_valid_species_names.end() ), all_valid_species_names.end() );
+    std::string ret = enumerate_as_string( all_valid_species_names );
     return ret;
 }
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1632,7 +1632,7 @@ std::string spell::list_targeted_species_names() const
 
 std::string spell::list_ignored_species_names() const
 {
-    if (type->ignored_species_ids.empty()) {
+    if( type->ignored_species_ids.empty() ) {
         return "";
     }
     std::vector<std::string> all_valid_species_names;

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -297,9 +297,9 @@ void spell_type::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "targeted_monster_species", targeted_species_ids,
               targeted_monster_species_reader );
 
-    const auto ignored_monster_species_reader = string_id_reader<::species_type>{};
-    optional(jo, was_loaded, "ignored_monster_species", ignored_species_ids,
-        ignored_monster_species_reader);
+    const auto ignored_monster_species_reader = string_id_reader<::species_type> {};
+    optional( jo, was_loaded, "ignored_monster_species", ignored_species_ids,
+              ignored_monster_species_reader );
 
 
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1636,8 +1636,8 @@ std::string spell::list_ignored_species_names() const
         return "";
     }
     std::vector<std::string> all_valid_species_names;
-    for (const species_id& species_id : type->ignored_species_ids) {
-        all_valid_species_names.emplace_back(species_id.str());
+    for( const species_id &species_id : type->ignored_species_ids ) {
+        all_valid_species_names.emplace_back( species_id.str() );
     }
     //remove repeat names
     all_valid_species_names.erase(std::unique(all_valid_species_names.begin(),

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1453,7 +1453,7 @@ bool spell::target_by_species_id( const tripoint &p ) const
     return valid;
 }
 
-bool spell::ignore_by_species_id(const tripoint& p) const
+bool spell::ignore_by_species_id( const tripoint &p ) const
 {
     if (type->ignored_species_ids.empty()) {
         return true;

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1455,7 +1455,7 @@ bool spell::target_by_species_id( const tripoint &p ) const
 
 bool spell::ignore_by_species_id( const tripoint &p ) const
 {
-    if (type->ignored_species_ids.empty()) {
+    if( type->ignored_species_ids.empty() ) {
         return true;
     }
     bool valid = true;

--- a/src/magic.h
+++ b/src/magic.h
@@ -614,7 +614,7 @@ class spell
         bool is_valid_target( spell_target t ) const;
         bool target_by_monster_id( const tripoint &p ) const;
         bool target_by_species_id( const tripoint &p ) const;
-        bool ignore_by_species_id(const tripoint& p) const;
+        bool ignore_by_species_id( const tripoint &p ) const;
 
         // picks a random valid tripoint from @area
         std::optional<tripoint> random_valid_target( const Creature &caster,

--- a/src/magic.h
+++ b/src/magic.h
@@ -342,6 +342,8 @@ class spell_type
 
         std::set<species_id> targeted_species_ids;
 
+        std::set<species_id> ignored_species_ids;
+
         // list of bodyparts this spell applies its effect to
         body_part_set affected_bps;
 
@@ -565,6 +567,8 @@ class spell
         std::string list_targeted_monster_names() const;
         //if targeted_species_ids is empty, it returns an empty string
         std::string list_targeted_species_names() const;
+        //if ignored_species_ids is empty, it returns an empty string
+        std::string list_ignored_species_names() const;
 
         std::string damage_string( const Character &caster ) const;
         std::string aoe_string( const Creature &caster ) const;
@@ -610,6 +614,7 @@ class spell
         bool is_valid_target( spell_target t ) const;
         bool target_by_monster_id( const tripoint &p ) const;
         bool target_by_species_id( const tripoint &p ) const;
+        bool ignore_by_species_id(const tripoint& p) const;
 
         // picks a random valid tripoint from @area
         std::optional<tripoint> random_valid_target( const Creature &caster,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Add ignored_monster_species spell parameter"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

One problem with implementing more telepathic powers in Mind Over Matter is that it's hard to make them thematic when they can be used on robots, zombies, hallucinations caused by the breakdown of reality, and other beings that don't have brains.  

Implements #63210
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Create the ignored_monster_species JSON parameter, the exact opposite of targeted_monster_species. A spell that has an ignored_monster_species list will work on everything _except_ those species. Also apply ignored_monster_species to the Mind Control power, so it no longer works on zombies, robots, or Nether creatures.

A spell that has a targeted_monster_species and an ignored_monster_species containing the same list of species won't affect anything. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Apply ignored_monster_species to Mind Control, spawn in zombie and cow. Cows are targetable and zombies result in 
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/d2328ecd-baab-48a9-ad64-e1f7686e82bb)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This will allow me to create a telepathic fear power so you can paralyze people with overwhelming terror and not having it be too powerful (because it won't work on zombies, robots, and other things that can't feel fear).

Still trying to figure out how to get Mind Control working on NPCs.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
