### PR TITLE
Encounters out in the fields

### DIFF
--- a/data/json/items/corpses/dead_yrax.json
+++ b/data/json/items/corpses/dead_yrax.json
@@ -23,7 +23,7 @@
     "description": "A large golden monolith.  Carefully carved asymmetric edges betray its artificial origin.",
     "volume": "930 L",
     "//": "A lot of gold in this bad boy.",
-    "weight": "8282000 kg",
+    "weight": "8282 kg",
     "price": "50 USD",
     "price_postapoc": "50 USD",
     "melee_damage": { "bash": 1000 },

--- a/data/json/items/corpses/dead_yrax.json
+++ b/data/json/items/corpses/dead_yrax.json
@@ -14,5 +14,40 @@
     "to_hit": -3,
     "flags": [ "TRADER_AVOID", "NO_REPAIR" ],
     "melee_damage": { "bash": 20, "cut": 15 }
+  },
+  {
+    "id": "broken_golden_monolith",
+    "type": "GENERIC",
+    "symbol": "I",
+    "name": { "str": "golden monolith" },
+    "description": "A large golden monolith.  Carefully carved asymmetric edges betray its artificial origin.",
+    "volume": "930 L",
+    "//": "A lot of gold in this bad boy.",
+    "weight": "8282000 kg",
+    "price": "50 USD",
+    "price_postapoc": "50 USD",
+    "melee_damage": { "bash": 1000 },
+    "material": [ "ceramic", "gold" ],
+    "color": "yellow",
+    "flags": [ "TRADER_AVOID", "NO_REPAIR" ]
+  },
+  {
+    "id": "broken_yrax_delta",
+    "type": "GENERIC",
+    "symbol": ",",
+    "name": { "str": "inert delta" },
+    "description": "A small piece of inscrutable alloy shaped like an arrow's broadhead.  It doesn't look like much of a robot once dead.",
+    "weight": "374 g",
+    "volume": "500 ml",
+    "longest_side": "20 cm",
+    "price": "50 USD",
+    "price_postapoc": "50 USD",
+    "to_hit": { "grip": "none", "length": "hand", "surface": "point", "balance": "good" },
+    "melee_damage": { "stab": 23 },
+    "material": [ "ceramic", "gold" ],
+    "color": "yellow",
+    "techniques": [ "RAPID" ],
+    "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 8 ] ],
+    "flags": [ "TRADER_AVOID", "NO_REPAIR" ]
   }
 ]

--- a/data/json/mapgen/map_extras/yrax_research.json
+++ b/data/json/mapgen/map_extras/yrax_research.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "mx_golden_monoliths_map",
+    "object": { "place_monster": [ { "monster": "mon_golden_monolith", "x": [ 0, 23 ], "y": [ 0, 23 ], "repeat": [ 5, 7 ] } ] }
+  }
+]

--- a/data/json/monster_special_attacks/monster_deaths.json
+++ b/data/json/monster_special_attacks/monster_deaths.json
@@ -626,6 +626,25 @@
     "effect_str": "EOC_last_amigara_death"
   },
   {
+    "id": "death_yrax_sphenocorona",
+    "type": "SPELL",
+    "name": { "str": "Sphenocorona Death?" },
+    "description": "Spawns a golden monolith.",
+    "flags": [ "HOSTILE_SUMMON", "PERMANENT", "NO_EXPLOSION_SFX", "SILENT", "NO_PROJECTILE" ],
+    "valid_targets": [ "ground", "self" ],
+    "max_level": 1,
+    "min_damage": 1,
+    "max_damage": 1,
+    "min_range": 0,
+    "max_range": 0,
+    "min_aoe": 1,
+    "max_aoe": 1,
+    "base_casting_time": 1,
+    "shape": "blast",
+    "effect": "summon",
+    "effect_str": "mon_golden_monolith"
+  },
+  {
     "id": "death_slimespring",
     "type": "SPELL",
     "name": { "str": "Slime Microbian Death" },

--- a/data/json/monster_special_attacks/yrax_special_attacks.json
+++ b/data/json/monster_special_attacks/yrax_special_attacks.json
@@ -1,0 +1,57 @@
+[
+  {
+    "id": "activate_yrax",
+    "type": "SPELL",
+    "name": "Base activate Yrax",
+    "description": "Base spell for Yrax (de)activation.",
+    "valid_targets": [ "hostile", "ally", "self" ],
+    "flags": [ "SILENT", "NO_HANDS", "NO_LEGS", "NO_PROJECTILE", "NO_EXPLOSION_SFX" ],
+    "effect": "targeted_polymorph",
+    "effect_str": "",
+    "shape": "blast",
+    "base_casting_time": 15,
+    "max_level": 1,
+    "min_damage": 10000000,
+    "max_damage": 10000000,
+    "damage_type": "pure",
+    "min_aoe": 50,
+    "max_aoe": 50
+  },
+  {
+    "id": "sphenocorona_active",
+    "type": "SPELL",
+    "name": "Activate Sphenocorona",
+    "description": "Golden monoliths to Sphenocoronae.",
+    "copy-from": "activate_yrax",
+    "targeted_monster_ids": [ "mon_yrax_sphenocorona_inert" ],
+    "effect_str": "mon_yrax_sphenocorona"
+  },
+  {
+    "id": "sphenocorona_inactive",
+    "type": "SPELL",
+    "name": "Activate Sphenocorona",
+    "description": "Sphenocoronae to Golden monoliths.",
+    "copy-from": "activate_yrax",
+    "targeted_monster_ids": [ "mon_yrax_sphenocorona" ],
+    "effect_str": "mon_golden_monolith"
+  },
+  {
+    "type": "SPELL",
+    "id": "release_the_deltas",
+    "name": { "str": "Release the deltas!" },
+    "description": "Summons a varying amount of Yrax deltas.",
+    "flags": [ "HOSTILE_SUMMON", "PERMANENT", "NO_EXPLOSION_SFX" ],
+    "valid_targets": [ "ground", "self" ],
+    "//": "make sure to only summon a prime number of deltas or I'll be mad",
+    "min_damage": 2,
+    "max_damage": 23,
+    "damage_increment": 1,
+    "max_level": 21,
+    "min_aoe": 2,
+    "max_aoe": 2,
+    "base_casting_time": 500,
+    "shape": "blast",
+    "effect": "summon",
+    "effect_str": "mon_yrax_delta"
+  }
+]

--- a/data/json/monsters/yrax.json
+++ b/data/json/monsters/yrax.json
@@ -67,7 +67,7 @@
     "default_faction": "yrax",
     "volume": "930 L",
     "//": "A lot of gold in this bad boy.",
-    "weight": "8282000 kg",
+    "weight": "8282 kg",
     "species": [ "ROBOT" ],
     "bodytype": "blob",
     "material": [ "gold", "steel" ],

--- a/data/json/monsters/yrax.json
+++ b/data/json/monsters/yrax.json
@@ -23,6 +23,7 @@
     "vision_day": 50,
     "vision_night": 20,
     "revert_to_itype": "bot_yrax_trifacet",
+    "aggro_character": false,
     "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT" ],
     "special_attacks": [
       {
@@ -59,6 +60,125 @@
     "armor": { "bash": 42, "cut": 48, "acid": 12, "heat": 8, "bullet": 35 }
   },
   {
+    "id": "mon_yrax_sphenocorona",
+    "type": "MONSTER",
+    "name": { "str": "Yrax sphenocorona" },
+    "description": "Manipulator arrays seamlessly protract from asymmetric facets, their testing spaces undisturbed by the forces affixing it to the sky.",
+    "default_faction": "yrax",
+    "volume": "930 L",
+    "//": "A lot of gold in this bad boy.",
+    "weight": "8282000 kg",
+    "species": [ "ROBOT" ],
+    "bodytype": "blob",
+    "material": [ "gold", "steel" ],
+    "speed": 40,
+    "symbol": "C",
+    "morale": 100,
+    "hp": 10,
+    "bleed_rate": 0,
+    "color": "yellow",
+    "melee_skill": 4,
+    "dodge": 4,
+    "melee_dice": 4,
+    "melee_dice_sides": 4,
+    "armor": { "bash": 42, "cut": 48, "acid": 35, "heat": 10, "bullet": 35 },
+    "tracking_distance": 3,
+    "vision_day": 50,
+    "aggro_character": false,
+    "vision_night": 20,
+    "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT" ],
+    "special_attacks": [
+      {
+        "type": "spell",
+        "id": "sphenocorona_inactive",
+        "spell_data": { "id": "sphenocorona_inactive", "hit_self": true },
+        "allow_no_target": true,
+        "condition": {
+          "and": [
+            {
+              "not": {
+                "or": [
+                  { "is_weather": "portal_storm" },
+                  { "and": [ { "is_weather": "distant_portal_storm" } ] },
+                  { "is_weather": "close_portal_storm" }
+                ]
+              }
+            },
+            "u_is_outside"
+          ]
+        },
+        "monster_message": "The %s abruptly falls to the ground!",
+        "cooldown": 5
+      },
+      {
+        "type": "spell",
+        "id": "killer_swarm",
+        "spell_data": { "id": "release_the_deltas", "hit_self": true, "min_level": 1 },
+        "monster_message": "Shards of gleaming alloy detach from the %s's surface!",
+        "cooldown": 60
+      }
+    ],
+    "death_function": {
+      "effect": { "id": "death_yrax_sphenocorona", "hit_self": true },
+      "message": "The %s abruptly falls to the ground",
+      "corpse_type": "NO_CORPSE"
+    },
+    "flags": [
+      "SEES",
+      "HEARS",
+      "GOODHEARING",
+      "NOHEAD",
+      "NO_BREATHE",
+      "PATH_AVOID_DANGER_2",
+      "FLIES",
+      "PRIORITIZE_TARGETS",
+      "ELECTRONIC"
+    ]
+  },
+  {
+    "id": "mon_golden_monolith",
+    "type": "MONSTER",
+    "name": { "str": "golden monolith" },
+    "copy-from": "mon_yrax_sphenocorona",
+    "description": "A large golden monolith.  Carefully carved asymmetric edges betray its artificial origin.",
+    "default_faction": "passive_machine",
+    "speed": 5,
+    "hp": 100,
+    "symbol": "I",
+    "armor": { "bash": 100, "cut": 150, "acid": 35, "heat": 10, "bullet": 100 },
+    "melee_skill": 0,
+    "aggro_character": false,
+    "dodge": 0,
+    "melee_dice": 1,
+    "melee_dice_sides": 1,
+    "flags": [ "GOODHEARING", "NOHEAD", "NO_BREATHE", "IMMOBILE", "PACIFIST" ],
+    "special_attacks": [
+      {
+        "type": "spell",
+        "id": "sphenocorona_active",
+        "spell_data": { "id": "sphenocorona_active", "hit_self": true },
+        "allow_no_target": true,
+        "condition": {
+          "or": [
+            { "is_weather": "portal_storm" },
+            { "and": [ { "is_weather": "distant_portal_storm" } ] },
+            { "is_weather": "close_portal_storm" }
+          ]
+        },
+        "monster_message": "The %s unfolds into an alien robot",
+        "cooldown": 5
+      },
+      {
+        "type": "spell",
+        "id": "killer_swarm",
+        "spell_data": { "id": "release_the_deltas", "hit_self": true, "min_level": 1 },
+        "monster_message": "Shards of gleaming alloy detach from the %s's surface!",
+        "cooldown": 60
+      }
+    ],
+    "death_function": { "corpse_type": "BROKEN" }
+  },
+  {
     "id": "mon_yrax_apeirogon",
     "type": "MONSTER",
     "name": { "str": "Yrax apeirohedra" },
@@ -74,6 +194,7 @@
     "morale": 100,
     "hp": 1000000,
     "color": "yellow",
+    "aggro_character": false,
     "melee_skill": 10,
     "melee_dice": 300,
     "melee_dice_sides": 10,
@@ -93,5 +214,32 @@
       "ELECTRONIC"
     ],
     "armor": { "bash": 1000, "cut": 1000, "acid": 100, "heat": 100, "bullet": 1000 }
+  },
+  {
+    "id": "mon_yrax_delta",
+    "copy-from": "base_drone",
+    "type": "MONSTER",
+    "name": { "str": "Yrax delta" },
+    "description": "A kite shaped blade of metal, darting through air and foes by indiscernible means.",
+    "default_faction": "yrax",
+    "weight": "374 g",
+    "volume": "500 ml",
+    "vision_day": 50,
+    "vision_night": 20,
+    "aggression": 7,
+    "aggro_character": false,
+    "symbol": "^",
+    "diff": 2,
+    "speed": 120,
+    "color": "yellow",
+    "melee_skill": 5,
+    "melee_dice": 2,
+    "melee_dice_sides": 4,
+    "anger_triggers": [ "FRIEND_ATTACKED", "FRIEND_DIED", "HURT" ],
+    "melee_damage": [ { "damage_type": "cut", "amount": 12 } ],
+    "death_function": { "corpse_type": "BROKEN" },
+    "extend": { "flags": [ "HIT_AND_RUN" ] },
+    "delete": { "flags": [ "PACIFIST" ] },
+    "armor": { "bash": 12, "cut": 18, "acid": 12, "heat": 8, "bullet": 1 }
   }
 ]

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -202,6 +202,18 @@
     "flags": [ "EXODII" ]
   },
   {
+    "id": "mx_golden_monoliths",
+    "type": "map_extra",
+    "name": { "str": "Golden monoliths" },
+    "description": "There are some strange metal formations here.",
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_golden_monoliths_map" },
+    "min_max_zlevel": [ 0, 0 ],
+    "sym": "x",
+    "color": "yellow",
+    "autonote": true,
+    "flags": [ "YRAX" ]
+  },
+  {
     "id": "mx_lab_concourse_area",
     "type": "map_extra",
     "name": { "str": "Start location concourse area" },

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -759,7 +759,8 @@
           "mx_science": 10,
           "mx_military": 4,
           "mx_exocrash_1": 5,
-          "mx_exocrash_2": 5
+          "mx_exocrash_2": 5,
+          "mx_golden_monoliths": 1
         }
       },
       "road": {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -1071,6 +1071,9 @@ std::string monster::extended_description() const
         ss += string_format( _( "Anger: %1$d" ), anger ) + "\n";
         ss += string_format( _( "Friendly: %1$d" ), friendly ) + "\n";
         ss += string_format( _( "Morale: %1$d" ), morale ) + "\n";
+        if( aggro_character ) {
+            ss += string_format( _( "<color_red>Agressive towards characters</color>" ) ) + "\n";
+        }
 
         const time_duration current_time = calendar::turn - calendar::turn_zero;
         ss += string_format( _( "Current Time: Turn %1$d  |  Day: %2$d" ),
@@ -2881,7 +2884,7 @@ void monster::die( Creature *nkiller )
                         // A character killed our friend
                         add_msg_debug( debugmode::DF_MONSTER, "%s's character aggro triggered by killing a friendly %s",
                                        critter.name(), name() );
-                        aggro_character = true;
+                        critter.aggro_character = true;
                     }
                 } else if( critter.type->has_fear_trigger( mon_trigger::FRIEND_DIED ) ) {
                     critter.morale -= 15;
@@ -3541,7 +3544,7 @@ void monster::on_hit( Creature *source, bodypart_id,
                         // A character attacked our friend
                         add_msg_debug( debugmode::DF_MONSTER, "%s's character aggro triggered by attacking a friendly %s",
                                        critter.name(), name() );
-                        aggro_character = true;
+                        critter.aggro_character = true;
                     }
                 } else if( critter.type->has_fear_trigger( mon_trigger::FRIEND_ATTACKED ) ) {
                     critter.morale -= 15;


### PR DESCRIPTION
#### Summary
Content "Add a variant of standing stones for fields"

#### Purpose of change

Its an Yrax content PR. I'll add a small chance for these to spawn in meatlabs later.

#### Describe the solution
This adds a scientist type Yrax robot and its defensive drones. They are only active during portal storms.

Also includes a likely bugfix for character aggro based on hurt allies.

#### Testing
Made sure the weather based activation happened properly and that the monsters worked properly in general.
