### PR TITLE
Refugee Center Arsonist's Mission Description Clarification

### DIFF
--- a/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
@@ -189,7 +189,7 @@
     "id": "MISSION_ARSONIST_1_AMMONIUM_NITRATE",
     "type": "mission_definition",
     "name": { "str": "Supply the arsonist" },
-    "description": "Bring the arsonist two bags of commercial fertilizer",
+    "description": "Bring the arsonist 120 units of commercial fertilizer",
     "difficulty": 1,
     "value": 500,
     "origins": [ "ORIGIN_SECONDARY" ],

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
@@ -198,7 +198,7 @@
     "count": 120,
     "dialogue": {
       "describe": "I could use some help getting some materials.",
-      "offer": "I could use some help getting some materials.  Molotovs are nice for burning down buildings but aren't all that for keeping yourself safe.  If you could get me two bags of commercial fertilizer I could make something a lot more potent.",
+      "offer": "I could use some help getting some materials.  Molotovs are nice for burning down buildings but aren't all that for keeping yourself safe.  If you could get me 120 units of commercial fertilizer I could make something a lot more potent.",
       "accepted": "Oh man, thanks so much friend.  You won't regret it.",
       "rejected": "Think it over.",
       "advice": "Commercial fertilizer tends to be made from ammonium nitrate, which is also usable as an explosive.  Try looking for some around the abandoned farms.",


### PR DESCRIPTION
#### Summary
None


#### Purpose of change

Edit Makayla's commercial fertilizer mission description (and the offer dialogue of the mission as requested by Renech) to specify the exact amount of commercial fertilizer instead of "2 bags".

Fixes #68715

#### Describe the solution

`2 bags` -> `120 units`

#### Describe alternatives you've considered

Not doing so
#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
![Screenshot_2023-10-17_18-55-24_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/78019001/e0160650-e025-490e-928f-2fdfa4785d9d)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
