### PR TITLE
Update required kevlar of the Steel Kevlar Jumpsuit

### DIFF
--- a/data/json/items/armor/bespoke_armor/custom_bodysuits.json
+++ b/data/json/items/armor/bespoke_armor/custom_bodysuits.json
@@ -280,7 +280,7 @@
     "category": "armor",
     "name": { "str": "steel-plated Kevlar jumpsuit" },
     "description": "A hand-built combination armor made of thick Kevlar with a moisture-wicking core and thin steel plating in many places.  Protects from the elements as well as from harm.",
-    "weight": "16200 g",
+    "weight": "9500 g",
     "volume": "12 L",
     "price": 200000,
     "price_postapoc": 7000,

--- a/data/json/recipes/armor/suit.json
+++ b/data/json/recipes/armor/suit.json
@@ -1894,7 +1894,7 @@
     "time": "20 h",
     "autolearn": true,
     "using": [
-      [ "tailoring_kevlar_fabric", 370 ],
+      [ "tailoring_kevlar_fabric", 160 ],
       [ "blacksmithing_standard", 12 ],
       [ "mc_steel_standard", 3 ],
       [ "fabric_lycra", 20 ],
@@ -1920,7 +1920,7 @@
       [ [ "metal_tank", -1 ] ],
       [ [ "water", -240 ], [ "water_clean", -240 ] ]
     ],
-    "byproducts": [ [ "scrap_kevlar", 37 ], [ "scrap_lycra", 5 ] ]
+    "byproducts": [ [ "scrap_kevlar", 20 ], [ "scrap_lycra", 5 ] ]
   },
   {
     "result": "xs_hsurvivor_jumpsuit",
@@ -1928,7 +1928,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "copy-from": "hsurvivor_jumpsuit",
     "using": [
-      [ "tailoring_kevlar_fabric", 259 ],
+      [ "tailoring_kevlar_fabric", 112 ],
       [ "blacksmithing_standard", 8 ],
       [ "mc_steel_standard", 2 ],
       [ "fabric_lycra", 15 ],
@@ -1951,7 +1951,7 @@
     "copy-from": "hsurvivor_jumpsuit",
     "time": "23 h",
     "using": [
-      [ "tailoring_kevlar_fabric", 555 ],
+      [ "tailoring_kevlar_fabric", 240 ],
       [ "blacksmithing_standard", 20 ],
       [ "mc_steel_standard", 5 ],
       [ "fabric_lycra", 30 ],


### PR DESCRIPTION
#### Summary
Balance "Update the required Kevlar of the Steel Kevlar jumpsuit in accordance with its thickness"

#### Purpose of change
I wasn't exactly satisfied with the required Kevlar I gave to the item in #68768, and I finally got around to calculate how much it should actually need.

#### Describe the solution
The "light Kevlar jumpsuit", an item with a somewhat lesser Kevlar thickness than the steel plated (2mm between its two layers, taken as equivalent of 1.9mm because of lesser coverage), requires 130 Kevlar sheets, so I just calculated the necessary Kevlar for such an item to have 2.3mm like the steel-plated kevlar jumpsuit has (2.3/1.9 = 1.21~, 130 sheets x 1.21 = 157.3), and rounded it up to 160 sheets for good measure.

The weight of the item was greatly changed too, since it no longer believes itself to be a monstrosity made of kevlar sheets, I adjusted its weight accordingly just by roughly adding together the weight of its components (ignoring the thread and the byproducts), it stills weighs more than the standard kevlar jumpsuit, but it should be easier to carry than before.

#### Describe alternatives you've considered
I did not touch the time it takes to craft the item since I do not know what proportion of that time is considered to be spent on stitching the Kevlar sheets, rather than the lycra/syntethic fabric or the time spent with the steel-plating of the item.

#### Testing
None, simple numbers change.

#### Additional context
