### PR TITLE
Bulk unloading and dropping items saves time cost

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3949,6 +3949,7 @@ std::unique_ptr<activity_actor> drop_activity_actor::deserialize( JsonValue &jsi
     jsobj.read( "unhandled_containers", actor.handler );
     jsobj.read( "placement", actor.placement );
     jsobj.read( "force_ground", actor.force_ground );
+    jsobj.read( "current_bulk_unload", actor.current_bulk_unload );
 
     return actor.clone();
 }
@@ -4113,6 +4114,7 @@ std::unique_ptr<activity_actor> stash_activity_actor::deserialize( JsonValue &js
     jsobj.read( "items", actor.items );
     jsobj.read( "unhandled_containers", actor.handler );
     jsobj.read( "placement", actor.placement );
+    jsobj.read( "current_bulk_unload", actor.current_bulk_unload );
 
     return actor.clone();
 }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -1037,6 +1037,7 @@ class drop_activity_actor : public activity_actor
         contents_change_handler handler;
         tripoint placement;
         bool force_ground = false;
+        bool current_bulk_unload = false;
 };
 
 class stash_activity_actor: public activity_actor
@@ -1071,6 +1072,7 @@ class stash_activity_actor: public activity_actor
         std::vector<drop_or_stash_item_info> items;
         contents_change_handler handler;
         tripoint placement;
+        bool current_bulk_unload = false;
 };
 
 class harvest_activity_actor : public activity_actor


### PR DESCRIPTION
#### Summary
Balance "Bulk unloading and dropping items saves time cost"

#### Purpose of change
Follow up #68214
Reflecting the points pointed out in #68442

#### Describe the solution
Apply same solution as #68214 to "unload container" action

#### Describe alternatives you've considered


#### Testing
Consumed time(1000 salts)
Before: 50:00
After: 00:11

Consumed time(100 apples)
Before:  5:11
After: 00:14

#### Additional context
