### PR TITLE
Fix missing labels in self-aware Spacebar UI

### DIFF
--- a/data/json/ui/spacebar/spacebar_body_and_health_block.json
+++ b/data/json/ui/spacebar/spacebar_body_and_health_block.json
@@ -145,12 +145,12 @@
     "arrange": "rows",
     "width": 12,
     "widgets": [
-      "hp_head_num_no_label",
-      "hp_torso_num_no_label",
-      "hp_left_arm_num_no_label",
-      "hp_right_arm_num_no_label",
-      "hp_left_leg_num_no_label",
-      "hp_right_leg_num_no_label"
+      "hp_head_num_label",
+      "hp_torso_num_label",
+      "hp_left_arm_num_label",
+      "hp_right_arm_num_label",
+      "hp_left_leg_num_label",
+      "hp_right_leg_num_label"
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Swaps UI widgets with ones that have proper labels"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I[18](https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/6806198163/job/18507065794?pr=69194#step:2:19)N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
The optional self-aware health block for the Spacebar UI was using widgets that came without labels that informed the player which limb is which. This change swaps them for the widgets that have those labels. Without the labels it's difficult to tell which limb you're looking at, you'd either have to memorize which line applies for which limb or make a guess.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Swapping the self-aware widgets without labels for the ones that have them.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None, it's not intended to be without labels, you can obviously tell your limbs apart. On top of that, the non self-aware version has its limbs labeled, see images below.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
![5345345](https://github.com/CleverRaven/Cataclysm-DDA/assets/45204409/ba4299ac-cc4a-4292-b71e-70a14d84d361)

My testing results:
![456456456464](https://github.com/CleverRaven/Cataclysm-DDA/assets/45204409/dbde57f7-d98b-4481-882b-afdd54fd361b)


#### Additional context

None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->