### PR TITLE
Shorten the JSON for aluminum pot and pan

### DIFF
--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -1328,7 +1328,6 @@
   },
   {
     "type": "GENERIC",
-    "category": "tools",
     "id": "aluminum_pan",
     "name": { "str": "aluminum frying pan" },
     "description": "An aluminum frying pan.  Makes a decent melee weapon, and is used for cooking.",
@@ -1341,7 +1340,6 @@
   },
   {
     "type": "GENERIC",
-    "category": "tools",
     "id": "pot_aluminum",
     "name": { "str": "aluminum pot" },
     "description": "A cooking pot, useful for boiling water and making all kinds of food.  Made from aluminum.",

--- a/data/json/items/generic/dining_kitchen.json
+++ b/data/json/items/generic/dining_kitchen.json
@@ -1332,24 +1332,11 @@
     "id": "aluminum_pan",
     "name": { "str": "aluminum frying pan" },
     "description": "An aluminum frying pan.  Makes a decent melee weapon, and is used for cooking.",
-    "copy-from": "base_cookpot",
+    "copy-from": "pan",
     "material": [ "aluminum" ],
-    "color": "light_gray",
-    "looks_like": "pan",
     "weight": "400 g",
     "volume": "3 L",
     "longest_side": "35 cm",
-    "to_hit": -2,
-    "pocket_data": [
-      {
-        "max_contains_volume": "1 L",
-        "max_contains_weight": "800 g",
-        "watertight": true,
-        "open_container": true,
-        "rigid": true
-      }
-    ],
-    "relative": { "qualities": [ [ "COOK", -1 ] ] },
     "melee_damage": { "bash": 7 }
   },
   {
@@ -1358,22 +1345,10 @@
     "id": "pot_aluminum",
     "name": { "str": "aluminum pot" },
     "description": "A cooking pot, useful for boiling water and making all kinds of food.  Made from aluminum.",
-    "copy-from": "base_cookpot",
+    "copy-from": "pot",
     "material": [ "aluminum" ],
-    "color": "light_gray",
     "weight": "231 g",
     "volume": "2100 ml",
-    "longest_side": "23 cm",
-    "to_hit": -2,
-    "pocket_data": [
-      {
-        "max_contains_volume": "2 L",
-        "max_contains_weight": "1 kg",
-        "watertight": true,
-        "open_container": true,
-        "rigid": true
-      }
-    ],
-    "melee_damage": { "bash": 6 }
+    "longest_side": "23 cm"
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I saw that the aluminum pot didn't copy it's sprite from the other pot. Then I went down the rabbithole and improved on their JSON a little.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changed the aluminum pot and pan to copy from their steel and cast iron counterparts respectively. This allowed to shorten the JSON a little, while also negating the weirdness of max weight for these items (they couldn't be filled to the brim with water), handling their ``to-hit`` better and making them copy the sprites of their counterparts.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
