### PR TITLE
Expand snippet descriptions when variants are set

### DIFF
--- a/src/item.h
+++ b/src/item.h
@@ -2341,6 +2341,9 @@ class item : public visitable
 
         void clear_itype_variant();
 
+        // Description of the item provided by the variant, or an empty string
+        std::string variant_description() const;
+
         /**
          * Quantity of shots in the gun. Looks at both ammo and available energy.
          * @param carrier is used for UPS and bionic power


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Item variants spawned in the debug menu would manually set the variants, exposing that when a variant that requests snippets be expanded is set, the description of the item does not update.

#### Describe the solution
Follow the same process for expanding snippets in descriptions for variants if a variant requests it, when the variant is set.

Add a function to collapse all the places variant descriptions are generated to one place.

#### Testing
Open the debug menu, and spawn (one by one) the `mean mug` item (make sure it is the variant called `mean mug`, not the base item with the same name) many times. Open your inventory and see that they don't stack (meaning they all have different descriptions), and check the descriptions to ensure there are no `<fuck_you>, <name_b>`s.