### PR TITLE
[Xedra Evolved] Change Arvore One with the Forest to reduce thirst

### DIFF
--- a/data/mods/Xedra_Evolved/effects/effects.json
+++ b/data/mods/Xedra_Evolved/effects/effects.json
@@ -755,7 +755,7 @@
     "apply_message": "",
     "remove_message": "",
     "rating": "mixed",
-    "max_intensity": 999,
+    "max_intensity": 100000,
     "show_intensity": false,
     "limb_score_mods": [ { "limb_score": "lift", "modifier": 0.51 }, { "limb_score": "grip", "modifier": 0.25 } ],
     "flags": [ "EFFECT_LIMB_SCORE_MOD", "EFFECT_IMPEDING" ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_eocs.json
@@ -440,6 +440,12 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_ARVORE_TREE_FORM_IMMOBILE",
-    "effect": [ { "u_add_effect": "effect_arvore_tree_immobility", "duration": 86400, "intensity": 100 } ]
+    "effect": [ { "u_add_effect": "effect_arvore_tree_immobility", "duration": 86400, "intensity": 50000 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_ARVORE_TREE_REDUCE_THIRST",
+    "condition": { "math": [ "u_val('thirst')", ">=", "-50" ] },
+    "effect": [ { "math": [ "u_val('thirst')", "-=", "1" ] } ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutation_spells.json
@@ -42,6 +42,12 @@
     ]
   },
   {
+    "type": "enchantment",
+    "id": "ench_arvore_tree_reduce_thirst",
+    "condition": "ALWAYS",
+    "intermittent_activation": { "effects": [ { "frequency": "180 seconds", "spell_effects": [ { "id": "arvore_reduce_thirst_spell" } ] } ] }
+  },
+  {
     "id": "spell_arvore_thorns_mut_counter",
     "type": "SPELL",
     "name": { "str": "Arvore Thorns Damage" },
@@ -559,5 +565,17 @@
         "( ( (u_val('spell_level', 'spell: arvore_traverse_the_wilds') * 300) + 3000) * (scaling_factor(u_val('perception') ) ) )"
       ]
     }
+  },
+  {
+    "id": "arvore_reduce_thirst_spell",
+    "type": "SPELL",
+    "name": "One with the Forest Reduce Thirst",
+    "description": "This is the actual spell that reduces thirst for tree form.",
+    "valid_targets": [ "self" ],
+    "skill": "deduction",
+    "flags": [ "SILENT" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_ARVORE_TREE_REDUCE_THIRST",
+    "shape": "blast"
   }
 ]

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
@@ -1106,6 +1106,18 @@
     "//": "Healing values copied from the Regeneration mutation",
     "attackcost_modifier": 900,
     "flags": [ "DEAF", "BLIND", "SEESLEEP", "NO_SCENT", "NO_SPELLCASTING" ],
+    "wet_protection": [
+      { "part": "head", "ignored": 40 },
+      { "part": "leg_l", "ignored": 40 },
+      { "part": "leg_r", "ignored": 40 },
+      { "part": "foot_l", "ignored": 40 },
+      { "part": "foot_r", "ignored": 40 },
+      { "part": "arm_l", "ignored": 40 },
+      { "part": "arm_r", "ignored": 40 },
+      { "part": "hand_l", "ignored": 40 },
+      { "part": "hand_r", "ignored": 40 },
+      { "part": "torso", "ignored": 40 }
+    ],
     "ignored_by": [
       "MAMMAL",
       "AMPHIBIAN",

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
@@ -1099,7 +1099,6 @@
     "category": [ "ARVORE" ],
     "threshreq": [ "THRESH_ARVORE" ],
     "metabolism_modifier": -0.5,
-    "thirst_modifier": -0.95,
     "fatigue_regen_modifier": 0.5,
     "healing_awake": 0.8,
     "healing_multiplier": 2.5,
@@ -1135,7 +1134,7 @@
       "HUMAN"
     ],
     "//2": "NETHER_EMANATION missing from the above list is deliberate--they hone in on mental activity and the transformed Arvore still thinks.",
-    "enchantments": [ "ench_arvore_tree_form" ]
+    "enchantments": [ "ench_arvore_tree_form", "ench_arvore_tree_reduce_thirst" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Change Arvore One with the Forest to reduce thirst"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

One with the Forest initially just reduced the rate at which thirst increased, but it really should reduce thirst since trees can do pretty well with rain and damp soil. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a periodic spell that reduces thirst by 1 every 3 minutes (as long as thirst is -50 or higher) while in tree form. This is enough to beat ambient thirst, but slowly. If a player really wants to spend 10 hours immobile in a field to reduce their thirst instead of just drinking from a water bottle, well, they should be able to. I also added some wet protection (ignored) for tree form.

I also edited the effect that keeps the tree rooted in place, because during testing breakouts occurred relatively often. I upped the max intensity (from 999 to the extreme overkill 100,000) and no further breakouts occurred. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Everything works. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
