### PR TITLE
Fix some Defense Mode mapgen bugs

### DIFF
--- a/data/mods/Magiclysm/mod_interactions/Defense_Mode/overmap_specials.json
+++ b/data/mods/Magiclysm/mod_interactions/Defense_Mode/overmap_specials.json
@@ -61,6 +61,7 @@
     "locations": [ "lake_surface" ],
     "city_distance": [ 40, -1 ],
     "occurrences": [ 100, 100 ],
+    "eoc": { "id": "EOC_DM_TOWER_GENERATE", "condition": { "mod_is_loaded": "defense_mode" } },
     "flags": [ "DEFENSE_MODE", "GLOBALLY_UNIQUE", "LAKE" ]
   }
 ]

--- a/data/mods/MindOverMatter/modinteractions/Defense_Mode/overmap_specials.json
+++ b/data/mods/MindOverMatter/modinteractions/Defense_Mode/overmap_specials.json
@@ -11,6 +11,7 @@
     "locations": [ "land" ],
     "city_distance": [ 40, -1 ],
     "occurrences": [ 100, 100 ],
+    "eoc": { "id": "EOC_DM_CUBICAL_GENERATE", "condition": { "mod_is_loaded": "defense_mode" } },
     "flags": [ "DEFENSE_MODE", "GLOBALLY_UNIQUE" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mod_interactions/Defense_Mode/overmap_specials.json
+++ b/data/mods/Xedra_Evolved/mod_interactions/Defense_Mode/overmap_specials.json
@@ -31,6 +31,7 @@
     "locations": [ "land" ],
     "city_distance": [ 40, -1 ],
     "occurrences": [ 100, 100 ],
+    "eoc": { "id": "EOC_DM_OFFICE_GENERATE", "condition": { "mod_is_loaded": "defense_mode" } },
     "flags": [ "DEFENSE_MODE", "GLOBALLY_UNIQUE" ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix Defense Mode mod compatibility map generation."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
It came to my attention that the variants of some mod locations used in Defense Mode would still spawn in the regular world, as they were contained in the other mods folders. This fixes that using a trick I discovered when working on the Norse Evangelicals (rest their souls and my effort).
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Using EOC conditions, I have made it to where these buildings will only spawn when Defense Mode is loaded into a game.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Removing these buildings and not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Went into various save games and poked around for buildings, no Defense Mode exclusives spawned.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
For any other contributors, the EOC condition can work with anything an EOC can use. It's quite handy!
(P.S I'm still sore about the Valhallists getting removed.)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
