### PR TITLE
fix: basic ferals mostly share drops with zombies

### DIFF
--- a/data/json/monsterdrops/feral_humans.json
+++ b/data/json/monsterdrops/feral_humans.json
@@ -13,14 +13,17 @@
           { "item": "crash_axe", "prob": 5, "damage": [ 1, 3 ] }
         ]
       },
-      { "group": "default_zombie_clothes", "prob": 100 }
+      { "group": "default_zombie_death_drops", "prob": 100, "damage": [ 1, 3 ] }
     ]
   },
   {
     "type": "item_group",
     "subtype": "collection",
     "id": "feral_humans_death_drops_pipe",
-    "entries": [ { "item": "pipe", "prob": 100, "damage": [ 0, 2 ] }, { "group": "default_zombie_clothes", "prob": 100 } ]
+    "entries": [
+      { "item": "pipe", "prob": 100, "damage": [ 0, 2 ] },
+      { "group": "default_zombie_death_drops", "prob": 100, "damage": [ 1, 3 ] }
+    ]
   },
   {
     "type": "item_group",
@@ -34,7 +37,7 @@
           { "item": "heavy_crowbar", "prob": 10, "damage": [ 2, 4 ] }
         ]
       },
-      { "group": "default_zombie_clothes", "prob": 100 }
+      { "group": "default_zombie_death_drops", "prob": 100, "damage": [ 1, 3 ] }
     ]
   },
   {

--- a/data/json/monsterdrops/zombie_default.json
+++ b/data/json/monsterdrops/zombie_default.json
@@ -300,13 +300,7 @@
         "distribution": [
           {
             "collection": [
-              {
-                "distribution": [
-                  { "group": "default_zombie_clothes", "prob": 90 },
-                  { "group": "default_zombie_clothes_christmas", "event": "christmas", "prob": 10 },
-                  { "group": "default_zombie_clothes_halloween", "event": "halloween", "prob": 10 }
-                ]
-              },
+              { "group": "default_zombie_clothes" },
               {
                 "distribution": [ { "group": "default_zombie_items", "prob": 80 }, { "group": "default_zombie_items_pockets", "prob": 20 } ]
               }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
resolves: #68512
make regular ferals share mostly the same drops as the regular zombies, clothes, items etc

also remove itemgroups related with events from the defaul zed drops, they don't work, at least zed spawn wit barely anything if I leave those lines there


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![Screenshot from 2023-10-10 18-02-39](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/53e0d4fb-4781-4427-bac8-23f4b0f377af)
![Screenshot from 2023-10-10 18-19-57](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/030f431c-9dc9-445c-b1ab-5e18391ef5b0)
![Screenshot from 2023-10-10 18-20-02](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/b5f1a967-b6d9-427d-b148-0f49f79c4b1b)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
