### PR TITLE
Fix Clang-tidy 16 warning

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6119,14 +6119,10 @@ void vehicle::refresh( const bool remove_fakes )
                                          static_cast<int>( p ), svpv );
         relative_parts[pt].insert( vii, p );
 
-        if( vpi.has_flag( VPFLAG_FLOATS ) ) {
-            //If it doesn't leak
-            if( vpi.has_flag( VPFLAG_NO_LEAK ) ) {
-                floating.push_back( p );
-                // If it's health is less than 50% then The hull has been breached and the air is leaking out
-            } else if( !( vp.part().health_percent() < vp.part().floating_leak_threshold() ) ) {
-                floating.push_back( p );
-            }
+        //If it doesn't leak or it's health is less than 50% then The hull has been breached and the air is leaking out
+        if( vpi.has_flag( VPFLAG_FLOATS ) && ( vpi.has_flag( VPFLAG_NO_LEAK ) ||
+                                               !( vp.part().health_percent() < vp.part().floating_leak_threshold() ) ) ) {
+            floating.push_back( p );
         }
 
         if( vp.part().is_unavailable() ) {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fix Clang-tidy 16 warning to prevent cl test fails.

#### Describe the solution


#### Describe alternatives you've considered


#### Testing


#### Additional context
