### PR TITLE
Fix handling of item modifiers overriding tool charges from subgroups

### DIFF
--- a/data/mods/Defense_Mode/npcs.json
+++ b/data/mods/Defense_Mode/npcs.json
@@ -184,7 +184,7 @@
       { "group": "preserved_food", "prob": 70 },
       { "group": "pet_food", "prob": 70 },
       { "group": "condiments", "prob": 70 },
-      { "group": "trader_guns&ammo", "prob": 70 },
+      { "group": "trader_guns&ammo", "prob": 70, "charges": 30 },
       { "group": "hardware", "prob": 70 },
       { "group": "defense_caravan_melee", "prob": 70 },
       { "group": "defense_caravan_ranged", "prob": 70, "charges": 30 },

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -569,13 +569,13 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
             // spawn a "water (0)" item.
             new_item.charges = std::max( 1, ch );
         } else if( new_item.is_tool() ) {
-            if( !new_item.magazine_default().is_null() ) {
+            if( !new_item.magazine_current() && !new_item.magazine_default().is_null() ) {
                 item mag( new_item.magazine_default() );
                 if( !mag.ammo_default().is_null() ) {
                     mag.ammo_set( mag.ammo_default(), ch );
                 }
                 new_item.put_in( mag, item_pocket::pocket_type::MAGAZINE_WELL );
-            } else if( new_item.is_magazine() ) {
+            } else if( new_item.is_magazine() || new_item.magazine_current() ) {
                 new_item.ammo_set( new_item.ammo_default(), ch );
             } else {
                 debugmsg( "in %s: tried to set ammo for %s which does not have ammo or a magazine",


### PR DESCRIPTION
#### Summary
Bugfixes "Fix handling of item modifiers overriding tool charges from subgroups"

#### Purpose of change

Fixes #67927 and reverts #68468

#### Describe the solution

Just make sure it doesn't try to put a magazine in when there's already one in the tool.

#### Describe alternatives you've considered

Address issues with determining compatible magazines mentioned in https://github.com/CleverRaven/Cataclysm-DDA/issues/67927#issuecomment-1755694616 and then handle tools and guns the same.

#### Testing

Ran tests with `--rng-seed 1696217676 '~*' --mods=dda,stats_through_kills,standard_combat_test,defense_mode,magiclysm,no_fungal_growth,blazeindustries,megafauna,ruralbiome,railroads,package_bionic_professions,Tamable_Wildlife,extra_mut_scens,sees_player_hitbutton,Mythos-Creatures,StatsThroughSkills,mindovermatter,my_sweet_cataclysm,generic_guns,speedydex,translate_dialogue,personal_portal_storms,alt_map_key,tropicata,cbm_slots,MMA,sees_player_retro,crazy_cataclysm,deadly_bites,no_npc_food,xedra_evolved,DinoMod,no_hope,Only_Wildlife,bombastic_perks` again.

#### Additional context

@MNG-cataclysm just letting you know this reverts #68468, so it's back to the intended behavior.