### PR TITLE
NPC swarm fleeing; Some more fleeing tweaks based on reports

### DIFF
--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -689,7 +689,7 @@ void npc::assess_danger()
     }
 
     // being outnumbered is serious.  Do a flat scale up your assessment if you're outnumbered.
-    // Hostile_count counts enemies within a range of 15 who exceed the NPC's bravery, mitigated 
+    // Hostile_count counts enemies within a range of 15 who exceed the NPC's bravery, mitigated
     // how much pain they're currently experiencing. This means a very brave NPC might ignore
     // large crowds of minor creatures, until they start getting hurt.
     if( hostile_count > friendly_count ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -718,12 +718,12 @@ void npc::assess_danger()
     }
 
     assessment *= NPC_COWARDICE_MODIFIER;
+    int flee_checks_failed;
     if( !has_effect( effect_npc_run_away ) && !has_effect( effect_npc_fire_bad ) ) {
-        float my_diff = evaluate_enemy( *this ) * 0.5f + rng( 0,
-                        bravery_vs_pain * 2.5 ) ;
+        float my_diff = evaluate_enemy( *this ) * 0.5f + personality.bravery - ( get_pain() / 5 )  + rng( -5, 5 ) + rng( -3, 3 );
         add_msg_debug( debugmode::DF_NPC, "Enemy Danger: %1f, Ally Strength: %2f.", assessment, my_diff );
         if( my_diff < assessment ) {
-            time_duration run_away_for = 10_turns + 1_turns * rng( 0, 10 ) - 1_turns * personality.bravery;
+            time_duration run_away_for = 10_turns + 1_turns * rng( 0, 10 ) - 1_turns * personality.bravery + 1_turns * static_cast<int>( get_pain() / 5 );
             warn_about( "run_away", run_away_for );
             add_effect( effect_npc_run_away, run_away_for );
             path.clear();

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -570,7 +570,7 @@ void npc::assess_danger()
             if( critter_threat > ( 8.0f + personality.bravery + rng( 0, 5 ) ) ) {
                 warn_about( "monster", 10_minutes, critter.type->nname(), dist, critter.pos() );
             }
-            if( dist < 15 && critter_threat > bravery_vs_pain ) {
+            if( dist < 8 && critter_threat > bravery_vs_pain ) {
                 hostile_count += 1;
             }
         }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -716,8 +716,8 @@ void npc::assess_danger()
     assessment *= NPC_COWARDICE_MODIFIER;
     int flee_checks_failed;
     if( !has_effect( effect_npc_run_away ) && !has_effect( effect_npc_fire_bad ) ) {
-        float my_diff = evaluate_enemy( *this ) * 0.5f + personality.bravery - ( get_pain() / 5 ) 
-            + rng( -5, 5 ) + rng( -3, 3 );
+        float my_diff = evaluate_enemy( *this ) * 0.5f + personality.bravery - ( get_pain() / 5 )
+                        + rng( -5, 5 ) + rng( -3, 3 );
         add_msg_debug( debugmode::DF_NPC, "Enemy Danger: %1f, Ally Strength: %2f.", assessment, my_diff );
         if( my_diff < assessment ) {
             time_duration run_away_for = 10_turns + 1_turns * rng( 0, 10 ) - 1_turns * personality.bravery 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -705,7 +705,8 @@ void npc::assess_danger()
             float min_danger = assessment >= NPC_DANGER_VERY_LOW ? NPC_DANGER_VERY_LOW : -10.0f;
             if( dist <= 3 ) {
                 assessment = std::max( min_danger, assessment - player_diff * ( 4 - dist ) / 2 );
-                swarm_count = 0; // don't try to fall back with your ranged weapon if you're in formation with the player.
+                swarm_count = 0;
+                    // don't try to fall back with your ranged weapon if you're in formation with the player.
                 friendly_count += 4 - dist; // when close to the player, weight swarms less.
             } else {
                 assessment = std::max( min_danger, assessment - player_diff * 0.5f );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -706,7 +706,7 @@ void npc::assess_danger()
             if( dist <= 3 ) {
                 assessment = std::max( min_danger, assessment - player_diff * ( 4 - dist ) / 2 );
                 swarm_count = 0;
-                    // don't try to fall back with your ranged weapon if you're in formation with the player.
+                // don't try to fall back with your ranged weapon if you're in formation with the player.
                 friendly_count += 4 - dist; // when close to the player, weight swarms less.
             } else {
                 assessment = std::max( min_danger, assessment - player_diff * 0.5f );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -653,8 +653,6 @@ void npc::assess_danger()
             }
         }
 
-
-
         if( !is_player_ally() || is_too_close || ok_by_rules( foe, dist, scaled_distance ) ) {
             float priority = std::max( foe_threat - 2.0f * ( scaled_distance - 1 ),
                                        is_too_close ? std::max( foe_threat, NPC_DANGER_VERY_LOW ) :
@@ -669,7 +667,6 @@ void npc::assess_danger()
         }
         return foe_threat;
     };
-
 
     for( const weak_ptr_fast<Creature> &guy : ai_cache.hostile_guys ) {
         Character *foe = dynamic_cast<Character *>( guy.lock().get() );
@@ -719,10 +716,12 @@ void npc::assess_danger()
     assessment *= NPC_COWARDICE_MODIFIER;
     int flee_checks_failed;
     if( !has_effect( effect_npc_run_away ) && !has_effect( effect_npc_fire_bad ) ) {
-        float my_diff = evaluate_enemy( *this ) * 0.5f + personality.bravery - ( get_pain() / 5 )  + rng( -5, 5 ) + rng( -3, 3 );
+        float my_diff = evaluate_enemy( *this ) * 0.5f + personality.bravery - ( get_pain() / 5 ) 
+            + rng( -5, 5 ) + rng( -3, 3 );
         add_msg_debug( debugmode::DF_NPC, "Enemy Danger: %1f, Ally Strength: %2f.", assessment, my_diff );
         if( my_diff < assessment ) {
-            time_duration run_away_for = 10_turns + 1_turns * rng( 0, 10 ) - 1_turns * personality.bravery + 1_turns * static_cast<int>( get_pain() / 5 );
+            time_duration run_away_for = 10_turns + 1_turns * rng( 0, 10 ) - 1_turns * personality.bravery 
+                + 1_turns * static_cast<int>( get_pain() / 5 );
             warn_about( "run_away", run_away_for );
             add_effect( effect_npc_run_away, run_away_for );
             path.clear();

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -740,7 +740,7 @@ void npc::assess_danger()
             path.clear();
         }
     }
-    }
+
     // update the threat cache
     for( size_t i = 0; i < 8; i++ ) {
         direction threat_dir = npc_threat_dir[i];

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -565,7 +565,6 @@ void npc::assess_danger()
         float critter_threat = evaluate_enemy( critter );
         // warn and consider the odds for distant enemies
         int dist = rl_dist( pos(), critter.pos() );
-        
         if( is_enemy() || !critter.friendly ) {
             assessment += critter_threat;
             if( critter_threat > ( 8.0f + personality.bravery + rng( 0, 5 ) ) ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -720,8 +720,8 @@ void npc::assess_danger()
                         + rng( -5, 5 ) + rng( -3, 3 );
         add_msg_debug( debugmode::DF_NPC, "Enemy Danger: %1f, Ally Strength: %2f.", assessment, my_diff );
         if( my_diff < assessment ) {
-            time_duration run_away_for = 10_turns + 1_turns * rng( 0, 10 ) - 1_turns * personality.bravery 
-                + 1_turns * static_cast<int>( get_pain() / 5 );
+            time_duration run_away_for = 10_turns + 1_turns * rng( 0, 10 ) - 1_turns * personality.bravery
+                                         + 1_turns * static_cast<int>( get_pain() / 5 );
             warn_about( "run_away", run_away_for );
             add_effect( effect_npc_run_away, run_away_for );
             path.clear();

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -715,7 +715,7 @@ void npc::assess_danger()
 
     assessment *= NPC_COWARDICE_MODIFIER;
     if( !has_effect( effect_npc_run_away ) && !has_effect( effect_npc_fire_bad ) ) {
-        float my_diff = evaluate_enemy( *this ) * 0.5f + personality.bravery * 2.0f - ( get_pain() / 5.0f )
+        float my_diff = evaluate_enemy( *this ) * 0.5f + personality.bravery - ( get_pain() / 5.0f )
                         + rng( -5, 5 ) + rng( -3, 3 );
         add_msg_debug( debugmode::DF_NPC, "Enemy Danger: %1f, Ally Strength: %2f.", assessment, my_diff );
         if( my_diff < assessment ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -714,9 +714,8 @@ void npc::assess_danger()
     }
 
     assessment *= NPC_COWARDICE_MODIFIER;
-    int flee_checks_failed;
     if( !has_effect( effect_npc_run_away ) && !has_effect( effect_npc_fire_bad ) ) {
-        float my_diff = evaluate_enemy( *this ) * 0.5f + personality.bravery - ( get_pain() / 5 )
+        float my_diff = evaluate_enemy( *this ) * 0.5f + personality.bravery * 2.0f - ( get_pain() / 5.0f )
                         + rng( -5, 5 ) + rng( -3, 3 );
         add_msg_debug( debugmode::DF_NPC, "Enemy Danger: %1f, Ally Strength: %2f.", assessment, my_diff );
         if( my_diff < assessment ) {


### PR DESCRIPTION
#### Summary
Features "Fixes NPCs being too afraid, makes swarm danger assessment more robust"

#### Purpose of change

In #67870 I made NPCs flee more and added some should-be-smart fixes, but they've been fleeing too often when there are any enemies at all visible on the map, and sometimes for other things

#### Describe the solution
I've known for a bit what needed to be done but been away, sorry for the delay.
On going to implement this, I found another change that I bugfixed, so this should be a lot better.

##### Bugfixing
I had the hostile count incrementing too soon, so neutral creatures were also getting pegged as part of the swarm. I have moved this, so that bug should be fixed. That's really the primary fix here, that should solve a lot. However, I made it a bit more robust.

#### Improvements
1. The NPC now only counts hostiles within 15 squares when it assesses to see if it's being swarmed. This number is arbitrary and should be tested. I want to leave it pretty large, because the goal here is to get NPCs to start running *before* they are swarmed.
2. I also made them only count enemies towards their swarm count if the enemy passes a threshold of threat, which should be sufficiently low that most of the time they'll count all enemies within 8 tiles. This is influenced by their pain though, so a very brave NPC might allow a large group of zombies to get in close but once they start feeling the hurt, they'll count them as more threatening.
- It might be good to make  this more based on the NPC's self assessment of their own danger level, before this merges, but for now this should be a lot better than it was.
3. I changed the randomness factor in the final decision to flee. Previously, NPC would assess their own toughness, then add a random factor from zero up to their own bravery x 2. Now, the NPC determines their own toughness, adds their bravery, subtracts a factor derived from their pain level, and then adds some random fuzz to the end. This should make their flee decisions much more predictable. The old way was necessary to ensure they didn't stand and fight to the death if they were too brave, but now that pain factors in that should be less of a problem.
4. NPCs with ranged weapons should count the enemies coming in very close (within 4 tiles) and, even if they don't decide to flee, should consider falling back for 2 turns. This behaviour gets cancelled if the player is also within that space, so that NPCs don't break formation to kite enemies. Also made the effect of having the player nearby a little more robust. Later, this should be extrapolated to be not the player but whoever the NPC sees as the "party leader"

#### Describe alternatives you've considered
I'd still like to try to add a bit more memory to this. Ideally, there should be a variable for "number of flee attempts" that is tracked outside of assess_danger(). Whenever `assess_danger()` ends in a decision to flee, the NPC increments this by at least 1, or more if the severity of the threat was determined to be extremely high. This value should determine how long the NPC tries to flee for - so if this is their first attempt to flee and it's kind of on the line, they don't actually flee but just fall back a bit to see if they can find a better position. If they still fail the assess, they flee longer, and longer, etc.

Along with this, I could add some different behaviours if they attempt to flee but don't get any farther from the threat, in which case they should instead try to stand and fight.

#### Testing
Briefly tested: compiles, and NPCs don't seem to be running quite as much, but I am not yet sure if the behaviour is smarter.

Further tested by Ms Antipode on discord, appears to be running as intended. Huzzah!

#### Additional context

There's a few more tweaks that could maybe be included here depending on how it goes.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
