### PR TITLE
Use absolute tripoints in spell test

### DIFF
--- a/tests/magic_spell_effect_test.cpp
+++ b/tests/magic_spell_effect_test.cpp
@@ -87,18 +87,17 @@ TEST_CASE( "remove_field_fd_fatigue", "[magic]" )
 
     avatar &dummy = get_avatar();
     clear_avatar();
-    tripoint player_initial_pos = dummy.pos();
+    tripoint_abs_ms player_initial_pos = dummy.get_location();
 
     const auto setup_and_remove_fields = [&]( const bool & with_light ) {
         CAPTURE( with_light );
-        CHECK( dummy.pos() == player_initial_pos );
-        tripoint_abs_ms player_global_pos = m.getglobal( player_initial_pos );
+        CHECK( dummy.get_location() == player_initial_pos );
 
         // create fd_fatigue of each intensity near player
-        tripoint_abs_ms p1 = player_global_pos + tripoint_east * 10;
-        tripoint_abs_ms p2 = player_global_pos + tripoint_east * 11;
-        tripoint_abs_ms p3 = player_global_pos + tripoint_east * 12;
-        tripoint_abs_ms p4 = player_global_pos + tripoint_east * 13;
+        tripoint_abs_ms p1 = player_initial_pos + tripoint_east * 10;
+        tripoint_abs_ms p2 = player_initial_pos + tripoint_east * 11;
+        tripoint_abs_ms p3 = player_initial_pos + tripoint_east * 12;
+        tripoint_abs_ms p4 = player_initial_pos + tripoint_east * 13;
         m.add_field( m.getlocal( p1 ), fd_fatigue, 1, 1_hours );
         m.add_field( m.getlocal( p2 ), fd_fatigue, 2, 1_hours );
         m.add_field( m.getlocal( p3 ), fd_fatigue, 3, 1_hours );
@@ -114,28 +113,28 @@ TEST_CASE( "remove_field_fd_fatigue", "[magic]" )
         m.build_map_cache( 0 );
         dummy.recalc_sight_limits();
 
-        CHECK( m.getglobal( dummy.pos() ) == player_global_pos );
+        CHECK( m.getglobal( dummy.pos() ) == player_initial_pos );
         CHECK( count_fields_near( p1, fd_fatigue ) == std::set<tripoint_abs_ms> { p1, p2, p3, p4 } );
 
-        spell_effect::remove_field( sp, dummy, player_initial_pos );
+        spell_effect::remove_field( sp, dummy, m.getlocal( player_initial_pos ) );
         calendar::turn += 1_turns;
         m.process_fields();
         calendar::turn += 1_turns;
         m.process_fields();
 
-        CHECK( m.getglobal( dummy.pos() ) == player_global_pos );
+        CHECK( m.getglobal( dummy.pos() ) == player_initial_pos );
         CHECK( count_fields_near( p1, fd_fatigue ) == std::set<tripoint_abs_ms> { p2, p3, p4 } );
 
-        spell_effect::remove_field( sp, dummy, player_initial_pos );
+        spell_effect::remove_field( sp, dummy, m.getlocal( player_initial_pos ) );
         calendar::turn += 1_turns;
         m.process_fields();
         calendar::turn += 1_turns;
         m.process_fields();
 
-        CHECK( m.getglobal( dummy.pos() ) == player_global_pos );
+        CHECK( m.getglobal( dummy.pos() ) == player_initial_pos );
         CHECK( count_fields_near( p1, fd_fatigue ) == std::set<tripoint_abs_ms> { p3, p4 } );
 
-        spell_effect::remove_field( sp, dummy, player_initial_pos );
+        spell_effect::remove_field( sp, dummy, m.getlocal( player_initial_pos ) );
         calendar::turn += 1_turns;
         m.process_fields();
         calendar::turn += 1_turns;
@@ -181,13 +180,14 @@ TEST_CASE( "remove_field_fd_fatigue", "[magic]" )
            "The tear in reality pulls you in as it closes and ejects you violently!" );
 
     // check that the player got teleported
-    CHECK( dummy.pos() != player_initial_pos );
+    CHECK( dummy.get_location() != player_initial_pos );
 
     // remove 3 fields again but without lighting this time
     clear_avatar();
     clear_map();
     Messages::clear_messages();
 
+    player_initial_pos = dummy.get_location();
     setup_and_remove_fields( false );
     capture_removal_messages();
 


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
This was causing a failure on one of my PRs (https://github.com/CleverRaven/Cataclysm-DDA/pull/68851). As best I can tell, the player had the same local position after teleporting due to a map shift.

#### Describe the solution
Use absolute points so it's not vulnerable to map shift issues like this.

#### Describe alternatives you've considered

#### Testing
Reproduces with `tests/cata_test --rng-seed=1698113342 'show_available_recipes_with_item_as_an_ingredient,remove_field_fd_fatigue'` before this change, on that PR.

No more failure with the changes I've made.

#### Additional context
I don't like how the lambda works, but I'm not going to change more than I need to make the test more robust.