### PR TITLE
Show estimated time when washing items

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8394,6 +8394,8 @@ std::optional<int> iuse::wash_items( Character *p, bool soft_items, bool hard_it
             total_volume += pair.first->volume( false, true, pair.second );
         }
         washing_requirements required = washing_requirements_for_volume( total_volume );
+        const std::string time = colorize( to_string( time_duration::from_moves( required.time ), true ),
+                                           c_light_gray );
         auto to_string = []( int val ) -> std::string {
             if( val == INT_MAX )
             {
@@ -8401,10 +8403,15 @@ std::optional<int> iuse::wash_items( Character *p, bool soft_items, bool hard_it
             }
             return string_format( "%3d", val );
         };
+        const std::string water = string_join( display_stat( "", required.water, available_water,
+                                               to_string ), "" );
+        const std::string cleanser = string_join( display_stat( "", required.cleanser, available_cleanser,
+                                     to_string ), "" );
         using stats = inventory_selector::stats;
         return stats{{
-                display_stat( _( "Water" ), required.water, available_water, to_string ),
-                display_stat( _( "Cleanser" ), required.cleanser, available_cleanser, to_string )
+                {{ _( "Water" ), water }},
+                {{ _( "Cleanser" ), cleanser }},
+                {{ _( "Estimated time" ), time }}
             }};
     };
     inventory_multiselector inv_s( *p, preset, _( "ITEMS TO CLEAN" ),


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Show estimated time when washing items"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Updates the UI when washing items so that it displays an estimate of the duration it will take to wash the selected items.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

* The time displayed is only an estimate since actual time will also depend on other factors.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* Currently, this uses `to_string` to format the duration like `1hr 32min`. Since it's an estimate, maybe it would be better to use `to_string_clipped`  (`1 hour`) or `to_string_approx` (`less than 2 hours`) to format the duration.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Before:
![estimated-time-befor](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/ca583d7d-32e8-4362-81b7-455b96334079)

After:
![estimated-time-after](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/10e0d9e1-49b2-4709-bc70-24ef07a88b3d)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
