### PR TITLE
Cattail can be planted in shallow water

### DIFF
--- a/data/json/items/comestibles/seed.json
+++ b/data/json/items/comestibles/seed.json
@@ -264,9 +264,15 @@
     "copy-from": "seed",
     "name": { "str_sp": "cattail seeds" },
     "color": "green",
-    "description": "Some cattail seeds.",
-    "flags": [ "NUTRIENT_OVERRIDE", "INEDIBLE" ],
-    "seed_data": { "plant_name": "cattail", "fruit": "cattail_stalk", "byproducts": [ "cattail_rhizome" ], "grow": "91 days" }
+    "description": "Some cattail seeds. Must be planted in shallow water.",
+    "flags": [ "PLANTABLE_SEED", "NUTRIENT_OVERRIDE", "INEDIBLE" ],
+    "seed_data": {
+      "plant_name": "cattail",
+      "fruit": "cattail_stalk",
+      "byproducts": [ "cattail_rhizome" ],
+      "grow": "91 days",
+      "required_terrain_flag": "SHALLOW_WATER"
+    }
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/seed.json
+++ b/data/json/items/comestibles/seed.json
@@ -264,7 +264,7 @@
     "copy-from": "seed",
     "name": { "str_sp": "cattail seeds" },
     "color": "green",
-    "description": "Some cattail seeds. Must be planted in shallow water.",
+    "description": "Some cattail seeds.  Must be planted in shallow water.",
     "flags": [ "PLANTABLE_SEED", "NUTRIENT_OVERRIDE", "INEDIBLE" ],
     "seed_data": {
       "plant_name": "cattail",

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -4034,9 +4034,12 @@ Every item type can have optional seed data, if the item has seed data, it's con
     "fruit_div": 2, // (optional, default is 1). Final amount of fruit charges produced is divided by this number. Works only if fruit item is counted by charges.
     "byproducts": ["withered", "straw_pile"], // A list of further items that should spawn upon harvest.
     "plant_name": "sunflower", // The name of the plant that grows from this seed. This is only used as information displayed to the user.
-    "grow" : 91 // A time duration: how long it takes for a plant to fully mature. Based around a 91 day season length (roughly a real world season) to give better accuracy for longer season lengths
+    "grow" : 91, // A time duration: how long it takes for a plant to fully mature. Based around a 91 day season length (roughly a real world season) to give better accuracy for longer season lengths
                 // Note that growing time is later converted based upon the season_length option, basing it around 91 is just for accuracy purposes
                 // A value 91 means 3 full seasons, a value of 30 would mean 1 season.
+    "required_terrain_flag": "PLANTABLE" // A tag that terrain and furniture would need to have in order for the seed to be plantable there.
+					 // Default is "PLANTABLE", and using this will cause any terain the plant is wrown on to turn into dirt once the plant is planted, unless furniture is used.
+					 // Using any other tag will not turn the terrain into dirt.
 }
 ```
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3217,10 +3217,12 @@ void activity_handlers::plant_seed_finish( player_activity *act, Character *you 
         }
         used_seed.front().set_flag( json_flag_HIDDEN_ITEM );
         here.add_item_or_charges( examp, used_seed.front() );
-        if( here.has_flag_furn( ter_furn_flag::TFLAG_PLANTABLE, examp ) ) {
+        if( here.has_flag_furn( seed_id->seed->required_terrain_flag, examp ) ) {
             here.furn_set( examp, furn_str_id( here.furn( examp )->plant->transform ) );
-        } else {
+        } else if( seed_id->seed->required_terrain_flag == ter_furn_flag::TFLAG_PLANTABLE ) {
             here.set( examp, t_dirt, f_plant_seed );
+        } else {
+            here.furn_set( examp, f_plant_seed );
         }
         you->add_msg_player_or_npc( _( "You plant some %s." ), _( "<npcname> plants some %s." ),
                                     item::nname( seed_id ) );

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -2558,6 +2558,11 @@ void iexamine::dirtmound( Character &you, const tripoint &examp )
     }
     const auto &seed_id = std::get<0>( seed_entries[seed_index] );
 
+    if( !here.has_flag_ter_or_furn( seed_id->seed->required_terrain_flag, examp ) ) {
+        add_msg( _( "This type of seed can not be planted in this location." ) );
+        return;
+    }
+
     plant_seed( you, examp, seed_id );
 }
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3369,6 +3369,8 @@ void islot_seed::load( const JsonObject &jo )
     mandatory( jo, was_loaded, "fruit", fruit_id );
     optional( jo, was_loaded, "seeds", spawn_seeds, true );
     optional( jo, was_loaded, "byproducts", byproducts );
+    optional( jo, was_loaded, "required_terrain_flag", required_terrain_flag,
+              ter_furn_flag::TFLAG_PLANTABLE );
 }
 
 void islot_seed::deserialize( const JsonObject &jo )

--- a/src/itype.h
+++ b/src/itype.h
@@ -22,6 +22,7 @@
 #include "game_constants.h"
 #include "item_pocket.h"
 #include "iuse.h" // use_function
+#include "mapdata.h"
 #include "proficiency.h"
 #include "relic.h"
 #include "stomach.h"
@@ -1065,7 +1066,10 @@ struct islot_seed {
      * Additionally items (a list of their item ids) that will spawn when harvesting the plant.
      */
     std::vector<itype_id> byproducts;
-
+    /**
+     * Terrain tag required to plant the seed.
+     */
+    ter_furn_flag required_terrain_flag = ter_furn_flag::TFLAG_PLANTABLE;
     islot_seed() = default;
 };
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Cattail can be planted in shallow water"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#68616 made cattail not plantable on land. This PR makes cattail farmable again. It also makes it so that different plants can have different terrain requirements for farming.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
`"seed_data"` has a new optional field, `"required_terrain_flag"`. This is set to `"PLANTABLE"` by default. In order to plant a seed somewhere, the terrain or furniture there needs to have the given flag.
If this flag is set to anything other than `"PLANTABLE"`, the terrain will not turn into dirt after the seed is planted. This is to prevent the water to turn into dirt when you plant stuff in it.
Places that previously checked for the `"PLANTABLE"` tag now instead checks for the tag specified by the `"seed_data"`.
Cattail seeds are set to have `"required_terrain_flag": "SHALLOW_WATER"`.
Documentation is updated to match.
A new hardcoded message string is added for when you're trying to plant a seed in an invalid spot; `add_msg( _( "This type of seed can not be planted in this location." ) );`. This might need translation.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Give shallow water `"examine_action": "dirtmound"` so that seeds can be planted. I felt this would clutter up the UI, but right now the seeds can not be planted manually, and have to instead be planted using the zone manager, which might be confusing.
Create aquatic farmland as a furniture item instead. This could be given the `"examine_action": "dirtmound"` to let players plant the crops manually. I felt like this would add extra pointless work for the player, but I'm not sure if it might be a better idea. Using a furniture instead of a terrain would also make it so I don't need a special case in order to not turn the planted terrain into dirt if we use special terrain.
Hide seeds that can't be planted from the seed selection menu. Felt like extra work, and would confuse the player. My hope is right now that they will try to plant cattail seeds in soil, get the error message that "This type of seed can not be planted in this location.", read the item description and notice that it says it must be planted in shallow water, and figure things out from there. Thus, hiding invalid seeds might be more confusing than helpful.
If this were to be used for non-seed like beehives, perhaps it would be a better idea to hide invalid seeds and change the message to "You can not plant <item_name_plural> in this location.".
Right now, if you define an area of dirt to be used to farm cattail using the zone manager, the player will still try to tilt the earth, but be unable to plant the seeds. Perhaps tilting of earth should not be done for farmlands where the seeds does not have `"required_terrain_flag": "PLANTABLE"`
Instead of always trying to tile an area, let `seed_data` define a `construction_group` it will try to use to make the area plantable. Seems like a much better solution, but also sounds like a bunch of extra work. Maybe later.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
From my testing, it seems to work.

Here I designated an area to be a cattail farm:
![Capture](https://github.com/CleverRaven/Cataclysm-DDA/assets/66904273/eb19ccb2-be21-4dcc-840c-58250d2a7198)

Here I am after having farmed the area:
![Capture2](https://github.com/CleverRaven/Cataclysm-DDA/assets/66904273/6b596981-8369-4507-b853-6634cb0ea406)

Harvesting also seems to work fine:
![Capture3](https://github.com/CleverRaven/Cataclysm-DDA/assets/66904273/5adea4b9-1525-437e-b562-d0dbb845767c)

Asking an NPC to work the field also seems to work fine. It also still works to plant normal crops both by yourself and with NPCs:
![Capture5](https://github.com/CleverRaven/Cataclysm-DDA/assets/66904273/a40df423-9117-4fc6-bd5d-bf87313f4a48)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
@harakka requested a ping.
Also pinging @AmarinReyny since they asked about this.
If anyone knows if any extra steps are needed to translate the hardcoded message I added, feel free to let me know. Translation is magic to me.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
