### PR TITLE
HWP breacher configuration

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/robofac_trade.json
+++ b/data/json/itemgroups/Locations_MapExtras/robofac_trade.json
@@ -144,6 +144,7 @@
           { "item": "robofac_gun_smg", "prob": 100, "count": 1 },
           { "item": "robofac_gun_dmr", "prob": 100, "count": 1 },
           { "item": "robofac_gun_shotgun", "prob": 100, "count": 1 },
+          { "item": "robofac_gun_shotgun_breach", "prob": 100, "count": 1 },
           { "item": "robofac_gun_46", "prob": 100, "count": 1 },
           { "item": "robofac_gun_57", "prob": 100, "count": 1 },
           { "item": "robofac_gun_kit", "prob": 100, "count": 1 }

--- a/data/json/items/armor/robofac_armor.json
+++ b/data/json/items/armor/robofac_armor.json
@@ -90,6 +90,7 @@
           "robofac_gun_smg",
           "robofac_gun_dmr",
           "robofac_gun_shotgun",
+          "robofac_gun_shotgun_breach",
           "robofac_gun_exodii",
           "robofac_gun_57",
           "robofac_gun_46"
@@ -191,6 +192,7 @@
           "robofac_gun_smg",
           "robofac_gun_dmr",
           "robofac_gun_shotgun",
+          "robofac_gun_shotgun_breach",
           "robofac_gun_exodii",
           "robofac_gun_57",
           "robofac_gun_46"

--- a/data/json/items/gun/robofac_gun.json
+++ b/data/json/items/gun/robofac_gun.json
@@ -282,6 +282,20 @@
     "description": "A Hub 01 Hybrid Weapons Platform quick swap conversion kit.  This version has a long barrel with \"00 CQC\" stamped into the metal and an integrated choke."
   },
   {
+    "id": "robofac_gun_shotgun_breach",
+    "copy-from": "robofac_gun_shotgun",
+    "type": "GUNMOD",
+    "mod_targets": [ "robofac_gun" ],
+    "integral_volume": "175 ml",
+    "integral_weight": "650 g",
+    "integral_longest_side": "12 cm",
+    "longest_side": "42 cm",
+    "shot_spread_multiplier_modifier": 1.25,
+    "//": "based on M26-MASS; shot_spread_multiplier_modifier is increased due the short barrel",
+    "name": { "str_sp": "HWP breacher configuration" },
+    "description": "A Hub 01 Hybrid Weapons Platform quick swap conversion kit.  This version looks like close quarters configuration, but has a shortened barrel with \"BREACH\" stamped into the metal."
+  },
+  {
     "id": "xedra_gun_shotgun",
     "copy-from": "robofac_gun_shotgun",
     "type": "GUNMOD",

--- a/data/json/items/gun/robofac_gun.json
+++ b/data/json/items/gun/robofac_gun.json
@@ -293,7 +293,7 @@
     "shot_spread_multiplier_modifier": 1.25,
     "//": "based on M26-MASS; shot_spread_multiplier_modifier is increased due the short barrel",
     "name": { "str_sp": "HWP breacher configuration" },
-    "description": "A Hub 01 Hybrid Weapons Platform quick swap conversion kit.  This version looks like close quarters configuration, but has a shortened barrel with \"BREACH\" stamped into the metal."
+    "description": "A Hub 01 Hybrid Weapons Platform quick swap conversion kit.  This version looks like the close quarters configuration, but has a shortened barrel with \"00 BREACH\" stamped into the metal."
   },
   {
     "id": "xedra_gun_shotgun",

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -1047,7 +1047,14 @@
         "max_contains_volume": "1500 ml",
         "max_contains_weight": "3000 g",
         "max_item_length": "60 cm",
-        "item_restriction": [ "robofac_gun_ar", "robofac_gun_smg", "robofac_gun_dmr", "robofac_gun_shotgun", "robofac_gun_exodii" ]
+        "item_restriction": [
+          "robofac_gun_ar",
+          "robofac_gun_smg",
+          "robofac_gun_dmr",
+          "robofac_gun_shotgun",
+          "robofac_gun_shotgun_breach",
+          "robofac_gun_exodii"
+        ]
       }
     ],
     "melee_damage": { "bash": 6 }

--- a/data/mods/Generic_Guns/gunmods/gg_gunmods_blacklist.json
+++ b/data/mods/Generic_Guns/gunmods/gg_gunmods_blacklist.json
@@ -19,6 +19,7 @@
       "robofac_gun_ar",
       "robofac_gun_dmr",
       "robofac_gun_shotgun",
+      "robofac_gun_shotgun_breach",
       "robofac_gun_smg",
       "robofac_gun_46",
       "robofac_gun_57",

--- a/data/mods/classic_zombies/items/blacklists.json
+++ b/data/mods/classic_zombies/items/blacklists.json
@@ -362,6 +362,7 @@
       "robofac_gun_smg",
       "robofac_gun_dmr",
       "robofac_gun_shotgun",
+      "robofac_gun_shotgun_breach",
       "robofac_handguard",
       "robofac_laser_sight",
       "robofac10",


### PR DESCRIPTION
#### Summary
Content "HWP breacher configuration"
#### Purpose of change
I, among some folks, was interested into firing slugs from HWP, but it was not possible because of integrated choke on barrel in cqc config
#### Describe the solution
Added breacher config, that has shortened barrel and length, bigger shot spread modifier (because of twice as short barrel) and without integrated choke
#### Describe alternatives you've considered
🤷 
#### Additional context
@John-Candlebury @bombasticSlacks is it good for you?