### PR TITLE
Adjust hungry and overweight coloring in sidebar

### DIFF
--- a/data/json/ui/hunger.json
+++ b/data/json/ui/hunger.json
@@ -14,10 +14,10 @@
         "condition": { "u_has_effect": "hunger_satisfied" }
       },
       { "id": "blank", "text": "", "color": "white", "condition": { "u_has_effect": "hunger_blank" } },
-      { "id": "hungry", "text": "Hungry", "color": "c_light_gray", "condition": { "u_has_effect": "hunger_hungry" } },
+      { "id": "hungry", "text": "Peckish", "color": "c_light_gray", "condition": { "u_has_effect": "hunger_hungry" } },
       {
         "id": "very_hungry",
-        "text": "Very hungry",
+        "text": "Hungry",
         "color": "yellow",
         "condition": { "u_has_effect": "hunger_very_hungry" }
       },

--- a/data/json/ui/hunger.json
+++ b/data/json/ui/hunger.json
@@ -14,7 +14,7 @@
         "condition": { "u_has_effect": "hunger_satisfied" }
       },
       { "id": "blank", "text": "", "color": "white", "condition": { "u_has_effect": "hunger_blank" } },
-      { "id": "hungry", "text": "Hungry", "color": "yellow", "condition": { "u_has_effect": "hunger_hungry" } },
+      { "id": "hungry", "text": "Hungry", "color": "c_light_gray", "condition": { "u_has_effect": "hunger_hungry" } },
       {
         "id": "very_hungry",
         "text": "Very hungry",

--- a/data/json/ui/sidebar-mobile.json
+++ b/data/json/ui/sidebar-mobile.json
@@ -1437,7 +1437,7 @@
         "condition": { "u_has_effect": "hunger_satisfied" }
       },
       { "id": "blank", "text": "    ", "color": "h_green", "condition": { "u_has_effect": "hunger_blank" } },
-      { "id": "hungry", "text": "█   ", "color": "h_yellow", "condition": { "u_has_effect": "hunger_hungry" } },
+      { "id": "hungry", "text": "█   ", "color": "c_light_gray", "condition": { "u_has_effect": "hunger_hungry" } },
       {
         "id": "very_hungry",
         "text": "██  ",

--- a/data/json/ui/weight.json
+++ b/data/json/ui/weight.json
@@ -51,7 +51,7 @@
       {
         "id": "overweight",
         "text": "Overweight",
-        "color": "yellow",
+        "color": "c_light_gray",
         "//": "5-10 points of BMI from fat (20-33% of body weight is fat)",
         "condition": {
           "and": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Adjust hungry and overweight coloring in sidebar"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

To mitigate the negative connotation of "overweight" and "hungry".

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Changed the text color from yellow to grey.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Also considered renaming "hungry" to "peckish" and "very hungry" to simply "hungry".

Think of a word to describe the "blank" hunger state?

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

"Overweight" has no explicit gameplay impact compared to "normal weight", and can even be considered advantageous post-cataclysm. As they are functionally the same, they get the same color.

Similarly, the "hungry" status doesn't even show up unless overweight (hunger goes straight to "very hungry" when below overweight, and changing the color to be more neutral should imply that it is something that it is not something that needs to be taken care of immediately (it still progresses to very hungry when appropriate).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
