### PR TITLE
[CR] Bashing furniture/terrain gradually gets easier

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1890,6 +1890,36 @@ ter_id map::ter( const tripoint_bub_ms &p ) const
     return ter( p.raw() );
 }
 
+int map::get_map_damage( const tripoint_bub_ms &p ) const
+{
+    if( !inbounds( p ) ) {
+        return 0;
+    }
+
+    point_sm_ms l;
+    const submap *const current_submap = unsafe_get_submap_at( p, l );
+    if( current_submap == nullptr ) {
+        debugmsg( "Called get_map_damage for unloaded submap" );
+        return 0;
+    }
+    return current_submap->get_map_damage( l );
+}
+
+void map::set_map_damage( const tripoint_bub_ms &p, int dmg )
+{
+    if( !inbounds( p ) ) {
+        return;
+    }
+
+    point_sm_ms l;
+    submap *const current_submap = unsafe_get_submap_at( p, l );
+    if( current_submap == nullptr ) {
+        debugmsg( "Called set_map_damage for unloaded submap" );
+        return;
+    }
+    return current_submap->set_map_damage( l, dmg );
+}
+
 uint8_t map::get_known_connections( const tripoint &p,
                                     const std::bitset<NUM_TERCONN> &connect_group,
                                     const std::map<tripoint, ter_id> &override ) const
@@ -3971,9 +4001,18 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
         }
         // Linear interpolation from str_min to str_max
         const int resistance = smin + ( params.roll * ( smax - smin ) );
-        if( params.strength >= resistance ) {
+        // Semi-persistant map damage. Increment by one for each bash over smin
+        // Gradually makes hard bashes easier
+        int damage = get_map_damage( tripoint_bub_ms( p ) );
+        add_msg_debug( debugmode::DF_MAP, "Bashing diff. %d to %d, roll %g. Strength is %d + %d vs %d",
+                       smin, smax, params.roll, params.strength, damage, resistance );
+        if( params.strength + damage >= resistance ) {
+            damage = 0;
             success = true;
+        } else if( params.strength >= smin ) {
+            damage += 1;
         }
+        set_map_damage( tripoint_bub_ms( p ), damage );
     }
 
     if( smash_furn ) {

--- a/src/map.h
+++ b/src/map.h
@@ -809,6 +809,9 @@ class map
             return ter( tripoint( p, abs_sub.z() ) );
         }
 
+        int get_map_damage( const tripoint_bub_ms &p ) const;
+        void set_map_damage( const tripoint_bub_ms &p, int dmg );
+
         // Return a bitfield of the adjacent tiles which connect to the given
         // connect_group.  From least-significant bit the order is south, east,
         // west, north (because that's what cata_tiles expects).

--- a/src/submap.h
+++ b/src/submap.h
@@ -123,6 +123,17 @@ class submap
             ensure_nonuniform();
             std::uninitialized_fill_n( &m->frn[0][0], elements, furn );
         }
+        int get_map_damage( const point_sm_ms &p ) const {
+            auto it = ephemeral_data.find( p );
+            if( it != ephemeral_data.end() ) {
+                return it->second.damage;
+            }
+            return 0;
+        }
+
+        void set_map_damage( const point_sm_ms &p, int dmg ) {
+            ephemeral_data[p] = { dmg };
+        }
 
         ter_id get_ter( const point &p ) const {
             if( is_uniform() ) {
@@ -294,7 +305,12 @@ class submap
         std::map<tripoint_sm_ms, partial_con> partial_constructions;
         std::unique_ptr<basecamp> camp;  // only allowing one basecamp per submap
 
+        struct tile_data {
+            int damage;
+        };
+
     private:
+        std::map<point_sm_ms, tile_data> ephemeral_data;
         std::map<point, computer> computers;
         std::unique_ptr<computer> legacy_computer;
         std::unique_ptr<maptile_soa> m;


### PR DESCRIPTION
#### Summary
Features "Furniture/terrain have semi-persistent damage from being bashed"

#### Purpose of change
Bashing is very non-deterministic and frustrating,  with destroying an object being random chance once you've exceeded it's min strength. For objects with a large difference between the min strength and the max strength, this just turns into successively rolling the dice until you manage to get a good roll.

This one-or-none style also makes it hard (and frustrating to the player) to represent that some objects could be destroyed with bashing, but only with significant effort.

#### Describe the solution
This is a proof-of-concept solution. It adds this data to submaps, accessors to maps, and changes the map bashing function to gradually increase the bash strength for each bash that has strength over the min bash strength.

This is not bug free. I expect it needs to be set to 0 when the ter/furn on a tile is changed, at the minimum.

I'm not tied to how this data interacts with bashing (in fact, I don't particularly like it), this just demonstrates adding data, so I can get opinions on how to improve it. I'd like to end up with (at least mostly) non-deterministic bashing.

A scheme I thought of is:
1. objects have a damage counter going from 0 to `str_max` * 10. When it reaches `str_max` * 10, the object is destroyed
2. bashes on the object under `str_min` do not increase the damage counter
3. All other bashes add the strength of the bash to the damage counter

Note this is entirely deterministic, it will take `(str_max * 10)/(player_strength + weapon_bash)` bashes to destroy an object.
For the door and couch below, that's: `(80 * 10)/(5 + 7)` = `800/12` = ... 67 bashes

But this makes this annoyance problem a lot worse, so bashing should either be an activity or I need to find another scheme.
 
#### Describe alternatives you've considered
See above. I'd like feedback on how this data interacts with bashing. 

#### Testing
At strength 5, smashing a door with a bash 7 rock:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/61cda3a6-cbc7-4d71-b5ce-c475f428ac3c)
Same setup, with a stone wall:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/6d81479f-15e8-4342-a008-06a851eee6ff)
Strength 6 with a bash 7 rock, bashing a couch, teleporting away and quicksaving to unload submaps, then teleporting back and bashing the same couch:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/e8ec0c2a-97b3-4f15-9b4e-e3955708f75d)
