### PR TITLE
[MoM] Add scaling to Metaphysics XP gain from powers, add penalty for power failure

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
@@ -108,6 +108,284 @@
         }
       ]
     },
-    "effect": [ { "math": [ "u_skill_exp('metaphysics', 'raw')", "+=", "250" ] } ]
+    "effect": [ { "math": [ "u_skill_exp('metaphysics', 'raw')", "+=", "(100 * _difficulty)" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSIONICS_BIOKINETIC_CHANNELING_FAILURE",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": {
+      "and": [
+        { "u_has_trait": "BIOKINETIC" },
+        { "compare_string": [ "BIOKINETIC", { "context_val": "school" } ] },
+        { "math": [ "_success", "==", "false" ] },
+        {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "(1 * ((( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
+              ]
+            },
+            "y": 1000
+          }
+        }
+      ]
+    },
+    "effect": [
+      { "u_message": "Your powers rage out of control!", "type": "bad" },
+      {
+        "u_add_effect": "psionic_overload",
+        "duration": {
+          "math": [ "u_val('time: 30 s') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      },
+      {
+        "u_add_effect": "effect_biokin_overload",
+        "duration": {
+          "math": [ "u_val('time: 15 s') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSIONICS_CLAIRSENTIENT_CHANNELING_FAILURE",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": {
+      "and": [
+        { "u_has_trait": "CLAIRSENTIENT" },
+        { "compare_string": [ "CLAIRSENTIENT", { "context_val": "school" } ] },
+        { "math": [ "_success", "==", "false" ] },
+        {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "(1 * ((( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
+              ]
+            },
+            "y": 1000
+          }
+        }
+      ]
+    },
+    "effect": [
+      { "u_message": "Your powers rage out of control!", "type": "bad" },
+      {
+        "u_add_effect": "psionic_overload",
+        "duration": {
+          "math": [ "u_val('time: 30 s') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      },
+      {
+        "u_add_effect": "blind_clair_overload",
+        "duration": {
+          "math": [ "u_val('time: 15 s') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      },
+      {
+        "u_add_effect": "deaf_clair_overload",
+        "duration": {
+          "math": [ "u_val('time: 15 s') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSIONICS_PYROKINETIC_CHANNELING_FAILURE",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": {
+      "and": [
+        { "u_has_trait": "PYROKINETIC" },
+        { "compare_string": [ "PYROKINETIC", { "context_val": "school" } ] },
+        { "math": [ "_success", "==", "false" ] },
+        {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "(1 * ((( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
+              ]
+            },
+            "y": 1000
+          }
+        }
+      ]
+    },
+    "effect": [
+      { "u_message": "Your powers rage out of control!", "type": "bad" },
+      {
+        "u_add_effect": "psionic_overload",
+        "duration": {
+          "math": [ "u_val('time: 30 s') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      },
+      {
+        "u_add_effect": "effect_pyrokin_overload",
+        "duration": {
+          "math": [ "u_val('time: 15 s') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSIONICS_TELEKINETIC_CHANNELING_FAILURE",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": {
+      "and": [
+        { "u_has_trait": "TELEKINETIC" },
+        { "compare_string": [ "TELEKINETIC", { "context_val": "school" } ] },
+        { "math": [ "_success", "==", "false" ] },
+        {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "(1 * ((( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
+              ]
+            },
+            "y": 1000
+          }
+        }
+      ]
+    },
+    "effect": [
+      { "u_message": "Your powers rage out of control!", "type": "bad" },
+      {
+        "u_add_effect": "psionic_overload",
+        "duration": {
+          "math": [ "u_val('time: 30 s') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      },
+      {
+        "u_add_effect": "effect_telekin_overload",
+        "duration": {
+          "math": [ "u_val('time: 15 s') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSIONICS_TELEPATH_CHANNELING_FAILURE",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": {
+      "and": [
+        { "u_has_trait": "TELEPATH" },
+        { "compare_string": [ "TELEPATH", { "context_val": "school" } ] },
+        { "math": [ "_success", "==", "false" ] },
+        {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "(1 * ((( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
+              ]
+            },
+            "y": 1000
+          }
+        }
+      ]
+    },
+    "effect": [
+      { "u_message": "Your powers rage out of control!", "type": "bad" },
+      {
+        "u_add_effect": "psionic_overload",
+        "duration": {
+          "math": [ "u_val('time: 30 s') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      },
+      {
+        "u_add_effect": "nightmares",
+        "duration": {
+          "math": [ "u_val('time: 30 m') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      },
+      {
+        "u_add_effect": "disrupted_sleep",
+        "duration": {
+          "math": [ "u_val('time: 30 m') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSIONICS_TELEPORTER_CHANNELING_FAILURE",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": {
+      "and": [
+        { "u_has_trait": "TELEPORTER" },
+        { "compare_string": [ "TELEPORTER", { "context_val": "school" } ] },
+        { "math": [ "_success", "==", "false" ] },
+        {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "(1 * ((( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
+              ]
+            },
+            "y": 1000
+          }
+        }
+      ]
+    },
+    "effect": [
+      { "u_message": "Your powers rage out of control!", "type": "bad" },
+      {
+        "u_add_effect": "psionic_overload",
+        "duration": {
+          "math": [ "u_val('time: 30 s') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      },
+      {
+        "u_add_effect": "effect_portal_storm_teleport",
+        "duration": {
+          "math": [ "u_val('time: 15 s') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSIONICS_VITAKINETIC_CHANNELING_FAILURE",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": {
+      "and": [
+        { "u_has_trait": "VITAKINETIC" },
+        { "compare_string": [ "VITAKINETIC", { "context_val": "school" } ] },
+        { "math": [ "_success", "==", "false" ] },
+        {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "(1 * ((( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
+              ]
+            },
+            "y": 1000
+          }
+        }
+      ]
+    },
+    "effect": [
+      { "u_message": "Your powers rage out of control!", "type": "bad" },
+      {
+        "u_add_effect": "psionic_overload",
+        "duration": {
+          "math": [ "u_val('time: 30 s') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      },
+      {
+        "u_add_effect": "effect_vitakin_overload",
+        "duration": {
+          "math": [ "u_val('time: 15 s') * (1 + ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ) ) * rng(1, _difficulty)" ]
+        }
+      }
+    ]
   }
 ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
@@ -87,7 +87,7 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_PSIONICS_METAPHYSICS_SKILL_EXP",
+    "id": "EOC_PSIONICS_METAPHYSICS_SKILL_EXP_SUCCESS",
     "eoc_type": "EVENT",
     "required_event": "spellcasting_finish",
     "condition": {
@@ -105,10 +105,37 @@
             { "compare_string": [ "TELEPORTER", { "context_val": "school" } ] },
             { "compare_string": [ "VITAKINETIC", { "context_val": "school" } ] }
           ]
-        }
+        },
+        { "math": [ "_success", "!=", "false" ] }
       ]
     },
     "effect": [ { "math": [ "u_skill_exp('metaphysics', 'raw')", "+=", "(100 * _difficulty)" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSIONICS_METAPHYSICS_SKILL_EXP_FAILURE",
+    "eoc_type": "EVENT",
+    "required_event": "spellcasting_finish",
+    "condition": {
+      "and": [
+        {
+          "u_has_any_trait": [ "BIOKINETIC", "CLAIRSENTIENT", "PYROKINETIC", "TELEKINETIC", "TELEPATH", "TELEPORTER", "VITAKINETIC" ]
+        },
+        {
+          "or": [
+            { "compare_string": [ "BIOKINETIC", { "context_val": "school" } ] },
+            { "compare_string": [ "CLAIRSENTIENT", { "context_val": "school" } ] },
+            { "compare_string": [ "PYROKINETIC", { "context_val": "school" } ] },
+            { "compare_string": [ "TELEKINETIC", { "context_val": "school" } ] },
+            { "compare_string": [ "TELEPATH", { "context_val": "school" } ] },
+            { "compare_string": [ "TELEPORTER", { "context_val": "school" } ] },
+            { "compare_string": [ "VITAKINETIC", { "context_val": "school" } ] }
+          ]
+        },
+        { "math": [ "_success", "==", "false" ] }
+      ]
+    },
+    "effect": [ { "math": [ "u_skill_exp('metaphysics', 'raw')", "+=", "(25 * _difficulty)" ] } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_misc.json
@@ -151,7 +151,7 @@
           "x_in_y_chance": {
             "x": {
               "math": [
-                "(1 * ((( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
+                "(10 * (min(0,( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
               ]
             },
             "y": 1000
@@ -189,7 +189,7 @@
           "x_in_y_chance": {
             "x": {
               "math": [
-                "(1 * ((( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
+                "(10 * (min(0,( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
               ]
             },
             "y": 1000
@@ -233,7 +233,7 @@
           "x_in_y_chance": {
             "x": {
               "math": [
-                "(1 * ((( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
+                "(10 * (min(0,( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
               ]
             },
             "y": 1000
@@ -271,7 +271,7 @@
           "x_in_y_chance": {
             "x": {
               "math": [
-                "(1 * ((( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
+                "(10 * (min(0,( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
               ]
             },
             "y": 1000
@@ -309,7 +309,7 @@
           "x_in_y_chance": {
             "x": {
               "math": [
-                "(1 * ((( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
+                "(10 * (min(0,( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
               ]
             },
             "y": 1000
@@ -353,7 +353,7 @@
           "x_in_y_chance": {
             "x": {
               "math": [
-                "(1 * ((( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
+                "(10 * (min(0,( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
               ]
             },
             "y": 1000
@@ -391,7 +391,7 @@
           "x_in_y_chance": {
             "x": {
               "math": [
-                "(1 * ((( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
+                "(10 * (min(0,( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"
               ]
             },
             "y": 1000


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Add scaling to Metaphysics XP gain from powers, add penalty for power failure"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I mentioned in #68555 that I wanted to scale the XP given based on power difficulty once that was an option, and now it is an option.

Also, I've long wanted to have the possibility of penalties for failed power usage--"An untrained telepath is a danger to themselves and everyone around them"--and now I can do that too.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change the formula for metaphysics XP to 100 XP * power Difficulty on a successful usage and 25 XP * power Difficulty on a failure.

Also, add the possibility of power overload on power failure! The formula is 

> "(10 * (min(0,( _difficulty - 1 - ( u_skill('metaphysics') / 2 ) ) * 15) ) + u_val('vitamin', 'name:vitamin_psionic_drain'))"

So a Difficulty 1 power at zero drain has a 1% chance of causing overload on a failed channel only. A Difficulty 5 power at moderate drain (vitamin 50) with metaphysics 4 has a 9.1% chance of causing overload, again only on a failed channel.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Everything works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
For some reason, { "math": [ "_success", "==", "true" ] } didn't fire, so I used { "math": [ "_success", "!=", "false" ] } to detect a successful power usage.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
