### PR TITLE
Categorize more containers by their contents

### DIFF
--- a/tests/itemname_test.cpp
+++ b/tests/itemname_test.cpp
@@ -157,3 +157,37 @@ TEST_CASE( "display_name_includes_item_contents", "[item][display_name][contents
            "<color_c_green>++</color>\u00A0"
            "test quiver > " + arrow_color + "test wooden broadhead arrows" + color_end_tag + " (10)" );
 }
+
+TEST_CASE( "display_name_rotten_food", "[item][display_name][contents]" )
+{
+    clear_avatar();
+
+    item wrapper( "wrapper" );
+    item butter_std( "butter" );
+    item butter_rot1( "butter" );
+    item butter_rot2( "butter" );
+    butter_std.set_relative_rot( 0.5 );
+    butter_rot1.set_relative_rot( 1.01 );
+    butter_rot2.set_relative_rot( 1.02 );
+
+    const std::string butter_std_tname =
+        colorize( butter_std.tname(), butter_std.color_in_inventory() );
+    const std::string butter_rot_tname =
+        colorize( butter_rot1.tname(), butter_rot1.color_in_inventory() );
+    REQUIRE( butter_std_tname == "<color_c_light_cyan>butter</color>" );
+    REQUIRE( butter_rot_tname == "<color_c_brown>butter (rotten)</color>" );
+    REQUIRE_FALSE( butter_std.stacks_with( butter_rot1 ) );
+    REQUIRE( butter_rot1.stacks_with( butter_rot2 ) );
+
+    REQUIRE( wrapper.put_in( butter_rot1, item_pocket::pocket_type::CONTAINER ).success() );
+    CHECK( wrapper.display_name() ==
+           "paper wrapper > " + butter_rot_tname + " hidden" );
+
+    REQUIRE( wrapper.put_in( butter_rot2, item_pocket::pocket_type::CONTAINER ).success() );
+    CHECK( wrapper.display_name() ==
+           "paper wrapper > " + butter_rot_tname + " (2) hidden" );
+
+    REQUIRE( wrapper.put_in( butter_std, item_pocket::pocket_type::CONTAINER ).success() );
+    CHECK( wrapper.display_name() ==
+           "paper wrapper > 3 hidden items" );
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Categorize more containers by their contents"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Updates containers so that more are categorized by their contents.
* Make rotting items stack with each other, regardless of how rotten they are.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

For example: a paper wrapper contains butter of varying degrees of rotting.
* Before: it would be categorized as "container"
* After: it is now categorized as "food"

Containers were already categorized by their contents even before this commit, but only if all contained items were of the **same type** and could be stacked. With this commit, the condition "all contained items are of the same type" is instead changed to "all contained items are of the same category".

Another example: a canvas bag contains a screwdriver and a hammer.
* Before: the canvas bag would be categorized as "container"
* After: the canvas bag will be categorized as "tools"

More advanced example: `plastic_bag { wrapper { butter }, wrapper { butter } }`
* Before: plastic_bag would be categorized as "container"
* After: plastic_bag is now categorized as "food"

Situations where "categorized by their contents" does not apply:
* Only applies to "containers". So for example, a pair of jeans that has butter in its pockets will still be categorized as "clothing" and not "food".
* Containers that contain items from more than one category will be categorized as "container". For example, a canvas bag that has both a watermelon and a glock - will be categorized as "container".

This commit makes rotting food stack with each other if possible regardless of how far in the rotting process the item has come. Specifically, `item::stacks_with` calculates `get_shelf_life() - rot`, which will be negative if the item is rotten. And doing `clipped_time()` does not work well on negative values: it clips to seconds and therefore only partitions into "buckets" of 1s each. This commit therefore clamps all rotten freshness-values to the 0-bucket for `item::stacks_with`.

In effect, food that has just started to rot will now be stacked with food that has been rotting for quite a while. Before, they would be different stacks.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Hierarchical view when picking up:
![contents-as-category-1](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/2521f662-7497-44cd-8065-4855d87dd29f)

Categorized view by pressing `;` when picking up:
![contents-as-category-2](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/fb6673dc-f251-4ce3-b537-a671ec3bea2b)

AIM:
![contents-as-category-3](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/a450b168-05f6-414c-9894-8b5bfc76e9a5)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
