### PR TITLE
Parametric microlabs (and meat overgrown microlab variant)

### DIFF
--- a/data/json/mapgen/microlab/microlab_distorted/microlab_distorted_hallway.json
+++ b/data/json/mapgen/microlab/microlab_distorted/microlab_distorted_hallway.json
@@ -23,7 +23,8 @@
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 0, "neighbors": { "north_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
-      ]
+      ],
+      "place_monster": [ { "group": "GROUP_DISTORTED_MICROLAB", "chance": 80, "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 2, 5 ] } ]
     }
   },
   {
@@ -43,7 +44,8 @@
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 0, "neighbors": { "north_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
-      ]
+      ],
+      "place_monster": [ { "group": "GROUP_DISTORTED_MICROLAB", "chance": 80, "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 2, 5 ] } ]
     }
   },
   {
@@ -62,7 +64,8 @@
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 0, "neighbors": { "north_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
-      ]
+      ],
+      "place_monster": [ { "group": "GROUP_DISTORTED_MICROLAB", "chance": 80, "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 2, 5 ] } ]
     }
   },
   {
@@ -81,7 +84,8 @@
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 0, "neighbors": { "north_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
-      ]
+      ],
+      "place_monster": [ { "group": "GROUP_DISTORTED_MICROLAB", "chance": 80, "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 2, 5 ] } ]
     }
   },
   {
@@ -100,7 +104,8 @@
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 0, "neighbors": { "north_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
-      ]
+      ],
+      "place_monster": [ { "group": "GROUP_DISTORTED_MICROLAB", "chance": 80, "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 2, 5 ] } ]
     }
   }
 ]

--- a/data/json/mapgen/microlab/microlab_edge_room_connector.json
+++ b/data/json/mapgen/microlab/microlab_edge_room_connector.json
@@ -31,8 +31,7 @@
         " c|22||||||  ||||||c c  ",
         "     |FFFF|  |FFFF|     "
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab" ]
     }
   }
 ]

--- a/data/json/mapgen/microlab/microlab_firebreak.json
+++ b/data/json/mapgen/microlab/microlab_firebreak.json
@@ -33,7 +33,18 @@
         "|||||| PP  PP  PP ||||||"
       ],
       "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" },
+      "place_nested": [
+        {
+          "chunks": [
+            {
+              "switch": { "param": "labtype", "fallback": "microlab_generic" },
+              "cases": { "microlab_meat": "micolab_meat_pools", "microlab_generic": "null" }
+            }
+          ],
+          "x": 0,
+          "y": 0
+        }
+      ],
       "computers": {
         "6": {
           "name": "Security Terminal",
@@ -78,7 +89,18 @@
         "|||||| PP  PP  PP ||||||"
       ],
       "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" },
+      "place_nested": [
+        {
+          "chunks": [
+            {
+              "switch": { "param": "labtype", "fallback": "microlab_generic" },
+              "cases": { "microlab_meat": "micolab_meat_pools", "microlab_generic": "null" }
+            }
+          ],
+          "x": 0,
+          "y": 0
+        }
+      ],
       "computers": {
         "6": {
           "name": "Security Terminal",
@@ -124,7 +146,6 @@
       ],
       "set": [ { "point": "bash", "x": [ 5, 18 ], "y": [ 0, 11 ], "repeat": [ 30, 100 ] } ],
       "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" },
       "monster": { "M": { "monster": "mon_mutant_alpha", "chance": 50 } },
       "place_monster": [ { "group": "GROUP_MUTANT_EVOLVED", "x": [ 6, 17 ], "y": [ 1, 10 ], "repeat": [ 2, 4 ] } ],
       "computers": {
@@ -172,7 +193,6 @@
       ],
       "set": [ { "point": "bash", "x": [ 6, 18 ], "y": [ 6, 18 ], "repeat": [ 30, 100 ] } ],
       "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" },
       "monster": { "M": { "monster": "mon_hunting_horror" }, "ü": { "monster": "mon_breather_hub" } },
       "computers": {
         "6": {

--- a/data/json/mapgen/microlab/microlab_generic.json
+++ b/data/json/mapgen/microlab/microlab_generic.json
@@ -2,15 +2,37 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "microlab_generic", "microlab_ratkin" ],
+    "om_terrain": [ "microlab_generic" ],
     "object": {
       "fill_ter": "t_strconc_floor",
       "place_nested": [
         { "chunks": [ "microlab_generic_tile" ], "x": 0, "y": 0 },
+        {
+          "chunks": [
+            {
+              "switch": { "param": "labtype", "fallback": "microlab_generic" },
+              "cases": { "microlab_meat": "micolab_meat_pools", "microlab_generic": "null" }
+            }
+          ],
+          "x": 0,
+          "y": 0
+        },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 0, "neighbors": { "north_west": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 0, "neighbors": { "north_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
+      ],
+      "place_monster": [
+        {
+          "group": {
+            "switch": { "param": "labtype", "fallback": "microlab_generic" },
+            "cases": { "microlab_meat": "GROUP_MEATLAB", "microlab_generic": "GROUP_MICROLAB" }
+          },
+          "chance": 80,
+          "x": [ 0, 23 ],
+          "y": [ 0, 23 ],
+          "repeat": [ 10, 20 ]
+        }
       ]
     }
   },

--- a/data/json/mapgen/microlab/microlab_generic_edge.json
+++ b/data/json/mapgen/microlab/microlab_generic_edge.json
@@ -26,11 +26,21 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ "microlab_generic_edge", "microlab_ratkin_edge" ],
+    "om_terrain": [ "microlab_generic_edge" ],
     "object": {
       "fill_ter": "t_strconc_floor",
       "place_nested": [
         { "chunks": [ "microlab_generic_edge_tile" ], "x": 0, "y": 0 },
+        {
+          "chunks": [
+            {
+              "switch": { "param": "labtype", "fallback": "microlab_generic" },
+              "cases": { "microlab_meat": "micolab_meat_pools", "microlab_generic": "null" }
+            }
+          ],
+          "x": 0,
+          "y": 0
+        },
         { "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 0, "neighbors": { "north": "microlab_rock_border" } },
         { "chunks": [ "concrete_wall_ns" ], "x": 23, "y": 0, "neighbors": { "east": "microlab_rock_border" } },
         { "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 23, "neighbors": { "south": "microlab_rock_border" } },
@@ -43,6 +53,18 @@
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 0, "neighbors": { "north_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
+      ],
+      "place_monster": [
+        {
+          "group": {
+            "switch": { "param": "labtype", "fallback": "microlab_generic" },
+            "cases": { "microlab_meat": "GROUP_MEATLAB", "microlab_generic": "GROUP_MICROLAB" }
+          },
+          "chance": 80,
+          "x": [ 0, 23 ],
+          "y": [ 0, 23 ],
+          "repeat": [ 10, 20 ]
+        }
       ]
     }
   },

--- a/data/json/mapgen/microlab/microlab_hallway.json
+++ b/data/json/mapgen/microlab/microlab_hallway.json
@@ -11,10 +11,32 @@
           "x": 0,
           "y": 0
         },
+        {
+          "chunks": [
+            {
+              "switch": { "param": "labtype", "fallback": "microlab_generic" },
+              "cases": { "microlab_meat": "micolab_meat_pools", "microlab_generic": "null" }
+            }
+          ],
+          "x": 0,
+          "y": 0
+        },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 0, "neighbors": { "north_west": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 0, "neighbors": { "north_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
+      ],
+      "place_monster": [
+        {
+          "group": {
+            "switch": { "param": "labtype", "fallback": "microlab_generic" },
+            "cases": { "microlab_meat": "GROUP_MEATLAB", "microlab_generic": "GROUP_LAB" }
+          },
+          "chance": 80,
+          "x": [ 0, 23 ],
+          "y": [ 0, 23 ],
+          "repeat": [ 2, 5 ]
+        }
       ]
     }
   },
@@ -30,6 +52,18 @@
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 0, "neighbors": { "north_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
+      ],
+      "place_monster": [
+        {
+          "group": {
+            "switch": { "param": "labtype", "fallback": "microlab_generic" },
+            "cases": { "microlab_meat": "GROUP_MEATLAB", "microlab_generic": "GROUP_LAB" }
+          },
+          "chance": 80,
+          "x": [ 0, 23 ],
+          "y": [ 0, 23 ],
+          "repeat": [ 2, 5 ]
+        }
       ]
     }
   },
@@ -45,6 +79,18 @@
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 0, "neighbors": { "north_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
+      ],
+      "place_monster": [
+        {
+          "group": {
+            "switch": { "param": "labtype", "fallback": "microlab_generic" },
+            "cases": { "microlab_meat": "GROUP_MEATLAB", "microlab_generic": "GROUP_LAB" }
+          },
+          "chance": 80,
+          "x": [ 0, 23 ],
+          "y": [ 0, 23 ],
+          "repeat": [ 2, 5 ]
+        }
       ]
     }
   },
@@ -60,6 +106,18 @@
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 0, "neighbors": { "north_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
+      ],
+      "place_monster": [
+        {
+          "group": {
+            "switch": { "param": "labtype", "fallback": "microlab_generic" },
+            "cases": { "microlab_meat": "GROUP_MEATLAB", "microlab_generic": "GROUP_LAB" }
+          },
+          "chance": 80,
+          "x": [ 0, 23 ],
+          "y": [ 0, 23 ],
+          "repeat": [ 2, 5 ]
+        }
       ]
     }
   },
@@ -95,8 +153,7 @@
         "  cc | PP  PP  PP |F c  ",
         "     | PP  PP  PP |     "
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab" ]
     }
   },
   {
@@ -131,8 +188,7 @@
         "    F| PP      PP |F c  ",
         "    F| PP  PP  PP |     "
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab" ]
     }
   },
   {
@@ -167,8 +223,7 @@
         "    F| PP      PP |F c  ",
         "    F| PP  PP  PP |     "
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab" ]
     }
   },
   {
@@ -203,8 +258,7 @@
         "|####| PP      PP |####|",
         "|||||| PP  PP  PP ||||||"
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab" ]
     }
   },
   {
@@ -239,8 +293,7 @@
         "  cc | PP  PP  PP |F i  ",
         "     | PP  PP  PP |     "
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab" ]
     }
   },
   {
@@ -275,8 +328,7 @@
         "  cc | PP  PP  PP |F i  ",
         "     | PP  PP  PP |     "
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab" ]
     }
   },
   {
@@ -311,8 +363,7 @@
         "    F| PP      PP |F c  ",
         "    F| PP  PP  PP |     "
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab" ]
     }
   },
   {
@@ -347,8 +398,7 @@
         "    F| PP      PP |F c  ",
         "    F| PP  PP  PP |     "
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab" ]
     }
   }
 ]

--- a/data/json/mapgen/microlab/microlab_hallway_start.json
+++ b/data/json/mapgen/microlab/microlab_hallway_start.json
@@ -19,6 +19,18 @@
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 0, "neighbors": { "north_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
+      ],
+      "place_monster": [
+        {
+          "group": {
+            "switch": { "param": "labtype", "fallback": "microlab_generic" },
+            "cases": { "microlab_meat": "GROUP_MEATLAB", "microlab_generic": "GROUP_LAB" }
+          },
+          "chance": 80,
+          "x": [ 0, 23 ],
+          "y": [ 0, 23 ],
+          "repeat": [ 2, 5 ]
+        }
       ]
     }
   },
@@ -54,8 +66,7 @@
         " cc  | PP  YY  PP |     ",
         " cc  | PP  YY  PP |     "
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab" ]
     }
   },
   {
@@ -90,8 +101,7 @@
         " cccc| PP  PP  PP |c6h  ",
         "  c h| PP  PP  PP |c    "
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab" ]
     }
   },
   {
@@ -126,8 +136,7 @@
         " cccc| PP  PP  PP |c6h  ",
         "  c h| PP  PP  PP |c    "
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab" ]
     }
   },
   {
@@ -162,8 +171,7 @@
         " cccc| PP  PP  PP |c6h  ",
         "  c h| PP  PP  PP |c    "
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab" ]
     }
   },
   {
@@ -208,8 +216,7 @@
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab" ]
     }
   }
 ]

--- a/data/json/mapgen/microlab/microlab_meat/microlab_meat_chunks.json
+++ b/data/json/mapgen/microlab/microlab_meat/microlab_meat_chunks.json
@@ -1,0 +1,121 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "micolab_meat_pools",
+    "//": "There should be about 75% chance of this nest being empty.  Please adjust the weight accordingly if you add more pool mapgen variants.",
+    "weight": 9,
+    "object": { "mapgensize": [ 24, 24 ], "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ] }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "micolab_meat_pools",
+    "weight": 1,
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "                        ",
+        "                        ",
+        "             wwww       ",
+        "               www      ",
+        "            wwwww       ",
+        "          wwwww         ",
+        "       wwwwwwwww     ww ",
+        "       wwwwww       www ",
+        "      wwww wwwww        ",
+        "             wwww       ",
+        "          wwwwwwww      ",
+        "            wwww        ",
+        "     wwwwww       ww    ",
+        "   wwwwww          ww   ",
+        "   wwww             www ",
+        "            ww    wwww  ",
+        "           wwwww        ",
+        "         wwwwww         ",
+        "           www          ",
+        "      wwwwwwwww         ",
+        "        wwwwww          ",
+        "           ww           ",
+        "                        ",
+        "                        "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": { "w": "t_water_sh_murky_underground" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "micolab_meat_pools",
+    "weight": 1,
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "                        ",
+        "                        ",
+        "             wwww       ",
+        "               www      ",
+        "            wwwww       ",
+        "          wwwww         ",
+        "       wwwwwwwww        ",
+        "       wwwwww           ",
+        "      wwww wwwww        ",
+        "             www        ",
+        "           wwww         ",
+        "        www   wwww      ",
+        "     wwwwww       ww    ",
+        "   wwwwww          ww   ",
+        "   wwww             www ",
+        "   www            wwww  ",
+        "    wwww                ",
+        "       www              ",
+        "       wwwwwww          ",
+        "      wwwww             ",
+        "                        ",
+        "                     ww ",
+        "                   www  ",
+        "                   w    "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": { "w": "t_water_sh_murky_underground" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "micolab_meat_pools",
+    "weight": 1,
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "      w ww              ",
+        "    wwwww               ",
+        "     wwwww              ",
+        "      wwwww             ",
+        "                w       ",
+        "              www       ",
+        "            wwww        ",
+        "           wwww         ",
+        "           wwwww        ",
+        "             www        ",
+        "           wwww         ",
+        "            www         ",
+        "                        ",
+        "                        ",
+        "                     ww ",
+        "                  wwww  ",
+        "                    ww  ",
+        "        w            w  ",
+        "      www             w ",
+        "    wwwwwww         www ",
+        "   wwwww            w   ",
+        "  www               www ",
+        " www               www  ",
+        "                   w    "
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "terrain": { "w": "t_water_sh_murky_underground" }
+    }
+  }
+]

--- a/data/json/mapgen/microlab/microlab_portal/microlab_MSU14.json
+++ b/data/json/mapgen/microlab/microlab_portal/microlab_MSU14.json
@@ -31,14 +31,8 @@
         "########################",
         "########################"
       ],
-      "palettes": [ "microlab" ],
-      "terrain": {
-        "`": "t_open_air",
-        "X": "t_region_shrub_decorative",
-        "P": "t_carpet_concrete_red",
-        "É": "t_card_science_security_black",
-        "Ú": "t_card_science_mu"
-      },
+      "palettes": [ "microlab_generic" ],
+      "terrain": { "`": "t_open_air", "É": "t_card_science_security_black", "Ú": "t_card_science_mu" },
       "items": { "Ñ": [ { "item": "guns_milspec", "chance": 10 }, { "item": "ammo_milspec", "chance": 70 } ] },
       "monster": { "T": { "monster": "mon_turret_rifle", "spawn_data": { "ammo": [ { "ammo_id": "556", "qty": [ 30, 90 ] } ] } } },
       "furniture": { "Ñ": "f_locker" }
@@ -76,7 +70,7 @@
         "#######|||    |||#######",
         "#########| YY |#########"
       ],
-      "palettes": [ "microlab" ],
+      "palettes": [ "microlab_generic" ],
       "terrain": { "P": "t_carpet_concrete_red", "É": "t_card_science_mu" },
       "furniture": { "Z": "f_server", ":": "f_xedra_antenna", "Ú": "f_melchior_unit" },
       "item": { "d": { "item": "msu14_password", "chance": 10 } },

--- a/data/json/mapgen/microlab/microlab_portal/microlab_portal_security_checkpoint.json
+++ b/data/json/mapgen/microlab/microlab_portal/microlab_portal_security_checkpoint.json
@@ -83,13 +83,11 @@
         "|   c|  ll|YY|ll   |c        $       $ ccc  ccc  111|811111  111118F1111 ccc$                                          |",
         "|||||||||||||||||||||||||||||||||||||||||||||||||||||81PP1111 11P18|||||||||||||||||||||||||||||||||||||||||||||||||||||"
       ],
-      "palettes": [ "microlab" ],
+      "palettes": [ "microlab_generic" ],
       "terrain": {
-        "X": "t_region_shrub_decorative",
         "G": "t_card_science",
         "W": "t_gates_mech_control_lab",
         "z": "t_strconc_floor",
-        "P": "t_carpet_concrete_red",
         "_": "t_carpet_concrete_red",
         "1": "t_nether_glass_floor",
         "8": "t_nether_glass_wall",

--- a/data/json/mapgen/microlab/microlab_portal/microlab_portal_unique.json
+++ b/data/json/mapgen/microlab/microlab_portal/microlab_portal_unique.json
@@ -37,7 +37,7 @@
         "|##|||            |####|",
         "||||||            ||||||"
       ],
-      "palettes": [ "microlab" ],
+      "palettes": [ "microlab_generic" ],
       "furniture": { "L": "f_locker" },
       "items": {
         "l": [ { "item": "lab_shoes" }, { "item": "lab_torso" }, { "item": "lab_pants" }, { "item": "underwear" } ],
@@ -79,8 +79,8 @@
         "########################",
         "########################"
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "`": "t_open_air", "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab_generic" ],
+      "terrain": { "`": "t_open_air" }
     }
   },
   {
@@ -115,16 +115,9 @@
         "########################",
         "########################"
       ],
-      "palettes": [ "microlab" ],
+      "palettes": [ "microlab_generic" ],
       "traps": { "9": "tr_microlab_portal_elevator_physics_shift" },
-      "terrain": {
-        "`": "t_open_air",
-        "X": "t_region_shrub_decorative",
-        "P": "t_carpet_concrete_red",
-        "1": "t_nether_glass_floor",
-        "9": "t_nether_glass_floor",
-        "8": "t_nether_glass_wall"
-      },
+      "terrain": { "`": "t_open_air", "1": "t_nether_glass_floor", "9": "t_nether_glass_floor", "8": "t_nether_glass_wall" },
       "signs": { "S": { "signage": "Warning:\nDo not proceed if red lights are on.\n\nRegulation EX-127 applies." } }
     }
   },
@@ -160,7 +153,7 @@
         "                        ",
         "                        "
       ],
-      "palettes": [ "microlab" ],
+      "palettes": [ "microlab_generic" ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "terrain": { ".": "t_nether_glass_floor", "2": "t_door_glass_frosted_lab_o" }
     }
@@ -197,8 +190,8 @@
         ",,,,,,,,,,,,,,,,,,,,,,,,",
         ",,,,,,,,,,,,,,,,,,,,,,,,"
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { ",": "t_nether_glass_floor", "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red" }
+      "palettes": [ "microlab_generic" ],
+      "terrain": { ",": "t_nether_glass_floor" }
     }
   }
 ]

--- a/data/json/mapgen/microlab/microlab_ratkin/microlab_ratkin_generic.json
+++ b/data/json/mapgen/microlab/microlab_ratkin/microlab_ratkin_generic.json
@@ -2,30 +2,26 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ [ "microlab_distorted" ] ],
+    "om_terrain": [ "microlab_ratkin" ],
     "object": {
-      "predecessor_mapgen": "microlab_generic",
+      "fill_ter": "t_strconc_floor",
       "place_nested": [
-        { "chunks": [ "microlab_distorted_chunk" ], "x": 0, "y": 0 },
-        { "chunks": [ "microlab_distorted_chunk" ], "x": 12, "y": 0 },
-        { "chunks": [ "microlab_distorted_chunk" ], "x": 0, "y": 12 },
-        { "chunks": [ "microlab_distorted_chunk" ], "x": 12, "y": 12 }
-      ],
-      "place_items": [ { "chance": 65, "item": "microlab_artifacts", "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 1, 3 ] } ],
-      "place_monster": [ { "group": "GROUP_DISTORTED_MICROLAB", "chance": 80, "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 10, 20 ] } ]
+        { "chunks": [ "microlab_generic_tile" ], "x": 0, "y": 0 },
+        { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 0, "neighbors": { "north_west": "microlab" } },
+        { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 0, "neighbors": { "north_east": "microlab" } },
+        { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
+        { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
+      ]
     }
   },
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ [ "microlab_distorted_edge" ] ],
+    "om_terrain": [ "microlab_ratkin_edge" ],
     "object": {
-      "predecessor_mapgen": "microlab_generic_edge",
+      "fill_ter": "t_strconc_floor",
       "place_nested": [
-        { "chunks": [ "microlab_distorted_chunk" ], "x": 0, "y": 0 },
-        { "chunks": [ "microlab_distorted_chunk" ], "x": 12, "y": 0 },
-        { "chunks": [ "microlab_distorted_chunk" ], "x": 0, "y": 12 },
-        { "chunks": [ "microlab_distorted_chunk" ], "x": 12, "y": 12 },
+        { "chunks": [ "microlab_generic_edge_tile" ], "x": 0, "y": 0 },
         { "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 0, "neighbors": { "north": "microlab_rock_border" } },
         { "chunks": [ "concrete_wall_ns" ], "x": 23, "y": 0, "neighbors": { "east": "microlab_rock_border" } },
         { "chunks": [ "concrete_wall_ew" ], "x": 0, "y": 23, "neighbors": { "south": "microlab_rock_border" } },
@@ -38,9 +34,7 @@
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 0, "neighbors": { "north_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 23, "y": 23, "neighbors": { "south_east": "microlab" } },
         { "else_chunks": [ "concrete_corner" ], "x": 0, "y": 23, "neighbors": { "south_west": "microlab" } }
-      ],
-      "place_items": [ { "chance": 65, "item": "microlab_artifacts", "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 1, 3 ] } ],
-      "place_monster": [ { "group": "GROUP_DISTORTED_MICROLAB", "chance": 80, "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 10, 20 ] } ]
+      ]
     }
   }
 ]

--- a/data/json/mapgen/microlab/microlab_reactor.json
+++ b/data/json/mapgen/microlab/microlab_reactor.json
@@ -37,7 +37,7 @@
         { "square": "radiation", "amount": 100, "x": 11, "y": 11, "x2": 18, "y2": 13 },
         { "square": "radiation", "amount": 10000, "x": 9, "y": 5, "x2": 14, "y2": 8 }
       ],
-      "palettes": [ "microlab" ],
+      "palettes": [ "microlab_generic" ],
       "items": { "d": { "item": "cop_armory", "chance": 5 }, "l": { "item": "decontamination_room", "chance": 70 } },
       "terrain": { "-": "t_wall_metal", "`": "t_hole", "#": "t_rock", "G": "t_card_science", "g": "t_bridge", "A": "t_bridge" },
       "furniture": { "A": "f_nuclear_fuel_cell" }
@@ -78,7 +78,7 @@
         { "square": "radiation", "amount": 1000, "x": 3, "y": 2, "x2": 20, "y2": 13 },
         { "square": "radiation", "amount": 10000, "x": 9, "y": 5, "x2": 14, "y2": 8 }
       ],
-      "palettes": [ "microlab" ],
+      "palettes": [ "microlab_generic" ],
       "terrain": { "-": "t_wall_metal", "#": "t_rock", "g": "t_bridge", "A": "t_bridge", "w": "t_water_pool" },
       "furniture": { "A": "f_nuclear_fuel_cell" }
     }

--- a/data/json/mapgen/microlab/microlab_shifting_hall.json
+++ b/data/json/mapgen/microlab/microlab_shifting_hall.json
@@ -43,7 +43,7 @@
         "                        ",
         "                        "
       ],
-      "palettes": [ "microlab" ],
+      "palettes": [ "microlab_generic" ],
       "terrain": { ".": "t_strconc_floor", "S": "t_strconc_floor", "^": "t_strconc_floor" },
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "traps": { "T": "tr_microlab_shifting_hall_2" },
@@ -86,7 +86,7 @@
         "                        ",
         "                        "
       ],
-      "palettes": [ "microlab" ],
+      "palettes": [ "microlab_generic" ],
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
       "terrain": { ".": "t_strconc_floor", "S": "t_strconc_floor" },
       "traps": { "T": "tr_microlab_shifting_hall" },

--- a/data/json/mapgen_palettes/microlab.json
+++ b/data/json/mapgen_palettes/microlab.json
@@ -2,12 +2,22 @@
   {
     "type": "palette",
     "id": "microlab",
+    "parameters": {
+      "labtype": { "type": "palette_id", "default": { "distribution": [ [ "microlab_generic", 6 ], [ "microlab_meat", 1 ] ] } }
+    },
+    "palettes": [ { "param": "labtype" } ]
+  },
+  {
+    "type": "palette",
+    "id": "microlab_generic",
     "terrain": {
       "+": "t_door_c",
       ".": "t_metal_floor",
       "3": "t_door_locked",
       "2": "t_door_glass_frosted_lab_c",
       "4": "t_door_metal_pickable",
+      "X": "t_region_shrub_decorative",
+      "P": "t_carpet_concrete_red",
       "5": "t_door_metal_locked",
       "[": "t_door_glass_c",
       "-": "t_wall_metal",
@@ -19,7 +29,7 @@
       "E": "t_elevator_control",
       "<": "t_stairs_up",
       ">": "t_stairs_down",
-      "Y": "t_utility_light",
+      "Y": "t_strconc_floor_olight",
       "#": "t_rock"
     },
     "furniture": {
@@ -78,6 +88,94 @@
       "O": [ { "item": "tools_robotics", "chance": 40, "repeat": [ 1, 3 ] }, { "item": "schematics", "chance": 2 } ],
       "i": { "item": "cleaning", "chance": 20 },
       "N": { "item": "fireman_cabinet", "chance": 100 }
+    },
+    "vendingmachines": { "V": {  } }
+  },
+  {
+    "type": "palette",
+    "id": "microlab_meat",
+    "terrain": {
+      "|": [ [ "t_concrete_wall", 1 ], [ "t_concrete_wall_flesh", 2 ] ],
+      " ": [ [ "t_null", 1 ], [ "t_thconc_floor_flesh", 2 ] ],
+      "+": "t_door_c",
+      ".": "t_metal_floor",
+      "3": "t_door_locked",
+      "2": "t_door_glass_frosted_lab_c",
+      "X": [ [ "t_thconc_floor_flesh", 1 ], [ "t_grass_dead", 2 ] ],
+      "P": [ [ "t_thconc_floor_flesh", 1 ], [ "t_carpet_concrete_red", 2 ] ],
+      "4": "t_door_metal_pickable",
+      "5": "t_door_metal_locked",
+      "[": "t_door_glass_c",
+      "-": "t_wall_metal",
+      "y": "t_pavement_y",
+      "=": [ [ "t_wall_glass", 3 ], [ "t_thconc_floor_flesh", 1 ] ],
+      "(": "t_reinforced_glass",
+      "e": "t_elevator",
+      "E": "t_elevator_control",
+      "<": "t_stairs_up",
+      ">": "t_stairs_down",
+      "Y": [ [ "t_strconc_floor_olight", 1 ], [ "t_thconc_floor_flesh", 2 ] ],
+      "#": "t_rock"
+    },
+    "furniture": {
+      ";": "f_toilet",
+      "~": "f_shower",
+      "@": "f_bed",
+      "6": "f_console_broken",
+      "a": "f_armchair",
+      "k": "f_cupboard",
+      "D": "f_dresser",
+      "h": "f_chair",
+      "b": "f_bench",
+      "B": "f_bookcase",
+      "c": "f_counter",
+      "l": "f_locker",
+      "n": "f_trashcan",
+      "d": "f_desk",
+      "f": "f_fridge",
+      "F": "f_glass_fridge",
+      "o": "f_oven",
+      "O": "f_utility_shelf",
+      "U": "f_utility_shelf",
+      "i": "f_sink",
+      "r": "f_rack",
+      "?": "f_sofa",
+      "t": "f_table",
+      "R": "f_table",
+      "N": "f_fireman_cabinet",
+      "^": "f_indoor_plant",
+      "x": "f_safe_l"
+    },
+    "toilets": { ";": {  } },
+    "items": {
+      "d": { "item": "office", "chance": 10, "repeat": [ 1, 3 ] },
+      "B": [ { "item": "textbooks", "chance": 10 }, { "item": "manuals", "chance": 50 } ],
+      "F": [
+        { "item": "supplies_reagents_lab", "chance": 10, "repeat": [ 2, 5 ] },
+        { "item": "supplies_samples_lab", "chance": 10, "repeat": [ 1, 3 ] }
+      ],
+      "U": [
+        { "item": "tools_science", "chance": 10, "repeat": [ 1, 3 ] },
+        { "item": "supplies_reagents_lab", "chance": 10, "repeat": [ 1, 3 ] }
+      ],
+      "c": [
+        { "item": "tools_science", "chance": 10, "repeat": [ 1, 3 ] },
+        { "item": "supplies_reagents_lab", "chance": 10, "repeat": [ 1, 3 ] },
+        { "item": "lab_files_generic", "chance": 5 }
+      ],
+      "R": [
+        { "item": "tools_robotics", "chance": 5, "repeat": [ 1, 3 ] },
+        { "item": "robots", "chance": 10, "repeat": [ 1, 3 ] },
+        { "item": "supplies_electronics", "chance": 5, "repeat": [ 1, 3 ] }
+      ],
+      "O": [ { "item": "tools_robotics", "chance": 5, "repeat": [ 1, 3 ] }, { "item": "schematics", "chance": 2 } ],
+      "i": { "item": "cleaning", "chance": 10 },
+      "N": { "item": "fireman_cabinet", "chance": 100 }
+    },
+    "monster": {
+      " ": [ { "monster": "mon_zombie_living_wall", "chance": 3 }, { "monster": "mon_breather_hub", "chance": 1 } ],
+      "c": { "monster": "mon_zombie_living_wall", "chance": 3 },
+      "@": { "monster": "mon_zombie_living_wall", "chance": 80 }
     },
     "vendingmachines": { "V": {  } }
   }

--- a/data/json/monstergroups/lab.json
+++ b/data/json/monstergroups/lab.json
@@ -225,6 +225,22 @@
   },
   {
     "type": "monstergroup",
+    "name": "GROUP_MEATLAB",
+    "monsters": [
+      { "monster": "mon_null", "weight": 9 },
+      { "monster": "mon_amalgamation_swarmer", "weight": 5, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_meat_cocoon_tiny", "weight": 5, "pack_size": [ 1, 2 ] },
+      { "monster": "mon_meat_cocoon_small", "weight": 2 },
+      { "monster": "mon_amalgamation_spotter", "weight": 2 },
+      { "monster": "mon_amalgamation_corroder", "weight": 2 },
+      { "monster": "mon_amalgamation_jumper", "pack_size": [ 1, 2 ], "weight": 1 },
+      { "monster": "mon_amalgamation_soldier", "weight": 1, "starts": "7 days" },
+      { "monster": "mon_amalgamation_zapper", "weight": 1, "starts": "14 days" },
+      { "monster": "mon_jabberwock", "weight": 1, "starts": "7 days" }
+    ]
+  },
+  {
+    "type": "monstergroup",
     "name": "GROUP_LAB_BASIC_SECURITY",
     "monsters": [
       { "monster": "mon_feral_labsecurity_9mm", "weight": 18, "cost_multiplier": 12 },

--- a/data/json/overmap/overmap_terrain/overmap_terrain_microlab.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_microlab.json
@@ -5,7 +5,6 @@
     "name": "science lab",
     "sym": "L",
     "color": "light_blue",
-    "spawns": { "group": "GROUP_MICROLAB", "population": [ 12, 25 ], "chance": 80 },
     "see_cost": 5,
     "flags": [ "NO_ROTATE", "RISK_HIGH", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
   },
@@ -40,7 +39,6 @@
     "name": "subway station?",
     "sym": "S",
     "color": "light_blue",
-    "spawns": { "group": "GROUP_LAB", "population": [ 12, 25 ], "chance": 80 },
     "see_cost": 5,
     "flags": [ "RISK_HIGH", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
   },
@@ -100,7 +98,6 @@
     "name": "lab hallway",
     "color": "light_red",
     "see_cost": 5,
-    "spawns": { "group": "GROUP_LAB", "population": [ 2, 5 ], "chance": 80 },
     "flags": [ "LINEAR" ]
   },
   {
@@ -117,7 +114,6 @@
     "id": [ "microlab_distorted", "microlab_distorted_edge" ],
     "name": "distorted science lab",
     "color": "pink",
-    "spawns": { "group": "GROUP_DISTORTED_MICROLAB", "population": [ 10, 25 ], "chance": 80 },
     "copy-from": "microlab_generic"
   },
   {
@@ -126,7 +122,6 @@
     "name": "distorted hallway",
     "color": "light_red",
     "see_cost": 5,
-    "spawns": { "group": "GROUP_DISTORTED_MICROLAB", "population": [ 2, 5 ], "chance": 80 },
     "flags": [ "LINEAR" ]
   },
   {

--- a/data/mods/Isolation-Protocol/Map/mapgen/elevator.json
+++ b/data/mods/Isolation-Protocol/Map/mapgen/elevator.json
@@ -59,8 +59,8 @@
         "########################",
         "########################"
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "`": "t_open_air", "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red", "E": "t_elevator_control_off" }
+      "palettes": [ "microlab_generic" ],
+      "terrain": { "`": "t_open_air", "E": "t_elevator_control_off" }
     }
   },
   {
@@ -95,8 +95,8 @@
         "########################",
         "########################"
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "`": "t_open_air", "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red", "E": "t_elevator_control_iso" }
+      "palettes": [ "microlab_generic" ],
+      "terrain": { "`": "t_open_air", "E": "t_elevator_control_iso" }
     }
   }
 ]

--- a/data/mods/Isolation-Protocol/Map/mapgen/hallway.json
+++ b/data/mods/Isolation-Protocol/Map/mapgen/hallway.json
@@ -61,8 +61,8 @@
         "|####||55||SS||55||####|",
         "|||||| YY      YY ||||||"
       ],
-      "palettes": [ "microlab" ],
-      "terrain": { "X": "t_region_shrub_decorative", "P": "t_carpet_concrete_red", "5": "t_door_metal_c" },
+      "palettes": [ "microlab_generic" ],
+      "terrain": { "5": "t_door_metal_c" },
       "furniture": { "A": "f_xedra_antenna" },
       "item": { "m": { "item": "xedra_microphone", "chance": 90 }, "s": { "item": "xedra_seismograph", "chance": 90 } },
       "items": { "ú": { "item": "SUS_evac_shelter_locker_used", "chance": 95 } },

--- a/data/mods/Magiclysm/worldgen/labs/microlab.json
+++ b/data/mods/Magiclysm/worldgen/labs/microlab.json
@@ -33,7 +33,7 @@
         " cccc|c   |^^|    |  cc ",
         "    c|c   2  2    |     "
       ],
-      "palettes": [ "microlab" ],
+      "palettes": [ "microlab_generic" ],
       "terrain": { "G": "t_card_science", "Ø": "t_rock_floor", "¢": "t_rock_floor" },
       "furniture": { "☿": "f_alembic", "β": "f_magic_bench", "Ø": "f_magic_circle" },
       "place_item": [


### PR DESCRIPTION
#### Summary
Features "Microlab Mapgen is now parameter based."

#### Purpose of change
This is the basic set of changes that would allow the design of fully specialized micro labs without the need of redefining overmap terrains, specials or having to make several mapgen chunks.

Since microlabs are built from nested chunks, the controling "labtype" parameter mostly affect the  palettes used within chunks. With some additional effects like controlling monster placement or enabling the conditional placement of extra chunks. The examples of how it works are found at the top of `microlab_generic.json`, `microlab_generic_edge.json` `microlab_hallways` (the files containing the actual mapgen) and the palette file `microlab.json`.


#### Describe the solution

I added simple variant to ensure the parametrization worked properly.  Which in this case is a ruined microlab overgrown with zombie flesh and patrolled by amalgamations. Atm the place is somewhat lacking in unique encounters, items and mechanics. It will get updates later, what is properly here is mostly just for testing purposes.

No changes should be evident in the normal generic version of microlabs. The ratkin and mod microlab features have also been excluded from parametrization.

#### Testing

Visited several labs, generic and meatified. All seems ok. 

#### Additional context

Here's a meat lab hallway:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/5290912/51c7eea1-7794-402d-a4fc-9e9a4d6b25c7)
