### PR TITLE
Misc fixes for martial arts techniques

### DIFF
--- a/data/json/martialarts.json
+++ b/data/json/martialarts.json
@@ -1029,6 +1029,7 @@
       "tec_ninjutsu_swift",
       "tec_ninjutsu_swift_crit",
       "tec_ninjutsu_takedown",
+      "tec_ninjutsu_takedown_melee",
       "tec_ninjutsu_precise",
       "tec_ninjutsu_staffdown",
       "tec_ninjutsu_downkill"

--- a/data/json/martialarts_fictional.json
+++ b/data/json/martialarts_fictional.json
@@ -368,7 +368,7 @@
     "unarmed_allowed": true,
     "weighting": 2,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
     "stun_dur": 1,
     "attack_vectors": [ "HAND" ]
   },
@@ -465,7 +465,7 @@
     "type": "technique",
     "id": "tec_lizard_break",
     "name": "Grab Break",
-    "messages": [ "The %s tries to grab you, but you outmaneuver it!", "The %s tries to grab <npcname>, but they outmaneuver it!" ],
+    "messages": [ "%s tries to grab you, but you outmaneuver it!", "%s tries to grab <npcname>, but they outmaneuver it!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,
@@ -627,7 +627,7 @@
     "type": "technique",
     "id": "tec_centipede_break",
     "name": "Grab Break",
-    "messages": [ "The %s tries to grab you, but you skitter free!", "The %s tries to grab <npcname>, but they skitter free!" ],
+    "messages": [ "%s tries to grab you, but you skitter free!", "%s tries to grab <npcname>, but they skitter free!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "defensive": true,
@@ -669,7 +669,7 @@
     "skill_requirements": [ { "name": "unarmed", "level": 4 } ],
     "unarmed_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
     "attack_vectors": [ "HAND" ]
   }
 ]

--- a/data/json/martialarts_fictional.json
+++ b/data/json/martialarts_fictional.json
@@ -368,7 +368,7 @@
     "unarmed_allowed": true,
     "weighting": 2,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
     "stun_dur": 1,
     "attack_vectors": [ "HAND" ]
   },
@@ -465,7 +465,7 @@
     "type": "technique",
     "id": "tec_lizard_break",
     "name": "Grab Break",
-    "messages": [ "%s tries to grab you, but you outmaneuver it!", "%s tries to grab <npcname>, but they outmaneuver it!" ],
+    "messages": [ "You were almost grabbed by %s, but you outmaneuver it!", "<npcname> was almost grabbed by %s, but they outmaneuver it!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,
@@ -627,7 +627,7 @@
     "type": "technique",
     "id": "tec_centipede_break",
     "name": "Grab Break",
-    "messages": [ "%s tries to grab you, but you skitter free!", "%s tries to grab <npcname>, but they skitter free!" ],
+    "messages": [ "You were almost grabbed by %s, but you skitter free!", "<npcname> was almost grabbed by %s, but they skitter free!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "defensive": true,
@@ -669,7 +669,7 @@
     "skill_requirements": [ { "name": "unarmed", "level": 4 } ],
     "unarmed_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
     "attack_vectors": [ "HAND" ]
   }
 ]

--- a/data/json/martialarts_fictional.json
+++ b/data/json/martialarts_fictional.json
@@ -368,7 +368,15 @@
     "unarmed_allowed": true,
     "weighting": 2,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
+    "tech_effects": [
+      {
+        "id": "disarmed",
+        "chance": 100,
+        "duration": 400,
+        "on_damage": true,
+        "message": "The weapon of %s has been forced out ot their hands!"
+      }
+    ],
     "stun_dur": 1,
     "attack_vectors": [ "HAND" ]
   },
@@ -465,7 +473,10 @@
     "type": "technique",
     "id": "tec_lizard_break",
     "name": "Grab Break",
-    "messages": [ "You were almost grabbed by %s, but you outmaneuver it!", "<npcname> was almost grabbed by %s, but they outmaneuver it!" ],
+    "messages": [
+      "You were almost grabbed by %s, but you outmaneuver it!",
+      "<npcname> was almost grabbed by %s, but they outmaneuver it!"
+    ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,
@@ -669,7 +680,15 @@
     "skill_requirements": [ { "name": "unarmed", "level": 4 } ],
     "unarmed_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
+    "tech_effects": [
+      {
+        "id": "disarmed",
+        "chance": 100,
+        "duration": 400,
+        "on_damage": true,
+        "message": "The weapon of %s has been forced out ot their hands!"
+      }
+    ],
     "attack_vectors": [ "HAND" ]
   }
 ]

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -2137,11 +2137,33 @@
   {
     "type": "technique",
     "id": "tec_ninjutsu_takedown",
-    "name": "Ninjutsu Takedown",
+    "name": "Ninjutsu Takedown (unarmed)",
     "messages": [ "You quickly grab and bring %s to the ground!", "<npcname> quickly grabs and brings %s to the ground!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 4 } ],
-    "melee_allowed": true,
     "unarmed_allowed": true,
+    "forbidden_buffs_all": [ "buff_ninjutsu_onattack" ],
+    "crit_tec": true,
+    "condition": {
+      "and": [
+        { "math": [ "u_val('size') + 1", ">=", "n_val('size')" ] },
+        { "not": { "npc_has_effect": "downed" } },
+        { "or": [ { "npc_bodytype": "human" }, { "npc_bodytype": "angel" } ] },
+        { "or": [ { "not": { "npc_has_flag": "FLIES" } }, { "npc_has_flag": "DISABLE_FLIGHT" } ] }
+      ]
+    },
+    "condition_desc": "* Only works on a <info>non-downed humanoid</info> target of <info>similar or smaller</info> size incapable of flight",
+    "down_dur": 2,
+    "weighting": 3,
+    "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 2.0 } ],
+    "attack_vectors": [ "THROW" ]
+  },
+  {
+    "type": "technique",
+    "id": "tec_ninjutsu_takedown_melee",
+    "name": "Ninjutsu Takedown (melee)",
+    "messages": [ "You quickly grab and bring %s to the ground!", "<npcname> quickly grabs and brings %s to the ground!" ],
+    "skill_requirements": [ { "name": "melee", "level": 4 } ],
+    "melee_allowed": true,
     "forbidden_buffs_all": [ "buff_ninjutsu_onattack" ],
     "weapon_categories_allowed": [ "KNIVES", "CLAWS" ],
     "crit_tec": true,

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -485,10 +485,7 @@
     "type": "technique",
     "id": "tec_aikido_break",
     "name": "Grab Break",
-    "messages": [
-      "%s tries to grab you, but you smoothly break free!",
-      "%s tries to grab <npcname>, but they smoothly break free!"
-    ],
+    "messages": [ "%s tries to grab you, but you smoothly break free!", "%s tries to grab <npcname>, but they smoothly break free!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,
@@ -941,10 +938,7 @@
     "type": "technique",
     "id": "tec_crane_break",
     "name": "Crane Flap",
-    "messages": [
-      "%s tries to grab you, but you swing your arms and break free!",
-      "%s tries to grab <npcname>, but they flap free!"
-    ],
+    "messages": [ "%s tries to grab you, but you swing your arms and break free!", "%s tries to grab <npcname>, but they flap free!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "defensive": true,

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -40,7 +40,15 @@
     "disarms": true,
     "skill_requirements": [ { "name": "melee", "level": 4 } ],
     "description": "Unwield target's weapon, min 4 melee",
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
+    "tech_effects": [
+      {
+        "id": "disarmed",
+        "chance": 100,
+        "duration": 400,
+        "on_damage": true,
+        "message": "The weapon of %s has been forced out ot their hands!"
+      }
+    ],
     "attack_vectors": [ "HAND" ]
   },
   {
@@ -266,7 +274,15 @@
     "disarms": true,
     "messages": [ "You disarm %s using your whip!", "<npcname> disarms %s using their whip!" ],
     "description": "Unwield target's weapon",
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
+    "tech_effects": [
+      {
+        "id": "disarmed",
+        "chance": 100,
+        "duration": 400,
+        "on_damage": true,
+        "message": "The weapon of %s has been forced out ot their hands!"
+      }
+    ],
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -285,7 +301,10 @@
     "melee_allowed": true,
     "defensive": true,
     "grab_break": true,
-    "messages": [ "You were almost grabbed by %s, but you break its grab!", "<npcname> was almost grabbed by %s, but they break its grab!" ]
+    "messages": [
+      "You were almost grabbed by %s, but you break its grab!",
+      "<npcname> was almost grabbed by %s, but they break its grab!"
+    ]
   },
   {
     "type": "technique",
@@ -403,7 +422,15 @@
     "required_buffs_all": [ "buff_aikido_onblock" ],
     "crit_ok": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
+    "tech_effects": [
+      {
+        "id": "disarmed",
+        "chance": 100,
+        "duration": 400,
+        "on_damage": true,
+        "message": "The weapon of %s has been forced out ot their hands!"
+      }
+    ],
     "//condition": "Humanoids of similar size and no flying",
     "condition": {
       "and": [
@@ -448,7 +475,15 @@
     "required_buffs_all": [ "buff_aikido_ondodge" ],
     "crit_ok": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
+    "tech_effects": [
+      {
+        "id": "disarmed",
+        "chance": 100,
+        "duration": 400,
+        "on_damage": true,
+        "message": "The weapon of %s has been forced out ot their hands!"
+      }
+    ],
     "//condition": "Humanoids of similar size and no flying",
     "condition": {
       "and": [
@@ -485,7 +520,10 @@
     "type": "technique",
     "id": "tec_aikido_break",
     "name": "Grab Break",
-    "messages": [ "You were almost grabbed by %s, but you smoothly break free!", "<npcname> was almost grabbed by %s, but they smoothly break free!" ],
+    "messages": [
+      "You were almost grabbed by %s, but you smoothly break free!",
+      "<npcname> was almost grabbed by %s, but they smoothly break free!"
+    ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,
@@ -589,7 +627,15 @@
     "melee_allowed": true,
     "crit_ok": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
+    "tech_effects": [
+      {
+        "id": "disarmed",
+        "chance": 100,
+        "duration": 400,
+        "on_damage": true,
+        "message": "The weapon of %s has been forced out ot their hands!"
+      }
+    ],
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -712,7 +758,10 @@
     "type": "technique",
     "id": "tec_brawl_break_melee",
     "name": "Grab Break",
-    "messages": [ "You were almost grabbed by %s, but you force yourself free!", "<npcname> was almost grabbed by %s, but they break free!" ],
+    "messages": [
+      "You were almost grabbed by %s, but you force yourself free!",
+      "<npcname> was almost grabbed by %s, but they break free!"
+    ],
     "skill_requirements": [ { "name": "melee", "level": 6 } ],
     "melee_allowed": true,
     "defensive": true,
@@ -722,7 +771,10 @@
     "type": "technique",
     "id": "tec_brawl_break_unarmed",
     "name": "Grab Break",
-    "messages": [ "You were almost grabbed by %s, but you force yourself free!", "<npcname> was almost grabbed by %s, but they break free!" ],
+    "messages": [
+      "You were almost grabbed by %s, but you force yourself free!",
+      "<npcname> was almost grabbed by %s, but they break free!"
+    ],
     "skill_requirements": [ { "name": "unarmed", "level": 6 } ],
     "unarmed_allowed": true,
     "defensive": true,
@@ -756,7 +808,15 @@
     "skill_requirements": [ { "name": "melee", "level": 6 } ],
     "melee_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
+    "tech_effects": [
+      {
+        "id": "disarmed",
+        "chance": 100,
+        "duration": 400,
+        "on_damage": true,
+        "message": "The weapon of %s has been forced out ot their hands!"
+      }
+    ],
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -767,7 +827,15 @@
     "skill_requirements": [ { "name": "unarmed", "level": 6 } ],
     "unarmed_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
+    "tech_effects": [
+      {
+        "id": "disarmed",
+        "chance": 100,
+        "duration": 400,
+        "on_damage": true,
+        "message": "The weapon of %s has been forced out ot their hands!"
+      }
+    ],
     "attack_vectors": [ "HAND" ]
   },
   {
@@ -938,7 +1006,10 @@
     "type": "technique",
     "id": "tec_crane_break",
     "name": "Crane Flap",
-    "messages": [ "You were almost grabbed by %s, but you swing your arms and break free!", "<npcname> was almost grabbed by %s, but they flap free!" ],
+    "messages": [
+      "You were almost grabbed by %s, but you swing your arms and break free!",
+      "<npcname> was almost grabbed by %s, but they flap free!"
+    ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "defensive": true,
@@ -1387,7 +1458,15 @@
     "melee_allowed": true,
     "unarmed_weapons_allowed": false,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
+    "tech_effects": [
+      {
+        "id": "disarmed",
+        "chance": 100,
+        "duration": 400,
+        "on_damage": true,
+        "message": "The weapon of %s has been forced out ot their hands!"
+      }
+    ],
     "condition": {
       "and": [
         { "math": [ "u_val('size')", "<=", "n_val('size')" ] },
@@ -1701,7 +1780,15 @@
     "unarmed_allowed": true,
     "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ],
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
+    "tech_effects": [
+      {
+        "id": "disarmed",
+        "chance": 100,
+        "duration": 400,
+        "on_damage": true,
+        "message": "The weapon of %s has been forced out ot their hands!"
+      }
+    ],
     "attack_vectors": [ "WEAPON", "HAND" ]
   },
   {
@@ -2084,7 +2171,10 @@
     "type": "technique",
     "id": "tec_muay_thai_break",
     "name": "Grab Break",
-    "messages": [ "You were almost grabbed by %s, but you break the clinch!", "<npcname> was almost grabbed by %s, but they break the clinch!" ],
+    "messages": [
+      "You were almost grabbed by %s, but you break the clinch!",
+      "<npcname> was almost grabbed by %s, but they break the clinch!"
+    ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,
@@ -2879,7 +2969,15 @@
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
+    "tech_effects": [
+      {
+        "id": "disarmed",
+        "chance": 100,
+        "duration": 400,
+        "on_damage": true,
+        "message": "The weapon of %s has been forced out ot their hands!"
+      }
+    ],
     "attack_vectors": [ "HAND" ]
   },
   {

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -40,7 +40,7 @@
     "disarms": true,
     "skill_requirements": [ { "name": "melee", "level": 4 } ],
     "description": "Unwield target's weapon, min 4 melee",
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
     "attack_vectors": [ "HAND" ]
   },
   {
@@ -266,7 +266,7 @@
     "disarms": true,
     "messages": [ "You disarm %s using your whip!", "<npcname> disarms %s using their whip!" ],
     "description": "Unwield target's weapon",
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -285,7 +285,7 @@
     "melee_allowed": true,
     "defensive": true,
     "grab_break": true,
-    "messages": [ "%s tries to grab you, but you break its grab!", "%s tries to grab <npcname>, but they break its grab!" ]
+    "messages": [ "You were almost grabbed by %s, but you break its grab!", "<npcname> was almost grabbed by %s, but they break its grab!" ]
   },
   {
     "type": "technique",
@@ -403,7 +403,7 @@
     "required_buffs_all": [ "buff_aikido_onblock" ],
     "crit_ok": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
     "//condition": "Humanoids of similar size and no flying",
     "condition": {
       "and": [
@@ -448,7 +448,7 @@
     "required_buffs_all": [ "buff_aikido_ondodge" ],
     "crit_ok": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
     "//condition": "Humanoids of similar size and no flying",
     "condition": {
       "and": [
@@ -485,7 +485,7 @@
     "type": "technique",
     "id": "tec_aikido_break",
     "name": "Grab Break",
-    "messages": [ "%s tries to grab you, but you smoothly break free!", "%s tries to grab <npcname>, but they smoothly break free!" ],
+    "messages": [ "You were almost grabbed by %s, but you smoothly break free!", "<npcname> was almost grabbed by %s, but they smoothly break free!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,
@@ -589,7 +589,7 @@
     "melee_allowed": true,
     "crit_ok": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -617,7 +617,7 @@
     "skill_requirements": [ { "name": "melee", "level": 2 } ],
     "melee_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s's hand is forced open!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The hand of %s is forced open!" } ],
     "mult_bonuses": [
       { "stat": "movecost", "scale": 0.5 },
       { "stat": "damage", "type": "bash", "scale": 0.66 },
@@ -712,7 +712,7 @@
     "type": "technique",
     "id": "tec_brawl_break_melee",
     "name": "Grab Break",
-    "messages": [ "%s tries to grab you, but you force yourself free!", "%s tries to grab <npcname>, but they break free!" ],
+    "messages": [ "You were almost grabbed by %s, but you force yourself free!", "<npcname> was almost grabbed by %s, but they break free!" ],
     "skill_requirements": [ { "name": "melee", "level": 6 } ],
     "melee_allowed": true,
     "defensive": true,
@@ -722,7 +722,7 @@
     "type": "technique",
     "id": "tec_brawl_break_unarmed",
     "name": "Grab Break",
-    "messages": [ "%s tries to grab you, but you force yourself free!", "%s tries to grab <npcname>, but they break free!" ],
+    "messages": [ "You were almost grabbed by %s, but you force yourself free!", "<npcname> was almost grabbed by %s, but they break free!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 6 } ],
     "unarmed_allowed": true,
     "defensive": true,
@@ -756,7 +756,7 @@
     "skill_requirements": [ { "name": "melee", "level": 6 } ],
     "melee_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -767,7 +767,7 @@
     "skill_requirements": [ { "name": "unarmed", "level": 6 } ],
     "unarmed_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
     "attack_vectors": [ "HAND" ]
   },
   {
@@ -938,7 +938,7 @@
     "type": "technique",
     "id": "tec_crane_break",
     "name": "Crane Flap",
-    "messages": [ "%s tries to grab you, but you swing your arms and break free!", "%s tries to grab <npcname>, but they flap free!" ],
+    "messages": [ "You were almost grabbed by %s, but you swing your arms and break free!", "<npcname> was almost grabbed by %s, but they flap free!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "defensive": true,
@@ -1302,7 +1302,7 @@
     "type": "technique",
     "id": "tec_medievalpole_break",
     "name": "Grab Break",
-    "messages": [ "%s tries to grab you, but you push away!", "%s tries to grab <npcname>, but they push away!" ],
+    "messages": [ "You were almost grabbed by %s, but you push away!", "<npcname> was almost grabbed by %s, but they push away!" ],
     "skill_requirements": [ { "name": "melee", "level": 4 } ],
     "melee_allowed": true,
     "defensive": true,
@@ -1387,7 +1387,7 @@
     "melee_allowed": true,
     "unarmed_weapons_allowed": false,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
     "condition": {
       "and": [
         { "math": [ "u_val('size')", "<=", "n_val('size')" ] },
@@ -1433,8 +1433,8 @@
     "id": "tec_judo_break",
     "name": "Grab Break",
     "messages": [
-      "%s tries to grab you, but you break their feeble grapple!",
-      "%s tries to grab <npcname>, but they break its feeble grapple!"
+      "You were almost grabbed by %s, but you break their feeble grapple!",
+      "<npcname> was almost grabbed by %s, but they break its feeble grapple!"
     ],
     "skill_requirements": [ { "name": "unarmed", "level": 1 } ],
     "unarmed_allowed": true,
@@ -1701,7 +1701,7 @@
     "unarmed_allowed": true,
     "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ],
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
     "attack_vectors": [ "WEAPON", "HAND" ]
   },
   {
@@ -1790,7 +1790,7 @@
         "chance": 100,
         "duration": 44000,
         "on_damage": true,
-        "message": "%s's arm is mangled beyond recognition!"
+        "message": "The arm of %s is mangled beyond recognition!"
       }
     ],
     "flat_bonuses": [ { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 1.0 } ],
@@ -1801,7 +1801,7 @@
     "type": "technique",
     "id": "tec_krav_maga_break",
     "name": "Grab Break",
-    "messages": [ "%s tries to grab you, but you wrestle free!", "%s tries to grab <npcname>, but they wrestle free!" ],
+    "messages": [ "You were almost grabbed by %s, but you wrestle free!", "<npcname> was almost grabbed by %s, but they wrestle free!" ],
     "skill_requirements": [ { "name": "melee", "level": 3 } ],
     "melee_allowed": true,
     "unarmed_allowed": true,
@@ -2084,7 +2084,7 @@
     "type": "technique",
     "id": "tec_muay_thai_break",
     "name": "Grab Break",
-    "messages": [ "%s tries to grab you, but you break the clinch!", "%s tries to grab <npcname>, but they break the clinch!" ],
+    "messages": [ "You were almost grabbed by %s, but you break the clinch!", "<npcname> was almost grabbed by %s, but they break the clinch!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,
@@ -2244,7 +2244,7 @@
     "weighting": 2,
     "stun_dur": 2,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s's hand is forced open!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The hand of %s is forced open!" } ],
     "attack_vectors": [ "WEAPON" ],
     "attack_vectors_random": [ "HAND", "ELBOW", "LOWER_LEG", "FOOT" ]
   },
@@ -2414,7 +2414,7 @@
     "type": "technique",
     "id": "tec_pankration_break",
     "name": "Grab Break",
-    "messages": [ "%s tries to grab you, but you wrestle free!", "%s tries to grab <npcname>, but they wrestle free!" ],
+    "messages": [ "You were almost grabbed by %s, but you wrestle free!", "<npcname> was almost grabbed by %s, but they wrestle free!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "defensive": true,
@@ -2445,7 +2445,7 @@
     "crit_ok": true,
     "weighting": 3,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s's hand is forced open!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The hand of %s is forced open!" } ],
     "flat_bonuses": [ { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 1.0 } ],
     "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.25 } ],
     "attack_vectors": [ "GRAPPLE" ]
@@ -2613,7 +2613,7 @@
     "type": "technique",
     "id": "tec_snake_break",
     "name": "Snake Slither",
-    "messages": [ "%s tries to grab you, but you slither free!", "%s tries to grab <npcname>, but they slither free!" ],
+    "messages": [ "You were almost grabbed by %s, but you slither free!", "<npcname> was almost grabbed by %s, but they slither free!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 4 } ],
     "unarmed_allowed": true,
     "defensive": true,
@@ -2879,7 +2879,7 @@
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
     "attack_vectors": [ "HAND" ]
   },
   {
@@ -3011,8 +3011,8 @@
     "id": "tec_tiger_break",
     "name": "Grab Break",
     "messages": [
-      "%s tries to grab you, but you are too powerful to be caged!",
-      "%s tries to grab <npcname>, but they are too powerful to be caged!"
+      "You were almost grabbed by %s, but you are too powerful to be caged!",
+      "<npcname> was almost grabbed by %s, but they are too powerful to be caged!"
     ],
     "unarmed_allowed": true,
     "defensive": true,
@@ -3277,7 +3277,7 @@
     "type": "technique",
     "id": "tec_zuiquan_break",
     "name": "Grab Break",
-    "messages": [ "%s tries to grab you, but you stumble away!", "%s tries to grab <npcname>, but they stumble away!" ],
+    "messages": [ "You were almost grabbed by %s, but you stumble away!", "<npcname> was almost grabbed by %s, but they stumble away!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 4 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,

--- a/data/json/techniques.json
+++ b/data/json/techniques.json
@@ -40,7 +40,7 @@
     "disarms": true,
     "skill_requirements": [ { "name": "melee", "level": 4 } ],
     "description": "Unwield target's weapon, min 4 melee",
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
     "attack_vectors": [ "HAND" ]
   },
   {
@@ -266,7 +266,7 @@
     "disarms": true,
     "messages": [ "You disarm %s using your whip!", "<npcname> disarms %s using their whip!" ],
     "description": "Unwield target's weapon",
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -285,7 +285,7 @@
     "melee_allowed": true,
     "defensive": true,
     "grab_break": true,
-    "messages": [ "The %s tries to grab you, but you break its grab!", "The %s tries to grab <npcname>, but they break its grab!" ]
+    "messages": [ "%s tries to grab you, but you break its grab!", "%s tries to grab <npcname>, but they break its grab!" ]
   },
   {
     "type": "technique",
@@ -403,7 +403,7 @@
     "required_buffs_all": [ "buff_aikido_onblock" ],
     "crit_ok": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
     "//condition": "Humanoids of similar size and no flying",
     "condition": {
       "and": [
@@ -448,7 +448,7 @@
     "required_buffs_all": [ "buff_aikido_ondodge" ],
     "crit_ok": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
     "//condition": "Humanoids of similar size and no flying",
     "condition": {
       "and": [
@@ -486,8 +486,8 @@
     "id": "tec_aikido_break",
     "name": "Grab Break",
     "messages": [
-      "The %s tries to grab you, but you smoothly break free!",
-      "The %s tries to grab <npcname>, but they smoothly break free!"
+      "%s tries to grab you, but you smoothly break free!",
+      "%s tries to grab <npcname>, but they smoothly break free!"
     ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
@@ -500,7 +500,7 @@
     "type": "technique",
     "id": "tec_bojutsu_thrust",
     "name": "Front Thrust",
-    "messages": [ "You thrust at the %s!", "<npcname> thrusts at %s!" ],
+    "messages": [ "You thrust at %s!", "<npcname> thrusts at %s!" ],
     "skill_requirements": [ { "name": "melee", "level": 1 } ],
     "melee_allowed": true,
     "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.2 } ],
@@ -592,7 +592,7 @@
     "melee_allowed": true,
     "crit_ok": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -620,7 +620,7 @@
     "skill_requirements": [ { "name": "melee", "level": 2 } ],
     "melee_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s's hand is forced open!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s's hand is forced open!" } ],
     "mult_bonuses": [
       { "stat": "movecost", "scale": 0.5 },
       { "stat": "damage", "type": "bash", "scale": 0.66 },
@@ -715,7 +715,7 @@
     "type": "technique",
     "id": "tec_brawl_break_melee",
     "name": "Grab Break",
-    "messages": [ "The %s tries to grab you, but you force yourself free!", "The %s tries to grab <npcname>, but they break free!" ],
+    "messages": [ "%s tries to grab you, but you force yourself free!", "%s tries to grab <npcname>, but they break free!" ],
     "skill_requirements": [ { "name": "melee", "level": 6 } ],
     "melee_allowed": true,
     "defensive": true,
@@ -725,7 +725,7 @@
     "type": "technique",
     "id": "tec_brawl_break_unarmed",
     "name": "Grab Break",
-    "messages": [ "The %s tries to grab you, but you force yourself free!", "The %s tries to grab <npcname>, but they break free!" ],
+    "messages": [ "%s tries to grab you, but you force yourself free!", "%s tries to grab <npcname>, but they break free!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 6 } ],
     "unarmed_allowed": true,
     "defensive": true,
@@ -759,7 +759,7 @@
     "skill_requirements": [ { "name": "melee", "level": 6 } ],
     "melee_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -770,7 +770,7 @@
     "skill_requirements": [ { "name": "unarmed", "level": 6 } ],
     "unarmed_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
     "attack_vectors": [ "HAND" ]
   },
   {
@@ -942,8 +942,8 @@
     "id": "tec_crane_break",
     "name": "Crane Flap",
     "messages": [
-      "The %s tries to grab you, but you swing your arms and break free!",
-      "The %s tries to grab <npcname>, but they flap free!"
+      "%s tries to grab you, but you swing your arms and break free!",
+      "%s tries to grab <npcname>, but they flap free!"
     ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
@@ -1308,7 +1308,7 @@
     "type": "technique",
     "id": "tec_medievalpole_break",
     "name": "Grab Break",
-    "messages": [ "The %s tries to grab you, but you push away!", "The %s tries to grab <npcname>, but they push away!" ],
+    "messages": [ "%s tries to grab you, but you push away!", "%s tries to grab <npcname>, but they push away!" ],
     "skill_requirements": [ { "name": "melee", "level": 4 } ],
     "melee_allowed": true,
     "defensive": true,
@@ -1393,7 +1393,7 @@
     "melee_allowed": true,
     "unarmed_weapons_allowed": false,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
     "condition": {
       "and": [
         { "math": [ "u_val('size')", "<=", "n_val('size')" ] },
@@ -1439,8 +1439,8 @@
     "id": "tec_judo_break",
     "name": "Grab Break",
     "messages": [
-      "The %s tries to grab you, but you break their feeble grapple!",
-      "The %s tries to grab <npcname>, but they break its feeble grapple!"
+      "%s tries to grab you, but you break their feeble grapple!",
+      "%s tries to grab <npcname>, but they break its feeble grapple!"
     ],
     "skill_requirements": [ { "name": "unarmed", "level": 1 } ],
     "unarmed_allowed": true,
@@ -1700,14 +1700,14 @@
   {
     "type": "technique",
     "id": "tec_krav_maga_disarm_simple",
-    "messages": [ "You quickly slap and disarm the %s!", "<npcname> quickly slaps and disarms the %s!" ],
+    "messages": [ "You quickly slap and disarm %s!", "<npcname> quickly slaps and disarms %s!" ],
     "name": "Disarming Slap",
     "skill_requirements": [ { "name": "unarmed", "level": 2 } ],
     "melee_allowed": true,
     "unarmed_allowed": true,
     "mult_bonuses": [ { "stat": "movecost", "scale": 0.9 } ],
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
     "attack_vectors": [ "WEAPON", "HAND" ]
   },
   {
@@ -1796,7 +1796,7 @@
         "chance": 100,
         "duration": 44000,
         "on_damage": true,
-        "message": "The %s's arm is mangled beyond recognition!"
+        "message": "%s's arm is mangled beyond recognition!"
       }
     ],
     "flat_bonuses": [ { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 1.0 } ],
@@ -1807,7 +1807,7 @@
     "type": "technique",
     "id": "tec_krav_maga_break",
     "name": "Grab Break",
-    "messages": [ "The %s tries to grab you, but you wrestle free!", "The %s tries to grab <npcname>, but they wrestle free!" ],
+    "messages": [ "%s tries to grab you, but you wrestle free!", "%s tries to grab <npcname>, but they wrestle free!" ],
     "skill_requirements": [ { "name": "melee", "level": 3 } ],
     "melee_allowed": true,
     "unarmed_allowed": true,
@@ -2090,7 +2090,7 @@
     "type": "technique",
     "id": "tec_muay_thai_break",
     "name": "Grab Break",
-    "messages": [ "The %s tries to grab you, but you break the clinch!", "The %s tries to grab <npcname>, but they break the clinch!" ],
+    "messages": [ "%s tries to grab you, but you break the clinch!", "%s tries to grab <npcname>, but they break the clinch!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,
@@ -2228,7 +2228,7 @@
     "weighting": 2,
     "stun_dur": 2,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s's hand is forced open!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s's hand is forced open!" } ],
     "attack_vectors": [ "WEAPON" ],
     "attack_vectors_random": [ "HAND", "ELBOW", "LOWER_LEG", "FOOT" ]
   },
@@ -2398,7 +2398,7 @@
     "type": "technique",
     "id": "tec_pankration_break",
     "name": "Grab Break",
-    "messages": [ "The %s tries to grab you, but you wrestle free!", "The %s tries to grab <npcname>, but they wrestle free!" ],
+    "messages": [ "%s tries to grab you, but you wrestle free!", "%s tries to grab <npcname>, but they wrestle free!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "defensive": true,
@@ -2429,7 +2429,7 @@
     "crit_ok": true,
     "weighting": 3,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s's hand is forced open!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s's hand is forced open!" } ],
     "flat_bonuses": [ { "stat": "arpen", "type": "bash", "scaling-stat": "str", "scale": 1.0 } ],
     "mult_bonuses": [ { "stat": "damage", "type": "bash", "scale": 1.25 } ],
     "attack_vectors": [ "GRAPPLE" ]
@@ -2597,7 +2597,7 @@
     "type": "technique",
     "id": "tec_snake_break",
     "name": "Snake Slither",
-    "messages": [ "The %s tries to grab you, but you slither free!", "The %s tries to grab <npcname>, but they slither free!" ],
+    "messages": [ "%s tries to grab you, but you slither free!", "%s tries to grab <npcname>, but they slither free!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 4 } ],
     "unarmed_allowed": true,
     "defensive": true,
@@ -2863,7 +2863,7 @@
     "skill_requirements": [ { "name": "unarmed", "level": 3 } ],
     "unarmed_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
     "attack_vectors": [ "HAND" ]
   },
   {
@@ -2995,8 +2995,8 @@
     "id": "tec_tiger_break",
     "name": "Grab Break",
     "messages": [
-      "The %s tries to grab you, but you are too powerful to be caged!",
-      "The %s tries to grab <npcname>, but they are too powerful to be caged!"
+      "%s tries to grab you, but you are too powerful to be caged!",
+      "%s tries to grab <npcname>, but they are too powerful to be caged!"
     ],
     "unarmed_allowed": true,
     "defensive": true,
@@ -3261,7 +3261,7 @@
     "type": "technique",
     "id": "tec_zuiquan_break",
     "name": "Grab Break",
-    "messages": [ "The %s tries to grab you, but you stumble away!", "The %s tries to grab <npcname>, but they stumble away!" ],
+    "messages": [ "%s tries to grab you, but you stumble away!", "%s tries to grab <npcname>, but they stumble away!" ],
     "skill_requirements": [ { "name": "unarmed", "level": 4 } ],
     "unarmed_allowed": true,
     "melee_allowed": true,

--- a/data/mods/MMA/techniques.json
+++ b/data/mods/MMA/techniques.json
@@ -114,7 +114,15 @@
     "messages": [ "You skillfully disarm %s!", "<npcname> skillfully disarms %s!" ],
     "unarmed_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
+    "tech_effects": [
+      {
+        "id": "disarmed",
+        "chance": 100,
+        "duration": 400,
+        "on_damage": true,
+        "message": "The weapon of %s has been forced out ot their hands!"
+      }
+    ],
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -511,7 +519,15 @@
     "melee_allowed": true,
     "crit_ok": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
+    "tech_effects": [
+      {
+        "id": "disarmed",
+        "chance": 100,
+        "duration": 400,
+        "on_damage": true,
+        "message": "The weapon of %s has been forced out ot their hands!"
+      }
+    ],
     "attack_vectors": [ "WEAPON" ]
   },
   {

--- a/data/mods/MMA/techniques.json
+++ b/data/mods/MMA/techniques.json
@@ -114,7 +114,7 @@
     "messages": [ "You skillfully disarm %s!", "<npcname> skillfully disarms %s!" ],
     "unarmed_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -511,7 +511,7 @@
     "melee_allowed": true,
     "crit_ok": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The %s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -605,8 +605,8 @@
     "id": "mma_tec_tiger_claw_break",
     "name": "Wolverine Stance",
     "messages": [
-      "The %s tries to grab you, but you thrash your way to freedom!",
-      "The %s tries to grab <npcname>, but they thrash their way to freedom!"
+      "%s tries to grab you, but you thrash your way to freedom!",
+      "%s tries to grab <npcname>, but they thrash their way to freedom!"
     ],
     "melee_allowed": true,
     "unarmed_allowed": true,

--- a/data/mods/MMA/techniques.json
+++ b/data/mods/MMA/techniques.json
@@ -114,7 +114,7 @@
     "messages": [ "You skillfully disarm %s!", "<npcname> skillfully disarms %s!" ],
     "unarmed_allowed": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -511,7 +511,7 @@
     "melee_allowed": true,
     "crit_ok": true,
     "disarms": true,
-    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "%s is disarmed!" } ],
+    "tech_effects": [ { "id": "disarmed", "chance": 100, "duration": 400, "on_damage": true, "message": "The weapon of %s has been forced out ot their hands!" } ],
     "attack_vectors": [ "WEAPON" ]
   },
   {
@@ -605,8 +605,8 @@
     "id": "mma_tec_tiger_claw_break",
     "name": "Wolverine Stance",
     "messages": [
-      "%s tries to grab you, but you thrash your way to freedom!",
-      "%s tries to grab <npcname>, but they thrash their way to freedom!"
+      "You were almost grabbed by %s, but you thrash your way to freedom!",
+      "<npcname> was almost grabbed by %s, but they thrash their way to freedom!"
     ],
     "melee_allowed": true,
     "unarmed_allowed": true,

--- a/doc/MONSTER_SPECIAL_ATTACKS.md
+++ b/doc/MONSTER_SPECIAL_ATTACKS.md
@@ -260,10 +260,11 @@ The monster fires a gun at a target.  If the monster is friendly, it will avoid 
 | `fake_per`                  | Perception stat of the fake NPC that will execute the attack.  8 if not specified.                                    |
 | `fake_skills`               | Array of 2 element arrays of skill id and skill level pairs.                                                          |
 | `move_cost`                 | Move cost of executing the attack.                                                                                    |
+| `condition`                 | Object, dialogue conditions enabling the attack.  See `NPCs.md` for the possible conditions, `u` refers to the monster.
 | `require_targeting_player`  | If true, the monster will need to "target" the player, wasting `targeting_cost` moves, putting the attack on cooldown and making warning sounds, unless it attacked something that needs to be targeted recently.  Gives "grace period" to player.                                                               |
 | `require_targeting_npc`     | As above, but with NPCs.                                                                                              |
 | `require_targeting_monster` | As above, but with monsters.                                                                                          |
-| 'target_moving_vehicles'    | If true, the monster will "target" moving vehicles even if it cannot see the player.
+| `target_moving_vehicles`    | If true, the monster will "target" moving vehicles even if it cannot see the player.
 | `targeting_timeout`         | Targeting status will be applied for this many turns.  Note that targeting applies to turret, not targets.            |
 | `targeting_timeout_extend`  | Successfully attacking will extend the targeting for this many turns.  Can be negative.                               |
 | `targeting_cost`            | Move cost of targeting the player. Only applied if attacking the player and didn't target player within last 5 turns. |


### PR DESCRIPTION
#### Summary
Bugfixes "Corrects duplicates /the/ in martial arts techs messages"

#### Purpose of change
It came to my attention that "%s" already includes "the" when referring to a specific monster, and some martial arts techs had "the %s" in their messages, so it was displayed as "the the" in the message log of the game... So I went and fixed all instances of duplicates "the" that I could find in the martial arts techniques!

The messages where "%s" was at the beginning of a sentence were rewritten so their capitalization remains correct.

Ninjutsu was devoid of its unarmed downing technique for mistake in another PR of mine, so i added the same technique in 2 versions, melee and unarmed, to maintain functionality.

Edit: Added missing documentation regarding #69052

#### Describe the solution
Simple JSON change of displayed text.

#### Describe alternatives you've considered
Nothing at all!

#### Testing
It works! No more duplicates.

#### Additional context

