### PR TITLE
Improved path for intelligent monsters

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1027,7 +1027,7 @@ void monster::move()
     if( try_to_move ) {
         // Move using vision by follow smells and sounds
         bool move_without_target = false;
-        if( is_wandering() && has_intelligent() && can_see() ) {
+        if( is_wandering() && has_intelligence() && can_see() ) {
             if( has_flag( mon_flag_SMELLS ) ) {
                 unset_dest();
                 tripoint tmp = scent_move();

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -214,6 +214,8 @@ bool monster::know_danger_at( const tripoint &p ) const
     bool avoid_fall = has_flag( mon_flag_PATH_AVOID_FALL );
     bool avoid_simple = has_flag( mon_flag_PATH_AVOID_DANGER_1 );
     bool avoid_complex = has_flag( mon_flag_PATH_AVOID_DANGER_2 );
+    bool avoid_sharp = get_pathfinding_settings().avoid_sharp;
+    bool avoid_traps = get_pathfinding_settings().avoid_traps;
     /*
      * Because some avoidance behaviors are supersets of others,
      * we can cascade through the implications. Complex implies simple,
@@ -222,15 +224,18 @@ bool monster::know_danger_at( const tripoint &p ) const
      */
     if( avoid_complex ) {
         avoid_simple = true;
+        avoid_traps = true;
     }
     if( avoid_simple ) {
         avoid_fire = true;
         avoid_fall = true;
+        avoid_sharp = true;
     }
 
     // technically this will shortcut in evaluation from fire or fall
     // before hitting simple or complex but this is more explicit
-    if( avoid_fire || avoid_fall || avoid_simple || avoid_complex ) {
+    if( avoid_fire || avoid_fall || avoid_simple ||
+        avoid_complex || avoid_traps || avoid_sharp ) {
         const ter_id target = here.ter( p );
         if( !here.has_vehicle_floor( p ) ) {
             // Don't enter lava if we have any concept of heat being bad
@@ -254,28 +259,27 @@ bool monster::know_danger_at( const tripoint &p ) const
             // Some things are only avoided if we're not attacking
             if( attitude( &get_player_character() ) != MATT_ATTACK ) {
                 // Sharp terrain is ignored while attacking
-                if( avoid_simple && here.has_flag( ter_furn_flag::TFLAG_SHARP, p ) &&
+                if( avoid_sharp && here.has_flag( ter_furn_flag::TFLAG_SHARP, p ) &&
                     !( type->size == creature_size::tiny || flies() ||
                        get_armor_type( damage_cut, bodypart_id( "torso" ) ) >= 10 ) ) {
                     return false;
                 }
             }
+
+            // Don't step on any traps (if we can see)
+            const trap &target_trap = here.tr_at( p );
+            if( avoid_traps && has_flag( mon_flag_SEES ) &&
+                !target_trap.is_benign() && here.has_floor_or_water( p ) ) {
+                return false;
+            }
         }
 
         const field &target_field = here.field_at( p );
-
         // Higher awareness is needed for identifying these as threats.
         if( avoid_complex ) {
             // Don't enter any dangerous fields
             if( is_dangerous_fields( target_field ) ) {
                 return false;
-            }
-            if( !here.has_vehicle_floor( p ) ) {
-                // Don't step on any traps (if we can see)
-                const trap &target_trap = here.tr_at( p );
-                if( has_flag( mon_flag_SEES ) && !target_trap.is_benign() && here.has_floor_or_water( p ) ) {
-                    return false;
-                }
             }
         }
 
@@ -1016,11 +1020,34 @@ void monster::move()
             }
         }
     }
+
     // If true, don't try to greedily avoid locally bad paths
     bool pathed = false;
-    const tripoint local_dest = here.getlocal( get_dest() );
+    tripoint local_dest = here.getlocal( get_dest() );
     if( try_to_move ) {
-        if( !is_wandering() ) {
+        // Move using vision by follow smells and sounds
+        bool move_without_target = false;
+        if( is_wandering() && has_intelligent() && can_see() ) {
+            if( has_flag( mon_flag_SMELLS ) ) {
+                unset_dest();
+                tripoint tmp = scent_move();
+                if( tmp.x != -1 ) {
+                    local_dest = tmp;
+                    move_without_target = true;
+                    add_msg_debug( debugmode::DF_MONMOVE, "%s follows smell using vision", name() );
+                }
+            }
+            if( !move_without_target && wandf > 0 && friendly == 0 ) {
+                unset_dest();
+                if( wander_pos != get_location() ) {
+                    local_dest = here.getlocal( wander_pos );
+                    move_without_target = true;
+                    add_msg_debug( debugmode::DF_MONMOVE, "%s follows sound using vision", name() );
+                }
+            }
+        }
+
+        if( !is_wandering() || move_without_target ) {
             while( !path.empty() && path.front() == pos() ) {
                 path.erase( path.begin() );
             }
@@ -1052,6 +1079,7 @@ void monster::move()
         if( tmp.x != -1 ) {
             destination = tmp;
             moved = true;
+            add_msg_debug( debugmode::DF_MONMOVE, "%s follows smell to not use vision", name() );
         }
     }
     if( wandf > 0 && !moved && friendly == 0 ) { // No LOS, no scent, so as a fall-back follow sound
@@ -1059,6 +1087,7 @@ void monster::move()
         if( wander_pos != get_location() ) {
             destination = here.getlocal( wander_pos );
             moved = true;
+            add_msg_debug( debugmode::DF_MONMOVE, "%s follows sound to not use vision", name() );
         }
     }
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1300,7 +1300,7 @@ bool monster::is_pet_follow() const
     return is_pet() && !has_flag( mon_flag_PET_WONT_FOLLOW );
 }
 
-bool monster::has_intelligent() const
+bool monster::has_intelligence() const
 {
     return has_flag( mon_flag_PATH_AVOID_FALL ) ||
            has_flag( mon_flag_PATH_AVOID_FIRE ) ||

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -177,10 +177,15 @@ static const mon_flag_str_id mon_flag_NO_BREATHE( "NO_BREATHE" );
 static const mon_flag_str_id mon_flag_NO_BREED( "NO_BREED" );
 static const mon_flag_str_id mon_flag_NO_FUNG_DMG( "NO_FUNG_DMG" );
 static const mon_flag_str_id mon_flag_PARALYZEVENOM( "PARALYZEVENOM" );
+static const mon_flag_str_id mon_flag_PATH_AVOID_DANGER_1( "PATH_AVOID_DANGER_1" );
+static const mon_flag_str_id mon_flag_PATH_AVOID_DANGER_2( "PATH_AVOID_DANGER_2" );
+static const mon_flag_str_id mon_flag_PATH_AVOID_FALL( "PATH_AVOID_FALL" );
+static const mon_flag_str_id mon_flag_PATH_AVOID_FIRE( "PATH_AVOID_FIRE" );
 static const mon_flag_str_id mon_flag_PET_MOUNTABLE( "PET_MOUNTABLE" );
 static const mon_flag_str_id mon_flag_PET_WONT_FOLLOW( "PET_WONT_FOLLOW" );
 static const mon_flag_str_id mon_flag_PHOTOPHOBIC( "PHOTOPHOBIC" );
 static const mon_flag_str_id mon_flag_PLASTIC( "PLASTIC" );
+static const mon_flag_str_id mon_flag_PRIORITIZE_TARGETS( "PRIORITIZE_TARGETS" );
 static const mon_flag_str_id mon_flag_QUEEN( "QUEEN" );
 static const mon_flag_str_id mon_flag_REVIVES( "REVIVES" );
 static const mon_flag_str_id mon_flag_REVIVES_HEALTHY( "REVIVES_HEALTHY" );
@@ -1293,6 +1298,17 @@ bool monster::is_pet() const
 bool monster::is_pet_follow() const
 {
     return is_pet() && !has_flag( mon_flag_PET_WONT_FOLLOW );
+}
+
+bool monster::has_intelligent() const
+{
+    return has_flag( mon_flag_PATH_AVOID_FALL ) ||
+           has_flag( mon_flag_PATH_AVOID_FIRE ) ||
+           has_flag( mon_flag_PATH_AVOID_DANGER_1 ) ||
+           has_flag( mon_flag_PATH_AVOID_DANGER_2 ) ||
+           has_flag( mon_flag_PRIORITIZE_TARGETS ) ||
+           get_pathfinding_settings().avoid_sharp ||
+           get_pathfinding_settings().avoid_traps;
 }
 
 std::vector<material_id> monster::get_absorb_material() const
@@ -3776,5 +3792,30 @@ const pathfinding_settings &monster::get_pathfinding_settings() const
 
 std::set<tripoint> monster::get_path_avoid() const
 {
-    return std::set<tripoint>();
+    std::set<tripoint> ret;
+
+    map &here = get_map();
+    int radius = std::min( sight_range( here.ambient_light_at( pos() ) ), 5 );
+
+    for( const tripoint &p : here.points_in_radius( pos(), radius ) ) {
+        if( !can_move_to( p ) ) {
+            if( bash_skill() <= 0 || !here.is_bashable( p ) ) {
+                ret.insert( p );
+            }
+        }
+    }
+
+    if( has_flag( mon_flag_PRIORITIZE_TARGETS ) ) {
+        radius = 2;
+    } else if( has_flag( mon_flag_PATH_AVOID_DANGER_1 ) ||
+               has_flag( mon_flag_PATH_AVOID_DANGER_2 ) ) {
+        radius = 1;
+    } else {
+        return ret;
+    }
+    for( Creature *critter : here.get_creatures_in_radius( pos(), radius ) ) {
+        ret.insert( critter->pos() );
+    }
+
+    return ret;
 }

--- a/src/monster.h
+++ b/src/monster.h
@@ -183,6 +183,7 @@ class monster : public Creature
         bool shearable() const;
         bool is_pet() const;
         bool is_pet_follow() const;
+        bool has_intelligent() const;
 
         bool avoid_trap( const tripoint &pos, const trap &tr ) const override;
 

--- a/src/monster.h
+++ b/src/monster.h
@@ -183,7 +183,7 @@ class monster : public Creature
         bool shearable() const;
         bool is_pet() const;
         bool is_pet_follow() const;
-        bool has_intelligent() const;
+        bool has_intelligence() const;
 
         bool avoid_trap( const tripoint &pos, const trap &tr ) const override;
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Improved path for intelligent monsters"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I'd like monsters with some intelligence to move a little more intelligently, so I improve it.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- If intelligent monsters have vision, they find routes when moving by following smells and sounds.
Up until now, any monsters would go straight to the source of the sound.

- Tiles that cannot be entered are excluded from pathfinding.
This avoids getting stuck in those inaccessible terrains.

- Some Monsters exclude nearby Creatures from their pathfinding.
This somewhat avoids allies getting stuck in the way.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Add an "intelligence" field to monsters and use it.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I confirmed that the behavior of migos, dogs, etc. has changed, but that zombies have not changed.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
https://github.com/CleverRaven/Cataclysm-DDA/assets/142076188/cd2a097e-e896-4397-880f-97a3e54ce8df
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
