### PR TITLE
Move the cockatrice to Mind Over Matter

### DIFF
--- a/data/mods/MindOverMatter/items/comestibles.json
+++ b/data/mods/MindOverMatter/items/comestibles.json
@@ -196,5 +196,12 @@
     "calories": 20,
     "fun": -6,
     "vitamins": [ [ "mutant_toxin", 800 ] ]
+  },
+  {
+    "type": "COMESTIBLE",
+    "id": "egg_cockatrice",
+    "name": { "str": "cockatrice egg" },
+    "copy-from": "egg_chicken",
+    "rot_spawn": "GROUP_EGG_COCKATRICE"
   }
 ]

--- a/data/mods/MindOverMatter/monstergroups/monstergroups_edited.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_edited.json
@@ -205,6 +205,9 @@
     "name": "GROUP_WILDERNESS_FOREST_MAMMAL_MUTANT",
     "default": "mon_null",
     "is_animal": true,
-    "monsters": [ { "monster": "mon_hodag", "weight": 1, "cost_multiplier": 10 } ]
+    "monsters": [
+      { "monster": "mon_hodag", "weight": 1, "cost_multiplier": 10 },
+      { "monster": "mon_cockatrice", "weight": 5, "starts": "10 days", "cost_multiplier": 10, "pack_size": [ 3, 5 ] }
+    ]
   }
 ]

--- a/data/mods/MindOverMatter/monstergroups/monstergroups_edited.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_edited.json
@@ -209,5 +209,26 @@
       { "monster": "mon_hodag", "weight": 1, "cost_multiplier": 10 },
       { "monster": "mon_cockatrice", "weight": 5, "starts": "10 days", "cost_multiplier": 10, "pack_size": [ 3, 5 ] }
     ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ROOF_ANIMAL",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [ { "monster": "mon_cockatrice", "weight": 2, "starts": "10 days", "cost_multiplier": 2 } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ROOF_ANIMAL",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [ { "monster": "mon_cockatrice", "weight": 10, "starts": "10 days", "cost_multiplier": 10, "pack_size": [ 3, 5 ] } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_SAFE",
+    "default": "mon_null",
+    "is_animal": true,
+    "monsters": [ { "monster": "mon_cockatrice", "weight": 2, "starts": "10 days" } ]
   }
 ]

--- a/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
+++ b/data/mods/MindOverMatter/monstergroups/monstergroups_new.json
@@ -179,5 +179,10 @@
       { "monster": "mon_darkman", "weight": 15, "cost_multiplier": 0 },
       { "monster": "mon_shoggoth", "weight": 5, "cost_multiplier": 0 }
     ]
+  },
+  {
+    "name": "GROUP_EGG_COCKATRICE",
+    "type": "monstergroup",
+    "monsters": [ { "monster": "mon_cockatrice_chick", "weight": 5 }, { "monster": "mon_chicken_chick", "weight": 1 } ]
   }
 ]

--- a/data/mods/MindOverMatter/monsters/animal_psychics.json
+++ b/data/mods/MindOverMatter/monsters/animal_psychics.json
@@ -100,5 +100,62 @@
     "biosignature": { "biosig_item": "feces_cow", "biosig_timer": 1 },
     "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "CORNERED_FIGHTER" ],
     "armor": { "bash": 16, "cut": 10, "stab": 10, "bullet": 4, "electric": 1 }
+  },
+  {
+    "id": "mon_cockatrice",
+    "type": "MONSTER",
+    "name": { "str": "cockatrice" },
+    "description": "This strange mutant bird gains its name from its odd appearance.  Although its features seem to be becoming more reptilian, it doesn't appear dangerous.  However, it looks at you like it understands you in some way.",
+    "default_faction": "small_animal",
+    "bodytype": "bird",
+    "categories": [ "WILDLIFE" ],
+    "species": [ "BIRD" ],
+    "volume": "750 ml",
+    "weight": "1 kg",
+    "hp": 20,
+    "speed": 130,
+    "material": [ "flesh" ],
+    "symbol": "v",
+    "color": "red",
+    "looks_like": "mon_chicken",
+    "aggression": 0,
+    "morale": 80,
+    "melee_skill": 2,
+    "melee_dice": 2,
+    "melee_dice_sides": 1,
+    "melee_damage": [ { "damage_type": "cut", "amount": 3 } ],
+    "dodge": 6,
+    "special_attacks": [
+      {
+        "id": "psi_cockatrice_telepathic_blast",
+        "type": "spell",
+        "spell_data": { "id": "telepathic_blast_monster", "min_level": 6 },
+        "cooldown": 18,
+        "monster_message": "%1$s stares and lets out a silent cry!"
+      }
+    ],
+    "anger_triggers": [ "HURT", "FRIEND_ATTACKED", "PLAYER_NEAR_BABY" ],
+    "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_flying", "prof_wp_basic_bird" ],
+    "weakpoint_sets": [ "wps_bird_body" ],
+    "harvest": "bird_tiny",
+    "dissect": "dissect_chimera_sample_small",
+    "reproduction": { "baby_egg": "egg_cockatrice", "baby_count": 3, "baby_timer": 10 },
+    "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ],
+    "biosignature": { "biosig_item": "feces_bird", "biosig_timer": 8 },
+    "flags": [ "SEES", "HEARS", "SMELLS", "ANIMAL", "PATH_AVOID_DANGER_1", "WARM", "FLIES", "CORNERED_FIGHTER" ]
+  },
+  {
+    "id": "mon_cockatrice_chick",
+    "type": "MONSTER",
+    "copy-from": "mon_generic_chick",
+    "description": "A strange tiny chick, it could be from a number of different species.",
+    "name": { "str": "strange chick" },
+    "petfood": {
+      "food": [ "BIRDFOOD" ],
+      "feed": "The %s seems to like you!  It runs around your legs and seems friendly.",
+      "pet": "The %s runs around your leg."
+    },
+    "extend": { "flags": [ "CANPLAY" ] },
+    "upgrades": { "age_grow": 12, "into": "mon_cockatrice" }
   }
 ]

--- a/data/mods/MindOverMatter/monsters/animal_psychics.json
+++ b/data/mods/MindOverMatter/monsters/animal_psychics.json
@@ -129,7 +129,7 @@
       {
         "id": "psi_cockatrice_telepathic_blast",
         "type": "spell",
-        "spell_data": { "id": "telepathic_blast_monster", "min_level": 6 },
+        "spell_data": { "id": "telepathic_fear_blast_monster", "min_level": 6 },
         "cooldown": 18,
         "monster_message": "%1$s stares and lets out a silent cry!"
       }

--- a/data/mods/MindOverMatter/monsters/monsters_spells.json
+++ b/data/mods/MindOverMatter/monsters/monsters_spells.json
@@ -374,6 +374,26 @@
     "ignored_monster_species": [ "ZOMBIE", "ROBOT", "NETHER", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME", "PSI_NULL" ]
   },
   {
+    "id": "telepathic_fear_blast_monster",
+    "type": "SPELL",
+    "name": "[Ψ]Telepathic Fear Blast Monster",
+    "description": "Short-circuit and overwhelm a target's brain, causing extreme damage or death, and instilling an extreme primal fear.  Does not affect targets without working brains.",
+    "valid_targets": [ "hostile" ],
+    "//": "The level scaling with this can get crazy, be especially careful with how high this will go.",
+    "flags": [ "CONCENTRATE", "NO_PROJECTILE", "SILENT", "NO_HANDS", "NO_LEGS" ],
+    "difficulty": 1,
+    "max_level": 20,
+    "effect": "attack",
+    "extra_effects": [
+      { "id": "telepathic_blast_monster", "hit_self": false, "max_level": 20 },
+      { "id": "telepathic_horror_monster", "hit_self": false, "max_level": 20 }
+    ],
+    "shape": "blast",
+    "min_range": 3,
+    "max_range": 15,
+    "range_increment": 1
+  },
+  {
     "id": "telepathic_horror_aoe_monster",
     "type": "SPELL",
     "name": { "str": "[Ψ]Telepathic Horror AoE Monster" },

--- a/data/mods/MindOverMatter/requirements.json
+++ b/data/mods/MindOverMatter/requirements.json
@@ -1,0 +1,34 @@
+[
+  {
+    "id": "eggs_bird",
+    "type": "requirement",
+    "//": "All of the different bird eggs. Extended from the original, requirements don't support \"copy-from\" without throwing a minor error on game loading.",
+    "components": [
+      [
+        [ "egg_bird", 1 ],
+        [ "egg_bird_unfert", 1 ],
+        [ "egg_chicken", 1 ],
+        [ "egg_grouse", 1 ],
+        [ "egg_crow", 1 ],
+        [ "egg_raven", 1 ],
+        [ "egg_bluejay", 1 ],
+        [ "egg_cardinal", 1 ],
+        [ "egg_robin", 1 ],
+        [ "egg_sparrow", 2 ],
+        [ "egg_duck", 1 ],
+        [ "egg_goose_canadian", 1 ],
+        [ "egg_turkey", 1 ],
+        [ "egg_pheasant", 1 ],
+        [ "egg_cockatrice", 1 ],
+        [ "egg_goose", 1 ],
+        [ "egg_goose_golden", 1 ],
+        [ "egg_hummingbird", 5 ],
+        [ "egg_woodpecker", 5 ],
+        [ "egg_coot", 1 ],
+        [ "egg_cormorant", 1 ],
+        [ "egg_moorhen", 1 ],
+        [ "egg_grebe", 1 ]
+      ]
+    ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Move the cockatrice to Mind Over Matter."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
With #69208 removing the cockatrice from the base game, I figured that it might be a good addition to Mind Over Matter, considering its mutant nature.
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Move most of the cockatrice code to Mind Over Matter. I decided to make it a telepathic monster, which begins spawning 10 days after the Cataclysm in most places where chickens can be found and wandering the wilderness on occasion. I did modify the aggression and morale to match the hodag, so the cockatrice could actually attack, but the monster is otherwise the same as it was before.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this, or leaving it in the base game.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Went into the game, played around with the cockatrices. Punched one in a large group and died quickly when they ganged up on me.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This relies on #69208 being merged. The cockatrice in this new form also has the tendency to gang up on threats with psychic barrages, much like the cuckoos from Legend of Zelda.

~I don't know about Mind Over Matter's lore all too well regarding psychic animals, so I don't know if psychic animals can birth more of themselves. I figured that the cockatrice's mutations and psychic powers were all caused by portal storms, and due to sufficient mutation, they could pass these traits on. @Standing-Storm is this lore-accurate?~
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
