### PR TITLE
Add EoC beta talker to combat events

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -485,6 +485,7 @@
     "id": "EOC_character_melee_attacks_character_event_test",
     "eoc_type": "EVENT",
     "required_event": "character_melee_attacks_character",
+    "condition": { "compare_string": [ "test_knife_combat", { "context_val": "weapon" } ] },
     "effect": [
       { "u_add_var": "last_event", "type": "test", "context": "event", "value": "character_melee_attacks_character" },
       {
@@ -500,6 +501,12 @@
     "id": "EOC_character_melee_attacks_monster_event_test",
     "eoc_type": "EVENT",
     "required_event": "character_melee_attacks_monster",
+    "condition": {
+      "and": [
+        { "compare_string": [ "test_knife_combat", { "context_val": "weapon" } ] },
+        { "compare_string": [ "mon_zombie", { "context_val": "victim_type" } ] }
+      ]
+    },
     "effect": [
       { "u_add_var": "last_event", "type": "test", "context": "event", "value": "character_melee_attacks_monster" },
       { "npc_add_var": "last_event", "type": "test", "context": "event", "value": "character_melee_attacks_monster" }
@@ -510,6 +517,7 @@
     "id": "EOC_character_ranged_attacks_character_event_test",
     "eoc_type": "EVENT",
     "required_event": "character_ranged_attacks_character",
+    "condition": { "compare_string": [ "shotgun_s", { "context_val": "weapon" } ] },
     "effect": [
       { "u_add_var": "last_event", "type": "test", "context": "event", "value": "character_ranged_attacks_character" },
       {
@@ -525,6 +533,12 @@
     "id": "EOC_character_ranged_attacks_monster_event_test",
     "eoc_type": "EVENT",
     "required_event": "character_ranged_attacks_monster",
+    "condition": {
+      "and": [
+        { "compare_string": [ "shotgun_s", { "context_val": "weapon" } ] },
+        { "compare_string": [ "mon_zombie", { "context_val": "victim_type" } ] }
+      ]
+    },
     "effect": [
       { "u_add_var": "last_event", "type": "test", "context": "event", "value": "character_ranged_attacks_monster" },
       { "npc_add_var": "last_event", "type": "test", "context": "event", "value": "character_ranged_attacks_monster" }

--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -485,7 +485,6 @@
     "id": "EOC_character_melee_attacks_character_event_test",
     "eoc_type": "EVENT",
     "required_event": "character_melee_attacks_character",
-    "condition": { "compare_string": [ "test_knife_combat", { "context_val": "weapon" } ] },
     "effect": [
       { "u_add_var": "last_event", "type": "test", "context": "event", "value": "character_melee_attacks_character" },
       {
@@ -493,7 +492,9 @@
         "type": "test",
         "context": "event",
         "value": "character_melee_attacks_character"
-      }
+      },
+      { "set_string_var": { "context_val": "weapon" }, "target_var": { "global_val": "weapon" } },
+      { "set_string_var": { "context_val": "victim_name" }, "target_var": { "global_val": "victim_name" } }
     ]
   },
   {
@@ -501,15 +502,11 @@
     "id": "EOC_character_melee_attacks_monster_event_test",
     "eoc_type": "EVENT",
     "required_event": "character_melee_attacks_monster",
-    "condition": {
-      "and": [
-        { "compare_string": [ "test_knife_combat", { "context_val": "weapon" } ] },
-        { "compare_string": [ "mon_zombie", { "context_val": "victim_type" } ] }
-      ]
-    },
     "effect": [
       { "u_add_var": "last_event", "type": "test", "context": "event", "value": "character_melee_attacks_monster" },
-      { "npc_add_var": "last_event", "type": "test", "context": "event", "value": "character_melee_attacks_monster" }
+      { "npc_add_var": "last_event", "type": "test", "context": "event", "value": "character_melee_attacks_monster" },
+      { "set_string_var": { "context_val": "weapon" }, "target_var": { "global_val": "weapon" } },
+      { "set_string_var": { "context_val": "victim_type" }, "target_var": { "global_val": "victim_type" } }
     ]
   },
   {
@@ -517,7 +514,6 @@
     "id": "EOC_character_ranged_attacks_character_event_test",
     "eoc_type": "EVENT",
     "required_event": "character_ranged_attacks_character",
-    "condition": { "compare_string": [ "shotgun_s", { "context_val": "weapon" } ] },
     "effect": [
       { "u_add_var": "last_event", "type": "test", "context": "event", "value": "character_ranged_attacks_character" },
       {
@@ -525,7 +521,9 @@
         "type": "test",
         "context": "event",
         "value": "character_ranged_attacks_character"
-      }
+      },
+      { "set_string_var": { "context_val": "weapon" }, "target_var": { "global_val": "weapon" } },
+      { "set_string_var": { "context_val": "victim_name" }, "target_var": { "global_val": "victim_name" } }
     ]
   },
   {
@@ -533,15 +531,11 @@
     "id": "EOC_character_ranged_attacks_monster_event_test",
     "eoc_type": "EVENT",
     "required_event": "character_ranged_attacks_monster",
-    "condition": {
-      "and": [
-        { "compare_string": [ "shotgun_s", { "context_val": "weapon" } ] },
-        { "compare_string": [ "mon_zombie", { "context_val": "victim_type" } ] }
-      ]
-    },
     "effect": [
       { "u_add_var": "last_event", "type": "test", "context": "event", "value": "character_ranged_attacks_monster" },
-      { "npc_add_var": "last_event", "type": "test", "context": "event", "value": "character_ranged_attacks_monster" }
+      { "npc_add_var": "last_event", "type": "test", "context": "event", "value": "character_ranged_attacks_monster" },
+      { "set_string_var": { "context_val": "weapon" }, "target_var": { "global_val": "weapon" } },
+      { "set_string_var": { "context_val": "victim_type" }, "target_var": { "global_val": "victim_type" } }
     ]
   },
   {

--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -482,6 +482,31 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_character_melee_attacks_character_event_test",
+    "eoc_type": "EVENT",
+    "required_event": "character_melee_attacks_character",
+    "effect": [
+      { "u_add_var": "last_event", "type": "test", "context": "event", "value": "character_melee_attacks_character" },
+      {
+        "npc_add_var": "last_event",
+        "type": "test",
+        "context": "event",
+        "value": "character_melee_attacks_character"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_character_melee_attacks_monster_event_test",
+    "eoc_type": "EVENT",
+    "required_event": "character_melee_attacks_monster",
+    "effect": [
+      { "u_add_var": "last_event", "type": "test", "context": "event", "value": "character_melee_attacks_monster" },
+      { "npc_add_var": "last_event", "type": "test", "context": "event", "value": "character_melee_attacks_monster" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_character_wields_item_event_test",
     "eoc_type": "EVENT",
     "required_event": "character_wields_item",

--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -507,6 +507,31 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_character_ranged_attacks_character_event_test",
+    "eoc_type": "EVENT",
+    "required_event": "character_ranged_attacks_character",
+    "effect": [
+      { "u_add_var": "last_event", "type": "test", "context": "event", "value": "character_ranged_attacks_character" },
+      {
+        "npc_add_var": "last_event",
+        "type": "test",
+        "context": "event",
+        "value": "character_ranged_attacks_character"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_character_ranged_attacks_monster_event_test",
+    "eoc_type": "EVENT",
+    "required_event": "character_ranged_attacks_monster",
+    "effect": [
+      { "u_add_var": "last_event", "type": "test", "context": "event", "value": "character_ranged_attacks_monster" },
+      { "npc_add_var": "last_event", "type": "test", "context": "event", "value": "character_ranged_attacks_monster" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_character_wields_item_event_test",
     "eoc_type": "EVENT",
     "required_event": "character_wields_item",

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -969,10 +969,10 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | character_kills_monster |  | { "killer", `character_id` },<br/> { "victim_type", `mtype_id` }, | character / NONE |
 | character_learns_spell |  | { "character", `character_id` },<br/> { "spell", `spell_id` } | character / NONE |
 | character_loses_effect |  | { "character", `character_id` },<br/> { "effect", `efftype_id` }, | character / NONE |
-| character_melee_attacks_character |  | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "hits", `bool` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character / NONE |
-| character_melee_attacks_monster | | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "hits", `bool` },<br/> { "victim_type", `mtype_id` },| character / NONE |
-| character_ranged_attacks_character | |  { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character / NONE |
-| character_ranged_attacks_monster | | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "victim_type", `mtype_id` }, | character / NONE |
+| character_melee_attacks_character |  | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "hits", `bool` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character (attacker) / character (victim) |
+| character_melee_attacks_monster | | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "hits", `bool` },<br/> { "victim_type", `mtype_id` },| character / monster |
+| character_ranged_attacks_character | |  { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character (attacker) / character (victim) |
+| character_ranged_attacks_monster | | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "victim_type", `mtype_id` }, | character / monster |
 | character_smashes_tile | | { "character", `character_id` },<br/> { "terrain", `ter_str_id` },  { "furniture", `furn_str_id` }, | character / NONE |
 | character_starts_activity | Triggered when character starts or resumes activity | { "character", `character_id` },<br/> { "activity", `activity_id` },<br/> { "resume", `bool` } | character / NONE |
 | character_takes_damage | | { "character", `character_id` },<br/> { "damage", `int` }, | character / NONE |

--- a/src/event_bus.cpp
+++ b/src/event_bus.cpp
@@ -5,6 +5,7 @@
 #include "character.h"
 #include "debug.h"
 #include "event_subscriber.h"
+#include "monster.h"
 #include "talker.h"
 
 event_subscriber::~event_subscriber()
@@ -65,6 +66,22 @@ void event_bus::send( const cata::event &e ) const
 {
     for( event_subscriber *s : subscribers ) {
         s->notify( e );
+    }
+}
+
+void event_bus::send_with_talker( Character *alpha, Character *beta,
+                                  const cata::event &e ) const
+{
+    for( event_subscriber *s : subscribers ) {
+        s->notify( e, get_talker_for( alpha ), get_talker_for( beta ) );
+    }
+}
+
+void event_bus::send_with_talker( Character *alpha, monster *beta,
+                                  const cata::event &e ) const
+{
+    for( event_subscriber *s : subscribers ) {
+        s->notify( e, get_talker_for( alpha ), get_talker_for( beta ) );
     }
 }
 

--- a/src/event_bus.cpp
+++ b/src/event_bus.cpp
@@ -2,10 +2,9 @@
 
 #include <algorithm>
 
-#include "character.h"
+#include "creature.h"
 #include "debug.h"
 #include "event_subscriber.h"
-#include "monster.h"
 #include "talker.h"
 
 event_subscriber::~event_subscriber()
@@ -69,7 +68,7 @@ void event_bus::send( const cata::event &e ) const
     }
 }
 
-void event_bus::send_with_talker( Character *alpha, Character *beta,
+void event_bus::send_with_talker( Creature *alpha, Creature *beta,
                                   const cata::event &e ) const
 {
     for( event_subscriber *s : subscribers ) {
@@ -77,15 +76,7 @@ void event_bus::send_with_talker( Character *alpha, Character *beta,
     }
 }
 
-void event_bus::send_with_talker( Character *alpha, monster *beta,
-                                  const cata::event &e ) const
-{
-    for( event_subscriber *s : subscribers ) {
-        s->notify( e, get_talker_for( alpha ), get_talker_for( beta ) );
-    }
-}
-
-void event_bus::send_with_talker( Character *alpha, item_location *beta,
+void event_bus::send_with_talker( Creature *alpha, item_location *beta,
                                   const cata::event &e ) const
 {
     for( event_subscriber *s : subscribers ) {

--- a/src/event_bus.h
+++ b/src/event_bus.h
@@ -7,7 +7,7 @@
 
 #include "event.h"
 
-class Character;
+class Creature;
 class event_subscriber;
 class item_location;
 class talker;
@@ -23,9 +23,8 @@ class event_bus
         void unsubscribe( event_subscriber * );
 
         void send( const cata::event & ) const;
-        void send_with_talker( Character *, Character *, const cata::event & ) const;
-        void send_with_talker( Character *, monster *, const cata::event & ) const;
-        void send_with_talker( Character *, item_location *, const cata::event & ) const;
+        void send_with_talker( Creature *, Creature *, const cata::event & ) const;
+        void send_with_talker( Creature *, item_location *, const cata::event & ) const;
         template<event_type Type, typename... Args>
         void send( Args &&... args ) const {
             send( cata::event::make<Type>( std::forward<Args>( args )... ) );

--- a/src/event_bus.h
+++ b/src/event_bus.h
@@ -23,6 +23,8 @@ class event_bus
         void unsubscribe( event_subscriber * );
 
         void send( const cata::event & ) const;
+        void send_with_talker( Character *, Character *, const cata::event & ) const;
+        void send_with_talker( Character *, monster *, const cata::event & ) const;
         void send_with_talker( Character *, item_location *, const cata::event & ) const;
         template<event_type Type, typename... Args>
         void send( Args &&... args ) const {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -646,11 +646,13 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
     const bool hits = hit_spread >= 0;
 
     if( monster *m = t.as_monster() ) {
-        get_event_bus().send<event_type::character_melee_attacks_monster>(
-            getID(), cur_weap.typeId(), hits, m->type->id );
+        cata::event e = cata::event::make<event_type::character_melee_attacks_monster>( getID(),
+                        cur_weap.typeId(), hits, m->type->id );
+        get_event_bus().send_with_talker( this, m, e );
     } else if( Character *c = t.as_character() ) {
-        get_event_bus().send<event_type::character_melee_attacks_character>(
-            getID(), cur_weap.typeId(), hits, c->getID(), c->get_name() );
+        cata::event e = cata::event::make<event_type::character_melee_attacks_character>( getID(),
+                        cur_weap.typeId(), hits, c->getID(), c->get_name() );
+        get_event_bus().send_with_talker( this, c, e );
     }
 
     const int skill_training_cap = t.is_monster() ? t.as_monster()->type->melee_training_cap :

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -959,11 +959,13 @@ int Character::fire_gun( const tripoint &target, int shots, item &gun )
         }
         for( std::pair<Creature *const, std::pair<int, int>> &hit_entry : targets_hit ) {
             if( monster *const m = hit_entry.first->as_monster() ) {
-                get_event_bus().send<event_type::character_ranged_attacks_monster>(
-                    getID(), gun_id, m->type->id );
+                cata::event e = cata::event::make<event_type::character_ranged_attacks_monster>( getID(), gun_id,
+                                m->type->id );
+                get_event_bus().send_with_talker( this, m, e );
             } else if( Character *const c = hit_entry.first->as_character() ) {
-                get_event_bus().send<event_type::character_ranged_attacks_character>(
-                    getID(), gun_id, c->getID(), c->get_name() );
+                cata::event e = cata::event::make<event_type::character_ranged_attacks_character>( getID(), gun_id,
+                                c->getID(), c->get_name() );
+                get_event_bus().send_with_talker( this, c, e );
             }
             if( multishot ) {
                 // TODO: Pull projectile name from the ammo entry.

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -806,6 +806,7 @@ TEST_CASE( "EOC_run_inv_test", "[eoc]" )
 
 TEST_CASE( "EOC_event_test", "[eoc]" )
 {
+    size_t loop;
     clear_avatar();
     clear_map();
 
@@ -899,20 +900,20 @@ TEST_CASE( "EOC_event_test", "[eoc]" )
     npc_dst.die( &npc_src );
 
     // character_ranged_attacks_monster
-    monster &mon = spawn_test_monster( "mon_zombie", get_avatar().pos() + tripoint_south_east );
+    monster &mon_dst = spawn_test_monster( "mon_zombie", get_avatar().pos() + tripoint_south_east );
 
     do {
         arm_shooter( npc_src, "shotgun_s" );
         npc_src.recoil = 0;
-        npc_src.fire_gun( mon.pos(), 1, *npc_src.get_wielded_item() );
-    } while( mon.get_value( "npctalk_var_test_event_last_event" ).empty() );
+        npc_src.fire_gun( mon_dst.pos(), 1, *npc_src.get_wielded_item() );
+    } while( mon_dst.get_value( "npctalk_var_test_event_last_event" ).empty() );
 
     CHECK( npc_src.get_value( "npctalk_var_test_event_last_event" ) ==
            "character_ranged_attacks_character" );
-    CHECK( mon.get_value( "npctalk_var_test_event_last_event" ) ==
+    CHECK( mon_dst.get_value( "npctalk_var_test_event_last_event" ) ==
            "character_ranged_attacks_character" );
 
-    mon.die( &npc_src );
+    mon_dst.die( &npc_src );
 }
 
 TEST_CASE( "EOC_spell_exp", "[eoc]" )

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -869,20 +869,8 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
     clear_npcs();
     clear_map();
 
-    const auto spawn_npc = [&]( const point & p, const std::string & npc_class )->npc* {
-        const string_id<npc_template> test_guy( npc_class );
-        const character_id model_id = get_map().place_npc( p, test_guy );
-        g->load_npcs();
-
-        npc *guy = g->find_npc( model_id );
-        REQUIRE( guy != nullptr );
-        CHECK( !guy->in_vehicle );
-        return guy;
-    };
-
     // character_melee_attacks_character
-    const tripoint melee_target_pos = get_avatar().pos() + point_east;
-    npc &npc_dst_1 = *spawn_npc( melee_target_pos.xy(), "thug" );
+    npc &npc_dst_1 = spawn_npc( get_avatar().pos().xy() + point_south, "thug" );
     item weapon_item( itype_test_knife_combat );
     get_avatar().wield( weapon_item );
     get_avatar().melee_attack( npc_dst_1, false );
@@ -902,45 +890,43 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
     CHECK( mon.get_value( "npctalk_var_test_event_last_event" ) == "character_melee_attacks_monster" );
 
     // character_ranged_attacks_character
-    constexpr tripoint shooter_pos{ 60, 60, 0 };
-    const tripoint target_pos = shooter_pos + point_east * 5;
+    const tripoint target_pos = get_avatar().pos() + point_east;
 
-    clear_map_and_put_player_underground();
-    npc &npc_src = *spawn_npc( shooter_pos.xy(), "thug" );
-    npc &npc_dst_2 = *spawn_npc( target_pos.xy(), "thug" );
+    clear_map();
+    npc &npc_dst_2 = spawn_npc( target_pos.xy(), "thug" );
 
-    REQUIRE( get_creature_tracker().creature_at( npc_dst_2.pos() ) );
+    REQUIRE( get_creature_tracker().creature_at( target_pos ) );
 
     for( loop = 0; loop < 1000; loop++ ) {
-        npc_src.set_body();
-        arm_shooter( npc_src, "shotgun_s" );
-        npc_src.recoil = 0;
-        npc_src.fire_gun( npc_dst_2.pos(), 1, *npc_src.get_wielded_item() );
+        get_avatar().set_body();
+        arm_shooter( get_avatar(), "shotgun_s" );
+        get_avatar().recoil = 0;
+        get_avatar().fire_gun( target_pos, 1, *get_avatar().get_wielded_item() );
         if( !npc_dst_2.get_value( "npctalk_var_test_event_last_event" ).empty() ) {
             break;
         }
     }
 
-    CHECK( npc_src.get_value( "npctalk_var_test_event_last_event" ) ==
+    CHECK( get_avatar().get_value( "npctalk_var_test_event_last_event" ) ==
            "character_ranged_attacks_character" );
     CHECK( npc_dst_2.get_value( "npctalk_var_test_event_last_event" ) ==
            "character_ranged_attacks_character" );
 
     // character_ranged_attacks_monster
-    clear_map_and_put_player_underground();
+    clear_map();
     monster &mon_dst = spawn_test_monster( "mon_zombie", target_pos );
 
     for( loop = 0; loop < 1000; loop++ ) {
-        npc_src.set_body();
-        arm_shooter( npc_src, "shotgun_s" );
-        npc_src.recoil = 0;
-        npc_src.fire_gun( mon_dst.pos(), 1, *npc_src.get_wielded_item() );
+        get_avatar().set_body();
+        arm_shooter( get_avatar(), "shotgun_s" );
+        get_avatar().recoil = 0;
+        get_avatar().fire_gun( mon_dst.pos(), 1, *get_avatar().get_wielded_item() );
         if( !mon_dst.get_value( "npctalk_var_test_event_last_event" ).empty() ) {
             break;
         }
     }
 
-    CHECK( npc_src.get_value( "npctalk_var_test_event_last_event" ) ==
+    CHECK( get_avatar().get_value( "npctalk_var_test_event_last_event" ) ==
            "character_ranged_attacks_monster" );
     CHECK( mon_dst.get_value( "npctalk_var_test_event_last_event" ) ==
            "character_ranged_attacks_monster" );

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -886,11 +886,14 @@ TEST_CASE( "EOC_event_test", "[eoc]" )
     standard_npc npc_dst( "TestCharacter", get_avatar().pos() + tripoint_south_east, {}, 8, 10, 10, 10,
                           10 );
 
-    do {
+    for( loop = 0; loop < 1000; loop++ ) {
         arm_shooter( npc_src, "shotgun_s" );
         npc_src.recoil = 0;
         npc_src.fire_gun( npc_dst.pos(), 1, *npc_src.get_wielded_item() );
-    } while( npc_dst.get_value( "npctalk_var_test_event_last_event" ).empty() );
+        if( !npc_dst.get_value( "npctalk_var_test_event_last_event" ).empty() ) {
+            break;
+        }
+    }
 
     CHECK( npc_src.get_value( "npctalk_var_test_event_last_event" ) ==
            "character_ranged_attacks_character" );
@@ -902,11 +905,14 @@ TEST_CASE( "EOC_event_test", "[eoc]" )
     // character_ranged_attacks_monster
     monster &mon_dst = spawn_test_monster( "mon_zombie", get_avatar().pos() + tripoint_south_east );
 
-    do {
+    for( loop = 0; loop < 1000; loop++ ) {
         arm_shooter( npc_src, "shotgun_s" );
         npc_src.recoil = 0;
         npc_src.fire_gun( mon_dst.pos(), 1, *npc_src.get_wielded_item() );
-    } while( mon_dst.get_value( "npctalk_var_test_event_last_event" ).empty() );
+        if( !mon_dst.get_value( "npctalk_var_test_event_last_event" ).empty() ) {
+            break;
+        }
+    }
 
     CHECK( npc_src.get_value( "npctalk_var_test_event_last_event" ) ==
            "character_ranged_attacks_character" );

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -89,7 +89,6 @@ static const furn_str_id furn_f_cardboard_box( "f_cardboard_box" );
 static const furn_str_id furn_test_f_eoc( "test_f_eoc" );
 
 static const itype_id itype_backpack( "backpack" );
-static const itype_id itype_shotgun_s( "shotgun_s" );
 static const itype_id itype_sword_wood( "sword_wood" );
 static const itype_id itype_test_knife_combat( "test_knife_combat" );
 

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -149,7 +149,7 @@ void clear_character( Character &dummy, bool skip_nutrition )
     dummy.set_focus( dummy.calc_focus_equilibrium() );
 }
 
-void arm_shooter( npc &shooter, const std::string &gun_type,
+void arm_shooter( Character &shooter, const std::string &gun_type,
                   const std::vector<std::string> &mods,
                   const std::string &ammo_type )
 {

--- a/tests/player_helpers.h
+++ b/tests/player_helpers.h
@@ -26,7 +26,7 @@ void give_and_activate_bionic( Character &, bionic_id const & );
 
 item tool_with_ammo( const std::string &tool, int qty );
 
-void arm_shooter( npc &shooter, const std::string &gun_type,
+void arm_shooter( Character &shooter, const std::string &gun_type,
                   const std::vector<std::string> &mods = {},
                   const std::string &ammo_type = "" );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
EoC combat events only set alpha talker (atacker).

#### Describe the solution
Add beta talker (victim) to following events.
- character_melee_attacks_character
- character_melee_attacks_monster
- character_ranged_attacks_character
- character_ranged_attacks_monster

#### Describe alternatives you've considered


#### Testing
Add Cl tests

#### Additional context
