### PR TITLE
Replace broken LMOE shelter generators with working ones

### DIFF
--- a/data/json/mapgen/lmoe.json
+++ b/data/json/mapgen/lmoe.json
@@ -103,12 +103,13 @@
         "##|c_TT___|__|rrrr__~|##",
         "##|c______|__|||||+|||##",
         "##|c______|__*__a|__A|##",
-        "##|ccccccc|<<=G_a|HlW|##",
+        "##|ccccccc|<<=___|HlW|##",
         "##||||||||||||||||||||##",
         "########################",
         "########################"
       ],
-      "palettes": [ "bunker", "empty_bunker_items" ]
+      "palettes": [ "bunker", "empty_bunker_items" ],
+      "place_vehicles": [ { "vehicle": "portable_generator", "x": 15, "y": 20, "chance": 100, "status": 0 } ]
     }
   },
   {
@@ -127,7 +128,7 @@
         "##....*....^############",
         "##....=....^############",
         "##===###Y...^###########",
-        "##G.R###-+|||####||||||#",
+        "##..R###-+|||####||||||#",
         "##a.l###A.|UUVVvv|{{{{|#",
         "##=*=###..|U.....:....|#",
         "##c..ll-..|Uuuu.u||||||#",
@@ -146,7 +147,8 @@
         "########################",
         "########################"
       ],
-      "palettes": [ "bunker", "empty_bunker_items" ]
+      "palettes": [ "bunker", "empty_bunker_items" ],
+      "place_vehicles": [ { "vehicle": "portable_generator", "x": 3, "y": 6, "chance": 100, "status": 0, "rotation": 180 } ]
     }
   },
   {
@@ -263,12 +265,13 @@
         "##|c_TT___|__|rrrr__~|##",
         "##|c______|__|||||+|||##",
         "##|c______|__*__a|__A|##",
-        "##|ccccccc|<<=G_a|HlW|##",
+        "##|ccccccc|<<=___|HlW|##",
         "##||||||||||||||||||||##",
         "########################",
         "########################"
       ],
-      "palettes": [ "bunker", "empty_prepperquest_bunker_items" ]
+      "palettes": [ "bunker", "empty_prepperquest_bunker_items" ],
+      "place_vehicles": [ { "vehicle": "portable_generator", "x": 15, "y": 20, "chance": 100, "status": 0 } ]
     }
   },
   {

--- a/data/json/mapgen/nested/lmoe_nested.json
+++ b/data/json/mapgen/nested/lmoe_nested.json
@@ -53,7 +53,7 @@
     "object": {
       "mapgensize": [ 10, 10 ],
       "rows": [
-        "l__RRRR=_G",
+        "l__RRRR=__",
         "l______*_a",
         "l_____c=_a",
         "__h___c=_l",
@@ -64,7 +64,8 @@
         "          ",
         "          "
       ],
-      "palettes": [ "bunker", "empty_bunker_items" ]
+      "palettes": [ "bunker", "empty_bunker_items" ],
+      "place_vehicles": [ { "vehicle": "portable_generator", "x": 8, "y": 0, "chance": 100, "status": 0 } ]
     }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "LMOE shelters now have working generators"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Make LMOE shelters great again(?)

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Replaced broken generators in LMOE shelters (except monster version) with working ones.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I originally aimed for a spawn chance on the working generator, but I didn't know how to have the broken generator spawn instead of the working one if the working one didn't spawn. If I had both in place, the portable generator vehicle smashed the broken generator upon generation and got damaged. And then it was sad if there was just an empty hole there when it didn't spawn if I only removed the broken generator. I don't mean to make players sad and 100% isn't unreasonable, so 100% it is! (available fuel in the generator is low though, and chance for extra fuel to spawn in it is also low!)

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Repeated starts with sheltered/LMOE scenario until I saw all the variants (except the quest and occupied versions) placed properly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Edit: Oops... I used the TCL portable generator vehicle and belatedly realized I probably should have used the furniture/appliance backup generator from roadblocks instead. But I kinda like the idea of random chance of extra loot (jumper cables, fuel can)  that can spawn in the vehicle. But the roadblock generator looks better and fits in one tile. Argh.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
