### PR TITLE
Aftershock: Remove escape pod supply box from crashing ship

### DIFF
--- a/data/mods/Aftershock/maps/crashing_ship.json
+++ b/data/mods/Aftershock/maps/crashing_ship.json
@@ -156,7 +156,7 @@
       "set": [ { "point": "trap", "id": "tr_escape_pod", "x": 68, "y": 42 } ],
       "mapping": {
         "e": { "items": [ { "item": "afs_ballistic_armory", "chance": 20 } ] },
-        "z": { "items": { "item": "afs_escape_pod_suppliesII", "chance": 100 }, "traps": [ "tr_escape_pod", 1 ] },
+        "z": { "traps": [ "tr_escape_pod", 1 ] },
         "L": {
           "items": [
             { "item": "gear_soldier_sidearm", "chance": 33 },


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Notice this awkward interaction between the supply box in the ship and the one that gets placed in the escape pod once its in the ground while watching Rycon's aftershock playthrough. This removes the possibility of item "duplication".

#### Describe the solution

Just remove the box from the ship's escape pod.

#### Describe alternatives you've considered
Doing more involved stuff involving the new Item EOCs, but I dont think the effort is warranted for this case. At least not yet.

#### Testing

Loaded the ship.