### PR TITLE
Allow NPC_DEATH EoC to prevent NPC dies

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -140,5 +140,16 @@
         ]
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_spawn_npc_test",
+    "effect": [ { "u_spawn_npc": "NPC_debug", "real_count": 1, "min_radius": 1, "max_radius": 3 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_event_NPC_DEATH_test",
+    "eoc_type": "NPC_DEATH",
+    "effect": [ { "u_set_hp": 999, "only_increase": true } ]
   }
 ]

--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -151,5 +151,13 @@
     "id": "EOC_event_NPC_DEATH_test",
     "eoc_type": "NPC_DEATH",
     "effect": [ { "u_set_hp": 999, "only_increase": true } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_event_character_dies_test",
+    "eoc_type": "EVENT",
+    "required_event": "character_dies",
+    "condition": { "u_has_trait": "DEBUG_PREVENT_DEATH" },
+    "effect": [ { "u_set_hp": 999, "only_increase": true } ]
   }
 ]

--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -150,7 +150,7 @@
     "type": "effect_on_condition",
     "id": "EOC_event_NPC_DEATH_test",
     "eoc_type": "NPC_DEATH",
-    "effect": [ { "u_set_hp": 999, "only_increase": true } ]
+    "effect": [ "u_prevent_death" ]
   },
   {
     "type": "effect_on_condition",
@@ -158,6 +158,6 @@
     "eoc_type": "EVENT",
     "required_event": "character_dies",
     "condition": { "u_has_trait": "DEBUG_PREVENT_DEATH" },
-    "effect": [ { "u_set_hp": 999, "only_increase": true } ]
+    "effect": [ "u_prevent_death" ]
   }
 ]

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -8795,7 +8795,7 @@
     "name": { "str": "Debug Prevent Death" },
     "points": 99,
     "valid": false,
-    "description": "You are prvented from death.",
+    "description": "You are prevented from death.",
     "debug": true
   },
   {

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -8791,6 +8791,15 @@
   },
   {
     "type": "mutation",
+    "id": "DEBUG_PREVENT_DEATH",
+    "name": { "str": "Debug Prevent Death" },
+    "points": 99,
+    "valid": false,
+    "description": "You are prvented from death.",
+    "debug": true
+  },
+  {
+    "type": "mutation",
     "id": "SQUEAMISH",
     "name": { "str": "Squeamish" },
     "points": -1,

--- a/data/json/npcs/npc.json
+++ b/data/json/npcs/npc.json
@@ -254,5 +254,17 @@
     "mission_offered": "MISSION_JOIN_TRACKER",
     "chat": "TALK_STRANGER_FRIENDLY",
     "faction": "no_faction"
+  },
+  {
+    "type": "npc",
+    "id": "NPC_debug",
+    "//": "Someone helps you test the game.",
+    "name_suffix": "Debug",
+    "class": "NC_NONE",
+    "attitude": 0,
+    "mission": 0,
+    "chat": "TALK_DONE",
+    "faction": "no_faction",
+    "death_eocs": [ "EOC_event_NPC_DEATH_test" ]
   }
 ]

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -2150,6 +2150,41 @@ You and NPC both die
 }
 ```
 
+#### `u_prevent_death`, `npc_prevent_death`
+You or NPC will be prevented from death. Intended for use in EoCs has `NPC_DEATH` or `EVENT(character_dies)` type (Take care that u will be the dying npc in these events).
+
+##### Valid talkers:
+
+| Avatar | Character | NPC | Monster |  Furniture | Item |
+| ------ | --------- | --------- | ---- | ------- | --- | 
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+
+##### Examples
+
+NPC is prevented from death.
+
+`NPC_DEATH`
+```json
+{
+  "type": "effect_on_condition",
+  "id": "EOC_event_NPC_DEATH_test",
+  "eoc_type": "NPC_DEATH",
+  "effect": [ "u_prevent_death" ]
+}
+```
+
+`EVENT`
+```json
+{
+  "type": "effect_on_condition",
+  "id": "EOC_event_character_dies_test",
+  "eoc_type": "EVENT",
+  "required_event": "character_dies",
+  "condition": { "u_has_trait": "DEBUG_PREVENT_DEATH" },
+  "effect": [ "u_prevent_death" ]
+}
+```
+
 ## Item effects
 
 #### `u_set_flag`, `npc_set_flag`

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -927,6 +927,7 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | causes_resonance_cascade | Triggers when resonance cascade option is activated via "old lab" finale's computer | NONE | avatar / NONE |
 | character_casts_spell |  | { "character", `character_id` },<br/> { "spell", `spell_id` },<br/> { "difficulty", `int` },<br/> { "cost", `int` },<br/> { "cast_time", `int` },<br/> { "damage", `int` }, | character / NONE |
 | character_consumes_item |  | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE |
+| character_dies |  | { "character", `character_id` }, | character / NONE |
 | character_eats_item |  | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE |
 | character_finished_activity | Triggered when character finished or canceled activity | { "character", `character_id` },<br/> { "activity", `activity_id` },<br/> { "canceled", `bool` } | character / NONE |
 | character_forgets_spell |  | { "character", `character_id` },<br/> { "spell", `spell_id` } | character / NONE |

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -46,7 +46,7 @@ An effect_on_condition is an object allowing the combination of dialog condition
 * `RECURRING` - activated automatically on schedule (see `recurrence`)
 * `SCENARIO_SPECIFIC` - automatically invoked once on scenario start.
 * `AVATAR_DEATH` - automatically invoked whenever the current avatar dies (it will be run with the avatar as `u`), if after it the player is no longer dead they will not die, if there are multiple EOCs they all be run until the player is not dead.
-* `NPC_DEATH` - EOCs can only be assigned to run on the death of an npc, in which case u will be the dying npc and npc will be the killer.
+* `NPC_DEATH` - EOCs can only be assigned to run on the death of an npc, in which case u will be the dying npc and npc will be the killer. If after it npc is no longer dead they will not die, if there are multiple they all be run until npc is not dead.
 * `OM_MOVE` - EOCs trigger when the player moves overmap tiles
 * `PREVENT_DEATH` - whenever the current avatar dies it will be run with the avatar as `u`, if after it the player is no longer dead they will not die, if there are multiple they all be run until the player is not dead.
 * `EVENT` - EOCs trigger when a specific event given by "required_event" takes place. 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3514,6 +3514,18 @@ void Character::die( Creature *nkiller )
     mission::on_creature_death( *this );
 }
 
+void Character::prevent_death()
+{
+    for( const bodypart_id &bp : get_all_body_parts( get_body_part_flags::only_main ) ) {
+        if( bp->is_vital ) {
+            if( get_part_hp_cur( bp ) <= 0 ) {
+                set_part_hp_cur( bp, 1 );
+            }
+        }
+    }
+    cached_dead_state.reset();
+}
+
 void Character::apply_skill_boost()
 {
     for( const skill_boost &boost : skill_boost::get_all() ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3499,21 +3499,8 @@ void Character::normalize()
 // Actual player death is mostly handled in game::is_game_over
 void Character::die( Creature *nkiller )
 {
-    set_all_parts_hp_cur( 0 );
-
-    dialogue d( get_talker_for( this ), nkiller == nullptr ? nullptr : get_talker_for( nkiller ) );
-    for( effect_on_condition_id &eoc : death_eocs ) {
-        if( eoc->type == eoc_type::NPC_DEATH ) {
-            eoc->activate( d );
-        } else {
-            debugmsg( "Tried to use non NPC_DEATH eoc_type %s for an npc death.", eoc.c_str() );
-        }
-    }
-    if( !is_dead_state() ) {
-        return;
-    }
-
     g->set_critter_died();
+    set_all_parts_hp_cur( 0 );
     set_killer( nkiller );
     set_time_died( calendar::turn );
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3499,10 +3499,7 @@ void Character::normalize()
 // Actual player death is mostly handled in game::is_game_over
 void Character::die( Creature *nkiller )
 {
-    g->set_critter_died();
     set_all_parts_hp_cur( 0 );
-    set_killer( nkiller );
-    set_time_died( calendar::turn );
 
     dialogue d( get_talker_for( this ), nkiller == nullptr ? nullptr : get_talker_for( nkiller ) );
     for( effect_on_condition_id &eoc : death_eocs ) {
@@ -3512,6 +3509,13 @@ void Character::die( Creature *nkiller )
             debugmsg( "Tried to use non NPC_DEATH eoc_type %s for an npc death.", eoc.c_str() );
         }
     }
+    if( !is_dead_state() ) {
+        return;
+    }
+
+    g->set_critter_died();
+    set_killer( nkiller );
+    set_time_died( calendar::turn );
 
     if( has_effect( effect_heavysnare ) ) {
         inv->add_item( item( "rope_6", calendar::turn_zero ) );

--- a/src/character.h
+++ b/src/character.h
@@ -2463,6 +2463,7 @@ class Character : public Creature, public visitable
          */
         void normalize() override;
         void die( Creature *nkiller ) override;
+        virtual void prevent_death();
 
         std::string get_name() const override;
 

--- a/src/character.h
+++ b/src/character.h
@@ -1159,7 +1159,7 @@ class Character : public Creature, public visitable
         /** Returns true if the player should be dead */
         bool is_dead_state() const override;
 
-    private:
+    protected:
         mutable std::optional<bool> cached_dead_state;
     public:
         void set_part_hp_cur( const bodypart_id &id, int set ) override;

--- a/src/character.h
+++ b/src/character.h
@@ -1159,7 +1159,7 @@ class Character : public Creature, public visitable
         /** Returns true if the player should be dead */
         bool is_dead_state() const override;
 
-    protected:
+    private:
         mutable std::optional<bool> cached_dead_state;
     public:
         void set_part_hp_cur( const bodypart_id &id, int set ) override;

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -66,6 +66,7 @@ struct talk_effect_fun_t {
         void set_cast_spell( const JsonObject &jo, std::string_view member, bool is_npc );
         void set_attack( const JsonObject &jo, std::string_view member, bool is_npc );
         void set_die( bool is_npc );
+        void set_prevent_death( bool is_npc );
         void set_lightning();
         void set_next_weather();
         void set_hp( const JsonObject &jo, std::string_view member, bool is_npc );

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -24,6 +24,7 @@ std::string enum_to_string<event_type>( event_type data )
         case event_type::buries_corpse: return "buries_corpse";
         case event_type::causes_resonance_cascade: return "causes_resonance_cascade";
         case event_type::character_consumes_item: return "character_consumes_item";
+        case event_type::character_dies: return "character_dies";
         case event_type::character_eats_item: return "character_eats_item";
         case event_type::character_casts_spell: return "character_casts_spell";
         case event_type::character_finished_activity: return "character_finished_activity";
@@ -133,7 +134,7 @@ DEFINE_EVENT_HELPER_FIELDS( event_spec_empty )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character_item )
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 96,
+static_assert( static_cast<int>( event_type::num_event_types ) == 97,
                "This static_assert is a reminder to add a definition below when you add a new "
                "event_type.  If your event_spec specialization inherits from another struct for "
                "its fields definition then you probably don't need a definition here." );
@@ -153,6 +154,7 @@ DEFINE_EVENT_FIELDS( buries_corpse )
 DEFINE_EVENT_FIELDS( character_finished_activity )
 DEFINE_EVENT_FIELDS( character_forgets_spell )
 DEFINE_EVENT_FIELDS( character_casts_spell )
+DEFINE_EVENT_FIELDS( character_dies )
 DEFINE_EVENT_FIELDS( character_gains_effect )
 DEFINE_EVENT_FIELDS( character_heals_damage )
 DEFINE_EVENT_FIELDS( character_kills_character )

--- a/src/event.h
+++ b/src/event.h
@@ -40,6 +40,7 @@ enum class event_type : int {
     // fueling bionics
     character_casts_spell,
     character_consumes_item,
+    character_dies,
     character_eats_item,
     character_finished_activity,
     character_forgets_spell,
@@ -181,7 +182,7 @@ struct event_spec_character_item {
     };
 };
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 96,
+static_assert( static_cast<int>( event_type::num_event_types ) == 97,
                "This static_assert is to remind you to add a specialization for your new "
                "event_type below" );
 
@@ -286,6 +287,14 @@ struct event_spec<event_type::character_casts_spell> {
             { "cast_time", cata_variant_type::int_},
             { "damage", cata_variant_type::int_}
 
+        }
+    };
+};
+
+template<>
+struct event_spec<event_type::character_dies> {
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 1> fields = {{
+            { "character", cata_variant_type::character_id }
         }
     };
 };

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -1096,6 +1096,7 @@ void memorial_logger::notify( const cata::event &e )
         case event_type::avatar_enters_omt:
         case event_type::avatar_moves:
         case event_type::character_consumes_item:
+        case event_type::character_dies:
         case event_type::character_eats_item:
         case event_type::character_finished_activity:
         case event_type::character_gets_headshot:

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2965,8 +2965,11 @@ void npc::die( Creature *nkiller )
     }
     get_event_bus().send<event_type::character_dies>( getID() );
     // Check if npc doesn't die due to EoC as a result
-    if( !is_dead() ) {
-        return;
+    if( prevent_death_reminder ) {
+        prevent_death_reminder = false;
+        if( !is_dead() ) {
+            return;
+        }
     }
 
     if( assigned_camp ) {
@@ -3033,6 +3036,7 @@ void npc::die( Creature *nkiller )
 void npc::prevent_death()
 {
     marked_for_death = false;
+    prevent_death_reminder = true;
     Character::prevent_death();
 }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2954,6 +2954,21 @@ void npc::die( Creature *nkiller )
         // *only* set to true in this function!
         return;
     }
+
+    dialogue d( get_talker_for( this ), nkiller == nullptr ? nullptr : get_talker_for( nkiller ) );
+    for( effect_on_condition_id &eoc : death_eocs ) {
+        if( eoc->type == eoc_type::NPC_DEATH ) {
+            eoc->activate( d );
+            // Invalidate cache in case the npc doesn't die due to EoC as a result
+            cached_dead_state.reset();
+        } else {
+            debugmsg( "Tried to use non NPC_DEATH eoc_type %s for an npc death.", eoc.c_str() );
+        }
+    }
+    if( !is_dead() ) {
+        return;
+    }
+
     if( assigned_camp ) {
         std::optional<basecamp *> bcp = overmap_buffer.find_camp( ( *assigned_camp ).xy() );
         if( bcp ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2955,6 +2955,7 @@ void npc::die( Creature *nkiller )
         return;
     }
 
+    prevent_death_reminder = false;
     dialogue d( get_talker_for( this ), nkiller == nullptr ? nullptr : get_talker_for( nkiller ) );
     for( effect_on_condition_id &eoc : death_eocs ) {
         if( eoc->type == eoc_type::NPC_DEATH ) {

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2959,12 +2959,13 @@ void npc::die( Creature *nkiller )
     for( effect_on_condition_id &eoc : death_eocs ) {
         if( eoc->type == eoc_type::NPC_DEATH ) {
             eoc->activate( d );
-            // Invalidate cache in case the npc doesn't die due to EoC as a result
-            cached_dead_state.reset();
         } else {
             debugmsg( "Tried to use non NPC_DEATH eoc_type %s for an npc death.", eoc.c_str() );
         }
     }
+    get_event_bus().send<event_type::character_dies>( getID() );
+    // Invalidate cache in case the npc doesn't die due to EoC as a result
+    cached_dead_state.reset();
     if( !is_dead() ) {
         return;
     }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2964,8 +2964,7 @@ void npc::die( Creature *nkiller )
         }
     }
     get_event_bus().send<event_type::character_dies>( getID() );
-    // Invalidate cache in case the npc doesn't die due to EoC as a result
-    cached_dead_state.reset();
+    // Check if npc doesn't die due to EoC as a result
     if( !is_dead() ) {
         return;
     }
@@ -3029,6 +3028,12 @@ void npc::die( Creature *nkiller )
     }
 
     place_corpse();
+}
+
+void npc::prevent_death()
+{
+    marked_for_death = false;
+    Character::prevent_death();
 }
 
 std::string npc_attitude_id( npc_attitude att )

--- a/src/npc.h
+++ b/src/npc.h
@@ -1000,6 +1000,7 @@ class npc : public Character
         void reboot();
         void die( Creature *killer ) override;
         bool is_dead() const;
+        void prevent_death() override;
         // How well we smash terrain (not corpses!)
         int smash_ability() const;
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -1410,6 +1410,8 @@ class npc : public Character
         int cbm_weapon_index = -1;
 
         bool dead = false;  // If true, we need to be cleaned up
+        // Temporary variable for preventing from death (used by EoC event)
+        bool prevent_death_reminder = false; // NOLINT(cata-serialize)
 
         bool sees_dangerous_field( const tripoint &p ) const;
         bool could_move_onto( const tripoint &p ) const;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4159,6 +4159,17 @@ void talk_effect_fun_t::set_die( bool is_npc )
     };
 }
 
+
+void talk_effect_fun_t::set_prevent_death( bool is_npc )
+{
+    function = [is_npc]( dialogue const & d ) {
+        Character *ch = d.actor( is_npc )->get_character();
+        if( ch ) {
+            ch->prevent_death();
+        }
+    };
+}
+
 void talk_effect_fun_t::set_lightning()
 {
     function = []( dialogue const &/* d */ ) {
@@ -5777,6 +5788,18 @@ void talk_effect_t::parse_string_effect( const std::string &effect_id, const Jso
 
     if( effect_id == "npc_die" ) {
         subeffect_fun.set_die( true );
+        set_effect( subeffect_fun );
+        return;
+    }
+
+    if( effect_id == "u_prevent_death" ) {
+        subeffect_fun.set_prevent_death( false );
+        set_effect( subeffect_fun );
+        return;
+    }
+
+    if( effect_id == "npc_prevent_death" ) {
+        subeffect_fun.set_prevent_death( true );
         set_effect( subeffect_fun );
         return;
     }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4159,7 +4159,6 @@ void talk_effect_fun_t::set_die( bool is_npc )
     };
 }
 
-
 void talk_effect_fun_t::set_prevent_death( bool is_npc )
 {
     function = [is_npc]( dialogue const & d ) {


### PR DESCRIPTION
#### Summary
Features "Allow NPC_DEATH EoC to prevent npc die"

#### Purpose of change
EoC has NPC_DEATH event that runs if NPC dies. However, restoring the NPC's HP during this event will not prevent the NPC from dying.

#### Describe the solution
Change the order of event processing to be before the NPC's complete death processing, and skip processing if the NPC no longer dies as a result of the event.
To prevent NPC death, use the newly added function `u_prevent_death`.
Also, add `character_dies` as a new EVENT type EOC.

It will be never used in vanilla, but it helps protect NPCs you need in the mod's questline. 

#### Describe alternatives you've considered

#### Testing
Add example EoCs.
Spawn test NPC by `EOC_spawn_npc_test`. Summons zombears and bear to attack NPC. NPC never dies.
I believe this does not affect the normal NPC death process, as automated testing has been successful.

#### Additional context
I wanted to make it as simple as `PREVENT_DEATH` provided for avatars, but NPC death processing is a bit complicated and didn't work the same way. Please let me know if you have any good implementation