### PR TITLE
Allow scanning several books into ereader at once

### DIFF
--- a/data/json/item_actions.json
+++ b/data/json/item_actions.json
@@ -446,7 +446,7 @@
   {
     "type": "item_action",
     "id": "EBOOKSAVE",
-    "name": { "str": "Store a book" }
+    "name": { "str": "Store books" }
   },
   {
     "type": "item_action",

--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -30,7 +30,7 @@
     "type": "activity_type",
     "id": "ACT_EBOOKSAVE",
     "activity_level": "NO_EXERCISE",
-    "verb": "taking pictures of the book",
+    "verb": "taking pictures of books",
     "rooted": true,
     "based_on": "speed",
     "auto_needs": true

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2655,21 +2655,61 @@ std::unique_ptr<activity_actor> lockpick_activity_actor::deserialize( JsonValue 
     return actor.clone();
 }
 
+int ebooksave_activity_actor::total_pages(
+    const std::vector<item_location> &books )
+{
+    int pages = 0;
+    for( const item_location &book : books ) {
+        pages += pages_in_book( book->typeId() );
+    }
+    return pages;
+}
+
+time_duration ebooksave_activity_actor::required_time(
+    const std::vector<item_location> &books )
+{
+    return total_pages( books ) * time_per_page;
+}
+
+int ebooksave_activity_actor::required_charges(
+    const std::vector<item_location> &books,
+    const item_location &ereader )
+{
+    const int charges = total_pages( books ) / pages_per_charge;
+    return charges * ereader->ammo_required();
+}
+
+void ebooksave_activity_actor::start_scanning_next_book( player_activity &act )
+{
+    while( !books.empty() && !books.back() ) {
+        add_msg_debug( debugmode::DF_ACT_EBOOK, "Skipping unavailable book at %s",
+                       books.back().describe() );
+        books.pop_back();
+    }
+    if( books.empty() ) {
+        act.moves_left = 0;
+        return;
+    }
+    const item_location &current_book = books.back();
+    const int pages_in_current_book = pages_in_book( current_book->typeId() );
+    turns_left_on_current_book = to_turns<int>( pages_in_current_book * time_per_page );
+    act.moves_left = to_moves<int>( required_time( books ) );
+}
+
+
 void ebooksave_activity_actor::start( player_activity &act, Character &/*who*/ )
 {
-    const int pages = pages_in_book( book->typeId() );
-    const time_duration scanning_time = pages < 1 ? time_per_page : pages * time_per_page;
-    add_msg_debug( debugmode::DF_ACT_EBOOK, "ebooksave pages = %d", pages );
+    const time_duration scanning_time = required_time( books );
     add_msg_debug( debugmode::DF_ACT_EBOOK, "scanning_time time = %s",
                    to_string_writable( scanning_time ) );
     act.moves_total = to_moves<int>( scanning_time );
-    act.moves_left = act.moves_total;
+    start_scanning_next_book( act );
 }
 
-void ebooksave_activity_actor::do_turn( player_activity &/*act*/, Character &who )
+void ebooksave_activity_actor::do_turn( player_activity &act, Character &who )
 {
     // only consume charges every 25 pages
-    if( calendar::once_every( 25 * time_per_page ) ) {
+    if( calendar::once_every( pages_per_charge * time_per_page ) ) {
         if( !ereader->ammo_sufficient( &who ) ) {
             add_msg_if_player_sees(
                 who,
@@ -2682,19 +2722,49 @@ void ebooksave_activity_actor::do_turn( player_activity &/*act*/, Character &who
 
         ereader->ammo_consume( ereader->ammo_required(), who.pos(), &who );
     }
+
+    turns_left_on_current_book--;
+    if( turns_left_on_current_book > 0 ) {
+        return; // not fully scanned yet
+    }
+
+    // We have now spent enough time to fully scan current book
+    item_location scanned_book = books.back();
+    books.pop_back();
+    if( scanned_book ) {
+        ereader->put_in( *scanned_book, item_pocket::pocket_type::EBOOK );
+        if( who.is_avatar() ) {
+            if( !who.has_identified( scanned_book->typeId() ) ) {
+                who.identify( *scanned_book );
+            }
+        }
+        handled_books++;
+    } else {
+        add_msg_debug( debugmode::DF_ACT_EBOOK,
+                       "Spent time to scan book at %s, but it is no longer available?",
+                       scanned_book.describe() );
+    }
+    start_scanning_next_book( act );
 }
 
 void ebooksave_activity_actor::finish( player_activity &act, Character &who )
 {
-    item book_copy = *book;
-    ereader->put_in( book_copy, item_pocket::pocket_type::EBOOK );
     if( who.is_avatar() ) {
-        if( !who.has_identified( book->typeId() ) ) {
-            who.identify( *book );
-        }
-        add_msg( m_info, _( "You scan the book into your device." ) );
+        add_msg( m_info, _( "You scan %d %s into your device." ), handled_books,
+                 n_gettext( "book", "books", handled_books ) );
     } else { // who.is_npc()
-        add_msg_if_player_sees( who, _( "%s scans the book into their device." ),
+        add_msg_if_player_sees( who, _( "%s scans %d %s into their device." ),
+                                who.disp_name( false, true ), handled_books, n_gettext( "book", "books", handled_books ) );
+    }
+    act.set_to_null();
+}
+
+void ebooksave_activity_actor::canceled( player_activity &act, Character &who )
+{
+    if( who.is_avatar() ) {
+        add_msg( m_info, _( "You stop scanning the remaining books." ) );
+    } else { // who.is_npc()
+        add_msg_if_player_sees( who, _( "%s stops scanning books." ),
                                 who.disp_name( false, true ) );
     }
     act.set_to_null();
@@ -2703,8 +2773,10 @@ void ebooksave_activity_actor::finish( player_activity &act, Character &who )
 void ebooksave_activity_actor::serialize( JsonOut &jsout ) const
 {
     jsout.start_object();
-    jsout.member( "book", book );
+    jsout.member( "books", books );
     jsout.member( "ereader", ereader );
+    jsout.member( "handled_books", handled_books );
+    jsout.member( "turns_left_on_current_book", turns_left_on_current_book );
     jsout.end_object();
 }
 
@@ -2713,8 +2785,16 @@ std::unique_ptr<activity_actor> ebooksave_activity_actor::deserialize( JsonValue
     ebooksave_activity_actor actor = ebooksave_activity_actor( {}, {} );
 
     JsonObject data = jsin.get_object();
-    data.read( "book", actor.book );
+    data.read( "books", actor.books );
+    if( data.has_member( "book" ) ) {
+        // legacy compatibility: in 0.G, this activity only handled one book each
+        item_location book;
+        data.read( "book", book );
+        actor.books.push_back( book );
+    }
     data.read( "ereader", actor.ereader );
+    data.read( "handled_books", actor.handled_books );
+    data.read( "turns_left_on_current_book", actor.turns_left_on_current_book );
     return actor.clone();
 }
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -629,8 +629,9 @@ class lockpick_activity_actor : public activity_actor
 class ebooksave_activity_actor : public activity_actor
 {
     public:
-        explicit ebooksave_activity_actor( const item_location &book, const item_location &ereader ) :
-            book( book ), ereader( ereader ) {};
+        explicit ebooksave_activity_actor( const std::vector<item_location> &books,
+                                           const item_location &ereader ) :
+            books( books ), ereader( ereader ) {};
 
         activity_id get_type() const override {
             return activity_id( "ACT_EBOOKSAVE" );
@@ -638,12 +639,17 @@ class ebooksave_activity_actor : public activity_actor
 
         static int pages_in_book( const itype_id &book ) {
             // an A4 sheet weights roughly 5 grams
-            return units::to_gram( book->weight ) / 5;
+            return std::max( 1, static_cast<int>( units::to_gram( book->weight ) / 5 ) );
         };
+        static int total_pages( const std::vector<item_location> &books );
+        static time_duration required_time( const std::vector<item_location> &books );
+        static int required_charges( const std::vector<item_location> &books,
+                                     const item_location &ereader );
 
         void start( player_activity &act, Character &/*who*/ ) override;
-        void do_turn( player_activity &/*act*/, Character &who ) override;
+        void do_turn( player_activity &act, Character &who ) override;
         void finish( player_activity &act, Character &who ) override;
+        void canceled( player_activity &act, Character &who ) override;
 
         std::unique_ptr<activity_actor> clone() const override {
             return std::make_unique<ebooksave_activity_actor>( *this );
@@ -653,16 +659,22 @@ class ebooksave_activity_actor : public activity_actor
         static std::unique_ptr<activity_actor> deserialize( JsonValue &jsin );
 
     private:
-        item_location book;
+        /**
+         * All remaining books left to scan.
+         * After a book is fully scanned to ereader, this list is modified so that the scanned book is removed from here.
+        */
+        std::vector<item_location> books;
         item_location ereader;
-        static constexpr time_duration time_per_page = 5_seconds;
+        /** How many books this activity has scanned to ereader so far. */
+        int handled_books = 0;
+        /** How much time is left on this book until it is fully scanned and we can move on to the next book. */
+        int turns_left_on_current_book = 0;
 
-        bool can_resume_with_internal( const activity_actor &other,
-                                       const Character &/*who*/ ) const override {
-            const ebooksave_activity_actor &actor = static_cast<const ebooksave_activity_actor &>
-                                                    ( other );
-            return actor.book == book && actor.ereader == ereader;
-        }
+        static constexpr time_duration time_per_page = 5_seconds;
+        // Every 25 pages requires one charge of the ereader
+        static constexpr int pages_per_charge = 25;
+
+        void start_scanning_next_book( player_activity &act );
 };
 
 class migration_cancel_activity_actor : public activity_actor

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1518,6 +1518,63 @@ item_location game_menus::inv::ebookread( Character &you, item_location &ereader
     return location;
 }
 
+drop_locations game_menus::inv::ebooksave( Character &who, item_location &ereader )
+{
+    std::set<itype_id> already_saved;
+    for( const item *ebook : ereader->ebooks() ) {
+        if( !ebook->is_book() ) {
+            debugmsg( "ebook type pocket contains non-book item %s", ebook->typeId().str() );
+            continue;
+        }
+
+        already_saved.insert( ebook->typeId() );
+    }
+    const inventory_filter_preset preset( [&who, &already_saved]( const item_location & loc ) {
+        return loc->is_book()
+               && loc->type->book->is_scannable
+               && !already_saved.count( loc->typeId() )
+               && loc->is_owned_by( who, true );
+    } );
+
+    const int available_charges = ereader->ammo_remaining();
+    auto make_raw_stats = [&available_charges, &ereader](
+                              const std::vector<std::pair<item_location, int>> &locs
+    ) {
+        std::vector<item_location> books;
+        books.reserve( locs.size() );
+        for( const auto &pair : locs ) {
+            books.push_back( pair.first );
+        }
+        const int required_charges = ebooksave_activity_actor::required_charges( books, ereader );
+        const time_duration required_time = ebooksave_activity_actor::required_time( books );
+        auto int_to_str = []( int val ) -> std::string {
+            return string_format( "%d", val );
+        };
+        const std::string charges = string_join( display_stat( "", required_charges,
+                                    available_charges,
+                                    int_to_str ), "" );
+        const std::string time = colorize( to_string( required_time, true ),
+                                           c_light_gray );
+        using stats = inventory_selector::stats;
+        return stats{{
+                {{ _( "Charges" ), charges }},
+                {{ _( "Estimated time" ), time }}
+            }};
+    };
+
+    inventory_multiselector inv_s( who, preset, _( "SELECT BOOKS TO SCAN" ),
+                                   make_raw_stats, /*allow_select_contained=*/true );
+    inv_s.set_invlet_type( inventory_selector::SELECTOR_INVLET_ALPHA );
+    inv_s.add_character_items( who );
+    inv_s.add_nearby_items( PICKUP_RANGE );
+    inv_s.set_title( _( "Scan which books?" ) );
+    if( inv_s.empty() ) {
+        popup( std::string( _( "You have no books to scan." ) ), PF_GET_KEY );
+        return drop_locations();
+    }
+    return inv_s.execute();
+}
+
 class steal_inventory_preset : public pickup_inventory_preset
 {
     public:

--- a/src/game_inventory.h
+++ b/src/game_inventory.h
@@ -117,6 +117,8 @@ item_location read( Character &you );
 item_location ereader_to_use( Character &you );
 /** eBook reading menu. */
 item_location ebookread( Character &you, item_location &ereader );
+/** Select books to save to E-Book reader menu. */
+drop_locations ebooksave( Character &who, item_location &ereader );
 /** Menu for stealing stuff. */
 item_location steal( avatar &you, Character &victim );
 /** Item activation menu. */

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8859,30 +8859,16 @@ std::optional<int> iuse::ebooksave( Character *p, item *it, const tripoint & )
         return std::nullopt;
     }
 
-    std::set<itype_id> ebooks;
-    for( const item *ebook : it->ebooks() ) {
-        if( !ebook->is_book() ) {
-            debugmsg( "ebook type pocket contains non-book item %s", ebook->typeId().str() );
-            continue;
-        }
-
-        ebooks.insert( ebook->typeId() );
-    }
-
-    const item_location book = game_menus::inv::titled_filter_menu(
-    [&ebooks, &p]( const item & itm ) {
-        return itm.is_book() && itm.type->book->is_scannable && !ebooks.count( itm.typeId() ) &&
-               itm.is_owned_by( *p, true );
-    },
-    *p->as_avatar(), _( "Scan which book?" ), PICKUP_RANGE );
-
-    if( !book ) {
-        p->add_msg_if_player( m_info, _( "Nevermind." ) );
+    item_location ereader = item_location( *p, it );
+    const drop_locations to_scan = game_menus::inv::ebooksave( *p, ereader );
+    if( to_scan.empty() ) {
         return std::nullopt;
     }
-
-    p->assign_activity( ebooksave_activity_actor( book, item_location( *p, it ) ) );
-
+    std::vector<item_location> books;
+    for( const auto &pair : to_scan ) {
+        books.push_back( pair.first );
+    }
+    p->assign_activity( ebooksave_activity_actor( books, ereader ) );
     return std::nullopt;
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Allow scanning several books into ereader at once"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Adds the ability to select multiple books to scan into e-book reader, and not just one book as before.
* Fixes #67886 .

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

* Updates `ebooksave_activity_actor` so that it stores a `std::vector<item_location>` of books that should be scanned, instead of just holding a reference to one book `item_location`.
* Reuses existing `inventory_multiselector` for selecting books.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* This solution pops the last elements from `std::vector` when they are fully scanned. Another way would be to just keep an index on "which book are we currently scanning?", and not modifying the list as the activity runs.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

![scan-multiple-books](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/547b4b13-a6ea-4577-85d4-5f892a0efbf2)

* Tried reading books from inventory - works ✔
* Placed some books on the pavement - they are also shown when selecting which books to scan ✔
* Set fire to the pile of books on the pavement, so that they will disappear "soon". Started scanning all books - works as expected that only some of the books were scanned (the first ones that hadn't burned up yet) ✔
* Cancelling the activity with `5` while scanning - works ✔

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
