### PR TITLE
Correct perk menu description of Closed Fist

### DIFF
--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -245,7 +245,7 @@
             }
           },
           {
-            "set_string_var": "Taking this means you can't take <trait_name:perk_way_closedfist> or <trait_name:perk_way_pinchedfingers>",
+            "set_string_var": "Taking this means you can't take <trait_name:perk_way_openpalm> or <trait_name:perk_way_pinchedfingers>",
             "target_var": { "context_val": "trait_additional_details" }
           }
         ],


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I was playing and noticed a little mistake with the perk menu of closed fist...

#### Describe the solution
Correct the text to reference the correct "Way of..."

#### Describe alternatives you've considered
To leave it be!

#### Testing
None, made in the github web editor. I just copied and pasted the trait reference from the text mentioned just before the one I changed.

#### Additional context

![imagen](https://github.com/CleverRaven/Cataclysm-DDA/assets/53200489/70006496-14e0-45fd-a801-df38a3d31e81)
Read the last sentence (This is the perk menu of Closed Fist)