### PR TITLE
Hobbies give weapon proficiencies + AFS & bat weapon categories

### DIFF
--- a/data/json/hobbies.json
+++ b/data/json/hobbies.json
@@ -310,7 +310,8 @@
     "name": "Baseball (Beginner)",
     "description": "You used to play baseball, occasionally.  Maybe you were on your school team growing up, but it was never a focus of yours.  Hopefully you can still remember how to use a bat when your life depends on it.",
     "points": 2,
-    "skills": [ { "level": 2, "name": "bashing" }, { "level": 2, "name": "throw" } ]
+    "skills": [ { "level": 2, "name": "bashing" }, { "level": 2, "name": "throw" } ],
+    "proficiencies": [ "prof_maces_familiar" ]
   },
   {
     "type": "profession",
@@ -320,7 +321,7 @@
     "description": "You got the stance, you got the grip, you got the game.  Swinging at a zombie's head is close enough to swinging at a baseball… right?",
     "points": 4,
     "skills": [ { "level": 4, "name": "bashing" }, { "level": 4, "name": "throw" }, { "level": 1, "name": "swimming" } ],
-    "proficiencies": [ "prof_athlete_basic" ]
+    "proficiencies": [ "prof_athlete_basic", "prof_maces_familiar", "prof_maces_pro" ]
   },
   {
     "type": "profession",
@@ -330,7 +331,7 @@
     "description": "You're accustomed to striking out poor batters at the plate and can probably throw a mean knuckleball.  Now you get to practice your fastball, but perhaps with rocks or grenades this time.",
     "points": 6,
     "skills": [ { "level": 4, "name": "bashing" }, { "level": 7, "name": "throw" }, { "level": 3, "name": "swimming" } ],
-    "proficiencies": [ "prof_athlete_basic" ]
+    "proficiencies": [ "prof_athlete_basic", "prof_maces_familiar", "prof_maces_pro" ]
   },
   {
     "type": "profession",
@@ -340,7 +341,7 @@
     "description": "You didn't quite make it into the big leagues, but you were close.  Now it's time to go for the grand slam or you'll be dealing with worse than a strike out.",
     "points": 6,
     "skills": [ { "level": 6, "name": "bashing" }, { "level": 5, "name": "throw" }, { "level": 3, "name": "swimming" } ],
-    "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert" ],
+    "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert", "prof_maces_familiar", "prof_maces_pro", "prof_maces_master" ],
     "traits": [ "GOODCARDIO" ]
   },
   {
@@ -350,7 +351,8 @@
     "name": "Wrestling (Beginner)",
     "description": "Maybe you've taken a few classes at a gym somewhere, or used to be on the youth team, or maybe you just liked to rough-house with your friends or family growing up.  You're not entirely unused to grappling, but you're hardly an expert.",
     "points": 2,
-    "skills": [ { "level": 1, "name": "melee" }, { "level": 2, "name": "unarmed" }, { "level": 2, "name": "dodge" } ]
+    "skills": [ { "level": 1, "name": "melee" }, { "level": 2, "name": "unarmed" }, { "level": 2, "name": "dodge" } ],
+    "proficiencies": [ "prof_unarmed_familiar" ]
   },
   {
     "type": "profession",
@@ -360,7 +362,7 @@
     "description": "While not the type of wrestler to use folding chairs as weapons, you have experience wrasslin' and tusslin' with others out on the mat.  There's no referees around to see, but hopefully your skills will help you avoid getting pinned by the undead.",
     "points": 5,
     "skills": [ { "level": 3, "name": "melee" }, { "level": 4, "name": "unarmed" }, { "level": 4, "name": "dodge" } ],
-    "proficiencies": [ "prof_athlete_basic" ],
+    "proficiencies": [ "prof_athlete_basic", "prof_unarmed_familiar", "prof_unarmed_pro" ],
     "traits": [ "FAST_REFLEXES" ]
   },
   {
@@ -371,7 +373,7 @@
     "description": "You were likely on the 100+ wins list back in school and maybe you're a collegiate wrestler or you're using it as part of something like MMA.  Considering how grabby those zombies are, you should get plenty of use out of your skills.",
     "points": 8,
     "skills": [ { "level": 5, "name": "melee" }, { "level": 6, "name": "unarmed" }, { "level": 6, "name": "dodge" } ],
-    "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert" ],
+    "proficiencies": [ "prof_athlete_basic", "prof_athlete_expert", "prof_unarmed_familiar", "prof_unarmed_pro", "prof_unarmed_master" ],
     "traits": [ "FAST_REFLEXES", "GOODCARDIO" ]
   },
   {
@@ -473,7 +475,14 @@
     "name": "Cooking (Intermediate)",
     "description": "You enjoyed cooking for yourself and others.  The grocery stores are closed for good, so you might need to start getting creative with your recipes.",
     "points": 2,
-    "proficiencies": [ "prof_baking", "prof_baking_bread", "prof_baking_desserts_1", "prof_food_prep", "prof_knife_skills" ],
+    "proficiencies": [
+      "prof_baking",
+      "prof_baking_bread",
+      "prof_baking_desserts_1",
+      "prof_food_prep",
+      "prof_knife_skills",
+      "prof_knives_familiar"
+    ],
     "skills": [ { "level": 4, "name": "cooking" } ]
   },
   {
@@ -492,7 +501,8 @@
       "prof_frying_dessert",
       "prof_frying",
       "prof_preservation",
-      "prof_scav_cooking"
+      "prof_scav_cooking",
+      "prof_knives_familiar"
     ],
     "skills": [ { "level": 7, "name": "cooking" } ]
   },
@@ -551,7 +561,8 @@
     "name": "Street Fighting (Intermediate)",
     "description": "You've been in quite a few fights in the street.  You can throw and dodge a punch better than most.",
     "points": 3,
-    "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 2, "name": "dodge" } ]
+    "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 2, "name": "dodge" } ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro" ]
   },
   {
     "type": "profession",
@@ -561,7 +572,8 @@
     "description": "Maybe you're the muscle of some criminal gang, maybe you're a bouncer at a club, or maybe you're just a huge asshole.  You've constantly been getting into fights with strangers on the streets for most of your life, and somehow you ain't dead yet, so you must be doing something right.",
     "points": 6,
     "skills": [ { "level": 5, "name": "melee" }, { "level": 6, "name": "unarmed" }, { "level": 4, "name": "dodge" } ],
-    "traits": [ "PAINRESIST" ]
+    "traits": [ "PAINRESIST" ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_unarmed_master" ]
   },
   {
     "type": "profession",
@@ -570,7 +582,8 @@
     "name": "Knife Throwing",
     "description": "You learned how to throw knives before the world ended, a skill that can be deadly in the right situation.",
     "points": 2,
-    "skills": [ { "level": 3, "name": "throw" } ]
+    "skills": [ { "level": 3, "name": "throw" } ],
+    "proficiencies": [ "prof_knives_familiar" ]
   },
   {
     "type": "profession",
@@ -611,7 +624,8 @@
     "description": "You were in a fencing club, and you weren't too shabby with a saber.  If you can get your hands on a real sword, you'll be a formidable fighter.",
     "points": 6,
     "skills": [ { "level": 3, "name": "stabbing" }, { "level": 3, "name": "melee" }, { "level": 3, "name": "dodge" } ],
-    "traits": [ "MARTIAL_FENCING" ]
+    "traits": [ "MARTIAL_FENCING" ],
+    "proficiencies": [ "prof_fencing_weapons_familiar", "prof_fencing_weapons_pro" ]
   },
   {
     "type": "profession",
@@ -621,7 +635,8 @@
     "description": "You've spent so long practicing your fencing you wouldn't look out of place in the Renaissance dueling with ne'er-do-wells and rapscallions.  En Garde!",
     "points": 10,
     "skills": [ { "level": 6, "name": "stabbing" }, { "level": 5, "name": "melee" }, { "level": 5, "name": "dodge" } ],
-    "traits": [ "MARTIAL_FENCING" ]
+    "traits": [ "MARTIAL_FENCING" ],
+    "proficiencies": [ "prof_fencing_weapons_familiar", "prof_fencing_weapons_pro", "prof_fencing_weapons_master" ]
   },
   {
     "type": "profession",
@@ -656,7 +671,8 @@
       { "level": 2, "name": "swimming" },
       { "level": 1, "name": "dodge" }
     ],
-    "traits": [ "PROF_KICKBOXER" ]
+    "traits": [ "PROF_KICKBOXER" ],
+    "proficiencies": [ "prof_unarmed_familiar" ]
   },
   {
     "type": "profession",
@@ -666,7 +682,8 @@
     "description": "You have received some martial arts training at a local dojo.  You start with your choice of Karate, Judo, Aikido, Tai Chi, Taekwondo, or Pankration.",
     "points": 5,
     "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 3, "name": "dodge" } ],
-    "traits": [ "MARTIAL_ARTS" ]
+    "traits": [ "MARTIAL_ARTS" ],
+    "proficiencies": [ "prof_unarmed_familiar" ]
   },
   {
     "type": "profession",
@@ -676,7 +693,8 @@
     "description": "You have taken some self-defense classes at a local gym.  You start with your choice of Boxing, Kickboxing, Capoeira, Krav Maga, Muay Thai, Ninjutsu, Wing Chun, or Zui Quan.",
     "points": 5,
     "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 3, "name": "dodge" } ],
-    "traits": [ "MARTIAL_ARTS2" ]
+    "traits": [ "MARTIAL_ARTS2" ],
+    "proficiencies": [ "prof_unarmed_familiar" ]
   },
   {
     "type": "profession",
@@ -686,7 +704,8 @@
     "description": "You have studied the arts of the Shaolin monks.  You start with one of the five animal fighting styles: Tiger, Crane, Leopard, Snake, or Dragon.",
     "points": 5,
     "skills": [ { "level": 2, "name": "melee" }, { "level": 3, "name": "unarmed" }, { "level": 3, "name": "dodge" } ],
-    "traits": [ "MARTIAL_ARTS3" ]
+    "traits": [ "MARTIAL_ARTS3" ],
+    "proficiencies": [ "prof_unarmed_familiar" ]
   },
   {
     "type": "profession",
@@ -701,7 +720,8 @@
       { "level": 5, "name": "dodge" },
       { "level": 3, "name": "swimming" }
     ],
-    "traits": [ "PROF_MA_BLACK" ]
+    "traits": [ "PROF_MA_BLACK" ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_unarmed_master" ]
   },
   {
     "type": "profession",
@@ -716,7 +736,16 @@
       { "level": 3, "name": "stabbing" },
       { "level": 3, "name": "cutting" }
     ],
-    "traits": [ "MARTIAL_ARTS5" ]
+    "traits": [ "MARTIAL_ARTS5" ],
+    "proficiencies": [
+      "prof_quarterstaves_familiar",
+      "prof_maces_familiar",
+      "prof_knives_familiar",
+      "prof_long_swords_familiar",
+      "prof_hooking_familiar",
+      "prof_fencing_weapons_familiar",
+      "prof_spears_familiar"
+    ]
   },
   {
     "type": "profession",
@@ -731,7 +760,23 @@
       { "level": 5, "name": "stabbing" },
       { "level": 5, "name": "cutting" }
     ],
-    "traits": [ "MARTIAL_ARTS5" ]
+    "traits": [ "MARTIAL_ARTS5" ],
+    "proficiencies": [
+      "prof_quarterstaves_familiar",
+      "prof_quarterstaves_pro",
+      "prof_maces_familiar",
+      "prof_maces_pro",
+      "prof_knives_familiar",
+      "prof_knives_pro",
+      "prof_long_swords_familiar",
+      "prof_long_swords_pro",
+      "prof_hooking_familiar",
+      "prof_hooking_pro",
+      "prof_fencing_weapons_familiar",
+      "prof_fencing_weapons_pro",
+      "prof_spears_familiar",
+      "prof_spears_pro"
+    ]
   },
   {
     "type": "profession",
@@ -780,7 +825,8 @@
     "description": "You absolutely love meat, and dislike eating fruits and vegetables.  Your particular tastes have turned you into a decent amateur butcher.",
     "points": -3,
     "traits": [ "ANTIFRUIT", "MEATARIAN" ],
-    "skills": [ { "level": 2, "name": "survival" }, { "level": 2, "name": "cooking" } ]
+    "skills": [ { "level": 2, "name": "survival" }, { "level": 2, "name": "cooking" } ],
+    "proficiencies": [ "prof_knives_familiar", "prof_knife_skills" ]
   },
   {
     "type": "profession",
@@ -1007,7 +1053,7 @@
     "name": "Shooting (Intermediate)",
     "description": "You liked going to the local gun range and shooting at some targets or blasting cans off of fence posts with a variety of firearms.  Maybe if you just imagine targets on those undead, this could help.",
     "points": 2,
-    "proficiencies": [ "prof_gun_cleaning" ],
+    "proficiencies": [ "prof_gun_cleaning", "prof_auto_pistols_familiar", "prof_auto_rifles_familiar" ],
     "skills": [
       { "level": 1, "name": "smg" },
       { "level": 2, "name": "shotgun" },
@@ -1044,7 +1090,7 @@
     "description": "You enjoyed inviting the neighborhood to a backyard cookout on the weekends.  You, of course, were the grill master.",
     "points": 1,
     "skills": [ { "level": 2, "name": "cooking" } ],
-    "proficiencies": [ "prof_food_prep", "prof_knife_skills" ]
+    "proficiencies": [ "prof_food_prep", "prof_knife_skills", "prof_knives_familiar" ]
   },
   {
     "type": "profession",
@@ -1128,7 +1174,8 @@
       "prof_baking_desserts_1",
       "prof_frying_dessert",
       "prof_food_prep",
-      "prof_knife_skills"
+      "prof_knife_skills",
+      "prof_knives_familiar"
     ],
     "skills": [ { "level": 3, "name": "cooking" } ]
   },

--- a/data/json/items/melee/bludgeons.json
+++ b/data/json/items/melee/bludgeons.json
@@ -85,7 +85,8 @@
     "flags": [ "DURABLE_MELEE", "BELT_CLIP", "NONCONDUCTIVE" ],
     "volume": "1750 ml",
     "price": 16000,
-    "melee_damage": { "bash": 22 }
+    "melee_damage": { "bash": 22 },
+    "weapon_category": [ "MACES" ]
   },
   {
     "type": "GENERIC",
@@ -104,7 +105,8 @@
     "flags": [ "DURABLE_MELEE", "BELT_CLIP" ],
     "volume": "1750 ml",
     "price": 16000,
-    "melee_damage": { "bash": 22 }
+    "melee_damage": { "bash": 22 },
+    "weapon_category": [ "MACES" ]
   },
   {
     "type": "GENERIC",
@@ -121,7 +123,8 @@
     "flags": [ "FRAGILE_MELEE", "BELT_CLIP", "NONCONDUCTIVE" ],
     "volume": "2250 ml",
     "price": "25 USD",
-    "melee_damage": { "bash": 1 }
+    "melee_damage": { "bash": 1 },
+    "weapon_category": [ "MACES" ]
   },
   {
     "type": "GENERIC",
@@ -444,7 +447,8 @@
     "longest_side": "90 cm",
     "to_hit": { "grip": "weapon", "length": "long", "surface": "any", "balance": "good" },
     "price": 20000,
-    "melee_damage": { "bash": 22, "cut": 8 }
+    "melee_damage": { "bash": 22, "cut": 8 },
+    "weapon_category": [ "MACES" ]
   },
   {
     "type": "GENERIC",
@@ -1416,7 +1420,8 @@
     "flags": [ "BELT_CLIP", "NONCONDUCTIVE" ],
     "price": 16000,
     "price_postapoc": 1750,
-    "melee_damage": { "bash": 22, "stab": 4 }
+    "melee_damage": { "bash": 22, "stab": 4 },
+    "weapon_category": [ "MACES" ]
   },
   {
     "type": "GENERIC",

--- a/data/mods/Aftershock/items/gun/10mm.json
+++ b/data/mods/Aftershock/items/gun/10mm.json
@@ -44,7 +44,8 @@
         "item_restriction": [ "afs_84k_20mag" ]
       }
     ],
-    "melee_damage": { "bash": 8 }
+    "melee_damage": { "bash": 8 },
+    "weapon_category": [ "AUTOMATIC_PISTOLS" ]
   },
   {
     "id": "afs_marsec_4",
@@ -129,6 +130,7 @@
     "valid_mod_locations": [ [ "sights", 1 ], [ "sling", 1 ] ],
     "flags": [ "NEVER_JAMS", "MUNDANE", "WONT_TRAIN_MARKSMANSHIP" ],
     "relic_data": { "passive_effects": [ { "id": "ench_smart_gun" } ] },
-    "melee_damage": { "bash": 8 }
+    "melee_damage": { "bash": 8 },
+    "weapon_category": [ "AUTOMATIC_PISTOLS" ]
   }
 ]

--- a/data/mods/Aftershock/items/gun/5x50.json
+++ b/data/mods/Aftershock/items/gun/5x50.json
@@ -53,7 +53,8 @@
     ],
     "flags": [ "WATERPROOF_GUN", "NEVER_JAMS" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "afs_5x50_100_mag", "afs_5x50_50_mag" ] } ],
-    "melee_damage": { "bash": 12 }
+    "melee_damage": { "bash": 12 },
+    "weapon_category": [ "AUTOMATIC_RIFLES" ]
   },
   {
     "id": "afs_needlepistol",

--- a/data/mods/Aftershock/items/gun/7.50mm.json
+++ b/data/mods/Aftershock/items/gun/7.50mm.json
@@ -60,7 +60,8 @@
         "item_restriction": [ "afs_UICASTA30", "afs_UICASTA100drum" ]
       }
     ],
-    "melee_damage": { "bash": 12 }
+    "melee_damage": { "bash": 12 },
+    "weapon_category": [ "AUTOMATIC_RIFLES" ]
   },
   {
     "id": "afs_gibrifle",
@@ -92,6 +93,7 @@
         "item_restriction": [ "afs_UICASTA30" ]
       }
     ],
-    "melee_damage": { "bash": 12 }
+    "melee_damage": { "bash": 12 },
+    "weapon_category": [ "AUTOMATIC_RIFLES" ]
   }
 ]

--- a/data/mods/Aftershock/items/gun/laser.json
+++ b/data/mods/Aftershock/items/gun/laser.json
@@ -149,7 +149,8 @@
         "magazine_well": "75 ml",
         "item_restriction": [ "afs_cartridge", "afs_compact_cartridge", "afs_bootleg_cartridge", "afs_archeotech_cartridge" ]
       }
-    ]
+    ],
+    "weapon_category": [ "AUTOMATIC_PISTOLS" ]
   },
   {
     "id": "afs_archeotech_laspistol",
@@ -181,7 +182,8 @@
         "magazine_well": "75 ml",
         "item_restriction": [ "afs_archeotech_cartridge" ]
       }
-    ]
+    ],
+    "weapon_category": [ "AUTOMATIC_PISTOLS" ]
   },
   {
     "id": "afs_explosive_pumped_laser",
@@ -268,7 +270,8 @@
         "magazine_well": "75 ml",
         "item_restriction": [ "afs_cartridge", "afs_compact_cartridge", "afs_bootleg_cartridge", "afs_archeotech_cartridge" ]
       }
-    ]
+    ],
+    "weapon_category": [ "AUTOMATIC_PISTOLS" ]
   },
   {
     "id": "afs_a7",

--- a/data/mods/Aftershock/items/weapons.json
+++ b/data/mods/Aftershock/items/weapons.json
@@ -227,7 +227,8 @@
     "material": [ "titanium" ],
     "price": 20000,
     "price_postapoc": 1750,
-    "melee_damage": { "bash": 22 }
+    "melee_damage": { "bash": 22 },
+    "weapon_category": [ "MACES" ]
   },
   {
     "id": "ceramic_knife",
@@ -243,7 +244,8 @@
     "color": "dark_gray",
     "qualities": [ [ "CUT", 2 ], [ "BUTCHER", 5 ] ],
     "flags": [ "SHEATH_KNIFE", "DURABLE_MELEE" ],
-    "melee_damage": { "bash": 2, "stab": 15 }
+    "melee_damage": { "bash": 2, "stab": 15 },
+    "weapon_category": [ "KNIVES" ]
   },
   {
     "type": "GENERIC",
@@ -263,7 +265,8 @@
     "flags": [ "SPEAR", "REACH_ATTACK", "NONCONDUCTIVE", "SHEATH_SPEAR" ],
     "price": 7500,
     "price_postapoc": 1200,
-    "melee_damage": { "bash": 5, "stab": 28 }
+    "melee_damage": { "bash": 5, "stab": 28 },
+    "weapon_category": [ "POLEARMS", "SPEARS" ]
   },
   {
     "id": "azabow_off",
@@ -340,7 +343,8 @@
     "to_hit": 2,
     "category": "weapons",
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 8 ] ],
-    "melee_damage": { "bash": 10, "cut": 50 }
+    "melee_damage": { "bash": 10, "cut": 50 },
+    "weapon_category": [ "LONG_SWORDS" ]
   },
   {
     "id": "scrapbow",


### PR DESCRIPTION
#### Summary
Content "Hobbies give weapon proficiency, Aftershock & baseball bats use weapon categories"

#### Purpose of change

1) Hobbies should give weapon proficiencies, especially the combat ones.
2) Aftershock's melee weapons don't have categories on them(other than one machine pistol 🤔)
3) Baseball bats, despite being top-heavy bludgeons similar to a mace in length, have no martial art.
 
#### Describe the solution

1) Give weapon proficiencies to the combat hobbies, as well as first level of knives to the cooking hobbies if they have Knife Skills(big think).
2) Give AFS weapon categories
3) Make vanilla + AFS titanium bats count as maces.

#### Describe alternatives you've considered

Cooking skills don't get knife familiarity.
Fabrication hobbies get baton familiarity(hammer & crowbar). Thought a hobby wasn't enough.

#### Testing

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/99621099/ab901f77-f507-439e-bd23-cc64bcf59826)

#### Additional context

Previous question on BBs as maces: https://github.com/CleverRaven/Cataclysm-DDA/pull/56995#issuecomment-1105829545

Melee Training catching all armed MAs is getting ridiculous now