### PR TITLE
Add launch configuration for VS Code dev container

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,13 @@
 {
     "C_Cpp.default.configurationProvider": "ms-vscode.makefile-tools",
+    "makefile.launchConfigurations": [
+        {
+            "cwd": "${workspaceRoot}",
+            "binaryPath": "${workspaceRoot}/${buildTarget}",
+            "binaryArgs": [],
+            "stopAtEntry": true
+        }
+  ],
     "makefile.configurations": [
         {
             "name" : "Linux - X64 - Tiles/Sound - Release",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Build "Add a launch and debug configuration to VS Code Dev Container"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
At least on my Linux setup, VS Code doesn't detect the selected build target as a launch configuration, so you can't run or debug the binary you just compiled with the press of a button. This config allows you to select the build target you just selected above as the launch target:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/2456481/d5923fce-0264-4e24-af5f-aa4487a024bd)
Allowing you to press these buttons to run the binary or to debug it: 
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/2456481/8be7ca96-b823-4c8d-ba5f-fc3a90257102)

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add some configuration to enable the VS Code Makefile Tools to pick up the build target you used as the launch target. Oddly enough I couldn't find the expandable config variables  documented anywhere but in this issue: https://github.com/microsoft/vscode-makefile-tools/issues/25#issuecomment-1509315108
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I considered leaving `"stopAtEntry": true` as `false`, instead, so it doesn't break into debugger immediately when you launch in debugging mode. I find this convenient but can be convinced otherwise.
  
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Use the launch config to run the game both with and without debugger.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
