### PR TITLE
Bugfix: Ensure all selected books are scanned to ereader

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2711,7 +2711,6 @@ void ebooksave_activity_actor::start_scanning_next_book( player_activity &act )
     act.moves_left = to_moves<int>( required_time( books ) );
 }
 
-
 void ebooksave_activity_actor::start( player_activity &act, Character &/*who*/ )
 {
     const time_duration scanning_time = required_time( books );
@@ -2744,6 +2743,12 @@ void ebooksave_activity_actor::do_turn( player_activity &act, Character &who )
     }
 
     // We have now spent enough time to fully scan current book
+    completed_scanning_current_book( act, who );
+}
+
+void ebooksave_activity_actor::completed_scanning_current_book( player_activity &act,
+        Character &who )
+{
     item_location scanned_book = books.back();
     books.pop_back();
     if( scanned_book ) {
@@ -2764,6 +2769,10 @@ void ebooksave_activity_actor::do_turn( player_activity &act, Character &who )
 
 void ebooksave_activity_actor::finish( player_activity &act, Character &who )
 {
+    while( !books.empty() ) {
+        // We can end up here with books left if the player has speed>100
+        completed_scanning_current_book( act, who );
+    }
     if( who.is_avatar() ) {
         add_msg( m_info, _( "You scan %d %s into your device." ), handled_books,
                  n_gettext( "book", "books", handled_books ) );

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -675,6 +675,7 @@ class ebooksave_activity_actor : public activity_actor
         static constexpr int pages_per_charge = 25;
 
         void start_scanning_next_book( player_activity &act );
+        void completed_scanning_current_book( player_activity &act, Character &who );
 };
 
 class migration_cancel_activity_actor : public activity_actor


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Ensure all selected books are scanned to ereader"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Fixes issue where not all selected books were scanned to ereader.
* Fixes #69012 .
* Follow-up to #68880 .

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

* The problem before was that:
	* `ebooksave_activity_actor` expected an exact number of calls to `do_turn()` until the current books was scanned.
	* But player speed affects the speed of activities such as this one.
	* In effect, `do_turn()` is called to few times compared to `to_turns<int>( duration )` when player speed > 100.
* This change therefore makes sure that all selected books are fully scanned when the activity is finished, regardless of number of calls to `do_turn()`.
* The number of calls to `do_turn()` does not really matter anyway, it's just used for supporting that some books are scanned while the activity is running.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Loaded savegame from #69012 and performed steps to reproduce. All books are now correctly stored.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
