### PR TITLE
Tweaks dirtmound constructions cost

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -8410,7 +8410,7 @@
     "post_terrain": "f_dirtmound_tall",
     "activity_level": "EXTRA_EXERCISE",
     "do_turn_special": "do_turn_shovel",
-    "components": [ [ [ "material_soil", 420 ] ] ]
+    "components": [ [ [ "material_soil", 200 ] ] ]
   },
   {
     "type": "construction",


### PR DESCRIPTION

#### Summary
Balance "Tweaked Tall Dirt Mound Soil Cost"

#### Purpose of change
420 is inconsistent with the dirt mound deconstruction.
#### Describe the solution
Change the dirt mound construction cost from 420 to 200.

#### Describe alternatives you've considered
N/A

#### Testing
Open character, check construction for Build A Dirt Mound, check the build cost.

#### Additional context
N/A