### PR TITLE
Tamable Wildlife: Lady Bugs and Mole Crickets

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -34,6 +34,8 @@ files:
     - ZhilkinSerg
   'data/mods/No_Hope/**':
     - Night-Pryanik
+  'data/mods/Tamable_Wildlife/**':
+    - Termineitor244
 
   '**/.clang-tidy':
     - jbytheway

--- a/data/mods/Tamable_Wildlife/insect_spider.json
+++ b/data/mods/Tamable_Wildlife/insect_spider.json
@@ -248,13 +248,6 @@
     "extend": { "flags": [ "CANPLAY" ] }
   },
   {
-    "id": "mon_lady_bug",
-    "type": "MONSTER",
-    "copy-from": "mon_lady_bug",
-    "name": { "str": "lady bug" },
-    "extend": { "flags": [ "CANPLAY", "PET_MOUNTABLE" ] }
-  },
-  {
     "id": "mon_lady_bug_giant",
     "type": "MONSTER",
     "copy-from": "mon_lady_bug_giant",
@@ -262,7 +255,7 @@
     "extend": { "flags": [ "CANPLAY", "PET_MOUNTABLE" ] }
   },
   {
-    "id": "mon_lady_bug_larva",
+    "id": "mon_lady_bug_larva_friendly",
     "type": "MONSTER",
     "copy-from": "mon_lady_bug_larva",
     "name": { "str": "ladybug larva", "str_pl": "ladybug larvae" },

--- a/data/mods/Tamable_Wildlife/insect_spider.json
+++ b/data/mods/Tamable_Wildlife/insect_spider.json
@@ -229,6 +229,51 @@
     "extend": { "flags": [ "CANPLAY", "PET_MOUNTABLE" ] }
   },
   {
+    "id": "mon_mole_cricket",
+    "type": "MONSTER",
+    "copy-from": "mon_mole_cricket",
+    "name": { "str": "giant mole cricket" },
+    "extend": { "flags": [ "CANPLAY", "PET_MOUNTABLE" ] }
+  },
+  {
+    "id": "mon_mole_cricket_nymph",
+    "type": "MONSTER",
+    "copy-from": "mon_mole_cricket_nymph",
+    "name": { "str": "mole cricket nymph" },
+    "petfood": {
+      "food": [ "BUGFOOD" ],
+      "feed": "The %s seems to… uhh, like you?  Well, as certainly as you could tell a giant bug could like you.  It skitters around your legs and seems friendly.",
+      "pet": "The %s skitters around your feet."
+    },
+    "extend": { "flags": [ "CANPLAY" ] }
+  },
+  {
+    "id": "mon_lady_bug",
+    "type": "MONSTER",
+    "copy-from": "mon_lady_bug",
+    "name": { "str": "lady bug" },
+    "extend": { "flags": [ "CANPLAY", "PET_MOUNTABLE" ] }
+  },
+  {
+    "id": "mon_lady_bug_giant",
+    "type": "MONSTER",
+    "copy-from": "mon_lady_bug_giant",
+    "name": { "str": "giant lady bug" },
+    "extend": { "flags": [ "CANPLAY", "PET_MOUNTABLE" ] }
+  },
+  {
+    "id": "mon_lady_bug_larva",
+    "type": "MONSTER",
+    "copy-from": "mon_lady_bug_larva",
+    "name": { "str": "ladybug larva", "str_pl": "ladybug larvae" },
+    "petfood": {
+      "food": [ "BUGFOOD" ],
+      "feed": "The %s seems to… uhh, like you?  Well, as certainly as you could tell a giant bug could like you.  It crawls around your legs and seems friendly.",
+      "pet": "The %s crawls around your feet."
+    },
+    "extend": { "flags": [ "CANPLAY" ] }
+  },
+  {
     "id": "mon_grasshopper_nymph",
     "type": "MONSTER",
     "copy-from": "mon_grasshopper_nymph",

--- a/data/mods/Tamable_Wildlife/items/comestibles/eggs.json
+++ b/data/mods/Tamable_Wildlife/items/comestibles/eggs.json
@@ -17,6 +17,14 @@
   },
   {
     "type": "COMESTIBLE",
+    "id": "egg_lady_bug_tame",
+    "name": { "str": "tame ladybug egg" },
+    "copy-from": "egg_lady_bug",
+    "description": "A ladybug egg. You can see a translucent, happy looking larva inside.  This one has been carefully tended for.  The larva inside seems more timid and calmer upon touch.",
+    "rot_spawn": "GROUP_EGG_LADY_BUG_TAME"
+  },
+  {
+    "type": "COMESTIBLE",
     "id": "egg_antlion_tame",
     "name": { "str": "tame antlion egg" },
     "copy-from": "egg_antlion",

--- a/data/mods/Tamable_Wildlife/items/comestibles/eggs.json
+++ b/data/mods/Tamable_Wildlife/items/comestibles/eggs.json
@@ -20,7 +20,7 @@
     "id": "egg_lady_bug_tame",
     "name": { "str": "tame ladybug egg" },
     "copy-from": "egg_lady_bug",
-    "description": "A ladybug egg. You can see a translucent, happy looking larva inside.  This one has been carefully tended for.  The larva inside seems more timid and calmer upon touch.",
+    "description": "A ladybug egg.  You can see a translucent, happy looking larva inside.  This one has been carefully tended for.  The larva inside seems more timid and calmer upon touch.",
     "rot_spawn": "GROUP_EGG_LADY_BUG_TAME"
   },
   {

--- a/data/mods/Tamable_Wildlife/monstergroups/eggs.json
+++ b/data/mods/Tamable_Wildlife/monstergroups/eggs.json
@@ -10,6 +10,11 @@
     "monsters": [ { "monster": "mon_mantis_nymph_friendly" } ]
   },
   {
+    "name": "GROUP_EGG_LADY_BUG_TAME",
+    "type": "monstergroup",
+    "monsters": [ { "monster": "mon_lady_bug_larva_friendly" } ]
+  },
+  {
     "name": "GROUP_EGG_ANTLION_TAME",
     "type": "monstergroup",
     "monsters": [ { "monster": "mon_antlion_larva_friendly" } ]

--- a/data/mods/Tamable_Wildlife/recipes/nested.json
+++ b/data/mods/Tamable_Wildlife/recipes/nested.json
@@ -11,6 +11,7 @@
     "nested_category_data": [
       "egg_dragonfly_tame",
       "egg_mantis_tame",
+      "egg_lady_bug_tame",
       "egg_antlion_tame",
       "egg_cicada_tame",
       "egg_water_beetle_tame",

--- a/data/mods/Tamable_Wildlife/recipes/recipe_egg.json
+++ b/data/mods/Tamable_Wildlife/recipes/recipe_egg.json
@@ -24,6 +24,18 @@
     "components": [ [ [ "egg_mantis", 1 ] ], [ [ "sweet_goop", 10 ] ] ]
   },
   {
+    "result": "egg_lady_bug_tame",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "survival",
+    "difficulty": 5,
+    "time": "15 m",
+    "autolearn": true,
+    "components": [ [ [ "egg_lady_bug", 1 ] ], [ [ "sweet_goop", 10 ] ] ]
+  },
+  {
     "result": "egg_antlion_tame",
     "type": "recipe",
     "activity_level": "NO_EXERCISE",


### PR DESCRIPTION
#### Summary
Mods "Makes the lady bug and mole cricket tamable in the Tamable Wildlife mod"

#### Purpose of change
I noticed these 2 monsters were untamable even though they had baby forms that could be tamed with enough love! (And sugar, looots of sugar).

#### Describe the solution
Adds both monsters as larvae/nymphs to the mod as tamable with bug food, the adult versions are mountable too! Now even troglobites can tame and mount their little (Or not so little...) pets in the subway! You only need to catch one first, they are pretty fast.

#### Describe alternatives you've considered
To add some other monsters of the file that could be added, but I'm sleepy...

#### Testing
It loads! The monsters can be tamed! And played with!

#### Additional context
![imagen](https://github.com/CleverRaven/Cataclysm-DDA/assets/53200489/7e851f47-54f7-4106-9a5e-fd47fae6f63e)
![imagen](https://github.com/CleverRaven/Cataclysm-DDA/assets/53200489/76391c6b-5e0f-4d24-9a4f-f36370f26b3d)
![imagen](https://github.com/CleverRaven/Cataclysm-DDA/assets/53200489/d65a92e8-2313-49a9-b984-f23faacb4d6a)

