### PR TITLE
add more (zombie) leather mask variant

### DIFF
--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -516,7 +516,49 @@
     "material_thickness": 0.5,
     "environmental_protection": 1,
     "flags": [ "FRAGILE" ],
-    "armor": [ { "encumbrance": 8, "coverage": 95, "covers": [ "head", "mouth" ] } ]
+    "armor": [ { "encumbrance": 8, "coverage": 95, "covers": [ "head", "mouth" ] } ],
+     "variant_type": "generic",
+     "variants": [
+      {
+        "id": "zombie_mask",
+        "name": { "str": "zombie mask" },
+        "description": "A flimsy leather zombie mask.  When zombies were still works of fiction.",
+        "weight": 100
+      },
+      {
+        "id": "chicken_mask",
+        "name": { "str": "chicken mask" },
+        "color": "light_gray",
+        "description": "A chicken mask that looks like a killer in Miami would wear.",
+        "weight": 30
+      },
+      {
+        "id": "green_mask",
+        "name": { "str": "green mask" },
+        "color": "green",
+        "description": "A green skinned full-face mask, much like the one from The Mask.",
+        "weight": 24
+      },
+      {
+        "id": "scream_mask",
+        "name": { "str": "Scream mask" },
+        "color": "dark_gray",
+        "description": "A white mask with a screaming face on it, much like the mask Ghostface worn in Scream, black hood included.",
+        "weight": 41
+      },
+      {
+        "id": "michael_myers_mask",
+        "name": { "str": "Michael Myers' mask" },
+        "description": "A full-head mask with hair, much like the one worn by Michael Myers in Halloween",
+        "weight": 17
+      },
+      {
+        "id": "frankenstein_mask",
+        "name": { "str": "Frankenstein's Monster mask" },
+        "description": "A full-head mask that looks like the head of Frankenstein's monster.",
+        "weight": 20
+      }
+    ]
   },
   {
     "id": "mask_plague",

--- a/data/json/items/armor/masks.json
+++ b/data/json/items/armor/masks.json
@@ -517,8 +517,8 @@
     "environmental_protection": 1,
     "flags": [ "FRAGILE" ],
     "armor": [ { "encumbrance": 8, "coverage": 95, "covers": [ "head", "mouth" ] } ],
-     "variant_type": "generic",
-     "variants": [
+    "variant_type": "generic",
+    "variants": [
       {
         "id": "zombie_mask",
         "name": { "str": "zombie mask" },


### PR DESCRIPTION


#### Summary
Content "More zombie mask variants"

#### Purpose of change

The zombie mask in which is made of leather could do with more variants, so i'm adding 5 variants.

#### Describe the solution

Adds:
- chicken mask
- green mask
- Scream mask
- Michael Myers' mask
- Frankenstein's Monster mask

#### Describe alternatives you've considered

Keeping it for myself.

#### Testing

I made a simple mod for adding the variants into the game and it works.

Also made the sprites for them (in msxotto+)
![Screenshot_2023-10-30_23-45-34_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/78019001/a6b8c2a6-1a6e-4dd4-998d-c77ff4f8ec33)


#### Additional context

Changing the descriptions to be less blunt will be appreciated, as i'm unable to make it less blunt sounding.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
