### PR TITLE
Prevent crashing when using item of "effect_on_conditions" type

### DIFF
--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5719,7 +5719,7 @@ std::optional<int> effect_on_conditons_actor::use( Character *p, item &it,
         }
     }
     // Prevents crash from trying to spend charge with item removed
-    if( loc.where() == item_location::type::invalid ) {
+    if( !p->has_item( it ) ) {
         return 0;
     }
     return 1;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5718,5 +5718,9 @@ std::optional<int> effect_on_conditons_actor::use( Character *p, item &it,
             debugmsg( "Must use an activation eoc for activation.  If you don't want the effect_on_condition to happen on its own (without the item's involvement), remove the recurrence min and max.  Otherwise, create a non-recurring effect_on_condition for this item with its condition and effects, then have a recurring one queue it." );
         }
     }
+    // Prevents crash from trying to spend charge with item removed
+    if( loc.where() == item_location::type::invalid ) {
+        return 0;
+    }
     return 1;
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
When starting EoC using an item of type "effect_on_conditions", the game may crash if you consume the item with something like "u_consume_item" function

#### Describe the solution
This is caused by attempting to consume more charges on an item after it has been deleted.
If the item has already been erased for some reason, you can avoid the crash by not consuming charges.

#### Describe alternatives you've considered
Add `u_consume_item` to the processing of the item `nre_recorder` EoC. 
I confirmed that even if you erase `nre_recorder` in EoC, it will not crash.

#### Testing


#### Additional context

