### PR TITLE
Find items that cover body part

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1023,27 +1023,74 @@ static const std::array<translation, 3> item_filter_rule_intros {
     to_translation( "Type part of an item's name to move nearby items to the top." )
 };
 
+namespace
+{
+struct ItemFilterPrefix {
+    char key;
+    translation example;
+    translation description;
+};
+} // namespace
+
+static const std::vector<ItemFilterPrefix> item_filter_prefixes = {
+    { 'c', to_translation( "food" ), to_translation( "<color_cyan>category</color> of item" ) },
+    { 'm', to_translation( "iron" ), to_translation( "<color_cyan>material</color> item is made of" ) },
+    { 'q', to_translation( "hammering" ), to_translation( "<color_cyan>quality</color> provided by tool" ) },
+    { 'n', to_translation( "toolshelf" ), to_translation( "<color_cyan>notes</color> written on item" ) },
+    { 's', to_translation( "devices" ), to_translation( "<color_cyan>skill</color> taught by books" ) },
+    { 'd', to_translation( "pipe" ), to_translation( "<color_cyan>disassembled</color> components" ) },
+    { 'v', to_translation( "hand" ), to_translation( "covers <color_cyan>body part</color>" ) },
+    { 'b', to_translation( "mre;sealed" ), to_translation( "items satisfying <color_cyan>both</color> conditions" ) }
+};
+
+static const translation item_filter_help_1 = to_translation(
+            "The default is to search item names.  Some single-character prefixes "
+            "can be used with a colon <color_red>:</color> to search in other ways.  Additional filters "
+            "are separated by commas <color_red>,</color>.\n"
+            "Example: back,flash,aid, ,band\n\n" // NOLINT(cata-text-style): literal comma
+        );
+static const translation item_filter_help_2 = to_translation(
+            "\nPlace [<color_red>--</color>] in front to include only matching items.\n"
+            // An example of how to exclude items with - when filtering items.
+            "Example: steel,-chunk,--c:spare parts"
+        );
+
 std::string item_filter_rule_string( const item_filter_type type )
 {
-    std::ostringstream str;
+    std::string description;
     const int tab_idx = static_cast<int>( type ) - static_cast<int>( item_filter_type::FIRST );
-    str << item_filter_rule_intros[tab_idx];
-    // NOLINTNEXTLINE(cata-text-style): literal comma
-    str << "\n\n" << _( "Separate multiple items with [<color_yellow>,</color>]." );
-    //~ An example of how to separate multiple items with a comma when filtering items.
-    str << "\n" << _( "Example: back,flash,aid, ,band" ); // NOLINT(cata-text-style): literal comma
-    str << "\n\n" << _( "Search [<color_yellow>c</color>]ategory, [<color_yellow>m</color>]aterial, "
-                        "[<color_yellow>q</color>]uality, [<color_yellow>n</color>]otes, "
-                        "[<color_yellow>s</color>]skill taught by books, "
-                        "[<color_yellow>d</color>]isassembled components, or "
-                        "items satisfying [<color_yellow>b</color>]oth conditions." );
-    //~ An example of how to filter items based on category or material.
-    str << "\n" << _( "Example: c:food,m:iron,q:hammering,n:toolshelf,d:pipe,s:devices,b:mre;sealed" );
-    str << "\n\n" << _( "To exclude items, place [<color_yellow>-</color>] in front.  "
-                        "Place [<color_yellow>--</color>] in front to include only matching items." );
-    //~ An example of how to exclude items with - when filtering items.
-    str << "\n" << _( "Example: steel,-chunk,--c:spare parts" );
-    return str.str();
+    description = item_filter_rule_intros[tab_idx] + "\n" + item_filter_help_1.translated();
+
+    int max_example_length = 0;
+    for( const auto &prefix : item_filter_prefixes ) {
+        max_example_length = std::max( max_example_length, utf8_width( prefix.example.translated() ) );
+    }
+    std::string spaces( max_example_length, ' ' );
+    {
+        std::string example_name = _( "shirt" );
+        int padding = max_example_length - utf8_width( example_name );
+        description += string_format(
+                           _( "  <color_white>%s</color>%.*s    %s\n" ),
+                           example_name, padding, spaces,
+                           _( "<color_cyan>name</color> of item" ) );
+
+        std::string example_exclude = _( "rotten" );
+        padding = max_example_length - utf8_width( example_exclude );
+        description += string_format(
+                           _( "  <color_yellow>-</color><color_white>%s</color>%.*s   %s\n" ),
+                           example_exclude, padding, spaces,
+                           _( "<color_cyan>names</color> to exclude" ) );
+    }
+
+    for( const auto &prefix : item_filter_prefixes ) {
+        int padding = max_example_length - utf8_width( prefix.example.translated() );
+        description += string_format(
+                           _( "  <color_yellow>%c</color><color_white>:%s</color>%.*s  %s\n" ),
+                           prefix.key, prefix.example, padding, spaces, prefix.description );
+    }
+
+    description += item_filter_help_2.translated();
+    return description;
 }
 
 void draw_item_filter_rules( const catacurses::window &win, const int starty, const int height,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Find items that cover body part"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
* Adds a way to filter items by whether or not they cover a given body part when worn.



#### Describe the solution

* Example: `v:hand` or `v:eyes` would find all gloves or glasses respectively.
* Example use case: I'd like to find all gloves in my stash, and possibly compare them to what I have now. Previously, we could filter items for something like `glove`, but that would miss stuff like `fire gauntlet` or `brass knuckles`.
* The filter applies to all items searches with `/` such as:
    * inventory
    * AIM
    * viewing nearby items with `V`
    * creating zone with `Loot: Custom`
    * comparing items with `I`.
* This commit also updates the help text for item filters so that it looks more like the help text shown when filtering recipes in `&`.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* Input is welcome on whether we should use another character than `v:` for this type of filter.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Before:
![filter-by-coverered-bodypart-before](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/d8b23519-184f-4dd2-b98f-8a22644a295d)

After:
![filter-by-coverered-bodypart-after](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/502419a4-989b-4d2e-98e1-d4b3f131a4e1)

![filter-by-coverered-bodypart-new](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/a3b3e245-50db-488a-885c-93c500bf4abd)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
