### PR TITLE
Sheathable Khopesh

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -1408,7 +1408,7 @@
     "color": "yellow",
     "techniques": [ "WBLOCK_2", "DEF_DISARM" ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 8 ] ],
-    "flags": [ "DURABLE_MELEE" ],
+    "flags": [ "DURABLE_MELEE", "SHEATH_SWORD" ],
     "weapon_category": [ "SHORT_SWORDS" ],
     "melee_damage": { "bash": 9, "cut": 27 }
   },


### PR DESCRIPTION
#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The Khopesh is currently unseathable since it lacks any flags for storage, this makes it difficult to carry for anyone wanting to use the weapon.

#### Describe the solution
Adds the `SHEATH_SWORD` flag to the Khopesh so that it can be sheathed in a scabbard or similar items.

#### Describe alternatives you've considered
To add a new kind of scabbard only for this weapon? It does has a somewhat different shape from most other swords but the sheath items accept a variety of different swords for a reason...
That or making it wearable in a belt or axe sheath.

#### Testing
It works! The scabbard already allows for the dimensions of the Khopesh.

#### Additional context
This is an example of how a scabbard for a Khopesh would look like, not so different than a standard scabbard.
![756d664e5a5eb5a6cc71cf4464a552eb-1193322508](https://github.com/CleverRaven/Cataclysm-DDA/assets/53200489/4953e918-c07a-4637-9afc-0a47d58e0faf)

