### PR TITLE
Raise overmap generation priority of Refugee Center

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -2241,6 +2241,7 @@
     "city_distance": [ 3, -1 ],
     "city_sizes": [ 4, -1 ],
     "occurrences": [ 75, 100 ],
+    "priority": 1,
     "flags": [ "GLOBALLY_UNIQUE", "SAFE_AT_WORLDGEN", "MAN_MADE" ]
   },
   {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Refugee Center is presented as the first destination after starting the game in the 
standard scenario, but the distance to get there can be hundreds of tiles.
In the past, not being able to reach refugee centers was not a big problem. Currently, many questlines center around refugee center, so not being able to reach that will limit the scope of play.

#### Describe the solution
Raise the priority of generating refugee center and reduces the probability of generation failure.
It may still spawn more than 300 tiles away, but should be better than it is now.

#### Describe alternatives you've considered
It may be wiser to introduce a new mechanism so that it always spawns within a certain distance from the game's starting point.

#### Testing
A simple test was conducted with #68389.

#### Additional context
What is the appropriate distance to the refugee center?