### PR TITLE
Aftershock: Attaching atompot to mounted kitchen

### DIFF
--- a/data/mods/Aftershock/vehicles/vehicle_parts.json
+++ b/data/mods/Aftershock/vehicles/vehicle_parts.json
@@ -195,5 +195,16 @@
       { "item": "welder", "charges": 0, "prob": 50 }
     ],
     "variants": [ { "symbols": "T", "symbols_broken": "x" } ]
+  },
+  {
+    "//": "It shouldnt cause any compability issues like this",
+    "id": "veh_tools_kitchen",
+    "type": "vehicle_part",
+    "copy-from": "veh_tools_kitchen",
+    "description": "A table rig with a faucet for water tank access, fume hood, drawers and fixtures for storing tools, low power electric connectors and valves for for fuel tank connections.",
+    "item": "veh_tools_kitchen",
+    "looks_like": "kitchen_unit",
+    "pseudo_tools": [ { "id": "water_faucet" } ],
+    "extend": { "allowed_tools": [ "afs_atompot" ] }
   }
 ]

--- a/data/mods/Aftershock/vehicles/vehicle_parts.json
+++ b/data/mods/Aftershock/vehicles/vehicle_parts.json
@@ -197,14 +197,13 @@
     "variants": [ { "symbols": "T", "symbols_broken": "x" } ]
   },
   {
-    "//": "It shouldnt cause any compability issues like this",
+    "//": "It shouldnt cause any compability issues like this ",
     "id": "veh_tools_kitchen",
     "type": "vehicle_part",
     "copy-from": "veh_tools_kitchen",
     "description": "A table rig with a faucet for water tank access, fume hood, drawers and fixtures for storing tools, low power electric connectors and valves for for fuel tank connections.",
     "item": "veh_tools_kitchen",
     "looks_like": "kitchen_unit",
-    "pseudo_tools": [ { "id": "water_faucet" } ],
     "extend": { "allowed_tools": [ "afs_atompot" ] }
   }
 ]

--- a/data/mods/Aftershock/vehicles/vehicle_parts.json
+++ b/data/mods/Aftershock/vehicles/vehicle_parts.json
@@ -197,7 +197,6 @@
     "variants": [ { "symbols": "T", "symbols_broken": "x" } ]
   },
   {
-    "//": "It shouldnt cause any compability issues like this ",
     "id": "veh_tools_kitchen",
     "type": "vehicle_part",
     "copy-from": "veh_tools_kitchen",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Other household items can be attached to mounted kitchen but atompot cant
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add the atompot to the mounted kitchens allowed_tools list by copying mounted kitchen and override it like that so it doesn't interfere with other mods
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I tried to just extend it with mounted kitchens id, type and extend. It gave errors with that
After that I tried to extend the abstract, it didn't gave any errors but didn't worked either

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawn undamaged camper van from debug > attach atompot into the kitchen

Start vehicle construction > install mounted kitchen > attach atompot into the kitchen

Also after doing the same for another mod:
-Tried to make a save without enabling one of it. No problem visible
-Tried to make a save with both mods enabled. Both mods items were attachable without any visible problems

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
