### PR TITLE
updated the drop hammer

### DIFF
--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -501,7 +501,7 @@
     "id": "f_drophammer",
     "name": "blacksmith drop hammer",
     "symbol": "#",
-    "description": "An anvil with a large metal hammer suspended above it in a metal framework.  If it were working, it would be useful for shaping softened metal plates, though now it is only useful for parts.",
+    "description": "An anvil with a large metal hammer suspended above it in a metal framework.  I would be useful for shaping softened metal plates, or you could use the anvil by itself.",
     "color": "white",
     "looks_like": "f_machinery_old",
     "move_cost_mod": 2,

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -501,7 +501,7 @@
     "id": "f_drophammer",
     "name": "blacksmith drop hammer",
     "symbol": "#",
-    "description": "An anvil with a large metal hammer suspended above it in a metal framework.  I would be useful for shaping softened metal plates, or you could use the anvil by itself.",
+    "description": "An anvil with a large metal hammer suspended above it in a metal framework.  It would be useful for shaping softened metal plates, or you could use the anvil by itself.",
     "color": "white",
     "looks_like": "f_machinery_old",
     "move_cost_mod": 2,

--- a/data/json/items/basecamp.json
+++ b/data/json/items/basecamp.json
@@ -77,7 +77,7 @@
     "copy-from": "fake_item",
     "name": { "str": "basecamp drop hammer" },
     "description": "A fake drop hammer used for basecamps.",
-    "qualities": [ [ "HAMMER", 5 ] ]
+    "qualities": [ [ "HAMMER", 5 ], [ "ANVIL", 3 ] ]
   },
   {
     "id": "parkour_practice",


### PR DESCRIPTION
#### Summary
Content "Gives the drop hammer an anvil quality."

#### Purpose of change

Despite having an anvil in it, the drop hammer appliance doesn't give the quality, you should be able to use the anvil part on it's own. It would be annoying to build this and then realize you need to make a second anvil.

#### Describe the solution

Gave the drop hammer basecamp tool an anvil quality of 3, and mentioned this in the description.

#### Describe alternatives you've considered

A different quality? I'm not sure.

#### Additional context

