### PR TITLE
Update cheap bandolier

### DIFF
--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -348,7 +348,7 @@
     "id": "cheap_ammo_pouch",
     "type": "ARMOR",
     "name": "military 5.56 bandolier",
-    "description": "A standard issue military bandolier for 5.56 NATO.  A simple bag on a strap, partitioned into pouches for four STANAG 30-round magazines or twelve 10-round 5.56x45mm stripper clips.  When full, this bandolier is more encumbering than proper kit and slower to reload from, but it at least offers a quick and cheap means of resupplying ammunition.",
+    "description": "A simple bag on a strap, partitioned into pouches for four STANAG 30-round magazines or twelve 10-round 5.56x45mm stripper clips.  When full, this bandolier is more encumbering than proper kit and slower to reload from, but it at least offers a quick and cheap means of resupplying ammunition.",
     "weight": "60 g",
     "volume": "40 ml",
     "price": 600,

--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -348,7 +348,7 @@
     "id": "cheap_ammo_pouch",
     "type": "ARMOR",
     "name": "military 5.56 bandolier",
-    "description": "A standard issue military bandolier for 5.56 NATO.  This simple mass manufactured bag on a strap contains four pouches that exactly fit STANAG 30-round magazines or 3 10-round boxes of 5.56 NATO each.  You could use them to store smaller clips or several other things.",
+    "description": "A standard issue military bandolier for 5.56 NATO.  This simple mass manufactured bag on a strap is partitioned into four pouches that fit four STANAG 30-round magazines or twelve 10-round 5.56x45mm stripper clips.  You could use them to store smaller clips or several other things.",
     "weight": "60 g",
     "volume": "40 ml",
     "price": 600,

--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -347,8 +347,8 @@
   {
     "id": "cheap_ammo_pouch",
     "type": "ARMOR",
-    "name": "cheap ammo bandolier",
-    "description": "A small bandolier with four pouches that perfectly fit standard STANAG 30-round magazines.  You could also use them to store several smaller ammo clips or other items.",
+    "name": "military 5.56 bandolier",
+    "description": "A standard issue military bandolier for 5.56 NATO.  This simple mass manufactured bag on a strap contains four pouches that exactly fit STANAG 30-round magazines or 3 10-round boxes of 5.56 NATO each.  You could use them to store smaller clips or several other things.",
     "weight": "60 g",
     "volume": "40 ml",
     "price": 600,
@@ -358,39 +358,43 @@
     "symbol": "[",
     "looks_like": "leather_pouch",
     "color": "brown",
-    "material_thickness": 1,
+    "material_thickness": 0.1,
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "290 ml",
         "max_contains_weight": "650 g",
         "max_item_length": "200 mm",
-        "volume_encumber_modifier": 0.3
+        "volume_encumber_modifier": 1.25,
+        "moves": 65
       },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "290 ml",
         "max_contains_weight": "650 g",
         "max_item_length": "200 mm",
-        "volume_encumber_modifier": 0.3
+        "volume_encumber_modifier": 1.25,
+        "moves": 65
       },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "290 ml",
         "max_contains_weight": "650 g",
         "max_item_length": "200 mm",
-        "volume_encumber_modifier": 0.3
+        "volume_encumber_modifier": 1.25,
+        "moves": 65
       },
       {
         "pocket_type": "CONTAINER",
         "max_contains_volume": "290 ml",
         "max_contains_weight": "650 g",
         "max_item_length": "200 mm",
-        "volume_encumber_modifier": 0.3
+        "volume_encumber_modifier": 1.25,
+        "moves": 65
       }
     ],
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
-    "armor": [ { "encumbrance": 4, "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ]
+    "armor": [ { "encumbrance": 0, "coverage": 100, "covers": [ "torso" ], "specifically_covers": [ "torso_waist" ] } ]
   },
   {
     "id": "cheap_ammo_pouch_belt223",

--- a/data/json/items/armor/bandolier.json
+++ b/data/json/items/armor/bandolier.json
@@ -348,7 +348,7 @@
     "id": "cheap_ammo_pouch",
     "type": "ARMOR",
     "name": "military 5.56 bandolier",
-    "description": "A standard issue military bandolier for 5.56 NATO.  This simple mass manufactured bag on a strap is partitioned into four pouches that fit four STANAG 30-round magazines or twelve 10-round 5.56x45mm stripper clips.  You could use them to store smaller clips or several other things.",
+    "description": "A standard issue military bandolier for 5.56 NATO.  A simple bag on a strap, partitioned into pouches for four STANAG 30-round magazines or twelve 10-round 5.56x45mm stripper clips.  When full, this bandolier is more encumbering than proper kit and slower to reload from, but it at least offers a quick and cheap means of resupplying ammunition.",
     "weight": "60 g",
     "volume": "40 ml",
     "price": 600,
@@ -365,7 +365,7 @@
         "max_contains_volume": "290 ml",
         "max_contains_weight": "650 g",
         "max_item_length": "200 mm",
-        "volume_encumber_modifier": 1.25,
+        "volume_encumber_modifier": 1.5,
         "moves": 65
       },
       {
@@ -373,7 +373,7 @@
         "max_contains_volume": "290 ml",
         "max_contains_weight": "650 g",
         "max_item_length": "200 mm",
-        "volume_encumber_modifier": 1.25,
+        "volume_encumber_modifier": 1.5,
         "moves": 65
       },
       {
@@ -381,7 +381,7 @@
         "max_contains_volume": "290 ml",
         "max_contains_weight": "650 g",
         "max_item_length": "200 mm",
-        "volume_encumber_modifier": 1.25,
+        "volume_encumber_modifier": 1.5,
         "moves": 65
       },
       {
@@ -389,7 +389,7 @@
         "max_contains_volume": "290 ml",
         "max_contains_weight": "650 g",
         "max_item_length": "200 mm",
-        "volume_encumber_modifier": 1.25,
+        "volume_encumber_modifier": 1.5,
         "moves": 65
       }
     ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Updated the cheap bandolier encumbrance, armor, and pocket accessibility.  Also renamed and improved description."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The existing cheap ammo bandolier has far too much encumbrance to ever be useful and pulling magazines out of it takes more moves than accessing cargo pants pockets.  The name and description also don't accurately reflect what it is and that it's an important part of standard US military equipment.  As it is a very thin and disposable cloth bag, it should not provide any armor value.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The bag now has no encumbrance when empty, and goes up to 5 when full with four magazines, while also taking a slightly shorter time to extract items from its pockets than cargo pants.  The armor value has been made negligible.  I also updated the name and description.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
There was some discussion on how high the encumbrance values should start at, but the bag is so light and flimsy that I cannot justify it giving any encumbrance when worn on its own and not conflicting with anything else.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I plugged the values into my local game file and booted it up.  Checked the edited item I possessed and everything appears to be fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
