### PR TITLE
[EoC] Update u_cast_spell and fix player_levels_spell event

### DIFF
--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -2716,7 +2716,8 @@ You or NPC cast a spell. The spell uses fake spell data (ignore `energy_cost`, `
 | "message" | optional | string or [variable object](##variable-object) | part of `_cast_spell`; message to send when spell is casted | 
 | "npc_message" | optional | string or [variable object](##variable-object) | part of `_cast_spell`; message if npc uses | 
 | "min_level", "max_level" | optional | int, float or [variable object](##variable-object) | part of `_cast_spell`; level of the spell that would be casted (min level define what the actual spell level would be casted, adding max_level make EoC pick a random level between min and max) | 
-| "targeted" | optional | boolean | default false; if true, allow you to aim casted spell, otherwise cast it in random place, like `RANDOM_TARGET` spell flag was used | 
+| "targeted" | optional | boolean | default false; if true, allow you to aim casted spell, otherwise cast it in the location set by "loc" | 
+| "loc" | optional | [variable object](##variable-object) | Set target location of the spell. If not used, target to caster's location |
 | "true_eocs" | optional | string, [variable object](##variable-object), `effect_on_condition` or range of all of them | if spell was casted successfully, all EoCs from this field would be triggered; | 
 | "false_eocs" | optional | string, [variable object](##variable-object), `effect_on_condition` or range of all of them | if spell was not casted successfully, all EoCs from this field would be triggered | 
 

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -1979,7 +1979,11 @@ void known_magic::set_spell_exp( const spell_id &sp, int new_exp, const Characte
     } else {
         if( new_exp >= 0 ) {
             spell &temp_sp = get_spell( sp );
+            int old_level = temp_sp.get_level();
             temp_sp.set_exp( new_exp );
+            if( guy->is_avatar() && old_level != temp_sp.get_level() ) {
+                get_event_bus().send<event_type::player_levels_spell>( guy->getID(), sp->id, temp_sp.get_level() );
+            }
         } else {
             get_event_bus().send<event_type::character_forgets_spell>( guy->getID(), sp->id );
             spellbook.erase( sp );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
`u_cast_spell` cannot predetermine target coordinates. Also, there are some differences between the documentation and the actual behavior.

Also resolve #68948

#### Describe the solution
Add ability to specify target coordinates to `u_cast_spell` and fix documentation
Add missing `player_levels_spell` event in `set_spell_exp`

#### Describe alternatives you've considered


#### Testing
1) I tried the following spells that are activated when attacking monsters
```
  {
    "type": "effect_on_condition",
    "id": "EOC_random_enchant_melee_attacks_monster_[test]",
    "eoc_type": "EVENT",
    "required_event": "character_melee_attacks_monster",
    "effect": [
      { "npc_location_variable": { "global_val": "monster_pos" } },
      {
        "u_cast_spell": { "id": "test_spell", "hit_self": true, "min_level": 1 },
        "loc": { "global_val": "monster_pos" }
      }
    ]
  },
  {
    "id": "test_spell",
    "type": "SPELL",
    "name": "test_spell",
    "description": "test_spell",
    "valid_targets": [ "self", "hostile" ],
    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
    "effect": "attack",
    "shape": "blast",
    "damage_type": "pure",
    "max_level": 10,
    "base_casting_time": 0,
    "min_range": 1,
    "min_damage": 0,
    "max_damage": 20,
    "damage_increment": 5
  }
```
Before: Spell targets only player.
After: Spell targets only monster.

2) Tried the EoC presented in #68948 and confirmed that the message appears

#### Additional context
