### PR TITLE
[EoC] Allow set_string_var to parse custom entries

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -460,6 +460,20 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_string_test",
+    "effect": [
+      { "set_string_var": "test1", "target_var": { "global_val": "key1" } },
+      { "set_string_var": "test2", "target_var": { "global_val": "key2" } },
+      { "set_string_var": "<global_val:key1> <global_val:key2>", "target_var": { "global_val": "key3" } },
+      {
+        "set_string_var": "<global_val:key1> <global_val:key2>",
+        "target_var": { "global_val": "key4" },
+        "parse_tags": true
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_character_finished_activity_event_test",
     "eoc_type": "EVENT",
     "required_event": "character_finished_activity",

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -2262,6 +2262,7 @@ Store string from `set_string_var` in the variable object `target_var`
 | --- | --- | --- | --- | 
 | "set_string_var" | **mandatory** | string, [variable object](##variable-object), or array of both | value, that would be put into `target_var` |
 | "target_var" | **mandatory** | [variable object](##variable-object) | variable, that accept the value; usually `context_val` | 
+| "parse_tags" | optional | boolean | Allo if parse [custom entries](NPCs.md#customizing-npc-speech) in string before storing | 
 
 
 ##### Valid talkers:
@@ -2287,6 +2288,11 @@ Replace text in `place_name` variable with one of 5 string, picked randomly; fur
   "set_string_var": [ "Somewhere", "Nowhere", "Everywhere", "Yesterday", "Tomorrow" ],
   "target_var": { "global_val": "place_name" }
 }
+```
+
+Concatenate string of variable `foo` and `bar`
+```json
+{ "set_string_var": "<global_val:foo><global_val:bar>", "target_var": { "global_val": "new" }, "parse_tags": true }
 ```
 
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4229,11 +4229,19 @@ void talk_effect_fun_t::set_set_string_var( const JsonObject &jo, std::string_vi
     } else {
         values.emplace_back( get_str_or_var( jo.get_member( member ), member ) );
     }
+    bool parse = jo.get_bool( "parse_tags", false );
     var_info var = read_var_info( jo.get_member( "target_var" ) );
-    function = [values, var]( dialogue & d ) {
+    function = [values, var, parse]( dialogue & d ) {
         int index = rng( 0, values.size() - 1 );
-        write_var_value( var.type, var.name, d.actor( var.type == var_type::npc ), &d,
-                         values[index].evaluate( d ) );
+        std::string str = values[index].evaluate( d );
+        if( parse ) {
+            itype_id &dummy = itype_id();
+            std::unique_ptr<talker> default_talker = get_talker_for( get_player_character() );
+            talker &alpha = d.has_alpha ? *d.actor( false ) : *default_talker;
+            talker &beta = d.has_beta ? *d.actor( true ) : *default_talker;
+            parse_tags( str, alpha, beta, d, dummy );
+        }
+        write_var_value( var.type, var.name, d.actor( var.type == var_type::npc ), &d, str );
     };
 }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4235,11 +4235,10 @@ void talk_effect_fun_t::set_set_string_var( const JsonObject &jo, std::string_vi
         int index = rng( 0, values.size() - 1 );
         std::string str = values[index].evaluate( d );
         if( parse ) {
-            itype_id &dummy = itype_id();
             std::unique_ptr<talker> default_talker = get_talker_for( get_player_character() );
             talker &alpha = d.has_alpha ? *d.actor( false ) : *default_talker;
             talker &beta = d.has_beta ? *d.actor( true ) : *default_talker;
-            parse_tags( str, alpha, beta, d, dummy );
+            parse_tags( str, alpha, beta, d );
         }
         write_var_value( var.type, var.name, d.actor( var.type == var_type::npc ), &d, str );
     };

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -84,6 +84,8 @@ effect_on_condition_EOC_run_with_test_queued( "EOC_run_with_test_queued" );
 static const effect_on_condition_id
 effect_on_condition_EOC_stored_condition_test( "EOC_stored_condition_test" );
 static const effect_on_condition_id
+effect_on_condition_EOC_string_test( "EOC_string_test" );
+static const effect_on_condition_id
 effect_on_condition_EOC_string_var_var( "EOC_string_var_var" );
 static const effect_on_condition_id effect_on_condition_EOC_teleport_test( "EOC_teleport_test" );
 static const effect_on_condition_id effect_on_condition_EOC_try_kill( "EOC_try_kill" );
@@ -1024,4 +1026,21 @@ TEST_CASE( "EOC_martial_art_test", "[eoc]" )
 
     CHECK( effect_on_condition_EOC_martial_art_test_2->activate( d ) );
     CHECK( !get_avatar().has_martialart( style_aikido ) );
+}
+
+TEST_CASE( "EOC_string_test", "[eoc]" )
+{
+    clear_avatar();
+    clear_map();
+
+    dialogue d( get_talker_for( get_avatar() ), std::make_unique<talker>() );
+    global_variables &globvars = get_globals();
+    globvars.clear_global_values();
+
+    REQUIRE( globvars.get_global_value( "npctalk_var_key3" ).empty() );
+    REQUIRE( globvars.get_global_value( "npctalk_var_key4" ).empty() );
+
+    CHECK( effect_on_condition_EOC_string_test->activate( d ) );
+    CHECK( globvars.get_global_value( "npctalk_var_key3" ) == "<global_val:key1> <global_val:key2>" );
+    CHECK( globvars.get_global_value( "npctalk_var_key4" ) == "test1 test2" );
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
EoC does not have a way to directly convert variables to strings like sprintf in C language

#### Describe the solution
It's difficult to reproduce sprintf as is, but you can use the existing message system to provide similar functionality in `set_string_var`.

```
      { "set_string_var": "test1", "target_var": { "global_val": "key1" } },
      { "set_string_var": "test2", "target_var": { "global_val": "key2" } },
      { "set_string_var": "<global_val:key1> <global_val:key2>", "target_var": { "global_val": "key3" } },
      {
        "set_string_var": "<global_val:key1> <global_val:key2>",
        "target_var": { "global_val": "key4" },
        "parse_tags": true
      }
```
"key3" stores "<global_val:key1> <global_val:key2>", "key4" stores "test1 test2"

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
