### PR TITLE
Add context value to "character_casts_spell", "spellcasting_finish"

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -450,9 +450,12 @@
     "eoc_type": "EVENT",
     "required_event": "character_casts_spell",
     "effect": [
-      { "math": [ "key1", "=", "_damage" ] },
-      { "math": [ "key2", "=", "_cast_time" ] },
-      { "math": [ "key3", "=", "_difficulty" ] }
+      { "set_string_var": { "context_val": "spell" }, "target_var": { "global_val": "key1" } },
+      { "set_string_var": { "context_val": "school" }, "target_var": { "global_val": "key2" } },
+      { "math": [ "key3", "=", "_difficulty" ] },
+      { "math": [ "key4", "=", "_cost" ] },
+      { "math": [ "key5", "=", "_cast_time" ] },
+      { "math": [ "key6", "=", "_damage" ] }
     ]
   },
   {

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -956,7 +956,7 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | broken_bone_mends | Triggered when `mending` effect is removed by expiry (Character::mend) | { "character", `character_id` },<br/> { "part", `body_part` }, | character / NONE |
 | buries_corpse | Triggers when item with flag CORPSE is located on same tile as construction with post-special `done_grave` is completed | { "character", `character_id` },<br/> { "corpse_type", `mtype_id` },<br/> { "corpse_name", `string` }, | character / NONE |
 | causes_resonance_cascade | Triggers when resonance cascade option is activated via "old lab" finale's computer | NONE | avatar / NONE |
-| character_casts_spell |  | { "character", `character_id` },<br/> { "spell", `spell_id` },<br/> { "difficulty", `int` },<br/> { "cost", `int` },<br/> { "cast_time", `int` },<br/> { "damage", `int` }, | character / NONE |
+| character_casts_spell | Triggers when a character casts spells. When a spell with multiple effects is cast, the number of effects will be triggered | { "character", `character_id` },<br/> { "spell", `spell_id` },<br/> { "school", `trait_id` },<br/> { "difficulty", `int` },<br/> { "cost", `int` },<br/> { "cast_time", `int` },<br/> { "damage", `int` }, | character / NONE |
 | character_consumes_item |  | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE |
 | character_dies |  | { "character", `character_id` }, | character / NONE |
 | character_eats_item |  | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE |
@@ -1030,7 +1030,7 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | releases_subspace_specimens | Triggers when Release Specimens option is activated via ("old lab" finale's?) computer | NONE | avatar / NONE |
 | removes_cbm | |  { "character", `character_id` },<br/> { "bionic", `bionic_id` }, | character / NONE |
 | seals_hazardous_material_sarcophagus | Triggers via `srcf_seal_order` computer action | NONE | avatar / NONE |
-| spellcasting_finish | | { "character", `character_id` },<br/> { "spell", `spell_id` },<br/> { "school", `trait_id` }  | character / NONE |
+| spellcasting_finish | Triggers only once when a character finishes casting a spell | { "character", `character_id` },<br/> { "success", `bool` },<br/>  { "spell", `spell_id` },<br/> { "school", `trait_id` },<br/> { "difficulty", `int` },<br/> { "cost", `int` },<br/> { "cast_time", `int` },<br/> { "damage", `int` }, | character / NONE |
 | telefrags_creature | (Unimplemented) | { "character", `character_id` },<br/> { "victim_name", `string` }, | character / NONE |
 | teleglow_teleports | Triggers when character(only avatar is actually eligible) is teleported due to teleglow effect | { "character", `character_id` } | character / NONE |
 | teleports_into_wall | Triggers when character(only avatar is actually eligible) is teleported into wall | { "character", `character_id` },<br/> { "obstacle_name", `string` }, | character / NONE |

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3743,6 +3743,10 @@ void activity_handlers::spellcasting_finish( player_activity *act, Character *yo
                     you->add_msg_if_player( m_good, _( "You gain %i experience.  New total %i." ), exp_gained / 5,
                                             spell_being_cast.xp() );
                 }
+                get_event_bus().send<event_type::spellcasting_finish>( you->getID(), false, sp,
+                        spell_being_cast.spell_class(), spell_being_cast.get_difficulty( *you ),
+                        spell_being_cast.energy_cost( *you ), spell_being_cast.casting_time( *you ),
+                        spell_being_cast.damage( *you ) );
                 return;
             }
 
@@ -3809,8 +3813,10 @@ void activity_handlers::spellcasting_finish( player_activity *act, Character *yo
                     you->consume_charges( it, it.type->charges_to_use() );
                 }
             }
-            get_event_bus().send<event_type::spellcasting_finish>( you->getID(), sp,
-                    spell_being_cast.spell_class() );
+            get_event_bus().send<event_type::spellcasting_finish>( you->getID(), true, sp,
+                    spell_being_cast.spell_class(), spell_being_cast.get_difficulty( *you ),
+                    spell_being_cast.energy_cost( *you ), spell_being_cast.casting_time( *you ),
+                    spell_being_cast.damage( *you ) );
         }
     }
 }

--- a/src/event.h
+++ b/src/event.h
@@ -279,14 +279,14 @@ struct event_spec<event_type::character_eats_item> : event_spec_character_item {
 
 template<>
 struct event_spec<event_type::character_casts_spell> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 6> fields = { {
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 7> fields = { {
             { "character", cata_variant_type::character_id },
             { "spell", cata_variant_type::spell_id },
+            { "school", cata_variant_type::trait_id },
             { "difficulty", cata_variant_type::int_},
             { "cost", cata_variant_type::int_},
             { "cast_time", cata_variant_type::int_},
             { "damage", cata_variant_type::int_}
-
         }
     };
 };
@@ -786,10 +786,15 @@ struct event_spec<event_type::seals_hazardous_material_sarcophagus> : event_spec
 
 template<>
 struct event_spec<event_type::spellcasting_finish> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = { {
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 8> fields = { {
             { "character", cata_variant_type::character_id },
+            { "success", cata_variant_type::bool_ },
             { "spell", cata_variant_type::spell_id },
-            { "school", cata_variant_type::trait_id }
+            { "school", cata_variant_type::trait_id },
+            { "difficulty", cata_variant_type::int_},
+            { "cost", cata_variant_type::int_},
+            { "cast_time", cata_variant_type::int_},
+            { "damage", cata_variant_type::int_}
         }
     };
 };

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1713,9 +1713,8 @@ void spell::cast_spell_effect( Creature &source, const tripoint &target ) const
     if( caster ) {
         character_id c_id = caster->getID();
         // send casting to the event bus
-        get_event_bus().send<event_type::character_casts_spell>( c_id, this->id(),
-                this->get_difficulty( source ), this->energy_cost( *caster ),
-                this->casting_time( *caster ),
+        get_event_bus().send<event_type::character_casts_spell>( c_id, this->id(), this->spell_class(),
+                this->get_difficulty( source ), this->energy_cost( *caster ), this->casting_time( *caster ),
                 this->damage( source ) );
     }
 

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -822,9 +822,12 @@ TEST_CASE( "EOC_event_test", "[eoc]" )
     temp_spell.set_level( get_avatar(), 5 );
     temp_spell.cast_all_effects( get_avatar(), tripoint() );
 
-    CHECK( globvars.get_global_value( "npctalk_var_key1" ) == "45" );
-    CHECK( globvars.get_global_value( "npctalk_var_key2" ) == "100" );
+    CHECK( globvars.get_global_value( "npctalk_var_key1" ) == "test_eoc_spell" );
+    CHECK( globvars.get_global_value( "npctalk_var_key2" ) == "MAGUS" );
     CHECK( globvars.get_global_value( "npctalk_var_key3" ) == "5" );
+    CHECK( globvars.get_global_value( "npctalk_var_key4" ) == "150" );
+    CHECK( globvars.get_global_value( "npctalk_var_key5" ) == "100" );
+    CHECK( globvars.get_global_value( "npctalk_var_key6" ) == "45" );
 
     // character_starts_activity
     globvars.clear_global_values();


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fixes #66728

#### Describe the solution
Clarify the difference between the two events.
Allows you to get equivalent spell information from two events.
Allows you to know if the spell casting was successful

#### Describe alternatives you've considered

#### Testing
Tested following code.
```
  {
    "type": "effect_on_condition",
    "id": "EOC_spell_event_test_2",
    "eoc_type": "EVENT",
    "required_event": "spellcasting_finish",
    "effect": [
      { "set_string_var": { "context_val": "spell" }, "target_var": { "context_val": "key1" } },
      { "set_string_var": { "context_val": "school" }, "target_var": { "context_val": "key2" } },
      { "math": [ "_key3", "=", "_difficulty" ] },
      { "math": [ "_key4", "=", "_cost" ] },
      { "math": [ "_key5", "=", "_cast_time" ] },
      { "math": [ "_key6", "=", "_damage" ] },
      { "math": [ "_key7", "=", "_success" ] },
      { "u_message": "id:        <context_val:key1>" },
      { "u_message": "school:    <context_val:key2>" },
      { "u_message": "difficulty:<context_val:key3>" },
      { "u_message": "cost:      <context_val:key4>" },
      { "u_message": "cast_time: <context_val:key5>" },
      { "u_message": "damage:    <context_val:key6>" },
      { "u_message": "success:   <context_val:key7>" }
    ]
  }
```
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13540013/8687599b-f453-431e-87e5-db293dd2e6f1)

#### Additional context
