### PR TITLE
Baldric audit?

### DIFF
--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -31,7 +31,7 @@
   {
     "id": "baldric",
     "type": "ARMOR",
-    "name": { "str": "baldric" },
+    "name": { "str": "longsword scabbard" },
     "description": "A leather scabbard, big enough for anything up to a longsword, or even a bit larger than that.  Designed to be worn at the waist, secured to the sturdy leather belt.  Activate to sheath/draw a sword.",
     "weight": "1625 g",
     "volume": "2 L",

--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -106,7 +106,7 @@
     ],
     "use_action": { "type": "holster", "holster_prompt": "Sheath sword", "holster_msg": "You sheath your %s" },
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY", "STURDY" ],
-    "armor": [ { "encumbrance": [ 3 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ],
+    "armor": [ { "encumbrance": 2, "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ],
     "melee_damage": { "bash": 4 }
   },
   {

--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -32,7 +32,7 @@
     "id": "baldric",
     "type": "ARMOR",
     "name": { "str": "baldric" },
-    "description": "A leather scabbard, big enough for anything up to a longsword, or even a bit larger than that.  Designed to be worn at the waist, secured by a shoulder belt.  Activate to sheath/draw a sword.",
+    "description": "A leather scabbard, big enough for anything up to a longsword, or even a bit larger than that.  Designed to be worn at the waist, secured to the sturdy leather belt.  Activate to sheath/draw a sword.",
     "weight": "1625 g",
     "volume": "2 L",
     "price": 7500,
@@ -50,17 +50,8 @@
         "max_item_length": "130 cm",
         "moves": 30,
         "holster": true,
-        "flag_restriction": [ "SHEATH_SWORD" ]
-      },
-      {
-        "holster": true,
-        "max_contains_volume": "2000 ml",
-        "max_contains_weight": "1750 g",
-        "max_item_length": "70 cm",
-        "moves": 60,
-        "description": "Clipped directly to side of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ],
-        "transparent": true
+        "flag_restriction": [ "SHEATH_SWORD" ],
+        "volume_encumber_modifier": 0.25
       },
       {
         "holster": true,
@@ -114,8 +105,8 @@
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Sheath sword", "holster_msg": "You sheath your %s" },
-    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
-    "armor": [ { "encumbrance": [ 3, 5 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ],
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY", "STURDY" ],
+    "armor": [ { "encumbrance": [ 3 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ],
     "melee_damage": { "bash": 4 }
   },
   {

--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -32,9 +32,9 @@
     "id": "baldric",
     "type": "ARMOR",
     "name": { "str": "baldric" },
-    "description": "A leather scabbard, big enough for anything up to a longsword, or even a bit larger than that.  Designed to be worn at the waist, attached to belt.  Activate to sheath/draw a sword.",
-    "weight": "1475 g",
-    "volume": "1650 ml",
+    "description": "A leather scabbard, big enough for anything up to a longsword, or even a bit larger than that.  Designed to be worn at the waist, secured by a shoulder belt.  Activate to sheath/draw a sword.",
+    "weight": "1625 g",
+    "volume": "2 L",
     "price": 7500,
     "price_postapoc": 500,
     "material": [ "leather", "wood" ],
@@ -50,13 +50,72 @@
         "max_item_length": "130 cm",
         "moves": 30,
         "holster": true,
-        "flag_restriction": [ "SHEATH_SWORD" ],
-        "volume_encumber_modifier": 0.3
+        "flag_restriction": [ "SHEATH_SWORD" ]
+      },
+      {
+        "holster": true,
+        "max_contains_volume": "2000 ml",
+        "max_contains_weight": "1750 g",
+        "max_item_length": "70 cm",
+        "moves": 60,
+        "description": "Clipped directly to side of the belt.",
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
+      },
+      {
+        "holster": true,
+        "max_contains_volume": "2000 ml",
+        "max_contains_weight": "1750 g",
+        "max_item_length": "70 cm",
+        "moves": 60,
+        "description": "Clipped directly to side of the belt.",
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
+      },
+      {
+        "holster": true,
+        "max_contains_volume": "2000 ml",
+        "max_contains_weight": "1750 g",
+        "max_item_length": "70 cm",
+        "moves": 60,
+        "description": "Clipped directly to side of the belt.",
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
+      },
+      {
+        "holster": true,
+        "max_contains_volume": "2000 ml",
+        "max_contains_weight": "1750 g",
+        "max_item_length": "70 cm",
+        "moves": 60,
+        "description": "Clipped directly to side of the belt.",
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
+      },
+      {
+        "holster": true,
+        "max_contains_volume": "2000 ml",
+        "max_contains_weight": "1750 g",
+        "max_item_length": "70 cm",
+        "moves": 110,
+        "description": "Clipped directly to back of the belt.",
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
+      },
+      {
+        "holster": true,
+        "max_contains_volume": "2000 ml",
+        "max_contains_weight": "1750 g",
+        "max_item_length": "70 cm",
+        "moves": 110,
+        "description": "Clipped directly to back of the belt.",
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Sheath sword", "holster_msg": "You sheath your %s" },
-    "flags": [ "NONCONDUCTIVE", "BELTED", "OVERSIZE", "WATER_FRIENDLY", "BELT_CLIP", "CANT_WEAR" ],
-    "armor": [ { "encumbrance": 3, "coverage": 50, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ],
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
+    "armor": [ { "encumbrance": [ 3, 5 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ],
     "melee_damage": { "bash": 4 }
   },
   {

--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -52,78 +52,66 @@
         "holster": true,
         "flag_restriction": [ "SHEATH_SWORD" ]
       },
-	  {
-      "holster": true,
-      "max_contains_volume": "2000 ml",
-      "max_contains_weight": "1750 g",
-      "max_item_length": "70 cm",
-      "moves": 60,
-      "description": "Clipped directly to side of the belt.",
-      "flag_restriction": [
-        "BELT_CLIP"
-      ],
-      "transparent": true
-    },
-    {
-      "holster": true,
-      "max_contains_volume": "2000 ml",
-      "max_contains_weight": "1750 g",
-      "max_item_length": "70 cm",
-      "moves": 60,
-      "description": "Clipped directly to side of the belt.",
-      "flag_restriction": [
-        "BELT_CLIP"
-      ],
-      "transparent": true
-    },
-    {
-      "holster": true,
-      "max_contains_volume": "2000 ml",
-      "max_contains_weight": "1750 g",
-      "max_item_length": "70 cm",
-      "moves": 60,
-      "description": "Clipped directly to side of the belt.",
-      "flag_restriction": [
-        "BELT_CLIP"
-      ],
-      "transparent": true
-    },
-    {
-      "holster": true,
-      "max_contains_volume": "2000 ml",
-      "max_contains_weight": "1750 g",
-      "max_item_length": "70 cm",
-      "moves": 60,
-      "description": "Clipped directly to side of the belt.",
-      "flag_restriction": [
-        "BELT_CLIP"
-      ],
-      "transparent": true
-    },
-    {
-      "holster": true,
-      "max_contains_volume": "2000 ml",
-      "max_contains_weight": "1750 g",
-      "max_item_length": "70 cm",
-      "moves": 110,
-      "description": "Clipped directly to back of the belt.",
-      "flag_restriction": [
-        "BELT_CLIP"
-      ],
-      "transparent": true
-    },
-    {
-      "holster": true,
-      "max_contains_volume": "2000 ml",
-      "max_contains_weight": "1750 g",
-      "max_item_length": "70 cm",
-      "moves": 110,
-      "description": "Clipped directly to back of the belt.",
-      "flag_restriction": [
-        "BELT_CLIP"
-      ],
-      "transparent": true
-    }
+      {
+        "holster": true,
+        "max_contains_volume": "2000 ml",
+        "max_contains_weight": "1750 g",
+        "max_item_length": "70 cm",
+        "moves": 60,
+        "description": "Clipped directly to side of the belt.",
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
+      },
+      {
+        "holster": true,
+        "max_contains_volume": "2000 ml",
+        "max_contains_weight": "1750 g",
+        "max_item_length": "70 cm",
+        "moves": 60,
+        "description": "Clipped directly to side of the belt.",
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
+      },
+      {
+        "holster": true,
+        "max_contains_volume": "2000 ml",
+        "max_contains_weight": "1750 g",
+        "max_item_length": "70 cm",
+        "moves": 60,
+        "description": "Clipped directly to side of the belt.",
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
+      },
+      {
+        "holster": true,
+        "max_contains_volume": "2000 ml",
+        "max_contains_weight": "1750 g",
+        "max_item_length": "70 cm",
+        "moves": 60,
+        "description": "Clipped directly to side of the belt.",
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
+      },
+      {
+        "holster": true,
+        "max_contains_volume": "2000 ml",
+        "max_contains_weight": "1750 g",
+        "max_item_length": "70 cm",
+        "moves": 110,
+        "description": "Clipped directly to back of the belt.",
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
+      },
+      {
+        "holster": true,
+        "max_contains_volume": "2000 ml",
+        "max_contains_weight": "1750 g",
+        "max_item_length": "70 cm",
+        "moves": 110,
+        "description": "Clipped directly to back of the belt.",
+        "flag_restriction": [ "BELT_CLIP" ],
+        "transparent": true
+      }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Sheath sword", "holster_msg": "You sheath your %s" },
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],

--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -32,9 +32,9 @@
     "id": "baldric",
     "type": "ARMOR",
     "name": { "str": "baldric" },
-    "description": "A leather scabbard, big enough for anything up to a longsword, or even a bit larger than that.  Designed to be worn at the waist, secured by a shoulder belt.  Activate to sheath/draw a sword.",
-    "weight": "1625 g",
-    "volume": "2 L",
+    "description": "A leather scabbard, big enough for anything up to a longsword, or even a bit larger than that.  Designed to be worn at the waist, attached to belt.  Activate to sheath/draw a sword.",
+    "weight": "1475 g",
+    "volume": "1650 ml",
     "price": 7500,
     "price_postapoc": 500,
     "material": [ "leather", "wood" ],
@@ -50,72 +50,13 @@
         "max_item_length": "130 cm",
         "moves": 30,
         "holster": true,
-        "flag_restriction": [ "SHEATH_SWORD" ]
-      },
-      {
-        "holster": true,
-        "max_contains_volume": "2000 ml",
-        "max_contains_weight": "1750 g",
-        "max_item_length": "70 cm",
-        "moves": 60,
-        "description": "Clipped directly to side of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ],
-        "transparent": true
-      },
-      {
-        "holster": true,
-        "max_contains_volume": "2000 ml",
-        "max_contains_weight": "1750 g",
-        "max_item_length": "70 cm",
-        "moves": 60,
-        "description": "Clipped directly to side of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ],
-        "transparent": true
-      },
-      {
-        "holster": true,
-        "max_contains_volume": "2000 ml",
-        "max_contains_weight": "1750 g",
-        "max_item_length": "70 cm",
-        "moves": 60,
-        "description": "Clipped directly to side of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ],
-        "transparent": true
-      },
-      {
-        "holster": true,
-        "max_contains_volume": "2000 ml",
-        "max_contains_weight": "1750 g",
-        "max_item_length": "70 cm",
-        "moves": 60,
-        "description": "Clipped directly to side of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ],
-        "transparent": true
-      },
-      {
-        "holster": true,
-        "max_contains_volume": "2000 ml",
-        "max_contains_weight": "1750 g",
-        "max_item_length": "70 cm",
-        "moves": 110,
-        "description": "Clipped directly to back of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ],
-        "transparent": true
-      },
-      {
-        "holster": true,
-        "max_contains_volume": "2000 ml",
-        "max_contains_weight": "1750 g",
-        "max_item_length": "70 cm",
-        "moves": 110,
-        "description": "Clipped directly to back of the belt.",
-        "flag_restriction": [ "BELT_CLIP" ],
-        "transparent": true
+        "flag_restriction": [ "SHEATH_SWORD" ],
+        "volume_encumber_modifier": 0.3
       }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Sheath sword", "holster_msg": "You sheath your %s" },
-    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
-    "armor": [ { "encumbrance": [ 3, 5 ], "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ],
+    "flags": [ "NONCONDUCTIVE", "BELTED", "OVERSIZE", "WATER_FRIENDLY", "BELT_CLIP", "CANT_WEAR" ],
+    "armor": [ { "encumbrance": 3, "coverage": 50, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ],
     "melee_damage": { "bash": 4 }
   },
   {

--- a/data/json/items/armor/sheath.json
+++ b/data/json/items/armor/sheath.json
@@ -51,7 +51,79 @@
         "moves": 30,
         "holster": true,
         "flag_restriction": [ "SHEATH_SWORD" ]
-      }
+      },
+	  {
+      "holster": true,
+      "max_contains_volume": "2000 ml",
+      "max_contains_weight": "1750 g",
+      "max_item_length": "70 cm",
+      "moves": 60,
+      "description": "Clipped directly to side of the belt.",
+      "flag_restriction": [
+        "BELT_CLIP"
+      ],
+      "transparent": true
+    },
+    {
+      "holster": true,
+      "max_contains_volume": "2000 ml",
+      "max_contains_weight": "1750 g",
+      "max_item_length": "70 cm",
+      "moves": 60,
+      "description": "Clipped directly to side of the belt.",
+      "flag_restriction": [
+        "BELT_CLIP"
+      ],
+      "transparent": true
+    },
+    {
+      "holster": true,
+      "max_contains_volume": "2000 ml",
+      "max_contains_weight": "1750 g",
+      "max_item_length": "70 cm",
+      "moves": 60,
+      "description": "Clipped directly to side of the belt.",
+      "flag_restriction": [
+        "BELT_CLIP"
+      ],
+      "transparent": true
+    },
+    {
+      "holster": true,
+      "max_contains_volume": "2000 ml",
+      "max_contains_weight": "1750 g",
+      "max_item_length": "70 cm",
+      "moves": 60,
+      "description": "Clipped directly to side of the belt.",
+      "flag_restriction": [
+        "BELT_CLIP"
+      ],
+      "transparent": true
+    },
+    {
+      "holster": true,
+      "max_contains_volume": "2000 ml",
+      "max_contains_weight": "1750 g",
+      "max_item_length": "70 cm",
+      "moves": 110,
+      "description": "Clipped directly to back of the belt.",
+      "flag_restriction": [
+        "BELT_CLIP"
+      ],
+      "transparent": true
+    },
+    {
+      "holster": true,
+      "max_contains_volume": "2000 ml",
+      "max_contains_weight": "1750 g",
+      "max_item_length": "70 cm",
+      "moves": 110,
+      "description": "Clipped directly to back of the belt.",
+      "flag_restriction": [
+        "BELT_CLIP"
+      ],
+      "transparent": true
+    }
     ],
     "use_action": { "type": "holster", "holster_prompt": "Sheath sword", "holster_msg": "You sheath your %s" },
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -2614,6 +2614,7 @@ sawblade
 sawblades
 sawteeth
 sayig
+scabbards
 scalable
 scatterer
 schippe


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Baldric description doesn't match with how it is represented in game"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Baldrics turn out to be pretty confusing. The actual baldrics supposed to be worn like this
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/112878543/a218ac88-5a6b-4232-9edc-d5568a58dd21)
In game tho, the cover the entire waist like a belt, which is wierd, becouse, as you can see even on this picture, you can wear one without problems. Another way to carry longsword is by using scabbards like this
https://www.youtube.com/watch?app=desktop&v=A2OeMstdna0&ab_channel=Tod%27sWorkshop
It is better match to the baldrics we currently have, so i think I'll just tweak the name and description accordingly
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fix description and name and make it have additional attachment points like all belts. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I guess adding an actual baldric as well, but probably not in this pr
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Works fine
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
