### PR TITLE
Gasoline Zombie Update

### DIFF
--- a/data/json/items/ammo_types.json
+++ b/data/json/items/ammo_types.json
@@ -826,5 +826,11 @@
     "id": "airgun_pellet",
     "name": "airgun pellet",
     "default": "airgun_pellet_target"
+  },
+  {
+    "type": "ammunition_type",
+    "id": "blobfuel",
+    "name": "tainted fuel",
+    "default": "blobfuel"
   }
 ]

--- a/data/json/items/fuel.json
+++ b/data/json/items/fuel.json
@@ -357,5 +357,5 @@
     "damage": { "damage_type": "heat", "amount": 3, "armor_penetration": 2 },
     "range": 4,
     "effects": [ "FLAME", "STREAM", "INCENDIARY", "NEVER_MISFIRES" ]
-  },
+  }
 ]

--- a/data/json/items/fuel.json
+++ b/data/json/items/fuel.json
@@ -335,5 +335,27 @@
     "range": 6,
     "damage": { "damage_type": "heat", "amount": 2, "armor_penetration": 2 },
     "effects": [ "FLAME", "STREAM" ]
-  }
+  },
+  {
+    "id": "blobfuel",
+    "type": "AMMO",
+    "name": { "str_sp": "tainted fuel" },
+    "description": "A vile brew of volatile fuel and rapidly decaying tissue.  Smells awful, and would ruin any engine that tried to burn it.  Would still work for lamps, at least.  When under pressure, it has the potential for violent explosion.",
+    "category": "fuel",
+    "weight": "750 mg",
+    "volume": "200ml",
+    "price": 40,
+    "price_postapoc": 125,
+    "count": 250,
+    "stack_size": 200,
+    "phase": "liquid",
+    "container": "jerrycan",
+    "material": [ "blobfuel" ],
+    "symbol": "=",
+    "color": "dark_red",
+    "ammo_type": "blobfuel",
+    "damage": { "damage_type": "heat", "amount": 3, "armor_penetration": 2 },
+    "range": 4,
+    "effects": [ "FLAME", "STREAM", "INCENDIARY", "NEVER_MISFIRES" ]
+  },
 ]

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -477,8 +477,8 @@
     "material": [ "glass", "steel" ],
     "symbol": ";",
     "color": "yellow",
-    "ammo": [ "gasoline" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "watertight": true, "ammo_restriction": { "gasoline": 500 } } ],
+    "ammo": [ "gasoline", "blobfuel" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "watertight": true, "ammo_restriction": { "gasoline": 500 }, { "blobfuel": 500 } } ],
     "charges_per_use": 1,
     "use_action": {
       "target": "gasoline_lantern_on",

--- a/data/json/items/tool/lighting.json
+++ b/data/json/items/tool/lighting.json
@@ -478,7 +478,7 @@
     "symbol": ";",
     "color": "yellow",
     "ammo": [ "gasoline", "blobfuel" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "watertight": true, "ammo_restriction": { "gasoline": 500 }, { "blobfuel": 500 } } ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "watertight": true, "ammo_restriction": { "gasoline": 500, "blobfuel": 500 } } ],
     "charges_per_use": 1,
     "use_action": {
       "target": "gasoline_lantern_on",

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -2890,5 +2890,16 @@
     "soft": true,
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 2.2, "cut": 3.5, "acid": 7, "heat": 1, "bullet": 1.4 }
+  },
+  {
+    "type": "material",
+    "id": "blobfuel",
+    "name": "Tainted fuel",
+    "density": 0.75,
+    "copy-from": "hydrocarbons",
+    "fuel_data": {
+      "energy": "29070 kJ",
+      "explosion_data": { "chance_hot": 2, "chance_cold": 5, "factor": 1, "fiery": true, "size_factor": 0.1 }
+    }
   }
 ]

--- a/data/json/monsters/monster_flags.json
+++ b/data/json/monsters/monster_flags.json
@@ -588,5 +588,10 @@
     "id": "SMALL_HIDER",
     "type": "monster_flag",
     "//": "This small monster can hide under or behind furniture such as beds, refrigerators, and underbrush"
+  },
+  {
+    "id": "DRIPS_BLOBFEUL",
+    "type": "monster_flag",
+    "//": "This monster occasionally drips tainted fuel on move"
   }
 ]

--- a/data/json/monsters/zed_explosive.json
+++ b/data/json/monsters/zed_explosive.json
@@ -132,12 +132,6 @@
     "grab_strength": 30,
     "special_attacks": [ { "id": "grab" }, { "id": "scratch_humanoid" }, { "id": "bite_humanoid" } ],
     "death_drops": "default_zombie_items",
-  "emit_fields": [
-    {
-      "emit_id": "emit_hot_air2_stream",
-      "delay": "10 s"
-    }
-  ],
     "death_function": {
       "effect": { "id": "death_conflagration", "hit_self": true },
       "message": "The %s explodes!",
@@ -154,7 +148,7 @@
       "GROUP_BASH",
       "POISON",
       "NO_BREATHE",
-      "DRIPS_GASOLINE",
+      "DRIPS_BLOBFUEL",
       "PUSH_MON",
       "FILTHY"
     ],

--- a/data/json/monsters/zed_explosive.json
+++ b/data/json/monsters/zed_explosive.json
@@ -132,6 +132,12 @@
     "grab_strength": 30,
     "special_attacks": [ { "id": "grab" }, { "id": "scratch_humanoid" }, { "id": "bite_humanoid" } ],
     "death_drops": "default_zombie_items",
+  "emit_fields": [
+    {
+      "emit_id": "emit_hot_air2_stream",
+      "delay": "10 s"
+    }
+  ],
     "death_function": {
       "effect": { "id": "death_conflagration", "hit_self": true },
       "message": "The %s explodes!",

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -85,6 +85,7 @@ static const mon_flag_str_id mon_flag_ACIDTRAIL( "ACIDTRAIL" );
 static const mon_flag_str_id mon_flag_AQUATIC( "AQUATIC" );
 static const mon_flag_str_id mon_flag_ATTACKMON( "ATTACKMON" );
 static const mon_flag_str_id mon_flag_CAN_OPEN_DOORS( "CAN_OPEN_DOORS" );
+static const mon_flag_str_id mon_flag_DRIPS_GASOLINE( "DRIPS_BLOBFUEL" );
 static const mon_flag_str_id mon_flag_DRIPS_GASOLINE( "DRIPS_GASOLINE" );
 static const mon_flag_str_id mon_flag_DRIPS_NAPALM( "DRIPS_NAPALM" );
 static const mon_flag_str_id mon_flag_ELECTRIC( "ELECTRIC" );

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -2124,7 +2124,7 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
         if( has_flag( mon_flag_DRIPS_GASOLINE ) ) {
             if( one_in( 5 ) ) {
                 // TODO: use same idea that limits napalm dripping
-                here.add_item_or_charges( pos(), item( "gasoline" ) );
+                here.add_item_or_charges( pos(), item( "blobfuel" ) );
             }
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Updates to Gasoline Zombies"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

As gasoline zombies no longer spontaneously explode, they don't present any real threat to a player who has a ranged weapon, and are easily used to gain a valuable resource without and danger.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
 Gasoline Zombies now drip tainted fuel, a nasty chemical mixture polluted with decaying zombie tissue which contains roughly 2/3rds of gasoline energy potential. It can still be used in a gas lantern but isn't suitable for cooking or use in an engine. Adds new fuel and ammo type, as well as a new flag (DRIPS_BLOBFUEL).
- [ ] update flags.json
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Original idea was to make gas zombies emit heat and eventually overheat an enclosed area, causing them to explode.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
WIP
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
We have in the past been very clear about the inability to use zombies as labor, resource farm fits under that rule. This non-explosive change still leaves a resource (tainted fuel oh oh) but as it cannot power a vehicle, should be of less value.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
