### PR TITLE
Fix a minor bug with mutations healing lost limbs.

### DIFF
--- a/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_effect_eocs.json
@@ -229,5 +229,37 @@
     "recurrence": [ "2 hour", "24 hours" ],
     "condition": { "and": [ { "u_has_trait": "SKIN_RASHY" }, { "not": { "u_has_effect": "formication" } } ] },
     "effect": [ { "u_add_effect": "formication", "duration": "10 minutes", "target_part": "random" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_MUTATE_LEG_HEAL",
+    "eoc_type": "EVENT",
+    "required_event": "gains_mutation",
+    "condition": {
+      "and": [
+        { "or": [ { "u_has_trait": "NO_LEFT_LEG" }, { "u_has_trait": "NO_RIGHT_LEG" } ] },
+        {
+          "and": [
+            {
+              "or": [
+                { "u_has_trait": "CRAB_LEGS" },
+                { "u_has_trait": "GASTROPOD_FOOT" },
+                { "u_has_trait": "AMORPHOUS" },
+                { "u_has_trait": "ROOTS1" },
+                { "u_has_trait": "LEG_TENTACLES" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "effect": [
+      { "u_lose_trait": "NO_LEFT_LEG" },
+      { "u_lose_trait": "NO_RIGHT_LEG" },
+      { "u_add_trait": "HAS_LEFT_LEG" },
+      { "u_add_trait": "HAS_RIGHT_LEG" },
+      { "u_lose_var": "missing_left_leg", "type": "traits", "context": "limbs" },
+      { "u_lose_var": "missing_right_leg", "type": "traits", "context": "limbs" }
+    ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix a minor bug with mutations healing lost limbs."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I noticed a bug with mutations healing lost limbs, in which the broken limb would return due to its reliance on EOCs. This fixes that.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add another EOC that properly removes the variables that cause lost limbs to return in the event you gain any of the traits that heal it, preventing the return EOCs from firing.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this, or having limb loss be a permanent, unhealable thing; that would be a sharp pain in the rear.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Went into the game and began mutating, the limb healed properly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
