### PR TITLE
Steel Kevlar Jumpsuit updated recipe

### DIFF
--- a/data/json/recipes/armor/bespoke_armor/survivor.json
+++ b/data/json/recipes/armor/bespoke_armor/survivor.json
@@ -200,7 +200,6 @@
       { "proficiency": "prof_polymerworking" },
       { "proficiency": "prof_elastics" }
     ],
-    "qualities": [ { "id": "FABRIC_CUT", "level": 2 } ],
     "byproducts": [ [ "scrap_kevlar", 17 ], [ "scrap_lycra", 7 ] ]
   },
   {

--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -1897,7 +1897,10 @@
       [ "tailoring_kevlar_fabric", 370 ],
       [ "blacksmithing_standard", 12 ],
       [ "mc_steel_standard", 3 ],
-      [ "fabric_lycra", 20 ]
+      [ "fabric_lycra", 20 ],
+      [ "fabric_nylon", 30 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ]
     ],
     "proficiencies": [
       { "proficiency": "prof_elastics", "time_multiplier": 1.3, "skill_penalty": 0.2 },
@@ -1917,10 +1920,6 @@
       [ [ "metal_tank", -1 ] ],
       [ [ "water", -240 ], [ "water_clean", -240 ] ]
     ],
-    "components": [
-      [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
-      [ [ "duct_tape", 300 ] ]
-    ],
     "byproducts": [ [ "scrap_kevlar", 37 ], [ "scrap_lycra", 9 ] ]
   },
   {
@@ -1932,7 +1931,10 @@
       [ "tailoring_kevlar_fabric", 259 ],
       [ "blacksmithing_standard", 8 ],
       [ "mc_steel_standard", 2 ],
-      [ "fabric_lycra", 15 ]
+      [ "fabric_lycra", 15 ],
+      [ "fabric_nylon", 23 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ]
     ],
     "qualities": [ { "id": "CHISEL", "level": 3 } ],
     "tools": [
@@ -1940,10 +1942,6 @@
       [ [ "swage", -1 ] ],
       [ [ "metal_tank", -1 ] ],
       [ [ "water", -240 ], [ "water_clean", -240 ] ]
-    ],
-    "components": [
-      [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
-      [ [ "duct_tape", 225 ] ]
     ]
   },
   {
@@ -1956,7 +1954,10 @@
       [ "tailoring_kevlar_fabric", 555 ],
       [ "blacksmithing_standard", 20 ],
       [ "mc_steel_standard", 5 ],
-      [ "fabric_lycra", 30 ]
+      [ "fabric_lycra", 30 ],
+      [ "fabric_nylon", 45 ],
+      [ "fastener_large", 1 ],
+      [ "clasps", 8 ]
     ],
     "qualities": [ { "id": "CHISEL", "level": 3 } ],
     "tools": [
@@ -1964,10 +1965,6 @@
       [ [ "swage", -1 ] ],
       [ [ "metal_tank", -1 ] ],
       [ [ "water", -240 ], [ "water_clean", -240 ] ]
-    ],
-    "components": [
-      [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
-      [ [ "duct_tape", 450 ] ]
     ]
   },
   {

--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -1920,7 +1920,7 @@
       [ [ "metal_tank", -1 ] ],
       [ [ "water", -240 ], [ "water_clean", -240 ] ]
     ],
-    "byproducts": [ [ "scrap_kevlar", 37 ], [ "scrap_lycra", 9 ] ]
+    "byproducts": [ [ "scrap_kevlar", 37 ], [ "scrap_lycra", 5 ] ]
   },
   {
     "result": "xs_hsurvivor_jumpsuit",

--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -1893,7 +1893,12 @@
     "skills_required": [ "fabrication", 7 ],
     "time": "20 h",
     "autolearn": true,
-    "using": [ [ "sewing_kevlar", 200 ], [ "blacksmithing_standard", 12 ], [ "mc_steel_standard", 3 ], [ "fabric_lycra", 20 ] ],
+    "using": [
+      [ "tailoring_kevlar_fabric", 370 ],
+      [ "blacksmithing_standard", 12 ],
+      [ "mc_steel_standard", 3 ],
+      [ "fabric_lycra", 20 ]
+    ],
     "proficiencies": [
       { "proficiency": "prof_elastics", "time_multiplier": 1.3, "skill_penalty": 0.2 },
       { "proficiency": "prof_closures", "time_multiplier": 1.1, "skill_penalty": 0.1 },
@@ -1914,8 +1919,7 @@
     ],
     "components": [
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
-      [ [ "duct_tape", 300 ] ],
-      [ [ "sheet_kevlar", 590 ] ]
+      [ [ "duct_tape", 300 ] ]
     ],
     "byproducts": [ [ "scrap_kevlar", 37 ], [ "scrap_lycra", 9 ] ]
   },
@@ -1924,7 +1928,12 @@
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
     "copy-from": "hsurvivor_jumpsuit",
-    "using": [ [ "sewing_kevlar", 150 ], [ "blacksmithing_standard", 8 ], [ "mc_steel_standard", 2 ], [ "fabric_lycra", 15 ] ],
+    "using": [
+      [ "tailoring_kevlar_fabric", 259 ],
+      [ "blacksmithing_standard", 8 ],
+      [ "mc_steel_standard", 2 ],
+      [ "fabric_lycra", 15 ]
+    ],
     "qualities": [ { "id": "CHISEL", "level": 3 } ],
     "tools": [
       [ [ "welder", 48 ], [ "welder_crude", 72 ], [ "soldering_iron", 72 ], [ "integrated_welder", 72 ] ],
@@ -1934,8 +1943,7 @@
     ],
     "components": [
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
-      [ [ "duct_tape", 225 ] ],
-      [ [ "sheet_kevlar", 408 ] ]
+      [ [ "duct_tape", 225 ] ]
     ]
   },
   {
@@ -1944,7 +1952,12 @@
     "activity_level": "MODERATE_EXERCISE",
     "copy-from": "hsurvivor_jumpsuit",
     "time": "23 h",
-    "using": [ [ "sewing_kevlar", 300 ], [ "blacksmithing_standard", 20 ], [ "mc_steel_standard", 5 ], [ "fabric_lycra", 30 ] ],
+    "using": [
+      [ "tailoring_kevlar_fabric", 555 ],
+      [ "blacksmithing_standard", 20 ],
+      [ "mc_steel_standard", 5 ],
+      [ "fabric_lycra", 30 ]
+    ],
     "qualities": [ { "id": "CHISEL", "level": 3 } ],
     "tools": [
       [ [ "welder", 72 ], [ "welder_crude", 109 ], [ "soldering_iron", 109 ], [ "integrated_welder", 109 ] ],
@@ -1954,8 +1967,7 @@
     ],
     "components": [
       [ [ "coat_rain", 1 ], [ "jacket_windbreaker", 1 ], [ "jacket_evac", 1 ], [ "coat_gut", 1 ] ],
-      [ [ "duct_tape", 450 ] ],
-      [ [ "sheet_kevlar", 864 ] ]
+      [ [ "duct_tape", 450 ] ]
     ]
   },
   {


### PR DESCRIPTION
#### Summary
Balance "Update the recipe of Steel Kevlar Jumpsuits for consistency"

#### Purpose of change
steel-plated Kevlar jumpsuits are made out of *only* kevlar sheets, not allowing use of kevlar patchwork sheets like the rest of kevlar jumpsuits, in addition to that they use a tremendously big amount of kevlar even though they only use it for one layer, which is a little thicker than the kevlar base layer of the other jumpsuits, but they have several layers of the component which end up with a bigger kevlar thickness in the other 2, those extra layers are replaced with steel so it makes little sense to ask for more than double the amount of kevlar of normal kevlar jumpsuits.

#### Describe the solution
Replace the direct calling for kevlar sheets and thread for the `tailoring_kevlar_fabric` requirements, which is in use by the other 2 kevlar jumpsuits and allows for a choice between both types of kevlar sheets.
Reduced the number of sheets required to be in sync with the number of kevlar scraps of the recipe (As is the case with the normal kevlar jumpsuit), could (Probably should) be even lower, but I was unsure what specific number to give so I opted for a relationship with the already defined scraps.

#### Describe alternatives you've considered
To divide the kevlar requirements in 2 so you could combine both types of kevlar sheets for the recipe (You still need a lot of one specific kind)? Something that probably should be part of the base crafting interactions.

#### Testing
Loaded the game, searched for the recipe... It works! 

#### Additional context
![imagen](https://github.com/CleverRaven/Cataclysm-DDA/assets/53200489/1250d291-a6d3-4ccb-8a02-78236cf9b705)
Updated the XS and XL versions too.
They all now require a big amount of strong thread too, but that is easier to acquire/produce than kevlar sheets.

Edit: Removed duct tape and other relics from the recipe and made it more similar with the regular kevlar jumpsuits.