### PR TITLE
Fix missing labels in self-aware Spacebar UI

### DIFF
--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -1597,7 +1597,7 @@
       }
     ],
     "material_thickness": 1,
-    "flags": [ "BELTED", "WATER_FRIENDLY" ],
+    "flags": [ "BELTED", "WATER_FRIENDLY", "OVERSIZE" ],
     "armor": [
       {
         "encumbrance": 4,
@@ -1987,7 +1987,7 @@
       }
     ],
     "material_thickness": 1,
-    "flags": [ "FANCY", "BELTED", "WATER_FRIENDLY" ],
+    "flags": [ "FANCY", "BELTED", "WATER_FRIENDLY", "OVERSIZE" ],
     "armor": [
       {
         "encumbrance": 2,
@@ -2219,7 +2219,7 @@
     ],
     "warmth": 2,
     "material_thickness": 1,
-    "flags": [ "BELTED", "WATER_FRIENDLY" ],
+    "flags": [ "BELTED", "WATER_FRIENDLY", "OVERSIZE" ],
     "armor": [
       {
         "encumbrance": 2,
@@ -2550,7 +2550,7 @@
     ],
     "warmth": 0,
     "material_thickness": 0,
-    "flags": [ "BELTED", "WATER_FRIENDLY", "TARDIS" ],
+    "flags": [ "BELTED", "WATER_FRIENDLY", "TARDIS", "OVERSIZE" ],
     "armor": [ { "encumbrance": [ 0, 0 ], "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ]
   },
   {

--- a/data/json/items/armor/storage.json
+++ b/data/json/items/armor/storage.json
@@ -973,7 +973,7 @@
     ],
     "warmth": 10,
     "material_thickness": 1,
-    "flags": [ "BELTED", "WATER_FRIENDLY" ],
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
     "armor": [
       {
         "encumbrance": 5,

--- a/data/json/ui/spacebar/spacebar_body_and_health_block.json
+++ b/data/json/ui/spacebar/spacebar_body_and_health_block.json
@@ -145,12 +145,12 @@
     "arrange": "rows",
     "width": 12,
     "widgets": [
-      "hp_head_num_no_label",
-      "hp_torso_num_no_label",
-      "hp_left_arm_num_no_label",
-      "hp_right_arm_num_no_label",
-      "hp_left_leg_num_no_label",
-      "hp_right_leg_num_no_label"
+      "hp_head_num_label",
+      "hp_torso_num_label",
+      "hp_left_arm_num_label",
+      "hp_right_arm_num_label",
+      "hp_left_leg_num_label",
+      "hp_right_leg_num_label"
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

The optional self-aware health block for the Spacebar UI was using a widgets that came without labels that informed the player which limb is which. This change swaps them for the widgets that have those labels.

#### Purpose of change

Without the labels it's difficult to tell which limb you're looking at, you'd either have to memorize which line applies for which limb or make a guess.

#### Describe the solution

Swapping the self-aware widgets without labels for the ones that have them.

#### Describe alternatives you've considered

None, it's not intended to be without labels, you can obviously tell your limbs apart. On top of that, the non self-aware version has its limbs labeled, see images below.

#### Testing

![5345345](https://github.com/CleverRaven/Cataclysm-DDA/assets/45204409/0628d8ac-f025-407a-bd78-75fd694b3fa2)

My testing results:
![456456456464](https://github.com/CleverRaven/Cataclysm-DDA/assets/45204409/e7490923-313c-41d1-bb2b-ef50cef77cc7)


#### Additional context

None.
