### PR TITLE
add volume encumber modifier to MOLLE webbing belt and scale belt clip volume encumber modifier

### DIFF
--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -483,7 +483,7 @@
       {
         "holster": true,
         "//": "volume encumber modifier set high since the whole belt is being scaled by 0.35. This equals .5005",
-        "volume_encumber_modifier": 1.43, 
+        "volume_encumber_modifier": 1.43,
         "max_contains_volume": "2000 ml",
         "max_contains_weight": "2500 g",
         "max_item_length": "70 cm",

--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -458,7 +458,8 @@
     "pocket_data": [
       {
         "holster": true,
-        "volume_encumber_modifier": 0.5,
+        "//": "volume encumber modifier set high since the whole belt is being scaled by 0.35. This equals .5005",
+        "volume_encumber_modifier": 1.43, 
         "max_contains_volume": "2000 ml",
         "max_contains_weight": "2500 g",
         "max_item_length": "70 cm",
@@ -469,7 +470,8 @@
       },
       {
         "holster": true,
-        "volume_encumber_modifier": 0.5,
+        "//": "volume encumber modifier set high since the whole belt is being scaled by 0.35. This equals .5005",
+        "volume_encumber_modifier": 1.43, 
         "max_contains_volume": "2000 ml",
         "max_contains_weight": "2500 g",
         "max_item_length": "70 cm",
@@ -480,7 +482,8 @@
       },
       {
         "holster": true,
-        "volume_encumber_modifier": 0.5,
+        "//": "volume encumber modifier set high since the whole belt is being scaled by 0.35. This equals .5005",
+        "volume_encumber_modifier": 1.43, 
         "max_contains_volume": "2000 ml",
         "max_contains_weight": "2500 g",
         "max_item_length": "70 cm",
@@ -491,7 +494,8 @@
       },
       {
         "holster": true,
-        "volume_encumber_modifier": 0.5,
+        "//": "volume encumber modifier set high since the whole belt is being scaled by 0.35. This equals .5005",
+        "volume_encumber_modifier": 1.43, 
         "max_contains_volume": "2000 ml",
         "max_contains_weight": "2500 g",
         "max_item_length": "70 cm",
@@ -507,7 +511,7 @@
       { "type": "detach_molle" }
     ],
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY", "NONCONDUCTIVE" ],
-    "armor": [ { "encumbrance": 1, "coverage": 50, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ]
+    "armor": [ { "encumbrance": 1, "coverage": 50, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ], "volume_encumber_modifier": 0.35 } ]
   },
   {
     "id": "suspenders_cloth",

--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -471,7 +471,7 @@
       {
         "holster": true,
         "//": "volume encumber modifier set high since the whole belt is being scaled by 0.35. This equals .5005",
-        "volume_encumber_modifier": 1.43, 
+        "volume_encumber_modifier": 1.43,
         "max_contains_volume": "2000 ml",
         "max_contains_weight": "2500 g",
         "max_item_length": "70 cm",

--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -511,7 +511,15 @@
       { "type": "detach_molle" }
     ],
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY", "NONCONDUCTIVE" ],
-    "armor": [ { "encumbrance": 1, "coverage": 50, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ], "volume_encumber_modifier": 0.35 } ]
+    "armor": [
+      {
+        "encumbrance": 1,
+        "coverage": 50,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_waist" ],
+        "volume_encumber_modifier": 0.35
+      }
+    ]
   },
   {
     "id": "suspenders_cloth",

--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -459,7 +459,7 @@
       {
         "holster": true,
         "//": "volume encumber modifier set high since the whole belt is being scaled by 0.35. This equals .5005",
-        "volume_encumber_modifier": 1.43, 
+        "volume_encumber_modifier": 1.43,
         "max_contains_volume": "2000 ml",
         "max_contains_weight": "2500 g",
         "max_item_length": "70 cm",

--- a/data/json/items/armor/belts.json
+++ b/data/json/items/armor/belts.json
@@ -495,7 +495,7 @@
       {
         "holster": true,
         "//": "volume encumber modifier set high since the whole belt is being scaled by 0.35. This equals .5005",
-        "volume_encumber_modifier": 1.43, 
+        "volume_encumber_modifier": 1.43,
         "max_contains_volume": "2000 ml",
         "max_contains_weight": "2500 g",
         "max_item_length": "70 cm",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "add volume encumber modifier to MOLLE webbing belt and pocket volume encumber modifier accordingly"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The MOLLE webbing belt does not have a volume encumber modifier defined. As a result, PALS pouches without a defined volume encumber modifier attached to the belt seem to add encumbrance at the default rate (1 enc per 0.25L).  This results in an attached IFAK, sheath, or holster (and possibly other items) adding more encumbrance than expected.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I have added a volume encumber modifier of 0.35 to the belt, which it had in the past. I have also scaled the existing modifier on the belt clip pockets to account for the whole belt modifier, an approach used on the load bearing vests.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Auditing all PALS items to ensure they have a volume_encumber_modifier set, but if another PALS item was added without a modifier set the issue would resurface.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I checked the encumbrance of the belt with a sheath attached to the belt before and after, and the encumbrance of the belt with a PR-24 in the belt clip pocket before and after. I'm not entirely sure how encumbrance rounding works, so it's possible that the effective 0.5005 volume encumber modifier on the belt clip pockets will not have the same result as the previous 0.5 volume encumber modifier with all items. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
