### PR TITLE
Reduce tool requirements for concrete removal

### DIFF
--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -331,7 +331,7 @@
         [ "masonrysaw_off", 100 ],
         [ "electric_masonrysaw_off", 1320 ]
       ],
-      [ [ "angle_grinder", 200 ],  [ "hacksaw", -1 ], [ "reciprocating_saw", 200] ]
+      [ [ "angle_grinder", 200 ], [ "hacksaw", -1 ], [ "reciprocating_saw", 200 ] ]
     ]
   },
   {

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -316,11 +316,7 @@
     "id": "concrete_removal_standard",
     "type": "requirement",
     "//": "Tools for removing concrete",
-    "qualities": [
-      { "id": "HAMMER", "level": 2 },
-      { "id": "CHISEL", "level": 2 },
-      { "id": "PRY", "level": 3 }
-    ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "CHISEL", "level": 2 }, { "id": "PRY", "level": 3 } ],
     "tools": [
       [
         [ "pickaxe", -1 ],

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -315,12 +315,11 @@
   {
     "id": "concrete_removal_standard",
     "type": "requirement",
-    "//": "Tools for removing concrete -- drill required to create holes in a complete wall",
+    "//": "Tools for removing concrete",
     "qualities": [
       { "id": "HAMMER", "level": 2 },
       { "id": "CHISEL", "level": 2 },
-      { "id": "PRY", "level": 3 },
-      { "id": "DIG", "level": 3 }
+      { "id": "PRY", "level": 3 }
     ],
     "tools": [
       [
@@ -328,11 +327,11 @@
         [ "bronze_pickaxe", -1 ],
         [ "jackhammer", 140 ],
         [ "elec_jackhammer", 1848 ],
-        [ "hammer_sledge", -1 ]
+        [ "hammer_sledge", -1 ],
+        [ "masonrysaw_off", 100 ],
+        [ "electric_masonrysaw_off", 1320 ]
       ],
-      [ [ "masonrysaw_off", 100 ], [ "electric_masonrysaw_off", 1320 ] ],
-      [ [ "cordless_drill", 200 ], [ "corded_powerdrill", 200 ] ],
-      [ [ "angle_grinder", 200 ] ]
+      [ [ "angle_grinder", 200 ],  [ "hacksaw", -1 ], [ "reciprocating_saw", 200] ]
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Sanity check for concrete removal - it doesn't take that many tools to demo concrete.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Removed digging requirement, drill requirement. Moved masonry saw as alternative with pickaxe/jackhammer/sledge for general demo, and added hacksaw and reciprocating saw as alternatives with angle grinder for rebar removal.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/26992604/61dc2f7b-f65f-46db-bab8-137406348a9e)


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
