### PR TITLE
Give artisan and hub-01's card reader a looks_like

### DIFF
--- a/data/json/furniture_and_terrain/terrain-mechanisms.json
+++ b/data/json/furniture_and_terrain/terrain-mechanisms.json
@@ -271,6 +271,7 @@
   {
     "type": "terrain",
     "id": "t_card_robofac",
+    "looks_like": "t_card_science",
     "name": "card reader",
     "description": "A smartcard reader.  It sports the stylized symbol of an atom inside a flask that is universally known to indicate SCIENCE.  An ominous red LED reminds you of a robot gone haywire from an old sci-fi flick.  You could swipe a scientific ID badge near it if you do not fear the machine.",
     "//": "It takes a science card/hack attempt and then calls iexamine::intercom",
@@ -423,6 +424,7 @@
   {
     "type": "terrain",
     "id": "t_card_artisans",
+    "looks_like": "t_card_science",
     "name": "card reader",
     "description": "A smartcard reader.  A sticky note plastered above it reads 'CO-OP MEMBERS ONLY'.",
     "//": "for the isolated artisans faction",


### PR DESCRIPTION

#### Summary
None

#### Purpose of change

Artisan and hub-01's card reader doesnt have a looks like so i gave it one.

#### Describe the solution
 
Give `"looks_like": "t_card_science",` to artisan and hub-01 card reader.


#### Describe alternatives you've considered

Let someone else do this.

#### Testing

![Screenshot_2023-10-24_05-10-25_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/78019001/60fad98b-5256-4d2d-b174-083437299b5f)
![Screenshot_2023-10-24_05-14-52_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/78019001/df6b29cf-cadb-4053-9332-6982adc4820c)


#### Additional context

