### PR TITLE
Fix evaluation of Knowledge in chargen

### DIFF
--- a/src/avatar.h
+++ b/src/avatar.h
@@ -108,7 +108,6 @@ class avatar : public Character
         bool load_template( const std::string &template_name, pool_type & );
         void save_template( const std::string &name, pool_type );
         void character_to_template( const std::string &name );
-        void add_default_background();
 
         bool is_avatar() const override {
             return true;

--- a/src/character.h
+++ b/src/character.h
@@ -2382,6 +2382,8 @@ class Character : public Creature, public visitable
         /** Returns a value used when attempting to intimidate NPC's */
         int intimidation() const;
 
+        void set_skills_from_hobbies();
+
         // --------------- Proficiency Stuff ----------------
         bool has_proficiency( const proficiency_id &prof ) const;
         float get_proficiency_practice( const proficiency_id &prof ) const;
@@ -2397,6 +2399,8 @@ class Character : public Creature, public visitable
         std::vector<proficiency_id> known_proficiencies() const;
         std::vector<proficiency_id> learning_proficiencies() const;
         int get_proficiency_bonus( const std::string &category, proficiency_bonus_type prof_bonus ) const;
+        void add_default_background();
+        void set_proficiencies_from_hobbies();
 
         // tests only!
         void set_proficiency_practice( const proficiency_id &id, const time_duration &amount );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix evaluation of Knowledge in chargen"

#### Purpose of change
Fixes #67685 

#### Describe the solution

- Encapsulate functions to set skills and proficiencies from hobbies
- Move add_default_background from avatar to Character
- Add default backgrounds to reference npc
- Add associated skills and hobbies
- Use the reference npc to evaluate knowledge instead of static values

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41293484/3f921f37-c498-4221-a993-7d0858884eb5)

#### Additional context

Hopefully I didn't mess anything by moving functions around

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
