### PR TITLE
Mercenary set Improvements

### DIFF
--- a/data/json/items/armor/bespoke_armor/custom_legs.json
+++ b/data/json/items/armor/bespoke_armor/custom_legs.json
@@ -184,21 +184,21 @@
     "id": "armor_mercenary_bottom",
     "type": "ARMOR",
     "name": { "str_sp": "mercenary pants" },
-    "description": "A sturdy pair of pants fit for a soldier of fortune.  Made from cargo pants padded with Kevlar panels.  It has a lot of storage space, but the added thickness makes it uncomfortable to wear any armor over it.",
+    "description": "A sturdy pair of pants fit for a soldier of fortune.  Made from work pants padded with Kevlar panels.  It gives good protection and decent storage, but the added thickness makes it uncomfortable to wear any armor over it.",
     "//": "weight is currently an estimation could be better",
     "weight": "3000 g",
     "volume": "7500 ml",
     "price": 180000,
     "price_postapoc": 2000,
     "to_hit": -3,
-    "material": [ "kevlar_layered", "cotton" ],
+    "material": [ "kevlar_layered", "canvas" ],
     "symbol": "[",
     "looks_like": "pants_army",
     "color": "green",
     "armor": [
       {
         "material": [
-          { "type": "cotton", "covered_by_mat": 100, "thickness": 0.2 },
+          { "type": "canvas", "covered_by_mat": 100, "thickness": 0.5 },
           { "type": "kevlar_layered", "covered_by_mat": 90, "thickness": 4.4 }
         ],
         "volume_encumber_modifier": 0.3,
@@ -225,20 +225,6 @@
       },
       {
         "pocket_type": "CONTAINER",
-        "max_contains_volume": "1250 ml",
-        "max_contains_weight": "4 kg",
-        "max_item_length": "19 cm",
-        "moves": 80
-      },
-      {
-        "pocket_type": "CONTAINER",
-        "max_contains_volume": "1250 ml",
-        "max_contains_weight": "4 kg",
-        "max_item_length": "19 cm",
-        "moves": 80
-      },
-      {
-        "pocket_type": "CONTAINER",
         "max_contains_volume": "1080 ml",
         "max_contains_weight": "4 kg",
         "max_item_length": "165 mm",
@@ -252,7 +238,7 @@
         "moves": 100
       }
     ],
-    "warmth": 40,
+    "warmth": 25,
     "material_thickness": 5,
     "valid_mods": [ "steel_padded" ],
     "environmental_protection": 2,

--- a/data/json/items/armor/bespoke_armor/custom_overcoats.json
+++ b/data/json/items/armor/bespoke_armor/custom_overcoats.json
@@ -218,7 +218,7 @@
         "flag_restriction": [ "ABLATIVE_MEDIUM" ]
       }
     ],
-    "warmth": 40,
+    "warmth": 25,
     "material_thickness": 5,
     "use_action": [ { "type": "attach_molle", "size": 10 }, { "type": "detach_molle" } ],
     "valid_mods": [ "steel_padded" ],

--- a/data/json/recipes/armor/legs.json
+++ b/data/json/recipes/armor/legs.json
@@ -866,7 +866,7 @@
       { "proficiency": "prof_closures_waterproofing" },
       { "proficiency": "prof_polymerworking" }
     ],
-    "components": [ [ [ "pants_army", 1 ], [ "pants_cargo", 1 ] ], [ [ "sheet_kevlar_layered", 24 ] ] ]
+    "components": [ [ [ "technician_pants_gray", 1 ] ], [ [ "sheet_kevlar_layered", 24 ] ] ]
   },
   {
     "result": "lsurvivor_pants",


### PR DESCRIPTION
#### Summary
Balance "Small improvements to the mercenary coat and pants"

#### Purpose of change
I noticed that the mercenary coat and pants gave way too much warmth, the mercenary coat, for example, is basically a Ballistic Vest +, but while the ballistic vest has 15 warmth, the mercenary coat (with the same thickness as the ballistic vest, and based around one) had a whooping 40 warmth! So I decided to fix both items.
Also, the mercenary pants were... Underwhelming, at least for me, since they provided a negligible protection as base for the item.

#### Describe the solution
Changed the warmth of both items to 25, it could less I guess, but definitely not more, this is the same warmth as the Kevlar Jumpsuit.
Changed the mercenary pants to be made of Work pants, and changed its base material from cotton to canvas, as well as its thickness to reflect the thickness of work pants. This sadly meant deleting a couple of pockets from when it was based (somewhat) of a Cargo Pants, but meh.

#### Describe alternatives you've considered
To change the Mercenary Pants to just be based around the army pants, so all mercenary items are made of a base of Synthetic Fabric + some amount of Ballistic Kevlar, but the army pants have a low thickness that gives you negligible protection, and it doesn't makes sense to use subpar items for something like this.

#### Testing
It loads! And both items are changed alright.

#### Additional context
![imagen](https://github.com/CleverRaven/Cataclysm-DDA/assets/53200489/ede760d3-f5f5-4bbf-a5d6-f1158c6b1781)


