### PR TITLE
Allow techniques on reach attacks.

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -1312,7 +1312,7 @@
         ]
       }
     ],
-    "techniques": [ "tec_sojutsu_feint", "tec_sojutsu_shove", "tec_sojutsu_trip" ],
+    "techniques": [ "tec_sojutsu_feint", "tec_sojutsu_shove", "tec_sojutsu_trip", "tec_sojutsu_jab" ],
     "weapon_category": [ "POLEARMS" ]
   },
   {

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -1286,6 +1286,7 @@
     "skill_requirements": [ { "name": "melee", "level": 2 } ],
     "melee_allowed": true,
     "forbidden_buffs_all": [ "buff_medievalpole_onmove" ],
+    "reach_ok": true,
     "mult_bonuses": [
       { "stat": "damage", "type": "bash", "scale": 1.1 },
       { "stat": "damage", "type": "cut", "scale": 1.1 },
@@ -1323,6 +1324,7 @@
     "melee_allowed": true,
     "required_buffs_all": "buff_medievalpole_onmiss",
     "crit_ok": true,
+    "reach_ok": true,
     "weighting": 2,
     "condition": {
       "and": [
@@ -1352,6 +1354,7 @@
     "condition": { "npc_has_effect": "downed" },
     "condition_desc": "* Only works on a <info>downed</info> target",
     "crit_tec": true,
+    "reach_ok": true,
     "weighting": 2,
     "mult_bonuses": [
       { "stat": "damage", "type": "bash", "scale": 1.5 },
@@ -2690,6 +2693,7 @@
     "messages": [ "You deftly trip %s!", "<npcname> deftly trips %s!" ],
     "skill_requirements": [ { "name": "melee", "level": 3 } ],
     "melee_allowed": true,
+    "reach_ok": true,
     "condition": {
       "and": [
         { "math": [ "u_val('size') + 1", ">=", "n_val('size')" ] },
@@ -2704,6 +2708,22 @@
       { "stat": "damage", "type": "bash", "scale": 0.5 },
       { "stat": "damage", "type": "cut", "scale": 0.5 },
       { "stat": "damage", "type": "stab", "scale": 0.5 }
+    ],
+    "attack_vectors": [ "WEAPON" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_sojutsu_jab",
+    "name": "Jab",
+    "messages": [ "You quickly strike %s!", "<npcname> quickly strikes %s!" ],
+    "skill_requirements": [ { "name": "melee", "level": 2 } ],
+    "melee_allowed": true,
+    "reach_tec": true,
+    "mult_bonuses": [
+      { "stat": "movecost", "scale": 0.5 },
+      { "stat": "damage", "type": "bash", "scale": 0.66 },
+      { "stat": "damage", "type": "cut", "scale": 0.66 },
+      { "stat": "damage", "type": "stab", "scale": 0.66 }
     ],
     "attack_vectors": [ "WEAPON" ]
   },

--- a/doc/MARTIALART_JSON.md
+++ b/doc/MARTIALART_JSON.md
@@ -89,6 +89,8 @@
   "needs_ammo": true,         // Technique works only if weapon is loaded; Consume 1 charge per attack 
   "crit_tec": true,           // This technique only works on a critical hit
   "crit_ok": true,            // This technique works on both normal and critical hits
+  "reach_tec": true,          // This technique only works on a reach attack hit
+  "reach_ok": true,           // This technique works on both normal and reach attack hits
   "attack_override": false,   // This technique replaces the base attack it triggered on, nulling damage and movecost (instead using the tech's flat_bonuses), and counts as unarmed for the purposes of skill training and special melee effects
   "condition": "u_is_outside",// Optional (array of) dialog conditions the attack requires to trigger.  Failing these will disqualify the tech from being selected
   "condition_desc": "Needs X",// Description string describing the conditions of this attack (since dialog conditions can't be automatically evaluated)       

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -221,6 +221,8 @@ void ma_technique::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "crit_ok", crit_ok, false );
     optional( jo, was_loaded, "attack_override", attack_override, false );
     optional( jo, was_loaded, "wall_adjacent", wall_adjacent, false );
+    optional( jo, was_loaded, "reach_tec", reach_tec, false );
+    optional( jo, was_loaded, "reach_ok", reach_ok, false );
 
     optional( jo, was_loaded, "needs_ammo", needs_ammo, false );
 
@@ -1864,6 +1866,13 @@ std::string ma_technique::get_description() const
                 std::string( "\n" );
     } else if( crit_tec ) {
         dump += _( "* Will only activate on a <info>crit</info>" ) + std::string( "\n" );
+    }
+
+    if( reach_ok ) {
+        dump += _( "* Can activate on a <info>normal</info> or a <info>reach attack</info> hit" ) +
+                std::string( "\n" );
+    } else if( reach_tec ) {
+        dump += _( "* Will only activate on a <info>reach attack</info>" ) + std::string( "\n" );
     }
 
     if( side_switch ) {

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -150,6 +150,8 @@ class ma_technique
         bool dummy = false;
         bool crit_tec = false;
         bool crit_ok = false;
+        bool reach_tec = false; // only possible to use during a reach attack
+        bool reach_ok = false; // possible to use during a reach attack
         bool attack_override = false; // The attack replaces the one it triggered off of
 
         ma_requirements reqs;

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -142,7 +142,6 @@ static const move_mode_id move_mode_prone( "prone" );
 
 static const skill_id skill_melee( "melee" );
 static const skill_id skill_spellcraft( "spellcraft" );
-static const skill_id skill_stabbing( "stabbing" );
 static const skill_id skill_unarmed( "unarmed" );
 
 static const trait_id trait_ARM_TENTACLES( "ARM_TENTACLES" );

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -725,10 +725,10 @@ bool Character::melee_attack_abstract( Creature &t, bool allow_special,
 
         // Pick one or more special attacks
         matec_id technique_id;
-        if( allow_special && !has_force_technique ) {
-            technique_id = pick_technique( t, cur_weapon, critical_hit, false, false );
-        } else if( has_force_technique ) {
+        if( has_force_technique ) {
             technique_id = force_technique;
+        } else if( allow_special ) {
+            technique_id = pick_technique( t, cur_weapon, critical_hit, false, false );
         } else {
             technique_id = tec_none;
         }
@@ -957,7 +957,8 @@ int Character::get_total_melee_stamina_cost( const item *weap ) const
 
 void Character::reach_attack( const tripoint &p, int forced_movecost )
 {
-    matec_id force_technique = tec_none;
+    static const matec_id no_technique_id( "" );
+    matec_id force_technique = no_technique_id;
     /** @EFFECT_MELEE >5 allows WHIP_DISARM technique */
     if( weapon.has_flag( flag_WHIP ) && ( get_skill_level( skill_melee ) > 5 ) && one_in( 3 ) ) {
         force_technique = WHIP_DISARM;
@@ -979,7 +980,7 @@ void Character::reach_attack( const tripoint &p, int forced_movecost )
     // 1 / mult because mult is the percent penalty, in the form 1.0 == 100%
     const float weary_mult = 1.0f / exertion_adjusted_move_multiplier( EXTRA_EXERCISE );
     int move_cost = attack_speed( weapon ) * weary_mult;
-    float skill = std::min( 10.0f, get_skill_level( skill_stabbing ) );
+    float skill = std::min( 10.0f, get_skill_level( skill_melee ) );
     int t = 0;
     map &here = get_map();
     std::vector<tripoint> path = line_to( pos(), p, t, 0 );
@@ -987,7 +988,7 @@ void Character::reach_attack( const tripoint &p, int forced_movecost )
     for( const tripoint &path_point : path ) {
         // Possibly hit some unintended target instead
         Creature *inter = creatures.creature_at( path_point );
-        /** @EFFECT_STABBING decreases chance of hitting intervening target on reach attack */
+        /** @EFFECT_MELEE decreases chance of hitting intervening target on reach attack */
         if( inter != nullptr &&
             !x_in_y( ( target_size * target_size + 1 ) * skill,
                      ( inter->get_size() * inter->get_size() + 1 ) * 10 ) ) {
@@ -1003,7 +1004,6 @@ void Character::reach_attack( const tripoint &p, int forced_movecost )
             }
             critter = inter;
             break;
-            /** @EFFECT_STABBING increases ability to reach attack through fences */
         } else if( here.impassable( path_point ) &&
                    // Fences etc. Spears can stab through those
                    !( weapon.has_flag( flag_SPEAR ) &&
@@ -1031,7 +1031,7 @@ void Character::reach_attack( const tripoint &p, int forced_movecost )
     }
 
     reach_attacking = true;
-    melee_attack_abstract( *critter, false, force_technique, false, forced_movecost );
+    melee_attack_abstract( *critter, true, force_technique, false, forced_movecost );
     reach_attacking = false;
 }
 
@@ -1524,6 +1524,18 @@ std::vector<matec_id> Character::evaluate_techniques( Creature &t, const item_lo
         // skip wall adjacent techniques if not next to a wall
         if( tec.wall_adjacent && !wall_adjacent ) {
             add_msg_debug( debugmode::DF_MELEE, "No adjacent walls found, attack discarded" );
+            continue;
+        }
+
+        // skip non reach ok techniques if reach attacking
+        if( !( tec.reach_ok || tec.reach_tec ) && reach_attacking ) {
+            add_msg_debug( debugmode::DF_MELEE, "Not usable with reach attack, attack discarded" );
+            continue;
+        }
+
+        // skip reach techniques if not reach attacking
+        if( tec.reach_tec && !reach_attacking ) {
+            add_msg_debug( debugmode::DF_MELEE, "Only usable with reach attack, attack discarded" );
             continue;
         }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Allow martial arts techniques to trigger on reach attacks."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It's always seemed a little odd to me that techniques didn't work with reach attacks, and the general consensus on the discord appeared to be it was a purely technical limitation, so I decided to fix it.

This adds two new flags to martial arts techniques:
`reach_ok`: The technique can be used during reach attacks (similar to `crit_ok`).
`reach_tec`: The technique can _only_ be used during reach attacks (similar to `crit_tec`).

It also changes some moves in Fior di Battaglia and Sojutsu to be `reach_ok`, and adds a new `reach_tec` rapid attack to Sojutsu. Is this balanced? You tell me. It sure was fun when playtesting it though.

Finally, it also made the chance to hit friendlies while reach attacking to be based on melee skill, not piercing skill, which didn't really make sense.

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Let reach attacks trigger specials, and filter allowed reach attacks with the two new flags. Also updated the technique info UI to display this information.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned a naginata and killed some zombies with Sojutsu, and it appears to work fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
