### PR TITLE
Tailoring practice update

### DIFF
--- a/data/json/recipes/practice/tailoring.json
+++ b/data/json/recipes/practice/tailoring.json
@@ -16,7 +16,31 @@
     "practice_data": { "min_difficulty": 0, "max_difficulty": 1, "skill_limit": 2 },
     "autolearn": [ [ "tailor", 0 ] ],
     "using": [ [ "tailoring_wool_knitting", 40 ] ],
-    "//": "Should give a morale bonus at completion or at the very least a byproduct called knitted art that you could use to gain some morale."
+    "result_eocs": [
+      {
+        "id": "EOC_KNITTING_MORALE",
+        "condition": { "math": [ "u_skill('tailor')", ">=", "3" ] },
+        "effect": [
+          {
+            "u_message": "You admire your designs and find happiness in your advancements in the field of knitting.",
+            "type": "good"
+          },
+          {
+            "u_add_morale": "morale_feeling_good",
+            "bonus": 10,
+            "max_bonus": 20,
+            "duration": "60 minutes",
+            "decay_start": "60 minutes"
+          }
+        ],
+        "false_effect": [
+          {
+            "u_message": "You contemplate your designs but fail to see any artistic value in them.  At least you learnt something.",
+            "type": "mixed"
+          }
+        ]
+      }
+    ]
   },
   {
     "id": "prac_closures",
@@ -32,7 +56,7 @@
     "practice_data": { "min_difficulty": 1, "max_difficulty": 2, "skill_limit": 3 },
     "autolearn": [ [ "tailor", 2 ] ],
     "book_learn": [ [ "mag_tailor", 1 ], [ "manual_tailor", 1 ] ],
-    "components": [ [ [ "sheet_cotton", 1 ], [ "sheet_cotton_patchwork", 1 ], [ "cotton_patchwork", 1 ], [ "scrap_cotton", 2 ] ] ],
+    "components": [ [ [ "sheet_cotton", 1 ], [ "sheet_cotton_patchwork", 1 ], [ "cotton_patchwork", 4 ], [ "scrap_cotton", 8 ] ] ],
     "using": [ [ "sewing_standard", 10 ], [ "fastener_small", 2 ] ]
   },
   {
@@ -42,7 +66,7 @@
     "category": "CC_PRACTICE",
     "subcategory": "CSC_PRACTICE_TAILORING",
     "name": "fabric waterproofing",
-    "description": "Practice the principles of sealing garments and fabric against water by making a basic waterproof layer from plastic bags duct taped together, you will need some water and a rag.",
+    "description": "Practice the principles of sealing garments and fabric against water by making a basic waterproof layer from plastic sheets duct taped together, you will need some water and a rag.",
     "skill_used": "tailor",
     "proficiencies": [ { "proficiency": "prof_closures_waterproofing", "time_multiplier": 1, "skill_penalty": 0 } ],
     "time": "1 h",
@@ -68,7 +92,16 @@
     "autolearn": [ [ "tailor", 2 ] ],
     "book_learn": [ [ "mag_tailor", 1 ], [ "manual_tailor", 1 ] ],
     "components": [
-      [ [ "sheet_kevlar", 1 ], [ "sheet_nomex", 1 ], [ "sheet_nomex_patchwork", 1 ], [ "nomex", 8 ], [ "scrap_nomex", 12 ] ]
+      [
+        [ "sheet_kevlar", 1 ],
+        [ "sheet_kevlar_patchwork", 1 ],
+        [ "kevlar_patch", 6 ],
+        [ "scrap_kevlar", 20 ],
+        [ "sheet_nomex", 1 ],
+        [ "sheet_nomex_patchwork", 1 ],
+        [ "nomex", 6 ],
+        [ "scrap_nomex", 20 ]
+      ]
     ],
     "using": [ [ "sewing_aramids", 20 ] ]
   },
@@ -86,7 +119,7 @@
     "practice_data": { "min_difficulty": 1, "max_difficulty": 2, "skill_limit": 3 },
     "autolearn": [ [ "tailor", 2 ] ],
     "book_learn": [ [ "mag_tailor", 1 ], [ "manual_tailor", 1 ] ],
-    "components": [ [ [ "sheet_lycra", 1 ], [ "sheet_lycra_patchwork", 1 ], [ "lycra_patch", 2 ] ] ],
+    "components": [ [ [ "sheet_lycra", 1 ], [ "sheet_lycra_patchwork", 1 ], [ "lycra_patch", 6 ] ] ],
     "using": [ [ "sewing_standard", 20 ] ],
     "byproducts": [ [ "scrap_lycra", 6 ] ]
   },
@@ -163,7 +196,7 @@
     "practice_data": { "min_difficulty": 3, "max_difficulty": 4, "skill_limit": 5 },
     "autolearn": [ [ "tailor", 4 ] ],
     "book_learn": [ [ "textbook_tailor", 3 ] ],
-    "components": [ [ [ "gloves_light", 1 ] ] ],
+    "components": [ [ [ "gloves_light", 1 ], [ "gloves_liner", 1 ], [ "long_glove_white", 1 ] ] ],
     "using": [ [ "tailoring_cotton_patchwork", 8 ], [ "filament", 30 ] ]
   }
 ]


### PR DESCRIPTION
#### Summary
Balance "Updates some tailoring practice recipes for new components or mechanics"

#### Purpose of change
The tailoring practice recipes are somewhat old, so they had some oversights with the current division of tailoring materials, and the knitting practice finally could make use of EoCs for recipes for a little morale bonus.

#### Describe the solution
Updates some recipes to make use of more components or adjusting their required numbers, for example you can now practice advanced polymer sewing with patchwork kevlar sheets or kevlar patches rather than only with a pristine kevlar sheet, you are practicing after all, not trying to craft something actually useful.

The knitting practice recipe can now give you a little morale bonus when finishing it! Feel the power of grandma knitting designs!

#### Describe alternatives you've considered

#### Testing
It loads! The EoC works fine and the recipes seem fine too.

#### Additional context
![imagen](https://github.com/CleverRaven/Cataclysm-DDA/assets/53200489/7b3aef42-be4c-4dea-98cc-2b72d6da4829)
![imagen](https://github.com/CleverRaven/Cataclysm-DDA/assets/53200489/be7b8ae1-f77b-4259-bbab-693ee48dc8aa)

