### PR TITLE
Balance tweaks for lieutenant 'Shadow'

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -4195,7 +4195,7 @@
           { "value": "ARMOR_COLD", "add": 15 },
           { "value": "ARMOR_ELEC", "add": 15 },
           { "value": "ARMOR_ACID", "add": 15 },
-          { "value": "ARMOR_BULLET", "add": 400 }
+          { "value": "ARMOR_BULLET", "add": 50 }
         ]
       }
     ]

--- a/data/json/monsters/zed_lieutenant.json
+++ b/data/json/monsters/zed_lieutenant.json
@@ -114,8 +114,6 @@
     "max_accuracy": 20,
     "min_range": 30,
     "max_range": 30,
-    "//": "A little bit of cast 'backswing' so that it can be caught in more situations.",
-    "base_casting_time": "800",
     "max_level": 1,
     "effect": "effect_on_condition",
     "effect_str": "EOC_LIEUTENANT_DRAIN_LIFE_TERRAIN"

--- a/data/json/monsters/zed_lieutenant.json
+++ b/data/json/monsters/zed_lieutenant.json
@@ -15,7 +15,7 @@
     "//6": "Slowed and weakened by light of sufficient brightness. (It lurks outside of flashlight range) Luring it into a trap is a viable path to killing it.",
     "speed": 200,
     "attack_cost": 200,
-    "regenerates": 5,
+    "regenerates": 1,
     "symbol": "L",
     "color": "red_white",
     "scents_tracked": [ "sc_human", "sc_fetid" ],
@@ -35,6 +35,7 @@
     "//1": "Try to stay this far away from the player with your regular moves, very important",
     "tracking_distance": 10,
     "path_settings": { "max_dist": 10, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "allow_climb_stairs": true },
+    "//2": "TODO? Upgrade doesn't actually work because amalgamations do not have evolutions. Ideally this would upgrade them one step *and also remove their timed lifespan*. If this is added/resolved the spell cooldowns probably need to be nerfed.",
     "special_attacks": [
       [ "UPGRADE", 20 ],
       {
@@ -67,7 +68,7 @@
         "//": "Dirty little hack: We have a condition that the target is male OR female, meaning it only evaluates true for the player (and NPCs)",
         "condition": { "or": [ "npc_male", "npc_female" ] },
         "spell_data": { "id": "LTNT_attract_nearby", "min_level": 1 },
-        "monster_message": "Your senses are overwhelmed!",
+        "monster_message": "Your hearing is overwhelmed by a booming sound!",
         "cooldown": 30
       }
     ],
@@ -86,7 +87,6 @@
       "CLIMBS",
       "BORES",
       "DESTROYS",
-      "FLIES",
       "FIREPROOF",
       "ALL_SEEING",
       "ALWAYS_SEES_YOU",
@@ -99,8 +99,8 @@
       "PHOTOPHOBIC",
       "PATH_AVOID_DANGER_2"
     ],
-    "//3": "Explicitly immune to bullets, meant to be lured into a close encounter(if you can see/engage it at all)",
-    "armor": { "cut": 25, "stab": 25, "bash": 25, "bullet": 500, "heat": 25, "cold": 25, "electric": 25, "acid": 25 }
+    "//3": "Explicitly resistant to bullets, meant to be lured into a close encounter(if you can see/engage it at all)",
+    "armor": { "cut": 25, "stab": 25, "bash": 25, "bullet": 100, "heat": 25, "cold": 25, "electric": 25, "acid": 25 }
   },
   {
     "id": "LTNT_LIFE_DRAIN",
@@ -114,8 +114,8 @@
     "max_accuracy": 20,
     "min_range": 30,
     "max_range": 30,
-    "//": "14 moves worth of casting time. It tends to stick 10 tiles away from you, so this means you can get some attacks in if you chase it. Currently toggled off, because it's too easy to run this thing down if it pauses while you move right at it.",
-    "//base_casting_time": "2800",
+    "//": "A little bit of cast 'backswing' so that it can be caught in more situations.",
+    "base_casting_time": "800",
     "max_level": 1,
     "effect": "effect_on_condition",
     "effect_str": "EOC_LIEUTENANT_DRAIN_LIFE_TERRAIN"
@@ -166,11 +166,13 @@
       {
         "u_spawn_monster": "GROUP_AMALGAMATIONS_SPAWNED",
         "group": true,
+        "//": "This always spawns 6 of the same type, which is not ideal (6 soldiers is way too deadly). Consider revising the weights if/when talk_effect_fun_t::set_spawn_monster can pick each individual spawn from the group.",
         "real_count": 6,
-        "lifespan": [ "20 seconds", "45 seconds" ],
+        "//2": "The maximum lifespan should not be terribly longer than the cooldown(currently 20 seconds), or else multiple groups can be active at once and make this much harder than desired.",
+        "lifespan": [ "15 seconds", "30 seconds" ],
         "target_var": { "global_val": "drain_terrain" }
       },
-      { "u_message": "The air hisses!", "type": "warning" }
+      { "u_message": "The air rings out with a piercing shriek!", "type": "warning" }
     ]
   },
   {
@@ -306,7 +308,7 @@
     "name": "GROUP_AMALGAMATIONS_SPAWNED",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_amalgamation_swarmer", "weight": 10 },
+      { "monster": "mon_amalgamation_swarmer", "weight": 20 },
       { "monster": "mon_amalgamation_corroder", "weight": 4 },
       { "monster": "mon_amalgamation_soldier", "weight": 1 }
     ]
@@ -315,7 +317,6 @@
     "type": "effect_on_condition",
     "id": "EOC_LIEUTENANT_ACTIVATE_SHADOW",
     "recurrence": 1,
-    "//1": "TODO long-term: 6 months into the cataclysm AND # of zombie kills? (Let's see how this shakes out first)",
     "condition": { "and": [ { "days_since_cataclysm": 7 }, { "math": [ "u_Lieutenants_active", "<", "1" ] } ] },
     "//2": "Integer value instead of bool, so more can be added later and use math for conditions",
     "effect": [ { "u_add_var": "Lieutenants_active", "value": "1" }, { "u_add_var": "Shadow_Lurking", "value": "1" } ],
@@ -324,13 +325,13 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_LIEUTENANT_SPAWN_SHADOW",
-    "recurrence": [ "4 hours", "4 hours" ],
-    "//1": "Night time, shadow is active, you are outdoors, and you are not likely to be near shelter.",
-    "//2": "Forcibly wake the player somehow? Just in case they are sleeping outside.",
+    "recurrence": [ "3 hours", "6 hours" ],
+    "//1": "Night time, shadow is active, you are outdoors *and awake*, and you are not likely to be near shelter.",
     "condition": {
       "and": [
         { "one_in_chance": 6 },
         { "not": "is_day" },
+        { "not": { "u_has_effect": "sleep" } },
         { "math": [ "u_Lieutenants_active", ">", "0" ] },
         { "math": [ "u_Shadow_Lurking", ">", "0" ] },
         "u_is_outside",


### PR DESCRIPTION
#### Summary
Balance "You will fear the night slightly less"

#### Purpose of change
There are some existing pain points related to the lieutenant zed, some parts where the design didn't work so well, some things I realized didn't work at all, and some assumptions that turned out to be wrong. This aims to fix all those, and make it a smoother, more consistent experience.

#### Describe the solution
Briefly listing all the changes and reasons for them...

Regeneration 5hp/turn --> 1hp/turn. With the speed differential being what it is, 5hp/turn allowed it to pretty consistently outheal the player chasing it. It is still desirable that it regenerates over a long enough fight, so 1hp/turn is the bare minimum.

Message changes: Obvious clarity pass. It helps the player know what's going on and gives it a bit more flavor.

FLIES: Was intended to let it avoid pits, but never saw the AI actually take flight so I assumed it was fine. It does actually fly in some situations, and that makes it completely unassailable. Obviously this just needs to go.

Bullet resistance 500-->100: While the player is still intended to engage with it more than just hose its general direction with gunfire, this allows some VERY high-end guns to do damage.

~~Casting time(for summon spell): default--->800 moves. With the speed scaling being what it is, a single summon of creatures could make you completely unable to catch it (you need to take time to avoid dying/smack some critters/etc). This gives it some 'backswing' so a particularly strong survivor still has time to close the distance.~~ This would be ideal but apparently it doesn't work!

Summon lifespan: min20s/max45s-->min15s/max30s. As above, these could simply harry the player too long. Additionally, if they lasted a long time this could allow as many as 3 (!!!) groups on the field at once, which is simply too many.

Group weights: Swarming amalgamations made about twice as likely. Because it spawns 6 of the same monster (as opposed to picking 6 times from the group) the larger spawns are exceptionally deadly. This simply tunes down how often that can happen by making the weakest option much more likely.

When shadow spawns: Time check randomized instead of like clockwork every 4 hours (now random between 3-6 hours), also increased the average so shadow spawns somewhat less often. Prevent it from spawning if the player happens to be sleeping. (Could remove the sleeping effect but stuff around sleep is so hardcoded I didn't want to touch it).

#### Describe alternatives you've considered
I would like to add a teleportation EoC that pops it away from you when it takes sufficient damage (allowing it time to cast spells/approach you from a different angle/etc), but there is an existing issue where location vars aren't playing nice with teleports, so I have not implemented that for the moment.

"Heavy duty" flashlights remain a pretty hard counter to it, since they are brighter and cause it to be affected by light even at its normal follow distance of 10. I have considered making it trail at a further distance, but then a default 8 perception character **cannot see it at that range**.I think the current approach where at longer ranges you might not be able to see it is still thematically/gameplay engaging, so even though it makes the monster "too easy to fight" sometimes it's still worth keeping this approach. Better than it be too easy (and engaging/fun) than the 'right amount' of difficult (and not fun).

#### Testing
I have only confirmed that the json loads without error.

#### Additional context
