### PR TITLE
Weapon familiarities for professions

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1802,7 +1802,7 @@
     "description": "You were hired to take care of the housekeeping for a wealthy family.  Naturally, when things got bad, they all took off on a family vacation to somewhere unknown, leaving you to your fate.",
     "points": 1,
     "skills": [ { "level": 3, "name": "tailor" }, { "level": 3, "name": "cooking" }, { "level": 3, "name": "driving" } ],
-    "proficiencies": [ "prof_food_prep", "prof_closures", "prof_knives_familiar" ],
+    "proficiencies": [ "prof_food_prep", "prof_closures", "prof_knife_skills", "prof_knives_familiar" ],
     "items": {
       "both": { "items": [ "pocketwatch", "knife_steak" ], "entries": [ { "group": "charged_smart_phone" } ] },
       "male": [ "briefs", "socks", "dress_shoes", "tux", "glasses_monocle", "collarpin" ],
@@ -6754,7 +6754,8 @@
       "prof_traps",
       "prof_disarming",
       "prof_trapsetting",
-      "prof_auto_rifles_familiar"
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
     ],
     "skills": [
       { "level": 6, "name": "traps" },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1906,7 +1906,7 @@
     "requirement": "achievement_kill_100_monsters",
     "description": "The boss always said he could rely on you to pull through on the tough jobs.  Shame he got himself smoked.  No problem; the world's always got a place for someone with your kind of talents.",
     "points": 4,
-    "proficiencies": [ "prof_knives_familiar", "prof_unarmed_familiar" ],
+    "proficiencies": [ "prof_knives_familiar", "prof_unarmed_familiar", "prof_shivs_familiar" ],
     "skills": [
       { "level": 3, "name": "gun" },
       { "level": 3, "name": "pistol" },
@@ -3773,7 +3773,7 @@
       { "level": 3, "name": "unarmed" },
       { "level": 3, "name": "dodge" }
     ],
-    "proficiencies": [ "prof_knives_familiar", "prof_knives_pro", "prof_unarmed_familiar", "prof_unarmed_pro" ],
+    "proficiencies": [ "prof_knives_familiar", "prof_knives_pro", "prof_unarmed_familiar", "prof_unarmed_pro", "prof_shivs_familiar" ],
     "traits": [ "PROF_ASSASSIN_CONVICT" ],
     "items": {
       "both": {

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -751,7 +751,14 @@
     "description": "Bork bork!  Years in the kitchen have left you carrying a prodigious bulk, but you managed to escape the carnage with your trusty butcher knife and only a small collection of stains on your uniform.",
     "points": 2,
     "skills": [ { "name": "cooking", "level": 6 } ],
-    "proficiencies": [ "prof_food_prep", "prof_knife_skills", "prof_baking", "prof_baking_desserts_1", "prof_frying" ],
+    "proficiencies": [
+      "prof_food_prep",
+      "prof_knife_skills",
+      "prof_baking",
+      "prof_baking_desserts_1",
+      "prof_frying",
+      "prof_knives_familiar"
+    ],
     "items": {
       "both": {
         "items": [ "pants_checkered", "socks", "dress_shoes" ],
@@ -774,7 +781,7 @@
     "description": "You spent most of your adult life in a butcher shop.  Your trusty knife has seen many different creatures and you know how to butcher them.",
     "points": 2,
     "skills": [ { "name": "cutting", "level": 2 }, { "name": "cooking", "level": 2 }, { "name": "survival", "level": 2 } ],
-    "proficiencies": [ "prof_food_prep", "prof_knife_skills", "prof_intro_biology", "prof_wp_basic_bird" ],
+    "proficiencies": [ "prof_food_prep", "prof_knife_skills", "prof_intro_biology", "prof_wp_basic_bird", "prof_knives_familiar" ],
     "items": {
       "both": {
         "items": [ "pants", "socks", "sneakers" ],
@@ -803,7 +810,7 @@
       },
       "female": [ "chestwrap" ]
     },
-    "proficiencies": [ "prof_fibers", "prof_carving", "prof_leatherworking_basic" ],
+    "proficiencies": [ "prof_fibers", "prof_carving", "prof_leatherworking_basic", "prof_knives_familiar" ],
     "skills": [
       { "level": 3, "name": "melee" },
       { "level": 3, "name": "throw" },
@@ -870,7 +877,7 @@
     "name": "Scoundrel",
     "description": "Your flexible outlook on the law, the scuffles you've been in (and avoided) at the bar, and your impressive ability to weasel your way out of the consequences of your actions - all these skills have helped ensure your survival.  How much longer will they hold out?",
     "points": 2,
-    "proficiencies": [ "prof_lockpicking" ],
+    "proficiencies": [ "prof_lockpicking", "prof_knives_familiar", "prof_unarmed_familiar" ],
     "skills": [
       { "level": 3, "name": "melee" },
       { "level": 3, "name": "stabbing" },
@@ -939,7 +946,7 @@
       { "level": 4, "name": "throw" },
       { "level": 4, "name": "swimming" }
     ],
-    "proficiencies": [ "prof_athlete_basic" ],
+    "proficiencies": [ "prof_athlete_basic", "prof_maces_familiar", "prof_maces_pro" ],
     "items": {
       "both": {
         "items": [ "baseball", "jacket_light", "jeans", "socks", "cleats", "helmet_ball", "sports_drink", "gum" ],
@@ -985,7 +992,7 @@
       { "level": 4, "name": "dodge" },
       { "level": 4, "name": "swimming" }
     ],
-    "proficiencies": [ "prof_athlete_basic" ],
+    "proficiencies": [ "prof_athlete_basic", "prof_unarmed_familiar" ],
     "items": {
       "both": {
         "items": [
@@ -1120,7 +1127,13 @@
     "requirement": "achievement_reach_military_bunker",
     "description": "You are one of the few and the proud: a member of the US Marine Corps.  Now that military command has collapsed in on itself as far as you can tell, you suppose that it falls to you to carry the memory of the Corps forward into the future.  Semper fi.",
     "points": 6,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 5, "name": "gun" },
       { "level": 5, "name": "rifle" },
@@ -1233,7 +1246,14 @@
     "requirement": "achievement_reach_aircraft_carrier",
     "description": "You were a member of a Naval Special Warfare diving group, a skilled soldier adept at underwater infiltration and marine combat.  You were suiting up for a practice dive when the aircraft carrier you were stationed on was somehow flung from the Yellow Sea to who knows where.  You seem to be the only one who survived with your sanity intact, but it's not safe to stay here.  At least you're already dressed to abandon ship.",
     "points": 5,
-    "proficiencies": [ "prof_spotting", "prof_gunsmithing_basic", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_spotting",
+      "prof_gunsmithing_basic",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 7, "name": "swimming" },
       { "level": 5, "name": "gun" },
@@ -1306,7 +1326,13 @@
     "requirement": "achievement_reach_military_bunker",
     "description": "Joining the military has been your dream for years.  You finally got in, just in time for your training to get interrupted by some sort of national emergency.  As far as you can tell, military command abandoned you in this hellhole when you missed the emergency evac.",
     "points": 3,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 3, "name": "gun" },
       { "level": 3, "name": "rifle" },
@@ -1462,7 +1488,14 @@
     "requirement": "achievement_reach_military_bunker",
     "description": "You're a veteran of several peacekeeping missions.  You led your squad as a sort of parental figure, and they relied on you to give orders and keep them alive.  You failed them.  And now you're alone.",
     "points": 7,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_spotting",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 6, "name": "speech" },
       { "level": 5, "name": "gun" },
@@ -1518,7 +1551,14 @@
     "requirement": "achievement_reach_military_bunker",
     "description": "When you were young, you dreamed of being a soldier.  War is hell and hell is war, but you never thought it would be this bad.",
     "points": 5,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_spotting",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 4, "name": "gun" },
       { "level": 4, "name": "rifle" },
@@ -1572,7 +1612,15 @@
     "name": "Navy SEAL Marksmen",
     "description": "Recruited into the ranks of the US Navy’s Special Warfare forces as a designated sniper, your training in precision marksmanship and maritime operations was extensive.  As a proficient soldier and combative in all respects, you provided overwatch and long-range elimination services in the line of duty.  Now, with naval command imploding and your spotter MIA, your skills with a rifle and covert operations are the only things standing between you and the Cataclysm.",
     "points": 8,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_wound_care", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_spotting",
+      "prof_wound_care",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 8, "name": "gun" },
       { "level": 8, "name": "rifle" },
@@ -1624,7 +1672,15 @@
     "requirement": "achievement_reach_aircraft_carrier",
     "description": "You were a member of the SEALs; a key component of the US Navy’s special forces and a proficient combatant in both maritime and ground operations.  'The only easy day was yesterday', and with the chain of command in ruins, you may fulfill your final mission in any way you see fit.",
     "points": 8,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_wound_care", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_spotting",
+      "prof_wound_care",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 7, "name": "gun" },
       { "level": 7, "name": "rifle" },
@@ -1684,7 +1740,15 @@
     "requirement": "achievement_reach_military_base",
     "description": "You were the best of the best, the military's finest.  That's why you're still alive, even after all your comrades fell to the undead.  As far as you can tell, military command abandoned you in this hellhole when you missed the emergency evac.",
     "points": 8,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_traps", "prof_disarming", "prof_spotting", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_traps",
+      "prof_disarming",
+      "prof_spotting",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar"
+    ],
     "skills": [
       { "level": 7, "name": "gun" },
       { "level": 7, "name": "smg" },
@@ -1738,7 +1802,7 @@
     "description": "You were hired to take care of the housekeeping for a wealthy family.  Naturally, when things got bad, they all took off on a family vacation to somewhere unknown, leaving you to your fate.",
     "points": 1,
     "skills": [ { "level": 3, "name": "tailor" }, { "level": 3, "name": "cooking" }, { "level": 3, "name": "driving" } ],
-    "proficiencies": [ "prof_food_prep", "prof_closures" ],
+    "proficiencies": [ "prof_food_prep", "prof_closures", "prof_knives_familiar" ],
     "items": {
       "both": { "items": [ "pocketwatch", "knife_steak" ], "entries": [ { "group": "charged_smart_phone" } ] },
       "male": [ "briefs", "socks", "dress_shoes", "tux", "glasses_monocle", "collarpin" ],
@@ -1760,6 +1824,7 @@
     "requirement": "achievement_reach_mi-Go_encampment",
     "description": "You were ready.  You went in determined to find and rescue your friends.  Now the atmosphere in these twisting corridors grows heavy, and you don't feel quite so confident anymore.  You might be the one in need of a rescue soon.",
     "points": 3,
+    "proficiencies": [ "prof_auto_rifles_familiar", "prof_knives_familiar", "prof_auto_pistols_familiar" ],
     "skills": [
       { "level": 4, "name": "gun" },
       { "level": 4, "name": "rifle" },
@@ -1841,6 +1906,7 @@
     "requirement": "achievement_kill_100_monsters",
     "description": "The boss always said he could rely on you to pull through on the tough jobs.  Shame he got himself smoked.  No problem; the world's always got a place for someone with your kind of talents.",
     "points": 4,
+    "proficiencies": [ "prof_knives_familiar", "prof_unarmed_familiar" ],
     "skills": [
       { "level": 3, "name": "gun" },
       { "level": 3, "name": "pistol" },
@@ -1915,6 +1981,7 @@
     "name": "Landscaper",
     "description": "You used to mow lawns and trim hedges for the wealthy.  Contract work was getting scarce even before the zombies came, but now you've got nothing left except your tools and expertise.",
     "points": 1,
+    "proficiencies": [ "prof_short_swords_familiar", "prof_short_swords_pro" ],
     "skills": [
       { "level": 3, "name": "fabrication" },
       { "level": 3, "name": "survival" },
@@ -1984,7 +2051,8 @@
       "prof_bow_expert",
       "prof_fletching",
       "prof_carving",
-      "prof_gun_cleaning"
+      "prof_gun_cleaning",
+      "prof_knives_familiar"
     ],
     "skills": [
       { "level": 6, "name": "survival" },
@@ -2071,7 +2139,7 @@
       { "level": 2, "name": "swimming" }
     ],
     "traits": [ "PROF_POLICE" ],
-    "proficiencies": [ "prof_spotting", "prof_gun_cleaning" ],
+    "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_batons_familiar", "prof_auto_pistols_familiar" ],
     "pets": [ { "name": "mon_dog_gshepherd", "amount": 1 } ],
     "items": {
       "both": {
@@ -2107,7 +2175,7 @@
       { "level": 2, "name": "swimming" }
     ],
     "traits": [ "PROF_POLICE" ],
-    "proficiencies": [ "prof_spotting", "prof_gun_cleaning" ],
+    "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_batons_familiar", "prof_auto_pistols_familiar" ],
     "pets": [ { "name": "mon_horse_police", "amount": 1 } ],
     "items": {
       "both": {
@@ -2203,7 +2271,7 @@
       { "level": 2, "name": "swimming" }
     ],
     "traits": [ "PROF_POLICE" ],
-    "proficiencies": [ "prof_spotting", "prof_gun_cleaning" ],
+    "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_batons_familiar", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
         "items": [ "pants_army", "socks", "badge_deputy", "police_belt", "boots", "whistle", "wristwatch", "baton" ],
@@ -2275,7 +2343,7 @@
     "requirement": "achievement_reach_police_station",
     "description": "As a member of the police force's most elite division, you are more than adequately trained and equipped to survive the brutal onslaught of the apocalypse.  Unfortunately, the chain of command has broken down; your only mission now is to stay alive.",
     "points": 6,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_gun_cleaning" ],
+    "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_gun_cleaning", "prof_auto_pistols_familiar", "prof_batons_familiar" ],
     "skills": [
       { "level": 5, "name": "gun" },
       { "level": 5, "name": "smg" },
@@ -2344,7 +2412,15 @@
       { "level": 3, "name": "swimming" }
     ],
     "traits": [ "PROF_SWAT" ],
-    "proficiencies": [ "prof_spotting", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_spotting",
+      "prof_gun_cleaning",
+      "prof_batons_familiar",
+      "prof_batons_pro",
+      "prof_unarmed_familiar",
+      "prof_unarmed_pro",
+      "prof_auto_pistols_familiar"
+    ],
     "items": {
       "both": {
         "items": [
@@ -2382,7 +2458,13 @@
     "requirement": "achievement_reach_police_station",
     "description": "Your skill as a sharpshooter served you well in the line of duty, protecting the innocent with a single, well-placed bullet.  Now your own life is on the line, and you can't afford to miss if you don't want to end up as something's dinner.",
     "points": 6,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_spotting",
+      "prof_gun_cleaning",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 7, "name": "gun" },
       { "level": 7, "name": "rifle" },
@@ -2441,7 +2523,7 @@
       { "level": 3, "name": "swimming" }
     ],
     "traits": [ "PROF_POLICE" ],
-    "proficiencies": [ "prof_spotting", "prof_gun_cleaning" ],
+    "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_batons_familiar", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
         "items": [
@@ -2485,7 +2567,7 @@
       { "level": 2, "name": "swimming" }
     ],
     "traits": [ "PROF_POLICE" ],
-    "proficiencies": [ "prof_spotting", "prof_gun_cleaning" ],
+    "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_batons_familiar", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
         "items": [
@@ -2569,8 +2651,13 @@
     "name": "Bow Hunter",
     "description": "Ever since you were a child you loved hunting, and quickly developed a talent for archery.  Why, if the world ended, there's nothing you'd want at your side more than your trusty bow.  So, when it did, you made sure to bring it along.",
     "points": 3,
-    "proficiencies": [ "prof_bow_basic", "prof_bowyery" ],
-    "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "archery" }, { "level": 2, "name": "swimming" } ],
+    "proficiencies": [ "prof_bow_basic", "prof_bowyery", "prof_knives_familiar" ],
+    "skills": [
+      { "level": 4, "name": "gun" },
+      { "level": 4, "name": "archery" },
+      { "level": 2, "name": "swimming" },
+      { "level": 3, "name": "survival" }
+    ],
     "items": {
       "both": {
         "items": [
@@ -2603,8 +2690,13 @@
     "name": "Crossbow Hunter",
     "description": "Ever since you were a child you loved hunting, and crossbow hunting was always your favorite.  Why, if the world ended, there's nothing you'd want at your side more than your trusty crossbow.  So, when it did, you made sure to bring it along, though most of your bolts were lost during the escape.",
     "points": 3,
-    "proficiencies": [ "prof_bow_basic", "prof_gunsmithing_spring" ],
-    "skills": [ { "level": 4, "name": "rifle" }, { "level": 4, "name": "gun" }, { "level": 2, "name": "swimming" } ],
+    "proficiencies": [ "prof_bow_basic", "prof_gunsmithing_spring", "prof_knives_familiar" ],
+    "skills": [
+      { "level": 4, "name": "rifle" },
+      { "level": 4, "name": "gun" },
+      { "level": 2, "name": "swimming" },
+      { "level": 3, "name": "survival" }
+    ],
     "items": {
       "both": {
         "items": [ "knit_scarf", "socks", "boots_steel", "pants_cargo", "jacket_flannel", "hat_hunting", "wristwatch", "single_sling" ],
@@ -2633,8 +2725,8 @@
     "name": "Shotgun Hunter",
     "description": "Ever since you were a child you loved hunting, and one year you got a shotgun for your birthday.  Why, if the world ended, there's nothing you'd want at your side more than your trusty shotgun.  So, when it did, you made sure to bring it along.",
     "points": 3,
-    "proficiencies": [ "prof_gun_cleaning" ],
-    "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "shotgun" } ],
+    "proficiencies": [ "prof_gun_cleaning", "prof_knives_familiar" ],
+    "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "shotgun" }, { "level": 3, "name": "survival" } ],
     "items": {
       "both": {
         "items": [ "knit_scarf", "socks", "boots_steel", "pants_cargo", "jacket_flannel", "hat_hunting", "wristwatch", "back_holster" ],
@@ -2664,8 +2756,8 @@
     "name": "Rifle Hunter",
     "description": "Ever since you were a child you loved hunting, and you fancy yourself a crack shot.  Why, if the world ended, there's nothing you'd want at your side more than your trusty rifle.  So, when it did, you made sure to bring it along.",
     "points": 3,
-    "proficiencies": [ "prof_gun_cleaning" ],
-    "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "rifle" } ],
+    "proficiencies": [ "prof_gun_cleaning", "prof_knives_familiar" ],
+    "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "rifle" }, { "level": 3, "name": "survival" } ],
     "items": {
       "both": {
         "items": [ "knit_scarf", "socks", "boots_steel", "pants_cargo", "jacket_flannel", "hat_hunting", "wristwatch", "back_holster" ],
@@ -2695,8 +2787,8 @@
     "name": "Big-Bore Hunter",
     "description": "You always harbored a passion for hunting and a particular fondness for big-bore rifle calibers and affordable conversion kits.  Whether it was their cost-effective nature or the simple, testosterone-amplifying notion that you could retool your rifle to belt out .50-caliber bullets, you preferred them for your hunting trips.  Now, with your converted rifle in hand, you fancy that there isn't any game too large for you to take down.",
     "points": 3,
-    "proficiencies": [ "prof_gun_cleaning" ],
-    "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "rifle" } ],
+    "proficiencies": [ "prof_gun_cleaning", "prof_knives_familiar" ],
+    "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "rifle" }, { "level": 3, "name": "survival" } ],
     "items": {
       "both": {
         "items": [
@@ -2944,7 +3036,7 @@
       { "level": 2, "name": "dodge" },
       { "level": 2, "name": "swimming" }
     ],
-    "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_driver" ],
+    "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_driver", "prof_batons_familiar", "prof_auto_pistols_familiar" ],
     "vehicle": "policecar",
     "traits": [ "PROF_POLICE" ],
     "items": {
@@ -2970,7 +3062,7 @@
     "requirement": "achievement_survive_28_days",
     "description": "You and a group of like-minded individuals built a hideout in the woods from which to launch looting raids in a jury-rigged pickup.  The last run went bad, and now all your comrades are dead.  Every breath you take now is an act of rebellion against the cruelty of this doomed world.  Do not let that flame of hope perish inside you.",
     "points": 4,
-    "proficiencies": [ "prof_driver" ],
+    "proficiencies": [ "prof_driver", "prof_auto_rifles_familiar", "prof_auto_pistols_familiar" ],
     "skills": [
       { "level": 4, "name": "gun" },
       { "level": 4, "name": "rifle" },
@@ -3079,6 +3171,7 @@
     "name": "Lumberjack",
     "description": "You're a lumberjack, and you're okay.  You felled trees before the world ended, and you suspect the undead aren't nearly as tough.",
     "points": 2,
+    "proficiencies": [ "prof_great_axes_familiar", "prof_great_axes_pro", "prof_hand_axes_familiar", "prof_hand_axes_pro" ],
     "skills": [
       { "level": 3, "name": "melee" },
       { "level": 3, "name": "bashing" },
@@ -3101,7 +3194,7 @@
     "description": "The diners at the fancy burger joint where you worked were even more irritable and unreasonable than usual today.  You showed them the meaning of fast food… by running for your life!",
     "points": 1,
     "skills": [ { "level": 3, "name": "cooking" } ],
-    "proficiencies": [ "prof_frying" ],
+    "proficiencies": [ "prof_frying", "prof_knives_familiar" ],
     "items": {
       "both": {
         "items": [ "pants", "sneakers", "socks", "knife_steak" ],
@@ -3364,7 +3457,7 @@
     "description": "You spent most of your life trapping with your father.  Both of you made a decent living selling your catches and running trapping tutorials.  Hopefully, your skills will come in useful against less conventional game.",
     "points": 3,
     "skills": [ { "level": 6, "name": "traps" }, { "level": 4, "name": "survival" } ],
-    "proficiencies": [ "prof_fibers", "prof_fibers_rope", "prof_traps", "prof_trapsetting" ],
+    "proficiencies": [ "prof_fibers", "prof_fibers_rope", "prof_traps", "prof_trapsetting", "prof_knives_familiar" ],
     "items": {
       "both": {
         "items": [
@@ -3640,6 +3733,7 @@
     "name": "Convict",
     "description": "Your trial was contentious, but ultimately you found yourself behind bars.  The Cataclysm has offered you a chance to escape, but freedom may come with a steep price.",
     "points": 0,
+    "proficiencies": [ "prof_unarmed_familiar" ],
     "skills": [
       { "level": 2, "name": "melee" },
       { "level": 2, "name": "stabbing" },
@@ -3658,6 +3752,7 @@
     "name": "Death Row Convict",
     "description": "You were a serial killer, ready to walk the green mile, but in a twist of fate you're one of the few still alive.  True death comes only from your hands, so you're in for a job.",
     "points": 1,
+    "proficiencies": [ "prof_knives_familiar", "prof_unarmed_familiar" ],
     "skills": [ { "level": 3, "name": "melee" }, { "level": 3, "name": "stabbing" }, { "level": 2, "name": "unarmed" } ],
     "traits": [ "KILLER" ],
     "items": {
@@ -3678,6 +3773,7 @@
       { "level": 3, "name": "unarmed" },
       { "level": 3, "name": "dodge" }
     ],
+    "proficiencies": [ "prof_knives_familiar", "prof_knives_pro", "prof_unarmed_familiar", "prof_unarmed_pro" ],
     "traits": [ "PROF_ASSASSIN_CONVICT" ],
     "items": {
       "both": {
@@ -3966,6 +4062,7 @@
     "points": 1,
     "flags": [ "NO_BONUS_ITEMS" ],
     "skills": [ { "level": 1, "name": "melee" }, { "level": 1, "name": "unarmed" } ],
+    "proficiencies": [ "prof_unarmed_familiar" ],
     "items": {
       "both": {
         "items": [ "karate_gi", "judo_belt_white", "mouthpiece", "socks_ankle", "sneakers" ],
@@ -4001,6 +4098,7 @@
       "style_wingchun",
       "style_zui_quan"
     ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro" ],
     "skills": [
       { "level": 4, "name": "melee" },
       { "level": 4, "name": "unarmed" },
@@ -4039,6 +4137,7 @@
       "style_wingchun",
       "style_zui_quan"
     ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_unarmed_master" ],
     "skills": [
       { "level": 8, "name": "melee" },
       { "level": 8, "name": "unarmed" },
@@ -4276,7 +4375,14 @@
     "requirement": "achievement_survive_91_days",
     "description": "One of the lucky few who escaped the Cataclysm, you made a life for yourself amidst the ruins of civilization.  Whether through force, guile, or luck, you've obtained the best gear you could find.",
     "points": 8,
-    "proficiencies": [ "prof_fibers", "prof_fibers_rope", "prof_knitting", "prof_closures" ],
+    "proficiencies": [
+      "prof_fibers",
+      "prof_fibers_rope",
+      "prof_knitting",
+      "prof_closures",
+      "prof_long_swords_familiar",
+      "prof_auto_rifles_familiar"
+    ],
     "skills": [
       { "level": 4, "name": "gun" },
       { "level": 4, "name": "rifle" },
@@ -4324,7 +4430,13 @@
     "requirement": "achievement_reach_military_bunker",
     "description": "You must have paid attention to your survival training in boot camp; otherwise, you would never have lived long enough to outlast the chain of command and find yourself in this predicament.  The only mission now is to survive.",
     "points": 6,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 4, "name": "gun" },
       { "level": 4, "name": "rifle" },
@@ -4426,7 +4538,8 @@
       "prof_bow_basic",
       "prof_bow_expert",
       "prof_fletching",
-      "prof_carving"
+      "prof_carving",
+      "prof_knives_familiar"
     ],
     "items": {
       "both": {
@@ -4464,7 +4577,7 @@
     "description": "You spent most of your days fishing in the swamp, getting by quietly on your catch.  You found the buzzing of insects enjoyable, but recently they've gotten bigger and meaner.  Now their horrible noises have you spooked - you just hope the fish aren't as nasty.",
     "points": 2,
     "skills": [ { "level": 5, "name": "survival" }, { "level": 2, "name": "swimming" } ],
-    "proficiencies": [ "prof_fibers" ],
+    "proficiencies": [ "prof_fibers", "prof_knives_familiar" ],
     "items": {
       "both": {
         "items": [
@@ -4653,6 +4766,7 @@
     "name": "Juvenile Delinquent",
     "description": "You never cared for grown-ups telling you what to do, so you ended up spending quite a few days in the principal's office.  Now, not needing grown-ups to tell you what to do is the only reason you're alive.  Man, you really should've played hooky today.",
     "points": 0,
+    "proficiencies": [ "prof_unarmed_familiar" ],
     "skills": [
       { "level": 1, "name": "gun" },
       { "level": 1, "name": "archery" },
@@ -5023,6 +5137,7 @@
       { "level": 6, "name": "dodge" },
       { "level": 4, "name": "swimming" }
     ],
+    "proficiencies": [ "prof_fencing_weapons_familiar", "prof_fencing_weapons_pro" ],
     "starting_styles": [ "style_fencing" ],
     "items": {
       "both": {
@@ -5245,7 +5360,13 @@
     "requirement": "achievement_reach_military_bunker",
     "description": "You like to think of yourself as a sniper, but really you're just infantry with a bigger gun.  That said, a big gun is a definite advantage now.",
     "points": 5,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 4, "name": "gun" },
       { "level": 4, "name": "rifle" },
@@ -5296,7 +5417,13 @@
     "requirement": "achievement_reach_military_bunker",
     "description": "You were trusted with a big-ass, belt-fed machine gun and plenty of ammo to lay down suppressing fire for your team.  Now that it's going to be much harder to resupply, you should probably be more selective with the ol' spray-and-pray.",
     "points": 5,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 4, "name": "gun" },
       { "level": 4, "name": "rifle" },
@@ -5350,7 +5477,13 @@
     "requirement": "achievement_reach_military_bunker",
     "description": "There's no kill like overkill, and not many people in this world can boast that they have a grenade launcher and know how to use it.  Just try not to blow yourself up, that would be really embarrassing.",
     "points": 4,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 4, "name": "gun" },
       { "level": 4, "name": "launcher" },
@@ -5406,7 +5539,13 @@
     "requirement": "achievement_reach_military_bunker",
     "description": "Doors and windows everywhere dare not speak your name.  You're going to be breaking into buildings for supplies rather than combat operations now, but the principle is about the same.",
     "points": 5,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 4, "name": "gun" },
       { "level": 4, "name": "shotgun" },
@@ -5462,7 +5601,13 @@
     "requirement": "achievement_reach_military_bunker",
     "description": "You're a crack shot with a rifle, and the farther you can stay away from zombies, the better.  The only thing stopping you is limited ammo, so you should try to find a place to restock sooner or later.",
     "points": 5,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 7, "name": "gun" },
       { "level": 7, "name": "rifle" },
@@ -5519,7 +5664,15 @@
     "requirement": "achievement_reach_military_bunker",
     "description": "'Hacker' is a silly pop-culture name, popularized by Hollywood and people with little to no knowledge of what your job entails.  You prefer 'Electronic Warfare Specialist,' though nobody's really left to make the distinction.",
     "points": 7,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_elec_soldering", "prof_appliance_repair", "prof_gun_cleaning" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_elec_soldering",
+      "prof_appliance_repair",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 7, "name": "computer" },
       { "level": 6, "name": "electronics" },
@@ -5578,7 +5731,7 @@
     "name": "Undercover Operative",
     "description": "You've been tailing your target for months, and now he's a zombie.  So much for that lead.  Command isn't responding to your calls for an evac, so you'll have to make do with what you have on you.",
     "points": 5,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning" ],
+    "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning", "prof_knives_familiar", "prof_auto_pistols_familiar" ],
     "skills": [
       { "level": 4, "name": "gun" },
       { "level": 4, "name": "pistol" },
@@ -5637,7 +5790,7 @@
       { "level": 2, "name": "throw" },
       { "level": 1, "name": "swimming" }
     ],
-    "proficiencies": [ "prof_helicopter_pilot", "prof_spotting", "prof_gun_cleaning" ],
+    "proficiencies": [ "prof_helicopter_pilot", "prof_spotting", "prof_gun_cleaning", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
         "items": [
@@ -5769,7 +5922,10 @@
       "prof_physiology",
       "prof_burn_care",
       "prof_dissect_humans",
-      "prof_gun_cleaning"
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
     ],
     "items": {
       "both": {
@@ -5938,6 +6094,7 @@
       { "level": 3, "name": "unarmed" },
       { "level": 3, "name": "dodge" }
     ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
         "items": [
@@ -6054,6 +6211,7 @@
       { "level": 4, "name": "throw" },
       { "level": 2, "name": "swimming" }
     ],
+    "proficiencies": [ "prof_long_swords_familiar" ],
     "items": {
       "both": {
         "items": [ "hood_ninja", "jacket_ninja", "trousers_ninja", "tabi_dress", "geta", "gloves_wraps", "bellywrap" ],
@@ -6320,7 +6478,15 @@
       { "level": 4, "name": "dodge" },
       { "level": 4, "name": "speech" }
     ],
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_wp_syn_armored" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_spotting",
+      "prof_wp_syn_armored",
+      "prof_auto_pistols_familiar",
+      "prof_auto_pistols_pro",
+      "prof_unarmed_familiar",
+      "prof_unarmed_pro"
+    ],
     "items": {
       "both": {
         "items": [
@@ -6380,7 +6546,7 @@
       { "level": 5, "name": "dodge" },
       { "level": 4, "name": "speech" }
     ],
-    "proficiencies": [ "prof_spotting", "prof_wp_syn_armored" ],
+    "proficiencies": [ "prof_spotting", "prof_wp_syn_armored", "prof_knives_familiar", "prof_knives_pro", "prof_knives_master" ],
     "items": {
       "both": {
         "items": [ "fancy_sunglasses", "platinum_watch", "knit_scarf_loose", "gloves_liner", "polaroid_photo", "switchblade" ],
@@ -6432,7 +6598,7 @@
       { "level": 2, "name": "throw" },
       { "level": 1, "name": "survival" }
     ],
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_gun_cleaning" ],
+    "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_gun_cleaning", "prof_auto_rifles_familiar" ],
     "items": {
       "both": {
         "items": [
@@ -6531,13 +6697,14 @@
     "name": "RV Hunter",
     "description": "Ever since you were a child you loved hunting and traveling; so when you scraped enough money, you bought yourself an old RV, a gun, and hit the road.  You've been all over the country, hunting for good game.  Unfortunately the country is all over this time, and even more unfortunately you've lost your ol' reliable in the chaos.  Now you gotta find a new reliable.",
     "points": 4,
-    "proficiencies": [ "prof_driver", "prof_basic_engines" ],
+    "proficiencies": [ "prof_driver", "prof_basic_engines", "prof_knives_familiar" ],
     "skills": [
       { "level": 3, "name": "rifle" },
       { "level": 3, "name": "gun" },
       { "level": 2, "name": "swimming" },
       { "level": 4, "name": "driving" },
-      { "level": 4, "name": "mechanics" }
+      { "level": 4, "name": "mechanics" },
+      { "level": 3, "name": "survival" }
     ],
     "vehicle": "rv",
     "items": {
@@ -6586,7 +6753,8 @@
       "prof_spotting",
       "prof_traps",
       "prof_disarming",
-      "prof_trapsetting"
+      "prof_trapsetting",
+      "prof_auto_rifles_familiar"
     ],
     "skills": [
       { "level": 6, "name": "traps" },

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -3733,7 +3733,7 @@
     "name": "Convict",
     "description": "Your trial was contentious, but ultimately you found yourself behind bars.  The Cataclysm has offered you a chance to escape, but freedom may come with a steep price.",
     "points": 0,
-    "proficiencies": [ "prof_unarmed_familiar" ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_shivs_familiar" ],
     "skills": [
       { "level": 2, "name": "melee" },
       { "level": 2, "name": "stabbing" },
@@ -3752,7 +3752,7 @@
     "name": "Death Row Convict",
     "description": "You were a serial killer, ready to walk the green mile, but in a twist of fate you're one of the few still alive.  True death comes only from your hands, so you're in for a job.",
     "points": 1,
-    "proficiencies": [ "prof_knives_familiar", "prof_unarmed_familiar" ],
+    "proficiencies": [ "prof_knives_familiar", "prof_unarmed_familiar", "prof_shivs_familiar" ],
     "skills": [ { "level": 3, "name": "melee" }, { "level": 3, "name": "stabbing" }, { "level": 2, "name": "unarmed" } ],
     "traits": [ "KILLER" ],
     "items": {

--- a/data/mods/Aftershock/player/professions.json
+++ b/data/mods/Aftershock/player/professions.json
@@ -102,7 +102,14 @@
       "bio_power_storage_mkII",
       "afs_bio_missiles"
     ],
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_traps", "prof_disarming" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_traps",
+      "prof_disarming",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "skills": [
       { "level": 3, "name": "gun" },
       { "level": 3, "name": "smg" },
@@ -270,6 +277,13 @@
       { "level": 2, "name": "dodge" },
       { "level": 1, "name": "firstaid" }
     ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_spotting",
+      "prof_wp_syn_armored",
+      "prof_auto_pistols_familiar",
+      "prof_knives_familiar"
+    ],
     "items": {
       "both": {
         "items": [
@@ -327,6 +341,7 @@
       { "level": 3, "name": "melee" },
       { "level": 3, "name": "bashing" }
     ],
+    "proficiencies": [ "prof_batons_familiar", "prof_auto_pistols_familiar" ],
     "traits": [ "PROF_SWAT", "UPLIFTED", "THRESH_MASTODON", "MUT_TANK", "TUSKS", "HUGE_OK" ],
     "//": "Need to add XL gear for MASTODON's in more items.",
     "items": {
@@ -377,6 +392,7 @@
       { "level": 1, "name": "melee" },
       { "level": 2, "name": "dodge" }
     ],
+    "proficiencies": [ "prof_auto_rifles_familiar", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
         "items": [

--- a/data/mods/MMA/professions.json
+++ b/data/mods/MMA/professions.json
@@ -6,6 +6,13 @@
     "description": "A combat-ready cyborg once salvaged from an obscure junkyard…",
     "points": 8,
     "starting_styles": [ "style_mma_panzer" ],
+    "proficiencies": [
+      "prof_unarmed_familiar",
+      "prof_unarmed_pro",
+      "prof_bionic_swords_familiar",
+      "prof_bionic_swords_pro",
+      "prof_bionics_familiar"
+    ],
     "skills": [ { "level": 3, "name": "unarmed" }, { "level": 3, "name": "melee" }, { "level": 1, "name": "dodge" } ],
     "items": { "both": { "items": [ "wetsuit", "trenchcoat", "gloves_fingerless", "knee_pads", "boots" ] } },
     "CBMs": [
@@ -26,6 +33,7 @@
     "points": 6,
     "traits": [ "ELFAEYES", "ELFA_EARS" ],
     "starting_styles": [ "style_mma_hylian" ],
+    "proficiencies": [ "prof_medium_swords_familiar", "prof_medium_swords_pro" ],
     "skills": [ { "level": 3, "name": "cutting" }, { "level": 3, "name": "melee" }, { "level": 1, "name": "dodge" } ],
     "items": {
       "both": {

--- a/data/mods/Magiclysm/professions.json
+++ b/data/mods/Magiclysm/professions.json
@@ -587,7 +587,7 @@
     "name": "Archer Druid",
     "description": "You were a skillful and committed archer druid, making constant excursions to the forests in which you dedicated yourself to living of and with what nature had to offer you.  You were returning from your last travel when civilization fell upon itself.",
     "points": 5,
-    "proficiencies": [ "prof_bowyery", "prof_bow_basic", "prof_bow_expert" ],
+    "proficiencies": [ "prof_bowyery", "prof_bow_basic", "prof_bow_expert", "prof_knives_familiar" ],
     "spells": [
       { "id": "druid_naturebow1", "level": 4 },
       { "id": "druid_natures_commune", "level": 3 },
@@ -602,7 +602,6 @@
       { "level": 1, "name": "gun" },
       { "level": 2, "name": "archery" }
     ],
-    "proficiencies": [ "prof_knives_familiar" ],
     "traits": [ "DRUID" ],
     "items": {
       "both": {

--- a/data/mods/Magiclysm/professions.json
+++ b/data/mods/Magiclysm/professions.json
@@ -535,7 +535,7 @@
     "description": "You are a descendant of a long line of housekeepers for magical families.  Trained in several spells to facilitate your job you were easily hired to take care of your current job, sadly, it looks like this could be your last.",
     "points": 4,
     "skills": [ { "level": 2, "name": "cooking" }, { "level": 2, "name": "spellcraft" }, { "level": 2, "name": "tailor" } ],
-    "proficiencies": [ "prof_food_prep", "prof_closures" ],
+    "proficiencies": [ "prof_food_prep", "prof_closures", "prof_knives_familiar" ],
     "spells": [
       { "id": "create_atomic_light", "level": 4 },
       { "id": "magus_force_jar", "level": 3 },
@@ -565,6 +565,7 @@
       { "id": "druid_summon_brambles", "level": 3 }
     ],
     "skills": [ { "level": 4, "name": "survival" }, { "level": 3, "name": "spellcraft" } ],
+    "proficiencies": [ "prof_knives_familiar" ],
     "traits": [ "ANIMALEMPATH", "SLOWREADER", "DRUID" ],
     "items": {
       "both": {
@@ -601,6 +602,7 @@
       { "level": 1, "name": "gun" },
       { "level": 2, "name": "archery" }
     ],
+    "proficiencies": [ "prof_knives_familiar" ],
     "traits": [ "DRUID" ],
     "items": {
       "both": {
@@ -626,6 +628,7 @@
     "points": 8,
     "spells": [ { "id": "ethereal_grasp", "level": 3 }, { "id": "obfuscated_body", "level": 3 }, { "id": "soulrend", "level": 2 } ],
     "skills": [ { "level": 3, "name": "melee" }, { "level": 2, "name": "cutting" }, { "level": 3, "name": "spellcraft" } ],
+    "proficiencies": [ "prof_hooking_familiar" ],
     "items": {
       "both": {
         "items": [ "grim_reaper_robe", "jumpsuit_skeleton_zipped", "gloves_skeleton", "socks", "boots" ],
@@ -774,7 +777,13 @@
       { "id": "jolt", "level": 4 },
       { "id": "stormshaper_ionization", "level": 2 }
     ],
-    "skills": [ { "level": 2, "name": "gun" }, { "level": 2, "name": "pistol" }, { "level": 4, "name": "spellcraft" } ],
+    "skills": [
+      { "level": 2, "name": "gun" },
+      { "level": 2, "name": "pistol" },
+      { "level": 4, "name": "spellcraft" },
+      { "level": 2, "name": "melee" }
+    ],
+    "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_batons_familiar", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
         "items": [ "pants_army", "socks", "badge_deputy", "boots", "whistle", "wristwatch" ],
@@ -804,6 +813,7 @@
       { "id": "recover_stamina", "level": 2 }
     ],
     "traits": [ "PROF_BOXER", "EARTHSHAPER" ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro" ],
     "skills": [
       { "level": 2, "name": "melee" },
       { "level": 3, "name": "unarmed" },
@@ -897,6 +907,7 @@
       { "level": 2, "name": "survival" },
       { "level": 1, "name": "fabrication" }
     ],
+    "proficiencies": [ "prof_gunsmithing_basic", "prof_gun_cleaning", "prof_auto_rifles_familiar", "prof_auto_pistols_familiar" ],
     "traits": [ "KELVINIST" ],
     "items": {
       "both": {
@@ -1025,6 +1036,7 @@
     "description": "You entertained the masses, displaying an expert hand tossing knives conjured from nowhere.  Now, you're bringing the show to them.",
     "points": 4,
     "skills": [ { "level": 3, "name": "throw" }, { "level": 1, "name": "stabbing" } ],
+    "proficiencies": [ "prof_knives_familiar" ],
     "items": {
       "both": {
         "items": [ "socks", "sneakers", "unitard", "wristwatch", "vest_leather" ],

--- a/data/mods/Xedra_Evolved/player/professions.json
+++ b/data/mods/Xedra_Evolved/player/professions.json
@@ -41,7 +41,7 @@
       { "level": 4, "name": "speech" },
       { "level": 5, "name": "deduction" }
     ],
-    "proficiencies": [ "prof_spotting" ],
+    "proficiencies": [ "prof_spotting", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
         "items": [
@@ -77,7 +77,7 @@
     "points": 6,
     "skills": [ { "level": 7, "name": "gun" }, { "level": 7, "name": "pistol" }, { "level": 5, "name": "speech" } ],
     "addictions": [ { "intensity": 10, "type": "diazepam" } ],
-    "proficiencies": [ "prof_spotting" ],
+    "proficiencies": [ "prof_spotting", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
         "items": [
@@ -119,6 +119,7 @@
       { "level": 5, "name": "speech" },
       { "level": 4, "name": "unarmed" }
     ],
+    "proficiencies": [ "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
         "items": [ "sneakers", "hoodie", "knit_scarf", "diving_watch", "backpack", "wristwatch", "pants_cargo" ],
@@ -186,7 +187,7 @@
     "traits": [ "XEDRA_CYBORG", "PROF_FED" ],
     "CBMs": [ "bio_claws", "bio_ears", "bio_cable", "bio_tattoo_led", "bio_dex_enhancer", "bio_power_storage" ],
     "points": 7,
-    "proficiencies": [ "prof_wp_skeleton" ],
+    "proficiencies": [ "prof_wp_skeleton", "prof_unarmed_familiar", "prof_claws_familiar", "prof_bionics_familiar", "prof_bionics_pro" ],
     "skills": [
       { "level": 6, "name": "cutting" },
       { "level": 6, "name": "dodge" },
@@ -235,7 +236,7 @@
     "name": "Xedra Offworld Team: Specter",
     "description": "Part of Xedra's Offworld Aquisitions team, you were trained to infiltrate any human compatible cultures that were discovered.  You never found any with technology worth stealing and you aren't sure what that says about humanity.",
     "traits": [ "XEDRA_CYBORG" ],
-    "proficiencies": [ "prof_wp_syn_armored" ],
+    "proficiencies": [ "prof_wp_syn_armored", "prof_auto_pistols_familiar" ],
     "points": 6,
     "CBMs": [ "bio_tattoo_led", "bio_cable", "bio_face_mask", "bio_power_storage" ],
     "skills": [
@@ -289,6 +290,7 @@
       { "level": 6, "name": "melee" },
       { "level": 7, "name": "deduction" }
     ],
+    "proficiencies": [ "prof_knives_familiar", "prof_auto_pistols_familiar" ],
     "spells": [
       { "id": "spring_heeled_leap", "level": 7 },
       { "id": "spell_dodge", "level": 7 },
@@ -343,6 +345,7 @@
       { "level": 4, "name": "melee" },
       { "level": 8, "name": "deduction" }
     ],
+    "proficiencies": [ "prof_auto_pistols_familiar" ],
     "spells": [
       { "id": "banish_nether_monsters", "level": 7 },
       { "id": "spell_dreamer_clairvoyance_eff", "level": 7 },

--- a/data/mods/innawood/professions.json
+++ b/data/mods/innawood/professions.json
@@ -127,8 +127,13 @@
     "name": "Bow Hunter",
     "description": "Ever since you were a child you loved hunting, and quickly developed a talent for archery.  Why, if the world ended, there's nothing you'd want at your side more than your trusty bow.  So, when it did, you made sure to bring it along.",
     "points": 3,
-    "proficiencies": [ "prof_bow_basic", "prof_bow_expert", "prof_fletching" ],
-    "skills": [ { "level": 2, "name": "archery" }, { "level": 1, "name": "gun" }, { "level": 1, "name": "swimming" } ],
+    "proficiencies": [ "prof_bow_basic", "prof_bow_expert", "prof_fletching", "prof_knives_familiar" ],
+    "skills": [
+      { "level": 2, "name": "archery" },
+      { "level": 1, "name": "gun" },
+      { "level": 1, "name": "swimming" },
+      { "level": 1, "name": "survival" }
+    ],
     "items": {
       "both": {
         "items": [ "mocassins", "shirt_straw", "skirt_grass", "longbow" ],
@@ -150,8 +155,10 @@
       { "level": 2, "name": "stabbing" },
       { "level": 2, "name": "melee" },
       { "level": 1, "name": "swimming" },
-      { "level": 1, "name": "dodge" }
+      { "level": 1, "name": "dodge" },
+      { "level": 1, "name": "survival" }
     ],
+    "proficiencies": [ "prof_spears_familiar", "prof_knives_familiar" ],
     "items": {
       "both": {
         "items": [ "footrags_leather", "shirt_straw", "skirt_grass" ],
@@ -169,7 +176,13 @@
     "name": "Javelin Hunter",
     "description": "Ever since you were a child you loved hunting, and quickly developed a talent for javelin throwing.  Why, if the world ended, there's nothing you'd want at your side more than your trusty javelins.  So, when it did, you made sure to bring them along.",
     "points": 3,
-    "skills": [ { "level": 2, "name": "throw" }, { "level": 1, "name": "stabbing" }, { "level": 1, "name": "swimming" } ],
+    "skills": [
+      { "level": 2, "name": "throw" },
+      { "level": 1, "name": "stabbing" },
+      { "level": 1, "name": "swimming" },
+      { "level": 1, "name": "survival" }
+    ],
+    "proficiencies": [ "prof_spears_familiar", "prof_knives_familiar" ],
     "items": {
       "both": {
         "items": [ "footrags_leather", "shirt_straw", "skirt_grass" ],
@@ -187,8 +200,13 @@
     "name": "Crossbow Hunter",
     "description": "Ever since you were a child you loved hunting, and crossbow hunting was always your favorite.  Why, if the world ended, there's nothing you'd want at your side more than your trusty crossbow.  So, when it did, you made sure to bring it along, though most of your bolts were lost during the escape.",
     "points": 3,
-    "proficiencies": [ "prof_bow_basic", "prof_fletching" ],
-    "skills": [ { "level": 2, "name": "rifle" }, { "level": 1, "name": "gun" }, { "level": 1, "name": "swimming" } ],
+    "proficiencies": [ "prof_bow_basic", "prof_fletching", "prof_knives_familiar" ],
+    "skills": [
+      { "level": 2, "name": "rifle" },
+      { "level": 1, "name": "gun" },
+      { "level": 1, "name": "swimming" },
+      { "level": 1, "name": "survival" }
+    ],
     "items": {
       "both": {
         "items": [ "mocassins", "shirt_straw", "skirt_grass" ],
@@ -215,7 +233,7 @@
     "points": 3,
     "skills": [ { "level": 2, "name": "swimming" }, { "level": 2, "name": "survival" } ],
     "traits": [ "OUTDOORSMAN" ],
-    "proficiencies": [ "prof_fibers" ],
+    "proficiencies": [ "prof_fibers", "prof_knives_familiar" ],
     "items": {
       "both": {
         "items": [ "wicker_backpack", "footrags_leather", "shirt_straw", "skirt_grass", "straw_hat" ],
@@ -236,7 +254,7 @@
     "vehicle": "canoe",
     "skills": [ { "level": 2, "name": "swimming" }, { "level": 2, "name": "survival" }, { "level": 1, "name": "driving" } ],
     "traits": [ "OUTDOORSMAN" ],
-    "proficiencies": [ "prof_fibers" ],
+    "proficiencies": [ "prof_fibers", "prof_knives_familiar" ],
     "items": {
       "both": {
         "items": [ "wicker_backpack", "footrags_leather", "shirt_straw", "skirt_grass", "straw_hat" ],
@@ -298,7 +316,7 @@
     "description": "You spent most of your life trapping with your father.  Both of you made a decent living selling your catches and running trapping tutorials.  Hopefully, your skills will come in useful against less conventional game.",
     "points": 2,
     "skills": [ { "level": 4, "name": "traps" }, { "level": 2, "name": "survival" } ],
-    "proficiencies": [ "prof_fibers", "prof_carving", "prof_traps", "prof_trapsetting" ],
+    "proficiencies": [ "prof_fibers", "prof_carving", "prof_traps", "prof_trapsetting", "prof_knives_familiar" ],
     "items": {
       "both": {
         "items": [
@@ -361,7 +379,13 @@
     "name": "Lumberjack",
     "description": "You're a lumberjack, and you're okay.  You felled trees before the world ended, and you suspect the undead aren't nearly as tough.",
     "points": 0,
-    "skills": [ { "level": 2, "name": "swimming" } ],
+    "skills": [
+      { "level": 2, "name": "swimming" },
+      { "level": 2, "name": "cutting" },
+      { "level": 2, "name": "bashing" },
+      { "level": 2, "name": "melee" }
+    ],
+    "proficiencies": [ "prof_great_axes_familiar", "prof_hand_axes_familiar", "prof_hand_axes_pro" ],
     "items": {
       "both": {
         "items": [ "pants", "socks", "mocassins", "straw_hat", "longshirt", "patchwork_scarf", "vest_leather", "rope_makeshift_6" ],
@@ -393,7 +417,7 @@
     "name": "Tribal Warrior Recruit",
     "description": "Joining the tribal guard has been your dream for years.  You finally got in, just in time for your training to get interrupted by some sort of emergency.  As far as you can tell, the elders abandoned you in this hellhole when you missed the emergency evac.",
     "points": 4,
-    "proficiencies": [ "prof_bow_basic", "prof_bow_expert" ],
+    "proficiencies": [ "prof_bow_basic", "prof_bow_expert", "prof_knives_familiar", "prof_spears_familiar" ],
     "skills": [
       { "level": 2, "name": "gun" },
       { "level": 2, "name": "archery" },
@@ -429,6 +453,7 @@
       { "level": 2, "name": "dodge" },
       { "level": 2, "name": "swimming" }
     ],
+    "proficiencies": [ "prof_short_swords_familiar", "prof_short_swords_pro", "prof_knives_familiar" ],
     "items": {
       "both": {
         "items": [ "helmet_larmor", "armor_larmor", "socks", "boots_larmor", "gauntlets_larmor" ],
@@ -448,8 +473,13 @@
     "name": "Tribal Arbalist",
     "description": "From your first hunt, you showed talent with a crossbow.  While the tribe was well guarded by your aim, you're all alone now.",
     "points": 3,
-    "proficiencies": [ "prof_bow_basic", "prof_bow_expert", "prof_fletching" ],
-    "skills": [ { "level": 3, "name": "rifle" }, { "level": 3, "name": "gun" }, { "level": 2, "name": "swimming" } ],
+    "proficiencies": [ "prof_bow_basic", "prof_bow_expert", "prof_fletching", "prof_knives_familiar" ],
+    "skills": [
+      { "level": 3, "name": "rifle" },
+      { "level": 3, "name": "gun" },
+      { "level": 2, "name": "swimming" },
+      { "level": 2, "name": "survival" }
+    ],
     "items": {
       "both": {
         "items": [ "leathersandals", "helmet_larmor", "vambrace_larmor", "socks", "skirt_grass", "vest_leather", "legguard_larmor" ],
@@ -503,7 +533,7 @@
     "description": "You were on the road with friends from your tribe to search for a new settlement spot when you seemed to be yanked somewhere completely different.  You see no sign of your friends, but at least you got your equipment and some seeds with you.",
     "points": 3,
     "skills": [ { "level": 4, "name": "survival" }, { "level": 2, "name": "archery" } ],
-    "proficiencies": [ "prof_basketweaving", "prof_pottery" ],
+    "proficiencies": [ "prof_basketweaving", "prof_pottery", "prof_knives_familiar" ],
     "items": {
       "both": {
         "items": [
@@ -536,7 +566,7 @@
     "points": 4,
     "description": "Living under your craftsmanship, the tribe was no longer bound to caves lest they freeze in the night.  You won't have to work nearly as hard for just yourself.",
     "skills": [ { "level": 4, "name": "fabrication" } ],
-    "proficiencies": [ "prof_carving", "prof_carpentry_basic" ],
+    "proficiencies": [ "prof_carving", "prof_carpentry_basic", "prof_hand_axes_familiar" ],
     "items": {
       "both": {
         "items": [ "wicker_backpack", "tunic", "clogs", "socks", "helmet_larmor", "copper_knife", "primitive_hammer", "loincloth" ],

--- a/data/mods/package_bionic_professions/bionic_professions.json
+++ b/data/mods/package_bionic_professions/bionic_professions.json
@@ -370,7 +370,7 @@
       { "level": 2, "name": "cutting" },
       { "level": 1, "name": "bashing" }
     ],
-    "proficiencies": [ "prof_fibers", "prof_fibers_rope", "prof_leatherworking", "prof_lockpicking" ],
+    "proficiencies": [ "prof_fibers", "prof_fibers_rope", "prof_leatherworking", "prof_lockpicking", "prof_short_swords_familiar" ],
     "items": {
       "both": {
         "items": [
@@ -431,7 +431,14 @@
     "name": "Bionic Sniper",
     "description": "A top-secret military program sought to convert you into the perfect sniper.  Your bionics, equipment, and extensive field training enable you to drop targets from implausible distances, even after weeks of total isolation in enemy territory.",
     "points": 8,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_spotting",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "CBMs": [
       "bio_eye_enhancer",
       "bio_targeting",
@@ -499,7 +506,14 @@
     "name": "Bionic Soldier",
     "description": "You are the result of one of the military's last research programs: a prototype cyborg soldier.  The wars they expected you to fight have become obsolete, but war never changes.",
     "points": 6,
-    "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting" ],
+    "proficiencies": [
+      "prof_gunsmithing_basic",
+      "prof_spotting",
+      "prof_gun_cleaning",
+      "prof_knives_familiar",
+      "prof_auto_rifles_familiar",
+      "prof_auto_pistols_familiar"
+    ],
     "CBMs": [
       "bio_targeting",
       "bio_purifier",
@@ -761,7 +775,7 @@
       "bio_water_extractor",
       "bio_taste_blocker"
     ],
-    "proficiencies": [ "prof_dissect_humans" ],
+    "proficiencies": [ "prof_dissect_humans", "prof_claws_familiar", "prof_bionics_familiar" ],
     "skills": [
       { "level": 3, "name": "melee" },
       { "level": 3, "name": "stabbing" },
@@ -834,6 +848,7 @@
     "points": 5,
     "CBMs": [ "bio_razors", "bio_armor_eyes", "bio_sunglasses", "bio_dex_enhancer", "bio_ears", "bio_carbon" ],
     "skills": [ { "level": 2, "name": "melee" }, { "level": 2, "name": "unarmed" }, { "level": 2, "name": "dodge" } ],
+    "proficiencies": [ "prof_unarmed_familiar", "prof_claws_familiar", "prof_bionics_familiar" ],
     "items": {
       "both": {
         "items": [ "socks", "tank_top", "jacket_leather", "pants_leather", "boots", "gloves_fingerless", "wristwatch", "gum" ],


### PR DESCRIPTION
#### Summary
Content "Adds weapon proficiencies to professions when adequate,"

#### Purpose of change
#68734 is adding new weapon proficiencies for most weapon categories in the game, the only problem is that professions and hobbies do not grant them yet!
#68990 is already making the hobbies, so why not help with the professions?

Closes #69215 (if the hobbies PR doesn't closes it first).

#### Describe the solution
Adds proficiencies when appropriate to the professions, the hunters receive basic knife familiarity because they are hunters, they now also have survival skills so they are hunters in more than just name... Food related professions also receive a basic familiarity with knifes, soldiers receive basic familiarity with knifes/rifles/pistols when appropriate, and more for the rest of professions.

#### Describe alternatives you've considered
None.

#### Testing
None yet, the PR in question has not been merged yet.

#### Additional context
Added the proficiencies to the modded professions! Any input on those is more than welcome since I'm not so confident in those.
Requires #68734
