### PR TITLE
EOD Fingies

### DIFF
--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -1337,7 +1337,7 @@
     "type": "ARMOR",
     "category": "armor",
     "name": { "str": "pair of EOD overhand protectors", "str_pl": "pairs of EOD overhand protectors" },
-    "description": "A pair of fragmentation resistant pads for wearing over the backs of one's hands, providing protection from shrapnel in case things go wrong.  Sold as an accessory for explosive ordnance disposal suits, but not often used.",
+    "description": "A pair of fragmentation resistant pads for wearing over the backs of one's hands, providing protection from shrapnel in case things go wrong.  Sold as an accessory for explosive ordnance disposal suits, but not often used due to the difficulty in armoring the entire hand and retaining dexterity.",
     "weight": "610 g",
     "volume": "1000 ml",
     "price": 70000,
@@ -1349,7 +1349,7 @@
     "flags": [ "STURDY", "OUTER", "ONLY_ONE", "NO_SALVAGE" ],
     "armor": [
       {
-        "encumbrance": 5,
+        "encumbrance": 10,
         "coverage": 40,
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_back_l", "hand_back_r" ],

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -1336,20 +1336,26 @@
     "id": "gloves_eod",
     "type": "ARMOR",
     "category": "armor",
-    "name": { "str": "pair of EOD gloves", "str_pl": "pairs of EOD gloves" },
-    "description": "A pair of armored gloves constructed from Kevlar and Nomex for use by explosive ordnance disposal technicians.",
-    "weight": "800 g",
-    "volume": "1500 ml",
+    "name": { "str": "pair of EOD overhand protectors", "str_pl": "pairs of EOD overhand protectors" },
+    "description": "A pair of fragmentation resistant pads for wearing over the backs of one's hands, providing protection from shrapnel in case things go wrong.  Sold as an accessory for explosive ordnance disposal suits, but not often used.",
+    "weight": "610 g",
+    "volume": "1000 ml",
     "price": 70000,
     "price_postapoc": 8000,
-    "warmth": 40,
-    "material": [ "kevlar_layered", "nomex" ],
+    "warmth": 10,
+    "material": [ "kevlar_layered" ],
     "symbol": "[",
     "color": "light_gray",
-    "environmental_protection": 2,
-    "material_thickness": 5,
-    "flags": [ "STURDY", "OUTER", "RAINPROOF", "ONLY_ONE" ],
-    "armor": [ { "encumbrance": 20, "coverage": 100, "covers": [ "hand_l", "hand_r" ] } ]
+    "flags": [ "STURDY", "OUTER", "ONLY_ONE", "NO_SALVAGE" ],
+    "armor": [
+      {
+        "encumbrance": 5,
+        "coverage": 40,
+        "covers": [ "hand_l", "hand_r" ],
+        "specifically_covers": [ "hand_back_l", "hand_back_r" ],
+        "material": [ { "type": "kevlar_layered", "covered_by_mat": 100, "thickness": 3, "ignore_sheet_thickness": true } ]
+      }
+    ]
   },
   {
     "id": "lc_demi_gaunt",


### PR DESCRIPTION
#### Summary
Balance "Make EOD gloves match their real life counterpart"

#### Purpose of change

EOD gloves are often forgone to allow for increased dexterity, and the layers of kevlar needed to provide frag resistance would make a full coverage glove incredibly prohibitive. MED-ENG does offer a "EOD glove" that can be worn with EOD suits as a option. It is my understanding that this is often not used.

#### Describe the solution

<https://www.med-eng.com/product/hand-protectors/> A link to the product in question. The glove can be abstracted into two items: The nomex gloves, which we already have in game as `nomex_gloves`, and the overhand protectors, which I adjust `gloves_eod` into.

The weight and volume of the gloves are subtracted from the item, and the coverage is reduced to something appropriate. The armor value is reduced to something between II and IIIA, which is about where I understand the peripheral protection of the MED-ENG suit to be.

Tossed no salvage on this, because they're tiny.
#### Describe alternatives you've considered

**Deleting** the EOD gloves. Seriously, as I understand it they're basically never used. Go look at pics of EOD techs, they're gloveless usually.

Doing of `kevlar` instead of `layered_kevlar` for the material. Without `"ignore_sheet_thickness": true`, the game was throwing an error for thicknesses lower than 4.4mm, which I understand to be IIIA protection in game. I am unsure of what material layered kevlar items offering protection lower than IIIA (Vintage flak armor, level II armor) are supposed to be . ~~I am leaving this in draft until I'm more certain of what was intended here.~~ eh someone  can tell me if I did something wrong.
#### Testing

Loaded game. Checked protection values.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/7764202/b7a27b0c-92ab-455b-901a-8d5f2157dbbf)


#### Additional context

Like these gloves, the protection on the rest of the EOD suit (save for the center torso plate) is way too high.
