### PR TITLE
Killed zombies in safe place scenario start locations

### DIFF
--- a/data/json/mapgen/cabin.json
+++ b/data/json/mapgen/cabin.json
@@ -33,7 +33,7 @@
         "-----------GG-----------"
       ],
       "palettes": [ { "distribution": [ [ "cabin_palette", 1 ], [ "cabin_palette_abandoned", 1 ] ] } ],
-      "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": 7, "y": 4 } ],
+      "place_loot": [ { "group": "corpse_generic_human", "x": 7, "y": 4, "chance": 100 } ],
       "place_nested": [ { "chunks": [ [ "KINDRED_Darren_Cooper_spawn", 20 ], [ "null", 80 ] ], "x": 12, "y": 14 } ]
     }
   },

--- a/data/json/mapgen/farm.json
+++ b/data/json/mapgen/farm.json
@@ -146,7 +146,7 @@
           { "item": "tools_common", "chance": 50 }
         ]
       },
-      "place_monster": [ { "group": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "repeat": [ 1, 3 ] } ]
+      "place_loot": [ { "group": "corpse_generic_human", "x": [ 2, 22 ], "y": [ 2, 22 ], "chance": 100 } ]
     }
   },
   {

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -140,7 +140,6 @@
       "sloc_horse_ranch",
       "sloc_lighthouse_ground",
       "sloc_lodge_ground",
-      "sloc_freshwater_research_station",
       "sloc_light_industry_scen"
     ],
     "start_name": "Safe Building",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Make safe place starts safer"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #68902 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Replaced monster spawns with corpse spawns in farm and cabin starting locations, with the intent that they'll revive for players discovering these locations later during a playthrough, while starting dead for players starting at these locations.

Removed FRS from safe place start options, as the number of monsters defined in mapgen did not make it seem to me that it was intended to be a safe place.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Just remove the monster spawns, or remove the location from the safe place scenario start location list.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/26992604/3ac38e71-7150-4ba3-ab99-4a2ee8f6b2bf)
Started with safe place cabin and farm, debug quick setup and confirmed there were corpses instead of monsters.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I like the idea of more corpses placed in mapgen in general - corpses tend to lead towards impromptu stories better than monsters do. Also might make for an interesting scenario if the corpse happens to randomly spawn in the farm shed for example, and the player decides not to open it until way later. It was safe to start at least...

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
