### PR TITLE
[EoC] Simple if-else statement

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -130,7 +130,13 @@
         "then": { "u_message": "You have variable." },
         "else": [
           { "u_message": "You don't have variable." },
-          { "u_add_var": "test", "type": "eoc_sample", "context": "if_else", "value": "yes" }
+          {
+            "if": { "not": { "u_has_var": "test", "type": "eoc_sample", "context": "if_else", "value": "yes" } },
+            "then": [
+              { "u_add_var": "test", "type": "eoc_sample", "context": "if_else", "value": "yes" },
+              { "u_message": "Vriable added." }
+            ]
+          }
         ]
       }
     ]

--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -120,5 +120,19 @@
       { "math": [ "u_volume_test", "=", "n_val('volume')" ] },
       { "u_message": "<npc_name> weight: <u_val:weight_test> volume: <u_val:volume_test>" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_if_else_test",
+    "effect": [
+      {
+        "if": { "u_has_var": "test", "type": "eoc_sample", "context": "if_else", "value": "yes" },
+        "then": { "u_message": "You have variable." },
+        "else": [
+          { "u_message": "You don't have variable." },
+          { "u_add_var": "test", "type": "eoc_sample", "context": "if_else", "value": "yes" }
+        ]
+      }
+    ]
   }
 ]

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1481,6 +1481,15 @@ Replace text in `place_name` variable with one of 5 string, picked randomly; fur
 ```
 
 
+#### `if`
+Set effects to be executed when conditions are met and when conditions are not met.
+
+| Syntax | Optionality | Value  | Info |
+| --- | --- | --- | --- | 
+| "if" | **mandatory** | [dialogue condition](#dialogue-conditions) | condition itself | 
+| "then" | **mandatory** | effect | Effect(s) executed when conditions are met. | 
+| "else" | optional | effect | Effect(s) executed when conditions are not met. | 
+
 #### `set_condition`
 Create a context value with condition, that you can pass down the next topic or EoC, using `get_condition`. Used, if you need to have dozens of EoCs, and you don't want to copy-paste it's conditions every time (also it's easier to maintain or edit one condition, comparing to two dozens)
 

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1490,6 +1490,32 @@ Set effects to be executed when conditions are met and when conditions are not m
 | "then" | **mandatory** | effect | Effect(s) executed when conditions are met. | 
 | "else" | optional | effect | Effect(s) executed when conditions are not met. | 
 
+##### Valid talkers:
+
+| Avatar | Character | NPC | Monster |  Furniture | Item |
+| ------ | --------- | --------- | ---- | ------- | --- | 
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+
+##### Examples
+Displays a different message the first time it is run and the second time onwards
+```json
+{
+  "if": { "u_has_var": "test", "type": "eoc_sample", "context": "if_else", "value": "yes" },
+  "then": { "u_message": "You have variable." },
+  "else": [
+    { "u_message": "You don't have variable." },
+    {
+      "if": { "not": { "u_has_var": "test", "type": "eoc_sample", "context": "if_else", "value": "yes" } },
+      "then": [
+        { "u_add_var": "test", "type": "eoc_sample", "context": "if_else", "value": "yes" },
+        { "u_message": "Vriable added." }
+      ]
+    }
+  ]
+}
+```
+
+
 #### `set_condition`
 Create a context value with condition, that you can pass down the next topic or EoC, using `get_condition`. Used, if you need to have dozens of EoCs, and you don't want to copy-paste it's conditions every time (also it's easier to maintain or edit one condition, comparing to two dozens)
 

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -58,6 +58,7 @@ struct talk_effect_fun_t {
         void set_run_inv_eocs( const JsonObject &jo, std::string_view member, bool is_npc );
         void set_queue_eocs( const JsonObject &jo, std::string_view member );
         void set_queue_eoc_with( const JsonObject &jo, std::string_view member );
+        void set_if( const JsonObject &jo, std::string_view member );
         void set_switch( const JsonObject &jo, std::string_view member );
         void set_roll_remainder( const JsonObject &jo, std::string_view member, bool is_npc );
         void set_weighted_list_eocs( const JsonObject &jo, std::string_view member );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5623,7 +5623,7 @@ parsers = {
     { "queue_eocs", jarg::member | jarg::array, &talk_effect_fun_t::set_queue_eocs },
     { "queue_eoc_with", jarg::member, &talk_effect_fun_t::set_queue_eoc_with },
     { "weighted_list_eocs", jarg::array, &talk_effect_fun_t::set_weighted_list_eocs },
-    { "if", jarg::member | jarg::array, &talk_effect_fun_t::set_if },
+    { "if", jarg::member, &talk_effect_fun_t::set_if },
     { "switch", jarg::member, &talk_effect_fun_t::set_switch },
     { "math", jarg::array, &talk_effect_fun_t::set_math },
     { "custom_light_level", jarg::member | jarg::array, &talk_effect_fun_t::set_custom_light_level },

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4921,7 +4921,9 @@ void talk_effect_fun_t::set_if( const JsonObject &jo, std::string_view member )
     talk_effect_t else_effect;
     read_condition( jo, std::string( member ), cond, false );
     then_effect.load_effect( jo, "then" );
-    else_effect.load_effect( jo, "else" );
+    if( jo.has_member( "else" ) || jo.has_array( "else" ) ) {
+        else_effect.load_effect( jo, "else" );
+    }
 
     function = [cond, then_effect, else_effect]( dialogue & d ) {
         if( cond( d ) ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4914,6 +4914,24 @@ void talk_effect_fun_t::set_weighted_list_eocs( const JsonObject &jo,
     };
 }
 
+void talk_effect_fun_t::set_if( const JsonObject &jo, std::string_view member )
+{
+    std::function<bool( dialogue & )> cond;
+    talk_effect_t then_effect;
+    talk_effect_t else_effect;
+    read_condition( jo, std::string( member ), cond, false );
+    then_effect.load_effect( jo, "then" );
+    else_effect.load_effect( jo, "else" );
+
+    function = [cond, then_effect, else_effect]( dialogue & d ) {
+        if( cond( d ) ) {
+            then_effect.apply( d );
+        } else {
+            else_effect.apply( d );
+        }
+    };
+}
+
 void talk_effect_fun_t::set_switch( const JsonObject &jo, std::string_view member )
 {
     std::function<double( dialogue &/* d */ )> eoc_switch = jo.has_string( member ) ?
@@ -5603,6 +5621,7 @@ parsers = {
     { "queue_eocs", jarg::member | jarg::array, &talk_effect_fun_t::set_queue_eocs },
     { "queue_eoc_with", jarg::member, &talk_effect_fun_t::set_queue_eoc_with },
     { "weighted_list_eocs", jarg::array, &talk_effect_fun_t::set_weighted_list_eocs },
+    { "if", jarg::member | jarg::array, &talk_effect_fun_t::set_if },
     { "switch", jarg::member, &talk_effect_fun_t::set_switch },
     { "math", jarg::array, &talk_effect_fun_t::set_math },
     { "custom_light_level", jarg::member | jarg::array, &talk_effect_fun_t::set_custom_light_level },


### PR DESCRIPTION
#### Summary
Infrastructure "[EoC] Simple if-else statement"

#### Purpose of change
EoC has switch statement but no if-else statement. 
`run_eocs` is an alternative, but it has the problems of being verbose and reducing the transparency of the function.

#### Describe the solution
Add simple if-else statement.

Old syntax
```
      {
        "run_eocs": {
          "id": "EOC_test_nested",
          "condition": { "u_has_var": "test", "type": "eoc_sample", "context": "if_else", "value": "yes" },
          "effect": { "u_message": "You have variable." },
          "false_effect": [
            { "u_message": "You don't have variable." },
            {
              "run_eocs": {
                "id": "EOC_test_nested_2",
                "condition": { "not": { "u_has_var": "test", "type": "eoc_sample", "context": "if_else", "value": "yes" } },
                "effect": [
                  { "u_add_var": "test", "type": "eoc_sample", "context": "if_else", "value": "yes" },
                  { "u_message": "Vriable added." }
                ]
              }
            }
          ]
        }
      }
```

New syntax
```
      {
        "if": { "u_has_var": "test", "type": "eoc_sample", "context": "if_else", "value": "yes" },
        "then": { "u_message": "You have variable." },
        "else": [
          { "u_message": "You don't have variable." },
          {
            "if": { "not": { "u_has_var": "test", "type": "eoc_sample", "context": "if_else", "value": "yes" } },
            "then": [
              { "u_add_var": "test", "type": "eoc_sample", "context": "if_else", "value": "yes" },
              { "u_message": "Vriable added." }
            ]
          }
        ]
      }
```
#### Describe alternatives you've considered

#### Testing
Add simple test to example_eocs.json and works collectly.

#### Additional context
