### PR TITLE
[innawood] Add streams to the river starting location

### DIFF
--- a/data/mods/innawood/start_locations.json
+++ b/data/mods/innawood/start_locations.json
@@ -10,5 +10,11 @@
     "id": "sloc_cave_underground_innawood",
     "name": "Cave - underground",
     "terrain": [ "cave_underground_innawood" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_river",
+    "copy-from": "sloc_river",
+    "terrain": [ "river", "stream", "stream_corner", "stream_end" ]
   }
 ]

--- a/lang/string_extractor/parsers/start_location.py
+++ b/lang/string_extractor/parsers/start_location.py
@@ -2,5 +2,7 @@ from ..write_text import write_text
 
 
 def parse_start_location(json, origin):
-    write_text(json["name"], origin,
-               comment="Name of starting location \"{}\"".format(json["id"]))
+    if "name" in json:
+        id = json["id"]
+        write_text(json["name"], origin,
+                   comment="Name of starting location \"{}\"".format(id))


### PR DESCRIPTION
#### Summary
Features "[innawood] Add streams to the river starting location"

#### Purpose of change

I want wilderness starts at streams.

#### Describe the solution

Add streams to the `sloc_river` starting location. This also adds it to a couple more scenarios.

#### Describe alternatives you've considered

Make it a separate starting location from rivers.

#### Testing

Started a few wilderness scenarios at river, put me at streams and rivers.

#### Additional context

