### PR TITLE
Tool to show a list of proficiencies gained from dissecting every monster in a table.

### DIFF
--- a/data/json/monsters/zed_amalgamation.json
+++ b/data/json/monsters/zed_amalgamation.json
@@ -131,7 +131,7 @@
     "copy-from": "mon_amalgamation_abstract_small",
     "//": "Small, nasty glass cannon spawning in groups  WP: mandible, leg",
     "name": { "str": "swarming amalgamation" },
-    "description": "An small, flat creature dashing around erratically on seven short legs.  Its form is dominated by an oversized set of black mandibles on an almost comically small head, featureless apart from a single, black eye.  The rest of the body is covered with sickly white skin crisscrossed by black veins.",
+    "description": "A small, flat creature dashing around erratically on seven short legs.  Its form is dominated by an oversized set of black mandibles on an almost comically small head, featureless apart from a single, black eye.  The rest of the body is covered with sickly white skin crisscrossed by black veins.",
     "volume": "20 L",
     "weight": "20 kg",
     "hp": 35,

--- a/tools/json_tools/proficiencies_from_dissecting.py
+++ b/tools/json_tools/proficiencies_from_dissecting.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""
+Print table of monster -> proficiencies from dissecting.
+
+Does resolve inheritance implemented by copy-from
+Prints EMPTY_PROFS_STRING if monster dissection provides no proficiencies,
+"NO PROFS" by default.
+"""
+
+from util import import_data
+
+# "NO PROFS" by default
+EMPTY_PROFS_STRING = "NO PROFS"
+# True: print only monsters that have give no proficiencies upon dissecting
+ONLY_NO_PROFS = False
+# can be 0 or 1
+SORT_BY_COL = 1
+
+
+def list_2d_to_table(list_2d, header):
+    """return table as string from data in list_2d with header.
+
+    list_2d is list of rows, header is list of headers.
+    Every row must have same number of elements and same number of elements
+    as the header has.
+
+    Example:
+    >>> print(list_2d_to_table(
+            (
+                (1, 2, 3),
+                (4, 5, 6),
+                ("hi there", "0", 5777)
+            ),
+            ("h1", "h2", "h3")
+        ))
+        ┌────────┬──┬────┐
+        │h1      │h2│h3  │
+        ├────────┼──┼────┤
+        │       1│ 2│   3|
+        │       4│ 5│   6|
+        │hi there│ 0│5777|
+        └────────┴──┴────┘
+    """
+
+    lens_list = []
+    column_count = len(header)
+    for column in range(column_count):
+        len_max = len(header[column])
+        for line in list_2d:
+            assert(column_count == len(line))
+            len_max = max(len_max, len(str(line[column])))
+        lens_list.append(len_max)
+
+    table = "┌%s┐\n" % "┬".join("─" * d for d in lens_list)
+
+    table += "│"
+    separator = ""
+    for column in range(column_count):
+        table += separator
+        table += ("%%-%ds" % lens_list[column]) % header[column]
+        separator = "│"
+    table += "│\n"
+
+    table += "├%s┤\n" % "┼".join("─" * d for d in lens_list)
+
+    for line in list_2d:
+        separator = ""
+        for cell, width in zip(line, lens_list):
+            table += ("│%%-%ds" % width) % cell
+        table += "|\n"
+
+    table += "└%s┘\n" % "┴".join("─" * d for d in lens_list)
+    return table
+
+
+def get_profs(monster):
+    if "families" in monster:
+        return monster["families"]
+    elif "copy-from" in monster:
+        return get_profs(monsters[monster["copy-from"]])
+    else:
+        return ()
+
+
+if __name__ == "__main__":
+    # make it dict for fast lookup:
+    monsters = {}
+    for data in import_data()[0]:
+        if data["type"] == "MONSTER":
+
+            if "id" in data:
+                name = data["id"]
+                # "This monster exists only for weakpoint testing purposes."
+                if name == "weakpoint_mon":
+                    continue
+            elif "abstract" in data:
+                name = data["abstract"]
+            else:
+                raise ValueError(
+                    f"'id' nor 'abstract' defined for json entry:\n{data}")
+            if name in monsters:
+                raise ValueError(f"duplicate: {name}")
+            monsters[name] = data
+
+    monster_count = 0
+    no_profs = 0
+    results = []
+    for name, monster in monsters.items():
+        profs = get_profs(monster)
+        if ONLY_NO_PROFS:
+            if not profs:
+                results.append((name,))
+                no_profs += 1
+        else:
+            if not profs:
+                profs = (EMPTY_PROFS_STRING,)
+                no_profs += 1
+
+            results.append((name, ", ".join(profs)))
+        monster_count += 1
+
+    if ONLY_NO_PROFS:
+        results.sort()
+        print(list_2d_to_table(results, ("monster id/abstract",)))
+    else:
+        results.sort(key=lambda line: (
+            line[SORT_BY_COL], line[0 if SORT_BY_COL else 1]))
+        print(list_2d_to_table(results, ("monster id/abstract",
+                               "proficiencies from dissecting")))
+
+    print(f"monster count: {monster_count}")
+    print(f"no profs: {no_profs}")


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Tool to show a list of proficiencies gained from dissecting every monster in a table."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
              Anyone up for making a python script to build s list of monsters that lack proficiencies?

_Originally posted by @Maleclypse in https://github.com/CleverRaven/Cataclysm-DDA/issues/68760#issuecomment-1771786720_

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make a tool that prints a table.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Print only the monsters with missing proficiencies.

Sort proficiencies in second column, but it looks worse, see "Testing".

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Run it with various settings.
See comments below, as the output is too long.


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I cannot write `proficiencies` and `dissecting`, sorry if there are any typos.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
