### PR TITLE
Add 3 variants of roadblock and rebalanced loot

### DIFF
--- a/data/json/itemgroups/corpses.json
+++ b/data/json/itemgroups/corpses.json
@@ -107,6 +107,28 @@
     ]
   },
   {
+    "id": "corpses_verydead",
+    "type": "item_group",
+    "//": "Generic corpses that will definitely not get up again",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "corpse_generic_male", "prob": 30, "damage-min": 4, "damage-max": 4 },
+      { "group": "corpse_generic_female", "prob": 30, "damage-min": 4, "damage-max": 4 },
+      { "group": "corpse_generic_boy", "prob": 10, "damage-min": 4, "damage-max": 4 },
+      { "group": "corpse_generic_girl", "prob": 10, "damage-min": 4, "damage-max": 4 },
+      { "group": "corpse_generic_human", "prob": 10, "damage-min": 4, "damage-max": 4 },
+      { "group": "corpse_generic_gunned", "prob": 30, "damage-min": 4, "damage-max": 4 },
+      { "group": "corpse_bloody", "prob": 15, "damage-min": 4, "damage-max": 4 },
+      { "group": "corpse_painful", "prob": 15, "damage-min": 4, "damage-max": 4 },
+      { "group": "corpse_scorched", "prob": 15, "damage-min": 4, "damage-max": 4 },
+      { "group": "corpse_stabbed", "prob": 15, "damage-min": 4, "damage-max": 4 },
+      { "group": "corpse_gunned", "prob": 15, "damage-min": 4, "damage-max": 4 },
+      { "group": "corpse_halved_upper", "prob": 15, "damage-min": 4, "damage-max": 4 },
+      { "group": "corpse_half_beheaded", "prob": 15, "damage-min": 4, "damage-max": 4 },
+      { "group": "corpse_child_gunned", "prob": 15, "damage-min": 4, "damage-max": 4 }
+    ]
+  },
+  {
     "id": "corpses_no_items",
     "type": "item_group",
     "subtype": "distribution",
@@ -128,6 +150,28 @@
       { "item": "corpse_child_calm", "prob": 10 },
       { "item": "corpse_child_gunned", "prob": 10, "damage": [ 2, 4 ] },
       { "item": "corpse_oldwoman_jewelry", "prob": 10, "damage": [ 1, 3 ] }
+    ]
+  },
+  {
+    "id": "corpses_verydead_no_items",
+    "type": "item_group",
+    "//": "Generic empty corpses that will definitely not get up again",
+    "subtype": "distribution",
+    "entries": [
+      { "item": "corpse_generic_male", "prob": 30, "damage-min": 4, "damage-max": 4 },
+      { "item": "corpse_generic_female", "prob": 30, "damage-min": 4, "damage-max": 4 },
+      { "item": "corpse_generic_boy", "prob": 10, "damage-min": 4, "damage-max": 4 },
+      { "item": "corpse_generic_girl", "prob": 10, "damage-min": 4, "damage-max": 4 },
+      { "item": "corpse_generic_human", "prob": 10, "damage-min": 4, "damage-max": 4 },
+      { "item": "corpse_generic_gunned", "prob": 30, "damage-min": 4, "damage-max": 4 },
+      { "item": "corpse_bloody", "prob": 15, "damage-min": 4, "damage-max": 4 },
+      { "item": "corpse_painful", "prob": 15, "damage-min": 4, "damage-max": 4 },
+      { "item": "corpse_scorched", "prob": 15, "damage-min": 4, "damage-max": 4 },
+      { "item": "corpse_stabbed", "prob": 15, "damage-min": 4, "damage-max": 4 },
+      { "item": "corpse_gunned", "prob": 15, "damage-min": 4, "damage-max": 4 },
+      { "item": "corpse_halved_upper", "prob": 15, "damage-min": 4, "damage-max": 4 },
+      { "item": "corpse_half_beheaded", "prob": 15, "damage-min": 4, "damage-max": 4 },
+      { "item": "corpse_child_gunned", "prob": 15, "damage-min": 4, "damage-max": 4 }
     ]
   },
   {

--- a/data/json/mapgen/map_extras/roadblock.json
+++ b/data/json/mapgen/map_extras/roadblock.json
@@ -41,17 +41,23 @@
         "                        "
       ],
       "furniture": { "s": "f_sandbag_half", "g": "f_active_backup_generator", "b": "f_barricade_road" },
-      "monster": { "T": { "monster": "mon_turret_riot", "chance": 100 }, "t": { "monster": "mon_turret_riot", "chance": 60 }, "L": { "monster": "mon_turret_searchlight" } },
+      "monster": {
+        "T": { "monster": "mon_turret_riot", "chance": 100 },
+        "t": { "monster": "mon_turret_riot", "chance": 60 },
+        "L": { "monster": "mon_turret_searchlight" }
+      },
       "place_vehicles": [
         { "vehicle": "policecar", "x": 12, "y": 7, "chance": 50, "status": 1, "rotation": 180 },
         { "vehicle": "policecar", "x": 11, "y": 16, "chance": 50, "status": 1 }
       ],
       "items": {
-		 "x": [ { "item": "corpses_verydead", "chance": 75 } ],
-		 "@": [ { "item": "corpses_verydead_no_items", "chance": 100 }, { "item": "mon_zombie_cop_death_drops", "chance": 75 } ] },
-	  "place_fields": [
-		  { "field": "fd_blood", "x": [ 2, 4 ], "y": [ 10, 12 ], "repeat": [ 2, 5 ] },
-		  { "field": "fd_blood", "x": [ 17, 21 ], "y": [ 10, 12 ], "repeat": [ 3, 6 ] } ],
+        "x": [ { "item": "corpses_verydead", "chance": 75 } ],
+        "@": [ { "item": "corpses_verydead_no_items", "chance": 100 }, { "item": "mon_zombie_cop_death_drops", "chance": 75 } ]
+      },
+      "place_fields": [
+        { "field": "fd_blood", "x": [ 2, 4 ], "y": [ 10, 12 ], "repeat": [ 2, 5 ] },
+        { "field": "fd_blood", "x": [ 17, 21 ], "y": [ 10, 12 ], "repeat": [ 3, 6 ] }
+      ],
       "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
@@ -91,18 +97,21 @@
       "monster": { "L": { "monster": "mon_turret_searchlight" } },
       "place_vehicles": [
         { "vehicle": "policecar", "x": 13, "y": 6, "chance": 75, "status": 1 },
-        { "vehicle": "policecar", "x": 11, "y": 17, "chance": 75, "status": 1, "rotation": 180  }
+        { "vehicle": "policecar", "x": 11, "y": 17, "chance": 75, "status": 1, "rotation": 180 }
       ],
       "place_monster": [
-		{ "group": "GROUP_ZOMBIE_COP", "x": [ 4, 20 ], "y": [ 4, 20 ], "repeat": [ 2, 4 ] },
-        { "group": "GROUP_ZOMBIE", "x": [ 4, 20 ], "y": [ 4, 20 ], "repeat": [ 3, 6 ] } ],
+        { "group": "GROUP_ZOMBIE_COP", "x": [ 4, 20 ], "y": [ 4, 20 ], "repeat": [ 2, 4 ] },
+        { "group": "GROUP_ZOMBIE", "x": [ 4, 20 ], "y": [ 4, 20 ], "repeat": [ 3, 6 ] }
+      ],
       "items": {
-		 "x": [ { "item": "corpses_verydead", "chance": 75 } ],
-		 "@": [ { "item": "corpses_verydead_no_items", "chance": 100 }, { "item": "mon_zombie_cop_death_drops", "chance": 65 } ] },
+        "x": [ { "item": "corpses_verydead", "chance": 75 } ],
+        "@": [ { "item": "corpses_verydead_no_items", "chance": 100 }, { "item": "mon_zombie_cop_death_drops", "chance": 65 } ]
+      },
       "place_item": [ { "item": "9mm_casing", "x": [ 7, 14 ], "y": [ 7, 14 ], "chance": 50, "repeat": 40 } ],
-	  "place_fields": [
-		  { "field": "fd_blood", "x": [ 13, 15 ], "y": [ 11, 13 ], "repeat": [ 3, 6 ] },
-		  { "field": "fd_blood", "x": [ 5, 7 ], "y": [ 7, 9 ], "repeat": [ 2, 5 ] } ],
+      "place_fields": [
+        { "field": "fd_blood", "x": [ 13, 15 ], "y": [ 11, 13 ], "repeat": [ 3, 6 ] },
+        { "field": "fd_blood", "x": [ 5, 7 ], "y": [ 7, 9 ], "repeat": [ 2, 5 ] }
+      ],
       "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   },
@@ -145,17 +154,19 @@
         { "vehicle": "suv", "x": 15, "y": 17, "chance": 100, "status": 1, "rotation": 250 }
       ],
       "place_monster": [
-		{ "group": "GROUP_ZOMBIE_COP", "x": [ 4, 20 ], "y": [ 4, 10 ], "repeat": [ 3, 6 ] },
-        { "group": "GROUP_ZOMBIE", "x": [ 4, 20 ], "y": [ 4, 10 ], "repeat": [ 4, 8 ] } ],
+        { "group": "GROUP_ZOMBIE_COP", "x": [ 4, 20 ], "y": [ 4, 10 ], "repeat": [ 3, 6 ] },
+        { "group": "GROUP_ZOMBIE", "x": [ 4, 20 ], "y": [ 4, 10 ], "repeat": [ 4, 8 ] }
+      ],
       "items": { "x": [ { "item": "corpses_verydead", "chance": 75 } ] },
-	  "item": {
+      "item": {
         "#": [ { "item": "bag_canvas", "amount": [ 2, 5 ] }, { "item": "material_sand", "amount": [ 3, 5 ] } ],
         ".": [ { "item": "splinter", "chance": 100, "amount": [ 1, 3 ] }, { "item": "2x4", "chance": 25 } ]
       },
       "place_loot": [ { "group": "cop_armory", "x": [ 6, 10 ], "y": [ 15, 18 ], "chance": 100, "repeat": [ 4, 10 ] } ],
-	  "place_fields": [
-		  { "field": "fd_blood", "x": [ 8, 10 ], "y": [ 16, 18 ], "repeat": [ 1, 4 ] },
-		  { "field": "fd_blood", "x": [ 20, 22 ], "y": [ 14, 17 ], "repeat": [ 1, 2 ] } ],
+      "place_fields": [
+        { "field": "fd_blood", "x": [ 8, 10 ], "y": [ 16, 18 ], "repeat": [ 1, 4 ] },
+        { "field": "fd_blood", "x": [ 20, 22 ], "y": [ 14, 17 ], "repeat": [ 1, 2 ] }
+      ],
       "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   }

--- a/data/json/mapgen/map_extras/roadblock.json
+++ b/data/json/mapgen/map_extras/roadblock.json
@@ -2,58 +2,161 @@
   {
     "type": "mapgen",
     "method": "json",
-    "nested_mapgen_id": "police_nest_3x3",
+    "update_mapgen_id": "mx_roadblock",
     "object": {
-      "mapgensize": [ 3, 3 ],
-      "place_items": [ { "item": "map_extra_police", "x": [ 0, 2 ], "y": [ 0, 2 ], "chance": 100 } ],
-      "place_fields": [ { "field": "fd_blood", "x": [ 0, 2 ], "y": [ 0, 2 ] }, { "field": "fd_gibs_flesh", "x": [ 0, 2 ], "y": [ 0, 2 ] } ]
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ],
+      "place_nested": [ { "chunks": [ "24x24_roadblock_turret", "24x24_roadblock_cops", "24x24_roadblock_crash" ], "x": 0, "y": 0 } ]
     }
   },
   {
     "type": "mapgen",
     "method": "json",
-    "update_mapgen_id": "mx_roadblock",
+    "nested_mapgen_id": "24x24_roadblock_turret",
     "object": {
+      "mapgensize": [ 24, 24 ],
       "rows": [
-        "----------------------  ",
-        "----------------------  ",
-        "----------------------  ",
-        "----bbbbbbb--bbbbbbb--  ",
-        "----------------------  ",
-        "-----------t----------  ",
-        "----------------------  ",
-        "----------------------  ",
-        "----------------------  ",
-        "----------------------  ",
-        "------ssss------------  ",
-        "-------Lg-------------  ",
-        "------ssss------------  ",
-        "----------------------  ",
-        "----------------------  ",
-        "----------------------  ",
-        "----------------------  ",
-        "----------------------  ",
-        "----------------------  ",
-        "------------t---------  ",
-        "----------------------  ",
-        "----bbbbbbb--bbbbbbb--  ",
+        "                        ",
+        "                        ",
+        "      bbbbb  bbbbb      ",
+        "           t            ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "  b                 b   ",
+        "  b                 b   ",
+        "  b                 b   ",
+        "  b  x   ssss    @  b   ",
+        "   T      Lg   @    x   ",
+        " x   @   ssss   x  t x  ",
+        "  b                 b   ",
+        "  b                 b   ",
+        "  b                 b   ",
+        "  b                 b   ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "            t           ",
+        "      bbbbb  bbbbb      ",
         "                        ",
         "                        "
       ],
       "furniture": { "s": "f_sandbag_half", "g": "f_active_backup_generator", "b": "f_barricade_road" },
-      "monster": { "t": { "monster": "mon_turret_riot" }, "L": { "monster": "mon_turret_searchlight" } },
+      "monster": { "T": { "monster": "mon_turret_riot", "chance": 100 }, "t": { "monster": "mon_turret_riot", "chance": 60 }, "L": { "monster": "mon_turret_searchlight" } },
       "place_vehicles": [
-        { "vehicle": "policecar", "x": 7, "y": 7, "chance": 100, "status": 1, "rotation": 180 },
-        { "vehicle": "policecar", "x": 18, "y": 10, "chance": 100, "status": 1 },
-        { "vehicle": "policecar", "x": 16, "y": 17, "chance": 100, "status": 1 }
+        { "vehicle": "policecar", "x": 12, "y": 7, "chance": 50, "status": 1, "rotation": 180 },
+        { "vehicle": "policecar", "x": 11, "y": 16, "chance": 50, "status": 1 }
       ],
-      "place_monster": [ { "group": "GROUP_POLICE_EXTRA", "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 3, 6 ] } ],
-      "place_loot": [
-        { "group": "cop_armory", "x": 9, "y": [ 6, 7 ], "chance": 100, "repeat": [ 0, 9 ] },
-        { "group": "cop_armory", "x": 16, "y": [ 10, 11 ], "chance": 100, "repeat": [ 0, 9 ] },
-        { "group": "cop_armory", "x": 14, "y": [ 17, 18 ], "chance": 100, "repeat": [ 0, 9 ] }
+      "items": {
+		 "x": [ { "item": "corpses_verydead", "chance": 75 } ],
+		 "@": [ { "item": "corpses_verydead_no_items", "chance": 100 }, { "item": "mon_zombie_cop_death_drops", "chance": 75 } ] },
+	  "place_fields": [
+		  { "field": "fd_blood", "x": [ 2, 4 ], "y": [ 10, 12 ], "repeat": [ 2, 5 ] },
+		  { "field": "fd_blood", "x": [ 17, 21 ], "y": [ 10, 12 ], "repeat": [ 3, 6 ] } ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "24x24_roadblock_cops",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "                        ",
+        "                        ",
+        "       bbbb xbbbbb      ",
+        "      b                 ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "  b                 b   ",
+        "   b   x            b   ",
+        "  b x @             b   ",
+        "  b     ssss  x     b   ",
+        "         gL  @  x       ",
+        "        ssss            ",
+        "  b          x      b   ",
+        "  b                 b   ",
+        "  b                  b  ",
+        "  b                  b  ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "      bbbbb  bbbbb      ",
+        "                        ",
+        "                        "
       ],
-      "nested": { "-": { "chunks": [ [ "police_nest_3x3", 1 ], [ "null", 150 ] ] } }
+      "furniture": { "s": "f_sandbag_half", "g": "f_active_backup_generator", "b": "f_barricade_road" },
+      "monster": { "L": { "monster": "mon_turret_searchlight" } },
+      "place_vehicles": [
+        { "vehicle": "policecar", "x": 13, "y": 6, "chance": 75, "status": 1 },
+        { "vehicle": "policecar", "x": 11, "y": 17, "chance": 75, "status": 1, "rotation": 180  }
+      ],
+      "place_monster": [
+		{ "group": "GROUP_ZOMBIE_COP", "x": [ 4, 20 ], "y": [ 4, 20 ], "repeat": [ 2, 4 ] },
+        { "group": "GROUP_ZOMBIE", "x": [ 4, 20 ], "y": [ 4, 20 ], "repeat": [ 3, 6 ] } ],
+      "items": {
+		 "x": [ { "item": "corpses_verydead", "chance": 75 } ],
+		 "@": [ { "item": "corpses_verydead_no_items", "chance": 100 }, { "item": "mon_zombie_cop_death_drops", "chance": 65 } ] },
+      "place_item": [ { "item": "9mm_casing", "x": [ 7, 14 ], "y": [ 7, 14 ], "chance": 50, "repeat": 40 } ],
+	  "place_fields": [
+		  { "field": "fd_blood", "x": [ 13, 15 ], "y": [ 11, 13 ], "repeat": [ 3, 6 ] },
+		  { "field": "fd_blood", "x": [ 5, 7 ], "y": [ 7, 9 ], "repeat": [ 2, 5 ] } ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "24x24_roadblock_crash",
+    "object": {
+      "mapgensize": [ 24, 24 ],
+      "rows": [
+        "                        ",
+        "                        ",
+        "      bbbbb  bbbbb      ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "  b                 b   ",
+        "  b                 b   ",
+        "  b                 b   ",
+        "  b       sssss     b   ",
+        "           Lg##         ",
+        "          ss#     b     ",
+        "  b       ##        b   ",
+        "  b                . x  ",
+        "  b               . .   ",
+        "  b    x            .   ",
+        "                  .   . ",
+        "          x             ",
+        "             . .  .     ",
+        "            b    .      ",
+        "      bbbbb  b .  .     ",
+        "                 .      ",
+        "                        "
+      ],
+      "furniture": { "s": "f_sandbag_half", "g": "f_active_backup_generator", "b": "f_barricade_road" },
+      "monster": { "L": { "monster": "mon_turret_searchlight" } },
+      "place_vehicles": [
+        { "vehicle": "policecar", "x": 12, "y": 15, "chance": 100, "status": 1, "rotation": 150 },
+        { "vehicle": "suv", "x": 15, "y": 17, "chance": 100, "status": 1, "rotation": 250 }
+      ],
+      "place_monster": [
+		{ "group": "GROUP_ZOMBIE_COP", "x": [ 4, 20 ], "y": [ 4, 10 ], "repeat": [ 3, 6 ] },
+        { "group": "GROUP_ZOMBIE", "x": [ 4, 20 ], "y": [ 4, 10 ], "repeat": [ 4, 8 ] } ],
+      "items": { "x": [ { "item": "corpses_verydead", "chance": 75 } ] },
+	  "item": {
+        "#": [ { "item": "bag_canvas", "amount": [ 2, 5 ] }, { "item": "material_sand", "amount": [ 3, 5 ] } ],
+        ".": [ { "item": "splinter", "chance": 100, "amount": [ 1, 3 ] }, { "item": "2x4", "chance": 25 } ]
+      },
+      "place_loot": [ { "group": "cop_armory", "x": [ 6, 10 ], "y": [ 15, 18 ], "chance": 100, "repeat": [ 4, 10 ] } ],
+	  "place_fields": [
+		  { "field": "fd_blood", "x": [ 8, 10 ], "y": [ 16, 18 ], "repeat": [ 1, 4 ] } ],
+		  { "field": "fd_blood", "x": [ 8, 10 ], "y": [ 16, 18 ], "repeat": [ 1, 2 ] } ],
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   }
 ]

--- a/data/json/mapgen/map_extras/roadblock.json
+++ b/data/json/mapgen/map_extras/roadblock.json
@@ -154,8 +154,8 @@
       },
       "place_loot": [ { "group": "cop_armory", "x": [ 6, 10 ], "y": [ 15, 18 ], "chance": 100, "repeat": [ 4, 10 ] } ],
 	  "place_fields": [
-		  { "field": "fd_blood", "x": [ 8, 10 ], "y": [ 16, 18 ], "repeat": [ 1, 4 ] } ],
-		  { "field": "fd_blood", "x": [ 8, 10 ], "y": [ 16, 18 ], "repeat": [ 1, 2 ] } ],
+		  { "field": "fd_blood", "x": [ 8, 10 ], "y": [ 16, 18 ], "repeat": [ 1, 4 ] },
+		  { "field": "fd_blood", "x": [ 20, 22 ], "y": [ 14, 17 ], "repeat": [ 1, 2 ] } ],
       "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ]
     }
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Add 3 variants of roadblock and rebalanced loot"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The jsonizing of the roadblock made all the variants of one type only - As well as greatly increasing the loot available, while making the roadblocks provide no threat.

This PR re-adds some variety and transforms each roadblock type into a variety with cop-tier balanced loot, enemies and required strategies.

#### Describe the solution

Changed roadblock map type into a nested map pack of 3 variants and removed the north/south orientation to be of all-orientation so it would not matter which road type it is placed on.  The amount of cars, enemies and loot present will vary.

The 3 variants are ;

* Roadblock with turrets.  Spawns 1 guaranteed turret and 3 possibles on other facings - on average you will encounter 2 turrets.  All the zombies are dead, having long since been pulverised by the turrets.  There are dead zombies and cops with loot to salvage.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/34361592/658d22c9-b6f2-4d55-aab4-510e0ff4a5f3)

* Roadblock without turrets.  The cops that manned this roadblock didn't have that equipment allocated, so they are still present, but were overwhelmed by zombies at some point, as evidenced by 9mm casings all over the place, so now the roadblock is filled with the undead.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/34361592/54b3d259-311d-4742-b9db-90a387fcfdcd)

* Roadblock with crash. The roadblock was overrun by a speeding SUV, smashing the roadblock and causing the roadblock to be overrun.  There is some high quality police armory loot that was scattered in the chaos to pick up.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/34361592/574583f9-3b0b-4f16-b40b-b64b8bb0b281)

#### Describe alternatives you've considered

N/A

#### Testing

Dialed mapgen frequency up to 999 and generated about 50 roadblocks, fine tuning the loot, placements, etc and confirmed its working as it should.

#### Additional context

This should fix a few problems, in addition to adding variant types of roadblock.

* The high quality loot from roadblocks is reduced to be in line with what a general cop would have - The high quality loot came from 2 sources - the spawned zombies were of higher than cop quality (soldier types etc) and the loot drops were up to 30 of militarised armoury drops, not general zombie cop drops like before.  The armoury drops are still present in the 3rd roadblock variant but at a much reduced drop rate. (up to 10 items instead of up to 30)

* The roadblocks were very easy to cheese - the turrets were no threat due to zombies, and the zombies were no threat due to turrets.  The variant types now make each threat stand on its own and now require strategy to tackle.

* I think the mapgen freqency chance for roadblocks should be put back to 1000 or higher - Since they very rarely spawn.  They are nowhere near their old spawning frequency, I guess due to the alternative spawning method which is called less.

* Another thing was that the old method of assigning damage to corpses no longer makes them stay dead - so I made two new monster groups - a duplicate of `corpses` and `corpses_no_items` called `corpses_verydead` and `corpses_verydead_no_items` which are similar with one difference, the corpses generated are always non-revivable.  I used this to generate corpses and make sure the turret roadblock wouldn't be affected by zombies.  These new groups should also hopefully provide some use to other mappers who want to spawn corpses that definitely stay dead.

* Should fix #68612

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
