### PR TITLE
Allow specifying vitamins by weight (mass) in items

### DIFF
--- a/data/json/items/comestibles/bread.json
+++ b/data/json/items/comestibles/bread.json
@@ -277,7 +277,7 @@
     "material": [ "fruit", "wheat" ],
     "primary_material": "wheat",
     "spoils_in": "7 days",
-    "relative": { "calories": 35, "fun": 3, "quench": 2, "vitamins": [ [ "vitC", 20 ] ] }
+    "relative": { "calories": 35, "fun": 3, "quench": 2, "vitamins": [ [ "vitC", "20 mg" ] ] }
   },
   {
     "type": "COMESTIBLE",

--- a/data/json/items/comestibles/protein.json
+++ b/data/json/items/comestibles/protein.json
@@ -25,7 +25,7 @@
     "calories": 100,
     "quench": 40,
     "fun": -1,
-    "vitamins": [ [ "calcium", 7 ] ],
+    "vitamins": [ [ "calcium", "73 mg" ] ],
     "flags": [ "EATEN_COLD" ]
   },
   {
@@ -92,7 +92,7 @@
     "volume": "500 ml",
     "charges": 2,
     "quench": 20,
-    "relative": { "vitamins": [ [ "vitC", 20 ] ] }
+    "relative": { "vitamins": [ [ "vitC", "20 mg" ] ] }
   },
   {
     "id": "protein_shake_fortified",
@@ -105,7 +105,7 @@
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "perturbing %s" } }
     ],
     "description": "A thick and tasty beverage made from pure refined protein and nutritious fruit.  It has been supplemented with extra vitamins and minerals.",
-    "relative": { "vitamins": [ [ "calcium", 5 ], [ "iron", 5 ], [ "vitC", 5 ] ] }
+    "relative": { "vitamins": [ [ "calcium", "52 mg" ], [ "iron", 5 ], [ "vitC", "5 mg" ] ] }
   },
   {
     "id": "milk_fortified",

--- a/data/json/vitamin.json
+++ b/data/json/vitamin.json
@@ -6,6 +6,11 @@
     "name": { "str": "Calcium" },
     "min": -48000,
     "max": 0,
+    "//": [
+      "96 units are consumed per day, with RDA of 1000mg / 96 = 10.42mg",
+      "1000mg for 19-50yr olds from https://ods.od.nih.gov/factsheets/calcium-HealthProfessional/#h2"
+    ],
+    "weight_per_unit": "10 mg",
     "rate": "15 m"
   },
   {
@@ -16,6 +21,12 @@
     "deficiency": "anemia",
     "min": -24000,
     "max": 3600,
+    "//": [
+      "96 units are consumed per day, with RDA of 18mg / 96 = 0.1875mg",
+      "18mg for 19-50yr olds from https://ods.od.nih.gov/factsheets/iron-HealthProfessional/#h2",
+      "As it varies with sex, the max value was chosen",
+      "still, mass only has mg resolution, so it cannot be in mass units (for now)"
+    ],
     "rate": "15 m",
     "disease": [ [ -9600, -11200 ], [ -11201, -12800 ], [ -12801, -24000 ] ]
   },
@@ -27,6 +38,12 @@
     "deficiency": "scurvy",
     "min": -5600,
     "max": 0,
+    "//": [
+      "96 units are consumed per day, with RDA of 90mg / 96 = 0.9375mg",
+      "90mg for 19-50yr olds from https://ods.od.nih.gov/factsheets/VitaminC-HealthProfessional/#h2",
+      "As it varies with sex, the max value was chosen"
+    ],
+    "weight_per_unit": "1 mg",
     "rate": "15 m",
     "disease": [ [ -2800, -3600 ], [ -3601, -4400 ], [ -4401, -5600 ] ]
   },

--- a/doc/VITAMIN.md
+++ b/doc/VITAMIN.md
@@ -12,6 +12,7 @@
   "deficiency": "anemia",
   "min": -12000,
   "max": 3600,
+  "weight_per_unit": "1 mg",
   "rate": "15 m",
   "flags": [ "FOO" ],
   "disease": [ [ -4800, -5600 ], [ -5601, -6400 ], [ -6401, -12000 ] ],
@@ -55,6 +56,10 @@ The smallest amount of this vitamin that the player can have.
 
 ### `max`
 The highest amount of this vitamin that the avatar can have.
+
+### `weight_per_unit`
+Allows specifying this vitamin in foods in terms of the amount of that vitamin in that food by weight.
+The weight specified for the food will be divided by this quantity to determine the units of this vitamin the food has.
 
 ### `rate`
 How long it takes to lose one unit of this vitamin.

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -938,7 +938,7 @@ void Character::update_stomach( const time_point &from, const time_point &to )
         guts.ingest( digested_to_guts );
 
         mod_stored_kcal( digested_to_body.nutr.kcal() );
-        vitamins_mod( effect_vitamin_mod( digested_to_body.nutr.vitamins ) );
+        vitamins_mod( effect_vitamin_mod( digested_to_body.nutr.vitamins() ) );
         log_activity_level( activity_history.average_activity() );
 
         if( !foodless && rates.hunger > 0.0f ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2579,7 +2579,7 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
         return string_format( format, v.first->name(), min_value, max_value );
     };
 
-    const auto max_nutr_vitamins = sorted_lex( max_nutr.vitamins );
+    const auto max_nutr_vitamins = sorted_lex( max_nutr.vitamins() );
     const std::string required_vits = enumerate_as_string( max_nutr_vitamins,
     [&]( const std::pair<vitamin_id, int> &v ) {
         return format_vitamin( v, true );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -611,11 +611,11 @@ void Item_factory::finalize_pre( itype &obj )
     npc_implied_flags( obj );
 
     if( obj.comestible ) {
-        std::map<vitamin_id, int> &vitamins = obj.comestible->default_nutrition.vitamins;
+        std::map<vitamin_id, int> vitamins = obj.comestible->default_nutrition.vitamins();
         if( get_option<bool>( "NO_VITAMINS" ) ) {
             for( auto &vit : vitamins ) {
                 if( vit.first->type() == vitamin_type::VITAMIN ) {
-                    vit.second = 0;
+                    obj.comestible->default_nutrition.set_vitamin( vit.first, 0 );
                 }
             }
         } else if( vitamins.empty() && obj.comestible->healthy >= 0 ) {
@@ -637,7 +637,7 @@ void Item_factory::finalize_pre( itype &obj )
                 if( !vitamins.count( v.first ) ) {
                     for( const auto &m : mat ) {
                         double amount = m.first->vitamin( v.first ) * healthy / mat.size();
-                        vitamins[v.first] += std::ceil( amount );
+                        obj.comestible->default_nutrition.add_vitamin( v.first, std::ceil( amount ) );
                     }
                 }
             }
@@ -3318,13 +3318,13 @@ void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std
     if( jo.has_array( "vitamins" ) ) {
         for( JsonArray pair : jo.get_array( "vitamins" ) ) {
             vitamin_id vit( pair.get_string( 0 ) );
-            slot.default_nutrition.vitamins[ vit ] = pair.get_int( 1 );
+            slot.default_nutrition.set_vitamin( vit, pair.get_int( 1 ) );
         }
 
     } else if( relative.has_array( "vitamins" ) ) {
         for( JsonArray pair : relative.get_array( "vitamins" ) ) {
             vitamin_id vit( pair.get_string( 0 ) );
-            slot.default_nutrition.vitamins[ vit ] += pair.get_int( 1 );
+            slot.default_nutrition.add_vitamin( vit, pair.get_int( 1 ) );
         }
     }
 

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -1213,7 +1213,7 @@ std::optional<int> iuse::purify_smart( Character *p, item *it, const tripoint & 
 
     item syringe( "syringe", it->birthday() );
     p->i_add( syringe );
-    p->vitamins_mod( it->get_comestible()->default_nutrition.vitamins );
+    p->vitamins_mod( it->get_comestible()->default_nutrition.vitamins() );
     get_event_bus().send<event_type::administers_mutagen>( p->getID(),
             mutagen_technique::injected_smart_purifier );
     return 1;

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -22,7 +22,8 @@ void nutrients::min_in_place( const nutrients &r )
         } else {
             auto our_vit = vitamins_.find( vit );
             if( our_vit != vitamins_.end() ) {
-                our_vit->second = std::min( our_vit->second, other );
+                // We must be finalized because we're calling vitamin::all()
+                our_vit->second = std::min( std::get<int>( our_vit->second ), other );
             }
         }
     }
@@ -35,15 +36,48 @@ void nutrients::max_in_place( const nutrients &r )
         const vitamin_id &vit = vit_pair.first;
         int other = r.get_vitamin( vit );
         if( other != 0 ) {
-            int &val = vitamins_[vit];
-            val = std::max( val, other );
+            std::variant<int, units::mass> &val = vitamins_[vit];
+            // We must be finalized because we're calling vitamin::all()
+            val = std::max( std::get<int>( val ), other );
         }
     }
 }
 
 std::map<vitamin_id, int> nutrients::vitamins() const
 {
-    return vitamins_;
+    if( !finalized ) {
+        debugmsg( "Called nutrients::vitamins() before they were finalized!" );
+        return std::map<vitamin_id, int>();
+    }
+
+    std::map<vitamin_id, int> ret;
+    for( const std::pair<const vitamin_id, std::variant<int, units::mass>> &vit : vitamins_ ) {
+        ret.emplace( vit.first, std::get<int>( vit.second ) );
+    }
+    return ret;
+}
+
+void nutrients::set_vitamin( const vitamin_id &vit, units::mass mass )
+{
+    if( finalized ) {
+        set_vitamin( vit, vit->units_from_mass( mass ) );
+        return;
+    }
+    vitamins_[vit] = mass;
+}
+
+void nutrients::add_vitamin( const vitamin_id &vit, units::mass mass )
+{
+    if( finalized ) {
+        add_vitamin( vit, vit->units_from_mass( mass ) );
+        return;
+    }
+    auto iter = vitamins_.emplace( vit, 0_kilogram ).first;
+    if( !std::holds_alternative<units::mass>( iter->second ) ) {
+        debugmsg( "Tried to add mass vitamin to units vitamin before vitamins were finalized!" );
+        return;
+    }
+    iter->second = std::get<units::mass>( iter->second ) + mass;
 }
 
 void nutrients::set_vitamin( const vitamin_id &vit, int units )
@@ -55,7 +89,11 @@ void nutrients::set_vitamin( const vitamin_id &vit, int units )
 void nutrients::add_vitamin( const vitamin_id &vit, int units )
 {
     auto iter = vitamins_.emplace( vit, 0 ).first;
-    iter->second = iter->second + units;
+    if( std::holds_alternative<units::mass>( iter->second ) ) {
+        debugmsg( "Tried to add mass vitamin to units vitamin before vitamins were finalized!" );
+        return;
+    }
+    iter->second = std::get<int>( iter->second ) + units;
 }
 
 void nutrients::remove_vitamin( const vitamin_id &vit )
@@ -69,12 +107,30 @@ int nutrients::get_vitamin( const vitamin_id &vit ) const
     if( it == vitamins_.end() ) {
         return 0;
     }
-    return it->second;
+    if( !finalized && std::holds_alternative<units::mass>( it->second ) ) {
+        debugmsg( "Called get_vitamin on a mass vitamin before vitamins were finalized!" );
+        return 0;
+    }
+    return std::get<int>( it->second );
 }
 
 int nutrients::kcal() const
 {
     return calories / 1000;
+}
+
+void nutrients::finalize_vitamins()
+{
+    for( std::pair<const vitamin_id, std::variant<int, units::mass> > &vit : vitamins_ ) {
+        if( std::holds_alternative<units::mass>( vit.second ) ) {
+            vit.second = vit.first->units_from_mass( std::get<units::mass>( vit.second ) );
+        }
+        if( std::holds_alternative<units::mass>( vit.second ) ) {
+            debugmsg( "Error occured during vitamin finalization!" );
+        }
+    }
+
+    finalized = true;
 }
 
 bool nutrients::operator==( const nutrients &r ) const
@@ -95,36 +151,52 @@ bool nutrients::operator==( const nutrients &r ) const
 
 nutrients &nutrients::operator+=( const nutrients &r )
 {
+    if( !finalized || !r.finalized ) {
+        debugmsg( "Nutrients not finalized when += called!" );
+    }
     calories += r.calories;
-    for( const std::pair<const vitamin_id, int> &vit : r.vitamins_ ) {
-        vitamins_[vit.first] += vit.second;
+    for( const std::pair<const vitamin_id, std::variant<int, units::mass>> &vit : r.vitamins_ ) {
+        std::variant<int, units::mass> &here = vitamins_[vit.first];
+        here = std::get<int>( here ) + std::get<int>( vit.second );
     }
     return *this;
 }
 
 nutrients &nutrients::operator-=( const nutrients &r )
 {
+    if( !finalized || !r.finalized ) {
+        debugmsg( "Nutrients not finalized when -= called!" );
+    }
     calories -= r.calories;
-    for( const std::pair<const vitamin_id, int> &vit : r.vitamins_ ) {
-        vitamins_[vit.first] -= vit.second;
+    for( const std::pair<const vitamin_id, std::variant<int, units::mass>> &vit : r.vitamins_ ) {
+        std::variant<int, units::mass> &here = vitamins_[vit.first];
+        here = std::get<int>( here ) - std::get<int>( vit.second );
     }
     return *this;
 }
 
 nutrients &nutrients::operator*=( int r )
 {
+    if( !finalized ) {
+        debugmsg( "Nutrients not finalized when *= called!" );
+    }
     calories *= r;
-    for( std::pair<const vitamin_id, int> &vit : vitamins_ ) {
-        vit.second *= r;
+    for( const std::pair<const vitamin_id, std::variant<int, units::mass>> &vit : vitamins_ ) {
+        std::variant<int, units::mass> &here = vitamins_[vit.first];
+        here = std::get<int>( here ) * r;
     }
     return *this;
 }
 
 nutrients &nutrients::operator/=( int r )
 {
+    if( !finalized ) {
+        debugmsg( "Nutrients not finalized when -= called!" );
+    }
     calories = divide_round_up( calories, r );
-    for( std::pair<const vitamin_id, int> &vit : vitamins_ ) {
-        vit.second = divide_round_up( vit.second, r );
+    for( const std::pair<const vitamin_id, std::variant<int, units::mass>> &vit : vitamins_ ) {
+        std::variant<int, units::mass> &here = vitamins_[vit.first];
+        here = divide_round_up( std::get<int>( here ), r );
     }
     return *this;
 }

--- a/src/stomach.h
+++ b/src/stomach.h
@@ -16,39 +16,49 @@ struct needs_rates;
 // Separate struct for nutrients so that we can easily perform arithmetic on
 // them
 struct nutrients {
-    /** amount of calories (1/1000s of kcal) this food has */
-    int calories = 0;
+        /** amount of calories (1/1000s of kcal) this food has */
+        int calories = 0;
 
-    /** vitamins potentially provided by this comestible (if any) */
-    std::map<vitamin_id, int> vitamins;
+        /** Replace the values here with the minimum (or maximum) of themselves and the corresponding
+         * values taken from r. */
+        void min_in_place( const nutrients &r );
+        void max_in_place( const nutrients &r );
 
-    /** Replace the values here with the minimum (or maximum) of themselves and the corresponding
-     * values taken from r. */
-    void min_in_place( const nutrients &r );
-    void max_in_place( const nutrients &r );
+        // vitamin -> how many vitamin units of it are included
+        std::map<vitamin_id, int> vitamins() const;
 
-    int get_vitamin( const vitamin_id & ) const;
-    int kcal() const;
+        void set_vitamin( const vitamin_id &, int units );
+        void add_vitamin( const vitamin_id &, int units );
 
-    bool operator==( const nutrients &r ) const;
-    bool operator!=( const nutrients &r ) const {
-        return !( *this == r );
-    }
+        // Remove a vitamin completely from the data structure
+        void remove_vitamin( const vitamin_id & );
 
-    nutrients &operator+=( const nutrients &r );
-    nutrients &operator-=( const nutrients &r );
-    nutrients &operator*=( int r );
-    nutrients &operator/=( int r );
+        int get_vitamin( const vitamin_id & ) const;
+        int kcal() const;
 
-    friend nutrients operator*( nutrients l, int r ) {
-        l *= r;
-        return l;
-    }
+        bool operator==( const nutrients &r ) const;
+        bool operator!=( const nutrients &r ) const {
+            return !( *this == r );
+        }
 
-    friend nutrients operator/( nutrients l, int r ) {
-        l /= r;
-        return l;
-    }
+        nutrients &operator+=( const nutrients &r );
+        nutrients &operator-=( const nutrients &r );
+        nutrients &operator*=( int r );
+        nutrients &operator/=( int r );
+
+        friend nutrients operator*( nutrients l, int r ) {
+            l *= r;
+            return l;
+        }
+
+        friend nutrients operator/( nutrients l, int r ) {
+            l /= r;
+            return l;
+        }
+
+    private:
+        /** vitamins potentially provided by this comestible (if any) */
+        std::map<vitamin_id, int> vitamins_;
 };
 
 // Contains all information that can pass out of (or into) a stomach

--- a/src/stomach.h
+++ b/src/stomach.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_STOMACH_H
 
 #include <map>
+#include <variant>
 
 #include "calendar.h"
 #include "type_id.h"
@@ -27,6 +28,12 @@ struct nutrients {
         // vitamin -> how many vitamin units of it are included
         std::map<vitamin_id, int> vitamins() const;
 
+        // For vitamins that support units::mass quantities
+        // If finalized == true, these will instantly convert to units,
+        // so make sure finalized = false if you call these before vitamins are loaded
+        void set_vitamin( const vitamin_id &, units::mass mass );
+        void add_vitamin( const vitamin_id &, units::mass mass );
+
         void set_vitamin( const vitamin_id &, int units );
         void add_vitamin( const vitamin_id &, int units );
 
@@ -35,6 +42,8 @@ struct nutrients {
 
         int get_vitamin( const vitamin_id & ) const;
         int kcal() const;
+
+        void finalize_vitamins();
 
         bool operator==( const nutrients &r ) const;
         bool operator!=( const nutrients &r ) const {
@@ -56,9 +65,14 @@ struct nutrients {
             return l;
         }
 
+        // All vitamins are in vitamin units, not units::mass (e.g. all JSON has been loaded)
+        // defaults to true because this is only false when nutrients are loaded from JSON,
+        // where it is set explicitly to false
+        bool finalized = true;
+
     private:
         /** vitamins potentially provided by this comestible (if any) */
-        std::map<vitamin_id, int> vitamins_;
+        std::map<vitamin_id, std::variant<int, units::mass>> vitamins_;
 };
 
 // Contains all information that can pass out of (or into) a stomach

--- a/src/vitamin.cpp
+++ b/src/vitamin.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <map>
 
+#include "assign.h"
 #include "calendar.h"
 #include "debug.h"
 #include "enum_conversions.h"
@@ -61,6 +62,7 @@ void vitamin::load_vitamin( const JsonObject &jo )
     vit.min_ = jo.get_int( "min" );
     vit.max_ = jo.get_int( "max", 0 );
     vit.rate_ = read_from_json_string<time_duration>( jo.get_member( "rate" ), time_duration::units );
+    assign( jo, "weight_per_unit", vit.weight_per_unit );
 
     if( !jo.has_string( "vit_type" ) ) {
         jo.throw_error_at( "vit_type", "vitamin must have a vitamin type" );
@@ -120,6 +122,16 @@ float vitamin::RDA_to_default( int percent ) const
         return percent;
     }
     return ( 24_hours / rate_ ) * ( static_cast<float>( percent ) / 100.0f );
+}
+
+int vitamin::units_from_mass( units::mass mass ) const
+{
+    if( !weight_per_unit.has_value() ) {
+        debugmsg( "Tried to convert vitamin in mass to units, but %s doesn't support mass for vitamins",
+                  id_.str() );
+        return 1;
+    }
+    return mass / *weight_per_unit;
 }
 
 namespace io

--- a/src/vitamin.h
+++ b/src/vitamin.h
@@ -12,6 +12,7 @@
 #include "calendar.h"
 #include "translations.h"
 #include "type_id.h"
+#include "units.h"
 
 class JsonObject;
 template <typename T> struct enum_traits;
@@ -108,10 +109,13 @@ class vitamin
          */
         float RDA_to_default( int percent ) const;
 
+        int units_from_mass( units::mass mass ) const;
+
     private:
         vitamin_id id_;
         vitamin_type type_ = vitamin_type::num_vitamin_types;
         translation name_;
+        std::optional<units::mass> weight_per_unit;
         efftype_id deficiency_;
         efftype_id excess_;
         int min_ = 0;

--- a/tests/comestible_test.cpp
+++ b/tests/comestible_test.cpp
@@ -144,7 +144,7 @@ static int byproduct_calories( const recipe &recipe_obj )
 
 static bool has_mutagen_vit( const islot_comestible &comest )
 {
-    const std::map<vitamin_id, int> &vits = comest.default_nutrition.vitamins;
+    const std::map<vitamin_id, int> &vits = comest.default_nutrition.vitamins();
     for( const vitamin_id &vit : mutagen_vit_list ) {
         if( vits.find( vit ) != vits.end() && vits.at( vit ) > 0 ) {
             return true;


### PR DESCRIPTION
#### Summary
Infrastructure "Allow specifying vitamins by weight (mass) in items"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/64722

Often, nutrition info will list vitamins by weight. Additionally, RDA, being defined by humans, is subject to change. For these reasons, it should be possible to specify vitamins by weight in items definitions.

#### Describe the solution
To do this, vitamins need to know how weight corresponds to units, and items need to load in weight as well as units, and convert to units as necessary. Unfortunately, as items may be loaded before vitamins, both the loaded weight values and units values must be stored until all data is loaded and they can be converted to units. To facilitate this, turn the vitamins data stored in nutrients into a map from vitamin id to a union of int and units::mass. This can then be finalized after loading to convert all units::mass values to units.

Several functions were added to ease the difficulty in navigating this new structure, and safety checks were added to prevent bugs.

#### Describe alternatives you've considered
There's a lot of rounding that the whole vitamins system is subject to. This adds some more rounding: Any fractional vitamins due to weight are discarded. However, this is the same as the previous approach, but happens at load time instead of when the content is being added.

Additionally, vitamins (like iron) that have an RDA of less than 1mg cannot really benefit from this system.

#### Testing
Before:
|drink|shake|fortified shake|
|-|-|-|
|![Image of protein drink item description, showing 6% RDA Calcium](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/366c8580-d3f8-4c84-8ba7-0c634ff0392c)|![Image of protein shake item description, showing 6% RDA calcium and 20% RDA vitamin C](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/e2a080dc-5ff7-4d8e-9ad4-af708b59a5d4)|![Image of fortified protein shake item description, showing 11% RDA calcium, 4% RDA iron, and 25% RDA vitamin C](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/43a450b5-6315-4bd2-8f04-dfefd70f2eb4)|

After:
|drink|shake|fortified shake|
|-|-|-|
|![Image of protein drink item description, showing 6% RDA Calcium](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/7beda0e0-5ce6-49e8-9c53-6b8376bbd207)|![Image of protein shake item description, showing 6% RDA calcium and 20% RDA vitamin C](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/2ddb1ed1-9620-483e-a06b-19546d9d20fd)|![Image of fortified protein shake item description, showing 11% RDA calcium, 4% RDA iron, and 25% RDA vitamin C](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/24cf2155-5d17-4bd6-a6a1-915401f231fe)|

#### Additional context
I'd prefer the commits not be squashed here, if possible.

If anyone has any ideas on how to handle iron with this, I'd appreciate hearing them. ~~My only idea so far was to increase the precision of the vitamin (e.g. consume 9600 units per day, instead of 96).~~