### PR TITLE
Fix up shot_spread_multiplier_modifier

### DIFF
--- a/data/json/items/gun/robofac_gun.json
+++ b/data/json/items/gun/robofac_gun.json
@@ -290,7 +290,7 @@
     "integral_weight": "650 g",
     "integral_longest_side": "12 cm",
     "longest_side": "42 cm",
-    "shot_spread_multiplier_modifier": 1.25,
+    "shot_spread_multiplier_modifier": 0.25,
     "//": "based on M26-MASS; shot_spread_multiplier_modifier is increased due the short barrel",
     "name": { "str_sp": "HWP breacher configuration" },
     "description": "A Hub 01 Hybrid Weapons Platform quick swap conversion kit.  This version looks like the close quarters configuration, but has a shortened barrel with \"00 BREACH\" stamped into the metal."

--- a/data/json/items/gun/robofac_gun.json
+++ b/data/json/items/gun/robofac_gun.json
@@ -290,7 +290,6 @@
     "integral_weight": "650 g",
     "integral_longest_side": "12 cm",
     "longest_side": "42 cm",
-    "shot_spread_multiplier_modifier": 0.25,
     "//": "based on M26-MASS; shot_spread_multiplier_modifier is increased due the short barrel",
     "name": { "str_sp": "HWP breacher configuration" },
     "description": "A Hub 01 Hybrid Weapons Platform quick swap conversion kit.  This version looks like the close quarters configuration, but has a shortened barrel with \"00 BREACH\" stamped into the metal."

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3946,7 +3946,7 @@ Gun mods can be defined like this:
 "energy_drain_multiplier": 1.2, // if weapon uses `energy_drain`, multiplies it on this amount
 "field_of_view": 270,           // #53180 has an image of it, but it represent how big FoV of the scope - when characters start to aim, it doesn't use the scope whatsoever, aiming into "general direction", and then transfer to using scope to pinpoint the target. The bigger FoV is, the sooner character would be able to use the scope (target acquisition with higher power scopes is very very difficult); put simple: the bigger FoV, the faster player can aim, to some degree; measured in MOA (minutes of angle)
 "min_skills": [ [ "weapon", 3 ], [ "gun", 4 ] ], // minimal skill level required to install this gunmod
-"shot_spread_multiplier_modifier": -0.8, // for shotguns, changes the spread of the pellets
+"shot_spread_multiplier_modifier": -0.8, // For shotguns, changes the spread of the pellets. Given a default multiplier of 1.0(100%), a multiplier of -0.8 results in 0.2(20%) shot spread.
 "energy_drain_modifier": "200 kJ",  // Optional field increasing or decreasing base gun energy consumption (per shot) by adding given value. This addition is not multiplied by energy_drains_multiplier.
 "energy_drains_multiplier": 2.5, // Optional field increasing or decreasing base gun energy consumption (per shot) by multiplying by given value.
 "reload_modifier": -10,        // Optional field increasing or decreasing base gun reload time in percent

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3946,7 +3946,7 @@ Gun mods can be defined like this:
 "energy_drain_multiplier": 1.2, // if weapon uses `energy_drain`, multiplies it on this amount
 "field_of_view": 270,           // #53180 has an image of it, but it represent how big FoV of the scope - when characters start to aim, it doesn't use the scope whatsoever, aiming into "general direction", and then transfer to using scope to pinpoint the target. The bigger FoV is, the sooner character would be able to use the scope (target acquisition with higher power scopes is very very difficult); put simple: the bigger FoV, the faster player can aim, to some degree; measured in MOA (minutes of angle)
 "min_skills": [ [ "weapon", 3 ], [ "gun", 4 ] ], // minimal skill level required to install this gunmod
-"shot_spread_multiplier_modifier": -0.8, // For shotguns, changes the spread of the pellets. Given a default multiplier of 1.0(100%), a multiplier of -0.8 results in 0.2(20%) shot spread.
+"shot_spread_multiplier_modifier": -0.8, // For shotguns, changes the spread of the pellets. Given a default multiplier of 1.0(100%), a multiplier modifier of -0.8 results in 0.2(20%) shot spread.
 "energy_drain_modifier": "200 kJ",  // Optional field increasing or decreasing base gun energy consumption (per shot) by adding given value. This addition is not multiplied by energy_drains_multiplier.
 "energy_drains_multiplier": 2.5, // Optional field increasing or decreasing base gun energy consumption (per shot) by multiplying by given value.
 "reload_modifier": -10,        // Optional field increasing or decreasing base gun reload time in percent

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3946,7 +3946,7 @@ Gun mods can be defined like this:
 "energy_drain_multiplier": 1.2, // if weapon uses `energy_drain`, multiplies it on this amount
 "field_of_view": 270,           // #53180 has an image of it, but it represent how big FoV of the scope - when characters start to aim, it doesn't use the scope whatsoever, aiming into "general direction", and then transfer to using scope to pinpoint the target. The bigger FoV is, the sooner character would be able to use the scope (target acquisition with higher power scopes is very very difficult); put simple: the bigger FoV, the faster player can aim, to some degree; measured in MOA (minutes of angle)
 "min_skills": [ [ "weapon", 3 ], [ "gun", 4 ] ], // minimal skill level required to install this gunmod
-"shot_spread_multiplier_modifier": -0.8, // For shotguns, changes the spread of the pellets. Given a default multiplier of 1.0(100%), a multiplier modifier of -0.8 results in 0.2(20%) shot spread.
+"shot_spread_multiplier_modifier": -0.8, // For shotguns, changes the spread of the pellets. Given a default multiplier of 1.0(100%), a multiplier modifier of -0.8 results in 0.2(20%) shot spread. Multipliers from all mods are summed up, but in vanilla game, only choke should be able to manipulate with shot spread - **shotgun barrel length doesn't affect pellet spread**
 "energy_drain_modifier": "200 kJ",  // Optional field increasing or decreasing base gun energy consumption (per shot) by adding given value. This addition is not multiplied by energy_drains_multiplier.
 "energy_drains_multiplier": 2.5, // Optional field increasing or decreasing base gun energy consumption (per shot) by multiplying by given value.
 "reload_modifier": -10,        // Optional field increasing or decreasing base gun reload time in percent

--- a/src/itype.h
+++ b/src/itype.h
@@ -881,7 +881,7 @@ struct islot_gunmod : common_ranged_data {
     int consume_divisor = 1;
 
     /** Enlarge or reduce shot spread */
-    float shot_spread_multiplier_modifier = 1.0f;
+    float shot_spread_multiplier_modifier = 0.0f;
 
     /** Modifies base strength required */
     int min_str_required_mod = 0;


### PR DESCRIPTION
#### Summary
Bugfixes "Gunmods on your shotgun do not change the dispersion unless explicitly intended to"

#### Purpose of change
* Fixes #68030

https://github.com/CleverRaven/Cataclysm-DDA/blob/ac204867cf06dde7c2ab2d79d537479d4c7427d7/src/item.cpp#L10535
https://github.com/CleverRaven/Cataclysm-DDA/blob/ac204867cf06dde7c2ab2d79d537479d4c7427d7/src/itype.h#L884

Default 1.0f means that every gunmod adds 1.0x more dispersion lol

#### Describe the solution
0.0f default (stops every random gunmod adding dispersion), clarify docs that the multiplier modifier is a **modifier**, edit the one json instance where the value was off the mark.

#### Describe alternatives you've considered
The value could be a multiplier instead but then the *modifier* part of its name is a bit off....

#### Testing
Compiled and shot up some debug monsters. HWP with its *five default gunmods* performs noticeably better to a normal shotgun, but not perfectly, and regular unmodded shotguns still do fine. Basically high-tech gun goes brrt

#### Additional context

