### PR TITLE
More stockings variants

### DIFF
--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -2902,6 +2902,54 @@
         "weight": 75,
         "color": "blue",
         "append": true
+      },
+            {
+        "id": "stockings_pride_genderqueer",
+        "name": { "str": "pair of genderqueer flag stockings", "str_pl": "pairs of genderqueer flag stockings" },
+        "description": "This one has patterns akin to the genderqueer flag.",
+        "weight": 55,
+        "color": "magenta",
+        "append": true
+      },
+      {
+        "id": "stockings_pride_genderfluid",
+        "name": { "str": "pair of genderfluid flag stockings", "str_pl": "pairs of genderfluid flag stockings" },
+        "description": "This one has patterns akin to the genderfluid flag.",
+        "weight": 45,
+        "color": "magenta",
+        "append": true
+      },
+      {
+        "id": "stockings_pride_agender",
+        "name": { "str": "pair of agender flag stockings", "str_pl": "pairs of agender flag stockings" },
+        "description": "This one has patterns akin to the agender flag.",
+        "weight": 45,
+        "color": "dark_gray",
+        "append": true
+      },
+      {
+        "id": "stockings_pride_nonbinary",
+        "name": { "str": "pair of non-binary flag stockings", "str_pl": "pairs of non-binary flag stockings" },
+        "description": "This one has patterns akin to the non-binary flag.",
+        "weight": 75,
+        "color": "yellow",
+        "append": true
+      },
+      {
+        "id": "stockings_pride_intersex",
+        "name": { "str": "pair of intersex flag stockings", "str_pl": "pairs of intersex flag stockings" },
+        "description": "This one has patterns akin to the intersex flag.",
+        "weight": 55,
+        "color": "yellow",
+        "append": true
+      },
+      {
+        "id": "stockings_pride_polysexual",
+        "name": { "str": "pair of polysexual flag stockings", "str_pl": "pairs of polysexual flag stockings" },
+        "description": "This one has patterns akin to the polysexual flag.",
+        "weight": 25,
+        "color": "green",
+        "append": true
       }
     ]
   },

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -2903,7 +2903,7 @@
         "color": "blue",
         "append": true
       },
-            {
+      {
         "id": "stockings_pride_genderqueer",
         "name": { "str": "pair of genderqueer flag stockings", "str_pl": "pairs of genderqueer flag stockings" },
         "description": "This one has patterns akin to the genderqueer flag.",


### PR DESCRIPTION


#### Summary
Content "Adds more of the pride stockings variants that i forgot"


#### Purpose of change

Adds more of the pride stockings i forgot to add because i got distracted somewhere.

#### Describe the solution

adds genderqueer, genderfluid, agender, non-binary, intersex, and polysexual stockings variants.
#### Describe alternatives you've considered

let someone else add this.
#### Testing

![Screenshot_2023-10-25_04-35-07_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/78019001/135c6b6b-ca80-48f0-b41f-8996e80a5ad2)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
