### PR TITLE
Allow math: u_val() function to expand variables

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -318,5 +318,14 @@
         "else": { "u_message": "Canceled" }
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_math_u_val_test",
+    "effect": [
+      { "u_add_var": "test_spell_id", "value": "art_summon_bees" },
+      { "math": [ "u_slv", "=", "u_val('spell_level', 'spell': u_test_spell_id)" ] },
+      { "u_message": "art_summon_bees: <u_val:slv>" }
+    ]
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
math: u_val() function does not expand variables, so writing something like the following will result in an error

```
      { "u_add_var": "test_spell_id", "value": "art_summon_bees" },
      { "math": [ "u_slv", "=", "u_val('spell_level', 'spell': u_test_spell_id)" ] },
      { "u_message": "art_summon_bees: <u_val:slv>" }
```

#### Describe the solution
Allow math: u_val() function to expand variables.

#### Describe alternatives you've considered

#### Testing

#### Additional context
