### PR TITLE
Open proficiency UI with relevant first selection

### DIFF
--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -1406,7 +1406,8 @@ static bool handle_player_display_action( Character &you, unsigned int &line,
                 break;
             }
             case player_display_tab::proficiencies:
-                show_proficiencies_window( you );
+                const std::vector<display_proficiency> profs = you.display_proficiencies();
+                show_proficiencies_window( you, profs[line].id );
                 break;
         }
     } else if( action == "CHANGE_PROFESSION_NAME" ) {

--- a/src/proficiency.h
+++ b/src/proficiency.h
@@ -222,6 +222,7 @@ class book_proficiency_bonuses
         float time_factor( const proficiency_id &id ) const;
 };
 
-void show_proficiencies_window( const Character &u );
+void show_proficiencies_window( const Character &u,
+                                std::optional<proficiency_id> default_selection = std::nullopt );
 
 #endif // CATA_SRC_PROFICIENCY_H

--- a/src/proficiency_ui.cpp
+++ b/src/proficiency_ui.cpp
@@ -58,7 +58,7 @@ struct prof_window {
     void draw_header();
     void draw_profs();
     void draw_details();
-    void run();
+    void run( std::optional<proficiency_id> default_selection = std::nullopt );
 };
 
 std::vector<display_prof_deps *> &prof_window::get_current_set()
@@ -306,7 +306,7 @@ shared_ptr_fast<ui_adaptor> prof_window::create_or_get_ui_adaptor()
     return current_ui;
 }
 
-void prof_window::run()
+void prof_window::run( std::optional<proficiency_id> default_selection )
 {
     if( !u ) {
         return;
@@ -325,6 +325,16 @@ void prof_window::run()
 
     populate_categories();
     shared_ptr_fast<ui_adaptor> current_ui = create_or_get_ui_adaptor();
+
+    if( default_selection ) {
+        std::vector<display_prof_deps *> &cur_set = get_current_set();
+        for( int i = 0; i < static_cast<int>( cur_set.size() ); i++ ) {
+            if( cur_set[i]->first.id == default_selection.value() ) {
+                sel_prof = i;
+                break;
+            }
+        }
+    }
 
     bool done = false;
     while( !done ) {
@@ -387,8 +397,9 @@ void prof_window::run()
     }
 }
 
-void show_proficiencies_window( const Character &u )
+void show_proficiencies_window( const Character &u,
+                                std::optional<proficiency_id> default_selection )
 {
     prof_window w( &u );
-    w.run();
+    w.run( default_selection );
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Open proficiency UI with relevant first selection"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
In the character display (`@`), selecting a proficiency and pressing enter/clicking opens the proficiency UI. With this PR, the proficiency UI opens with the selected/clicked proficiency already selected.


<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Pass a `std::optional<proficiency_id>` to `show_proficiencies_window` and `prof_window::run`.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Click or press enter here:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/1546926/7cb4eca4-531d-4477-bd35-2819ed414a4b)

And the window will open with Lockpicking selected, instead of Driving:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/1546926/fbe0307b-9768-4f75-a735-7642e7bc4d15)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
