### PR TITLE
Add spell class selecter to spell casting menu

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2580,8 +2580,8 @@ int known_magic::select_spell( Character &guy )
     spellcasting_callback cb( known_spells, casting_ignore );
     spell_menu.callback = &cb;
     spell_menu.add_category( "all", _( "All" ) );
-    for( auto s : known_spells ) {
-        if( s->spell_class().is_valid() ) {
+    for( const spell *s : known_spells ) {
+        if( s->can_cast( guy ) && s->spell_class().is_valid() ) {
             spell_menu.add_category( s->spell_class().str(), s->spell_class().obj().name() );
         }
     }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2204,11 +2204,13 @@ class spellcasting_callback : public uilist_callback
         }
 
         void refresh( uilist *menu ) override {
+            const std::string space( menu->pad_right - 2, ' ' );
             mvwputch( menu->window, point( menu->w_width - menu->pad_right, 0 ), c_magenta, LINE_OXXX );
             mvwputch( menu->window, point( menu->w_width - menu->pad_right, menu->w_height - 1 ), c_magenta,
                       LINE_XXOX );
             for( int i = 1; i < menu->w_height - 1; i++ ) {
                 mvwputch( menu->window, point( menu->w_width - menu->pad_right, i ), c_magenta, LINE_XOXO );
+                mvwputch( menu->window, point( menu->w_width - menu->pad_right + 1, i ), menu->text_color, space );
             }
             std::string ignore_string = casting_ignore ? _( "Ignore Distractions" ) :
                                         _( "Popup Distractions" );
@@ -2577,6 +2579,21 @@ int known_magic::select_spell( Character &guy )
     spell_menu.hilight_disabled = true;
     spellcasting_callback cb( known_spells, casting_ignore );
     spell_menu.callback = &cb;
+    spell_menu.add_category( "all", _( "All" ) );
+    for( auto s : known_spells ) {
+        if( s->spell_class().is_valid() ) {
+            spell_menu.add_category( s->spell_class().str(), s->spell_class().obj().name() );
+        }
+    }
+    spell_menu.set_category_filter( [known_spells]( const uilist_entry & entry,
+    const std::string & key )->bool {
+        if( key == "all" )
+        {
+            return true;
+        }
+        return known_spells[entry.retval]->spell_class().is_valid() && known_spells[entry.retval]->spell_class().str() == key;
+    } );
+    spell_menu.set_category( "all" );
 
     std::set<int> used_invlets{ cb.reserved_invlets };
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -378,6 +378,7 @@ class uilist // NOLINT(cata-xy)
                            const std::string &txt, const std::string &column,
                            const std::string &desc = std::string() );
         void settext( const std::string &str );
+
         void add_category( const std::string &key, const std::string &name );
         void set_category( const std::string &key );
         void set_category_filter( const std::function<bool( const uilist_entry &, const std::string & )>
@@ -505,6 +506,7 @@ class uilist // NOLINT(cata-xy)
         int vmax = 0;
 
         int desc_lines = 0;
+        int category_lines = 0;
 
         bool started = false;
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -378,6 +378,10 @@ class uilist // NOLINT(cata-xy)
                            const std::string &txt, const std::string &column,
                            const std::string &desc = std::string() );
         void settext( const std::string &str );
+        void add_category( const std::string &key, const std::string &name );
+        void set_category( const std::string &key );
+        void set_category_filter( const std::function<bool( const uilist_entry &, const std::string & )>
+                                  &fun );
 
         void reset();
 
@@ -505,6 +509,10 @@ class uilist // NOLINT(cata-xy)
         bool started = false;
 
         bool recalc_start = false;
+
+        std::vector<std::pair<std::string, std::string>> categories;
+        std::function<bool( const uilist_entry &, const std::string & )> category_filter;
+        int current_category = 0;
 
         int find_entry_by_coordinate( const point &p ) const;
 


### PR DESCRIPTION
#### Summary
Interface "Add spell class selecter to spell casting menu"

#### Purpose of change
Spell casting menu becomes difficult to navigate as the number of spells increases.

#### Describe the solution
Add classification by spell class to improve viewability. Classes can be switched using the left and right keys

#### Describe alternatives you've considered

#### Testing
![Animation1](https://github.com/CleverRaven/Cataclysm-DDA/assets/13540013/e36cd040-a017-4886-9011-f96c94f3fc3f)

#### Additional context
