### PR TITLE
Procgen relic "multiply" enchantments use float not integer

### DIFF
--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -710,7 +710,7 @@ relic relic_procgen_data::generate( const relic_procgen_data::generation_rules &
                     passive_mult_procgen_values.pick();
                 if( mult != nullptr ) {
                     enchant_cache ench;
-                    float value = rng( mult->min_value, mult->max_value );
+                    float value = rng_float( mult->min_value, mult->max_value );
                     ench.add_value_mult( mult->type, value );
                     int negative_ench_attribute = power_level( ench );
                     if( negative_ench_attribute < 0 ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
* Fixes #67905

#### Describe the solution
Use `rng_float` instead of `rng`

#### Describe alternatives you've considered


#### Testing
See linked PR

#### Additional context
