### PR TITLE
Fix aftershock chemrig bugs

### DIFF
--- a/data/json/morale_types.json
+++ b/data/json/morale_types.json
@@ -418,5 +418,10 @@
     "id": "morale_impossible_shape",
     "type": "morale_type",
     "text": "Saw something that hurts to remember"
+  },
+  {
+    "id": "morale_afs_drugs",
+    "type": "morale_type",
+    "text": "Chemical enhancement moodswing"
   }
 ]

--- a/data/mods/Aftershock/effects.json
+++ b/data/mods/Aftershock/effects.json
@@ -230,7 +230,13 @@
     "rating": "bad",
     "int_dur_factor": "8 h",
     "max_duration": "24 h",
-    "base_mods": { "stim_amount": [ -5 ], "stim_max_val": [ -60 ], "perspiration_amount": [ 2 ], "stamina_amount": [ -10 ] },
+    "base_mods": {
+      "stim_min": [ -20 ],
+      "stim_min_val": [ -60 ],
+      "perspiration_min": [ 1 ],
+      "perspiration_chance": [ 60 ],
+      "stamina_min": [ -10 ]
+    },
     "blood_analysis_description": "Post overdose quantities of multiple drugs in analyzed blood.",
     "show_in_info": true
   },

--- a/data/mods/Aftershock/player/bionic_eocs.json
+++ b/data/mods/Aftershock/player/bionic_eocs.json
@@ -21,18 +21,37 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "afs_eoc_chembaseline",
+    "effect": [
+      { "u_lose_effect": "decreased_performance" },
+      {
+        "u_add_morale": "morale_afs_drugs",
+        "bonus": 20,
+        "max_bonus": 60,
+        "duration": "36 hours",
+        "decay_start": "24 hours"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "afs_eoc_hangover_baseline",
     "effect": [
       { "u_add_effect": "decreased_performance", "duration": "6 hours" },
       { "u_add_effect": "disrupted_sleep", "duration": "8 hours" },
       {
-        "u_add_morale": "morale_off_drugs",
+        "u_add_morale": "morale_afs_drugs",
         "bonus": -20,
         "max_bonus": -60,
         "duration": "36 hours",
         "decay_start": "24 hours"
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "afs_eoc_chemspeed",
+    "effect": [ { "u_lose_effect": "post_speed_injection" } ]
   },
   {
     "type": "effect_on_condition",
@@ -41,7 +60,7 @@
       { "u_add_effect": "post_speed_injection", "duration": "6 hours" },
       { "u_add_effect": "disrupted_sleep", "duration": "8 hours" },
       {
-        "u_add_morale": "morale_off_drugs",
+        "u_add_morale": "morale_afs_drugs",
         "bonus": -20,
         "max_bonus": -60,
         "duration": "36 hours",
@@ -51,18 +70,34 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "afs_eoc_chemhealing",
+    "effect": [ { "u_lose_effect": "post_healing_injection" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "afs_eoc_chemhealing_pkill",
+    "condition": { "one_in_chance": 40 },
+    "effect": [ { "math": [ "u_pain()", "--" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "afs_eoc_hangover_healing",
     "effect": [
-      { "u_add_effect": "post_healing_injection", "duration": "6 hours" },
+      { "u_add_effect": "post_healing_injection", "duration": "6 hours", "target_part": "torso" },
       { "arithmetic": [ { "u_val": "fatigue" }, "+=", { "const": 80 } ] },
       {
-        "u_add_morale": "morale_off_drugs",
+        "u_add_morale": "morale_afs_drugs",
         "bonus": -20,
         "max_bonus": -60,
         "duration": "36 hours",
         "decay_start": "24 hours"
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "afs_eoc_chemstrength",
+    "effect": [ { "u_lose_effect": "post_strength_injection" } ]
   },
   {
     "type": "effect_on_condition",
@@ -71,7 +106,7 @@
       { "u_add_effect": "post_strength_injection", "duration": "6 hours" },
       { "arithmetic": [ { "u_val": "fatigue" }, "+=", { "const": 80 } ] },
       {
-        "u_add_morale": "morale_off_drugs",
+        "u_add_morale": "morale_afs_drugs",
         "bonus": -20,
         "max_bonus": -60,
         "duration": "36 hours",

--- a/data/mods/Aftershock/player/bionics.json
+++ b/data/mods/Aftershock/player/bionics.json
@@ -91,6 +91,8 @@
     "description": "An implanted AI module and medication dispenser calculates the optimal chemical mix to keep you on your toes and ready for combat.  This bionic must be active to function and while it functions your body is at a heightened performance but if it turns off it will take you several days to get back to normal.  There are a significant number of baseline bonuses granted by this setup but people around will notice your junkie behavior.",
     "occupied_bodyparts": [ [ "head", 5 ], [ "torso", 10 ], [ "arm_l", 3 ], [ "arm_r", 3 ], [ "leg_l", 3 ], [ "leg_r", 3 ] ],
     "flags": [ "BIONIC_TOGGLED" ],
+    "activated_eocs": [ "afs_eoc_chembaseline" ],
+    "activated_on_install": true,
     "enchantments": [ "heightened_performance" ],
     "included_bionics": [ "afs_speed_injection", "afs_healing_injection", "afs_strength_injection" ],
     "deactivated_eocs": [ "afs_eoc_hangover_baseline" ],
@@ -118,6 +120,7 @@
         ]
       }
     ],
+    "activated_eocs": [ "afs_eoc_chemspeed" ],
     "deactivated_eocs": [ "afs_eoc_hangover_speed" ],
     "act_cost": "100 J",
     "react_cost": "20 J",
@@ -140,9 +143,10 @@
           { "value": "METABOLISM", "multiply": 1.5 },
           { "value": "REGEN_HP", "multiply": 2 }
         ]
-      },
-      { "condition": "ACTIVE", "ench_effects": [ { "effect": "pain_recovery", "intensity": 1 } ] }
+      }
     ],
+    "activated_eocs": [ "afs_eoc_chemhealing" ],
+    "processed_eocs": [ "afs_eoc_chemhealing_pkill" ],
     "deactivated_eocs": [ "afs_eoc_hangover_healing" ],
     "act_cost": "100 J",
     "react_cost": "20 J",
@@ -169,6 +173,7 @@
         ]
       }
     ],
+    "activated_eocs": [ "afs_eoc_chemstrength" ],
     "deactivated_eocs": [ "afs_eoc_hangover_strength" ],
     "act_cost": "100 J",
     "react_cost": "20 J",

--- a/data/mods/Aftershock/spells/enchantments.json
+++ b/data/mods/Aftershock/spells/enchantments.json
@@ -31,10 +31,11 @@
       { "value": "DEXTERITY", "add": 1 },
       { "value": "STRENGTH", "add": 1 },
       { "value": "SPEED", "add": 3 },
-      { "value": "HUNGER", "multiply": 1.5 },
-      { "value": "THIRST", "multiply": 1.5 },
-      { "value": "METABOLISM", "multiply": 1.5 },
-      { "value": "SOCIAL_PERSUADE", "add": -10 }
+      { "value": "HUNGER", "multiply": 1.1 },
+      { "value": "THIRST", "multiply": 1.1 },
+      { "value": "METABOLISM", "multiply": 1.1 },
+      { "value": "SOCIAL_PERSUADE", "add": -10 },
+      { "value": "SOCIAL_INTIMIDATE", "add": 2 }
     ]
   },
   {

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1864,10 +1864,10 @@ Your character or the NPC will gain a morale bonus
 | ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
 
 ##### Examples
-Gives `morale_off_drugs` thought with +1 mood bonus
+Gives `morale_afs_drugs` thought with +1 mood bonus
 ```json
 {
-  "u_add_morale": "morale_off_drugs",
+  "u_add_morale": "morale_afs_drugs",
 }
 ```
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix aftershock several chemrig bugs"

#### Purpose of change

Fix #65990

#### Describe the solution
Added a painkill EOC based mechanic that helps reduce pain as originally planned. Deliberatedly works without using painkillers, so the character does feel pain but quickly forgets about it. Seemed sorta interesting and less broken mechanics wise.

Also resolves some secundary issues related to effects not applying their penalties, a missing morale category and made activating the bionic resolve the hangover style effects.

#### Testing
Made a test character with the bionic, noticed no additional mayor issues.

#### Additional context

The bionic allows you to perpetually activate its very powerfull secondary effects, I believe this isnt inteded, a more carefull and involved solution is necesarry to resolve that.

Probably nexy week.