### PR TITLE
Professions can start with multiple martial arts

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3920,7 +3920,25 @@
     "name": "Martial Artist",
     "description": "'Drop the martial arts!', they said.  'Learn a skill for the REAL world!', they said.  Well, you're about to show them!  SHOW THEM ALL!",
     "points": 3,
-    "traits": [ "PROF_MA_ORANGE" ],
+    "starting_styles_choices": [
+      "style_aikido",
+      "style_capoeira",
+      "style_crane",
+      "style_dragon",
+      "style_judo",
+      "style_karate",
+      "style_krav_maga",
+      "style_leopard",
+      "style_muay_thai",
+      "style_ninjutsu",
+      "style_pankration",
+      "style_snake",
+      "style_taekwondo",
+      "style_tai_chi",
+      "style_tiger",
+      "style_wingchun",
+      "style_zui_quan"
+    ],
     "skills": [
       { "level": 4, "name": "melee" },
       { "level": 4, "name": "unarmed" },
@@ -3940,7 +3958,25 @@
     "name": "Black Belt",
     "description": "As the world ends, you alone stand against the coming darkness with your fists of steel.",
     "points": 8,
-    "traits": [ "PROF_MA_BLACK" ],
+    "starting_styles_choices": [
+      "style_aikido",
+      "style_capoeira",
+      "style_crane",
+      "style_dragon",
+      "style_judo",
+      "style_karate",
+      "style_krav_maga",
+      "style_leopard",
+      "style_muay_thai",
+      "style_ninjutsu",
+      "style_pankration",
+      "style_snake",
+      "style_taekwondo",
+      "style_tai_chi",
+      "style_tiger",
+      "style_wingchun",
+      "style_zui_quan"
+    ],
     "skills": [
       { "level": 8, "name": "melee" },
       { "level": 8, "name": "unarmed" },
@@ -4893,7 +4929,7 @@
       { "level": 6, "name": "dodge" },
       { "level": 4, "name": "swimming" }
     ],
-    "traits": [ "MARTIAL_FENCING" ],
+    "starting_styles": [ "style_fencing" ],
     "items": {
       "both": {
         "items": [

--- a/data/mods/MMA/professions.json
+++ b/data/mods/MMA/professions.json
@@ -5,7 +5,7 @@
     "name": "Battle Angel",
     "description": "A combat-ready cyborg once salvaged from an obscure junkyard…",
     "points": 8,
-    "traits": [ "MMA_MARTIAL_ARTS_PANZER" ],
+    "starting_styles": [ "style_mma_panzer" ],
     "skills": [ { "level": 3, "name": "unarmed" }, { "level": 3, "name": "melee" }, { "level": 1, "name": "dodge" } ],
     "items": { "both": { "items": [ "wetsuit", "trenchcoat", "gloves_fingerless", "knee_pads", "boots" ] } },
     "CBMs": [
@@ -24,7 +24,8 @@
     "name": "Hylian Adventurer",
     "description": "Sucked through a vortex into what appears to be a shadow realm, you will continue to fight for justice.",
     "points": 6,
-    "traits": [ "MMA_MARTIAL_ARTS_HYLIAN", "ELFAEYES", "ELFA_EARS" ],
+    "traits": [ "ELFAEYES", "ELFA_EARS" ],
+    "starting_styles": [ "style_mma_hylian" ],
     "skills": [ { "level": 3, "name": "cutting" }, { "level": 3, "name": "melee" }, { "level": 1, "name": "dodge" } ],
     "items": {
       "both": {

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -262,6 +262,10 @@ void profession::load( const JsonObject &jo, const std::string_view )
               string_id_reader<::mutation_branch> {} );
     optional( jo, was_loaded, "flags", flags, auto_flags_reader<> {} );
 
+    optional( jo, was_loaded, "starting_styles", _starting_martialarts );
+    optional( jo, was_loaded, "starting_styles_choices", _starting_martialarts_choices );
+    optional( jo, was_loaded, "starting_styles_choices_amount", ma_choice_amount, 1 );
+
     // Flag which denotes if a profession is a hobby
     optional( jo, was_loaded, "subtype", _subtype, "" );
     optional( jo, was_loaded, "missions", _missions, string_id_reader<::mission_type> {} );
@@ -547,6 +551,16 @@ std::vector<bionic_id> profession::CBMs() const
 std::vector<proficiency_id> profession::proficiencies() const
 {
     return _starting_proficiencies;
+}
+
+std::vector<matype_id> profession::ma_known() const
+{
+    return _starting_martialarts;
+}
+
+std::vector<matype_id> profession::ma_choices() const
+{
+    return _starting_martialarts_choices;
 }
 
 std::vector<trait_and_var> profession::get_locked_traits() const

--- a/src/profession.h
+++ b/src/profession.h
@@ -72,6 +72,8 @@ class profession
         std::vector<bionic_id> _starting_CBMs;
         std::vector<proficiency_id> _starting_proficiencies;
         std::vector<trait_and_var> _starting_traits;
+        std::vector<matype_id> _starting_martialarts;
+        std::vector<matype_id> _starting_martialarts_choices;
         std::set<trait_id> _forbidden_traits;
         std::vector<mtype_id> _starting_pets;
         vproto_id _starting_vehicle = vproto_id::NULL_ID();
@@ -117,6 +119,9 @@ class profession
         std::vector<mtype_id> pets() const;
         std::vector<bionic_id> CBMs() const;
         std::vector<proficiency_id> proficiencies() const;
+        std::vector<matype_id> ma_known() const;
+        std::vector<matype_id> ma_choices() const;
+        int ma_choice_amount;
         StartingSkillList skills() const;
         const std::vector<mission_type_id> &missions() const;
         int age_lower = 21;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Professions can start with multiple martial arts"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Professions can start with multiple martial arts and no longer need style traits

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

The parameters for professions.json definitions has been updated to allow martial arts to be assigned to a profession directly. This means that profession no longer need a special feat to assign them a martial art or offer a choice of a martial arts to the player at chargen. 

This update adds the following fields to the profession definitions:
**starting_styles** - Profession automatically learns all listed martial at the start of the game. The values used in this field are the style ids ("style_fencing") but these will be displayed in-game as the actual names of the styles. This field is optional and blank by default meaning that the profession does not know any martial art styles.

**starting_styles_choices** - Offers the player a choice of the listed martial arts in the same vain as the martial arts traits. The values used in this field are the style ids ("style_fencing") but these will be displayed in-game as the actual names of the styles. This field is optional and blank by default meaning that the profession does not know any martial art styles and the player will not be offered any choices from the profession.

**starting_styles_choices_amount** - Indicates how many martial arts from the starting_styles_choices list will be learned. This is done by repeatedly showing the "learn style" menu with previously selected choices removed. By default this parameter is 1, meaning a single style from starting_styles_choices (if any) will be learned. If this parameter is 0 or less, the player will not learn any martial arts from the profession. If this parameter is greater than the number of styles in starting_styles_choices, the player will learn all styles in the list (chosen one at a time) until all styles are known before starting the game.

In addition, the professions Competitive Fencer, Martial Artist, and Black Belt have been updated to use these new parameter while removing their martial arts enabling traits.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Currently, players will begin the game using a random style from their known styles. This can cause some oddities such as being in an unarmed only style while holding a weapon if they know a martial art from a different source (i.e. background) but this is easily fixed by changing styles to something else. Creating a method to select a random martial art based off of a held item (if any) is complex, might not be doable at chargen, and starts veering outside of the scope of this PR. Better to revisit it at a later time.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

1. New section of the profession summary and available martial arts for profession can be in the profession section of the chargen screen.
2. Creating a Competitive Fencer will start with Fencing known.
3. Creating a Martial Artist or Black Belt will offer you a choice of styles as normal. Added **starting_styles_choices_amount = 3,** to either profession in profession.json will allow you to select three styles instead.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

New "Profession Martial Arts" section in profession section of chargen:
![CDDA1](https://github.com/CleverRaven/Cataclysm-DDA/assets/11396600/498a756f-360a-42a7-8e22-d2eab9f24c85)

Competitive Fencer with a "known" style:
![CDDA2](https://github.com/CleverRaven/Cataclysm-DDA/assets/11396600/48b56e16-8e5b-4811-90c5-f801592ddbb6)

Black Belt with a "choice" of styles:
![CDDA3](https://github.com/CleverRaven/Cataclysm-DDA/assets/11396600/6862ecf6-8681-4cca-963c-82498c76ba7b)

A "what if" example of Survivor with "known" style and "choice" styles:
![CDDA4](https://github.com/CleverRaven/Cataclysm-DDA/assets/11396600/b755a641-4927-44a9-aa82-27a75e8d1acf)

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
