### PR TITLE
allow disassembly of blanks

### DIFF
--- a/data/json/items/generic/casing.json
+++ b/data/json/items/generic/casing.json
@@ -45,6 +45,21 @@
     "weight": "1 g"
   },
   {
+    "id": "22_casing_new_short",
+    "looks_like": "22_casing_new",
+    "type": "GENERIC",
+    "category": "spare_parts",
+    "price": 90,
+    "price_postapoc": 0,
+    "name": { "str": "unused .22 blank casing" },
+    "symbol": "=",
+    "color": "yellow",
+    "description": "An unfired, like-new .22 round casing, with the primer still intact. This one appears to be sourced from a blank round and is thus shorter.": [ "powder", "brass" ],
+    "stackable": true,
+    "volume": "2 ml",
+    "weight": "1 g"
+  },
+  {
     "id": "3006_casing",
     "copy-from": "casing",
     "looks_like": "223_casing",

--- a/data/json/items/generic/casing.json
+++ b/data/json/items/generic/casing.json
@@ -51,7 +51,7 @@
     "category": "spare_parts",
     "price": 90,
     "price_postapoc": 0,
-    "name": { "str": "unused .22 blank casing" },
+    "name": { "str": "unused .22 short casing" },
     "symbol": "=",
     "color": "yellow",
     "description": "An unfired, like-new .22 round casing, with the primer still intact. This one appears to be sourced from a blank round and is thus shorter.",

--- a/data/json/items/generic/casing.json
+++ b/data/json/items/generic/casing.json
@@ -54,7 +54,7 @@
     "name": { "str": "unused .22 short casing" },
     "symbol": "=",
     "color": "yellow",
-    "description": "An unfired, like-new .22 round casing, with the primer still intact. This one appears to be sourced from a blank round and is thus shorter.",
+    "description": "An unfired, like-new .22 short casing, with the priming compound still intact.",
     "material": [ "powder", "brass" ],
     "stackable": true,
     "volume": "2 ml",

--- a/data/json/items/generic/casing.json
+++ b/data/json/items/generic/casing.json
@@ -54,7 +54,8 @@
     "name": { "str": "unused .22 blank casing" },
     "symbol": "=",
     "color": "yellow",
-    "description": "An unfired, like-new .22 round casing, with the primer still intact. This one appears to be sourced from a blank round and is thus shorter.": [ "powder", "brass" ],
+    "description": "An unfired, like-new .22 round casing, with the primer still intact. This one appears to be sourced from a blank round and is thus shorter.",
+    "material": [ "powder", "brass" ],
     "stackable": true,
     "volume": "2 ml",
     "weight": "1 g"

--- a/data/json/uncraft/ammo/22.json
+++ b/data/json/uncraft/ammo/22.json
@@ -6,7 +6,7 @@
     "skill_used": "gun",
     "difficulty": 5,
     "time": "5 s",
-    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
     "components": [ [ [ "22_casing_new", 1 ] ], [ [ "gunpowder_pistol", 1 ] ] ]
   },
   {

--- a/data/json/uncraft/ammo/22.json
+++ b/data/json/uncraft/ammo/22.json
@@ -1,5 +1,15 @@
 [
   {
+    "result": "22_blank",
+    "type": "uncraft",
+    "activity_level": "MODERATE_EXERCISE",
+    "skill_used": "gun",
+    "difficulty": 5,
+    "time": "5 s",
+    "qualities": [ { "id": "PULL", "level": 1 } ],
+    "components": [ [ [ "22_casing_new", 1 ] ], [ [ "gunpowder_pistol", 1 ] ] ]
+  },
+  {
     "result": "22_cb",
     "type": "uncraft",
     "activity_level": "MODERATE_EXERCISE",

--- a/data/json/uncraft/ammo/22.json
+++ b/data/json/uncraft/ammo/22.json
@@ -7,7 +7,7 @@
     "difficulty": 5,
     "time": "5 s",
     "qualities": [ { "id": "SCREW_FINE", "level": 1 } ],
-    "components": [ [ [ "22_casing_new", 1 ] ], [ [ "gunpowder_pistol", 1 ] ] ]
+    "components": [ [ [ "22_casing_new_short", 1 ] ], [ [ "gunpowder_pistol", 1 ] ] ]
   },
   {
     "result": "22_cb",


### PR DESCRIPTION
I noticed 22 blanks cannot be uncrafted into valuable gunpowder. This should fix it.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "allow disassembly of blanks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Allow disassembly of blanks to recover gunpowder and casings.

#### Describe the solution

Fixes what seems to be an oversight that excluded uncraft recipe for this item.

#### Describe alternatives you've considered

None seemed necessary.

#### Testing

Not tested.

#### Additional context

If someone thinks we need to add more uncraft recipes to some other blanks I am unaware of, perhaps we can do it with this PR since it would basically be fixing the same issue. **Also, just as heavier slugged versions of the same caliber come with less gunpowder (to prevent overpressure in the barrel), it seems some blanks are loaded with more gunpowder than ordinary rounds. Not sure if this should be reflected with _more_ gunpowder being generated from the disassembly of one of these.**