### PR TITLE
Reword actions in repair gui

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2195,12 +2195,12 @@ void activity_handlers::start_engines_finish( player_activity *act, Character *y
 enum class repeat_type : int {
     // INIT should be zero. In some scenarios (vehicle welder), activity value default to zero.
     INIT = 0,       // Haven't found repeat value yet.
-    ONCE = 1,       // Repeat just once
+    ONCE = 1,       // Attempt repair (and refit if possible) just once
     // value 2 obsolete - previously used for reinforcement
-    FULL = 3,       // Repeat until damage==0
-    EVENT = 4,      // Repeat until something interesting happens
-    REFIT_ONCE = 5, // Try refitting once
-    REFIT_FULL = 6, // Reapeat until item fits
+    FULL = 3,       // Continue repairing until damage==0 (and until refitted if possible)
+    EVENT = 4,      // Continue repairing (and refit if possible) until something interesting happens
+    REFIT_ONCE = 5, // Try refitting once, but don't repair
+    REFIT_FULL = 6, // Continue refitting until item fits, but don't repair
     CANCEL = 7,     // Stop repeating
 };
 
@@ -2226,11 +2226,13 @@ static repeat_type repeat_menu( const std::string &title, repeat_type last_selec
     uilist rmenu;
     rmenu.text = title;
 
-    rmenu.addentry( static_cast<int>( repeat_type::ONCE ), true, '1', _( "Repeat once" ) );
+    rmenu.addentry( static_cast<int>( repeat_type::ONCE ), true, '1',
+                    can_refit ? _( "Attempt to refit or repair once" ) : _( "Attempt to repair once" ) );
     rmenu.addentry( static_cast<int>( repeat_type::FULL ), true, '2',
-                    _( "Repeat until fully repaired" ) );
+                    can_refit ? _( "Repeat until refitted and fully repaired" ) : _( "Repeat until fully repaired" ) );
     rmenu.addentry( static_cast<int>( repeat_type::EVENT ), true, '3',
-                    _( "Repeat until success/failure/level up" ) );
+                    can_refit ? _( "Refit or repair until success/failure/level up" ) :
+                    _( "Repair until success/failure/level up" ) );
     rmenu.addentry( static_cast<int>( repeat_type::REFIT_ONCE ), can_refit, '4',
                     _( "Attempt to refit once" ) );
     rmenu.addentry( static_cast<int>( repeat_type::REFIT_FULL ), can_refit, '5',


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Reword actions in repair gui"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Updates the wording in the repair ui to make it clear which actions are "repair", and which actions include "refit".
* Change wording of "repeat once" to make it clear that it in fact does not repeat but is instead only one attempt.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

* `repeat_type::ONCE`
    * Before: `Repeat once`
    * Suggested: `Attempt to (refit or) repair once`
    * The intention here is both to make it clear whether this is a "repair" and/or "refit" action; and that it is only one attempt, not any repeating action.
* `repeat_type::EVENT`
    * Before: `Repeat until success/..`
    * Suggested: `(Refit or) Repair until success/..`
    * The intention is here is to make it clear whether this is a "repair" and/or "refit" action

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* We could question whether we should keep the "attempt once" options. Sure, there's a use-case when you want to have control over how many threads are being used up, but for the most part, the player probably only wants to fix the item?
* We could question whether the wording on option 3 should include "level up" or not. The player probably already expects that since other actions (such as training recipes) usually prompt for that.
* Another way we could reword action 2 would be `Refit and fully repair`
* Another way we could reword action 3 would be `Refit or repair until condition changes`

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Used a sewing kit - works ✔
* Used a sewing kit on item that can also refitted - works ✔
* Used an arc welder - works ✔

![repair-gui-reword2](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/944bdbb6-d8b0-4533-999a-708487043352)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
