### PR TITLE
remove memorial group from homebooks

### DIFF
--- a/data/json/itemgroups/books.json
+++ b/data/json/itemgroups/books.json
@@ -324,11 +324,16 @@
       { "item": "fermenting_book", "prob": 8 },
       { "item": "distilling_cookbook", "prob": 3 },
       { "item": "cookbook_bloodforgood", "prob": 2 },
-      { "group": "memorial", "prob": 10 },
       { "item": "book_judaica_hardcover", "prob": 5 },
       { "group": "home_martial_arts_books", "prob": 1 },
       { "item": "book_judaica_softcover", "prob": 5 }
     ]
+  },
+  {
+    "id": "homebooks_memorial",
+    "type": "item_group",
+    "subtype": "distribution",
+    "entries": [ { "group": "memorial", "prob": 10 }, { "group": "homebooks", "prob": 100 } ]
   },
   {
     "id": "ranch_homebooks",

--- a/data/json/itemgroups/books.json
+++ b/data/json/itemgroups/books.json
@@ -330,12 +330,6 @@
     ]
   },
   {
-    "id": "homebooks_memorial",
-    "type": "item_group",
-    "subtype": "distribution",
-    "entries": [ { "group": "memorial", "prob": 10 }, { "group": "homebooks", "prob": 100 } ]
-  },
-  {
     "id": "ranch_homebooks",
     "type": "item_group",
     "subtype": "distribution",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Closes #69046. "homebooks" group in json had an item group for a memorial with urn and candles and flags and whatnot. This caused a memorial to appear in absurd places, like bookstores or megastores.

#### Describe the solution
Removed it from "homebooks" group and made another group called "homebooks_memorial" in case somebody wants to use it.

#### Describe alternatives you've considered
none

#### Testing
haven't done it but this gotta fix it
