### PR TITLE
Allow rioter mask to use more t-shirts

### DIFF
--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -1817,7 +1817,16 @@
     "time": "1 m 30 s",
     "reversible": true,
     "autolearn": true,
-    "components": [ [ [ "tshirt", 1 ], [ "flag_shirt", 1 ], [ "linuxtshirt", 1 ], [ "tshirt_text", 1 ] ] ],
+    "components": [
+      [
+        [ "tshirt", 1 ],
+        [ "flag_shirt", 1 ],
+        [ "linuxtshirt", 1 ],
+        [ "tshirt_tour", 1 ],
+        [ "technician_shirt_gray", 1 ],
+        [ "tshirt_text", 1 ]
+      ]
+    ],
     "flags": [ "BLIND_HARD", "NO_RESIZE" ]
   },
   {


### PR DESCRIPTION
#### Summary
Content "Allows rioter mask recipe to use all the t-shirts"

#### Purpose of change

I noticed that rioter masks couldn't use the work t-shirt, or the technician shirt.

#### Describe the solution

Add those shirts to the recipe.

#### Describe alternatives you've considered

None. 

#### Testing

Loaded game. Made some masks.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/7764202/57237969-35a9-4731-8576-7ae7c241d4d9)


#### Additional context
None