### PR TITLE
Enforce wrap of ASCII `picture` format

### DIFF
--- a/tools/format/format.cpp
+++ b/tools/format/format.cpp
@@ -23,7 +23,7 @@ static void write_object( TextJsonIn &jsin, JsonOut &jsout, int depth, bool forc
         std::string name = jsin.get_member_name();
         jsout.member( name );
         bool override_wrap = false;
-        if( name == "rows" || name == "blueprint" ) {
+        if( name == "rows" || name == "blueprint" || name == "picture" ) {
             // Introspect into the row, if it has more than one element, force it to wrap.
             int in_start_pos = jsin.tell();
             bool ate_separator = jsin.get_ate_separator();


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
#68667 revealed that linter doesn't work correctly with short ASCII pictures; since there is not much of said short pictures, it is assumed to be okay to enforce wrap on it
#### Describe the solution
add `picture` to the list of fields to force wrap
#### Describe alternatives you've considered
Not adding it, as it doesn't matter in most cases
#### Additional context
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/3ca1fa20-4846-4440-b661-f2de29a2a802)