### PR TITLE
Add ALLOWS_REMOTE_USE to all items with HOTPLATE function.

### DIFF
--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -1122,7 +1122,7 @@
     "material": [ "steel", "plastic" ],
     "weight": "11339 g",
     "volume": "9 L",
-    "use_action": [ "HOTPLATE", "HEAT_FOOD", { "type": "link_up", "cable_length": 2, "charge_rate": "1800 W" } ],
+    "use_action": [ "HOTPLATE", { "type": "link_up", "cable_length": 2, "charge_rate": "1800 W" } ],
     "qualities": [ [ "COOK", 1 ], [ "OVEN", 1 ] ],
     "flags": [ "WATER_BREAK", "ALLOWS_REMOTE_USE" ],
     "charges_per_use": 25,

--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -1124,7 +1124,7 @@
     "volume": "9 L",
     "use_action": [ "HOTPLATE", "HEAT_FOOD", { "type": "link_up", "cable_length": 2, "charge_rate": "1800 W" } ],
     "qualities": [ [ "COOK", 1 ], [ "OVEN", 1 ] ],
-    "flags": [ "WATER_BREAK" ],
+    "flags": [ "WATER_BREAK", "ALLOWS_REMOTE_USE" ],
     "charges_per_use": 25,
     "ammo": [ "battery" ],
     "pocket_data": [

--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -19,7 +19,7 @@
     "color": "light_green",
     "use_action": [ "HOTPLATE_ATOMIC", { "type": "link_up", "cable_length": 2, "charge_rate": "1 kW" } ],
     "//": "This now uses energy to heat food, the RTG is just a minor cost-saving element.  However in a pinch you could use just the RTG to unfreeze water",
-    "flags": [ "LEAK_DAM", "RADIOACTIVE", "DURABLE_MELEE", "WATER_BREAK" ],
+    "flags": [ "LEAK_DAM", "RADIOACTIVE", "DURABLE_MELEE", "WATER_BREAK", "ALLOWS_REMOTE_USE" ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE_WELL",
@@ -223,6 +223,7 @@
     "ammo": [ "charcoal", "coal" ],
     "//": "contains up to 2 liters of charcoal. Or the same amount of coal by weight, 1u coal weighs about as much as 1u of charcoal and has the same energy although it is 5x smaller.",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "charcoal": 400, "coal": 2000 } } ],
+    "flags": [ "ALLOWS_REMOTE_USE" ],
     "charges_per_use": 5,
     "use_action": [ "HOTPLATE" ],
     "melee_damage": { "bash": 4 }
@@ -293,7 +294,7 @@
     "symbol": ";",
     "color": "light_gray",
     "ammo": [ "battery" ],
-    "flags": [ "WATER_BREAK" ],
+    "flags": [ "WATER_BREAK", "ALLOWS_REMOTE_USE" ],
     "charges_per_use": 25,
     "qualities": [ [ "BOIL", 1 ] ],
     "use_action": [ "HOTPLATE", { "type": "link_up", "cable_length": 2, "charge_rate": "1 kW" } ],
@@ -374,6 +375,7 @@
     "color": "light_gray",
     "ammo": [ "esbit" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "esbit": 100 } } ],
+    "flags": [ "ALLOWS_REMOTE_USE" ],
     "charges_per_use": 2,
     "use_action": [ "HOTPLATE", "HEAT_FOOD" ],
     "melee_damage": { "bash": 2 }
@@ -449,6 +451,7 @@
     "color": "green",
     "ammo": [ "gasoline" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "gasoline": 500 }, "watertight": true, "rigid": true } ],
+    "flags": [ "ALLOWS_REMOTE_USE" ],
     "charges_per_use": 2,
     "use_action": [ "HOTPLATE" ],
     "melee_damage": { "bash": 4 }
@@ -499,7 +502,7 @@
     "material": [ "aluminum", "plastic" ],
     "symbol": ";",
     "color": "green",
-    "flags": [ "WATER_BREAK" ],
+    "flags": [ "WATER_BREAK", "ALLOWS_REMOTE_USE" ],
     "ammo": [ "battery" ],
     "charges_per_use": 35,
     "use_action": [ "HOTPLATE", { "type": "link_up", "cable_length": 3, "charge_rate": "1 kW" } ],
@@ -528,7 +531,7 @@
     "material": [ "aluminum", "plastic" ],
     "symbol": ";",
     "color": "green",
-    "flags": [ "WATER_BREAK", "ELECTRONIC" ],
+    "flags": [ "WATER_BREAK", "ELECTRONIC", "ALLOWS_REMOTE_USE" ],
     "ammo": [ "battery" ],
     "charges_per_use": 25,
     "use_action": [ "HOTPLATE", { "type": "link_up", "cable_length": 3, "charge_rate": "1500 W" } ],
@@ -708,6 +711,7 @@
     "color": "green",
     "ammo": [ "lamp_oil" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "lamp_oil": 800 }, "watertight": true, "rigid": true } ],
+    "flags": [ "ALLOWS_REMOTE_USE" ],
     "charges_per_use": 2,
     "use_action": [ "HOTPLATE" ],
     "melee_damage": { "bash": 4 }
@@ -814,6 +818,7 @@
     "color": "light_gray",
     "ammo": [ "conc_alcohol" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "conc_alcohol": 500 }, "watertight": true, "rigid": true } ],
+    "flags": [ "ALLOWS_REMOTE_USE" ],
     "charges_per_use": 3,
     "use_action": [ "HOTPLATE" ],
     "melee_damage": { "bash": 1 }
@@ -962,6 +967,7 @@
     "ammo": [ "lamp_oil" ],
     "sub": "oil_cooker",
     "pocket_data": [ { "pocket_type": "MAGAZINE", "ammo_restriction": { "lamp_oil": 800 }, "watertight": true, "rigid": true } ],
+    "flags": [ "ALLOWS_REMOTE_USE" ],
     "charges_per_use": 2,
     "qualities": [ [ "COOK", 3 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ], [ "CHEM", 1 ] ],
     "use_action": [ "HOTPLATE", "HEAT_FOOD" ],

--- a/data/json/items/tool/science.json
+++ b/data/json/items/tool/science.json
@@ -51,7 +51,7 @@
     "symbol": ";",
     "color": "light_gray",
     "ammo": [ "battery" ],
-    "flags": [ "WATER_BREAK" ],
+    "flags": [ "WATER_BREAK", "ALLOWS_REMOTE_USE" ],
     "sub": "hotplate",
     "charges_per_use": 1,
     "qualities": [ [ "DISTILL", 1 ], [ "CHEM", 3 ], [ "BOIL", 1 ] ],

--- a/data/json/items/tool/workshop.json
+++ b/data/json/items/tool/workshop.json
@@ -276,6 +276,7 @@
     "ammo": [ "battery" ],
     "charges_per_use": 20,
     "qualities": [ [ "CONTAIN", 1 ] ],
+    "flags": [ "ALLOWS_REMOTE_USE" ],
     "use_action": [ "HOTPLATE", { "type": "link_up", "cable_length": 15, "charge_rate": "1500 W" } ],
     "pocket_data": [
       {

--- a/data/json/obsoletion/obsolete_items.json
+++ b/data/json/obsoletion/obsolete_items.json
@@ -544,6 +544,7 @@
     "color": "green",
     "ammo": [ "battery" ],
     "sub": "hotplate_induction",
+    "flags": [ "ALLOWS_REMOTE_USE" ],
     "charges_per_use": 25,
     "qualities": [ [ "COOK", 2 ], [ "BOIL", 2 ], [ "CONTAIN", 1 ] ],
     "use_action": [ "HOTPLATE", "HEAT_FOOD" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Items that can heat up food (microwaves, coffeemakers, chemistry sets, etc) can be used or reloaded from an adjacent space without picking them up."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

"You pick up the microwave.  You heat up the black coffee." — statements dreamed up by the utterly deranged

This is a simple QoL fix to make it easier to heat up your breakfast without the unsettling experience of "your microwave's cable is stretched to its limit!" as you walk to the table to eat.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The ALLOWS_REMOTE_USE flag has been added to every appliance with the HOTPLATE or HOTPLATE_ATOMIC function.  This includes a variety of cooking tools, the chemistry set and the concrete mixer(??) as well as the obsoleted military mess kit.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

N/A.  This is a commonsense change as far as I'm concerned.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Compiled and loaded up the game.  Tested heating up toast-ems with hotplate, atomic coffeemaker, microwave and hexamine stove.

Workflows can handle the rest.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Possible issue:   I noticed concrete mixer doesn't define energy consumption for the HOTPLATE action.  Does this mean reheating your leftovers in a masonry appliance is the new meta..?!

Another issue:  Microwaves as well as various portable stove appliances enable both the HOTPLATE and HEAT_FOOD functions.  The latter seems to be for heating food over a fire.  While this makes a bit of sense for little stoves with a removable grill it's very silly to imagine turning a microwave on its side and using it like a cookpot.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
