### PR TITLE
Display what mod the contents belong to, scenario, profession, map

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -41,6 +41,7 @@
 #include "make_static.h"
 #include "mapsharing.h"
 #include "martialarts.h"
+#include "mod_manager.h"
 #include "monster.h"
 #include "mutation.h"
 #include "name.h"
@@ -1940,6 +1941,13 @@ static std::string assemble_profession_details( const avatar &u, const input_con
 {
     std::string assembled;
 
+    // Display Origin
+    const std::string mod_src = enumerate_as_string( sorted_profs[cur_id]->src, [](
+    const std::pair<profession_id, mod_id> &source ) {
+        return string_format( "'%s'", source.second->name() );
+    }, enumeration_conjunction::arrow );
+    assembled += string_format( _( "Origin: %s" ), mod_src ) + "\n";
+
     assembled += string_format( g_switch_msg( u ), ctxt.get_desc( "CHANGE_GENDER" ),
                                 sorted_profs[cur_id]->gender_appropriate_name( !u.male ) ) + "\n";
 
@@ -3042,6 +3050,13 @@ static std::string assemble_scenario_details( const avatar &u, const input_conte
         const scenario *current_scenario )
 {
     std::string assembled;
+    // Display Origin
+    const std::string mod_src = enumerate_as_string( current_scenario->src,
+    []( const std::pair<string_id<scenario>, mod_id> &source ) {
+        return string_format( "'%s'", source.second->name() );
+    }, enumeration_conjunction::arrow );
+    assembled += string_format( _( "Origin: %s" ), mod_src ) + "\n";
+
     assembled += string_format( g_switch_msg( u ), ctxt.get_desc( "CHANGE_GENDER" ),
                                 current_scenario->gender_appropriate_name( !u.male ) ) + "\n";
     assembled += string_format(

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -28,6 +28,7 @@
 #include "line.h"
 #include "map.h"
 #include "memory_fast.h"
+#include "mod_manager.h"
 #include "mongroup.h"
 #include "monster.h"
 #include "npc.h"
@@ -1586,6 +1587,13 @@ std::string overmapbuffer::get_description_at( const tripoint_abs_sm &where )
             format_string = pgettext( "terrain description", "%1$s in %3$s" );
         }
     }
+
+    // Display Origin
+    const std::string mod_src = enumerate_as_string( oter->get_type_id().obj().src,
+    []( const std::pair<oter_type_str_id, mod_id> &source ) {
+        return string_format( "'%s'", source.second->name() );
+    }, enumeration_conjunction::arrow );
+    format_string += "\n" + string_format( _( "Origin: %s" ), mod_src );
 
     return string_format( format_string, ter_name, dir_name, closest_city_name );
 }

--- a/src/profession.h
+++ b/src/profession.h
@@ -47,7 +47,6 @@ class profession
 
     private:
         string_id<profession> id;
-        std::vector<std::pair<string_id<profession>, mod_id>> src;
         bool was_loaded = false;
 
         translation _name_male;
@@ -126,6 +125,8 @@ class profession
         const std::vector<mission_type_id> &missions() const;
         int age_lower = 21;
         int age_upper = 55;
+
+        std::vector<std::pair<string_id<profession>, mod_id>> src;
 
         std::optional<achievement_id> get_requirement() const;
 

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -24,7 +24,6 @@ class scenario
         friend class generic_factory<scenario>;
         friend struct mod_tracker;
         string_id<scenario> id;
-        std::vector<std::pair<string_id<scenario>, mod_id>> src;
         bool was_loaded = false;
         translation _name_male;
         translation _name_female;
@@ -150,6 +149,7 @@ class scenario
         const std::vector<effect_on_condition_id> &eoc() const;
         const std::vector<std::pair<mongroup_id, float>> &surround_groups() const;
 
+        std::vector<std::pair<string_id<scenario>, mod_id>> src;
 };
 
 struct scen_blacklist {


### PR DESCRIPTION
#### Summary
Interface "Display what mod the contents belong to, scenario, profession, map"

#### Purpose of change
Some other content will also display the mod or core it belongs to, like items and monsters.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13540013/575d5fed-2f59-41fd-8cee-2af2e6abaf8f)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13540013/5b756fc5-39af-40f3-9c0f-24e7a6cf22ec)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13540013/bdc088ee-3146-4ed6-98a4-d2651cc25e16)

#### Additional context
