### PR TITLE
Better Gas masks - Model concentration better, and make gas mask cartiges last longer 

### DIFF
--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -336,7 +336,7 @@
         "color": "white",
         "dangerous": true,
         "translucency": 0.1,
-        "concentration:": 1,
+        "concentration": 1,
         "convection_temperature_mod": -10,
         "effects": [
           {
@@ -356,7 +356,7 @@
         "color": "white",
         "convection_temperature_mod": -20,
         "translucency": 0.4,
-        "concentration:": 2,
+        "concentration": 2,
         "effects": [
           {
             "effect_id": "poison",
@@ -375,7 +375,7 @@
         "color": "white",
         "convection_temperature_mod": -30,
         "translucency": 0.7,
-        "concentration:": 4,
+        "concentration": 4,
         "effects": [
           {
             "effect_id": "poison",
@@ -455,7 +455,7 @@
         "sym": "8",
         "dangerous": true,
         "translucency": 1,
-        "concentration:": 1,
+        "concentration": 1,
         "effects": [
           {
             "effect_id": "smoke_eyes",
@@ -482,7 +482,7 @@
         "color": "light_gray",
         "transparent": false,
         "translucency": 10,
-        "concentration:": 2,
+        "concentration": 2,
         "effects": [
           {
             "effect_id": "smoke_eyes",
@@ -509,7 +509,7 @@
         "name": "thick smoke",
         "color": "dark_gray",
         "translucency": 0,
-        "concentration:": 4,
+        "concentration": 4,
         "effects": [
           {
             "effect_id": "smoke_eyes",
@@ -644,7 +644,7 @@
         "sym": "8",
         "dangerous": true,
         "translucency": 1,
-        "concentration:": 1,
+        "concentration": 1,
         "effects": [
           {
             "effect_id": "tpollen",
@@ -663,7 +663,7 @@
         "color": "light_green",
         "transparent": false,
         "translucency": 10,
-        "concentration:": 2,
+        "concentration": 2,
         "effects": [
           {
             "effect_id": "tpollen",
@@ -703,16 +703,10 @@
         "color": "light_green",
         "transparent": false,
         "translucency": 10,
-        "concentration:": 2,
+        "concentration": 2,
         "scent_neutralization": 1
       },
-      {
-        "name": "thick tear gas",
-        "color": "green",
-        "translucency": 0,
-        "concentration:": 4,
-        "scent_neutralization": 5
-      }
+      { "name": "thick tear gas", "color": "green", "translucency": 0, "concentration": 4, "scent_neutralization": 5 }
     ],
     "decay_amount_factor": 5,
     "gas_absorption_factor": "80m",
@@ -738,15 +732,15 @@
         "sym": "8",
         "dangerous": true,
         "translucency": 10,
-        "concentration:": 1,
+        "concentration": 1,
         "extra_radiation_max": 1
       },
-      { "name": "radioactive gas", "color": "light_green", "extra_radiation_max": 2, "concentration:": 2 },
+      { "name": "radioactive gas", "color": "light_green", "extra_radiation_max": 2, "concentration": 2 },
       {
         "name": "thick radioactive gas",
         "color": "green",
         "transparent": false,
-        "concentration:": 4,
+        "concentration": 4,
         "extra_radiation_max": 3,
         "radiation_hurt_damage_min": 1,
         "radiation_hurt_damage_max": 3,
@@ -769,7 +763,7 @@
     "id": "fd_gas_vent",
     "type": "field_type",
     "legacy_enum_id": 16,
-    "intensity_levels": [ { "name": "gas vent", "concentration:": 4 }, { "//": "repeat last entry" }, { "//": "repeat last entry" } ],
+    "intensity_levels": [ { "name": "gas vent", "concentration": 4 }, { "//": "repeat last entry" }, { "//": "repeat last entry" } ],
     "description_affix": "under",
     "wandering_field": "fd_toxic_gas",
     "gas_absorption_factor": "80m",

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -410,7 +410,7 @@
     "display_items": false,
     "display_field": true,
     "looks_like": "fd_fog",
-    "gas_absorption_factor": 1,
+    "gas_absorption_factor": "20h",
     "has_fume": true,
     "percent_spread": 90,
     "dirty_transparency_cache": true,
@@ -534,7 +534,7 @@
       }
     ],
     "decay_amount_factor": 5,
-    "gas_absorption_factor": 12,
+    "gas_absorption_factor": "100m",
     "dirty_transparency_cache": true,
     "percent_spread": 10,
     "outdoor_age_speedup": "0 turns",
@@ -621,7 +621,7 @@
       }
     ],
     "decay_amount_factor": 5,
-    "gas_absorption_factor": 5,
+    "gas_absorption_factor": "80m",
     "percent_spread": 30,
     "outdoor_age_speedup": "3 minutes",
     "dirty_transparency_cache": true,
@@ -679,7 +679,7 @@
       }
     ],
     "decay_amount_factor": 5,
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": "80m",
     "percent_spread": 30,
     "outdoor_age_speedup": "3 minutes",
     "dirty_transparency_cache": true,
@@ -706,10 +706,16 @@
         "concentration:": 2,
         "scent_neutralization": 1
       },
-      { "name": "thick tear gas", "color": "green", "translucency": 0, "concentration:": 4, "scent_neutralization": 5 }
+      {
+        "name": "thick tear gas",
+        "color": "green",
+        "translucency": 0,
+        "concentration:": 4,
+        "scent_neutralization": 5
+      }
     ],
     "decay_amount_factor": 5,
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": "80m",
     "percent_spread": 10,
     "outdoor_age_speedup": "0 turns",
     "dirty_transparency_cache": true,
@@ -727,7 +733,14 @@
     "type": "field_type",
     "legacy_enum_id": 15,
     "intensity_levels": [
-      { "name": "hazy cloud", "sym": "8", "dangerous": true, "translucency": 10, "concentration:": 1, "extra_radiation_max": 1 },
+      {
+        "name": "hazy cloud",
+        "sym": "8",
+        "dangerous": true,
+        "translucency": 10,
+        "concentration:": 1,
+        "extra_radiation_max": 1
+      },
       { "name": "radioactive gas", "color": "light_green", "extra_radiation_max": 2, "concentration:": 2 },
       {
         "name": "thick radioactive gas",
@@ -759,7 +772,7 @@
     "intensity_levels": [ { "name": "gas vent", "concentration:": 4 }, { "//": "repeat last entry" }, { "//": "repeat last entry" } ],
     "description_affix": "under",
     "wandering_field": "fd_toxic_gas",
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": "80m",
     "dirty_transparency_cache": true,
     "immunity_data": { "body_part_env_resistance": [ [ "mouth", 15 ] ] },
     "phase": "gas",
@@ -789,7 +802,7 @@
     "half_life": "10 seconds",
     "accelerated_decay": true,
     "wandering_field": "fd_tindalos_gas",
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": "80m",
     "dirty_transparency_cache": true,
     "phase": "gas",
     "display_items": false,
@@ -1299,7 +1312,7 @@
       }
     ],
     "decay_amount_factor": 5,
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": "80m",
     "percent_spread": 15,
     "outdoor_age_speedup": "5 minutes",
     "dirty_transparency_cache": true,
@@ -1321,7 +1334,7 @@
       { "//": "repeat last entry" }
     ],
     "decay_amount_factor": 5,
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": "80m",
     "percent_spread": 25,
     "outdoor_age_speedup": "1 minutes",
     "dirty_transparency_cache": true,
@@ -1343,7 +1356,7 @@
       { "name": "dense fog", "translucency": 1 }
     ],
     "decay_amount_factor": 15,
-    "gas_absorption_factor": 5,
+    "gas_absorption_factor": "80m",
     "percent_spread": 30,
     "outdoor_age_speedup": "1 minutes",
     "dirty_transparency_cache": true,
@@ -1365,7 +1378,7 @@
       { "name": "thick fungal haze", "transparent": false, "concentration": 4 }
     ],
     "decay_amount_factor": 5,
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": "80m",
     "percent_spread": 13,
     "outdoor_age_speedup": "5 turns",
     "dirty_transparency_cache": true,
@@ -1571,7 +1584,7 @@
       }
     ],
     "decay_amount_factor": 5,
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": "80m",
     "percent_spread": 30,
     "outdoor_age_speedup": "3 minutes",
     "dirty_transparency_cache": true,
@@ -1591,7 +1604,7 @@
       { "name": "thick fungicidal haze", "color": "dark_gray", "transparent": false, "concentration": 4 }
     ],
     "decay_amount_factor": 5,
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": "80m",
     "percent_spread": 100,
     "outdoor_age_speedup": "1 minutes",
     "dirty_transparency_cache": true,
@@ -1613,7 +1626,7 @@
       { "name": "thick insecticidal haze", "color": "dark_gray", "transparent": false, "concentration": 4 }
     ],
     "decay_amount_factor": 5,
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": "80m",
     "percent_spread": 100,
     "outdoor_age_speedup": "1 minutes",
     "dirty_transparency_cache": true,
@@ -1630,10 +1643,14 @@
     "id": "fd_smoke_vent",
     "type": "field_type",
     "legacy_enum_id": 50,
-    "intensity_levels": [ { "name": "smoke vent", "dangerous": true, "concentration": 4 }, { "//": "repeat last entry" }, { "//": "repeat last entry" } ],
+    "intensity_levels": [
+      { "name": "smoke vent", "dangerous": true, "concentration": 4 },
+      { "//": "repeat last entry" },
+      { "//": "repeat last entry" }
+    ],
     "description_affix": "under",
     "wandering_field": "fd_smoke",
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": "80m",
     "dirty_transparency_cache": true,
     "has_fume": true,
     "phase": "gas",
@@ -1697,7 +1714,7 @@
     "type": "field_type",
     "intensity_levels": [ { "name": "clairvoyance", "sym": "8", "dangerous": false, "concentration": 1 } ],
     "decay_amount_factor": 5,
-    "gas_absorption_factor": 12,
+    "gas_absorption_factor": "100m",
     "dirty_transparency_cache": true,
     "outdoor_age_speedup": "0 turns",
     "priority": 8,
@@ -1714,7 +1731,7 @@
       { "name": "a cloud of bees", "color": "green", "translucency": 0 }
     ],
     "decay_amount_factor": 5,
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": "80m",
     "percent_spread": 25,
     "outdoor_age_speedup": "10 minutes",
     "dirty_transparency_cache": true,
@@ -1768,7 +1785,7 @@
       { "//": "repeat last entry" }
     ],
     "decay_amount_factor": 5,
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": "80m",
     "percent_spread": 25,
     "outdoor_age_speedup": "1 minutes",
     "dirty_transparency_cache": true,
@@ -1806,7 +1823,7 @@
       { "//": "repeat last entry" }
     ],
     "decay_amount_factor": 5,
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": "80m",
     "percent_spread": 25,
     "outdoor_age_speedup": "1 minutes",
     "dirty_transparency_cache": true,

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -407,7 +407,7 @@
     "display_items": false,
     "display_field": true,
     "looks_like": "fd_fog",
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": 1,
     "has_fume": true,
     "percent_spread": 90,
     "dirty_transparency_cache": true,
@@ -550,6 +550,7 @@
         "sym": "8",
         "dangerous": true,
         "translucency": 1,
+        "concentration": 1,
         "effects": [
           {
             "effect_id": "poison",
@@ -568,6 +569,7 @@
         "color": "light_green",
         "transparent": false,
         "translucency": 10,
+        "concentration": 2,
         "effects": [
           {
             "effect_id": "poison",
@@ -585,6 +587,7 @@
         "name": "thick toxic gas",
         "color": "green",
         "translucency": 0,
+        "concentration": 4,
         "effects": [
           {
             "effect_id": "poison",

--- a/data/json/field_type.json
+++ b/data/json/field_type.json
@@ -336,6 +336,7 @@
         "color": "white",
         "dangerous": true,
         "translucency": 0.1,
+        "concentration:": 1,
         "convection_temperature_mod": -10,
         "effects": [
           {
@@ -355,6 +356,7 @@
         "color": "white",
         "convection_temperature_mod": -20,
         "translucency": 0.4,
+        "concentration:": 2,
         "effects": [
           {
             "effect_id": "poison",
@@ -373,6 +375,7 @@
         "color": "white",
         "convection_temperature_mod": -30,
         "translucency": 0.7,
+        "concentration:": 4,
         "effects": [
           {
             "effect_id": "poison",
@@ -452,6 +455,7 @@
         "sym": "8",
         "dangerous": true,
         "translucency": 1,
+        "concentration:": 1,
         "effects": [
           {
             "effect_id": "smoke_eyes",
@@ -478,6 +482,7 @@
         "color": "light_gray",
         "transparent": false,
         "translucency": 10,
+        "concentration:": 2,
         "effects": [
           {
             "effect_id": "smoke_eyes",
@@ -504,6 +509,7 @@
         "name": "thick smoke",
         "color": "dark_gray",
         "translucency": 0,
+        "concentration:": 4,
         "effects": [
           {
             "effect_id": "smoke_eyes",
@@ -615,7 +621,7 @@
       }
     ],
     "decay_amount_factor": 5,
-    "gas_absorption_factor": 15,
+    "gas_absorption_factor": 5,
     "percent_spread": 30,
     "outdoor_age_speedup": "3 minutes",
     "dirty_transparency_cache": true,
@@ -638,6 +644,7 @@
         "sym": "8",
         "dangerous": true,
         "translucency": 1,
+        "concentration:": 1,
         "effects": [
           {
             "effect_id": "tpollen",
@@ -656,6 +663,7 @@
         "color": "light_green",
         "transparent": false,
         "translucency": 10,
+        "concentration:": 2,
         "effects": [
           {
             "effect_id": "tpollen",
@@ -689,15 +697,16 @@
     "type": "field_type",
     "legacy_enum_id": 14,
     "intensity_levels": [
-      { "name": "hazy cloud", "sym": "8", "dangerous": true, "translucency": 1 },
+      { "name": "hazy cloud", "sym": "8", "dangerous": true, "translucency": 1, "concentration": 1 },
       {
         "name": "tear gas",
         "color": "light_green",
         "transparent": false,
         "translucency": 10,
+        "concentration:": 2,
         "scent_neutralization": 1
       },
-      { "name": "thick tear gas", "color": "green", "translucency": 0, "scent_neutralization": 5 }
+      { "name": "thick tear gas", "color": "green", "translucency": 0, "concentration:": 4, "scent_neutralization": 5 }
     ],
     "decay_amount_factor": 5,
     "gas_absorption_factor": 15,
@@ -718,12 +727,13 @@
     "type": "field_type",
     "legacy_enum_id": 15,
     "intensity_levels": [
-      { "name": "hazy cloud", "sym": "8", "dangerous": true, "translucency": 10, "extra_radiation_max": 1 },
-      { "name": "radioactive gas", "color": "light_green", "extra_radiation_max": 2 },
+      { "name": "hazy cloud", "sym": "8", "dangerous": true, "translucency": 10, "concentration:": 1, "extra_radiation_max": 1 },
+      { "name": "radioactive gas", "color": "light_green", "extra_radiation_max": 2, "concentration:": 2 },
       {
         "name": "thick radioactive gas",
         "color": "green",
         "transparent": false,
+        "concentration:": 4,
         "extra_radiation_max": 3,
         "radiation_hurt_damage_min": 1,
         "radiation_hurt_damage_max": 3,
@@ -746,7 +756,7 @@
     "id": "fd_gas_vent",
     "type": "field_type",
     "legacy_enum_id": 16,
-    "intensity_levels": [ { "name": "gas vent" }, { "//": "repeat last entry" }, { "//": "repeat last entry" } ],
+    "intensity_levels": [ { "name": "gas vent", "concentration:": 4 }, { "//": "repeat last entry" }, { "//": "repeat last entry" } ],
     "description_affix": "under",
     "wandering_field": "fd_toxic_gas",
     "gas_absorption_factor": 15,
@@ -761,12 +771,13 @@
     "id": "fd_tindalos_rift",
     "type": "field_type",
     "intensity_levels": [
-      { "name": "angular ripple", "color": "light_gray", "sym": "*", "light_emitted": 160 },
-      { "name": "angular rift", "color": "dark_gray" },
+      { "name": "angular ripple", "color": "light_gray", "sym": "*", "light_emitted": 160, "concentration": 1 },
+      { "name": "angular rift", "color": "dark_gray", "concentration": 1 },
       {
         "name": "fractal fissure",
         "color": "magenta",
         "transparent": false,
+        "concentration": 1,
         "monster_spawn_chance": 15,
         "monster_spawn_count": 1,
         "monster_spawn_radius": 1,
@@ -1243,6 +1254,7 @@
         "sym": ".",
         "dangerous": true,
         "translucency": 5,
+        "concentration": 1,
         "effects": [
           {
             "effect_id": "relax_gas",
@@ -1258,6 +1270,7 @@
       {
         "name": "sedative gas",
         "color": "pink",
+        "concentration": 2,
         "effects": [
           {
             "effect_id": "relax_gas",
@@ -1272,6 +1285,7 @@
       {
         "name": "relaxation gas",
         "color": "cyan",
+        "concentration": 4,
         "effects": [
           {
             "effect_id": "relax_gas",
@@ -1302,7 +1316,7 @@
     "id": "fd_swamp_gas",
     "type": "field_type",
     "intensity_levels": [
-      { "name": "swamp gas", "sym": ".", "dangerous": true, "translucency": 5 },
+      { "name": "swamp gas", "sym": ".", "dangerous": true, "translucency": 5, "concentration": 1 },
       { "//": "repeat last entry" },
       { "//": "repeat last entry" }
     ],
@@ -1324,7 +1338,7 @@
     "id": "fd_fog",
     "type": "field_type",
     "intensity_levels": [
-      { "name": "mist", "sym": "~", "dangerous": false, "transparent": false, "translucency": 5 },
+      { "name": "mist", "sym": "~", "dangerous": false, "transparent": false, "translucency": 5, "concentration": 0.5 },
       { "name": "fog", "translucency": 3 },
       { "name": "dense fog", "translucency": 1 }
     ],
@@ -1346,9 +1360,9 @@
     "type": "field_type",
     "legacy_enum_id": 40,
     "intensity_levels": [
-      { "name": "hazy cloud", "sym": ".", "dangerous": true },
-      { "name": "fungal haze", "color": "cyan" },
-      { "name": "thick fungal haze", "transparent": false }
+      { "name": "hazy cloud", "sym": ".", "dangerous": true, "concentration": 1 },
+      { "name": "fungal haze", "color": "cyan", "concentration": 2 },
+      { "name": "thick fungal haze", "transparent": false, "concentration": 4 }
     ],
     "decay_amount_factor": 5,
     "gas_absorption_factor": 15,
@@ -1516,6 +1530,7 @@
         "name": "foul-smelling air",
         "sym": "8",
         "dangerous": true,
+        "concentration": 1,
         "effects": [
           {
             "effect_id": "migo_atmosphere",
@@ -1530,6 +1545,7 @@
       {
         "name": "foul-smelling air",
         "translucency": 1,
+        "concentration": 2,
         "effects": [
           {
             "effect_id": "migo_atmosphere",
@@ -1542,6 +1558,7 @@
       },
       {
         "name": "foul-smelling air",
+        "concentration": 4,
         "effects": [
           {
             "effect_id": "migo_atmosphere",
@@ -1569,9 +1586,9 @@
     "type": "field_type",
     "legacy_enum_id": 49,
     "intensity_levels": [
-      { "name": "fungicidal mist", "sym": "8", "dangerous": true },
-      { "name": "fungicidal haze", "color": "light_gray" },
-      { "name": "thick fungicidal haze", "color": "dark_gray", "transparent": false }
+      { "name": "fungicidal mist", "sym": "8", "dangerous": true, "concentration": 1 },
+      { "name": "fungicidal haze", "color": "light_gray", "concentration": 2 },
+      { "name": "thick fungicidal haze", "color": "dark_gray", "transparent": false, "concentration": 4 }
     ],
     "decay_amount_factor": 5,
     "gas_absorption_factor": 15,
@@ -1591,9 +1608,9 @@
     "id": "fd_insecticidal_gas",
     "type": "field_type",
     "intensity_levels": [
-      { "name": "insecticidal mist", "sym": "8", "dangerous": true },
-      { "name": "insecticidal haze", "color": "light_gray" },
-      { "name": "thick insecticidal haze", "color": "dark_gray", "transparent": false }
+      { "name": "insecticidal mist", "sym": "8", "dangerous": true, "concentration": 1 },
+      { "name": "insecticidal haze", "color": "light_gray", "concentration": 2 },
+      { "name": "thick insecticidal haze", "color": "dark_gray", "transparent": false, "concentration": 4 }
     ],
     "decay_amount_factor": 5,
     "gas_absorption_factor": 15,
@@ -1613,7 +1630,7 @@
     "id": "fd_smoke_vent",
     "type": "field_type",
     "legacy_enum_id": 50,
-    "intensity_levels": [ { "name": "smoke vent", "dangerous": true }, { "//": "repeat last entry" }, { "//": "repeat last entry" } ],
+    "intensity_levels": [ { "name": "smoke vent", "dangerous": true, "concentration": 4 }, { "//": "repeat last entry" }, { "//": "repeat last entry" } ],
     "description_affix": "under",
     "wandering_field": "fd_smoke",
     "gas_absorption_factor": 15,
@@ -1678,7 +1695,7 @@
   {
     "id": "fd_clairvoyant",
     "type": "field_type",
-    "intensity_levels": [ { "name": "clairvoyance", "sym": "8", "dangerous": false } ],
+    "intensity_levels": [ { "name": "clairvoyance", "sym": "8", "dangerous": false, "concentration": 1 } ],
     "decay_amount_factor": 5,
     "gas_absorption_factor": 12,
     "dirty_transparency_cache": true,
@@ -1736,6 +1753,7 @@
         "dangerous": true,
         "light_emitted": 10,
         "translucency": 5,
+        "concentration": 1,
         "effects": [
           {
             "effect_id": "glowing_gas_cover",
@@ -1773,6 +1791,7 @@
         "dangerous": true,
         "light_emitted": 10,
         "translucency": 5,
+        "concentration": 1,
         "effects": [
           {
             "effect_id": "glowing_gas",

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -5931,7 +5931,7 @@ Fields can exist on top of terrain/furniture, and support different intensity le
         "light_emitted": 2.5, // light level emitted by this intensity
         "light_override": 3.7 }, //light level on the tile occupied by this field will be set at 3.7 no matter the ambient light.
         "translucency": 2.0, // How much light the field blocks (higher numbers mean less light can penetrate through)
-        "concentration": 1, // How concentrated this intensity of gas is. Generally the thin/hazy cloud intensity will be 1, the standard gas will be 2, and thick gas will be 4. Affects how much gas mask charge is expended.
+        "concentration": 1, // How concentrated this intensity of gas is. Generally the thin/hazy cloud intensity will be 1, the standard gas will be 2, and thick gas will be 4. The amount of time a gas mask filter will last will be divided by this value.
         "convection_temperature_mod": 12, // Heat given off by this level of intensity
         "effects":  // List of effects applied to any creatures within the field as long as they aren't immune to the effect or the field itself
         [
@@ -5966,7 +5966,7 @@ Fields can exist on top of terrain/furniture, and support different intensity le
     "percent_spread": 90, // The field must succeed on a `rng( 1, 100 - local windpower ) > percent_spread` roll to spread. The field must have a non-zero spread percent and the GAS phase to be eligible to spread in the first place
     "phase": "gas", // Phase of the field. Gases can spread after spawning and can be spawned out of emitters through impassable terrain with the PERMEABLE flag
     "apply_slime_factor": 10, // Intensity of slime to apply to creatures standing in this field (Why not use an effect? No idea.)
-    "gas_absorption_factor": "80m", // Length a full 100 charge gas mask filter will last in this gas. Will be modified by the concentration of the gas, and should be 80m for concentration 1 toxic gas or similar. The worst gas should still be kept out for 20 minutes.
+    "gas_absorption_factor": "80m", // Length a full 100 charge gas mask filter will last in this gas. Will be divided by the concentration of the gas, and should be 80m for concentration 1 toxic gas or similar. The worst gas should still be kept out for 20 minutes in a concentration 4 thick gas.
     "is_splattering": true, // If splatters of this field should bloody vehicle parts
     "dirty_transparency_cache": true, // Should the transparency cache be recalculated when the field is modified (used for nontransparent, spreading fields)
     "has_fire": false, // Is this field a kind of fire (for immunity, monster avoidance and similar checks)

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -5931,6 +5931,7 @@ Fields can exist on top of terrain/furniture, and support different intensity le
         "light_emitted": 2.5, // light level emitted by this intensity
         "light_override": 3.7 }, //light level on the tile occupied by this field will be set at 3.7 no matter the ambient light.
         "translucency": 2.0, // How much light the field blocks (higher numbers mean less light can penetrate through)
+        "concentration": 1, // How concentrated this intensity of gas is. Generally the thin/hazy cloud intensity will be 1, the standard gas will be 2, and thick gas will be 4. Affects how much gas mask charge is expended.
         "convection_temperature_mod": 12, // Heat given off by this level of intensity
         "effects":  // List of effects applied to any creatures within the field as long as they aren't immune to the effect or the field itself
         [
@@ -5965,7 +5966,7 @@ Fields can exist on top of terrain/furniture, and support different intensity le
     "percent_spread": 90, // The field must succeed on a `rng( 1, 100 - local windpower ) > percent_spread` roll to spread. The field must have a non-zero spread percent and the GAS phase to be eligible to spread in the first place
     "phase": "gas", // Phase of the field. Gases can spread after spawning and can be spawned out of emitters through impassable terrain with the PERMEABLE flag
     "apply_slime_factor": 10, // Intensity of slime to apply to creatures standing in this field (Why not use an effect? No idea.)
-    "gas_absorption_factor": 15, // Amount of gasmask charges the field uses up per tick
+    "gas_absorption_factor": "80m", // Length a full 100 charge gas mask filter will last in this gas. Will be modified by the concentration of the gas, and should be 80m for concentration 1 toxic gas or similar. The worst gas should still be kept out for 20 minutes.
     "is_splattering": true, // If splatters of this field should bloody vehicle parts
     "dirty_transparency_cache": true, // Should the transparency cache be recalculated when the field is modified (used for nontransparent, spreading fields)
     "has_fire": false, // Is this field a kind of fire (for immunity, monster avoidance and similar checks)

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -284,7 +284,7 @@ void field_type::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "decay_amount_factor", decay_amount_factor, 0 );
     optional( jo, was_loaded, "percent_spread", percent_spread, 0 );
     optional( jo, was_loaded, "apply_slime_factor", apply_slime_factor, 0 );
-    optional( jo, was_loaded, "gas_absorption_factor", gas_absorption_factor, 0 );
+    optional( jo, was_loaded, "gas_absorption_factor", gas_absorption_factor, 0_turns);
     optional( jo, was_loaded, "is_splattering", is_splattering, false );
     optional( jo, was_loaded, "dirty_transparency_cache", dirty_transparency_cache, false );
     optional( jo, was_loaded, "has_fire", has_fire, false );

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -223,7 +223,7 @@ void field_type::load( const JsonObject &jo, const std::string_view )
         optional( jao, was_loaded, "translucency", intensity_level.translucency,
                   fallback_intensity_level.translucency );
         optional(jao, was_loaded, "concentration", intensity_level.concentration,
-            fallback_intensity_level.concentration);
+            1);
         optional( jao, was_loaded, "convection_temperature_mod", intensity_level.convection_temperature_mod,
                   fallback_intensity_level.convection_temperature_mod );
         if( jao.has_array( "effects" ) ) {

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -222,6 +222,8 @@ void field_type::load( const JsonObject &jo, const std::string_view )
                   fallback_intensity_level.local_light_override );
         optional( jao, was_loaded, "translucency", intensity_level.translucency,
                   fallback_intensity_level.translucency );
+        optional(jao, was_loaded, "concentration", intensity_level.concentration,
+            fallback_intensity_level.concentration);
         optional( jao, was_loaded, "convection_temperature_mod", intensity_level.convection_temperature_mod,
                   fallback_intensity_level.convection_temperature_mod );
         if( jao.has_array( "effects" ) ) {

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -223,7 +223,7 @@ void field_type::load( const JsonObject &jo, const std::string_view )
         optional( jao, was_loaded, "translucency", intensity_level.translucency,
                   fallback_intensity_level.translucency );
         optional( jao, was_loaded, "concentration", intensity_level.concentration,
-            1 );
+                  1 );
         optional( jao, was_loaded, "convection_temperature_mod", intensity_level.convection_temperature_mod,
                   fallback_intensity_level.convection_temperature_mod );
         if( jao.has_array( "effects" ) ) {

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -222,8 +222,8 @@ void field_type::load( const JsonObject &jo, const std::string_view )
                   fallback_intensity_level.local_light_override );
         optional( jao, was_loaded, "translucency", intensity_level.translucency,
                   fallback_intensity_level.translucency );
-        optional(jao, was_loaded, "concentration", intensity_level.concentration,
-            1);
+        optional( jao, was_loaded, "concentration", intensity_level.concentration,
+            1 );
         optional( jao, was_loaded, "convection_temperature_mod", intensity_level.convection_temperature_mod,
                   fallback_intensity_level.convection_temperature_mod );
         if( jao.has_array( "effects" ) ) {
@@ -284,7 +284,7 @@ void field_type::load( const JsonObject &jo, const std::string_view )
     optional( jo, was_loaded, "decay_amount_factor", decay_amount_factor, 0 );
     optional( jo, was_loaded, "percent_spread", percent_spread, 0 );
     optional( jo, was_loaded, "apply_slime_factor", apply_slime_factor, 0 );
-    optional( jo, was_loaded, "gas_absorption_factor", gas_absorption_factor, 0_turns);
+    optional( jo, was_loaded, "gas_absorption_factor", gas_absorption_factor, 0_turns );
     optional( jo, was_loaded, "is_splattering", is_splattering, false );
     optional( jo, was_loaded, "dirty_transparency_cache", dirty_transparency_cache, false );
     optional( jo, was_loaded, "has_fire", has_fire, false );

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -118,6 +118,7 @@ struct field_intensity_level {
     float light_emitted = 0.0f;
     float local_light_override = -1.0f;
     float translucency = 0.0f;
+    int concentration = 0.0f;
     int convection_temperature_mod = 0;
     int scent_neutralization = 0;
     std::vector<field_effect> field_effects;

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -118,7 +118,7 @@ struct field_intensity_level {
     float light_emitted = 0.0f;
     float local_light_override = -1.0f;
     float translucency = 0.0f;
-    int concentration = 0.0f;
+    int concentration = 0;
     int convection_temperature_mod = 0;
     int scent_neutralization = 0;
     std::vector<field_effect> field_effects;

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -198,7 +198,7 @@ struct field_type {
         int decay_amount_factor = 0;
         int percent_spread = 0;
         int apply_slime_factor = 0;
-        int gas_absorption_factor = 0;
+        time_duration gas_absorption_factor = 0_turns;
         bool is_splattering = false;
         bool dirty_transparency_cache = false;
         bool has_fire = false;

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4184,24 +4184,24 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
         const field &gasfield = get_map().field_at( pos );
         for( const auto &dfield : gasfield ) {
             const field_entry &entry = dfield.second;
-            int gas_abs_factor = to_turns<int>(entry.get_field_type()->gas_absorption_factor);
-            const field_intensity_level& int_level = entry.get_intensity_level();
+            int gas_abs_factor = to_turns<int>( entry.get_field_type()->gas_absorption_factor);
+            const field_intensity_level &int_level = entry.get_intensity_level();
             // 6000 is the amount of "gas absorbed" charges in a full 100 capacity gas mask cartridge.
             // factor/concentration gives an amount of seconds the cartidge is expected to last in current conditions.
             /// 6000/that is the amount of "gas absorbed" charges to tick up every second in order to reach that number.
-            float gas_absorbed = 6000/((float)gas_abs_factor / (float)int_level.concentration);
-            if(gas_absorbed > 0 ) {
+            float gas_absorbed = 6000 / ( ( float )gas_abs_factor / ( float )int_level.concentration );
+            if( gas_absorbed > 0 ) {
                 it->set_var( "gas_absorbed", it->get_var( "gas_absorbed", 0 ) + gas_absorbed);
             }
         }
         if( it->get_var( "gas_absorbed", 0 ) >= 60 ) {
             it->ammo_consume( 1, pos, p );
             it->set_var( "gas_absorbed", 0 );
-            if (it->ammo_remaining() < 10) {
+            if(it->ammo_remaining() < 10) {
                 p->add_msg_player_or_npc(
                     m_bad,
-                    _("Your %s is getting hard to breathe in!"),
-                    _("<npcname>'s gas mask is getting hard to breathe in!")
+                    _( "Your %s is getting hard to breathe in!" ),
+                    _( "<npcname>'s gas mask is getting hard to breathe in!" )
                     , it->tname());
             }
         }
@@ -4211,7 +4211,7 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
                 _( "Your %s requires new filters!" ),
                 _( "<npcname> needs new gas mask filters!" )
                 , it->tname() );
-        } 
+        }
     }
 
     if( it->ammo_remaining() == 0 ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4183,8 +4183,9 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
         const field &gasfield = get_map().field_at( pos );
         for( const auto &dfield : gasfield ) {
             const field_entry &entry = dfield.second;
-            const int gas_abs_factor = entry.get_field_type()->gas_absorption_factor;
+            int gas_abs_factor = entry.get_field_type()->gas_absorption_factor;
             const field_intensity_level& int_level = entry.get_intensity_level();
+            gas_abs_factor = gas_abs_factor * int_level.concentration;
             if( gas_abs_factor > 0 ) {
                 it->set_var( "gas_absorbed", it->get_var( "gas_absorbed", 0 ) + gas_abs_factor );
             }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4189,7 +4189,7 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
             // 6000 is the amount of "gas absorbed" charges in a full 100 capacity gas mask cartridge.
             // factor/concentration gives an amount of seconds the cartidge is expected to last in current conditions.
             /// 6000/that is the amount of "gas absorbed" charges to tick up every second in order to reach that number.
-            float gas_absorbed = 6000 / ( ( float )gas_abs_factor / ( float )int_level.concentration );
+            float gas_absorbed = 6000 / ( static_cast<float>( gas_abs_factor ) / static_cast<float>( int_level.concentration ) );
             if( gas_absorbed > 0 ) {
                 it->set_var( "gas_absorbed", it->get_var( "gas_absorbed", 0 ) + gas_absorbed );
             }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4184,6 +4184,7 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
         for( const auto &dfield : gasfield ) {
             const field_entry &entry = dfield.second;
             const int gas_abs_factor = entry.get_field_type()->gas_absorption_factor;
+            const field_intensity_level& int_level = entry.get_intensity_level();
             if( gas_abs_factor > 0 ) {
                 it->set_var( "gas_absorbed", it->get_var( "gas_absorbed", 0 ) + gas_abs_factor );
             }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4189,7 +4189,8 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
             // 6000 is the amount of "gas absorbed" charges in a full 100 capacity gas mask cartridge.
             // factor/concentration gives an amount of seconds the cartidge is expected to last in current conditions.
             /// 6000/that is the amount of "gas absorbed" charges to tick up every second in order to reach that number.
-            float gas_absorbed = 6000 / ( static_cast<float>( gas_abs_factor ) / static_cast<float>( int_level.concentration ) );
+            float gas_absorbed = 6000 / ( static_cast<float>( gas_abs_factor ) / static_cast<float>
+                                          ( int_level.concentration ) );
             if( gas_absorbed > 0 ) {
                 it->set_var( "gas_absorbed", it->get_var( "gas_absorbed", 0 ) + gas_absorbed );
             }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4189,9 +4189,9 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
             // 6000 is the amount of "gas absorbed" charges in a full 100 capacity gas mask cartridge.
             // factor/concentration gives an amount of seconds the cartidge is expected to last in current conditions.
             /// 6000/that is the amount of "gas absorbed" charges to tick up every second in order to reach that number.
-            gas_abs_factor = 6000/(gas_abs_factor / int_level.concentration);
-            if( gas_abs_factor > 0 ) {
-                it->set_var( "gas_absorbed", it->get_var( "gas_absorbed", 0 ) + gas_abs_factor );
+            float gas_absorbed = 6000/((float)gas_abs_factor / (float)int_level.concentration);
+            if(gas_absorbed > 0 ) {
+                it->set_var( "gas_absorbed", it->get_var( "gas_absorbed", 0 ) + gas_absorbed);
             }
         }
         if( it->get_var( "gas_absorbed", 0 ) >= 60 ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4190,7 +4190,7 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
                 it->set_var( "gas_absorbed", it->get_var( "gas_absorbed", 0 ) + gas_abs_factor );
             }
         }
-        if( it->get_var( "gas_absorbed", 0 ) >= 100 ) {
+        if( it->get_var( "gas_absorbed", 0 ) >= 240 ) {
             it->ammo_consume( 1, pos, p );
             it->set_var( "gas_absorbed", 0 );
         }

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -120,6 +120,7 @@
 #include "vitamin.h"
 #include "vpart_position.h"
 #include "vpart_range.h"
+#include "units.h"
 #include "weather.h"
 #include "weather_gen.h"
 #include "weather_type.h"
@@ -4183,14 +4184,17 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
         const field &gasfield = get_map().field_at( pos );
         for( const auto &dfield : gasfield ) {
             const field_entry &entry = dfield.second;
-            int gas_abs_factor = entry.get_field_type()->gas_absorption_factor;
+            int gas_abs_factor = to_turns<int>(entry.get_field_type()->gas_absorption_factor);
             const field_intensity_level& int_level = entry.get_intensity_level();
-            gas_abs_factor = gas_abs_factor * int_level.concentration;
+            // 6000 is the amount of "gas absorbed" charges in a full 100 capacity gas mask cartridge.
+            // factor/concentration gives an amount of seconds the cartidge is expected to last in current conditions.
+            /// 6000/that is the amount of "gas absorbed" charges to tick up every second in order to reach that number.
+            gas_abs_factor = 6000/(gas_abs_factor / int_level.concentration);
             if( gas_abs_factor > 0 ) {
                 it->set_var( "gas_absorbed", it->get_var( "gas_absorbed", 0 ) + gas_abs_factor );
             }
         }
-        if( it->get_var( "gas_absorbed", 0 ) >= 240 ) {
+        if( it->get_var( "gas_absorbed", 0 ) >= 60 ) {
             it->ammo_consume( 1, pos, p );
             it->set_var( "gas_absorbed", 0 );
             if (it->ammo_remaining() < 10) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4184,25 +4184,25 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
         const field &gasfield = get_map().field_at( pos );
         for( const auto &dfield : gasfield ) {
             const field_entry &entry = dfield.second;
-            int gas_abs_factor = to_turns<int>( entry.get_field_type()->gas_absorption_factor);
+            int gas_abs_factor = to_turns<int>( entry.get_field_type()->gas_absorption_factor );
             const field_intensity_level &int_level = entry.get_intensity_level();
             // 6000 is the amount of "gas absorbed" charges in a full 100 capacity gas mask cartridge.
             // factor/concentration gives an amount of seconds the cartidge is expected to last in current conditions.
             /// 6000/that is the amount of "gas absorbed" charges to tick up every second in order to reach that number.
             float gas_absorbed = 6000 / ( ( float )gas_abs_factor / ( float )int_level.concentration );
             if( gas_absorbed > 0 ) {
-                it->set_var( "gas_absorbed", it->get_var( "gas_absorbed", 0 ) + gas_absorbed);
+                it->set_var( "gas_absorbed", it->get_var( "gas_absorbed", 0 ) + gas_absorbed );
             }
         }
         if( it->get_var( "gas_absorbed", 0 ) >= 60 ) {
             it->ammo_consume( 1, pos, p );
             it->set_var( "gas_absorbed", 0 );
-            if(it->ammo_remaining() < 10) {
+            if( it->ammo_remaining() < 10 ) {
                 p->add_msg_player_or_npc(
                     m_bad,
                     _( "Your %s is getting hard to breathe in!" ),
                     _( "<npcname>'s gas mask is getting hard to breathe in!" )
-                    , it->tname());
+                    , it->tname() );
             }
         }
         if( it->ammo_remaining() == 0 ) {

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4193,6 +4193,13 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
         if( it->get_var( "gas_absorbed", 0 ) >= 240 ) {
             it->ammo_consume( 1, pos, p );
             it->set_var( "gas_absorbed", 0 );
+            if (it->ammo_remaining() < 10) {
+                p->add_msg_player_or_npc(
+                    m_bad,
+                    _("Your %s is getting hard to breathe in!"),
+                    _("<npcname>'s gas mask is getting hard to breathe in!")
+                    , it->tname());
+            }
         }
         if( it->ammo_remaining() == 0 ) {
             p->add_msg_player_or_npc(
@@ -4200,7 +4207,7 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
                 _( "Your %s requires new filters!" ),
                 _( "<npcname> needs new gas mask filters!" )
                 , it->tname() );
-        }
+        } 
     }
 
     if( it->ammo_remaining() == 0 ) {


### PR DESCRIPTION
#### Summary
Balance "Gas mask cartriges last quite a bit longer, and lower concentration gas takes less charges"

#### Purpose of change

Per issue https://github.com/CleverRaven/Cataclysm-DDA/issues/68554, our gas masks last a really short amount of time. I considered just about tripling the gas mask charge costs to bring it in line with estimates mentioned in the issue, but decided it would be better to have a concentration calculation in the charge buildup.

#### Describe the solution

My aim is to have an additional entry for gasses that is "concentration" that acts as a multiplier on charges spent, so thick toxic gas burns through your charges quicker than thin gas. I'll then go adjust numbers for gasses so that thick toxic gas means your gas mask will last about 20 minutes, and less problematic substances (read normal smoke) arn't as bad.

I also switched how the gas_absorption_factor works, it's now no longer what percent of a charge it uses per tick, its now how long a full 100 charge filter lasts in a concentration 1 gas.

Finally I also added another little message to the player when their gas mask charges go under 10. IRL a gas mask gets harder to breathe in as the filter clogs up, so it made sense for players to get a warning as they are running out.

#### Describe alternatives you've considered

I could just not add concentration, which would just require adjusting the gas absorption numbers, but it would still leave light gasses to unrealistically burn through charges.

I also considered basing the multiplier on intensity, but that doesn't work great as that number is primarily used for the amount of effect, and as such the numbers don't line up (toxic gas and thick toxic gas have the same number at 4) and could get modified and cause unintentional changes to gas mask charges.

Finally, I could have left gas absorption values the same, but it ended up with some very messy calculations so I decided it was better to change how the system works to be more based on how we measure gas mask lifetime in real life.

#### Testing

Tested both manually and via walking through code.

I booted up the game and spawned a gas vent in a small building. then waited till the room filled up. I then both watched the calculation via stepping through code, and confirmed it was taking the appropriate amount of charges off by waiting in the cloud with a mask on.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
