### PR TITLE
fixed broken salt water pipe

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -2869,7 +2869,8 @@ bool basecamp::common_salt_water_pipe_construction(
         }
     }
 
-    basecamp_action_components components( making, {}, 1, *this );
+    mapgen_arguments arg;  //  Created with a default value.
+    basecamp_action_components components( making, arg, 1, *this );
     if( !components.choose_components() ) {
         return false;
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix the Workshop 2 expansion salt water pipe that was broken when someone replaced list parameters with sets.
Fix #66318.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Since an empty list is accepted syntactically, but the type of the parameter used has some kind of default value a value with the default value was created and passed instead of the empty list, which caused the hash stuff to stop blowing up trying to access the first element of an empty map.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Continue to wait to no avail for someone who actually know what they're doing to fix the problem.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

1. Loaded a save with a partially built Workshop 2 expansion.
2. Ordered the companion to build a salt water pipe.
3. Repeated the construction until the whole pipe was constructed.
4. Verified that examining the pump offered it to provide me with salt water.
5. Followed the "pipe" to the well in the swamp to verify the well and the "pipe" was still there.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Tried to set up a hide site and to build a palisade as both of these missions are given empty lists as their parameters as well. Both were sent off successfully, so they're probably not broken. It's possible these missions aren't considered blueprints and thus aren't sent to the exploding hash finding function, but I haven't checked as they work as is.

As should be clear by the above, I don't really know what I'm doing here, although the guess about using a default value is a reasonable one. Thus, it would be useful if someone who actually has any idea of how the hash macro mess works takes a look at it.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
