### PR TITLE
Rename advanced object deconstruction to deconstruct fireplace, replace stone fireplace with brick fireplace

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2488,42 +2488,8 @@
     "category": "FURN",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "120 m",
-    "qualities": [
-    [
-      {
-        "id": "SMOOTH",
-        "level": 2
-      }
-    ]
-  ],
-    "components": [
-    [
-      [
-        "brick",
-        30
-      ]
-    ],
-    [
-      [
-        "mortar_build",
-        1
-      ],
-      [
-        "mortar_lime",
-        1
-      ]
-    ],
-    [
-      [
-        "water",
-        1
-      ],
-      [
-        "water_clean",
-        1
-      ]
-    ]
-  ],
+    "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
+    "components": [ [ [ "brick", 30 ] ], [ [ "mortar_build", 1 ], [ "mortar_lime", 1 ] ], [ [ "water", 1 ], [ "water_clean", 1 ] ] ],
     "pre_special": "check_empty",
     "post_terrain": "f_fireplace"
   },

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2484,12 +2484,45 @@
   {
     "type": "construction",
     "id": "constr_fireplace",
-    "group": "build_stone_fireplace",
+    "group": "build_brick_fireplace",
     "category": "FURN",
-    "required_skills": [ [ "fabrication", 2 ], [ "survival", 1 ] ],
+    "required_skills": [ [ "fabrication", 3 ] ],
     "time": "120 m",
-    "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "DIG", "level": 2 } ] ],
-    "components": [ [ [ "rock", 40 ] ] ],
+    "qualities": [
+    [
+      {
+        "id": "SMOOTH",
+        "level": 2
+      }
+    ]
+  ],
+  "components": [
+    [
+      [
+        "brick",
+        30
+      ]
+    ],
+    [
+      [
+        "mortar_build",
+        1
+      ],
+      [
+        "mortar_lime",
+        1
+      ]
+    ],
+    [
+      [
+        "water",
+        1
+      ],
+      [
+        "water_clean",
+        1
+      ]
+    ]
     "pre_special": "check_empty",
     "post_terrain": "f_fireplace"
   },

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2496,7 +2496,7 @@
       }
     ]
   ],
-  "components": [
+    "components": [
     [
       [
         "brick",
@@ -2522,7 +2522,8 @@
         "water_clean",
         1
       ]
-    ],
+    ]
+  ],
     "pre_special": "check_empty",
     "post_terrain": "f_fireplace"
   },

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -2522,7 +2522,7 @@
         "water_clean",
         1
       ]
-    ]
+    ],
     "pre_special": "check_empty",
     "post_terrain": "f_fireplace"
   },

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1646,8 +1646,8 @@
   },
   {
     "type": "construction_group",
-    "id": "advanced_object_deconstruction",
-    "name": "Advanced Object Deconstruction"
+    "id": "deconstruct_fireplace",
+    "name": "Deconstruct Fireplace"
   },
   {
     "type": "construction_group",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -781,8 +781,8 @@
   },
   {
     "type": "construction_group",
-    "id": "build_stone_fireplace",
-    "name": "Build Stone Fireplace"
+    "id": "build_brick_fireplace",
+    "name": "Build Brick Fireplace"
   },
   {
     "type": "construction_group",

--- a/data/json/deconstruction.json
+++ b/data/json/deconstruction.json
@@ -1033,12 +1033,12 @@
     "type": "construction",
     "id": "constr_remove_object_fireplace",
     "group": "deconstruct_fireplace",
-    "//": "Breaks a fireplace apart giving you back most of the rocks used in its construction.",
+    "//": "Breaks a fireplace apart giving you back most of the bricks used in its construction.",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 2 ] ],
     "time": "90 m",
     "using": [ [ "cement_removal", 1 ] ],
-    "byproducts": [ { "item": "rock", "count": [ 35, 40 ] } ],
+    "byproducts": [ { "item": "brick", "count": [ 25, 30 ] } ],
     "pre_terrain": "f_fireplace",
     "post_terrain": "f_null"
   }

--- a/data/json/deconstruction.json
+++ b/data/json/deconstruction.json
@@ -1037,7 +1037,7 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 2 ] ],
     "time": "90 m",
-    "using": [ [ "object_deconstruction_advanced", 1 ] ],
+    "using": [ [ "cement_removal", 1 ] ],
     "byproducts": [ { "item": "rock", "count": [ 35, 40 ] } ],
     "pre_terrain": "f_fireplace",
     "post_terrain": "f_null"

--- a/data/json/deconstruction.json
+++ b/data/json/deconstruction.json
@@ -1032,7 +1032,7 @@
   {
     "type": "construction",
     "id": "constr_remove_object_fireplace",
-    "group": "advanced_object_deconstruction",
+    "group": "deconstruct_fireplace",
     "//": "Breaks a fireplace apart giving you back most of the rocks used in its construction.",
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 2 ] ],

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -374,11 +374,7 @@
     "id": "cement_removal",
     "type": "requirement",
     "//": "Tools for deconstructing items built with mortar or cement",
-    "qualities": [
-      { "id": "HAMMER", "level": 2 },
-      { "id": "CHISEL", "level": 2 },
-      { "id": "PRY", "level": 3 }
-    ]
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CHISEL", "level": 2 }, { "id": "PRY", "level": 3 } ]
   },
   {
     "id": "marking_hard",

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -378,7 +378,6 @@
       { "id": "HAMMER", "level": 2 },
       { "id": "CHISEL", "level": 2 },
       { "id": "PRY", "level": 3 },
-      { "id": "SCREW", "level": 1 }
     ]
   },
   {

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -377,7 +377,7 @@
     "qualities": [
       { "id": "HAMMER", "level": 2 },
       { "id": "CHISEL", "level": 2 },
-      { "id": "PRY", "level": 3 },
+      { "id": "PRY", "level": 3 }
     ]
   },
   {

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -371,9 +371,9 @@
     "tools": [ [ [ "angle_grinder", 200 ], [ "oxy_torch", 20 ] ] ]
   },
   {
-    "id": "object_deconstruction_advanced",
+    "id": "cement_removal",
     "type": "requirement",
-    "//": "Tools for doing advanced deconstruction",
+    "//": "Tools for deconstructing items built with mortar or cement",
     "qualities": [
       { "id": "HAMMER", "level": 2 },
       { "id": "CHISEL", "level": 2 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Replace stone fireplace with brick fireplace"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Confusion regarding what advanced object deconstruction is.

Edit: Replaced stone fireplace with brick fireplace, along with the updated construction recipe and materials. fab 3 requirement matches brick wall.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changed the name of the advanced object deconstruction group to deconstruct fireplace, because that's the only thing it does for now.
Also removed screw requirement from object_deconstruction_advanced requirement group, since again deconstructing fireplace is the only thing using it right now and that does not require a screwdriver.

Edit: rename and specify the "object_deconstruction_advanced" toolset to "cement_removal", which are tools to break down objects that have cement or mortar. Currently only used for fireplace removal.

Edit: Updated the current stone fireplace to a proper brick fireplace built with bricks and mortar, which better represents it's sprite and how it is found in pre-existing buildings. I'm having trouble imagining a fireplace that's just built with 40 stones and a shovel, so I got rid of it. Someone can argue for it and re-add it later, I don't mind. Or if insisted they can duel me in Nidhogg and I'll add it back if they win.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

There may be confusion between a fireplace and a fire pit, to be explored in another PR.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
