### PR TITLE
Give Eddie McKenzie some more missions

### DIFF
--- a/data/json/effects_on_condition/mapgen_eocs/godco_mapgen_eocs.json
+++ b/data/json/effects_on_condition/mapgen_eocs/godco_mapgen_eocs.json
@@ -81,5 +81,32 @@
       { "arithmetic": [ { "global_val": "var", "var_name": "wall_in_progress" }, "=", { "const": 2 } ] },
       { "npc_lose_var": "wall_started_building", "type": "timer", "context": "trade" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "godco_place_warehouse",
+    "recurrence": 100,
+    "global": false,
+    "//": "1 hour 30 minutes per wood wall * 50 walls = 75 hours for walls. 132 wood floors * 1 hour 40 minutes a floor = 220 hours. 1 hour 30 minutes per shelf * 68 shelves = 102 hours. (397 so far)  2 hours per roof * 132 roof tiles (assume same as floors) = 264 hours.",
+    "//2": "In total, this takes 661 labor hours to build. Assuming work is in 8-hour shifts, that's 83 days, or 2 months and 22 days for a single worker.  Assume we have ~6 people on the job (isn't as urgent as a wall), this takes us ~14 days to build, or two weeks.",
+    "condition": {
+      "and": [
+        { "math": [ "godco_warehouse_in_progress", "==", "1" ] },
+        {
+          "u_compare_time_since_var": "warehouse_started_building",
+          "type": "timer",
+          "context": "trade",
+          "op": ">=",
+          "time": "14 d"
+        },
+        { "u_near_om_location": "godco_1_1", "range": 1 }
+      ]
+    },
+    "deactivate_condition": { "math": [ "godco_warehouse_in_progress", "==", "2" ] },
+    "effect": [
+      { "mapgen_update": "place_food_warehouse", "om_terrain": "forest_thick" },
+      { "math": [ "godco_warehouse_in_progress", "=", "2" ] },
+      { "u_lose_var": "warehouse_started_building", "type": "timer", "context": "trade" }
+    ]
   }
 ]

--- a/data/json/effects_on_condition/npc_eocs/godco_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/godco_npc_eocs.json
@@ -104,5 +104,20 @@
       { "u_lose_var": "u_think_suspicious_price", "type": "general", "context": "trade" },
       { "finish_mission": "MISSION_INVESTIGATE_TRADER", "success": false }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "GODCO_EDDIE_CANNING_MISSION_ADD",
+    "condition": {
+      "and": [
+        { "math": [ "godco_has_canningpots", "==", "1" ] },
+        { "not": { "npc_has_var": "got_mission", "type": "dialogue", "context": "missions", "value": "yes" } }
+      ]
+    },
+    "deactivate_condition": { "npc_has_var": "got_mission", "type": "dialogue", "context": "missions", "value": "yes" },
+    "effect": [
+      { "offer_mission": "MISSION_GODCO_FOOD_GUARD_CANNING_STARTUP" },
+      { "npc_add_var": "got_mission", "type": "dialogue", "context": "missions", "value": "yes" }
+    ]
   }
 ]

--- a/data/json/mapgen/godco/mapgen_updates.json
+++ b/data/json/mapgen/godco/mapgen_updates.json
@@ -79,6 +79,12 @@
   },
   {
     "type": "mapgen",
+    "update_mapgen_id": "place_food_warehouse",
+    "method": "json",
+    "object": { "place_nested": [ { "chunks": [ "eddie_food_storage" ], "x": 6, "y": 6 } ] }
+  },
+  {
+    "type": "mapgen",
     "update_mapgen_id": "helena_planer",
     "method": "json",
     "object": {

--- a/data/json/mapgen/godco/nested.json
+++ b/data/json/mapgen/godco/nested.json
@@ -63,6 +63,35 @@
   {
     "type": "mapgen",
     "method": "json",
+    "nested_mapgen_id": "eddie_food_storage",
+    "object": {
+      "mapgensize": [ 14, 14 ],
+      "rotation": 1,
+      "rows": [
+        "||||||++||||||",
+        "|;..........;|",
+        "|;.;;..;;...;|",
+        "|;.;;..;;...;|",
+        "|;.;;..;;...;|",
+        "|;.;;..;;...;|",
+        "|;.;;..;;...;|",
+        "|;.;;..;;...;|",
+        "|;.;;..;;...;|",
+        "|;.;;..;;...;|",
+        "|;.;;..;;...;|",
+        "|;.;;..;;...;|",
+        "|;.;;..;;...;|",
+        "||||||||||||||"
+      ],
+      "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ],
+      "palettes": [ "godco_camp" ],
+      "furniture": { ";": "f_warehouse_shelf" },
+      "terrain": { ";": "t_floor" }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "nested_mapgen_id": "kostas_herb_garden",
     "object": {
       "mapgensize": [ 7, 7 ],

--- a/data/json/npcs/godco/godco_missions.json
+++ b/data/json/npcs/godco/godco_missions.json
@@ -84,11 +84,11 @@
     "item": "novel_mystery",
     "count": 3,
     "origins": [ "ORIGIN_SECONDARY" ],
-    "followup": "MISSION_INVESTIGATE_CULT",
+    "has_generic_rewards": false,
     "dialogue": {
       "describe": "I'd like to read some mystery novels.",
-      "offer": "Hmm, that would be great!  But if you do, please bring more than just one.  I could read a single novel in a day.  Could you get me… 3 mystery novels?",
-      "accepted": "Just bring it to me when you have it.",
+      "offer": "Sometimes it gets a little bit boring up here, and I like to read something to take my mind off of things.  Problem is, I've run out of books.  I've been wanting to read some mystery novels as of late, so could you get me three of them?",
+      "accepted": "Just bring them to me when you have it.",
       "rejected": "Nevermind then.  I hope you'll change your mind.",
       "advice": "I'd loot libraries and bookstores.",
       "inquire": "So, have you found the books?",
@@ -97,6 +97,90 @@
       "failure": "Fine.  I can read something else."
     },
     "end": { "effect": [ { "u_spawn_item": "icon", "count": 2 } ], "opinion": { "trust": 2 } }
+  },
+  {
+    "id": "MISSION_GODCO_FOOD_GUARD_CANNING_STARTUP",
+    "type": "mission_definition",
+    "name": { "str": "Canning Startup" },
+    "description": "Find 100 medium tin cans to can with.",
+    "goal": "MGOAL_FIND_ITEM",
+    "difficulty": 2,
+    "value": 0,
+    "item": "can_medium",
+    "count": 100,
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "followup": "MISSION_GODCO_FOOD_GUARD_GET_TRAP_BOOK",
+    "has_generic_rewards": false,
+    "dialogue": {
+      "describe": "I'd like to have some cans to store food in.",
+      "offer": "Now that we have some canning pots from Helena, we can start storing foodstuffs more easily around here.  Recycling our old tin cans is great and all, but if we get a big influx of new foods, then we can't properly store it all.  As such, if you could find about 100 more empty tin cans for me, I'd really appreciate it.",
+      "accepted": "Just bring it to me when you have it.",
+      "rejected": "Nevermind then.  I hope you'll change your mind.",
+      "advice": "I'd look anywhere there's food waste or scrap piles.  We can wash out the cans when we get them.",
+      "inquire": "So, have you found the cans?",
+      "success": "Thank you, now we won't have to worry about running out of food in the winter.",
+      "success_lie": "Could you give them to me?",
+      "failure": "Fine.  I'll get them myself."
+    },
+    "end": { "effect": [ { "u_spawn_item": "icon", "count": 10 } ], "opinion": { "trust": 2 } }
+  },
+  {
+    "id": "MISSION_GODCO_FOOD_GUARD_GET_TRAP_BOOK",
+    "type": "mission_definition",
+    "name": { "str": "Find a copy of The Modern Trapper" },
+    "description": "Find a copy of The Modern Trapper so Eddie can learn how.",
+    "goal": "MGOAL_FIND_ITEM",
+    "difficulty": 2,
+    "value": 0,
+    "item": "manual_traps",
+    "count": 1,
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "followup": "MISSION_GODCO_FOOD_GUARD_BETTER_FOOD_STORAGE",
+    "has_generic_rewards": false,
+    "dialogue": {
+      "describe": "I'd like to read some trapping guides.",
+      "offer": "Since we've got all the stuff to store away food, I figure that it's time we get some more.  I've been talking it over with Russell, and I think setting out animal traps is a good way to go.  The problem is, nobody here knows how to do it.  I've heard that The Modern Trapper is a good place to start, so if you could get me a copy, I'd really appreciate it.",
+      "accepted": "Just bring it to me when you have it.",
+      "rejected": "Too trivial for you?",
+      "advice": "I'd loot libraries and bookstores.",
+      "inquire": "So, have you found it?",
+      "success": "Thank you, me and Russell will start studying it soon.",
+      "success_lie": "Where is it?",
+      "failure": "Fine.  I can read something else."
+    },
+    "end": { "effect": [ { "u_spawn_item": "icon", "count": 7 } ], "opinion": { "trust": 1 } }
+  },
+  {
+    "id": "MISSION_GODCO_FOOD_GUARD_BETTER_FOOD_STORAGE",
+    "type": "mission_definition",
+    "name": { "str": "Store Up Your Grain" },
+    "description": "Find 5,398 pounds of sheet metal (408 units) to help Eddie build a warehouse.",
+    "goal": "MGOAL_FIND_ITEM",
+    "difficulty": 5,
+    "value": 0,
+    "item": "sheet_metal",
+    "count": 408,
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "has_generic_rewards": false,
+    "dialogue": {
+      "describe": "I'd like to have better food storage.",
+      "offer": "I've been drawing up some plans to expand our food storage around here.  Now that we won't starve to death anytime soon, our old crates just aren't cutting it, so we're going to build a small warehouse to store everything, and I've gathered a crew to build it.  We've got most of the materials covered, but we don't have enough sheet metal to make the shelves.  If you could get us about 5,000 pounds of the stuff, I'll pay you handsomely with what we have.  How does that sound?",
+      "accepted": "Just bring it to me when you have it.",
+      "rejected": "Alright, I'll find someone else.",
+      "advice": "If you can find a steel mill, I'd look there.",
+      "inquire": "Do you have the sheet metal?",
+      "success": "I can't thank you enough, here's the pay for it.  Here in a while, we'll have a spot to put all of our food.",
+      "success_lie": "Alright, where's it all at?",
+      "failure": "Sorry, I had to find someone else since you didn't come through."
+    },
+    "end": {
+      "effect": [
+        { "math": [ "godco_warehouse_in_progress", "=", "1" ] },
+        { "npc_add_var": "warehouse_started_building", "type": "timer", "context": "trade", "time": true },
+        { "u_spawn_item": "icon", "count": 137 }
+      ],
+      "opinion": { "trust": 7, "value": 6, "anger": -3 }
+    }
   },
   {
     "id": "MISSION_GODCO_GET_GUITAR_STRING",
@@ -1186,6 +1270,7 @@
     "value": 0,
     "end": {
       "effect": [
+        { "math": [ "godco_has_canningpots", "=", "1" ] },
         { "u_spawn_item": "icon", "count": 80 },
         { "u_spawn_item": "pickled_egg", "count": 10, "container": "jar_glass_sealed" }
       ]

--- a/data/json/npcs/godco/members/foodguard.json
+++ b/data/json/npcs/godco/members/foodguard.json
@@ -17,6 +17,7 @@
         "no": "Hello.  What brings you around here?"
       }
     },
+    "speaker_effect": { "effect": { "run_eocs": "GODCO_EDDIE_CANNING_MISSION_ADD" } },
     "responses": [
       {
         "text": "Who are you?",
@@ -87,6 +88,7 @@
       { "text": "Would you be willing to buy any food?", "topic": "TALK_GODCO_guard_food_buy" },
       { "text": "Has anyone stolen from here?", "topic": "TALK_GODCO_guard_food_theft" },
       { "text": "How much food do you have?", "topic": "TALK_GODCO_guard_food_stock" },
+      { "text": "Is there anything I can do to help you?", "topic": "TALK_MISSION_LIST" },
       { "text": "Good luck with that.", "topic": "TALK_DONE" }
     ]
   },
@@ -96,6 +98,7 @@
     "dynamic_line": [ "Name's Eddie.  I'm making sure this stockpile is alright." ],
     "responses": [
       { "text": "Could you just chat for a bit?", "topic": "TALK_GODCO_guard_food_idlechat" },
+      { "text": "Is there anything I can do to help you?", "topic": "TALK_MISSION_LIST" },
       { "text": "Could I borrow something from the stock?", "topic": "TALK_GODCO_guard_food_borrow" },
       { "text": "Has anyone stolen from here?", "topic": "TALK_GODCO_guard_food_theft" },
       { "text": "How much food do you have?", "topic": "TALK_GODCO_guard_food_stock" },
@@ -255,7 +258,7 @@
     "type": "talk_topic",
     "id": "TALK_GODCO_guard_food_hobbies",
     "dynamic_line": [
-      "I really like to draw things, I primarily did landscapes in my spare time.  I like paper-and-pencil sketches, but I have worked with watercolors and oil canvases.  Never could get my head around the digital stuff, though, too complex for me and I never had a good free hand with a stylus.  I also shot a bit, went hunting a few times.  I mainly went to the gun range though, shotguns were always my forte.  Besides that, I watched some TV and regular ol' stuff."
+      "I really like to draw things, I primarily did landscapes in my spare time.  I like paper-and-pencil sketches, but I have worked with watercolors and oil canvases.  Never could get my head around the digital stuff, though, too complex for me and I never had a good free hand with a stylus.  I also shot a bit, went hunting a few times.  I mainly went to the gun range though, shotguns were always my forte.  Besides that, I watched some TV and regular ol' stuff.  I also like to read quite a bit, too."
     ],
     "responses": [
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Give Eddie McKenzie more missions."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
As the (for now) final part of fleshing out Eddie, I've given him three new missions to give the player, all of which involve securing the food supply for God's Chosen in some way. I also noticed that he had a mission already, but it wasn't hooked up in the dialogue, so I fixed that.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The first mission comes into play after you've got canning pots for Helena, Eddie asks you to get more medium tin cans so he can put stuff in them. Afterwards, he asks you to get a copy of The Modern Trapper so he and Russell can start getting more food for the NECC. Sometime later, he will organize a labor crew to build a small warehouse outside the compound and will need you to get sheet metal for this. All of these quests give a reward, with the final being the most sizeable. His existing book mission is also available as a result of this, and I've started using the newer `math` functions to replace `arithmetic` and `compare_num` strings for these additions.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this, or leaving him jobless as a generic guard. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I went into the game and played around with everything; it all works as I'd like it to.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I plan to have the NECC NPCs react to these new developments at some point in the future, and alter their dialogue to reflect the sect not having to worry about the food supply anymore. But before that, I plan to convert the old `arithmetic` syntax in the mission and EOC files to `math`.

I also wish that there was a way to reference the assorted fields in faction definitions for EOC stuff, making the `food` entry go up or down based on trade and inventory developments, or using it for dialogue conditions. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
