### PR TITLE
[Aftershock] Fix Patched Fur Mutation Conflicts

### DIFF
--- a/data/mods/Aftershock/mutations/mutations.json
+++ b/data/mods/Aftershock/mutations/mutations.json
@@ -480,7 +480,7 @@
     "visibility": 2,
     "ugliness": 1,
     "description": "Your skin has patches of light fur.  This has no impact on your life except marking you as not fully human.",
-    "types": [ "SKIN" ],
+    "types": [ "SKIN", "BODY_ARMOR", "BODY_ARMOR_MOD", "ARMOR" ],
     "changes_to": [ "LIGHTFUR" ],
     "category": [ "MASTODON", "SPIDER", "MOUSE", "BEAST", "CATTLE", "RAT", "FELINE", "LUPINE", "RABBIT", "INSECT", "URSINE" ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix AFS Patched Fur mutation conflicts"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
The aftershock Patched Fur mutation was missing several categories necessary for it to work properly. Due to this it wasn't being replaced by other mutations and was creating conflicts such as this failed molt:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/94415528/8b780d48-0532-4545-9c06-0bb9b5f7f17b)


#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Added the appropriate categories (ARMOR, BODY_ARMOR, BODY_ARMOR_MOD) to the mutation. It is the same sort of mutation as smooth skin, hirsute, etc. and needs all of these to be properly lost when it should be replaced by another mutation. This is how I set these mutations up in #66068 

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Loaded a game, gave myself the patched fur mutation. Tried giving myself a different skin mutation and saw that patched fur is now properly lost.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Bug was reported on reddit - https://www.reddit.com/r/cataclysmdda/comments/17if8so/why_is_my_momy_long_legs_losing_its_mutations/

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
