### PR TITLE
Allow clairsentients to have premonitions about Defense Mode events

### DIFF
--- a/data/mods/MindOverMatter/modinteractions/Defense_Mode/premonition_instances.json
+++ b/data/mods/MindOverMatter/modinteractions/Defense_Mode/premonition_instances.json
@@ -4,6 +4,7 @@
     "id": "DEFENSE_MODE_WAVE_CONTROL",
     "//": "Copied EOC.  Original is in mods/Defense_Mode/eocs.json",
     "recurrence": "1 day",
+    "condition": { "mod_is_loaded": "defense_mode" },
     "global": true,
     "effect": [
       {

--- a/data/mods/MindOverMatter/modinteractions/Defense_Mode/premonition_instances.json
+++ b/data/mods/MindOverMatter/modinteractions/Defense_Mode/premonition_instances.json
@@ -1,0 +1,96 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "DEFENSE_MODE_WAVE_CONTROL",
+    "//": "Copied EOC.  Original is in mods/Defense_Mode/eocs.json",
+    "recurrence": "1 day",
+    "global": true,
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "DEFENSE_MODE_WAVE_CONTROL_PREMENITION",
+            "global": true,
+            "condition": { "math": [ "u_val('spell_level', 'spell: clair_danger_sense')", ">=", "1" ] },
+            "effect": [
+              {
+                "u_message": "You feel a multitude of foes coming for you, bleary-eyed and full of bloodlust.  Steel yourself, for the horde is coming.",
+                "type": "bad",
+                "popup": true
+              },
+              {
+                "queue_eocs": "DEFENSE_MODE_WAVE_CONTROL_ACTUAL",
+                "time_in_future": { "math": [ "(u_val('spell_level', 'spell: clair_danger_sense') * 4) + 5" ] }
+              }
+            ],
+            "false_effect": { "run_eocs": [ "DEFENSE_MODE_WAVE_CONTROL_ACTUAL" ] }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "DEFENSE_MODE_WAVE_CONTROL_ACTUAL",
+    "global": true,
+    "effect": [
+      { "u_teleport": { "global_val": "your_spawnpoint" } },
+      { "arithmetic": [ { "global_val": "var", "var_name": "wave_number" }, "+=", { "const": 1 } ] },
+      { "math": [ "wave_cash_number", "++" ] },
+      { "u_message": "Welcome to wave <global_val:wave_number>!", "type": "bad", "popup": false },
+      { "run_eocs": [ "defense_mode_money_add", "DEFENSE_MODE_WAVE_SPECIAL_DECIDER" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DEFENSE_MODE_RANDOM_NPC_ROBBER",
+    "//": "Copied EOC.  Original is in mods/Defense_Mode/eocs.json",
+    "condition": { "math": [ "u_val('spell_level', 'spell: clair_danger_sense')", ">=", "1" ] },
+    "effect": [
+      {
+        "u_message": "You feel greedy, insidious eyes watching you and rapidly getting closer.  Someone has it out for your stuff.",
+        "type": "bad",
+        "popup": true
+      },
+      {
+        "queue_eocs": "EOC_DEFENSE_MODE_RANDOM_NPC_ROBBER_ACTUAL",
+        "time_in_future": { "math": [ "(u_val('spell_level', 'spell: clair_danger_sense') * 4) + 5" ] }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DEFENSE_MODE_RANDOM_NPC_ROBBER_ACTUAL",
+    "effect": [
+      {
+        "u_spawn_npc": "random_survivor_nefarious",
+        "outdoor_only": true,
+        "real_count": 1,
+        "min_radius": 15,
+        "max_radius": 40
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DEFENSE_MODE_BANDIT_ATTACK",
+    "//": "Copied EOC.  Original is in mods/Defense_Mode/eocs.json",
+    "condition": { "math": [ "u_val('spell_level', 'spell: clair_danger_sense')", ">=", "1" ] },
+    "effect": [
+      {
+        "u_message": "You feel a multitude of hostile eyes watching you and rapidly getting closer.  The masses have it in for you.",
+        "type": "bad",
+        "popup": true
+      },
+      {
+        "queue_eocs": "EOC_DEFENSE_MODE_BANDIT_ATTACK_ACTUAL",
+        "time_in_future": { "math": [ "(u_val('spell_level', 'spell: clair_danger_sense') * 4) + 5" ] }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DEFENSE_MODE_BANDIT_ATTACK_ACTUAL",
+    "effect": [ { "u_spawn_npc": "defense_mode_raider", "outdoor_only": true, "real_count": 5, "min_radius": 15, "max_radius": 25 } ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Clairsentients can have premonitions about Defense Mode events."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Clairsentients can have premonitions about things in a normal game, so why can't they see things coming in Defense Mode?
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Copy some EOCs and change them to allow clairsentients to predict what's coming, giving the player some time to react. This includes waves, robbers, and bandit attacks.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Went into the game and had some premonitions about a wave showing up.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None. This might be meta, but I haven't written out any lore for that yet.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
