### PR TITLE
Leather sheets for crafting leather-padded armor

### DIFF
--- a/data/json/recipes/armor/bespoke_armor/survivor.json
+++ b/data/json/recipes/armor/bespoke_armor/survivor.json
@@ -416,6 +416,7 @@
   {
     "result": "survivor_adhoc_leather_shirt",
     "type": "recipe",
+    "id_suffix": "sheets",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_TORSO",
@@ -458,6 +459,7 @@
   {
     "result": "survivor_adhoc_leather_torso",
     "type": "recipe",
+    "id_suffix": "sheets",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_TORSO",
@@ -492,6 +494,7 @@
   {
     "result": "survivor_adhoc_leather_sleeves",
     "type": "recipe",
+    "id_suffix": "sheets",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_ARMS",
@@ -537,6 +540,7 @@
   {
     "result": "survivor_adhoc_leather_pants",
     "type": "recipe",
+    "id_suffix": "sheets",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_LEGS",

--- a/data/json/recipes/armor/bespoke_armor/survivor.json
+++ b/data/json/recipes/armor/bespoke_armor/survivor.json
@@ -399,20 +399,34 @@
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "category": "CC_ARMOR",
-    "subcategory": "CSC_ARMOR_SUIT",
+    "subcategory": "CSC_ARMOR_TORSO",
     "skill_used": "tailor",
     "difficulty": 2,
     "time": "45 m",
     "autolearn": true,
-    "using": [ [ "sewing_standard", 100 ] ],
+    "using": [ [ "sewing_standard", 100 ], [ "adhesive", 8 ] ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
     "byproducts": [ [ "leather", 2 ], [ "scrap_leather", 28 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_leatherworking_basic" } ],
     "components": [
       [ [ "trenchcoat_leather", 1 ], [ "duster_leather", 1 ], [ "jacket_leather", 1 ], [ "leather_police_jacket", 1 ] ],
-      [ [ "sweatshirt", 1 ], [ "hoodie", 1 ] ],
-      [ [ "duct_tape", 200 ] ]
+      [ [ "sweatshirt", 1 ], [ "hoodie", 1 ] ]
     ]
+  },
+  {
+    "result": "survivor_adhoc_leather_shirt",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "180 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 150 ], [ "tailoring_leather_patchwork", 3 ], [ "adhesive", 4 ] ],
+    "byproducts": [ [ "scrap_leather", 4 ] ],
+    "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_leatherworking_basic" } ],
+    "components": [ [ [ "sweatshirt", 1 ], [ "hoodie", 1 ] ] ]
   },
   {
     "result": "survivor_adhoc_leather_torso",
@@ -424,7 +438,7 @@
     "difficulty": 2,
     "time": "25 m",
     "autolearn": true,
-    "using": [ [ "sewing_standard", 60 ] ],
+    "using": [ [ "sewing_standard", 60 ], [ "adhesive", 5 ] ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
     "byproducts": [ [ "leather", 6 ], [ "scrap_leather", 22 ], [ "cotton_patchwork", 4 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_leatherworking_basic" } ],
@@ -438,9 +452,23 @@
         [ "leather_police_jacket", 1 ],
         [ "vest_leather", 1 ]
       ],
-      [ [ "sweatshirt", 1 ], [ "hoodie", 1 ] ],
-      [ [ "duct_tape", 120 ] ]
+      [ [ "sweatshirt", 1 ], [ "hoodie", 1 ] ]
     ]
+  },
+  {
+    "result": "survivor_adhoc_leather_torso",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_TORSO",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "120 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 90 ], [ "tailoring_leather_patchwork", 2 ], [ "adhesive", 3 ] ],
+    "byproducts": [ [ "scrap_leather", 2 ], [ "cotton_patchwork", 4 ] ],
+    "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_leatherworking_basic" } ],
+    "components": [ [ [ "sweatshirt", 1 ], [ "hoodie", 1 ] ] ]
   },
   {
     "result": "survivor_adhoc_leather_sleeves",
@@ -452,15 +480,29 @@
     "difficulty": 2,
     "time": "20 m",
     "autolearn": true,
-    "using": [ [ "sewing_standard", 40 ] ],
+    "using": [ [ "sewing_standard", 40 ], [ "adhesive", 3 ] ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
     "byproducts": [ [ "leather", 15 ], [ "scrap_leather", 18 ], [ "cotton_patchwork", 12 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_leatherworking_basic" } ],
     "components": [
       [ [ "trenchcoat_leather", 1 ], [ "duster_leather", 1 ], [ "jacket_leather", 1 ], [ "leather_police_jacket", 1 ] ],
-      [ [ "sweatshirt", 1 ], [ "hoodie", 1 ] ],
-      [ [ "duct_tape", 80 ] ]
+      [ [ "sweatshirt", 1 ], [ "hoodie", 1 ] ]
     ]
+  },
+  {
+    "result": "survivor_adhoc_leather_sleeves",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_ARMS",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "60 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 60 ], [ "tailoring_leather_patchwork", 1 ], [ "adhesive", 2 ] ],
+    "byproducts": [ [ "scrap_leather", 2 ], [ "cotton_patchwork", 12 ] ],
+    "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_leatherworking_basic" } ],
+    "components": [ [ [ "sweatshirt", 1 ], [ "hoodie", 1 ] ] ]
   },
   {
     "result": "survivor_adhoc_leather_torso",
@@ -486,10 +528,25 @@
     "difficulty": 2,
     "time": "36 m",
     "autolearn": true,
-    "using": [ [ "sewing_standard", 80 ] ],
+    "using": [ [ "sewing_standard", 80 ], [ "adhesive", 5 ] ],
     "qualities": [ { "id": "LEATHER_AWL", "level": 1 } ],
     "byproducts": [ [ "leather", 4 ], [ "scrap_leather", 14 ] ],
     "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_leatherworking_basic" } ],
-    "components": [ [ [ "pants_leather", 1 ] ], [ [ "technician_pants_gray", 1 ] ], [ [ "duct_tape", 120 ] ] ]
+    "components": [ [ [ "pants_leather", 1 ] ], [ [ "technician_pants_gray", 1 ] ] ]
+  },
+  {
+    "result": "survivor_adhoc_leather_pants",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_LEGS",
+    "skill_used": "tailor",
+    "difficulty": 3,
+    "time": "180 m",
+    "autolearn": true,
+    "using": [ [ "sewing_standard", 120 ], [ "tailoring_leather_patchwork", 3 ], [ "adhesive", 3 ] ],
+    "byproducts": [ [ "scrap_leather", 4 ] ],
+    "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_leatherworking_basic" } ],
+    "components": [ [ [ "technician_pants_gray", 1 ] ] ]
   }
 ]


### PR DESCRIPTION
#### Summary
Content "Adds some new recipes to craft the leather-padded armor from sheets"

#### Purpose of change
These items were originally added in #60837, where it was discussed the idea of allowing crafting them with leather sheets, but it was discarded so the recipe wasn't too complicated... So why not just add a new recipe?

Also fixes: The leather-padded shirt was in the "suits" rather than "torso" category, and the duct tape was not replaceable with glue.

#### Describe the solution
Adds some new recipes for crafting the leather-padded clothing, these ones are a level harder to craft, and require several times more time than just using clothing already shaped that you will just affix to the shirt, but allows you to recycle components of other leather clothing to pad the shirt, using leather sheets. The recipe also uses less duct tape, but more thread, since you will have to sew more surface area than just using cut products from a jacket.

#### Describe alternatives you've considered
To remove duct tape? But well, I suppose for properly crafted leather armor you can make other things.

#### Testing
The game loads, the recipes appear in my crafting menu, all of them.

#### Additional context
![imagen](https://github.com/CleverRaven/Cataclysm-DDA/assets/53200489/a41e31ee-8a95-4720-b50e-5fcc2f8508ee)

Working on another PR to rectify some weird values/components of leather clothing thanks to this...
