### PR TITLE
Improve monster reaction to player theft

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1392,7 +1392,8 @@ void monster::witness_thievery( item *it )
         anger = 100;
         return;
     }
-    random_entry( friends )->witness_thievery( it );
+    std::sort( friends.begin(), friends.end(), npc::theft_witness_compare );
+    friends[0]->witness_thievery( it );
 }
 
 bool monster::is_fleeing( Character &u ) const

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3699,6 +3699,26 @@ void npc::set_attitude( npc_attitude new_attitude )
     attitude = new_attitude;
 }
 
+bool npc::theft_witness_compare( const npc *lhs, const npc *rhs )
+{
+    const auto class_score = []( const npc * const guy ) {
+        // Apparently a guard?
+        if( guy->myclass == NC_BOUNTY_HUNTER ) {
+            return 0;
+            // If the guard? doesn't notice, the shopkeep will complain
+            // Because they're probably the person who you have to talk to
+            // and so will ensure the theft is noticed
+        } else if( guy->mission == NPC_MISSION_SHOPKEEP ) {
+            return 1;
+            // Patrolling NPCs more likely to notice/be guards?
+        } else if( guy->mission == NPC_MISSION_GUARD_PATROL ) {
+            return 2;
+        }
+        return 3;
+    };
+    return class_score( lhs ) < class_score( rhs );
+}
+
 npc_follower_rules::npc_follower_rules()
 {
     engagement = combat_engagement::CLOSE;

--- a/src/npc.h
+++ b/src/npc.h
@@ -1378,6 +1378,10 @@ class npc : public Character
 
         void set_known_to_u( bool known );
 
+        // Comparator between two NPCs as to who is a better person to respond
+        // to a theft being witnessed
+        static bool theft_witness_compare( const npc *lhs, const npc *rhs );
+
         /// Set up (start) a companion mission.
         void set_companion_mission( npc &p, const mission_id &miss_id );
         void set_companion_mission( const tripoint_abs_omt &omt_pos, const std::string &role_id,


### PR DESCRIPTION
#### Summary
Bugfixes "Ensure Rubik responds to item theft, instead of Luliya"

#### Purpose of change
Restore NPCs who see theft saying something about seeing theft.
Make the order of who responds to theft make a bit more sense.

#### Describe the solution
Sort the arrays of witnesses based on some criteria (monsters/npc, difficulty if monster, mission/class if npc), and pick the best candidate.

The following behavior results:

1. If only monsters see, the most dangerous monster will respond to the theft
2. If any NPC sees, they will respond before a monster does
3. If multiple NPCs see, the most suitable one will respond. NC_BOUNTY_HUNTER (guards?) respond first, then shopkeepers, then NPCs with a patrol route, then any NPC.
4. When monsters alert NPCs, they use the same logic in picking who to alert

Shopkeepers are high in the response list because they're often in visible places or the NPC you will interact with the most, ensuring that the theft will receive a response.

#### Describe alternatives you've considered
More nuanced sorting behavior. This seems sufficient.

#### Testing
Go to the exodii faction base and steal some stuff in front of a monster. Rubik is always alerted, and Luliya is never alerted. Debug kill all NPCs. When stealing in front of a quad, a worker, and a turret, the quad becomes aggressive. When stealing in front of a worker and a turret, the worker becomes aggressive.