### PR TITLE
EOD loudout added

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -6448,8 +6448,9 @@
     "name": "Explosive Ordinance Disposal Technician",
     "description": "Ever since you were a child you were fascinated with explosives and all things that go boom. As soon as you turned 18 you joined the army to become an EOD technician. When your base was overrun, you find yourself alone in the middle of nowhere with nothing but your precious training, gear and cherished love of explosives",
     "points": 5,
-    "proficiencies": [ "prof_elec_circuits", "prof_intro_chemistry", "prof_athlete_expert", "prof_gun_cleaning" ],
+    "proficiencies": [ "prof_elec_circuits", "prof_intro_chemistry", "prof_athlete_expert", "prof_gun_cleaning", "prof_spotting", "prof_traps", "prof_disarming", "prof_trapsetting" ],
     "skills": [
+      { "level": 6, "name": "traps" },
       { "level": 4, "name": "melee" },
       { "level": 4, "name": "gun" },
       { "level": 4, "name": "rifle" },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -6446,7 +6446,7 @@
     "type": "profession",
     "id": "explosive_ordinance_disposal",
     "name": "Explosive Ordinance Disposal Technician",
-    "description": "Ever since you were a child you were fascinated with explosives and all things that go boom. As soon as you turned 18 you joined the army to become an EOD technician. While out on a call about a potential explosive in the neighbouring county, your team was overrun by hordes of the undead. You are alone, with nothing but your precious training, gear and love of explosives",
+    "description": "Ever since you were a child you were fascinated with explosives and all things that go boom.  As soon as you turned 18 you joined the army to become an EOD technician.  While out on a call about a potential explosive in the neighboring county, your team was overrun by hordes of the undead.  You are alone, with nothing but your precious training, gear and love of explosives",
     "points": 5,
     "proficiencies": [
       "prof_elec_circuits",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -6444,11 +6444,20 @@
   },
   {
     "type": "profession",
-    "id": "explosive_ordinance_disposal_on_duty",
+    "id": "explosive_ordinance_disposal",
     "name": "Explosive Ordinance Disposal Technician",
-    "description": "Ever since you were a child you were fascinated with explosives and all things that go boom. As soon as you turned 18 you joined the army to become an EOD technician. When your base was overrun, you find yourself alone in the middle of nowhere with nothing but your precious training, gear and cherished love of explosives",
+    "description": "Ever since you were a child you were fascinated with explosives and all things that go boom. As soon as you turned 18 you joined the army to become an EOD technician. While out on a call about a potential explosive in the neighbouring county, your team was overrun by hordes of the undead. You are alone, with nothing but your precious training, gear and love of explosives",
     "points": 5,
-    "proficiencies": [ "prof_elec_circuits", "prof_intro_chemistry", "prof_athlete_expert", "prof_gun_cleaning", "prof_spotting", "prof_traps", "prof_disarming", "prof_trapsetting" ],
+    "proficiencies": [
+      "prof_elec_circuits",
+      "prof_intro_chemistry",
+      "prof_athlete_expert",
+      "prof_gun_cleaning",
+      "prof_spotting",
+      "prof_traps",
+      "prof_disarming",
+      "prof_trapsetting"
+    ],
     "skills": [
       { "level": 6, "name": "traps" },
       { "level": 4, "name": "melee" },
@@ -6475,7 +6484,6 @@
       },
       "male": [ "boxer_shorts" ],
       "female": [ "panties", "bra" ]
-    },
-    "flags": [ "SCEN_ONLY" ]
+    }
   }
 ]

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -6441,5 +6441,40 @@
       "male": [ "boxer_shorts" ],
       "female": [ "panties", "bra" ]
     }
+  },
+  {
+    "type": "profession",
+    "id": "explosive_ordinance_disposal_on_duty",
+    "name": "Explosive Ordinance Disposal Technician",
+    "description": "Ever since you were a child you were fascinated with explosives and all things that go boom. As soon as you turned 18 you joined the army to become an EOD technician. When your base was overrun, you find yourself alone in the middle of nowhere with nothing but your precious training, gear and cherished love of explosives",
+    "points": 5,
+    "proficiencies": [ "prof_elec_circuits", "prof_intro_chemistry", "prof_athlete_expert", "prof_gun_cleaning" ],
+    "skills": [
+      { "level": 4, "name": "melee" },
+      { "level": 4, "name": "gun" },
+      { "level": 4, "name": "rifle" },
+      { "level": 3, "name": "pistol" },
+      { "level": 3, "name": "dodge" },
+      { "level": 3, "name": "firstaid" },
+      { "level": 3, "name": "throw" },
+      { "level": 3, "name": "survival" }
+    ],
+    "items": {
+      "both": {
+        "items": [ "undershirt", "socks", "helmet_eod", "jacket_eod", "gloves_eod", "trousers_eod", "foot_protectors_eod" ],
+        "entries": [
+          {
+            "item": "modular_m4_carbine",
+            "variant": "modular_m4a1",
+            "ammo-item": "556_mk318",
+            "charges": 30,
+            "contents-item": [ "shoulder_strap", "holo_sight" ]
+          }
+        ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "panties", "bra" ]
+    },
+    "flags": [ "SCEN_ONLY" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Added a new loadout to start as an EOD technician"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This change was requested as a part of issue #56471. It also makes sense that since EOD gear is in the game, there should be a starting profession as an EOD technician.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The solution edits the professions.json file to add the EOD technician as a profession.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Having EOD technician only available when playing the overrun scenario felt quite restrictive and pointless, since you can find EOD gear on military bases anyway. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Checked that EOD technician showed up as an option when starting a new game.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
