### PR TITLE
[Xedra Evolved] Reduce the installation requirements of some Mad Genius gunmods

### DIFF
--- a/data/mods/Xedra_Evolved/items/inventor/gunmods.json
+++ b/data/mods/Xedra_Evolved/items/inventor/gunmods.json
@@ -15,7 +15,7 @@
     "damage_modifier": { "damage_type": "bullet", "amount": 5 },
     "dispersion_modifier": 5,
     "loudness_modifier": 40,
-    "min_skills": [ [ "weapon", 4 ], [ "deduction", 5 ] ]
+    "min_skills": [ [ "weapon", 4 ], [ "deduction", 4 ] ]
   },
   {
     "id": "trinket_range",
@@ -33,7 +33,7 @@
     "range_modifier": 3,
     "damage_modifier": { "damage_type": "bullet", "amount": 6 },
     "dispersion_modifier": 40,
-    "min_skills": [ [ "weapon", 4 ], [ "deduction", 5 ] ]
+    "min_skills": [ [ "weapon", 4 ], [ "deduction", 4 ] ]
   },
   {
     "id": "trinket_sound",
@@ -51,7 +51,7 @@
     "loudness_modifier": -150,
     "damage_modifier": { "damage_type": "bullet", "amount": -4 },
     "range_modifier": -2,
-    "min_skills": [ [ "weapon", 4 ], [ "deduction", 5 ] ]
+    "min_skills": [ [ "weapon", 4 ], [ "deduction", 4 ] ]
   },
   {
     "id": "mod_inv_pistol_booster",
@@ -74,7 +74,7 @@
     "range_modifier": 2,
     "handling_modifier": 9,
     "//": "should add an additional set of mags, boosting the amount of ammo for three times, but alas not possible.",
-    "min_skills": [ [ "weapon", 4 ], [ "deduction", 5 ] ]
+    "min_skills": [ [ "weapon", 4 ], [ "deduction", 4 ] ]
   },
   {
     "id": "inventor_lasmod_close_range",

--- a/data/mods/Xedra_Evolved/items/inventor/gunmods.json
+++ b/data/mods/Xedra_Evolved/items/inventor/gunmods.json
@@ -15,7 +15,7 @@
     "damage_modifier": { "damage_type": "bullet", "amount": 5 },
     "dispersion_modifier": 5,
     "loudness_modifier": 40,
-    "min_skills": [ [ "weapon", 6 ], [ "deduction", 5 ] ]
+    "min_skills": [ [ "weapon", 4 ], [ "deduction", 5 ] ]
   },
   {
     "id": "trinket_range",
@@ -33,7 +33,7 @@
     "range_modifier": 3,
     "damage_modifier": { "damage_type": "bullet", "amount": 6 },
     "dispersion_modifier": 40,
-    "min_skills": [ [ "weapon", 6 ], [ "deduction", 5 ] ]
+    "min_skills": [ [ "weapon", 4 ], [ "deduction", 5 ] ]
   },
   {
     "id": "trinket_sound",
@@ -51,7 +51,7 @@
     "loudness_modifier": -150,
     "damage_modifier": { "damage_type": "bullet", "amount": -4 },
     "range_modifier": -2,
-    "min_skills": [ [ "weapon", 6 ], [ "deduction", 5 ] ]
+    "min_skills": [ [ "weapon", 4 ], [ "deduction", 5 ] ]
   },
   {
     "id": "mod_inv_pistol_booster",
@@ -74,7 +74,7 @@
     "range_modifier": 2,
     "handling_modifier": 9,
     "//": "should add an additional set of mags, boosting the amount of ammo for three times, but alas not possible.",
-    "min_skills": [ [ "weapon", 6 ], [ "deduction", 5 ] ]
+    "min_skills": [ [ "weapon", 4 ], [ "deduction", 5 ] ]
   },
   {
     "id": "inventor_lasmod_close_range",


### PR DESCRIPTION

#### Summary
None


#### Purpose of change

I feel that Weapon 6 for installating Mad Genius' gunmods is too big of an ask imo, so im changing it.

#### Describe the solution

`Weapon 6 -> weapon 4` and `deduction 5 -> deduction 4`
on gunmods:
- force silencer
- projectile accelerator
- rocket bullets
- pistol's booster
#### Describe alternatives you've considered

Not doing so.

#### Testing

It should work cuz it's basically just changing some numbers to 4.
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
