### PR TITLE
NPCs won't complain about noise if traits are set to ignore noise

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4478,13 +4478,13 @@ void npc::warn_about( const std::string &type, const time_duration &d, const std
         snip = chatbin.snip_cant_flee;
     } else if( type == "fire_bad" ) {
         snip = chatbin.snip_fire_bad;
-    } else if( type == "speech_noise" ) {
+    } else if( type == "speech_noise" && !has_trait( trait_IGNORE_SOUND ) ) {
         snip = chatbin.snip_speech_warning;
         spriority = sounds::sound_t::speech;
-    } else if( type == "combat_noise" ) {
+    } else if( type == "combat_noise" && !has_trait( trait_IGNORE_SOUND ) ) {
         snip = chatbin.snip_combat_noise_warning;
         spriority = sounds::sound_t::speech;
-    } else if( type == "movement_noise" ) {
+    } else if( type == "movement_noise" && !has_trait( trait_IGNORE_SOUND ) ) {
         snip = chatbin.snip_movement_noise_warning;
         spriority = sounds::sound_t::speech;
     } else if( type == "heal_self" ) {


### PR DESCRIPTION
#### Summary
Bugfixes "Rubik will stop complaining about the heavy thuds of their own robots"

#### Purpose of change
* Fixes #61655
* Closes #68689

#### Describe the solution
If a NPC has the trait "Ignores sounds" then the logic for selecting a warning/complaint skips any stimulus that is noise-based.

This trait is only used for static NPCs so we should be kosher.

#### Describe alternatives you've considered


#### Testing
I was only able to get Rubik to complain twice (after ~10-15 minutes of trying) without these changes, but not at all afterwards, so it should be working.

#### Additional context
