### PR TITLE
Preparing for a hit, Brawling Buff

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -300,7 +300,7 @@
       {
         "id": "buff_brawling_onpause",
         "name": "Preparation to Hit",
-        "description": "You take a moment to prepare your stance before the enemy, allowing you to hit a little more accurately.\n\n+1 accuracy. Lasts 2 turns.  Stacks 2 times",
+        "description": "You take a moment to prepare your stance before the enemy, allowing you to hit a little more accurately.\n\n+1 accuracy.  Lasts 2 turns.  Stacks 2 times",
         "unarmed_allowed": true,
         "melee_allowed": true,
         "skill_requirements": [ { "name": "melee", "level": 1 } ],

--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -296,6 +296,19 @@
         "bonus_blocks": 1
       }
     ],
+    "onpause_buffs": [
+      {
+        "id": "buff_brawling_onpause",
+        "name": "Preparation to Hit",
+        "description": "You take a moment to prepare your stance before the enemy, allowing you to hit a little more accurately.\n\n+1 accuracy. Lasts 2 turns.  Stacks 2 times",
+        "unarmed_allowed": true,
+        "melee_allowed": true,
+        "skill_requirements": [ { "name": "melee", "level": 1 } ],
+        "max_stacks": 2,
+        "buff_duration": 2,
+        "flat_bonuses": [ { "stat": "hit", "scale": 1.0 } ]
+      }
+    ],
     "techniques": [
       "tec_brawl_disarm_unarmed",
       "tec_brawl_feint_unarmed",


### PR DESCRIPTION
#### Summary
Content "Adds a small onpause buff to Brawling"

#### Purpose of change
Brawling is the style for the self-taught, but those self-taught fighters are usually very bad at actually hitting things... So why not prepare a little your stance so you can improve, even if just a little bit, your chances of hitting your enemy?

#### Describe the solution
Adds a new onpause buff to Brawling, which improves a little bit of accuracy when staying in place, so if you see a zombie coming for you, the turns you wait for it to come to you actually help you a little bit to actually hitting it! (Like in real life, staying in place and watching with attention what you want to hit as it comes to you actually improves your chances of hitting it).

#### Describe alternatives you've considered
To make it stack until 3, or the buff to last 3 turns, but this is supposed to be a small buff for people fighting as they can.

#### Testing
It works! The buff is applied when staying in place and charges until 2.

#### Additional context
This buff could be used as a requirement for certain weapon techniques to trigger (Like making a brutal strike with a baseball bat, which I think should require preparing your stance first).
