### PR TITLE
Fix cash cards spawning with rand_charges

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -314,7 +314,9 @@ item::item( const itype *type, time_point turn, int qty ) : type( type ), bday( 
     } else {
         if( type->tool && type->tool->rand_charges.size() > 1 ) {
             const int charge_roll = rng( 1, type->tool->rand_charges.size() - 1 );
-            charges = rng( type->tool->rand_charges[charge_roll - 1], type->tool->rand_charges[charge_roll] );
+            const int charge_count = rng( type->tool->rand_charges[charge_roll - 1],
+                                          type->tool->rand_charges[charge_roll] );
+            ammo_set( ammo_default(), charge_count );
         } else {
             charges = type->charges_default();
         }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix cash cards spawning with rand_charges"

#### Purpose of change

Fixes #68018
Technically only fixes new spawns of cash cards. Saves with broken spawns remain broken until the cash cards in them are removed.

#### Describe the solution

Set ammo instead of charges on tools with `rand_charges`.

#### Describe alternatives you've considered

Removing `rand_charges`, but that'd mean auditing all cash card spawns.

#### Testing

Tested the `office_supplies` group. Without the change, all cash cards would spawn with 0$ indicating they have charges set instead, with the change they got money in them.

#### Additional context

