### PR TITLE
[MoM] Wakeful Rest revamp

### DIFF
--- a/data/mods/MindOverMatter/powers/vitakinesis.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis.json
@@ -217,44 +217,22 @@
     "type": "SPELL",
     "name": "[Ψ]Wakeful Rest",
     "description": "In lieu of sleep, you can meditate.  As long as you maintain your meditations, you will rarely need to spend a night sleeping.",
-    "message": "You meditate for a while and feel refreshed.",
+    "message": "You begin meditating.",
     "teachable": false,
     "valid_targets": [ "self" ],
     "spell_class": "VITAKINETIC",
     "skill": "metaphysics",
     "flags": [ "CONCENTRATE", "SILENT", "NO_HANDS", "NO_LEGS", "RANDOM_DAMAGE" ],
-    "effect": "recover_energy",
-    "effect_str": "FATIGUE",
-    "extra_effects": [
-      { "id": "vita_no_sleep_dep", "hit_self": true, "max_level": 1 },
-      { "id": "psionic_drained_difficulty_four", "hit_self": true }
-    ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_VITAKIN_SLEEP",
+    "extra_effects": [ { "id": "psionic_drained_difficulty_four", "hit_self": true } ],
     "shape": "blast",
     "difficulty": 4,
     "max_level": { "math": [ "int_to_level(1)" ] },
-    "min_damage": {
-      "math": [ "( (u_val('spell_level', 'spell: vita_sleeping_trance') * 2) + 40) * (scaling_factor(u_val('intelligence') ) )" ]
-    },
-    "max_damage": {
-      "math": [ "( (u_val('spell_level', 'spell: vita_sleeping_trance') * 2) + 150) * (scaling_factor(u_val('intelligence') ) )" ]
-    },
     "energy_source": "STAMINA",
     "base_energy_cost": 1000,
-    "base_casting_time": 360000,
-    "final_casting_time": 90000,
-    "casting_time_increment": -13500,
+    "base_casting_time": 100,
     "learn_spells": { "vita_healing_trance": 9, "vita_blood_purge": 12, "vita_banish_illness": 15 }
-  },
-  {
-    "id": "vita_no_sleep_dep",
-    "type": "SPELL",
-    "name": "[Ψ]Wakeful Rest Remove Sleep Deprivation",
-    "description": "The second part of the Wakeful Rest power, to remove sleep deprivation.",
-    "valid_targets": [ "self" ],
-    "flags": [ "SILENT", "NO_HANDS", "NO_LEGS" ],
-    "effect": "effect_on_condition",
-    "effect_str": "EOC_VITAKIN_SLEEP",
-    "shape": "blast"
   },
   {
     "id": "vita_stop_infection",

--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -25,6 +25,7 @@
     "verb": "meditating",
     "based_on": "time",
     "no_resume": true,
+    "rooted": true,
     "do_turn_eoc": "EOC_VITAKIN_WAKEFUL_REST_MEDITATE"
   },
   {

--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -14,7 +14,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VITAKIN_SLEEP",
-    "condition": { "or": [ { "math": [ "u_val('fatigue')", ">=", "0" ] }, { "math": [ "u_val('sleep_deprivation')", ">=", "0" ] } ] },
+    "condition": { "or": [ { "math": [ "u_val('fatigue')", ">=", "0" ] } ] },
     "effect": [ { "u_assign_activity": "ACT_VITAKIN_WAKEFUL_REST_MEDITATE", "duration": "510 minutes" } ],
     "false_effect": [ { "u_message": "You're feeling refreshed and have no need to meditate.", "type": "mixed" } ]
   },
@@ -51,7 +51,7 @@
         {
           "x_in_y_chance": {
             "x": 1,
-            "y": { "math": [ "80 - (max(u_val('spell_level', 'spell: vita_sleeping_trance'), 25) * 2) - ( u_skill('metaphysics') )" ] }
+            "y": { "math": [ "max( (55 - ( u_val('spell_level', 'spell: vita_sleeping_trance') * 2) - u_skill('metaphysics') ), 15 )" ] }
           }
         }
       ]

--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -14,7 +14,54 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VITAKIN_SLEEP",
-    "effect": [ { "math": [ "u_val('sleep_deprivation')", "-=", "500" ] } ]
+    "condition": { "or": [ { "math": [ "u_val('fatigue')", ">=", "0" ] }, { "math": [ "u_val('sleep_deprivation')", ">=", "0" ] } ] },
+    "effect": [ { "u_assign_activity": "ACT_VITAKIN_WAKEFUL_REST_MEDITATE", "duration": "510 minutes" } ],
+    "false_effect": [ { "u_message": "You're feeling refreshed and have no need to meditate.", "type": "mixed" } ]
+  },
+  {
+    "id": "ACT_VITAKIN_WAKEFUL_REST_MEDITATE",
+    "type": "activity_type",
+    "activity_level": "NO_EXERCISE",
+    "verb": "meditating",
+    "based_on": "time",
+    "no_resume": true,
+    "do_turn_eoc": "EOC_VITAKIN_WAKEFUL_REST_MEDITATE"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VITAKIN_WAKEFUL_REST_MEDITATE",
+    "condition": { "math": [ "u_val('fatigue')", ">=", "0" ] },
+    "effect": [ { "run_eocs": [ "EOC_VITAKIN_SLEEP_FATIGUE", "EOC_VITAKIN_SLEEP_DEPRIVATION" ] } ],
+    "false_effect": [
+      {
+        "u_message": "You are fully refreshed, and can end your meditations now.",
+        "popup": true,
+        "popup_w_interrupt_query": true,
+        "interrupt_type": "eoc"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VITAKIN_SLEEP_FATIGUE",
+    "condition": {
+      "and": [
+        { "math": [ "u_val('fatigue')", ">=", "0" ] },
+        {
+          "x_in_y_chance": {
+            "x": 1,
+            "y": { "math": [ "80 - (max(u_val('spell_level', 'spell: vita_sleeping_trance'), 25) * 2) - ( u_skill('metaphysics') )" ] }
+          }
+        }
+      ]
+    },
+    "effect": [ { "math": [ "u_val('fatigue')", "-=", "1" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VITAKIN_SLEEP_DEPRIVATION",
+    "condition": { "math": [ "u_val('sleep_deprivation')", ">=", "5" ] },
+    "effect": { "math": [ "u_val('sleep_deprivation')", "-=", "1" ] }
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Wakeful Rest revamp"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Wakeful Rest doesn't actually feel like you're meditating, it feels like casting a spell.  Also, having all the benefits come at the end leads to weird behavior and weird design requirements, like how I had to make the duration and effects shorter (requiring four uses per night) so a single failed channel doesn't ruin an entire night of sleep. 

Also, apparently there's no custom player activity with a do_turn_eoc currently in the game, so I can provide an example of one.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Revamp Wakeful Rest so the channel takes one second which then starts a meditation activity. As you meditate, your fatigue and sleep deprivation will gradually go down--sleep deprivation basically immediately (1 point per second), and fatigue with a 1 in ("max( (55 - ( u_val('spell_level', 'spell: vita_sleeping_trance') * 2) - u_skill('metaphysics') ), 15 )") chance per second. This means that a Dead Tired psion with Wakeful Rest level 1 and no metaphysics needs to meditate around 8 hours on average to be fully refreshed, about as much as sleep, but with the benefit of being able to stop at any time and not being bothered by light. A Dead Tired psion with Wakeful Rest 7 and metaphysics 5 needs to meditate about five hours, and a Dead Tired psion with Wakeful Rest 15 and metaphysics 8 needs to meditate about two hours.  Minimum meditation time (at max skill/power level) is about an hour and a half at Dead Tired. Being less tired will cause a correspondingly lower meditation time. Once your fatigue hits 0, you get an informative popup and the chance to end the meditation.

This means that interruptions aren't so bad, since any amount of meditating still has some benefit. It also makes the actual meditation a NO_EXERCISE activity so you recover weariness at the full rate while doing it. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/f9e6695b-b399-4dea-8a59-d1c08fbddabe)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/6d07198b-d6bb-45eb-82f6-6ccfeeb52efc)

However, while ending the meditation works fine, it currently throws the following error message: 
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/9f27afa5-ee01-4ce7-99ee-2f43cfadc120)

It's otherwise ready.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Is there really no u_stop_activity? Apparently not. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
