### PR TITLE
Amputees don't have socks, mutant has wheelchair

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3276,7 +3276,9 @@
       { "level": 4, "name": "electronics" }
     ],
     "items": {
-      "both": { "items": [ "dress_shirt", "pants", "socks", "boots", "knit_scarf", "coat_lab", "glasses_safety", "wristwatch" ] },
+      "both": {
+        "items": [ "dress_shirt", "pants", "knit_scarf", "coat_lab", "glasses_safety", "wristwatch", "folded_wheelchair_generic" ]
+      },
       "male": [ "briefs" ],
       "female": [ "bra", "panties" ]
     },
@@ -4026,7 +4028,7 @@
     "skills": [ { "level": 2, "name": "driving" }, { "level": 2, "name": "swimming" } ],
     "items": {
       "both": {
-        "items": [ "jeans", "longshirt", "socks", "mbag", "pockknife", "water_clean", "wristwatch", "folded_wheelchair_generic" ],
+        "items": [ "jeans", "longshirt", "mbag", "pockknife", "water_clean", "wristwatch", "folded_wheelchair_generic" ],
         "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_matches" } ]
       },
       "male": [ "boxer_shorts" ],


### PR DESCRIPTION
#### Summary
Bugfixes "Fix bugs with Para-amputee professions"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/68580

Both amputee professions started with socks, when they can't wear them, so they end up going in to their inventory.

The mutant additionally started with boots and without a wheelchair. Remove the useless boots and give them a wheelchair.

#### Describe the solution
Remove boots/socks, add wheelchair.

#### Testing
Start as a Para-amputee, see you have no socks in your inventory.
Start as a mutant Para-amputee, see you are not wielding boots with socks in your inventory, and instead are wielding a wheelchair.

#### Additional context
The wheelchair seems a little busted on good terrain - you can fly along at 3 tiles per turn without too much stamina burn.