### PR TITLE
Adding some basic blacksmithing tools to the general tools pool

### DIFF
--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -20,35 +20,36 @@
     "id": "tools_simple_blacksmith",
     "type": "item_group",
     "//": "Tools commonly used by amateur blacksmiths. A subset of blacksmiths tools",
-    "items": [
-      [ "basic_metalworking_a", 40 ],
-      [ "basic_metalworking_b", 60 ]
-    ]
+    "items": [ { "group": "basic_metalworking_a", "prob": 40 }, { "group": "basic_metalworking_b", "prob": 60 } ]
   },
   {
     "id": "basic_metalworking_a",
     "type": "item_group",
     "subtype": "collection",
-    "items": [
-      [ "anvil" ],
-      [ "chisel" ],
-      [ "metal_file" ],
-      [ "hotcut" ],
-      [ "metalworking_tongs" ],
-      [ "hammer" ],
-      [ "sandpaper" ]
+    "//": "This group was created automatically and may contain errors.",
+    "container-item": "box_large",
+    "entries": [
+      { "item": "anvil", "count": 1 },
+      { "item": "chisel", "count": 1 },
+      { "item": "metal_file", "count": 1 },
+      { "item": "hotcut", "count": 1 },
+      { "item": "metalworking_tongs", "count": 1 },
+      { "item": "hammer", "count": 1 },
+      { "item": "sandpaper", "count": 1 }
     ]
   },
   {
     "id": "basic_metalworking_b",
     "type": "item_group",
     "subtype": "collection",
-    "items": [
-      [ "anvil" ],
-      [ "metal_file" ],
-      [ "metalworking_tongs" ],
-      [ "hammer" ],
-      [ "sandpaper" ]
+    "//": "This group was created automatically and may contain errors.",
+    "container-item": "box_large",
+    "entries": [
+      { "item": "anvil", "count": 1 },
+      { "item": "metal_file", "count": 1 },
+      { "item": "metalworking_tongs", "count": 1 },
+      { "item": "hammer", "count": 1 },
+      { "item": "sandpaper", "count": 1 }
     ]
   },
   {

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -21,13 +21,34 @@
     "type": "item_group",
     "//": "Tools commonly used by amateur blacksmiths. A subset of blacksmiths tools",
     "items": [
-      [ "anvil", 90 ],
-      [ "chisel", 90 ],
-      [ "metal_file", 90 ],
-      [ "hotcut", 30 ],
-      [ "metalworking_tongs", 90 ],
-      [ "hammer", 90 ],
-      [ "sandpaper", 90 ]
+      [ "basic_metalworking_a", 40 ],
+      [ "basic_metalworking_b", 60 ]
+    ]
+  },
+  {
+    "id": "basic_metalworking_a",
+    "type": "item_group",
+    "subtype": "collection",
+    "items": [
+      [ "anvil" ],
+      [ "chisel" ],
+      [ "metal_file" ],
+      [ "hotcut" ],
+      [ "metalworking_tongs" ],
+      [ "hammer" ],
+      [ "sandpaper" ]
+    ]
+  },
+  {
+    "id": "basic_metalworking_b",
+    "type": "item_group",
+    "subtype": "collection",
+    "items": [
+      [ "anvil" ],
+      [ "metal_file" ],
+      [ "metalworking_tongs" ],
+      [ "hammer" ],
+      [ "sandpaper" ]
     ]
   },
   {
@@ -185,7 +206,7 @@
       { "group": "tools_lighting_industrial", "prob": 100 },
       { "group": "tools_mechanic", "prob": 20 },
       { "group": "tools_plumbing", "prob": 20 },
-      { "group": "tools_simple_blacksmith", "prob": 20 },
+      { "group": "tools_simple_blacksmith", "prob": 10 },
       [ "jumper_cable_heavy", 2 ],
       [ "lug_wrench", 20 ],
       [ "jerrycan", 10 ],

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -17,6 +17,20 @@
     ]
   },
   {
+    "id": "tools_simple_blacksmith",
+    "type": "item_group",
+    "//": "Tools commonly used by amateur blacksmiths. A subset of blacksmiths tools",
+    "items": [
+      [ "anvil", 90 ],
+      [ "chisel", 90 ],
+      [ "metal_file", 90 ],
+      [ "hotcut", 30 ],
+      [ "metalworking_tongs", 90 ],
+      [ "hammer", 90 ],
+      [ "sandpaper", 90 ]
+    ]
+  },
+  {
     "id": "tools_carpentry",
     "type": "item_group",
     "//": "Portable tools used for carpentry",
@@ -171,6 +185,7 @@
       { "group": "tools_lighting_industrial", "prob": 100 },
       { "group": "tools_mechanic", "prob": 20 },
       { "group": "tools_plumbing", "prob": 20 },
+      { "group": "tools_simple_blacksmith", "prob": 20 },
       [ "jumper_cable_heavy", 2 ],
       [ "lug_wrench", 20 ],
       [ "jerrycan", 10 ],


### PR DESCRIPTION
#### Summary
Balance "Add basic metalworking equipment to the general tools pools, meaning they'll show up in more places"

#### Purpose of change

Amateur blacksmithing is a thing, and many professions have need for basic metalworking tools. It makes sense to add some of the simpler blacksmithing equipment to the general tools loot pool (with a low chance).

#### Describe the solution

I made a couple of sets of blacksmithing tools that have been added to tools-general, one is less complete and is more common and vice versa.

#### Describe alternatives you've considered

Make it spawn individual tools. Commentators mentioned it seemed more realistic to have these in a group rather than individual, unlike a lot of tools an anvil on its own is kind of useless.

#### Testing

Port around and confirmed I could find blacksmith tools occasionally.

#### Additional context
