### PR TITLE
"Fungal infestation in city park" map extra

### DIFF
--- a/data/json/mapgen/road.json
+++ b/data/json/mapgen/road.json
@@ -1068,6 +1068,20 @@
   {
     "type": "mapgen",
     "method": "json",
+    "om_terrain": "city_center",
+    "//": "Need to fix magical teleportation with actual aligned manhole placement",
+    "object": {
+      "fill_ter": "t_region_grass",
+      "place_nested": [
+        { "chunks": [ "24x24_road_four_way_crossroad" ], "x": 0, "y": 0 },
+        { "chunks": [ "1x1_manhole" ], "x": [ 5, 18 ], "y": [ 5, 18 ] }
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "nested_mapgen_id": "24x24_road_four_way_rotary",
     "object": {
       "mapgensize": [ 24, 24 ],

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -588,6 +588,14 @@
     "flags": [ "MAN_MADE" ]
   },
   {
+    "id": "mx_fungal_zone",
+    "type": "map_extra",
+    "name": { "str": "Fungal infestation" },
+    "description": "Fungal-infested location.",
+    "generator": { "generator_method": "map_extra_function", "generator_id": "mx_fungal_zone" },
+    "min_max_zlevel": [ 0, 0 ]
+  },
+  {
     "id": "mx_reed",
     "type": "map_extra",
     "name": { "str": "Reed" },

--- a/data/json/overmap/overmap_connections.json
+++ b/data/json/overmap/overmap_connections.json
@@ -8,6 +8,7 @@
       { "terrain": "road", "locations": [ "forest" ], "basic_cost": 20 },
       { "terrain": "road", "locations": [ "swamp" ], "basic_cost": 40 },
       { "terrain": "road_nesw_manhole", "locations": [  ] },
+      { "terrain": "city_center", "locations": [ "field", "road" ] },
       { "terrain": "bridge", "locations": [ "water" ], "basic_cost": 120 },
       { "terrain": "bridgehead_ground", "locations": [ "water" ], "basic_cost": 120, "flags": [ "ORTHOGONAL" ] }
     ]

--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -22,6 +22,17 @@
   },
   {
     "type": "overmap_terrain",
+    "id": "city_center",
+    "copy-from": "generic_transportation",
+    "name": "road",
+    "sym": "┼",
+    "color": "dark_gray",
+    "see_cost": 2,
+    "extras": "city_center",
+    "flags": [ "NO_ROTATE" ]
+  },
+  {
+    "type": "overmap_terrain",
     "abstract": "generic_bridge",
     "copy-from": "generic_transportation",
     "name": "bridge",

--- a/data/json/regional_map_settings.json
+++ b/data/json/regional_map_settings.json
@@ -789,6 +789,7 @@
         }
       },
       "bridgehead_ground": { "chance": 5, "extras": { "mx_minefield": 100 } },
+      "city_center": { "chance": 20, "extras": { "mx_fungal_zone": 100 } },
       "road_nesw_manhole": { "chance": 20, "extras": { "mx_city_trap": 100 } },
       "build": {
         "chance": 90,

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -28,6 +28,7 @@
 #include "enums.h"
 #include "field_type.h"
 #include "fungal_effects.h"
+#include "game.h"
 #include "game_constants.h"
 #include "generic_factory.h"
 #include "item.h"
@@ -102,6 +103,7 @@ static const map_extra_id map_extra_mx_city_trap( "mx_city_trap" );
 static const map_extra_id map_extra_mx_clay_deposit( "mx_clay_deposit" );
 static const map_extra_id map_extra_mx_corpses( "mx_corpses" );
 static const map_extra_id map_extra_mx_dead_vegetation( "mx_dead_vegetation" );
+static const map_extra_id map_extra_mx_fungal_zone( "mx_fungal_zone" );
 static const map_extra_id map_extra_mx_grove( "mx_grove" );
 static const map_extra_id map_extra_mx_helicopter( "mx_helicopter" );
 static const map_extra_id map_extra_mx_jabberwock( "mx_jabberwock" );
@@ -125,6 +127,8 @@ static const mongroup_id GROUP_MIL_WEAK( "GROUP_MIL_WEAK" );
 static const mongroup_id GROUP_NETHER_PORTAL( "GROUP_NETHER_PORTAL" );
 static const mongroup_id GROUP_STRAY_DOGS( "GROUP_STRAY_DOGS" );
 static const mongroup_id GROUP_TURRET_SPEAKER( "GROUP_TURRET_SPEAKER" );
+
+static const mtype_id mon_fungaloid_queen( "mon_fungaloid_queen" );
 
 static const oter_type_str_id oter_type_bridge( "bridge" );
 static const oter_type_str_id oter_type_bridgehead_ground( "bridgehead_ground" );
@@ -2118,6 +2122,60 @@ static bool mx_city_trap( map &/*m*/, const tripoint &abs_sub )
     return true;
 }
 
+static bool mx_fungal_zone( map &/*m*/, const tripoint &abs_sub )
+{
+    //First, find a city
+    // TODO: fix point types
+    const city_reference c = overmap_buffer.closest_city( tripoint_abs_sm( abs_sub ) );
+    const tripoint_abs_omt city_center_omt = project_to<coords::omt>( c.abs_sm_pos );
+
+    //Then find out which types of parks (defined in regional settings) exist in this city
+    std::vector<tripoint_abs_omt> valid_omt;
+    const auto &parks = g->get_cur_om().get_settings().city_spec.get_all_parks();
+    for( const auto &elem : parks ) {
+        for( const tripoint_abs_omt &p : points_in_radius( city_center_omt, c.city->size ) ) {
+            if( overmap_buffer.check_overmap_special_type( elem.obj, p ) ) {
+                valid_omt.push_back( p );
+            }
+        }
+    }
+
+    // If there's no parks in the city, bail out
+    if( valid_omt.empty() ) {
+        return false;
+    }
+
+    const tripoint_abs_omt &park_omt = random_entry( valid_omt, city_center_omt );
+
+    tinymap fungal_map;
+    fungal_map.load( project_to<coords::sm>( park_omt ), false );
+
+    // Then find suitable location for fungal spire to spawn (grass, dirt etc)
+    const tripoint submap_center = { SEEX, SEEY, abs_sub.z };
+    std::vector<tripoint> suitable_locations;
+    for( const tripoint &loc : fungal_map.points_in_radius( submap_center, 10 ) ) {
+        if( fungal_map.has_flag_ter( ter_furn_flag::TFLAG_DIGGABLE, loc ) ) {
+            suitable_locations.push_back( loc );
+        }
+    }
+
+    // If there's no suitable location found, bail out
+    if( suitable_locations.empty() ) {
+        return false;
+    }
+
+    const tripoint suitable_location = random_entry( suitable_locations, submap_center );
+    fungal_map.add_spawn( mon_fungaloid_queen, 1, suitable_location );
+    fungal_map.place_spawns( GROUP_FUNGI_FUNGALOID, 1,
+                             suitable_location.xy() + point_north_west,
+                             suitable_location.xy() + point_south_east,
+                             3, true );
+
+    fungal_map.save();
+
+    return true;
+}
+
 static FunctionMap builtin_functions = {
     { map_extra_mx_null, mx_null },
     { map_extra_mx_roadworks, mx_roadworks },
@@ -2137,7 +2195,8 @@ static FunctionMap builtin_functions = {
     { map_extra_mx_looters, mx_looters },
     { map_extra_mx_corpses, mx_corpses },
     { map_extra_mx_city_trap, mx_city_trap },
-    { map_extra_mx_reed, mx_reed }
+    { map_extra_mx_reed, mx_reed },
+    { map_extra_mx_fungal_zone, mx_fungal_zone },
 };
 
 map_extra_pointer get_function( const map_extra_id &name )

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -70,6 +70,7 @@ static const mongroup_id GROUP_ZOMBIE( "GROUP_ZOMBIE" );
 static const oter_str_id oter_central_lab( "central_lab" );
 static const oter_str_id oter_central_lab_core( "central_lab_core" );
 static const oter_str_id oter_central_lab_train_depot( "central_lab_train_depot" );
+static const oter_str_id oter_city_center( "city_center" );
 static const oter_str_id oter_empty_rock( "empty_rock" );
 static const oter_str_id oter_field( "field" );
 static const oter_str_id oter_forest( "forest" );
@@ -937,7 +938,7 @@ bool oter_t::type_is( const oter_type_t &type ) const
 bool oter_t::has_connection( om_direction::type dir ) const
 {
     // TODO: It's a DAMN UGLY hack. Remove it as soon as possible.
-    if( id == oter_road_nesw_manhole ) {
+    if( id == oter_road_nesw_manhole || id == oter_city_center ) {
         return true;
     }
     return om_lines::has_segment( line, dir );
@@ -5181,6 +5182,10 @@ void overmap::place_cities()
             do {
                 build_city_street( local_road, tmp.pos, tmp.size, cur_dir, tmp );
             } while( ( cur_dir = om_direction::turn_right( cur_dir ) ) != start_dir );
+
+            // Replace city's original intersection OMT with a dedicated 'city_center' OMT
+            // This allows setting map extras specifically to cities (or their centers)
+            ter_set( tripoint_om_omt( tmp.pos, 0 ), oter_city_center );
         }
     }
 }

--- a/src/overmapbuffer.cpp
+++ b/src/overmapbuffer.cpp
@@ -49,6 +49,7 @@ static const oter_type_str_id oter_type_bridge( "bridge" );
 static const oter_type_str_id oter_type_bridge_road( "bridge_road" );
 static const oter_type_str_id oter_type_bridgehead_ground( "bridgehead_ground" );
 static const oter_type_str_id oter_type_bridgehead_ramp( "bridgehead_ramp" );
+static const oter_type_str_id oter_type_city_center( "city_center" );
 static const oter_type_str_id oter_type_deep_rock( "deep_rock" );
 static const oter_type_str_id oter_type_empty_rock( "empty_rock" );
 static const oter_type_str_id oter_type_field( "field" );
@@ -921,7 +922,8 @@ static int get_terrain_cost( const tripoint_abs_omt &omt_pos, const overmap_path
         ( oter->get_type_id() == oter_type_bridge_road ) ||
         ( oter->get_type_id() == oter_type_bridgehead_ground ) ||
         ( oter->get_type_id() == oter_type_bridgehead_ramp ) ||
-        ( oter->get_type_id() == oter_type_road_nesw_manhole ) ) {
+        ( oter->get_type_id() == oter_type_road_nesw_manhole ) ||
+        ( oter->get_type_id() == oter_type_city_center ) ) {
         return params.road_cost;
     } else if( oter->get_type_id() == oter_type_field ) {
         return params.field_cost;

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -33,6 +33,9 @@ class building_bin
         std::vector<std::string> all;
         void clear();
         void finalize();
+        weighted_int_list<overmap_special_id> get_all_buildings() const {
+            return buildings;
+        }
 };
 
 struct city_settings {
@@ -59,6 +62,18 @@ struct city_settings {
 
     overmap_special_id pick_park() const {
         return parks.pick()->id;
+    }
+
+    weighted_int_list<overmap_special_id> get_all_houses() const {
+        return houses.get_all_buildings();
+    }
+
+    weighted_int_list<overmap_special_id> get_all_shops() const {
+        return shops.get_all_buildings();
+    }
+
+    weighted_int_list<overmap_special_id> get_all_parks() const {
+        return parks.get_all_buildings();
     }
 
     void finalize();


### PR DESCRIPTION
#### Summary
Content "Fungal infestation map extra"

#### Purpose of change
Add some fungal fun to cities.

#### Describe the solution
Ported https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/pull/89 and some infrastructure tweaks from https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/pull/90:

- Added a special `city_center` OMT which can be assigned as a place for guaranteed spawn of map extras inside city borders. This feels like a hack and has some unintended side effects, but until #68228 is implemented, this is the only solution I found.
- `city_center` OMT is placed on top of city's starting intersection OMT right after city creation is complete. It functions as ordinary road intersection in all road-related interactions.
- Added three new getters for `houses`, `parks`, and `shops` sections of city settings in regional settings.
- Added fungal infestation map extra. 5% chance to spawn in every city. It will spawn only if there's at least one park-type location found in the city (the list of parks is defined in regional settings). It will search for suitable location (grass, dirt, sand etc) inside one of the parks, and if search is successful, it will spawn fungal spire on suitable tile and 1..3 fungaloids around.

#### Describe alternatives you've considered
None.

#### Testing
Debug-spawned map extra in a city with a park. Checked that fungal spire and fungaloids are correctly spawned on random suitable location.
Also teleported around the world and searched for map extra to spawn naturally.

#### Additional context
Screenshot of fungal spire (circled in yellow) that spawned in a city's park and got a rather big territory after ~6 ingame hours (without `Slowdown Fungal Growth` mod).
![16953266592820](https://github.com/Cataclysm-TISH-team/Cataclysm-TISH/assets/11132525/b4407a40-3742-45a1-be4b-da9bef8083fa)