### PR TITLE
Fix and rebalance Defense Mode's final wave

### DIFF
--- a/data/mods/Defense_Mode/eocs.json
+++ b/data/mods/Defense_Mode/eocs.json
@@ -450,19 +450,6 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "DEFENSE_MODE_WIN_SCREEN",
-    "global": true,
-    "recurrence": 100,
-    "condition": { "math": [ "final_wave_defeated", "==", "1" ] },
-    "effect": [ { "open_dialogue": { "topic": "TALK_DEFENSE_MODE_WIN" } } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "DEFENSE_MODE_QUEUE_WIN_SCREEN",
-    "effect": [ { "math": [ "final_wave_defeated", "=", "1" ] } ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "DEFENSE_MODE_RANDOM_EVENT",
     "recurrence": [ "2 days", "4 days" ],
     "//": "A general EOC for selecting a random event.  Can and should be expanded.",

--- a/data/mods/Defense_Mode/missions.json
+++ b/data/mods/Defense_Mode/missions.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "MISSION_DEFENSE_MODE_SURVIVE",
+    "type": "mission_definition",
+    "name": { "str": "Survive" },
+    "description": "You don't know how you got here, or why.  All you know is that you need to live.",
+    "goal": "MGOAL_KILL_MONSTER_TYPE",
+    "monster_type": "mon_boss_shadow",
+    "monster_kill_goal": 1,
+    "difficulty": 3,
+    "value": 0,
+    "end": { "effect": [ { "open_dialogue": { "topic": "TALK_DEFENSE_MODE_WIN" } } ] },
+    "origins": [ "ORIGIN_GAME_START" ]
+  }
+]

--- a/data/mods/Defense_Mode/monster_spells.json
+++ b/data/mods/Defense_Mode/monster_spells.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "SPELL",
+    "id": "gargantuan_raptor_spawn",
+    "name": { "str": "Summon Raptor Horde" },
+    "description": "Summons a horde of zombiespawn raptors.",
+    "flags": [ "HOSTILE_SUMMON", "RANDOM_DAMAGE", "PERMANENT", "NO_EXPLOSION_SFX" ],
+    "valid_targets": [ "ground", "self" ],
+    "min_damage": 7,
+    "max_damage": 15,
+    "min_aoe": 4,
+    "max_aoe": 4,
+    "base_casting_time": 500,
+    "shape": "blast",
+    "effect": "summon",
+    "effect_str": "mon_spawn_raptor"
+  }
+]

--- a/data/mods/Defense_Mode/monster_spells.json
+++ b/data/mods/Defense_Mode/monster_spells.json
@@ -10,8 +10,6 @@
     "max_damage": 15,
     "min_aoe": 4,
     "max_aoe": 4,
-    "min_range": 6,
-    "max_range": 12,
     "base_casting_time": 500,
     "shape": "blast",
     "effect": "summon",

--- a/data/mods/Defense_Mode/monster_spells.json
+++ b/data/mods/Defense_Mode/monster_spells.json
@@ -10,6 +10,8 @@
     "max_damage": 15,
     "min_aoe": 4,
     "max_aoe": 4,
+    "min_range": 6,
+    "max_range": 12,
     "base_casting_time": 500,
     "shape": "blast",
     "effect": "summon",

--- a/data/mods/Defense_Mode/monsters.json
+++ b/data/mods/Defense_Mode/monsters.json
@@ -336,7 +336,7 @@
     "volume": "100 L",
     "weight": "100 kg",
     "phase": "GAS",
-    "hp": 350,
+    "hp": 3000,
     "//6": "Slowed and weakened by light of sufficient brightness. (It lurks outside of flashlight range) Luring it into a trap is a viable path to killing it.",
     "speed": 200,
     "attack_cost": 200,
@@ -360,9 +360,9 @@
     "tracking_distance": 6,
     "path_settings": { "max_dist": 40, "allow_open_doors": true, "avoid_traps": true, "avoid_sharp": true, "allow_climb_stairs": true },
     "special_attacks": [
-      [ "UPGRADE", 10 ],
-      [ "RESURRECT", 5 ],
-      [ "SHRIEK_ALERT", 20 ],
+      [ "UPGRADE", 0 ],
+      [ "RESURRECT", 0 ],
+      [ "SHRIEK_ALERT", 0 ],
       {
         "type": "melee",
         "id": "LTNT_ILLUMINATE_YOU",
@@ -376,21 +376,17 @@
         "damage_max_instance": [ { "damage_type": "pure", "amount": 0.0 } ],
         "no_dmg_msg_u": "The shadows recede, leaving you with nowhere to hide!",
         "no_dmg_msg_npc": "The shadows recede from <npcname>, and now they stand out like a floodlight!",
-        "cooldown": 10
+        "cooldown": 1
       },
       {
         "type": "spell",
-        "spell_data": { "id": "hive_raptor_spawn", "hit_self": true },
-        "cooldown": 10,
-        "monster_message": "The shadow opens its mouth, and a gore-smeared winged beast flies out of it!"
+        "spell_data": { "id": "gargantuan_raptor_spawn", "hit_self": true },
+        "cooldown": 0,
+        "monster_message": "The shadow opens its mouth, and gore-smeared winged beasts fly out of it!"
       }
     ],
     "anger_triggers": [ "HURT", "PLAYER_CLOSE", "PLAYER_WEAK" ],
-    "death_function": {
-      "effect": { "id": "death_defense_mode_victory", "hit_self": true, "min_level": 1 },
-      "message": "Grapsing at the air, the shadow melts away and vanishes!",
-      "corpse_type": "NO_CORPSE"
-    },
+    "death_function": { "message": "Grapsing at the air, the shadow melts away and vanishes!", "corpse_type": "NO_CORPSE" },
     "flags": [
       "SEES",
       "HEARS",
@@ -417,18 +413,5 @@
     ],
     "//3": "Because it's Defense Mode, you can hurt it with bullets.  Otherwise, It'd be too hard to fight.",
     "armor": { "cut": 25, "stab": 25, "bash": 25, "bullet": 25, "heat": 25, "cold": 25, "electric": 25, "acid": 25 }
-  },
-  {
-    "id": "death_defense_mode_victory",
-    "type": "SPELL",
-    "name": { "str": "Victory Death" },
-    "valid_targets": [ "hostile" ],
-    "description": "Ends the game in a win condition.",
-    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
-    "shape": "blast",
-    "min_range": 100,
-    "max_range": 100,
-    "effect": "effect_on_condition",
-    "effect_str": "DEFENSE_MODE_QUEUE_WIN_SCREEN"
   }
 ]

--- a/data/mods/Defense_Mode/scenarios.json
+++ b/data/mods/Defense_Mode/scenarios.json
@@ -28,6 +28,7 @@
     ],
     "eoc": [ "scenario_defense_mode" ],
     "forced_traits": [ "HAS_NEMESIS" ],
+    "missions": [ "MISSION_DEFENSE_MODE_SURVIVE" ],
     "flags": [ "LONE_START" ],
     "start_name": "Holdout",
     "reveal_locale": false


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Fix and rebalance Defense Mode's final wave."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I noticed that the endgame screen, meant to pop up after killing the Shadow of Reality, was not working. This fixes that. It also came to my attention that the final wave was too easy after the player had built up a base and amassed resources, so I decided to make the shadow fight far more difficult to properly scale with the endgame characters.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
First off, I removed the nonfunctional EOCs which triggered the end game screen and replaced them with a mission, received on the game's start. When completed, the dialogue box will now open properly and lets the player choose to end the game or roll over into Endless Mode.

As for rebalancing, the Shadow of Reality's health has been increased twelvefold from 250 to 3000 (equivalent to 10 beastial mutants), requiring sustained gunfire or large volumes of explosives to kill effectively. Before this, a single burst from a minigun could wipe out the shadow entirely, it now takes five of these to kill it, or two dynamite bombs. Additionally, the shadow can now summon 7-15 raptors at a time with a single attack, instead of the very weak one-at-a-time spawn rate it had before. I have also massively dropped the cooldown timers of all of its attacks, including it's upgrading and resurrection behaviors.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not changing the shadow fight at all, or not buffing it to the current degree. I might move the mission gain to an option in the start menu to support different final bosses, like a Jotunn horde for Xedra Evolved or an ancient dragon for Magiclysm.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I went into the game and played around with the shadow fight. It summoned about 120 minions over 30 minutes time, and two dynamite bombs were able to effectively kill it.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
If I made buffed the final fight too much, please let me know and I'll balance it.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
