### PR TITLE
Add corded electric chainsaw

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -441,6 +441,7 @@
       { "item": "radio", "prob": 20, "charges": [ 0, 100 ] },
       [ "chainsaw_off", 7 ],
       { "item": "elec_chainsaw_off", "prob": 4, "charges": [ 0, 500 ] },
+      { "item": "elec_chainsaw_cord_off", "prob": 4 },
       { "item": "carver_off", "prob": 7, "charges": [ 0, 500 ] },
       [ "jackhammer", 2 ],
       [ "elec_jackhammer", 1 ],

--- a/data/json/itemgroups/tools.json
+++ b/data/json/itemgroups/tools.json
@@ -886,6 +886,7 @@
       { "item": "chainsaw_off", "prob": 10, "charges": [ 0, 450 ] },
       { "item": "polesaw_off", "prob": 10, "charges": [ 0, 450 ] },
       { "item": "elec_chainsaw_off", "prob": 10, "charges": [ 0, 500 ] },
+      { "item": "elec_chainsaw_cord_off", "prob": 10 },
       { "item": "trimmer_off", "prob": 40, "charges": [ 0, 600 ] },
       { "item": "jackhammer", "prob": 50, "charges": [ 0, 1200 ] },
       { "item": "elec_jackhammer", "prob": 50, "charges": [ 0, 1320 ] },
@@ -913,7 +914,8 @@
       { "item": "bow_saw", "prob": 80 },
       { "item": "circsaw_off", "prob": 50, "charges": [ 0, 500 ] },
       [ "circsaw_blade", 10 ],
-      { "item": "elec_chainsaw_off", "prob": 35, "charges": [ 0, 500 ] }
+      { "item": "elec_chainsaw_off", "prob": 35, "charges": [ 0, 500 ] },
+      { "item": "elec_chainsaw_cord_off", "prob": 35 }
     ]
   },
   {

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -267,6 +267,28 @@
     "melee_damage": { "bash": 4, "cut": 70 }
   },
   {
+    "id": "elec_chainsaw_cord_off",
+    "copy-from": "elec_chainsaw_off",
+    "looks_like": "elec_chainsaw_off",
+    "type": "TOOL",
+    "price": "66 USD",
+    "name": { "str": "corded electric chainsaw (off)", "str_pl": "corded electric chainsaws (off)" },
+    "description": "A treecutting tool moonlighting as a weapon of opportunity.  It has a short electric cord, which you can connect to the generator or your home grid.  Extension cord not included.",
+    "use_action": [ "ELEC_CHAINSAW_OFF", { "type": "link_up", "cable_length": 4, "charge_rate": "2400 W" } ],
+    "pocket_data": [  ]
+  },
+  {
+    "id": "elec_chainsaw_cord_on",
+    "copy-from": "elec_chainsaw_off",
+    "looks_like": "elec_chainsaw_on",
+    "type": "TOOL",
+    "name": { "str": "corded electric chainsaw (on)", "str_pl": "corded electric chainsaws (on)" },
+    "use_action": [ "TOOLWEAPON_DEACTIVATE", { "type": "link_up", "cable_length": 4, "charge_rate": "2400 W" } ],
+    "tick_action": [ "ELEC_CHAINSAW_ON" ],
+    "qualities": [ [ "AXE", 4 ], [ "BUTCHER", -100 ] ],
+    "revert_to": "elec_chainsaw_cord_off"
+  },
+  {
     "id": "hand_axe",
     "type": "TOOL",
     "name": { "str": "stone axe head" },

--- a/data/json/items/tool/woodworking.json
+++ b/data/json/items/tool/woodworking.json
@@ -285,7 +285,9 @@
     "name": { "str": "corded electric chainsaw (on)", "str_pl": "corded electric chainsaws (on)" },
     "use_action": [ "TOOLWEAPON_DEACTIVATE", { "type": "link_up", "cable_length": 4, "charge_rate": "2400 W" } ],
     "tick_action": [ "ELEC_CHAINSAW_ON" ],
+    "power_draw": "2 kW",
     "qualities": [ [ "AXE", 4 ], [ "BUTCHER", -100 ] ],
+    "flags": [ "MESSY", "TRADER_AVOID", "NONCONDUCTIVE", "POWERED", "FRAGILE_MELEE" ],
     "revert_to": "elec_chainsaw_cord_off"
   },
   {


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Someone told it would be nice
They never actually made it
#### Describe the solution
Added corded electric chainsaw, which copies the stats of electric chainsaw, but except of using baterries it has a short cord
#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/603d5a47-fe50-4fa5-860e-51aac8ae0d89)
#### Additional context
`Chop tree` zone seems to not work good without really long cord