### PR TITLE
Colored skirts

### DIFF
--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -1718,6 +1718,89 @@
     "armor": [
       { "coverage": 100, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_hip_l", "leg_hip_r" ] },
       { "coverage": 75, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+    ],
+    "variant_type": "generic",
+    "variants": [
+      {
+        "id": "skirt_red",
+        "name": { "str": "red skirt" },
+        "description": "This one is colored red.",
+        "color": "red",
+        "append": true,
+        "weight": 100
+      },
+      {
+        "id": "skirt_blue",
+        "name": { "str": "blue skirt" },
+        "color": "blue",
+        "description": "This one is colored blue.",
+        "append": true,
+        "weight": 30
+      },
+      {
+        "id": "skirt_yellow",
+        "name": { "str": "yellow skirt" },
+        "color": "yellow",
+        "description": "This one is colored yellow.",
+        "append": true,
+        "weight": 24
+      },
+      {
+        "id": "skirt_green",
+        "name": { "str": "green skirt" },
+        "color": "green",
+        "description": "This one is colored green.",
+        "append": true,
+        "weight": 24
+      },
+      {
+        "id": "skirt_purple",
+        "name": { "str": "purple skirt" },
+        "color": "magenta",
+        "description": "This one is colored purple.",
+        "append": true,
+        "weight": 24
+      },
+      {
+        "id": "skirt_pink",
+        "name": { "str": "pink skirt" },
+        "color": "magenta",
+        "description": "This one is colored pink.",
+        "append": true,
+        "weight": 24
+      },
+      {
+        "id": "skirt_cyan",
+        "name": { "str": "cyan skirt" },
+        "color": "cyan",
+        "description": "This one is colored cyan.",
+        "append": true,
+        "weight": 24
+      },
+      {
+        "id": "skirt_black",
+        "name": { "str": "black skirt" },
+        "color": "dark_gray",
+        "description": "This one is colored black.",
+        "append": true,
+        "weight": 24
+      },
+      {
+        "id": "skirt_white",
+        "name": { "str": "white skirt" },
+        "color": "light_gray",
+        "description": "This one is colored white.",
+        "append": true,
+        "weight": 24
+      },
+      {
+        "id": "skirt_brown",
+        "name": { "str": "brown skirt" },
+        "color": "brown",
+        "description": "This one is colored brown.",
+        "append": true,
+        "weight": 24
+      }
     ]
   },
   {

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -1727,7 +1727,7 @@
         "description": "This one is colored red.",
         "color": "red",
         "append": true,
-        "weight": 100
+        "weight": 40
       },
       {
         "id": "skirt_blue",
@@ -1735,7 +1735,7 @@
         "color": "blue",
         "description": "This one is colored blue.",
         "append": true,
-        "weight": 30
+        "weight": 24
       },
       {
         "id": "skirt_yellow",


### PR DESCRIPTION

#### Summary
Content "Colored skirts"

#### Purpose of change

The `skirt` can do with some color variants, so im adding one

#### Describe the solution

adds variants:
- skirt_red
- skirt_blue
- skirt_yellow
- skirt_green
- skirt_purple
- skirt_pink
- skirt_cyan
- skirt_black
- skirt_white
- skirt_brown

#### Describe alternatives you've considered

Keeping it to myself.

#### Testing

Put it in as a mod, it works. I also made sprites for the colored skirts (for MSXotto+), ~~but i haven't taken a screenshot of it.~~
![Screenshot_2023-11-05_07-55-59_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/78019001/f92a9d49-584f-4292-beb1-b01be5e7ea72)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
