### PR TITLE
[MoM] Allow use of psionics to train Metaphysics

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
@@ -108,14 +108,6 @@
         }
       ]
     },
-    "effect": [ { "run_eocs": "EOC_METAPHYSICS_EXP_BOOST" } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_METAPHYSICS_EXP_BOOST",
-    "condition": {
-      "u_has_any_trait": [ "BIOKINETIC", "CLAIRSENTIENT", "PYROKINETIC", "TELEKINETIC", "TELEPATH", "TELEPORTER", "VITAKINETIC" ]
-    },
     "effect": [ { "math": [ "u_skill_exp('metaphysics', 'raw')", "+=", "250" ] } ]
   }
 ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
@@ -87,60 +87,27 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_BIOKINESIS_METAPHYSICS_SKILL_EXP",
-    "eoc_type": "EVENT",
-    "required_event": "spellcasting_finish",
-    "condition": { "and": [ { "u_has_trait": "BIOKINETIC" }, { "compare_string": [ "BIOKINETIC", { "context_val": "school" } ] } ] },
-    "effect": [ { "run_eocs": "EOC_METAPHYSICS_EXP_BOOST" } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_CLAIRSENTIENCE_METAPHYSICS_SKILL_EXP",
+    "id": "EOC_PSIONICS_METAPHYSICS_SKILL_EXP",
     "eoc_type": "EVENT",
     "required_event": "spellcasting_finish",
     "condition": {
-      "and": [ { "u_has_trait": "CLAIRSENTIENT" }, { "compare_string": [ "CLAIRSENTIENT", { "context_val": "school" } ] } ]
+      "and": [
+        {
+          "u_has_any_trait": [ "BIOKINETIC", "CLAIRSENTIENT", "PYROKINETIC", "TELEKINETIC", "TELEPATH", "TELEPORTER", "VITAKINETIC" ]
+        },
+        {
+          "or": [
+            { "compare_string": [ "BIOKINETIC", { "context_val": "school" } ] },
+            { "compare_string": [ "CLAIRSENTIENT", { "context_val": "school" } ] },
+            { "compare_string": [ "PYROKINETIC", { "context_val": "school" } ] },
+            { "compare_string": [ "TELEKINETIC", { "context_val": "school" } ] },
+            { "compare_string": [ "TELEPATH", { "context_val": "school" } ] },
+            { "compare_string": [ "TELEPORTER", { "context_val": "school" } ] },
+            { "compare_string": [ "VITAKINETIC", { "context_val": "school" } ] }
+          ]
+        }
+      ]
     },
-    "effect": [ { "run_eocs": "EOC_METAPHYSICS_EXP_BOOST" } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_PYROKINESIS_METAPHYSICS_SKILL_EXP",
-    "eoc_type": "EVENT",
-    "required_event": "spellcasting_finish",
-    "condition": { "and": [ { "u_has_trait": "PYROKINETIC" }, { "compare_string": [ "PYROKINETIC", { "context_val": "school" } ] } ] },
-    "effect": [ { "run_eocs": "EOC_METAPHYSICS_EXP_BOOST" } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_TELEKINESIS_METAPHYSICS_SKILL_EXP",
-    "eoc_type": "EVENT",
-    "required_event": "spellcasting_finish",
-    "condition": { "and": [ { "u_has_trait": "TELEKINETIC" }, { "compare_string": [ "TELEKINETIC", { "context_val": "school" } ] } ] },
-    "effect": [ { "run_eocs": "EOC_METAPHYSICS_EXP_BOOST" } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_TELEPATHY_METAPHYSICS_SKILL_EXP",
-    "eoc_type": "EVENT",
-    "required_event": "spellcasting_finish",
-    "condition": { "and": [ { "u_has_trait": "TELEPATH" }, { "compare_string": [ "TELEPATH", { "context_val": "school" } ] } ] },
-    "effect": [ { "run_eocs": "EOC_METAPHYSICS_EXP_BOOST" } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_TELEPORTATION_METAPHYSICS_SKILL_EXP",
-    "eoc_type": "EVENT",
-    "required_event": "spellcasting_finish",
-    "condition": { "and": [ { "u_has_trait": "TELEPORTER" }, { "compare_string": [ "TELEPORTER", { "context_val": "school" } ] } ] },
-    "effect": [ { "run_eocs": "EOC_METAPHYSICS_EXP_BOOST" } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_VITAKINESIS_METAPHYSICS_SKILL_EXP",
-    "eoc_type": "EVENT",
-    "required_event": "spellcasting_finish",
-    "condition": { "and": [ { "u_has_trait": "VITAKINETIC" }, { "compare_string": [ "VITAKINETIC", { "context_val": "school" } ] } ] },
     "effect": [ { "run_eocs": "EOC_METAPHYSICS_EXP_BOOST" } ]
   },
   {
@@ -149,6 +116,6 @@
     "condition": {
       "u_has_any_trait": [ "BIOKINETIC", "CLAIRSENTIENT", "PYROKINETIC", "TELEKINETIC", "TELEPATH", "TELEPORTER", "VITAKINETIC" ]
     },
-    "effect": [ { "math": [ "u_skill_exp('metaphysics', 'raw')", "+=", "10" ] } ]
+    "effect": [ { "math": [ "u_skill_exp('metaphysics', 'raw')", "+=", "250" ] } ]
   }
 ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
@@ -84,5 +84,71 @@
     "recurrence": [ "20 hours", "28 hours" ],
     "condition": { "math": [ "telepathically_stole_recently", ">=", "1" ] },
     "effect": [ { "math": [ "telepathically_stole_recently", "=", "0" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_BIOKINESIS_METAPHYSICS_SKILL_EXP",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": { "and": [ { "u_has_trait": "BIOKINETIC" }, { "compare_string": [ "BIOKINETIC", { "context_val": "school" } ] } ] },
+    "effect": [ { "run_eocs": "EOC_METAPHYSICS_EXP_BOOST" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CLAIRSENTIENCE_METAPHYSICS_SKILL_EXP",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": {
+      "and": [ { "u_has_trait": "CLAIRSENTIENT" }, { "compare_string": [ "CLAIRSENTIENT", { "context_val": "school" } ] } ]
+    },
+    "effect": [ { "run_eocs": "EOC_METAPHYSICS_EXP_BOOST" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PYROKINESIS_METAPHYSICS_SKILL_EXP",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": { "and": [ { "u_has_trait": "PYROKINETIC" }, { "compare_string": [ "PYROKINETIC", { "context_val": "school" } ] } ] },
+    "effect": [ { "run_eocs": "EOC_METAPHYSICS_EXP_BOOST" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEKINESIS_METAPHYSICS_SKILL_EXP",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": { "and": [ { "u_has_trait": "TELEKINETIC" }, { "compare_string": [ "TELEKINETIC", { "context_val": "school" } ] } ] },
+    "effect": [ { "run_eocs": "EOC_METAPHYSICS_EXP_BOOST" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEPATHY_METAPHYSICS_SKILL_EXP",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": { "and": [ { "u_has_trait": "TELEPATH" }, { "compare_string": [ "TELEPATH", { "context_val": "school" } ] } ] },
+    "effect": [ { "run_eocs": "EOC_METAPHYSICS_EXP_BOOST" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_TELEPORTATION_METAPHYSICS_SKILL_EXP",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": { "and": [ { "u_has_trait": "TELEPORTER" }, { "compare_string": [ "TELEPORTER", { "context_val": "school" } ] } ] },
+    "effect": [ { "run_eocs": "EOC_METAPHYSICS_EXP_BOOST" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VITAKINESIS_METAPHYSICS_SKILL_EXP",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": { "and": [ { "u_has_trait": "VITAKINETIC" }, { "compare_string": [ "VITAKINETIC", { "context_val": "school" } ] } ] },
+    "effect": [ { "run_eocs": "EOC_METAPHYSICS_EXP_BOOST" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_METAPHYSICS_EXP_BOOST",
+    "condition": {
+      "u_has_any_trait": [ "BIOKINETIC", "CLAIRSENTIENT", "PYROKINETIC", "TELEKINETIC", "TELEPATH", "TELEPORTER", "VITAKINETIC" ]
+    },
+    "effect": [ { "math": [ "u_skill_exp('metaphysics', 'raw')", "+=", "10" ] } ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Allow use of psionics to train Metaphysics"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Spellcraft was created before the theoretical/practical skill split and was conceived of as theoretical knowledge of magic, which is why casting spells doesn't train it. But that doesn't apply to all forms of supernatural power. Using psionics is pretty much the only way to train them and the game should reflect that.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add an EoC that runs for the spellcasting_finish event. It checks to make sure that it's a psionic power, and that the user is a awakened psion, and if so, trains metaphysics slightly.

At the moment this is a flat amount. If/when the spellcasting_finish event is modified to take spell difficulty into account, I can scale it based on power difficulty.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
