### PR TITLE
Fix Gemma Johnstone's mission bug

### DIFF
--- a/data/json/npcs/godco/godco_missions.json
+++ b/data/json/npcs/godco/godco_missions.json
@@ -570,7 +570,7 @@
         "search_range": 1000,
         "min_distance": 3
       },
-      "update_mapgen": { "place_item": [ { "item": "fert_supplement", "x": 15, "y": 15, "amount": 1 } ] }
+      "update_mapgen": { "place_loot": [ { "group": "fertility_supplements", "x": 15, "y": 15 } ] }
     },
     "end": {
       "effect": [
@@ -1253,5 +1253,11 @@
       "success_lie": "If you see this, it's a bug.",
       "failure": "Of course, you have no evidence."
     }
+  },
+  {
+    "id": "fertility_supplements",
+    "type": "item_group",
+    "subtype": "collection",
+    "items": [ { "item": "fert_supplement", "count": 25 } ]
   }
 ]

--- a/data/json/npcs/godco/members/NPC_Gemma_Johnstone.json
+++ b/data/json/npcs/godco/members/NPC_Gemma_Johnstone.json
@@ -12,6 +12,7 @@
       "TALK_GODCO_Gemma_Joinee"
     ],
     "responses": [
+      { "text": "About that job…", "topic": "TALK_MISSION_INQUIRE", "condition": "has_assigned_mission" },
       { "text": "What's your story?", "topic": "TALK_GODCO_Gemma_Story" },
       { "text": "How are things here?", "topic": "TALK_GODCO_Gemma_Mood" },
       { "text": "What does a dorm leader do exactly?", "topic": "TALK_GODCO_Gemma_Leader" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix Gemma Johnstone's mission bug."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/68031. Additionally, because of charge removals, only one pill would spawn. I had to change the mission requirements to reflect that, as spawning more pills created a bottle with each pill.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add code to let the player talk about missions and change `place_item` to `place_loot`.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Went into the game with both the cactus and fertility supplement missions, completed them both in one pass without exiting and re-entering the conversation. I also discovered that if the branch of this is on my local repository outside another copy of my main game, the .exe file will think that the mission has a duplicate copy, even though it doesn't. I have no idea why it does this or how to fix it.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I closed the other PR to try and fix the duplicate ID issue, but that didn't work.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
