### PR TITLE
Warn on invalid world name

### DIFF
--- a/src/char_validity_check.cpp
+++ b/src/char_validity_check.cpp
@@ -4,9 +4,8 @@
 
 /**
  * Returns whether or not the given (ASCII) character is usable.
- * Called to check player name validity and world name validity.
- * Only printable symbols not reserved by the filesystem are
- * permitted.
+ * Called to check world name validity. Only printable symbols
+ * not reserved by the filesystem are permitted.
  * @param ch The char to check.
  * @return true if the char is allowed in a name, false if not.
  */
@@ -40,7 +39,8 @@ bool is_char_allowed( int ch )
     if( !std::isprint( ch ) ) {
         return false;
     }
-    if( ch == '\\' || ch == '/' ) {
+    if( ch == '\\' || ch == '/' || ch == ':' || ch == '*' || ch == '?' || ch == '"' || ch == '<' ||
+        ch == '>' || ch == '|' ) {
         // not valid in file names
         return false;
     }

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -294,6 +294,7 @@ void worldfactory::set_active_world( WORLD *world )
 bool WORLD::save( const bool is_conversion ) const
 {
     if( !assure_dir_exist( folder_path() ) ) {
+        debugmsg( "Unable to create or open world[%s] directory for saving", world_name );
         DebugLog( D_ERROR, DC_ALL ) << "Unable to create or open world[" << world_name <<
                                     "] directory for saving";
         return false;

--- a/tests/char_validity_check_test.cpp
+++ b/tests/char_validity_check_test.cpp
@@ -11,6 +11,15 @@ TEST_CASE( "char_validity_check" )
     CHECK( is_char_allowed( '\\' ) == false );
     CHECK( is_char_allowed( '/' ) == false );
     CHECK( is_char_allowed( ' ' ) == true );
-    CHECK( is_char_allowed( '?' ) == true );
+    CHECK( is_char_allowed( '?' ) == false );
+    CHECK( is_char_allowed( ':' ) == false );
+    CHECK( is_char_allowed( '*' ) == false );
+    CHECK( is_char_allowed( '"' ) == false );
+    CHECK( is_char_allowed( '<' ) == false );
+    CHECK( is_char_allowed( '>' ) == false );
+    CHECK( is_char_allowed( '|' ) == false );
     CHECK( is_char_allowed( '!' ) == true );
+    CHECK( is_char_allowed( '@' ) == true );
+    CHECK( is_char_allowed( '\'' ) == true );
+    CHECK( is_char_allowed( '[' ) == true );
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Warn on invalid world name"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
On Windows, when the world name is an invalid folder name, the Create World dialog fails without feedback. This PR gives the user feedback in that scenario. Fixes #68793.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
* Completed the list of invalid characters with `:*?"<>|`, so the user is informed when these are in the world name. These characters *are* allowed on other systems, but since the function was already not system-agnostic (disallowing `\`) I figured that was fine. This could be considered a regression on non-Windows systems, or a portability feature.
* If saving the world fails anyway, the error message is displayed to the user instead of silently failing.
* Removed char_validity_check.cpp comment reference to player name -- seems it's only used for validating the world name.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
* Validating the world name by trying to save the world instead of predicting whether a filename is correct.
* Not using the exact world name as save path.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Added `is_char_allowed` test cases. Tried creating worlds with valid and invalid names.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
