### PR TITLE
Make character creation evaluations less explicit

### DIFF
--- a/src/player_difficulty.cpp
+++ b/src/player_difficulty.cpp
@@ -342,17 +342,17 @@ std::string player_difficulty::format_output( float percent_band, float per )
 {
     std::string output;
     if( per < -1 * percent_band ) {
-        output = string_format( "<color_%s>%s</color>", "light_red", _( "underpowered" ) );
+        output = string_format( "<color_%s>%s</color>", "light_red", _( "---" ) );
     } else if( per < 0.0f ) {
-        output = string_format( "<color_%s>%s</color>", "light_red", _( "weak" ) );
+        output = string_format( "<color_%s>%s</color>", "light_red", _( "--" ) );
     } else if( per < percent_band ) {
-        output = string_format( "<color_%s>%s</color>", "yellow", _( "average" ) );
+        output = string_format( "<color_%s>%s</color>", "yellow", _( "-" ) );
     } else if( per < 2 * percent_band ) {
-        output = string_format( "<color_%s>%s</color>", "light_green", _( "strong" ) );
+        output = string_format( "<color_%s>%s</color>", "light_green", _( "+" ) );
     } else if( per < 3 * percent_band ) {
-        output = string_format( "<color_%s>%s</color>", "light_green", _( "powerful" ) );
+        output = string_format( "<color_%s>%s</color>", "light_green", _( "++" ) );
     } else {
-        output = string_format( "<color_%s>%s</color>", "light_green", _( "overpowered" ) );
+        output = string_format( "<color_%s>%s</color>", "light_green", _( "+++" ) );
     }
 
     if( get_option<bool>( "DEBUG_DIFFICULTIES" ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Character creation evaluation less explicit"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Resolves #68935 

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Replace the following terms in character creation to be less explicit, in an attempt to alleviate player's preconceptions of the positive and/or negative connotations of the words on either side of the spectrum. I'm hoping the symbols simply convey "relatively better" or "relatively worse".

"underpowered" to "---"
"weak" to "--"
"average" to "-"
"strong" to "+"
"powerful" to "++"
"overpowered" to "+++"

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Average is "-", analogous to how overweight is "desirable" in the cataclysm, while average ratings are "undesirable". It flows better too, so the minuses and plusses are equal and I don't have to think of an awkward symbol for neutral. The color remains yellow for that one, as opposed to red for "--" and "---". Also very slightly indirectly nudges the scale upward, as some people (myself included) have mentioned that the ratings feel overly generous towards judging characters as "overpowered". I believe it is common for people to create "themselves" in game and end up well above average in general.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
