### PR TITLE
Info msg when melee skill is too low to see melee values

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5429,6 +5429,13 @@ void item::melee_combat_info( std::vector<iteminfo> &info, const iteminfo_query 
                                iteminfo::lower_is_better, attack_cost );
         }
         insert_separation_line( info );
+    } else if( player_character.get_skill_level( skill_melee ) < 3 ) {
+        insert_separation_line( info );
+        if( parts->test( iteminfo_parts::DESCRIPTION_MELEEDMG ) ) {
+            info.emplace_back( "DESCRIPTION", _( "<bold>Average melee damage</bold>:" ) );
+        }
+        info.emplace_back( "BASE",
+                           _( "You don't know enough about fighting to know how effectively you could use this." ) );
     }
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5434,9 +5434,9 @@ void item::melee_combat_info( std::vector<iteminfo> &info, const iteminfo_query 
         insert_separation_line( info );
         if( parts->test( iteminfo_parts::DESCRIPTION_MELEEDMG ) ) {
             info.emplace_back( "DESCRIPTION", _( "<bold>Average melee damage</bold>:" ) );
+            info.emplace_back( "BASE",
+                               _( "You don't know enough about fighting to know how effectively you could use this." ) );
         }
-        info.emplace_back( "BASE",
-                           _( "You don't know enough about fighting to know how effectively you could use this." ) );
     }
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5429,7 +5429,8 @@ void item::melee_combat_info( std::vector<iteminfo> &info, const iteminfo_query 
                                iteminfo::lower_is_better, attack_cost );
         }
         insert_separation_line( info );
-    } else if( player_character.get_skill_level( skill_melee ) < 3 ) {
+    } else if( player_character.get_skill_level( skill_melee ) < 3 &&
+               ( !dmg_types.empty() || type->m_to_hit > 0 ) ) {
         insert_separation_line( info );
         if( parts->test( iteminfo_parts::DESCRIPTION_MELEEDMG ) ) {
             info.emplace_back( "DESCRIPTION", _( "<bold>Average melee damage</bold>:" ) );


### PR DESCRIPTION
#### Summary
Interface "Melee weapons tell you your skill is too low to see melee values instead of just hiding them"

#### Purpose of change
Was testing relic enchantments for ATTACK_SPEED and was very confused I could not see adjusted moves per attack on the item's info panel. Turns out the entire section is just hidden(not added) if you don't have enough melee skill.

#### Describe the solution
Still insert the section, but only with a blurb telling you the character has too little skill.

#### Describe alternatives you've considered

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/cf4128f5-468d-46f0-ada3-968274e22700)

#### Additional context

