### PR TITLE
New characters don't start with martial arts style set to 'Force unarmed'

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -5,6 +5,7 @@
     "name": { "str": "No style" },
     "description": "Not a martial art, this is just plain old punching and kicking.",
     "initiate": [ "You decide to not use any martial arts.", "%s enters a generic combat stance." ],
+    "priority": 0,
     "arm_block": 1,
     "leg_block": 99,
     "allow_all_weapons": true,
@@ -16,6 +17,7 @@
     "name": { "str": "Force unarmed" },
     "description": "Not a martial art, setting this style will prevent weapon attacks and force punches (with a free hand) or kicks.",
     "initiate": [ "You force yourself to fight unarmed.", "%s decides to fight unarmed." ],
+    "priority": -1,
     "arm_block": 1,
     "leg_block": 99,
     "force_unarmed": true,
@@ -28,6 +30,7 @@
     "name": { "str": "Aikido" },
     "description": "Aikido is a Japanese martial art focused on self-defense, while minimizing injury to the attacker.  It uses defensive throws and disarms but its techniques lack offensive power.",
     "initiate": [ "You enter the hanmi stance.", "%s enters a relaxed combat posture." ],
+    "priority": 1,
     "learn_difficulty": 5,
     "arm_block": 0,
     "static_buffs": [
@@ -109,6 +112,7 @@
     "name": { "str": "Bōjutsu" },
     "description": "Bōjutsu, \"The Way of the Staff\", is the Japanese martial art of fighting with a staff.  Bōjutsu focuses on maintaining a good stance to effectively block and counterattack.",
     "initiate": [ "You position yourself into an agile stance.", "%s enters an agile stance." ],
+    "priority": 1,
     "learn_difficulty": 5,
     "primary_skill": "bashing",
     "strictly_melee": true,
@@ -159,6 +163,7 @@
       "You heft your weapon, stretch your shoulders, and slide into the Represa.",
       "%s rolls their shoulders and prepares to duel."
     ],
+    "priority": 1,
     "learn_difficulty": 8,
     "primary_skill": "bashing",
     "strictly_melee": true,
@@ -235,6 +240,7 @@
     "name": { "str": "Boxing" },
     "description": "Sport of the true gentleman, modern boxing has evolved from the prizefights of the Victorian era.  Strength reduces blocked damage and moving increase Dodging skill.",
     "initiate": [ "You lower your chin and raise your fists to eye level.", "%s prepares to fight with raised fists." ],
+    "priority": 1,
     "learn_difficulty": 1,
     "arm_block": 1,
     "static_buffs": [
@@ -281,6 +287,7 @@
     "name": { "str": "Brawling" },
     "description": "You're used to hand-to-creature fighting.  You know how to fight when unarmed or with any weapon to a certain extent.  It's not stylish or sporting, but it gets the job done.",
     "initiate": [ "You grit your teeth and prepare for a good fight.", "%s gets ready to brawl." ],
+    "priority": 1,
     "autolearn": [ [ "melee", 1 ] ],
     "arm_block": 1,
     "nonstandard_block": 5,
@@ -326,6 +333,7 @@
     "name": { "str": "Capoeira" },
     "description": "A dance-like style with its roots in Brazilian slavery, Capoeira is focused on fluid movement and sweeping kicks.  Moving briefly enables stronger techniques.  Missing an attack grants bonus damage for a short time.",
     "initiate": [ "You begin performing the ginga.", "%s begins to rhythmically rock back and forth." ],
+    "priority": 1,
     "learn_difficulty": 4,
     "static_buffs": [
       {
@@ -378,6 +386,7 @@
     "name": { "str": "Crane Kung Fu" },
     "description": "One of the five Shaolin animal styles.  The Crane uses intricate hand techniques and jumping dodges.  Dexterity determines your damage, rather than Strength; you have a higher chance to dodge and dodging unlocks strong techniques for a limited time.",
     "initiate": [ "You raise your leg slightly and balance like a crane.", "%s assumes a crane-like stance." ],
+    "priority": 1,
     "learn_difficulty": 10,
     "arm_block": 3,
     "static_buffs": [
@@ -426,6 +435,7 @@
     "name": { "str": "Dragon Kung Fu" },
     "description": "One of the five Shaolin animal styles.  The Dragon uses fluid movements and hard strikes.  Intelligence improves your accuracy and damage instead of Dexterity and Strength.  Dodging and blocking increases your damage.  Pausing increases your defenses.  You can perform a powerful strike against a downed opponent.",
     "initiate": [ "You relax and patiently await conflict like the great dragon.", "%s assumes a dragon-like stance." ],
+    "priority": 1,
     "learn_difficulty": 10,
     "arm_block": 2,
     "static_buffs": [
@@ -495,6 +505,7 @@
     "name": { "str": "Eskrima" },
     "description": "Eskrima, also known as Kali, is a Filipino martial art.  It emphasizes rapid strikes with knife and baton weapons, along with a variety of improvised substitutes.",
     "initiate": [ "You enter an open guard stance and prepare to strike.", "%s enters an open stance." ],
+    "priority": 1,
     "learn_difficulty": 8,
     "primary_skill": "bashing",
     "strictly_melee": true,
@@ -539,6 +550,7 @@
     "name": { "str": "Fencing" },
     "description": "The noble art of fencing is taught with flexible competition blades, but the techniques are derived from (and applicable to) more functional examples.  Skilled fencers can take advantage of blocks and feints to deliver accurate strikes.",
     "initiate": [ "You move into the en-garde stance.", "%s moves into a fencing stance." ],
+    "priority": 1,
     "learn_difficulty": 5,
     "primary_skill": "stabbing",
     "strictly_melee": true,
@@ -593,6 +605,7 @@
     "name": { "str": "Fior Di Battaglia" },
     "description": "Medieval Europe's martial techniques for fighting with hooked weapons.  The \"Flower of Battle\" places great focus on countering one's opponent and knocking them down before landing a killing blow.",
     "initiate": [ "You hold your weapon in a firm grip, ready to block any attack.", "%s grips their weapon tightly." ],
+    "priority": 1,
     "learn_difficulty": 6,
     "primary_skill": "bashing",
     "strictly_melee": true,
@@ -663,6 +676,7 @@
     "name": { "str": "Judo" },
     "description": "Judo is a martial art that focuses on grabs and throws, both defensive and offensive.  You are resistant to most effects that can knock you down and can counter grab and takedown attacks with a strong judo throw.",
     "initiate": [ "You prepare yourself for a grapple.", "%s prepares for a grapple." ],
+    "priority": 1,
     "learn_difficulty": 4,
     "static_buffs": [
       {
@@ -700,6 +714,7 @@
     "name": { "str": "Karate" },
     "description": "Karate is a popular martial art, originating from Japan.  It focuses on rapid, precise attacks, blocks, and fluid movement.  A successful hit allows you an extra dodge and an extra block on the following round.",
     "initiate": [ "You adopt a classic karate stance.", "%s adopts a classic karate stance." ],
+    "priority": 1,
     "learn_difficulty": 5,
     "arm_block": 2,
     "static_buffs": [
@@ -736,6 +751,7 @@
     "name": { "str": "Kickboxing" },
     "description": "A martial art that combines western boxing with elements of Karate, Taekwondo, Muay Thai, and Savate, particularly in the use of kicks.  American Kickboxing in particular focuses on high kicks without knee or elbow strikes.",
     "initiate": [ "You bring your fists up and stay light on your feet.", "%s brings their fists up and stays light on their feet." ],
+    "priority": 1,
     "learn_difficulty": 4,
     "arm_block": 2,
     "leg_block": 4,
@@ -762,6 +778,7 @@
     "name": { "str": "Krav Maga" },
     "description": "Originating in Israel, Krav Maga is based on taking down an enemy quickly and effectively.  It focuses on applicable attacks rather than showy or complex moves.  Popular among police and armed forces everywhere.",
     "initiate": [ "You assume a practical combat stance.", "%s assumes a practical combat stance." ],
+    "priority": 1,
     "learn_difficulty": 6,
     "arm_block": 2,
     "leg_block": 4,
@@ -797,6 +814,7 @@
     "name": { "str": "Leopard Kung Fu" },
     "description": "One of the five Shaolin animal styles.  The Leopard focuses on rapid, strategically-planned strikes.  Dexterity determines your damage, rather than Strength and also increases your critical hit chance.",
     "initiate": [ "You prepare to pounce like a leopard.", "%s assumes a leopard-like stance." ],
+    "priority": 1,
     "learn_difficulty": 10,
     "static_buffs": [
       {
@@ -836,6 +854,7 @@
     "name": { "str": "Medieval Swordsmanship" },
     "description": "The art of the longsword and sword & buckler, preceding the later development of fencing.  Designed for combat both unarmored and in armor, it includes grappling as well as defensive and offensive sword techniques.  This style is a combination of the Italian and German traditions.",
     "initiate": [ "You take on a knightly stance.", "%s takes on a knightly stance." ],
+    "priority": 1,
     "strictly_melee": true,
     "learn_difficulty": 6,
     "primary_skill": "cutting",
@@ -896,6 +915,7 @@
     "name": { "str": "Muay Thai" },
     "description": "Also referred to as the \"Art of 8 Limbs,\" Muay Thai is a popular fighting technique from Thailand that uses powerful strikes.  Your Strength decreases blocked damage.  Blocking attacks or getting hit will increase your damage and blocked damage further.",
     "initiate": [ "You perform a short wai khru in honor of your teachers.", "%s performs a short war-dance." ],
+    "priority": 1,
     "learn_difficulty": 5,
     "arm_block": 2,
     "leg_block": 4,
@@ -938,6 +958,7 @@
     "name": { "str": "Ninjutsu" },
     "description": "Ninjutsu is a martial art and set of tactics used by ninja in feudal Japan.  It focuses on rapid, precise, silent strikes.  Ninjutsu is almost entirely silent and you have a higher chance to critically hit on your first attack.  It also provides small combat bonuses every time you move.",
     "initiate": [ "You perform a kuji-in mantra with your hands.  Rin, Kai, Jin!", "%s performs a series of intricate hand signs." ],
+    "priority": 1,
     "learn_difficulty": 6,
     "arm_block": 3,
     "static_buffs": [
@@ -1006,6 +1027,7 @@
     "name": { "str": "Niten Ichi-Ryu" },
     "description": "Niten Ichi-Ryu is an ancient school of combat, transmitting a style of classical Japanese swordsmanship conceived by the warrior Miyamoto Musashi.  Perception increases damage and reduces blocked damage.  Moving and attacking reduces dodging and damage until you pause.  Pausing for a moment increases Dodging skill.",
     "initiate": [ "You clear your mind as you prepare yourself for combat.", "%s relaxes and prepares for combat." ],
+    "priority": 1,
     "learn_difficulty": 8,
     "primary_skill": "cutting",
     "strictly_melee": true,
@@ -1080,6 +1102,7 @@
     "name": { "str": "Pankration" },
     "description": "An ancient Greek martial art once used by the Spartans.  It combines boxing and wrestling techniques to create a brutal sport, though the modern revival of the art is more restrained and rules-based.",
     "initiate": [ "You crouch slightly and prepare to rush forward.", "%s crouches slightly, ready to rush forward." ],
+    "priority": 1,
     "learn_difficulty": 3,
     "arm_block": 2,
     "leg_block": 4,
@@ -1129,6 +1152,7 @@
     "name": { "str": "Silat" },
     "description": "Pencak Silat, of Indonesian origin, is a fighting style that covers the use of short blades and bludgeons.  Fighters stay low and mobile to avoid attacks, then unleash deadly critical hits.",
     "initiate": [ "You give a salute of respect as you prepare for combat.", "%s gives a combat salute." ],
+    "priority": 1,
     "learn_difficulty": 7,
     "primary_skill": "cutting",
     "strictly_melee": true,
@@ -1173,6 +1197,7 @@
     "name": { "str": "Snake Kung Fu" },
     "description": "One of the five Shaolin animal styles.  The Snake focuses on sinuous movement and precision strikes.  Perception determines your accuracy and damage, rather than Dexterity and Strength.  Standing still increases the accuracy and critical hit chance of your next few attacks.",
     "initiate": [ "You adopt a fluid stance, ready to strike like a snake.", "%s assumes a snake-like stance." ],
+    "priority": 1,
     "learn_difficulty": 10,
     "arm_block": 2,
     "static_buffs": [
@@ -1244,6 +1269,7 @@
     "name": { "str": "Sōjutsu" },
     "description": "Sōjutsu, \"The Way of the Spear\", is the Japanese martial art of fighting with a spear.  Sōjutsu focuses on keeping opponents at a distance in order to maintain the advantage in combat.  Standing still gives you an extra block attempt but moving will briefly increase your damage.",
     "initiate": [ "You prepare to defend against all that approach you.", "%s assumes a wide, defensive stance." ],
+    "priority": 1,
     "learn_difficulty": 7,
     "primary_skill": "stabbing",
     "strictly_melee": true,
@@ -1281,6 +1307,7 @@
     "name": { "str": "Taekwondo" },
     "description": "Taekwondo is the national sport of Korea, and was used by the South Korean army in the 20th century.  Focused on kicks, it does not benefit from wielded weapons.  It also includes strength training; your blocks absorb extra damage and your attacks do more damage if you are not holding anything.",
     "initiate": [ "You adopt a narrow fighting stance.", "%s adopts a narrow fighting stance." ],
+    "priority": 1,
     "learn_difficulty": 5,
     "arm_block": 1,
     "leg_block": 3,
@@ -1322,6 +1349,7 @@
     "name": { "str": "Tai Chi" },
     "description": "Though Tai Chi is often seen as a form of mental and physical exercise, it is a legitimate martial art, focused on self-defense.  Its ability to absorb the force of an attack makes your Perception decrease damage further on a block.  Pausing for a moment enables powerful palm strike techniques.",
     "initiate": [ "You settle into a gentle stance and prepare to defend yourself.", "%s settles into a gentle stance." ],
+    "priority": 1,
     "learn_difficulty": 4,
     "arm_block": 0,
     "static_buffs": [
@@ -1369,6 +1397,7 @@
     "name": { "str": "Tiger Kung Fu" },
     "description": "One of the five Shaolin animal styles.  The Tiger focuses on relentless attacks above all else.  Your Strength determines your accuracy, and your attacks do increasing damage as you continue attacking.",
     "initiate": [ "You clench your hands into ferocious, tiger-like claws.", "%s assumes a tiger-like stance." ],
+    "priority": 1,
     "learn_difficulty": 10,
     "static_buffs": [
       {
@@ -1407,6 +1436,7 @@
       "You take your stance and prepare to receive the gift of violence.",
       "%s patiently assumes a curiously pigeon-toed stance."
     ],
+    "priority": 1,
     "learn_difficulty": 8,
     "arm_block": 2,
     "leg_block": 3,
@@ -1456,6 +1486,7 @@
     "name": { "str": "Zui Quan" },
     "description": "AKA \"drunken boxing,\" Zui Quan imitates the movement of a drunk to confuse the enemy.  You gain a passive Dodging skill bonus based on Intelligence and dodge attempts.  Dodging increases your damage and accuracy based on Intelligence for a short time.  Moving gives you an additional dodging bonus.",
     "initiate": [ "You begin to sway to and fro with a confident swagger.", "%s stumbles as if pretending to be drunk." ],
+    "priority": 1,
     "learn_difficulty": 8,
     "static_buffs": [
       {
@@ -1504,6 +1535,7 @@
     "name": { "str": "Debug Mastery" },
     "description": "A secret martial art used only by developers and cheaters.",
     "initiate": [ "You get ready pwn some zeds!", "%s prepares to cheat at martial arts!" ],
+    "priority": 1,
     "arm_block": 99,
     "leg_block": 99,
     "static_buffs": [

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -349,6 +349,7 @@ void martialart::load( const JsonObject &jo, const std::string &src )
         int skill_level = skillArray.get_int( 1 );
         autolearn_skills.emplace_back( skill_name, skill_level );
     }
+    optional( jo, was_loaded, "priority", priority, 0 );
     optional( jo, was_loaded, "primary_skill", primary_skill, skill_unarmed );
     optional( jo, was_loaded, "learn_difficulty", learn_difficulty );
     optional( jo, was_loaded, "teachable", teachable, true );

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -354,6 +354,7 @@ class martialart
         translation name;
         translation description;
         std::vector<translation> initiate;
+        int priority = 0;
         std::vector<std::pair<std::string, int>> autolearn_skills;
         skill_id primary_skill;
         bool teachable = true;

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -86,7 +86,6 @@ static const flag_id json_flag_no_auto_equip( "no_auto_equip" );
 static const json_character_flag json_flag_BIONIC_TOGGLED( "BIONIC_TOGGLED" );
 
 static const matype_id style_none( "style_none" );
-static const matype_id style_kicks( "style_kicks" );
 
 static const profession_group_id
 profession_group_adult_basic_background( "adult_basic_background" );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -933,15 +933,6 @@ void avatar::initialize( character_type type )
         }
     }
 
-    // Select a random known style, except for style_kicks.
-    std::vector<matype_id> all_styles = martial_arts_data->get_known_styles( false );
-    std::vector<matype_id>::iterator it_kicks = std::find( all_styles.begin(), all_styles.end(),
-            style_kicks );
-    if( it_kicks != all_styles.end() ) {
-        all_styles.erase( it_kicks );
-    }
-    martial_arts_data->set_style( random_entry( all_styles, style_none ) );
-
     for( const trait_id &t : get_base_traits() ) {
         std::vector<matype_id> styles;
         for( const matype_id &s : t->initial_ma_styles ) {
@@ -952,9 +943,23 @@ void avatar::initialize( character_type type )
         if( !styles.empty() ) {
             const matype_id ma_type = choose_ma_style( type, styles, *this );
             martial_arts_data->add_martialart( ma_type );
-            martial_arts_data->set_style( ma_type );
         }
     }
+
+    // Select a random known style
+    std::vector<matype_id> selectable_styles = martial_arts_data->get_known_styles( false );
+    if( !selectable_styles.empty() ) {
+        std::vector<matype_id>::iterator it_max_priority = std::max_element( selectable_styles.begin(),
+        selectable_styles.end(), []( const matype_id & a, const matype_id & b ) {
+            return a->priority < b->priority;
+        } );
+        int max_priority = ( *it_max_priority )->priority;
+        selectable_styles.erase( std::remove_if( selectable_styles.begin(),
+        selectable_styles.end(), [max_priority]( const matype_id & style ) {
+            return style->priority != max_priority;
+        } ), selectable_styles.end() );
+    }
+    martial_arts_data->set_style( random_entry( selectable_styles, style_none ) );
 
     for( const mtype_id &elem : prof->pets() ) {
         starting_pets.push_back( elem );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -935,10 +935,11 @@ void avatar::initialize( character_type type )
 
     // Select a random known style, except for style_kicks.
     std::vector<matype_id> all_styles = martial_arts_data->get_known_styles( false );
-    std::vector<matype_id>::iterator it_kicks = std::find( all_styles.begin(), all_styles.end(), style_kicks );
-    if ( it_kicks != all_styles.end() ) {
+    std::vector<matype_id>::iterator it_kicks = std::find( all_styles.begin(), all_styles.end(),
+            style_kicks );
+    if( it_kicks != all_styles.end() ) {
         all_styles.erase( it_kicks );
-    } 
+    }
     martial_arts_data->set_style( random_entry( all_styles, style_none ) );
 
     for( const trait_id &t : get_base_traits() ) {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -86,6 +86,7 @@ static const flag_id json_flag_no_auto_equip( "no_auto_equip" );
 static const json_character_flag json_flag_BIONIC_TOGGLED( "BIONIC_TOGGLED" );
 
 static const matype_id style_none( "style_none" );
+static const matype_id style_kicks( "style_kicks" );
 
 static const profession_group_id
 profession_group_adult_basic_background( "adult_basic_background" );
@@ -932,7 +933,12 @@ void avatar::initialize( character_type type )
         }
     }
 
+    // Select a random known style, except for style_kicks.
     std::vector<matype_id> all_styles = martial_arts_data->get_known_styles( false );
+    std::vector<matype_id>::iterator it_kicks = std::find( all_styles.begin(), all_styles.end(), style_kicks );
+    if ( it_kicks != all_styles.end() ) {
+        all_styles.erase( it_kicks );
+    } 
     martial_arts_data->set_style( random_entry( all_styles, style_none ) );
 
     for( const trait_id &t : get_base_traits() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "New characters don't start with martial arts style set to 'Force unarmed'"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

New characters default to a randomly selected martial arts style. As such, characters without martial arts knowledge randomly select style_no (desired) or style_kicks (undesired). This PR ensures style_kicks is never selected. Fixes #68722.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Removed style_kicks from the list of randomly-selectable martial arts on character initialization.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

It's not clear to me if this is the desired behaviour. Alternatives are:
- Characters always start with no style selected, even if the character knows an "interesting" (not style_none or style_kicks) style.
- Characters always start with an interesting style if the character knows one, and style_none if not.
- Either of the above, but they never start with other "force unarmed" martial styles either.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Tested by generating 40 martial-arts characters and non-martial-arts characters before and after changes. I'm not sure in what circumstance characters start with multiple known styles, let me know and I'll test that as well. The test suite ran fine.

If requested, I'd be happy to write a test case to ensure this doesn't regress in the future.

#### Additional context

This is my first contribution and I didn't get astyle working right away -- apologies in advance.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
