### PR TITLE
Aftershock: Gauss shotguns

### DIFF
--- a/data/mods/Aftershock/ammo_effects.json
+++ b/data/mods/Aftershock/ammo_effects.json
@@ -21,6 +21,11 @@
     "aoe": { "field_type": "fd_elect_anomaly", "intensity_min": 2, "intensity_max": 3, "radius": 0 }
   },
   {
+    "id": "SMALL_ELECTRIC_BURST",
+    "type": "ammo_effect",
+    "aoe": { "field_type": "fd_electricity", "intensity_min": 1, "intensity_max": 2, "chance": 10, "radius": 1 }
+  },
+  {
     "id": "TACTICAL_LASER_EXPLOSION",
     "type": "ammo_effect",
     "trigger_chance": 5,

--- a/data/mods/Aftershock/itemgroups/weapons/balistic_gun_groups.json
+++ b/data/mods/Aftershock/itemgroups/weapons/balistic_gun_groups.json
@@ -28,7 +28,8 @@
       [ "afs_gibrifle", 40 ],
       [ "afs_shotgun", 15 ],
       [ "afs_25mm_goa", 5 ],
-      [ "afs_drotik_shotpistol", 5 ]
+      [ "afs_drotik_shotpistol", 5 ],
+      [ "afs_shotgun_railgun", 5 ]
     ]
   },
   {

--- a/data/mods/Aftershock/itemgroups/weapons/balistic_gun_groups.json
+++ b/data/mods/Aftershock/itemgroups/weapons/balistic_gun_groups.json
@@ -29,7 +29,7 @@
       [ "afs_shotgun", 15 ],
       [ "afs_25mm_goa", 5 ],
       [ "afs_drotik_shotpistol", 5 ],
-      [ "afs_shotgun_railgun", 5 ]
+      [ "afs_shotgun_magnastorm", 5 ]
     ]
   },
   {

--- a/data/mods/Aftershock/items/gun/shot.json
+++ b/data/mods/Aftershock/items/gun/shot.json
@@ -27,6 +27,14 @@
     ]
   },
   {
+    "id": "afs_shotgun_magnastorm",
+    "copy-from": "mossberg_590",
+    "type": "GUN",
+    "name": { "str": "Accipiter Magnastorm-12" },
+    "description": "An advanced shotgun that combines chemical and electromagnetic propulsion systems to accelerate and focus a cloud of steel flechettes.  Resulting in a longer effective range and greater penetration than whats conventionally possible.  Most often deployed during low-intensity corporate conflicts.",
+    "built_in_mods": [ "afs_magnetic_choke", "afs_shotgun_gauss" ]
+  },
+  {
     "id": "afs_raketa_shotgun",
     "copy-from": "shotgun_base",
     "looks_like": "remington_870",
@@ -53,6 +61,7 @@
       [ "brass catcher", 1 ],
       [ "grip mount", 1 ],
       [ "rail mount", 1 ],
+      [ "bore", 1 ],
       [ "sights mount", 1 ],
       [ "underbarrel mount", 1 ]
     ],
@@ -78,7 +87,15 @@
     "dispersion": 350,
     "durability": 8,
     "clip_size": 8,
-    "valid_mod_locations": [ [ "grip", 1 ], [ "mechanism", 4 ], [ "rail", 1 ], [ "sights", 1 ], [ "stock mount", 1 ], [ "underbarrel mount", 1 ] ],
+    "valid_mod_locations": [
+      [ "grip", 1 ],
+      [ "mechanism", 4 ],
+      [ "rail", 1 ],
+      [ "bore", 1 ],
+      [ "sights", 1 ],
+      [ "stock mount", 1 ],
+      [ "underbarrel mount", 1 ]
+    ],
     "pocket_data": [
       {
         "pocket_type": "MAGAZINE",

--- a/data/mods/Aftershock/items/gun/shot.json
+++ b/data/mods/Aftershock/items/gun/shot.json
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "id": "afs_shotgun_magnastorm",
+    "id": "afs_shotgun_railgun",
     "copy-from": "mossberg_590",
     "type": "GUN",
     "name": { "str": "Accipiter Magnastorm-12" },

--- a/data/mods/Aftershock/items/gun/shot.json
+++ b/data/mods/Aftershock/items/gun/shot.json
@@ -27,7 +27,7 @@
     ]
   },
   {
-    "id": "afs_shotgun_railgun",
+    "id": "afs_shotgun_magnastorm",
     "copy-from": "mossberg_590",
     "type": "GUN",
     "name": { "str": "Accipiter Magnastorm-12" },

--- a/data/mods/Aftershock/items/gunmods/shotguns.json
+++ b/data/mods/Aftershock/items/gunmods/shotguns.json
@@ -19,5 +19,31 @@
     "install_time": "3 m",
     "shot_spread_multiplier_modifier": -0.8,
     "flags": [ "CHOKE" ]
+  },
+  {
+    "id": "afs_shotgun_gauss",
+    "type": "GUNMOD",
+    "name": { "str": "shotgun guass array" },
+    "//": "Flechettes should be made a distinct ammo type, but that would break other vanilla shotguns. Change should happen when aftershock becomes total conversion.",
+    "description": "A tuned set of electromagnets that accelerate projectiles to a much higher velocity than normal, increasing range and damage.  The required modifications are invasive and cannot be removed once installed.",
+    "weight": "1610 g",
+    "integral_weight": "410 g",
+    "volume": "1500 ml",
+    "integral_volume": "310 ml",
+    "price": 72000,
+    "price_postapoc": 500,
+    "install_time": "5 m",
+    "material": [ "steel" ],
+    "symbol": ":",
+    "color": "light_gray",
+    "location": "bore",
+    "mod_targets": [ "shotgun" ],
+    "damage_modifier": { "damage_type": "electric", "amount": 3, "armor_penetration": 7 },
+    "ammo_effects": [ "SMALL_ELECTRIC_BURST" ],
+    "dispersion_modifier": 15,
+    "range_modifier": 5,
+    "handling_modifier": -2,
+    "min_skills": [ [ "electronics", 6 ] ],
+    "flags": [ "IRREMOVABLE" ]
   }
 ]

--- a/data/mods/Aftershock/items/gunmods/shotguns.json
+++ b/data/mods/Aftershock/items/gunmods/shotguns.json
@@ -45,6 +45,6 @@
     "range_modifier": 5,
     "handling_modifier": -2,
     "min_skills": [ [ "electronics", 6 ] ],
-    "flags": [ "IRREMOVABLE" ]
+    "flags": [ "IRREMOVABLE", "USE_UPS" ]
   }
 ]

--- a/data/mods/Aftershock/items/gunmods/shotguns.json
+++ b/data/mods/Aftershock/items/gunmods/shotguns.json
@@ -39,6 +39,7 @@
     "location": "bore",
     "mod_targets": [ "shotgun" ],
     "damage_modifier": { "damage_type": "electric", "amount": 3, "armor_penetration": 7 },
+    "energy_drain_modifier": "20 kJ",
     "ammo_effects": [ "SMALL_ELECTRIC_BURST" ],
     "dispersion_modifier": 15,
     "range_modifier": 5,

--- a/data/mods/Aftershock/recipes/gunmods.json
+++ b/data/mods/Aftershock/recipes/gunmods.json
@@ -1,0 +1,32 @@
+[
+  {
+    "result": "afs_shotgun_gauss",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MODS",
+    "skill_used": "electronics",
+    "difficulty": 6,
+    "time": "50 m",
+    "autolearn": [ [ "electronics", 6 ] ],
+    "book_learn": [ [ "advanced_electronics", 3 ], [ "textbook_electronics", 3 ] ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
+    "using": [ [ "soldering_standard", 10 ], [ "electric_probing", 1 ] ],
+    "components": [ [ [ "cable", 20 ] ], [ [ "afs_energy_storage_4", 1 ] ], [ [ "afs_material_2", 2 ] ] ]
+  },
+  {
+    "result": "afs_magnetic_choke",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_WEAPON",
+    "subcategory": "CSC_WEAPON_MODS",
+    "skill_used": "fabrication",
+    "difficulty": 6,
+    "time": "50 m",
+    "autolearn": [ [ "electronics", 6 ] ],
+    "book_learn": [ [ "advanced_electronics", 3 ], [ "textbook_electronics", 3 ] ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
+    "using": [ [ "nanosmithing_standard", 3 ], [ "electric_probing", 1 ] ],
+    "components": [ [ [ "afs_magnet_4", 1 ] ], [ [ "afs_material_2", 2 ] ] ]
+  }
+]


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Add a shotgun mod that turns shotguns into coilguns "

#### Purpose of change
Shotguns are cool, this is an invariable fact of life.
They are less cool when shots just bounce off of anything with paperthin ultracomposite armor. Solution? Add some electric damage to the mix.

The main purpose of this is a small buff to the exosuit heavy shotguns that lets them keep up with other heavy weapons.

#### Describe the solution

Adds an irremovable gauss mod that adds a small bit of electric damage to shot. The result is that shotguns with this mod can again do meaningful damage to ballistic armored foes, without greatly buffing slug type loads. This mod is craftable with high skills.

This also adds a premoded shotgun to the mod: The Accipiter Magnastorm-12 which has both the gauss accelerator and magnetic choke mod.  The high-tech shotgun of tomorrow! *basically a low capacity AR

#### Describe alternatives you've considered
Shotguns just aren't good against armored enemies and the heavy shotguns are just exclusively great at punching down.

#### Testing

Shot some stuff

