### PR TITLE
Nemesis spawn location checks on z=0 only

### DIFF
--- a/src/mission_start.cpp
+++ b/src/mission_start.cpp
@@ -68,7 +68,8 @@ void mission_start::kill_nemesis( mission * )
 {
     // Pick an area for the nemesis to spawn
 
-    const tripoint_abs_omt center = get_player_character().global_omt_location();
+    // Force z = 0 for overmapbuffer::find_random. (spawning on a rooftop is valid!)
+    const tripoint_abs_omt center = { get_player_character().global_omt_location().xy(), 0 };
     tripoint_abs_omt site = overmap::invalid_tripoint;
 
     static const std::array<float, 3> attempts_multipliers {1.0f, 1.5f, 2.f};


### PR DESCRIPTION
#### Summary
Bugfixes "Your nemesis will still hunt you even if you spawn on a roof at the start"

#### Purpose of change
Fixes #68422

#### Describe the solution
Since we're looking for a good place to spawn the nemesis and we don't know where the player starts (z-level wise), always search z=0 for `field` OMTs instead of just the player's starting z-level.

#### Describe alternatives you've considered
Maybe there's some spherical search function that should be used instead, or maybe the nemesis spawn shouldn't look for just fields, but this is an easy and simple solution with no real chance of breakage. z=0 should always be z=0 regardless of changes to OVERMAP_DEPTH/OVERMAP_HEIGHT/OVERMAP_LAYERS or other fundamental things.

#### Testing
Compiled, spawned. No error message about being unable to start the mission. Mission log has the mission. Did not stick around to wave to the nemesis.

#### Additional context
