### PR TITLE
Picky Eaters won't drink unsavory drinks

### DIFF
--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -880,6 +880,11 @@ ret_val<edible_rating> Character::can_eat( const item &food ) const
                 _( "You deserve better food than this." ) );
     }
 
+    if ( has_trait( trait_PICKYEATER ) && drinkable && !food.is_medication() &&
+        fun_for( food ).first < -2 && get_thirst() < 240 ) {
+        return ret_val<edible_rating>::make_failure( INEDIBLE_MUTATION, _( "You are not going to drink this." ) );
+    }
+
     return ret_val<edible_rating>::make_success();
 }
 

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -882,7 +882,7 @@ ret_val<edible_rating> Character::can_eat( const item &food ) const
 
     if( has_trait( trait_PICKYEATER ) && drinkable && !food.is_medication() &&
         fun_for( food ).first < 0 && get_thirst() < 240 ) {
-        return ret_val<edible_rating>::make_failure( INEDIBLE_MUTATION, 
+        return ret_val<edible_rating>::make_failure( INEDIBLE_MUTATION,
                 _( "You are not going to drink this." ) );
     }
 

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -880,9 +880,10 @@ ret_val<edible_rating> Character::can_eat( const item &food ) const
                 _( "You deserve better food than this." ) );
     }
 
-    if ( has_trait( trait_PICKYEATER ) && drinkable && !food.is_medication() &&
-        fun_for( food ).first < -2 && get_thirst() < 240 ) {
-        return ret_val<edible_rating>::make_failure( INEDIBLE_MUTATION, _( "You are not going to drink this." ) );
+    if( has_trait( trait_PICKYEATER ) && drinkable && !food.is_medication() &&
+        fun_for( food ).first < 0 && get_thirst() < 240 ) {
+        return ret_val<edible_rating>::make_failure( INEDIBLE_MUTATION, 
+                _( "You are not going to drink this." ) );
     }
 
     return ret_val<edible_rating>::make_success();


### PR DESCRIPTION
#### Summary
Bugfixes "Picky eaters won't drink unsavory drinks"

#### Purpose of change
Adresses #69078. As @MildlySereneFox has said, it makes no sense for picky eaters to not eat a protein ration but drink a liter of animal blood.

#### Describe the solution
Characters with picky eater trait won't drink liquids under 0 enjoyability unless they are dehydrated.

#### Describe alternatives you've considered
~~maybe change the text or change the minimum enjoyability from -2 to 0~~ done
or maybe make it apply for quench instead of enjoyability

#### Testing
![Ekran görüntüsü 2023-11-04 034922](https://github.com/CleverRaven/Cataclysm-DDA/assets/30256012/cf42d11e-b59f-4939-8060-dd3f3ab9cbe6)
picky cunt
![Ekran görüntüsü 2023-11-04 035116](https://github.com/CleverRaven/Cataclysm-DDA/assets/30256012/498b6797-e683-472f-a104-e8f93da9c586)
yup
