### PR TITLE
[Xedra Evolved] Take Eaters MTF's extra watch

### DIFF
--- a/data/mods/Xedra_Evolved/player/professions.json
+++ b/data/mods/Xedra_Evolved/player/professions.json
@@ -311,7 +311,6 @@
           "gloves_tactical",
           "socks",
           "boots_combat",
-          "wristwatch",
           "molle_pack",
           "hammer_sledge"
         ],


### PR DESCRIPTION


#### Summary
None

#### Purpose of change

Eaters MTF accidentally got issued 2 watches instead of 1. Unless it was for some flavour reasons, it probably should be 1.

#### Describe the solution

Delete the extra `wristwatch` in the eaters MTF profession.

#### Describe alternatives you've considered

Let @GuardianDll deal with it, but it feels a bit petty when i can just easily do it.

#### Testing


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
