### PR TITLE
Fix No Legs mutation conflicts, allow drastic mutation to fix them

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -344,7 +344,26 @@
     "restricts_gear": [ "foot_r" ],
     "prereqs": "HAS_RIGHT_LEG",
     "allowed_items": [ "LEG_PROSTHETIC" ],
-    "enchantments": [ "ENCH_NO_RIGHT_LEG" ]
+    "enchantments": [ "ENCH_NO_RIGHT_LEG" ],
+    "cancels": [
+      "BADKNEES",
+      "LIGHTSTEP",
+      "STRONGKNEES",
+      "STRONG_LEGS",
+      "PADDED_FEET",
+      "ANIMAL_FEET",
+      "FELINE_LEAP",
+      "LEAPING_LEGS",
+      "LEAPING_LEGS2",
+      "BIRD_LEGS",
+      "FLEET2",
+      "FLEET",
+      "HOOVES",
+      "RABBIT_FEET",
+      "TOUGH_FEET",
+      "RAP_TALONS",
+      "WEBBED_FEET"
+    ]
   },
   {
     "type": "mutation",
@@ -358,7 +377,26 @@
     "restricts_gear": [ "foot_l" ],
     "prereqs": "HAS_LEFT_LEG",
     "allowed_items": [ "LEG_PROSTHETIC" ],
-    "enchantments": [ "ENCH_NO_LEFT_LEG" ]
+    "enchantments": [ "ENCH_NO_LEFT_LEG" ],
+    "cancels": [
+      "BADKNEES",
+      "LIGHTSTEP",
+      "STRONGKNEES",
+      "STRONG_LEGS",
+      "PADDED_FEET",
+      "ANIMAL_FEET",
+      "FELINE_LEAP",
+      "LEAPING_LEGS",
+      "LEAPING_LEGS2",
+      "BIRD_LEGS",
+      "FLEET2",
+      "FLEET",
+      "HOOVES",
+      "RABBIT_FEET",
+      "TOUGH_FEET",
+      "RAP_TALONS",
+      "WEBBED_FEET"
+    ]
   },
   {
     "type": "mutation",
@@ -5243,7 +5281,7 @@
     "leads_to": [ "SCUTTLE" ],
     "visibility": 8,
     "ugliness": 9,
-    "restricts_gear": [ "leg_l", "leg_r", "foot_l", "foot_r" ],
+    "restricts_gear": [ "leg_l", "leg_r", "foot_l", "foot_r", "leg_stub_r", "leg_stub_l" ],
     "noise_modifier": 0.9,
     "destroys_gear": true,
     "flags": [ "TOUGH_FEET" ]
@@ -5266,7 +5304,7 @@
     "ugliness": 9,
     "encumbrance_always": [ [ "leg_l", 10 ], [ "leg_r", 10 ], [ "foot_l", 10 ], [ "foot_r", 10 ] ],
     "movecost_flatground_modifier": 1.25,
-    "restricts_gear": [ "leg_l", "leg_r", "foot_l", "foot_r" ],
+    "restricts_gear": [ "leg_l", "leg_r", "foot_l", "foot_r", "leg_stub_r", "leg_stub_l" ],
     "noise_modifier": 0.25,
     "destroys_gear": true
   },
@@ -7160,6 +7198,7 @@
     "description": "Your flesh is a pleasing gel-like consistency.  Your bodily functions seem to be moving around, and your leg-equivalents flow comfortably - if a little slower than your old meat-legs.",
     "purifiable": false,
     "leads_to": [ "INT_SLIME", "PER_SLIME" ],
+    "restricts_gear": [ "leg_stub_r", "leg_stub_l" ],
     "prereqs": [ "VISCOUS" ],
     "prereqs2": [ "BENDY2", "SLIME_HANDS" ],
     "threshreq": [ "THRESH_SLIME" ],
@@ -7345,6 +7384,7 @@
     "changes_to": [ "ROOTS2" ],
     "cancels": [ "LEG_TENTACLES", "HOOVES" ],
     "category": [ "PLANT" ],
+    "restricts_gear": [ "leg_stub_r", "leg_stub_l" ],
     "encumbrance_covered": [ [ "foot_l", 10 ], [ "foot_r", 10 ] ]
   },
   {
@@ -7834,7 +7874,7 @@
       { "part": "foot_l", "neutral": 6 },
       { "part": "foot_r", "neutral": 6 }
     ],
-    "restricts_gear": [ "foot_l", "foot_r" ],
+    "restricts_gear": [ "foot_l", "foot_r", "leg_stub_r", "leg_stub_l" ],
     "movecost_modifier": 1.2,
     "noise_modifier": 0.0,
     "flags": [ "TOUGH_FEET" ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix No Legs allowing for conflicting mutations."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #68928. This has the side effect of allowing significant enough mutation to restore your legs via some extreme leg-based mutations that would significantly alter your limbs.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add `cancels` entries to No Right Leg and No Left Leg mutations, and give a `restricts_gear` entry to the mutations which would reasonably grant new limbs to allow them to cancel this style of limb loss, such as Leg Tentacles or Crab Legs. Due to the dependance of the missing limb mutations on EOCs, this is done the same way.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this, or making limb loss permanent.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded the game and played around with mutations, everything works like I intend it to.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I have plans to limb-ify the various leg mutations the same way that gastropod foot does it.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
