### PR TITLE
Performance: Optimize monster planning

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -168,7 +168,10 @@ Creature::Creature( Creature && ) noexcept( map_is_noexcept &&list_is_noexcept )
 Creature &Creature::operator=( const Creature & ) = default;
 Creature &Creature::operator=( Creature && ) noexcept = default;
 
-Creature::~Creature() = default;
+Creature::~Creature()
+{
+    get_map().remove_creature_from_reachability( this );
+}
 
 tripoint Creature::pos() const
 {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -170,7 +170,9 @@ Creature &Creature::operator=( Creature && ) noexcept = default;
 
 Creature::~Creature()
 {
-    get_map().remove_creature_from_reachability( this );
+    if( g ) {
+        get_map().remove_creature_from_reachability( this );
+    }
 }
 
 tripoint Creature::pos() const

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -46,6 +46,7 @@
 #include "field.h"
 #include "field_type.h"
 #include "flag.h"
+#include "flood_fill.h"
 #include "fragment_cloud.h"
 #include "fungal_effects.h"
 #include "game.h"
@@ -10269,5 +10270,68 @@ tripoint drawsq_params::center() const
         return player_character.pos() + player_character.view_offset;
     } else {
         return view_center;
+    }
+}
+
+/** This is lazily evaluated on demand. Each creature in a zone is visited
+ * as it flood fills, then the zone number is incremented. At the end all creatures in
+ * the same zone will have the same zone number assigned, which can be used to have creatures in
+ * different zones ignore each other very cheaply.
+ */
+void map::flood_fill_zone( const Creature &origin )
+{
+    creature_tracker &tracker = get_creature_tracker();
+
+    ff::flood_fill_visit_10_connected( origin.pos_bub(),
+    [this]( const tripoint_bub_ms & loc, int direction ) {
+        if( direction == 0 ) {
+            return inbounds( loc ) && ( is_transparent_wo_fields( loc.raw() ) ||
+                                        passable( loc ) );
+        }
+        if( direction == 1 ) {
+            const maptile &up = maptile_at( loc );
+            const ter_t &up_ter = up.get_ter_t();
+            if( up_ter.id.is_null() ) {
+                return false;
+            }
+            if( ( ( up_ter.movecost != 0 && up.get_furn_t().movecost >= 0 ) ||
+                  is_transparent_wo_fields( loc.raw() ) ) &&
+                ( up_ter.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) ||
+                  up_ter.has_flag( ter_furn_flag::TFLAG_GOES_DOWN ) ) ) {
+                return true;
+            }
+        }
+        if( direction == -1 ) {
+            const maptile &up = maptile_at( loc + tripoint_above );
+            const ter_t &up_ter = up.get_ter_t();
+            if( up_ter.id.is_null() ) {
+                return false;
+            }
+            const maptile &down = maptile_at( loc );
+            const ter_t &down_ter = up.get_ter_t();
+            if( down_ter.id.is_null() ) {
+                return false;
+            }
+            if( ( ( down_ter.movecost != 0 && down.get_furn_t().movecost >= 0 ) ||
+                  is_transparent_wo_fields( loc.raw() ) ) &&
+                ( up_ter.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) ||
+                  up_ter.has_flag( ter_furn_flag::TFLAG_GOES_DOWN ) ) ) {
+                return true;
+            }
+        }
+        return false;
+    },
+    [&tracker, this]( const tripoint_bub_ms & loc ) {
+        Creature *creature = tracker.creature_at<Creature>( loc );
+        if( creature ) {
+            const int n = zone_number * zone_tick;
+            creatures_by_zone[n].push_back( creature );
+            creature->set_reachable_zone( n );
+        }
+    } );
+    if( zone_number == std::numeric_limits<int>::max() ) {
+        zone_number = 1;
+    } else {
+        zone_number++;
     }
 }

--- a/src/map.h
+++ b/src/map.h
@@ -2236,14 +2236,59 @@ class map
         bool _main_requires_cleanup = false;
         std::optional<bool> _main_cleanup_override = std::nullopt;
 
-        // Tracks the dirtiness of the visitable zones cache, but that cache does not live here,
-        // it is distributed among the active monsters. This must be flipped when
+        // Tracks the dirtiness of the visitable zones cache. This must be flipped when
         // persistent visibility from terrain or furniture changes
         // (this excludes vehicles and fields) or when persistent traversability changes,
         // which means walls and floors.
         bool visitable_cache_dirty = false;
+        int zone_number = 1;
+        int zone_tick = 1;
+        std::unordered_map<int, std::vector<Creature *>> creatures_by_zone;
+        std::unordered_set<Creature *> to_remove;
+
+        void flood_fill_zone( const Creature &origin );
+
+        void flood_fill_if_needed( const Creature &origin ) {
+            if( get_visitable_zones_cache_dirty() ) {
+                creatures_by_zone.clear();
+                to_remove.clear();
+                zone_tick = zone_tick > 0 ? -1 : 1;
+                set_visitable_zones_cache_dirty( false );
+                zone_number = 1;
+            }
+            // This check insures we only flood fill when the target monster has an uninitialized zone,
+            // or if it has a zone from last turn.  In other words it only triggers on
+            // the first monster in a zone each turn. We can detect this because the sign
+            // of the zone numbers changes on every invalidation.
+            int old_zone = origin.get_reachable_zone();
+            // Compare with zone_tick == old_zone && old_zone != 0
+            if( old_zone * zone_tick <= 0 ) {
+                flood_fill_zone( origin );
+            }
+        }
 
     public:
+        // Only call from the Creature destructor.
+        void remove_creature_from_reachability( Creature *creature ) {
+            to_remove.insert( creature );
+        }
+
+        template <typename Functor>
+        void visit_reachable_creatures( const Creature &origin, Functor f ) {
+            flood_fill_if_needed( origin );
+            const auto map_iter = creatures_by_zone.find( origin.get_reachable_zone() );
+            if( map_iter != creatures_by_zone.end() ) {
+                auto vector_iter = map_iter->second.begin();
+                const auto vector_end = map_iter->second.end();
+                for( ; vector_iter != vector_end; ++vector_iter ) {
+                    Creature *other = *vector_iter;
+                    if( to_remove.count( other ) == 0 ) {
+                        f( *other );
+                    }
+                }
+            }
+        }
+
         void queue_main_cleanup();
         bool is_main_cleanup_queued() const;
         void main_cleanup_override( bool over );

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -485,85 +485,6 @@ bool monster::mating_angry() const
     return mating_angry;
 }
 
-/** This is lazily evaluated in monster::plan(). Each monster in a zone is visited
- * as it flood fills, then the zone number is incremented. At the end all monsters in
- * the same zone will have the same zone number assigned, which can be used to have monsters in
- * different zones ignore each other very cheaply.
- */
-static void flood_fill_zone( Creature &origin )
-{
-    static int zone_number = 1;
-    static int zone_tick = 1;
-    map &here = get_map();
-    if( here.get_visitable_zones_cache_dirty() ) {
-        zone_tick = zone_tick > 0 ? -1 : 1;
-        here.set_visitable_zones_cache_dirty( false );
-        zone_number = 1;
-    }
-    // This check insures we only flood fill when the target monster has an uninitialized zone,
-    // or if it has a zone from last turn.  In other words it only triggers on
-    // the first monster in a zone each turn. We can detect this because the sign
-    // of the zone numbers changes on every invalidation.
-    int old_zone = origin.get_reachable_zone();
-    // Compare with zone_tick == old_zone && old_zone != 0
-    if( ( zone_tick > 0 && old_zone > 0 ) ||
-        ( zone_tick < 0 && old_zone < 0 ) ) {
-        return;
-    }
-    creature_tracker &tracker = get_creature_tracker();
-
-    ff::flood_fill_visit_10_connected( origin.pos_bub(),
-    [&here]( const tripoint_bub_ms & loc, int direction ) {
-        if( direction == 0 ) {
-            return here.inbounds( loc ) && ( here.is_transparent_wo_fields( loc.raw() ) ||
-                                             here.passable( loc ) );
-        }
-        if( direction == 1 ) {
-            const maptile &up = here.maptile_at( loc );
-            const ter_t &up_ter = up.get_ter_t();
-            if( up_ter.id.is_null() ) {
-                return false;
-            }
-            if( ( ( up_ter.movecost != 0 && up.get_furn_t().movecost >= 0 ) ||
-                  here.is_transparent_wo_fields( loc.raw() ) ) &&
-                ( up_ter.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) ||
-                  up_ter.has_flag( ter_furn_flag::TFLAG_GOES_DOWN ) ) ) {
-                return true;
-            }
-        }
-        if( direction == -1 ) {
-            const maptile &up = here.maptile_at( loc + tripoint_above );
-            const ter_t &up_ter = up.get_ter_t();
-            if( up_ter.id.is_null() ) {
-                return false;
-            }
-            const maptile &down = here.maptile_at( loc );
-            const ter_t &down_ter = up.get_ter_t();
-            if( down_ter.id.is_null() ) {
-                return false;
-            }
-            if( ( ( down_ter.movecost != 0 && down.get_furn_t().movecost >= 0 ) ||
-                  here.is_transparent_wo_fields( loc.raw() ) ) &&
-                ( up_ter.has_flag( ter_furn_flag::TFLAG_NO_FLOOR ) ||
-                  up_ter.has_flag( ter_furn_flag::TFLAG_GOES_DOWN ) ) ) {
-                return true;
-            }
-        }
-        return false;
-    },
-    [&tracker]( const tripoint_bub_ms & loc ) {
-        Creature *creature = tracker.creature_at<Creature>( loc );
-        if( creature ) {
-            creature->set_reachable_zone( zone_number * zone_tick );
-        }
-    } );
-    if( zone_number == std::numeric_limits<int>::max() ) {
-        zone_number = 1;
-    } else {
-        zone_number++;
-    }
-}
-
 void monster::plan()
 {
     const auto &factions = g->critter_tracker->factions();
@@ -574,7 +495,6 @@ void monster::plan()
     std::bitset<OVERMAP_LAYERS> seen_levels = here.get_inter_level_visibility( pos().z );
     monster_attitude mood = attitude();
     Character &player_character = get_player_character();
-    flood_fill_zone( *this );
     // If we can see the player, move toward them or flee.
     if( friendly == 0 && seen_levels.test( player_character.pos().z + OVERMAP_DEPTH ) &&
         sees( player_character ) ) {
@@ -679,52 +599,40 @@ void monster::plan()
                                  turns_since_target );
     int turns_to_skip = max_turns_to_skip * rate_limiting_factor;
     if( friendly == 0 && ( turns_to_skip == 0 || turns_since_target % turns_to_skip == 0 ) ) {
-        for( const auto &fac_list : factions ) {
-            mf_attitude faction_att = faction.obj().attitude( fac_list.first );
+        here.visit_reachable_creatures( *this, [this, &seen_levels, &mon_plan,
+              &valid_targets]( Creature & other ) {
+            mf_attitude faction_att = faction.obj().attitude( other.get_monster_faction() );
             if( faction_att == MFA_NEUTRAL || faction_att == MFA_FRIENDLY ) {
-                continue;
+                return;
             }
-
-            for( const auto &fac : fac_list.second ) {
-                if( !seen_levels.test( fac.first + OVERMAP_DEPTH ) ) {
-                    continue;
-                }
-                for( const weak_ptr_fast<monster> &weak : fac.second ) {
-                    const shared_ptr_fast<monster> shared = weak.lock();
-                    if( !shared ) {
-                        continue;
-                    }
-                    monster &mon = *shared;
-                    if( get_reachable_zone() != mon.get_reachable_zone() ) {
-                        continue;
-                    }
-                    float rating = rate_target( mon, mon_plan.dist, mon_plan.smart_planning );
-                    if( rating == mon_plan.dist ) {
-                        ++valid_targets;
-                        if( one_in( valid_targets ) ) {
-                            mon_plan.target = &mon;
-                        }
-                    }
-                    if( rating < mon_plan.dist ) {
-                        mon_plan.target = &mon;
-                        mon_plan.dist = rating;
-                        valid_targets = 1;
-                    }
-                    if( rating <= 5 ) {
-                        if( anger <= 30 ) {
-                            anger += mon_plan.angers_hostile_near;
-                        }
-                        morale -= mon_plan.fears_hostile_near;
-                    }
-                    if( !mon_plan.fleeing && anger <= 20 && valid_targets != 0 ) {
-                        anger += mon_plan.angers_hostile_seen;
-                    }
-                    if( !mon_plan.fleeing && valid_targets != 0 ) {
-                        morale -= mon_plan.fears_hostile_seen;
-                    }
+            if( !seen_levels.test( other.posz() + OVERMAP_DEPTH ) ) {
+                return;
+            }
+            float rating = rate_target( other, mon_plan.dist, mon_plan.smart_planning );
+            if( rating == mon_plan.dist ) {
+                ++valid_targets;
+                if( one_in( valid_targets ) ) {
+                    mon_plan.target = &other;
                 }
             }
-        }
+            if( rating < mon_plan.dist ) {
+                mon_plan.target = &other;
+                mon_plan.dist = rating;
+                valid_targets = 1;
+            }
+            if( rating <= 5 ) {
+                if( anger <= 30 ) {
+                    anger += mon_plan.angers_hostile_near;
+                }
+                morale -= mon_plan.fears_hostile_near;
+            }
+            if( !mon_plan.fleeing && anger <= 20 && valid_targets != 0 ) {
+                anger += mon_plan.angers_hostile_seen;
+            }
+            if( !mon_plan.fleeing && valid_targets != 0 ) {
+                morale -= mon_plan.fears_hostile_seen;
+            }
+        } );
     }
     if( mon_plan.target == nullptr ) {
         // Just avoiding overflow.

--- a/timed_event_list.output
+++ b/timed_event_list.output
@@ -1,0 +1,1 @@
+|;when;type;key;string_id;strength;map_point;faction_id;

--- a/timed_event_list.output
+++ b/timed_event_list.output
@@ -1,1 +1,0 @@
-|;when;type;key;string_id;strength;map_point;faction_id;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Reduced wait times in high traffic areas by ~15-20%"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Waiting in TCL is slow, there were a few easy ways to make it less slow.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Moved the reachability flood fill into map so it could be used in the monster planner to iterate over hostile monsters in O(monsters_in_zone) instead of O(all_monsters).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I originally was also using the zone reachability to optimize `sees`, but it ended up having no impact. I believe there are some other improvements that could be made to the zone reachability flood fill in general, but it's a pretty small part of the profile now. Worst part by far is the pathfinding.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Game doesn't crash and the tests pass. PR is still being worked on.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
