### PR TITLE
Fix skill rust

### DIFF
--- a/src/skill.cpp
+++ b/src/skill.cpp
@@ -384,6 +384,7 @@ bool SkillLevel::rust( int rust_resist, float rust_multiplier )
     }
 
     _rustAccumulator += rust_amount;
+    _exercise -= rust_amount;
     on_exercise_change();
 
     return false;

--- a/tests/skill_test.cpp
+++ b/tests/skill_test.cpp
@@ -1,0 +1,44 @@
+#include "calendar.h"
+#include "cata_catch.h"
+#include "character.h"
+#include "player_helpers.h"
+#include "skill.h"
+
+TEST_CASE( "skill_rust_occurs", "[character][skill]" )
+{
+    Character &guy = get_player_character();
+    clear_avatar();
+
+    // Set every skill to two, so they can rust
+    for( const Skill &skill : Skill::skills ) {
+        INFO( skill.ident().str() );
+        guy.set_skill_level( skill.ident(), 2 );
+        REQUIRE( guy.get_skill_level( skill.ident() ) == 2.f );
+        REQUIRE( guy.get_knowledge_level( skill.ident() ) == 2 );
+        REQUIRE_FALSE( guy.get_skill_level_object( skill.ident() ).isRusty() );
+    }
+
+    // Wait three days
+    for( int i = 0; i < to_seconds<int>( 3_days ); ++i ) {
+        calendar::turn += 1_seconds;
+        guy.update_body();
+        if( calendar::once_every( 4_hours ) ) {
+            // Don't starve
+            guy.set_stored_kcal( guy.get_healthy_kcal() );
+            // Clear thirst and fatigue
+            guy.environmental_revert_effect();
+            // And sleep deprivation
+            guy.set_sleep_deprivation( 0 );
+        }
+    }
+
+    // Ensure they have rusted
+    for( const Skill &skill : Skill::skills ) {
+        INFO( skill.ident().str() );
+        // Rust is about 1% per day with a one day grace period
+        CHECK( guy.get_skill_level( skill.ident() ) < 2.f );
+        CHECK( guy.get_knowledge_level( skill.ident() ) == 2 );
+        CHECK( guy.get_skill_level_object( skill.ident() ).isRusty() );
+    }
+}
+


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/68777
One line too many was deleted in https://github.com/CleverRaven/Cataclysm-DDA/pull/68490, resulting in skill rust no longer functioning.

#### Describe the solution
Restore the accidentally deleted line and add a regression test.

#### Testing
Test fails before, passes after.
