### PR TITLE
Add favorite category to spell casting menu & minor bugfix

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -308,7 +308,7 @@
     "id": "SCROLL_FAVORITE",
     "category": "SPELL_MENU",
     "name": "Toggle spell as favorite",
-    "bindings": [ 
+    "bindings": [
       { "input_method": "keyboard_char", "key": "*" },
       { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
       { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -305,6 +305,17 @@
   },
   {
     "type": "keybinding",
+    "id": "SCROLL_FAVORITE",
+    "category": "SPELL_MENU",
+    "name": "Toggle spell as favorite",
+    "bindings": [ 
+      { "input_method": "keyboard_char", "key": "*" },
+      { "input_method": "keyboard_code", "key": "KEYPAD_MULTIPLY" },
+      { "input_method": "keyboard_code", "key": "8", "mod": [ "shift" ] }
+    ]
+  },
+  {
+    "type": "keybinding",
     "id": "ADD_RULE",
     "category": "AUTO_PICKUP",
     "name": "Add rule",

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2156,6 +2156,19 @@ std::vector<spell> Character::spells_known_of_class( const trait_id &spell_class
     return ret;
 }
 
+static void reflesh_favorite( uilist *menu, std::vector<spell *> known_spells )
+{
+    for( auto &e : menu->entries ) {
+        if( get_player_character().magic->is_favorite( known_spells[e.retval]->id() ) ) {
+            e.extratxt.left = 2;
+            e.extratxt.txt = _( "*" );
+            e.extratxt.color = c_white;
+        } else {
+            e.extratxt.txt = "";
+        }
+    }
+}
+
 class spellcasting_callback : public uilist_callback
 {
     private:
@@ -2165,16 +2178,17 @@ class spellcasting_callback : public uilist_callback
         std::vector<spell *> known_spells;
         void spell_info_text( const spell &sp, int width );
         void draw_spell_info( const uilist *menu );
+        bool do_reflesh_favorite = true;
     public:
         // invlets reserved for special functions
-        const std::set<int> reserved_invlets{ 'I', '=' };
+        const std::set<int> reserved_invlets{ 'I', '=', '*' };
         bool casting_ignore;
 
         spellcasting_callback( std::vector<spell *> &spells,
                                bool casting_ignore ) : known_spells( spells ),
             casting_ignore( casting_ignore ) {}
         bool key( const input_context &ctxt, const input_event &event, int entnum,
-                  uilist * /*menu*/ ) override {
+                  uilist *menu ) override {
             const std::string &action = ctxt.input_to_action( event );
             if( action == "CAST_IGNORE" ) {
                 casting_ignore = !casting_ignore;
@@ -2198,11 +2212,19 @@ class spellcasting_callback : public uilist_callback
                 return true;
             } else if( action == "SCROLL_UP_SPELL_MENU" || action == "SCROLL_DOWN_SPELL_MENU" ) {
                 scroll_pos += action == "SCROLL_DOWN_SPELL_MENU" ? 1 : -1;
+            } else if( action == "SCROLL_FAVORITE" ) {
+                get_player_character().magic->toggle_favorite( known_spells[entnum]->id() );
+                do_reflesh_favorite = true;
+                refresh( menu );
             }
             return false;
         }
 
         void refresh( uilist *menu ) override {
+            if( do_reflesh_favorite ) {
+                do_reflesh_favorite = false;
+                reflesh_favorite( menu, known_spells );
+            }
             const std::string space( menu->pad_right - 2, ' ' );
             mvwputch( menu->window, point( menu->w_width - menu->pad_right, 0 ), c_magenta, LINE_OXXX );
             mvwputch( menu->window, point( menu->w_width - menu->pad_right, menu->w_height - 1 ), c_magenta,
@@ -2522,6 +2544,20 @@ void known_magic::rem_invlet( const spell_id &sp )
     invlets.erase( sp );
 }
 
+void known_magic::toggle_favorite( const spell_id &sp )
+{
+    if( favorites.count( sp ) > 0 ) {
+        favorites.erase( sp );
+    } else {
+        favorites.emplace( sp );
+    }
+}
+
+bool known_magic::is_favorite( const spell_id &sp )
+{
+    return favorites.count( sp ) > 0;
+}
+
 int known_magic::get_invlet( const spell_id &sp, std::set<int> &used_invlets )
 {
     auto found = invlets.find( sp );
@@ -2575,20 +2611,37 @@ int known_magic::select_spell( Character &guy )
     spell_menu.additional_actions.emplace_back( "CAST_IGNORE", translation() );
     spell_menu.additional_actions.emplace_back( "SCROLL_UP_SPELL_MENU", translation() );
     spell_menu.additional_actions.emplace_back( "SCROLL_DOWN_SPELL_MENU", translation() );
+    spell_menu.additional_actions.emplace_back( "SCROLL_FAVORITE", translation() );
     spell_menu.hilight_disabled = true;
     spellcasting_callback cb( known_spells, casting_ignore );
     spell_menu.callback = &cb;
     spell_menu.add_category( "all", _( "All" ) );
+    spell_menu.add_category( "favorites", _( "Favorites" ) );
+
+    std::vector<std::pair<std::string, std::string>> categories;
     for( const spell *s : known_spells ) {
         if( s->can_cast( guy ) && s->spell_class().is_valid() ) {
-            spell_menu.add_category( s->spell_class().str(), s->spell_class().obj().name() );
+            categories.emplace_back( s->spell_class().str(), s->spell_class().obj().name() );
+            std::sort( categories.begin(), categories.end(), []( const std::pair<std::string, std::string> &a,
+            const std::pair<std::string, std::string> &b ) {
+                return localized_compare( a.second, b.second );
+            } );
+            const auto itr = std::unique( categories.begin(), categories.end() );
+            categories.erase( itr, categories.end() );
         }
     }
-    spell_menu.set_category_filter( [known_spells]( const uilist_entry & entry,
+    for( std::pair<std::string, std::string> &cat : categories ) {
+        spell_menu.add_category( cat.first, cat.second );
+    }
+
+    spell_menu.set_category_filter( [&guy, known_spells]( const uilist_entry & entry,
     const std::string & key )->bool {
         if( key == "all" )
         {
             return true;
+        } else if( key == "favorites" )
+        {
+            return guy.magic->is_favorite( known_spells[entry.retval]->id() );
         }
         return known_spells[entry.retval]->spell_class().is_valid() && known_spells[entry.retval]->spell_class().str() == key;
     } );
@@ -2600,6 +2653,7 @@ int known_magic::select_spell( Character &guy )
         spell_menu.addentry( static_cast<int>( i ), known_spells[i]->can_cast( guy ),
                              get_invlet( known_spells[i]->id(), used_invlets ), known_spells[i]->name() );
     }
+    reflesh_favorite( &spell_menu, known_spells );
 
     spell_menu.query();
 

--- a/src/magic.h
+++ b/src/magic.h
@@ -629,6 +629,8 @@ class known_magic
         std::map<spell_id, spell> spellbook;
         // invlets assigned to spell_id
         std::map<spell_id, int> invlets;
+        // list of favorite spells
+        std::unordered_set<spell_id> favorites;
         // the base mana a Character would start with
         int mana_base = 0; // NOLINT(cata-serialize)
         // current mana
@@ -697,6 +699,9 @@ class known_magic
         // returns false if invlet is already used
         bool set_invlet( const spell_id &sp, int invlet, const std::set<int> &used_invlets );
         void rem_invlet( const spell_id &sp );
+
+        void toggle_favorite( const spell_id &sp );
+        bool is_favorite( const spell_id &sp );
     private:
         // gets length of longest spell name
         int get_spellname_max_width();

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -325,8 +325,10 @@ input_context uilist::create_main_input_context() const
         ctxt.register_action( "SELECT" );
     }
     ctxt.register_action( "UILIST.FILTER" );
-    ctxt.register_action( "UILIST.LEFT" );
-    ctxt.register_action( "UILIST.RIGHT" );
+    if( !categories.empty() ) {
+        ctxt.register_action( "UILIST.LEFT" );
+        ctxt.register_action( "UILIST.RIGHT" );
+    }
     ctxt.register_action( "ANY_INPUT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     uilist_scrollbar->set_draggable( ctxt );
@@ -1267,12 +1269,6 @@ void uilist::set_selected( int index )
 void uilist::add_category( const std::string &key, const std::string &name )
 {
     categories.emplace_back( key, name );
-    std::sort( categories.begin(), categories.end(), []( const std::pair<std::string, std::string> &a,
-    const std::pair<std::string, std::string> &b ) {
-        return localized_compare( a.second, b.second );
-    } );
-    const auto itr = std::unique( categories.begin(), categories.end() );
-    categories.erase( itr, categories.end() );
 }
 
 void uilist::set_category( const std::string &key )


### PR DESCRIPTION
#### Summary
Interface "Add favorite category to spell casting menu"

#### Purpose of change
Follow up #68761
Fix an issue where the left and right keys did not work in Debug > Change time menu

#### Describe the solution
Use the "*" key to register spells as favorites so that they can be grouped together on the favorites page.

#### Describe alternatives you've considered

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13540013/7d76f76f-9b65-42f6-9e33-f7f09d238556)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13540013/72645317-985a-44a2-bed7-385e9e79537a)

#### Additional context
