### PR TITLE
More armor categorized as armor

### DIFF
--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -1002,6 +1002,7 @@
   {
     "id": "gloves_cut_resistant",
     "type": "ARMOR",
+    "category": "armor",
     "name": { "str": "pair of cut-resistant gloves", "str_pl": "pairs of cut-resistant gloves" },
     "description": "A pair of cut-resistant gloves, useful for butchery or routine work with bladed objects.",
     "weight": "240 g",

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -1172,6 +1172,7 @@
   {
     "id": "chaps_cut_resistant",
     "type": "ARMOR",
+    "category": "armor",
     "name": { "str_sp": "chainsaw chaps" },
     "description": "A pair of tough chaps made of Kevlar.  Chainsaw kickbacks are potentially fatal; personal protective equipment like these chaps help protect your femoral arteries.  The layered Kevlar is designed to fray on contact with the chain and bind up the tool.",
     "weight": "1519 g",
@@ -2190,6 +2191,7 @@
   {
     "id": "survivor_adhoc_leather_pants",
     "type": "ARMOR",
+    "category": "armor",
     "name": { "str": "leather-padded pants", "str_pl": "pairs of leather-padded pants" },
     "description": "A pair of tough canvas pants with sections from leather pants affixed, excluding the joints.  Offers mild protection without compromising mobility too much, but a lot of the pockets have been removed to make room for the leather.",
     "weight": "1970 g",
@@ -2244,6 +2246,7 @@
     "id": "canvas_pants_padded",
     "repairs_like": "jeans",
     "type": "ARMOR",
+    "category": "armor",
     "name": { "str": "cloth-padded pants", "str_pl": "pairs of cloth-padded pants" },
     "description": "A pair of tough canvas pants with sections of cotton sewn onto it in a crossing pattern, clearly done by an amateur.",
     "weight": "1970 g",

--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -30,6 +30,7 @@
   {
     "id": "balaclava_cut_resistant",
     "type": "ARMOR",
+    "category": "armor",
     "name": { "str": "cut-resistant balaclava" },
     "description": "A face covering that helps protect from slashes and cuts, in addition to the cold.",
     "copy-from": "balclava",

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -349,6 +349,7 @@
   {
     "id": "apron_plastic",
     "type": "ARMOR",
+    "category": "armor",
     "name": { "str": "plastic apron" },
     "description": "An apron made of plastic, provides good protection against accidental chemical splashes.",
     "copy-from": "apron_leather",
@@ -359,6 +360,7 @@
   {
     "id": "apron_cut_resistant",
     "type": "ARMOR",
+    "category": "armor",
     "name": { "str": "cut-resistant apron" },
     "description": "An apron made of Kevlar fabric.",
     "copy-from": "apron_leather",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Some clothing items that are used in real life (and in the game) as armor are considered clothing in the game.

#### Describe the solution
Change the cut resistant items, the plastic and kevlar aprons, as well as the padded pants to be categorized as armor, the cut resistant ones explain by themselves, the plastic (and kevlar) aprons are used for protection and not fashion/everyday clothing, and the padded items are literally crafted to work as improvised armor.

#### Describe alternatives you've considered
To add the motorcycle stuff (Including the track touring suit) as armor too, but they can be considered clothing since, even if they are intended for protection, their main use before the cataclysm is to serve as clothing.

#### Testing
It works!

#### Additional context
Any additional suggestions for clothing that should be considered armor?
