### PR TITLE
No more house of dogs

### DIFF
--- a/data/json/mapgen/house/house_rural.json
+++ b/data/json/mapgen/house/house_rural.json
@@ -128,7 +128,7 @@
         { "chance": 35, "item": "misc_smoking", "x": 9, "y": 17 },
         { "chance": 35, "item": "misc_smoking", "x": 10, "y": 14 }
       ],
-      "place_monsters": [ { "monster": "GROUP_DOGS", "x": 5, "y": 14 } ]
+      "place_monster": [ { "group": "GROUP_VANILLA", "x": [ 5, 8 ], "y": [ 7, 14 ], "chance": 50, "repeat": [ 2, 4 ] } ]
     }
   },
   {


### PR DESCRIPTION
#### Summary
Bugfixes "Changes the house full of zombie dogs to normal"

#### Purpose of change
While debug-exploring I found out a weird house... One that I immediately knew what the problem was... We were attacked again by the sinister `place_monsters`...

#### Describe the solution
Changes the monster spawns in rural_house2 to use `place_monster` and replaced the dogs with more variety of zombies, since the house itself by default does not spawns anything related to dogs, like, at all.

#### Describe alternatives you've considered
To continue filling the house with dogs and just adding more dog related stuff to the house, but this is just a minor fix that I decided to make since I found this problem in the wild...

#### Testing
It works!

#### Additional context
**This** is what motivated me to change the spawns...
![imagen](https://github.com/CleverRaven/Cataclysm-DDA/assets/53200489/0e90ec97-0063-48c2-87ef-3e8f9acc69ec)

