### PR TITLE
Use microgram (μg) resolution mass for food vitamins

### DIFF
--- a/data/json/items/comestibles/protein.json
+++ b/data/json/items/comestibles/protein.json
@@ -105,7 +105,7 @@
       { "type": "COMPONENT_ID_SUBSTRING", "condition": "mutant", "name": { "str_sp": "perturbing %s" } }
     ],
     "description": "A thick and tasty beverage made from pure refined protein and nutritious fruit.  It has been supplemented with extra vitamins and minerals.",
-    "relative": { "vitamins": [ [ "calcium", "52 mg" ], [ "iron", 5 ], [ "vitC", "5 mg" ] ] }
+    "relative": { "vitamins": [ [ "calcium", "52 mg" ], [ "iron", "940 μg" ], [ "vitC", "5 mg" ] ] }
   },
   {
     "id": "milk_fortified",

--- a/data/json/vitamin.json
+++ b/data/json/vitamin.json
@@ -10,7 +10,7 @@
       "96 units are consumed per day, with RDA of 1000mg / 96 = 10.42mg",
       "1000mg for 19-50yr olds from https://ods.od.nih.gov/factsheets/calcium-HealthProfessional/#h2"
     ],
-    "weight_per_unit": "10 mg",
+    "weight_per_unit": "10 mg 420 μg",
     "rate": "15 m"
   },
   {
@@ -24,9 +24,9 @@
     "//": [
       "96 units are consumed per day, with RDA of 18mg / 96 = 0.1875mg",
       "18mg for 19-50yr olds from https://ods.od.nih.gov/factsheets/iron-HealthProfessional/#h2",
-      "As it varies with sex, the max value was chosen",
-      "still, mass only has mg resolution, so it cannot be in mass units (for now)"
+      "As it varies with sex, the max value was chosen"
     ],
+    "weight_per_unit": "188 ug",
     "rate": "15 m",
     "disease": [ [ -9600, -11200 ], [ -11201, -12800 ], [ -12801, -24000 ] ]
   },
@@ -43,7 +43,7 @@
       "90mg for 19-50yr olds from https://ods.od.nih.gov/factsheets/VitaminC-HealthProfessional/#h2",
       "As it varies with sex, the max value was chosen"
     ],
-    "weight_per_unit": "1 mg",
+    "weight_per_unit": "938 mcg",
     "rate": "15 m",
     "disease": [ [ -2800, -3600 ], [ -3601, -4400 ], [ -4401, -5600 ] ]
   },

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3768,7 +3768,7 @@ CBMs can be defined like this:
 "cooks_like": "meat_cooked",         // (Optional) If the item is used in a recipe, replaces it with its cooks_like
 "parasites": 10,            // (Optional) Probability of becoming parasitized when eating
 "contamination": [ { "disease": "bad_food", "probability": 5 } ],         // (Optional) List of diseases carried by this comestible and their associated probability. Values must be in the [0, 100] range.
-"vitamins": [ [ "calcium", 5 ], [ "iron", 12 ] ],         // Vitamins provided by consuming a charge (portion) of this.  An integer percentage of ideal daily value average.  Vitamins array keys include the following: calcium, iron, vitA, vitB, vitC, mutant_toxin, bad_food, blood, and redcells.  Note that vitB is B12.
+"vitamins": [ [ "calcium", "60 mg" ], [ "iron", 12 ] ],         // Vitamins provided by consuming a charge (portion) of this.  Some vitamins ("calcium", "iron", "vitC") can be specified with the weight of the vitamins in that food.  Vitamins specified by weight can be in grams ("g"), milligrams ("mg") or micrograms ("μg", "ug", "mcg").  If a vitamin is not specified by weight, it is specified in "units", with meaning according to the vitamin definition.  Nutrition vitamins ("calcium", "iron", "vitC") are an integer percentage of ideal daily value average.  Vitamins array keys include the following: calcium, iron, vitC, mutant_toxin, bad_food, blood, and redcells.
 "material": [                     // All materials (IDs) this food is made of
   { "type": "flesh", "portion": 3 }, // See Generic Item attributes for type and portion details
   { "type": "wheat", "portion": 5 }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3328,7 +3328,7 @@ void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std
             if( pair.has_int( 1 ) ) {
                 slot.default_nutrition.set_vitamin( vit, pair.get_int( 1 ) );
             } else {
-                units::mass val = read_from_json_string<units::mass>( pair[1], units::mass_units );
+                vitamin_units::mass val = read_from_json_string( pair[1], vitamin_units::mass_units );
                 slot.default_nutrition.set_vitamin( vit, val );
             }
         }
@@ -3339,7 +3339,7 @@ void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std
             if( pair.has_int( 1 ) ) {
                 slot.default_nutrition.add_vitamin( vit, pair.get_int( 1 ) );
             } else {
-                units::mass val = read_from_json_string<units::mass>( pair[1], units::mass_units );
+                vitamin_units::mass val = read_from_json_string( pair[1], vitamin_units::mass_units );
                 slot.default_nutrition.add_vitamin( vit, val );
             }
         }

--- a/src/stomach.h
+++ b/src/stomach.h
@@ -14,6 +14,23 @@ class JsonObject;
 class JsonOut;
 struct needs_rates;
 
+namespace vitamin_units
+{
+using mass = units::quantity<int, units::mass_in_microgram_tag>;
+
+constexpr mass microgram = units::quantity<int, units::mass_in_microgram_tag>( 1, {} );
+constexpr mass milligram = units::quantity<int, units::mass_in_microgram_tag>( 1000, {} );
+constexpr mass gram = units::quantity<int, units::mass_in_microgram_tag>( 1'000'000, {} );
+const std::vector<std::pair<std::string, mass>> mass_units = { {
+        { "ug", microgram },
+        { "μg", microgram },
+        { "mcg", microgram },
+        { "mg", milligram },
+        { "g", gram }
+    }
+};
+} // namespace vitamin_units
+
 // Separate struct for nutrients so that we can easily perform arithmetic on
 // them
 struct nutrients {
@@ -31,8 +48,8 @@ struct nutrients {
         // For vitamins that support units::mass quantities
         // If finalized == true, these will instantly convert to units,
         // so make sure finalized = false if you call these before vitamins are loaded
-        void set_vitamin( const vitamin_id &, units::mass mass );
-        void add_vitamin( const vitamin_id &, units::mass mass );
+        void set_vitamin( const vitamin_id &, vitamin_units::mass mass );
+        void add_vitamin( const vitamin_id &, vitamin_units::mass mass );
 
         void set_vitamin( const vitamin_id &, int units );
         void add_vitamin( const vitamin_id &, int units );
@@ -72,7 +89,7 @@ struct nutrients {
 
     private:
         /** vitamins potentially provided by this comestible (if any) */
-        std::map<vitamin_id, std::variant<int, units::mass>> vitamins_;
+        std::map<vitamin_id, std::variant<int, vitamin_units::mass>> vitamins_;
 };
 
 // Contains all information that can pass out of (or into) a stomach

--- a/src/units_fwd.h
+++ b/src/units_fwd.h
@@ -16,6 +16,10 @@ class volume_in_milliliter_tag
 
 using volume = quantity<int, volume_in_milliliter_tag>;
 
+class mass_in_microgram_tag
+{
+};
+
 class mass_in_milligram_tag
 {
 };

--- a/src/vitamin.cpp
+++ b/src/vitamin.cpp
@@ -62,7 +62,11 @@ void vitamin::load_vitamin( const JsonObject &jo )
     vit.min_ = jo.get_int( "min" );
     vit.max_ = jo.get_int( "max", 0 );
     vit.rate_ = read_from_json_string<time_duration>( jo.get_member( "rate" ), time_duration::units );
-    assign( jo, "weight_per_unit", vit.weight_per_unit );
+
+    if( jo.has_string( "weight_per_unit" ) ) {
+        vit.weight_per_unit = read_from_json_string( jo.get_member( "weight_per_unit" ),
+                              vitamin_units::mass_units );
+    }
 
     if( !jo.has_string( "vit_type" ) ) {
         jo.throw_error_at( "vit_type", "vitamin must have a vitamin type" );
@@ -124,14 +128,14 @@ float vitamin::RDA_to_default( int percent ) const
     return ( 24_hours / rate_ ) * ( static_cast<float>( percent ) / 100.0f );
 }
 
-int vitamin::units_from_mass( units::mass mass ) const
+int vitamin::units_from_mass( vitamin_units::mass val ) const
 {
     if( !weight_per_unit.has_value() ) {
         debugmsg( "Tried to convert vitamin in mass to units, but %s doesn't support mass for vitamins",
                   id_.str() );
         return 1;
     }
-    return mass / *weight_per_unit;
+    return val / *weight_per_unit;
 }
 
 namespace io

--- a/src/vitamin.h
+++ b/src/vitamin.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "calendar.h"
+#include "stomach.h"
 #include "translations.h"
 #include "type_id.h"
 #include "units.h"
@@ -109,13 +110,13 @@ class vitamin
          */
         float RDA_to_default( int percent ) const;
 
-        int units_from_mass( units::mass mass ) const;
+        int units_from_mass( vitamin_units::mass val ) const;
 
     private:
         vitamin_id id_;
         vitamin_type type_ = vitamin_type::num_vitamin_types;
         translation name_;
-        std::optional<units::mass> weight_per_unit;
+        std::optional<vitamin_units::mass> weight_per_unit;
         efftype_id deficiency_;
         efftype_id excess_;
         int min_ = 0;


### PR DESCRIPTION
#### Summary
SUMMARY: None

Built on https://github.com/CleverRaven/Cataclysm-DDA/pull/68986. Please do not merge until that is merged.

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/68986
Vitamins are often present in very small quantities, so to specify vitamins by weight, more precision that 1mg is required for mass.

#### Describe the solution
Introduce and use a special higher-precision units type for vitamin mass, and plug it into the code to all the vitamin mass parsing code.

`μg`, `ug`, `mcg` are supported when representing mass strings in JSON.

#### Testing
Vitamins on protein drink, shake, and fortified shake are loaded correctly.

#### Additional context
Thanks for the assistance in coming to this solution.