### PR TITLE
Allow npctalk messages to parse nested tags

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -484,6 +484,18 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_string_test_nest",
+    "effect": [
+      { "u_add_var": "nest1", "value": "nest2" },
+      { "u_add_var": "nest2", "value": "nest3" },
+      { "u_add_var": "nest3", "value": "nest4" },
+      { "set_string_var": "<u_val:nest1>", "target_var": { "u_val": "key1" }, "parse_tags": true },
+      { "set_string_var": "<u_val:<u_val:nest1>>", "target_var": { "u_val": "key2" }, "parse_tags": true },
+      { "set_string_var": "<u_val:<u_val:<u_val:nest1>>>", "target_var": { "u_val": "key3" }, "parse_tags": true }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_character_finished_activity_event_test",
     "eoc_type": "EVENT",
     "required_event": "character_finished_activity",

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2006,10 +2006,18 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
     const Character *me_chr = me.get_character();
     size_t fa;
     size_t fb;
+    size_t fa_;
     std::string tag;
     do {
         fa = phrase.find( '<' );
         fb = phrase.find( '>' );
+        fa_ = fa;
+        do {
+            fa_ = phrase.find( '<', fa_ + 1 );
+            if( fa_ < fb ) {
+                fb = phrase.find( '>', fb + 1 );
+            }
+        } while( fa_ > fb && fa_ != std::string::npos && fb != std::string::npos );
         int l = fb - fa + 1;
         if( fa != std::string::npos && fb != std::string::npos ) {
             tag = phrase.substr( fa, fb - fa + 1 );
@@ -2085,18 +2093,24 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
             var.pop_back();
+            // resolve nest
+            parse_tags( var, u, me, d, item_type );
             phrase.replace( fa, l, u.get_value( "npctalk_var_" + var ) );
         } else if( tag.find( "<npc_val:" ) != std::string::npos ) {
             //adding a npc variable to the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
             var.pop_back();
+            // resolve nest
+            parse_tags( var, u, me, d, item_type );
             phrase.replace( fa, l, me.get_value( "npctalk_var_" + var ) );
         } else if( tag.find( "<global_val:" ) != std::string::npos ) {
             //adding a global variable to the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
             var.pop_back();
+            // resolve nest
+            parse_tags( var, u, me, d, item_type );
             global_variables &globvars = get_globals();
             phrase.replace( fa, l, globvars.get_global_value( "npctalk_var_" + var ) );
         } else if( tag.find( "<context_val:" ) != std::string::npos ) {
@@ -2104,12 +2118,16 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
             var.pop_back();
+            // resolve nest
+            parse_tags( var, u, me, d, item_type );
             phrase.replace( fa, l, d.get_value( "npctalk_var_" + var ) );
         } else if( tag.find( "<item_name:" ) != std::string::npos ) {
             //embedding an items name in the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
             var.pop_back();
+            // resolve nest
+            parse_tags( var, u, me, d, item_type );
             // attempt to cast as an item
             phrase.replace( fa, l, itype_id( var )->nname( 1 ) );
         } else if( tag.find( "<item_description:" ) != std::string::npos ) {
@@ -2117,6 +2135,8 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
             var.pop_back();
+            // resolve nest
+            parse_tags( var, u, me, d, item_type );
             // attempt to cast as an item
             phrase.replace( fa, l, itype_id( var )->description.translated() );
         } else if( tag.find( "<trait_name:" ) != std::string::npos ) {
@@ -2124,6 +2144,8 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
             var.pop_back();
+            // resolve nest
+            parse_tags( var, u, me, d, item_type );
             // attempt to cast as an item
             phrase.replace( fa, l, trait_id( var )->name() );
         } else if( tag.find( "<trait_description:" ) != std::string::npos ) {
@@ -2131,6 +2153,8 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
             var.pop_back();
+            // resolve nest
+            parse_tags( var, u, me, d, item_type );
             // attempt to cast as an item
             phrase.replace( fa, l, trait_id( var )->desc() );
         } else if( tag.find( "<city>" ) != std::string::npos ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2011,13 +2011,18 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
     do {
         fa = phrase.find( '<' );
         fb = phrase.find( '>' );
-        fa_ = fa;
-        do {
-            fa_ = phrase.find( '<', fa_ + 1 );
-            if( fa_ < fb ) {
+        if( fa != std::string::npos ) {
+            size_t nest = 0;
+            fa_ = phrase.find( '<', fa + 1 );
+            while( fa_ < fb && fa_ != std::string::npos ) {
+                nest++;
+                fa_ = phrase.find( '<', fa_ + 1 );
+            }
+            while( nest > 0 && fb != std::string::npos ) {
+                nest--;
                 fb = phrase.find( '>', fb + 1 );
             }
-        } while( fa_ > fb && fa_ != std::string::npos && fb != std::string::npos );
+        }
         int l = fb - fa + 1;
         if( fa != std::string::npos && fb != std::string::npos ) {
             tag = phrase.substr( fa, fb - fa + 1 );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2093,7 +2093,7 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             const npc *guy = dynamic_cast<const npc *>( me_chr );
             std::string restock_interval = guy ? guy->get_restock_interval() : _( "a few days" );
             phrase.replace( fa, l, restock_interval );
-        } else if( tag.find( "<u_val:" ) != std::string::npos ) {
+        } else if( tag.find( "<u_val:" ) == 0 ) {
             //adding a user variable to the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
@@ -2101,7 +2101,7 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             // resolve nest
             parse_tags( var, u, me, d, item_type );
             phrase.replace( fa, l, u.get_value( "npctalk_var_" + var ) );
-        } else if( tag.find( "<npc_val:" ) != std::string::npos ) {
+        } else if( tag.find( "<npc_val:" ) == 0 ) {
             //adding a npc variable to the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
@@ -2109,7 +2109,7 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             // resolve nest
             parse_tags( var, u, me, d, item_type );
             phrase.replace( fa, l, me.get_value( "npctalk_var_" + var ) );
-        } else if( tag.find( "<global_val:" ) != std::string::npos ) {
+        } else if( tag.find( "<global_val:" ) == 0 ) {
             //adding a global variable to the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
@@ -2118,7 +2118,7 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             parse_tags( var, u, me, d, item_type );
             global_variables &globvars = get_globals();
             phrase.replace( fa, l, globvars.get_global_value( "npctalk_var_" + var ) );
-        } else if( tag.find( "<context_val:" ) != std::string::npos ) {
+        } else if( tag.find( "<context_val:" ) == 0 ) {
             //adding a context variable to the string requires dialogue to exist
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
@@ -2126,7 +2126,7 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             // resolve nest
             parse_tags( var, u, me, d, item_type );
             phrase.replace( fa, l, d.get_value( "npctalk_var_" + var ) );
-        } else if( tag.find( "<item_name:" ) != std::string::npos ) {
+        } else if( tag.find( "<item_name:" ) == 0 ) {
             //embedding an items name in the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
@@ -2135,7 +2135,7 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             parse_tags( var, u, me, d, item_type );
             // attempt to cast as an item
             phrase.replace( fa, l, itype_id( var )->nname( 1 ) );
-        } else if( tag.find( "<item_description:" ) != std::string::npos ) {
+        } else if( tag.find( "<item_description:" ) == 0 ) {
             //embedding an items name in the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
@@ -2144,7 +2144,7 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             parse_tags( var, u, me, d, item_type );
             // attempt to cast as an item
             phrase.replace( fa, l, itype_id( var )->description.translated() );
-        } else if( tag.find( "<trait_name:" ) != std::string::npos ) {
+        } else if( tag.find( "<trait_name:" ) == 0 ) {
             //embedding an items name in the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
@@ -2153,7 +2153,7 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             parse_tags( var, u, me, d, item_type );
             // attempt to cast as an item
             phrase.replace( fa, l, trait_id( var )->name() );
-        } else if( tag.find( "<trait_description:" ) != std::string::npos ) {
+        } else if( tag.find( "<trait_description:" ) == 0 ) {
             //embedding an items name in the string
             std::string var = tag.substr( tag.find( ':' ) + 1 );
             // remove the trailing >
@@ -2162,7 +2162,7 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             parse_tags( var, u, me, d, item_type );
             // attempt to cast as an item
             phrase.replace( fa, l, trait_id( var )->desc() );
-        } else if( tag.find( "<city>" ) != std::string::npos ) {
+        } else if( tag.find( "<city>" ) == 0 ) {
             std::string cityname = "nowhere";
             tripoint_abs_sm abs_sub = get_map().get_abs_sub();
             const city *c = overmap_buffer.closest_city( abs_sub ).city;

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -88,6 +88,8 @@ effect_on_condition_EOC_stored_condition_test( "EOC_stored_condition_test" );
 static const effect_on_condition_id
 effect_on_condition_EOC_string_test( "EOC_string_test" );
 static const effect_on_condition_id
+effect_on_condition_EOC_string_test_nest( "EOC_string_test_nest" );
+static const effect_on_condition_id
 effect_on_condition_EOC_string_var_var( "EOC_string_var_var" );
 static const effect_on_condition_id effect_on_condition_EOC_teleport_test( "EOC_teleport_test" );
 static const effect_on_condition_id effect_on_condition_EOC_try_kill( "EOC_try_kill" );
@@ -1039,4 +1041,9 @@ TEST_CASE( "EOC_string_test", "[eoc]" )
     CHECK( effect_on_condition_EOC_string_test->activate( d ) );
     CHECK( globvars.get_global_value( "npctalk_var_key3" ) == "<global_val:key1> <global_val:key2>" );
     CHECK( globvars.get_global_value( "npctalk_var_key4" ) == "test1 test2" );
+
+    CHECK( effect_on_condition_EOC_string_test_nest->activate( d ) );
+    CHECK( get_avatar().get_value( "npctalk_var_key1" ) == "nest2" );
+    CHECK( get_avatar().get_value( "npctalk_var_key2" ) == "nest3" );
+    CHECK( get_avatar().get_value( "npctalk_var_key3" ) == "nest4" );
 }


### PR DESCRIPTION
#### Summary
Features "Allow messages to parse nested tags"

#### Purpose of change
npctalk tags cant parse nested tags like "<item_name:<u_val:item_var>>"
For this reason, it is not possible to store the item ID in a variable and refer to the item name.

#### Describe the solution
Implement nested tag.

#### Describe alternatives you've considered


#### Testing
Add Cl test.

#### Additional context
