### PR TITLE
Make roofs bashable again

### DIFF
--- a/data/json/furniture_and_terrain/terrain-roofs.json
+++ b/data/json/furniture_and_terrain/terrain-roofs.json
@@ -113,7 +113,7 @@
     "color": "dark_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": true }
+    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -125,7 +125,7 @@
     "color": "dark_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "FLAT" ],
-    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": true }
+    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -137,7 +137,7 @@
     "color": "green",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "FLAT" ],
-    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": true }
+    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -149,7 +149,7 @@
     "color": "yellow",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE" ],
-    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": true }
+    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -161,7 +161,7 @@
     "color": "light_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": true }
+    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -173,7 +173,7 @@
     "color": "white",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "FLAMMABLE" ],
-    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": true }
+    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -204,7 +204,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT" ],
-    "bash": { "str_min": 100, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": true }
+    "bash": { "str_min": 100, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -234,7 +234,7 @@
       "sound_vol": 8,
       "sound_fail_vol": 4,
       "ter_set": "t_hole",
-      "bash_below": true
+      "bash_below": false
     }
   },
   {
@@ -256,7 +256,7 @@
       "sound_vol": 15,
       "sound_fail_vol": 10,
       "ter_set": "t_hole",
-      "bash_below": true
+      "bash_below": false
     }
   },
   {
@@ -269,7 +269,7 @@
     "color": "dark_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 100, "str_max": 400, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": true }
+    "bash": { "str_min": 100, "str_max": 400, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -281,7 +281,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE", "FLAT" ],
-    "bash": { "str_min": 50, "str_max": 400, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": true }
+    "bash": { "str_min": 50, "str_max": 400, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -293,7 +293,7 @@
     "color": "brown",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE_HARD", "FLAT" ],
-    "bash": { "str_min": 50, "str_max": 400, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": true }
+    "bash": { "str_min": 50, "str_max": 400, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -305,7 +305,7 @@
     "color": "dark_gray",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 200, "str_max": 500, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": true }
+    "bash": { "str_min": 200, "str_max": 500, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -317,7 +317,7 @@
     "color": "green",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAMMABLE" ],
-    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": true }
+    "bash": { "str_min": 30, "str_max": 210, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": false }
   },
   {
     "type": "terrain",
@@ -328,6 +328,6 @@
     "color": "red",
     "move_cost": 2,
     "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
-    "bash": { "str_min": 48, "str_max": 80, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": true }
+    "bash": { "str_min": 48, "str_max": 80, "sound": "crash!", "sound_fail": "whump!", "ter_set": "t_hole", "bash_below": false }
   }
 ]


### PR DESCRIPTION


#### Summary
None


#### Purpose of change

Fixes #68527 

As per the issue mentioned above, i doubt the roofs are *that* tough to be exempt from being bashable, so i'm making it bashable.

#### Describe the solution
Turn the `bash_below` from `true` to `false` for the roofs in terrain-roofs.json

#### Describe alternatives you've considered

Not doing so and assume US solved roofing.

#### Testing

I applied the change as a mod and do as follows:

1. spawns in the roofs which present in the terrain-roofs.json on a roof.
2. give myself 9999 strength.
3. bash all the spawned in roofs.
4. they got bashed and becomes holes on the roof.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
