### PR TITLE
Gas masks: Only absorb from fields with gas_absorption set

### DIFF
--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4185,12 +4185,18 @@ std::optional<int> iuse::gasmask( Character *p, item *it, const tripoint &pos )
         for( const auto &dfield : gasfield ) {
             const field_entry &entry = dfield.second;
             int gas_abs_factor = to_turns<int>( entry.get_field_type()->gas_absorption_factor );
+            // Not set, skip this field
+            if( gas_abs_factor == 0 ) {
+                continue;
+            }
             const field_intensity_level &int_level = entry.get_intensity_level();
             // 6000 is the amount of "gas absorbed" charges in a full 100 capacity gas mask cartridge.
             // factor/concentration gives an amount of seconds the cartidge is expected to last in current conditions.
             /// 6000/that is the amount of "gas absorbed" charges to tick up every second in order to reach that number.
             float gas_absorbed = 6000 / ( static_cast<float>( gas_abs_factor ) / static_cast<float>
                                           ( int_level.concentration ) );
+            add_msg_debug( debugmode::DF_IUSE, "Absorbing %g/60 from field: 6000 / (%d * %d)", gas_absorbed,
+                           gas_abs_factor, int_level.concentration );
             if( gas_absorbed > 0 ) {
                 it->set_var( "gas_absorbed", it->get_var( "gas_absorbed", 0 ) + gas_absorbed );
             }


### PR DESCRIPTION
#### Summary
Bugfixes "Gas masks only use charges on fields with gas_absorption_factor set"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/68678

#### Describe the solution
Skip fields without `gas_absorption_factor` set. Add a debug message for better visibility into has gas mask charges are consumed due to fields.

#### Testing
Spawn gas mask and gas mask cartridge, load it.
Activate and wear gas mask.
Spawn zombie, and debug kill it.
Pulp zombie, creating blood field. See gas mask is not drained when in blood field.
Spawn bloated zombie, debug kill it. See gas mask drains when in poison gas field.
