### PR TITLE
"Faction Succession" Mission Description Clarification

### DIFF
--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -948,7 +948,7 @@
     "type": "mission_definition",
     "name": { "str": "Faction succession" },
     "goal": "MGOAL_CONDITION",
-    "description": "You have some time left before the peaceful transfer of power can take place again.",
+    "description": "You have some time left until you can transfer control to your companions, provided you have <color_yellow>established a Basecamp</color> and <color_yellow>have atleast 1 npc companion</color>.",
     "difficulty": 0,
     "value": 0,
     "invisible_on_complete": true,

--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -948,7 +948,7 @@
     "type": "mission_definition",
     "name": { "str": "Faction succession" },
     "goal": "MGOAL_CONDITION",
-    "description": "You have some time left until you can transfer control to your companions, provided you have <color_yellow>established a Basecamp</color> and <color_yellow>have atleast 1 npc companion</color>.",
+    "description": "You have some time left until you can transfer control to your companions, provided you have <color_yellow>established a Basecamp</color> and <color_yellow>have at least 1 NPC companion</color>.",
     "difficulty": 0,
     "value": 0,
     "invisible_on_complete": true,


### PR DESCRIPTION

#### Summary
None

#### Purpose of change

The "Faction Succession" mission description is vague and confuses some folks on what its purpose for.

#### Describe the solution

Add the part where it requires a basecamp and atleast 1 npc companion.

#### Describe alternatives you've considered

Change the mission name also, but i can't think of any non-meta sounding name for it.

#### Testing

![Screenshot_2023-10-20_23-30-32_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/78019001/7d7adec0-b528-44a7-8d70-84064b044f30)


#### Additional context

Fixes to my grammar will be appreciated.