### PR TITLE
Rabbits 2: Oh god they zoomin

### DIFF
--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -2477,8 +2477,8 @@
     "volume": "5 L",
     "weight": "2 kg",
     "hp": 8,
-    "speed": 666,
-    "attack_cost": 666,
+    "speed": 300,
+    "attack_cost": 300,
     "material": [ "flesh" ],
     "symbol": "r",
     "color": "brown",
@@ -2492,7 +2492,17 @@
     "families": [ "prof_intro_biology" ],
     "fear_triggers": [ "SOUND", "PLAYER_CLOSE" ],
     "petfood": { "food": [ "CATTLEFOOD" ], "feed": "The %s seems to like you!  It lets you pat its head and seems friendly." },
-    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "PET_WONT_FOLLOW", "WARM", "CAN_BE_CULLED" ]
+    "flags": [
+      "SEES",
+      "HEARS",
+      "SMELLS",
+      "ANIMAL",
+      "PATH_AVOID_DANGER_1",
+      "PET_WONT_FOLLOW",
+      "WARM",
+      "CAN_BE_CULLED",
+      "GOODHEARING"
+    ]
   },
   {
     "id": "mon_rabbit_baby",
@@ -2503,8 +2513,8 @@
     "volume": "150 ml",
     "weight": "30 g",
     "hp": 1,
-    "speed": 175,
-    "attack_cost": 175,
+    "speed": 125,
+    "attack_cost": 125,
     "dodge": 8,
     "upgrades": { "age_grow": 45, "into": "mon_rabbit" },
     "delete": { "reproduction": { "baby_monster": "mon_rabbit_baby", "baby_count": 6, "baby_timer": 33 } },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Remember when in #68516 I said I wasn't sold on the speed stat?
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Lowered the speed of adult rabbits from 666 to 300, rabbit kits from 175 to 125 - this is roughly 50% of the accurate max speed for adults, but assuming that they're constantly running at full speed is kinda stupid
- Gave rabbits ``GOODHEARING``
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
- Lowering daylight vision, but I wanted it to be the same as turkeys and turkeys have it *higher* than rabbits already so I just didn't touch it
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
