### PR TITLE
Fix cached dead state

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1869,6 +1869,14 @@ void Character::set_part_hp_cur( const bodypart_id &id, int set )
     Creature::set_part_hp_cur( id, set );
 }
 
+void Character::mod_part_hp_cur( const bodypart_id &id, int set )
+{
+    if( set <= 0 ) {
+        cached_dead_state.reset();
+    }
+    Creature::set_part_hp_cur( id, set );
+}
+
 void Character::on_try_dodge()
 {
     ret_val<void> can_dodge = can_try_doge();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1863,18 +1863,18 @@ bool Character::is_dead_state() const
 
 void Character::set_part_hp_cur( const bodypart_id &id, int set )
 {
-    if( set <= 0 ) {
+    Creature::set_part_hp_cur( id, set );
+    if( get_part_hp_cur( id ) <= 0 ) {
         cached_dead_state.reset();
     }
-    Creature::set_part_hp_cur( id, set );
 }
 
 void Character::mod_part_hp_cur( const bodypart_id &id, int set )
 {
-    if( set <= 0 ) {
+    Creature::mod_part_hp_cur( id, set );
+    if( get_part_hp_cur( id ) <= 0 ) {
         cached_dead_state.reset();
     }
-    Creature::set_part_hp_cur( id, set );
 }
 
 void Character::on_try_dodge()

--- a/src/character.h
+++ b/src/character.h
@@ -1167,6 +1167,7 @@ class Character : public Creature, public visitable
         mutable std::optional<bool> cached_dead_state;
     public:
         void set_part_hp_cur( const bodypart_id &id, int set ) override;
+        void mod_part_hp_cur( const bodypart_id &id, int set ) override;
 
         void calc_all_parts_hp( float hp_mod = 0.0, float hp_adjust = 0.0, int str_max = 0,
                                 int dex_max = 0, int per_max = 0, int int_max = 0, int healthy_mod = 0,

--- a/src/creature.h
+++ b/src/creature.h
@@ -846,7 +846,7 @@ class Creature : public viewer
 
         void set_part_mut_drench( const bodypart_id &id, std::pair<water_tolerance, int> set );
 
-        void mod_part_hp_cur( const bodypart_id &id, int mod );
+        virtual void mod_part_hp_cur( const bodypart_id &id, int mod );
         void mod_part_hp_max( const bodypart_id &id, int mod );
         void mod_part_healed_total( const bodypart_id &id, int mod );
         void mod_part_damage_disinfected( const bodypart_id &id, int mod );


### PR DESCRIPTION
#### Summary
Bugfixes "Fix cached dead state"

#### Purpose of change
The NPC death state check process is sped up by `cached_dead_state`, but some caches may not be discarded at the appropriate time.
This means that even if an NPC is shot with a shotgun and its HP drops to 0, it will not die for a short period of time before the cache is destroyed due to other factors.

#### Describe the solution
The cache will be discarded when an NPC is shot with a shotgun, etc.

#### Describe alternatives you've considered


#### Testing


#### Additional context


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
