### PR TITLE
Portal Dependent Update

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3822,7 +3822,7 @@
       "The world around you seems calmer with your presence and actions.",
       "The world around you seems to regard you as one of their own, your body is a little easier to move now.",
       "You can more easily exert your will around you, this dimension is, if not welcoming you, obeying you a little.  You have managed to secure a foothold in this reality.",
-      "The very fabric of reality is blending in with your body, your will is greatly easier to exert around you and your body is trying to permanently assimilate with this world, it just needs a little push..."
+      "The very fabric of reality is blending in with your body, your will is greatly easier to exert around you and your body is trying to permanently assimilate with this world, it just needs a little push…"
     ],
     "max_intensity": 4,
     "rating": "good",

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3816,6 +3816,46 @@
   },
   {
     "type": "effect_type",
+    "id": "pd_strengthened_reality",
+    "name": [ "World's Acceptance", "World's Embracement", "Dimensional Foothold", "Dimensional Assimilation" ],
+    "desc": [
+      "The world around you seems calmer with your presence and actions.",
+      "The world around you seems to regard you as one of their own, your body is a little easier to move now.",
+      "You can more easily exert your will around you, this dimension is, if not welcoming you, obeying you a little.  You have managed to secure a foothold in this reality.",
+      "The very fabric of reality is blending in with your body, your will is greatly easier to exert around you and your body is trying to permanently assimilate with this world, it just needs a little push..."
+    ],
+    "max_intensity": 4,
+    "rating": "good",
+    "int_dur_factor": "3 days",
+    "base_mods": { "speed_mod": [ 2 ] },
+    "scaling_mods": { "speed_mod": [ 3 ], "dodge_mod": [ 0.7 ] },
+    "apply_message": "Your eyes open to a whole new world!",
+    "remove_message": "You start to feel rejected by the world again.",
+    "decay_messages": [
+      [ "The world no longer embraces you as its child.  At least it still tolerates your presence.", "mixed" ],
+      [
+        "You have lost your foothold and can no longer command the world around you, the world sees you now as only an unruly child.",
+        "mixed"
+      ],
+      [
+        "You can no longer bend the world to your will.  You have failed in blending in with this reality and have now only a foothold left.",
+        "mixed"
+      ]
+    ],
+    "miss_messages": [
+      [ "Did the world just oppose you?", 1 ],
+      [ "For a moment you felt a great hostility all around you.", 1 ],
+      [ "Did your enemy just vanish for a moment?.", 2 ],
+      [ "You felt weird for a moment.", 3 ],
+      [ "Was that a spark?", 5 ],
+      [ "Your grip suddenly failed you.", 6 ],
+      [ "Something just flashed in front of your eyes.", 8 ],
+      [ "Why did the hit went that way?", 15 ],
+      [ "You could have swear you hit it!", 25 ]
+    ]
+  },
+  {
+    "type": "effect_type",
     "id": "grown_of_fuse",
     "name": [ "Grown of Fusion" ],
     "desc": [ "AI effect to increase stats after fusing with another critter.  1 stack means one absorbed max_hp." ],

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3853,7 +3853,7 @@
       [ "Your grip suddenly failed you.", 6 ],
       [ "Something just flashed in front of your eyes.", 8 ],
       [ "Why did the hit go that way?", 15 ],
-      [ "You could have swear you hit it!", 25 ]
+      [ "You could swear that you hit it!", 25 ]
     ]
   },
   {

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3808,7 +3808,7 @@
       "Faint sparks surround your every move, your body aches more with every passing second.",
       "Sparks swarm around you, your body hurts and even the air seems to reject your existence."
     ],
-    "decay_messages": [ [ "The rejecting you feel from all around you has become a little easier to bear.", "mixed" ] ],
+    "decay_messages": [ [ "The rejection you feel from all around you has become a little easier to bear.", "mixed" ] ],
     "remove_message": "The world is no longer trying to eject you from this plane of existence, for now.",
     "max_intensity": 2,
     "rating": "bad",

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3808,6 +3808,8 @@
       "Faint sparks surround your every move, your body aches more with every passing second.",
       "Sparks swarm around you, your body hurts and even the air seems to reject your existence."
     ],
+    "decay_messages": [ [ "The rejecting you feel from all around you has become a little easier to bear.", "mixed" ] ],
+    "remove_message": "The world is no longer trying to eject you from this plane of existence, for now.",
     "max_intensity": 2,
     "rating": "bad",
     "int_dur_factor": "7 m",

--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -3852,7 +3852,7 @@
       [ "Was that a spark?", 5 ],
       [ "Your grip suddenly failed you.", 6 ],
       [ "Something just flashed in front of your eyes.", 8 ],
-      [ "Why did the hit went that way?", 15 ],
+      [ "Why did the hit go that way?", 15 ],
       [ "You could have swear you hit it!", 25 ]
     ]
   },

--- a/data/json/effects_on_condition/nether_eocs/portal_dependent_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_dependent_effect_on_condition.json
@@ -536,7 +536,7 @@
     "//": "Basic reward for experiencing a different reality when your own fabric of reality is damaged.",
     "effect": [
       {
-        "u_message": "You feel invigorated by what you just experienced, so...  What is this feeling of regret for leaving that place?",
+        "u_message": "You feel invigorated by what you just experienced, so…  What is this feeling of regret for leaving that place?",
         "type": "good"
       },
       {
@@ -554,7 +554,7 @@
     "//": "Standard reward for experiencing a different reality and integrating a little with it.",
     "effect": [
       {
-        "u_message": "You feel like the shackles of your body are loosening a little.  The world seems to accept your distorted presence for now.  You wonder if what you currently feel would have been greater if only you had gone deeper...",
+        "u_message": "You feel like the shackles of your body are loosening a little.  The world seems to accept your distorted presence for now.  You wonder if what you currently feel would have been greater if only you had gone deeper…",
         "type": "good"
       },
       {
@@ -573,7 +573,7 @@
     "//": "Improved reward for experiencing a different reality and integrating a little with it.",
     "effect": [
       {
-        "u_message": "You suddenly feel in calm, your body a little faster, and your surroundings less hostile than what you remember.  Before this new sensation passes away though, you hear a little voice in your head saying \"deeper...\"",
+        "u_message": "You suddenly feel in calm, your body a little faster, and your surroundings less hostile than what you remember.  Before this new sensation passes away though, you hear a little voice in your head saying \"deeper…\"",
         "type": "good"
       },
       {
@@ -592,7 +592,7 @@
     "//": "Big reward for experiencing a different reality and partially integrating your self with it.",
     "effect": [
       {
-        "u_message": "You return to your reality with a sense of ecstasy, your body feels great, your shackles have come loose and you feel powerful because of it.  But you can feel it, this exhilarating feeling is only the beginning, you need to go deeper...",
+        "u_message": "You return to your reality with a sense of ecstasy, your body feels great, your shackles have come loose and you feel powerful because of it.  But you can feel it, this exhilarating feeling is only the beginning, you need to go deeper…",
         "type": "good"
       },
       {
@@ -611,7 +611,7 @@
     "//": "Great reward for experiencing a different reality, partially integrating with it and bringing some of that reality with you.",
     "effect": [
       {
-        "u_message": "You feel in communion with the world around you, the world is no longer rejecting you, at least for now, YOU are rejecting IT.  Your whole body craves for what you could have gained if only you had gone a little deeper...",
+        "u_message": "You feel in communion with the world around you, the world is no longer rejecting you, at least for now, YOU are rejecting IT.  Your whole body craves for what you could have gained if only you had gone a little deeper…",
         "type": "good"
       },
       {

--- a/data/json/effects_on_condition/nether_eocs/portal_dependent_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_dependent_effect_on_condition.json
@@ -11,7 +11,7 @@
           "or": [
             { "is_weather": "portal_storm" },
             { "and": [ { "is_weather": "early_portal_storm" }, { "x_in_y_chance": { "x": 5, "y": 10 } } ] },
-            { "and": [ { "is_weather": "distant_portal_storm" }, { "x_in_y_chance": { "x": 5, "y": 10 } } ] },
+            { "and": [ { "is_weather": "distant_portal_storm" }, { "x_in_y_chance": { "x": 6, "y": 10 } } ] },
             { "and": [ { "is_weather": "near_portal_storm" }, { "x_in_y_chance": { "x": 8, "y": 10 } } ] },
             { "and": [ { "u_has_effect": "pd_strengthened_reality" }, { "x_in_y_chance": { "x": 1, "y": 10 } } ] }
           ]
@@ -564,7 +564,7 @@
         "duration": "180 minutes",
         "decay_start": "80 minutes"
       },
-      { "u_add_effect": "pd_strengthened_reality", "duration": "3 days" }
+      { "u_add_effect": "pd_strengthened_reality", "duration": "2 days" }
     ]
   },
   {
@@ -583,7 +583,7 @@
         "duration": "240 minutes",
         "decay_start": "100 minutes"
       },
-      { "u_add_effect": "pd_strengthened_reality", "duration": "6 days", "intensity": 2 }
+      { "u_add_effect": "pd_strengthened_reality", "duration": "5 days", "intensity": 2 }
     ]
   },
   {
@@ -602,7 +602,7 @@
         "duration": "260 minutes",
         "decay_start": "120 minutes"
       },
-      { "u_add_effect": "pd_strengthened_reality", "duration": "9 days", "intensity": 3 }
+      { "u_add_effect": "pd_strengthened_reality", "duration": "8 days", "intensity": 3 }
     ]
   },
   {
@@ -621,7 +621,7 @@
         "duration": "280 minutes",
         "decay_start": "140 minutes"
       },
-      { "u_add_effect": "pd_strengthened_reality", "duration": "12 days", "intensity": 4 }
+      { "u_add_effect": "pd_strengthened_reality", "duration": "11 days", "intensity": 4 }
     ]
   },
   {
@@ -695,7 +695,7 @@
               "u_message": "You suddenly feel a profound sense of belonging take root inside you, temporally amplifying your grasp of reality.  For some time you will be the master of your surroundings.",
               "type": "good"
             },
-            { "u_add_effect": "pd_strengthened_reality", "duration": "15 days", "intensity": 4 }
+            { "u_add_effect": "pd_strengthened_reality", "duration": "14 days", "intensity": 4 }
           ]
         }
       },

--- a/data/json/effects_on_condition/nether_eocs/portal_dependent_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_dependent_effect_on_condition.json
@@ -3,15 +3,34 @@
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_DEPENDENT_EFFECTS_ACCEPTANCE",
     "//": "Mainly good effects, since your unstable grasp on reality will strengthen with the distorted reality of the portal storms.",
-    "recurrence": [ "15 minutes", "50 minutes" ],
+    "recurrence": [ "5 minutes", "15 minutes" ],
     "condition": {
       "and": [
         { "u_has_trait": "PORTAL_DEPENDENT" },
-        { "is_weather": "portal_storm" },
+        {
+          "or": [
+            { "is_weather": "portal_storm" },
+            { "and": [ { "is_weather": "early_portal_storm" }, { "x_in_y_chance": { "x": 5, "y": 10 } } ] },
+            { "and": [ { "is_weather": "distant_portal_storm" }, { "x_in_y_chance": { "x": 5, "y": 10 } } ] },
+            { "and": [ { "is_weather": "near_portal_storm" }, { "x_in_y_chance": { "x": 8, "y": 10 } } ] },
+            { "and": [ { "u_has_effect": "pd_strengthened_reality" }, { "x_in_y_chance": { "x": 1, "y": 10 } } ] }
+          ]
+        },
         { "not": { "u_has_worn_with_flag": "DIMENSIONAL_ANCHOR" } }
       ]
     },
-    "deactivate_condition": { "not": { "or": [ { "u_has_trait": "PORTAL_DEPENDENT" }, { "is_weather": "portal_storm" } ] } },
+    "deactivate_condition": {
+      "not": {
+        "or": [
+          { "u_has_trait": "PORTAL_DEPENDENT" },
+          { "is_weather": "portal_storm" },
+          { "is_weather": "early_portal_storm" },
+          { "is_weather": "near_portal_storm" },
+          { "is_weather": "distant_portal_storm" },
+          { "u_has_effect": "pd_strengthened_reality" }
+        ]
+      }
+    },
     "effect": {
       "run_eocs": {
         "id": "EOC_PDEPENDENT_STRONG_WEAK_EFFECTS_ACCEPTANCE",
@@ -116,6 +135,14 @@
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_DEPENDENT_ACCEPTANCE_4",
     "//": "Your feel greatly more accepted by the world, your body partially stabilizes itself in this reality if you are outside.",
+    "condition": {
+      "or": [
+        { "is_weather": "portal_storm" },
+        { "is_weather": "early_portal_storm" },
+        { "is_weather": "near_portal_storm" },
+        { "is_weather": "distant_portal_storm" }
+      ]
+    },
     "effect": {
       "run_eocs": {
         "id": "EOC_PORTAL_DEPENDENT_ACCEPTANCE_OUTSIDE",
@@ -159,11 +186,34 @@
     "condition": {
       "and": [
         { "u_has_trait": "PORTAL_DEPENDENT" },
-        { "not": { "is_weather": "portal_storm" } },
+        {
+          "not": {
+            "or": [
+              { "u_has_effect": "pd_strengthened_reality" },
+              { "is_weather": "portal_storm" },
+              { "is_weather": "early_portal_storm" },
+              { "is_weather": "near_portal_storm" },
+              { "is_weather": "distant_portal_storm" }
+            ]
+          }
+        },
         { "not": { "u_has_worn_with_flag": "DIMENSIONAL_ANCHOR" } }
       ]
     },
-    "deactivate_condition": { "or": [ { "not": { "u_has_trait": "PORTAL_DEPENDENT" } }, { "is_weather": "portal_storm" } ] },
+    "deactivate_condition": {
+      "or": [
+        { "not": { "u_has_trait": "PORTAL_DEPENDENT" } },
+        {
+          "or": [
+            { "u_has_effect": "pd_strengthened_reality" },
+            { "is_weather": "portal_storm" },
+            { "is_weather": "early_portal_storm" },
+            { "is_weather": "near_portal_storm" },
+            { "is_weather": "distant_portal_storm" }
+          ]
+        }
+      ]
+    },
     "effect": {
       "run_eocs": {
         "id": "EOC_PDEPENDENT_STRONG_WEAK_EFFECTS_REJECTION",
@@ -417,5 +467,245 @@
     "//": "Messages about strange/bad things that you think/feel/do related to your mental condition.",
     "condition": { "and": [ { "not": { "u_has_effect": "sleep" } }, "u_can_see" ] },
     "effect": [ { "u_message": "PORTAL_DEPENDENT_MESSAGES_INT_BAD", "snippet": true, "type": "mixed" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD",
+    "//": "Rewards for Portal Dependent characters that survive the dimensional experience of a portal dungeon.",
+    "effect": {
+      "switch": { "global_val": "var", "var_name": "portal_dungeon_level" },
+      "cases": [
+        {
+          "case": 0,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_0", { "const": 16 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_1", { "const": 3 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_2", { "const": 1 } ]
+            ]
+          }
+        },
+        {
+          "case": 1,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_0", { "const": 6 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_1", { "const": 12 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_2", { "const": 2 } ]
+            ]
+          }
+        },
+        {
+          "case": 2,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_0", { "const": 1 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_1", { "const": 5 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_2", { "const": 12 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_3", { "const": 2 } ]
+            ]
+          }
+        },
+        {
+          "case": 3,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_1", { "const": 2 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_2", { "const": 5 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_3", { "const": 12 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_4", { "const": 1 } ]
+            ]
+          }
+        },
+        {
+          "case": 4,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_2", { "const": 2 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_3", { "const": 6 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_4", { "const": 12 } ]
+            ]
+          }
+        }
+      ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_0",
+    "//": "Basic reward for experiencing a different reality when your own fabric of reality is damaged.",
+    "effect": [
+      {
+        "u_message": "You feel invigorated by what you just experienced, so...  What is this feeling of regret for leaving that place?",
+        "type": "good"
+      },
+      {
+        "u_add_morale": "morale_feeling_good",
+        "bonus": 20,
+        "max_bonus": 40,
+        "duration": "120 minutes",
+        "decay_start": "60 minutes"
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_1",
+    "//": "Standard reward for experiencing a different reality and integrating a little with it.",
+    "effect": [
+      {
+        "u_message": "You feel like the shackles of your body are loosening a little.  The world seems to accept your distorted presence for now.  You wonder if what you currently feel would have been greater if only you had gone deeper...",
+        "type": "good"
+      },
+      {
+        "u_add_morale": "morale_feeling_good",
+        "bonus": 20,
+        "max_bonus": 40,
+        "duration": "180 minutes",
+        "decay_start": "80 minutes"
+      },
+      { "u_add_effect": "pd_strengthened_reality", "duration": "3 days" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_2",
+    "//": "Improved reward for experiencing a different reality and integrating a little with it.",
+    "effect": [
+      {
+        "u_message": "You suddenly feel in calm, your body a little faster, and your surroundings less hostile than what you remember.  Before this new sensation passes away though, you hear a little voice in your head saying \"deeper...\"",
+        "type": "good"
+      },
+      {
+        "u_add_morale": "morale_feeling_good",
+        "bonus": 20,
+        "max_bonus": 40,
+        "duration": "240 minutes",
+        "decay_start": "100 minutes"
+      },
+      { "u_add_effect": "pd_strengthened_reality", "duration": "6 days", "intensity": 2 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_3",
+    "//": "Big reward for experiencing a different reality and partially integrating your self with it.",
+    "effect": [
+      {
+        "u_message": "You return to your reality with a sense of ecstasy, your body feels great, your shackles have come loose and you feel powerful because of it.  But you can feel it, this exhilarating feeling is only the beginning, you need to go deeper...",
+        "type": "good"
+      },
+      {
+        "u_add_morale": "morale_feeling_good",
+        "bonus": 25,
+        "max_bonus": 40,
+        "duration": "260 minutes",
+        "decay_start": "120 minutes"
+      },
+      { "u_add_effect": "pd_strengthened_reality", "duration": "9 days", "intensity": 3 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_4",
+    "//": "Great reward for experiencing a different reality, partially integrating with it and bringing some of that reality with you.",
+    "effect": [
+      {
+        "u_message": "You feel in communion with the world around you, the world is no longer rejecting you, at least for now, YOU are rejecting IT.  Your whole body craves for what you could have gained if only you had gone a little deeper...",
+        "type": "good"
+      },
+      {
+        "u_add_morale": "morale_feeling_good",
+        "bonus": 25,
+        "max_bonus": 40,
+        "duration": "280 minutes",
+        "decay_start": "140 minutes"
+      },
+      { "u_add_effect": "pd_strengthened_reality", "duration": "12 days", "intensity": 4 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PORTAL_DEPENDENT_DUNGEON_FINAL_REWARD",
+    "//": "Rewards for Portal Dependent characters that survive the last level of a portal dungeon.",
+    "effect": {
+      "switch": { "global_val": "var", "var_name": "portal_dungeon_level" },
+      "cases": [
+        {
+          "case": 5,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_3", { "const": 6 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_4", { "const": 10 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_5", { "const": 4 } ]
+            ]
+          }
+        },
+        {
+          "case": 6,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_3", { "const": 4 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_4", { "const": 8 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_5", { "const": 8 } ]
+            ]
+          }
+        },
+        {
+          "case": 7,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_3", { "const": 1 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_4", { "const": 6 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_5", { "const": 13 } ]
+            ]
+          }
+        },
+        {
+          "case": 8,
+          "effect": {
+            "weighted_list_eocs": [
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_4", { "const": 2 } ],
+              [ "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_5", { "const": 18 } ]
+            ]
+          }
+        },
+        { "case": 9, "effect": [ { "run_eocs": "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_5" } ] }
+      ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD_5",
+    "//": "Final reward for experiencing a whole different reality, allowing you to partially anchor yourself to reality again.",
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_PORTAL_DEPENDENT_ACCEPTANCE_TRAIT",
+          "condition": { "not": { "u_has_trait": "REALITY_GRASP" } },
+          "effect": [
+            {
+              "u_message": "You suddenly feel a profound sense of belonging take root inside you, spreading throughout your body.  It fades quickly, but something warm remains…",
+              "type": "good"
+            },
+            { "u_add_trait": "REALITY_GRASP" }
+          ],
+          "false_effect": [
+            {
+              "u_message": "You suddenly feel a profound sense of belonging take root inside you, temporally amplifying your grasp of reality.  For some time you will be the master of your surroundings.",
+              "type": "good"
+            },
+            { "u_add_effect": "pd_strengthened_reality", "duration": "15 days", "intensity": 4 }
+          ]
+        }
+      },
+      {
+        "u_add_morale": "morale_feeling_good",
+        "bonus": 30,
+        "max_bonus": 60,
+        "duration": "300 minutes",
+        "decay_start": "150 minutes"
+      }
+    ]
   }
 ]

--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -1062,15 +1062,38 @@
       "cases": [
         {
           "case": 0,
+          "effect": [
+            {
+              "weighted_list_eocs": [
+                [ "EOC_PORTAL_DUNGEON_REWARD_WEAKENED_INERTIA", { "const": 1 } ],
+                [ "EOC_PORTAL_DUNGEON_REWARD_WARPED_VIEWPOINT", { "const": 1 } ],
+                [ "EOC_PORTAL_DUNGEON_REWARD_WEAKENED_GRAVITY", { "const": 1 } ]
+              ]
+            },
+            {
+              "run_eocs": [
+                {
+                  "id": "EOC_PORTAL_DEPENDENT_DUNGEON",
+                  "condition": { "u_has_trait": "PORTAL_DEPENDENT" },
+                  "effect": { "run_eocs": "EOC_PORTAL_DEPENDENT_DUNGEON_REWARD" }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "case": 5,
           "effect": {
-            "weighted_list_eocs": [
-              [ "EOC_PORTAL_DUNGEON_REWARD_WEAKENED_INERTIA", { "const": 1 } ],
-              [ "EOC_PORTAL_DUNGEON_REWARD_WARPED_VIEWPOINT", { "const": 1 } ],
-              [ "EOC_PORTAL_DUNGEON_REWARD_WEAKENED_GRAVITY", { "const": 1 } ]
+            "run_eocs": [
+              { "id": "EOC_PORTAL_DUNGEON_REWARD_ITEM" },
+              {
+                "id": "EOC_PORTAL_DEPENDENT_DUNGEON_FINAL",
+                "condition": { "u_has_trait": "PORTAL_DEPENDENT" },
+                "effect": { "run_eocs": "EOC_PORTAL_DEPENDENT_DUNGEON_FINAL_REWARD" }
+              }
             ]
           }
-        },
-        { "case": 5, "effect": { "run_eocs": "EOC_PORTAL_DUNGEON_REWARD_ITEM" } }
+        }
       ]
     }
   },

--- a/data/json/effects_on_condition/scenario_specific_eocs.json
+++ b/data/json/effects_on_condition/scenario_specific_eocs.json
@@ -38,6 +38,16 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "scenario_portal_dependent",
+    "eoc_type": "SCENARIO_SPECIFIC",
+    "effect": [
+      {
+        "run_eocs": [ "EOC_PORTAL_DEPENDENT_MESSAGES_BAD", "EOC_PORTAL_DEPENDENT_FOCUS_BAD", "EOC_PORTAL_DEPENDENT_DAMAGE_CONSTANT" ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "scenario_mansion_pursuit",
     "eoc_type": "SCENARIO_SPECIFIC",
     "effect": [

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -921,6 +921,7 @@
   },
   {
     "type": "scenario",
+    "copy-from": "mutant",
     "id": "portal_dependent",
     "name": "Challenge - Portal Dependent",
     "points": -8,
@@ -929,10 +930,23 @@
     "flags": [ "CHALLENGE", "LONE_START" ],
     "start_name": "Field",
     "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island" ],
-    "eoc": [ "scenario_strong_portal_storm" ],
+    "eoc": [ "scenario_strong_portal_storm", "scenario_portal_dependent" ],
     "requirement": "achievement_reach_lab_finale",
     "reveal_locale": false,
-    "professions": [ "portal_traveler", "churl", "true_foodperson", "unemployed", "naked" ]
+    "professions": [
+      "portal_traveler",
+      "churl",
+      "true_foodperson",
+      "unemployed",
+      "naked",
+      "mutant_patient",
+      "mutant_volunteer",
+      "mutant_amputee",
+      "labtech",
+      "security",
+      "medic",
+      "paranormal_investigator"
+    ]
   },
   {
     "type": "scenario",

--- a/data/mods/MMA/scenarios.json
+++ b/data/mods/MMA/scenarios.json
@@ -2,7 +2,7 @@
   {
     "copy-from": "portal_dependent",
     "type": "scenario",
-    "extend": { "professions": [ "mma_battle_angel" ] },
+    "extend": { "professions": [ "mma_battle_angel", "mma_hylian_adventurer" ] },
     "id": "portal_dependent"
   }
 ]

--- a/data/mods/Magiclysm/scenarios.json
+++ b/data/mods/Magiclysm/scenarios.json
@@ -112,5 +112,11 @@
     "type": "scenario",
     "extend": { "professions": [ "magic_miner" ] },
     "id": "Mine_bottom"
+  },
+  {
+    "copy-from": "portal_dependent",
+    "type": "scenario",
+    "extend": { "professions": [ "dimensionalist" ] },
+    "id": "portal_dependent"
   }
 ]

--- a/data/mods/MindOverMatter/scenarios.json
+++ b/data/mods/MindOverMatter/scenarios.json
@@ -1,0 +1,8 @@
+[
+  {
+    "copy-from": "portal_dependent",
+    "type": "scenario",
+    "extend": { "professions": [ "psi_new_psychic", "psi_telekinetic_testsubject", "psi_teleporter_slider" ] },
+    "id": "portal_dependent"
+  }
+]

--- a/data/mods/innawood/scenarios.json
+++ b/data/mods/innawood/scenarios.json
@@ -402,6 +402,7 @@
   },
   {
     "type": "scenario",
+    "copy-from": "mutant",
     "id": "portal_dependent",
     "name": "Challenge - Portal Dependent",
     "points": -8,
@@ -410,10 +411,23 @@
     "flags": [ "CHALLENGE", "LONE_START" ],
     "start_name": "Field",
     "allowed_locs": [ "sloc_field", "sloc_forest", "sloc_desert_island" ],
-    "eoc": [ "scenario_strong_portal_storm" ],
+    "eoc": [ "scenario_strong_portal_storm", "scenario_portal_dependent" ],
     "requirement": "achievement_witnessed_portal_storm",
     "reveal_locale": false,
-    "professions": [ "portal_traveler", "churl", "true_foodperson", "unemployed", "naked" ]
+    "professions": [
+      "portal_traveler",
+      "churl",
+      "true_foodperson",
+      "unemployed",
+      "naked",
+      "mutant_patient",
+      "mutant_volunteer",
+      "mutant_amputee",
+      "labtech",
+      "security",
+      "medic",
+      "paranormal_investigator"
+    ]
   },
   {
     "type": "scenario",


### PR DESCRIPTION
#### Summary
Content "Updates the Portal Dependent mechanics and introduces rewards for exploring the portal dungeons."

#### Purpose of change
I have always wanted for portal dungeons to reward portal dependent characters with something appropriate for them and for it to be possible to permanently improve your grasp of reality by exploring them, and I finally found the time (And creativity) to do it!

When doing this I noticed that some aspects of the EoCs of their mechanics were in need of an update since the change from static portal storms to mobile/regional portal storms, so I went and updated them too.

#### Describe the solution
Adds a new effect that represents a temporal alignment/subversion of the local reality to accommodate your unstable state in the world, given by exploring the portal dungeon and improving the more levels you complete, with the final possible reward being the "Stabilized in Reality" trait that permanently disables the worst effects of the portal dependent trait and improves your chances of benign effects when suffering from your lack of portal storms.

The trait already existed, but the only way to obtain it was by exposing yourself to the portal storms for a significant time, so it was necessary a more proactive method, even if equally dangerous.

Edit: Also added some more professions to the scenario! Mainly researchers/guinea pigs from labs that could have ended up caught in this dimensional travel business, You can now select from any of the mutations that the mutated scenarios use too! Since being trapped in a portal storm of this magnitude can definitely change you in strange ways. You will now start with some debuffs too to emphasize your distorted presence and the initial damage from being involved in something like this.

Added mod professions to the scenario when appropriate! Now your nether touched psychics can start in the middle of the portal storm that gave them their powers!

#### Describe alternatives you've considered
To implement the effect as an artifact like my first mental draft of this? I ended up doing it this way but I´m not against adding different rewards in the shape of an artifact that helps you lessen your reality decay problems.

#### Testing
it loads! The effects appear and work on the player! They are given when completing the appropriate levels of the portal dungeon! You can gain the stabilization trait by making a deep exploration of the dungeon! I have make testing seeing of the professions/traits appear in the mod and seeing that portal dungeon standard rewards are not affected by this changes, it all seems to work fine.

#### Additional context
I would like to add some new EoCs with more effects of the reality rejecting you, specially as a consequence of abusing portal dungeons and bringing instability to your surroundings just by trying to make the world fit you again in it. But my creative mind has dried up for now so maybe later or in another PR...

![imagen](https://github.com/CleverRaven/Cataclysm-DDA/assets/53200489/8e76153e-4a05-4ce2-94ab-2c00b8cd419b)

This PR was planned since 2 years ago! [Here](https://github.com/CleverRaven/Cataclysm-DDA/pull/52968#issuecomment-988218483)
