### PR TITLE
Lower requirements to use underbarrel gun attachments

### DIFF
--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -425,7 +425,7 @@
       "blackpowder_tolerance": 60,
       "clip_size": 1
     },
-    "min_skills": [ [ "weapon", 2 ], [ "launcher", 1 ] ],
+    "min_skills": [ [ "weapon", 1 ], [ "launcher", 1 ] ],
     "flags": [ "NEVER_JAMS", "RELOAD_EJECT" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "40x46mm": 1 } } ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
@@ -462,7 +462,7 @@
       "blackpowder_tolerance": 60,
       "clip_size": 1
     },
-    "min_skills": [ [ "weapon", 2 ], [ "launcher", 1 ] ],
+    "min_skills": [ [ "weapon", 1 ], [ "launcher", 1 ] ],
     "flags": [ "NEVER_JAMS", "RELOAD_EJECT" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "40x46mm": 1 } } ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
@@ -527,7 +527,7 @@
     "location": "underbarrel",
     "mod_targets": [ "rifle", "crossbow" ],
     "gun_data": { "ammo": "shot", "skill": "shotgun", "dispersion": 330, "durability": 10, "clip_size": 4 },
-    "min_skills": [ [ "weapon", 2 ], [ "shotgun", 1 ] ],
+    "min_skills": [ [ "weapon", 1 ], [ "shotgun", 1 ] ],
     "flags": [ "RELOAD_ONE" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "shot": 4 } } ]
   },
@@ -557,7 +557,7 @@
     "location": "underbarrel",
     "mod_targets": [ "rifle" ],
     "gun_data": { "ammo": "shot", "skill": "shotgun", "dispersion": 310, "durability": 10, "clip_size": 5 },
-    "min_skills": [ [ "weapon", 2 ], [ "shotgun", 1 ] ],
+    "min_skills": [ [ "weapon", 1 ], [ "shotgun", 1 ] ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "m26_mass_mag_3", "m26_mass_mag_5" ] } ]
   },
   {
@@ -592,7 +592,7 @@
       "blackpowder_tolerance": 60,
       "clip_size": 1
     },
-    "min_skills": [ [ "weapon", 2 ], [ "launcher", 1 ] ],
+    "min_skills": [ [ "weapon", 1 ], [ "launcher", 1 ] ],
     "flags": [ "RELOAD_EJECT" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "40x46mm": 1 } } ],
     "faults": [ "fault_gun_blackpowder", "fault_gun_dirt" ]
@@ -613,7 +613,7 @@
     "color": "light_gray",
     "location": "underbarrel",
     "mod_targets": [ "pistol" ],
-    "min_skills": [ [ "weapon", 2 ], [ "melee", 1 ] ],
+    "min_skills": [ [ "weapon", 1 ], [ "melee", 1 ] ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 15 ] ],
     "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
     "flags": [  ],
@@ -666,7 +666,7 @@
     "location": "underbarrel",
     "mod_targets": [ "rifle", "crossbow" ],
     "gun_data": { "ammo": "shot", "skill": "shotgun", "dispersion": 375, "durability": 10, "clip_size": 2 },
-    "min_skills": [ [ "weapon", 2 ], [ "shotgun", 1 ] ],
+    "min_skills": [ [ "weapon", 1 ], [ "shotgun", 1 ] ],
     "flags": [ "RELOAD_ONE" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "shot": 2 } } ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Lower requirements to use underbarrel gun attachments"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #68753

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Made skill requirements match, so "weapon" requirements dropped to 1. This should have minimal impact as the difference between 1 and 2 skill for the modified gun is insignificant. The result would be that if you can install the mod, you can use it too.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Increase the mod's specific requirement to 2, but given the difficulty of skilling up launchers I opted for the other way around. I also don't want to get torched by redditors.

Also implement a system where the requirements to attach the mod and fire the mod are independent of each other, but this was the quicker fix.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
~~TBD. Hoping having two of the "same" requirement defined doesn't break anything.~~

Tested with an M4 and M320 glm. Showed requirement to attach as rifles 1, launchers 1, debug added required skills, was able to attach, then fire the grenade (extremely inaccurately, which is great).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

There is nothing that differentiates skill requirements between being able to use an attachment to mount it on a gun and being able to use it to fire it as an attachment on your gun.

The specific requirements for the underslung grenade launchers, shotguns, and bayonet were [ "weapon", 2 ], [ "launcher/shotgun/melee", 1 ]. This resulted in the ability to attach for example "launchers" at skill 1, but then when using it, "weapon" also refers to launchers which resulted in the requirements ending up now being [weapon (launchers)", 2], ["launcher", 1]. This effectively means that after getting launchers to 1 to install the gunmod, you now need another level before you can actually use it. 

Given our ability to use firearms at 0 skill, I'm assuming this is a quirk of the code rather than an intended gameplay challenge to overcome.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
