### PR TITLE
Add the throwing axe to the HAND_AXES category

### DIFF
--- a/data/json/items/ranged/throwing.json
+++ b/data/json/items/ranged/throwing.json
@@ -116,6 +116,7 @@
     "volume": "750 ml",
     "weight": "792 g",
     "to_hit": -1,
+    "weapon_category": [ "HAND_AXES" ],
     "thrown_damage": [ { "damage_type": "bash", "amount": 6 }, { "damage_type": "cut", "amount": 16 } ],
     "melee_damage": { "bash": 10, "cut": 17 }
   },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The throwing axe was not a member of the HAND_AXES weapon category, even though its a hatchet as per the description.

#### Describe the solution
Adds the item to the weapon category.

#### Describe alternatives you've considered

#### Testing

#### Additional context
I didn't remember that this category existed, in part because this is a category currently only used for the MMA mod martial arts.
