### PR TITLE
Add Accessibility mod category

### DIFF
--- a/data/mods/Generic_Guns/modinfo.json
+++ b/data/mods/Generic_Guns/modinfo.json
@@ -6,7 +6,7 @@
     "authors": [ "Tonkatsu" ],
     "maintainers": [ "Tonkatsu" ],
     "description": "Replaces guns and ammo with generic types.  Warning: can cause issues with other gun mods.",
-    "category": "items",
+    "category": "accessibility",
     "dependencies": [ "dda" ]
   }
 ]

--- a/data/mods/translate-dialogue/modinfo.json
+++ b/data/mods/translate-dialogue/modinfo.json
@@ -5,7 +5,7 @@
     "name": "Translate Complex Dialogue",
     "authors": [ "I-am-Erk" ],
     "description": "Adds a translation for some of the weirder dialogue in game.  Keeps the original flavour dialogue visible.",
-    "category": "misc_additions",
+    "category": "accessibility",
     "dependencies": [ "dda" ]
   }
 ]

--- a/doc/IN_REPO_MODS.md
+++ b/doc/IN_REPO_MODS.md
@@ -21,7 +21,7 @@ There are however things that might be expected but are not guaranteed:
 There are three primary categories of mods:
 
 *  Content mods, which provide some kind of distinct experience from the core Dark Days Ahead game. This could be a change to lore, a change to a specific part of gameplay.
-*  User Experience (UX) mods, which alter the look and feel of the game interface itself.
+*  User Experience (UX) mods, which alter the look and feel of the game interface itself. Accessibility mods fall under this category.
 *  Development mods, which aren't "mods" in the typical sense but are instead there to ease the transition between "incomplete feature" and "complete feature", when a feature in the core game is sufficiently incomplete that the developers believe it needs to be optional to minimize disruption to players.
 
 ## What is necessary for a mod to be included in the repository?

--- a/doc/IN_REPO_MODS.md
+++ b/doc/IN_REPO_MODS.md
@@ -27,6 +27,7 @@ There are three primary categories of mods:
 ## What is necessary for a mod to be included in the repository?
 
 The most crucial criteria for a mod to be in the CleverRaven repository is that it has someone acting as a curator. This ensures that there is someone who is keeping an eye out for possible problems with the mod, and helping steer its development so that it continues to develop in accordance with its design purpose.
+In some rare cases we might treat a mod as an important but optional extension of the game itself, such as for some accessibility or development mods. When that happens, the 'curator' is the developer and contributor team collectively, just as with Dark Days Ahead itself. We try to do this sparingly, due to the obvious difficulty of pushing volunteers towards tasks they aren't personally interested in.
 
 Furthermore, there are additional criteria:
 

--- a/doc/IN_REPO_MODS.md
+++ b/doc/IN_REPO_MODS.md
@@ -21,7 +21,7 @@ There are however things that might be expected but are not guaranteed:
 There are three primary categories of mods:
 
 *  Content mods, which provide some kind of distinct experience from the core Dark Days Ahead game. This could be a change to lore, a change to a specific part of gameplay.
-*  User Experience (UX) mods, which alter the look and feel of the game interface itself. Accessibility mods fall under this category.
+*  User Experience (UX) mods, which alter the look and feel of the game interface itself. Accessibility mods, which make it possible for someone to play the game when they otherwise couldn't, fall under this category. Mods which simply adjust game elements for preferences and taste do not.
 *  Development mods, which aren't "mods" in the typical sense but are instead there to ease the transition between "incomplete feature" and "complete feature", when a feature in the core game is sufficiently incomplete that the developers believe it needs to be optional to minimize disruption to players.
 
 ## What is necessary for a mod to be included in the repository?

--- a/src/mod_manager.cpp
+++ b/src/mod_manager.cpp
@@ -70,6 +70,7 @@ const std::vector<std::pair<std::string, translation>> &get_mod_list_categories(
         {"item_exclude", to_translation( "ITEM EXCLUSION MODS" )},
         {"monster_exclude", to_translation( "MONSTER EXCLUSION MODS" )},
         {"graphical", to_translation( "GRAPHICAL MODS" )},
+        {"accessibility", to_translation( "ACCESSIBILITY MODS" )},
         {"", to_translation( "NO CATEGORY" )}
     };
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

#### Purpose of change

- Add Accessibility mod category
- Clarify rule about accessibility mods a little bit
- Put Generic Guns, and Translate Complex Dialogue in the Acessibility category

#### Describe the solution

- add category
- add a sentence in IN_REPO_MODS.md
- put GG in the accessibility category

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41293484/084e57bd-b839-4005-9cf2-3713c395d6d9)
#### Additional context

This also clarifies that I was wrong about https://github.com/CleverRaven/Cataclysm-DDA/pull/64388 while the solution was probably not the one we'd want the mod could be welcome in the repo

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
