### PR TITLE
[MoM] change Inferno Grenade fuse

### DIFF
--- a/data/mods/MindOverMatter/recipes/weapons.json
+++ b/data/mods/MindOverMatter/recipes/weapons.json
@@ -21,7 +21,7 @@
     "components": [
       [ [ "fuse", 1 ] ],
       [ [ "superglue", 1 ], [ "duct_tape", 75 ], [ "cordage", 1, "LIST" ] ],
-      [ [ "can_medium", 1 ] ],
+      [ [ "small_grenade_case", 1, "LIST" ] ],
       [ [ "matrix_crystal_pyrokin_dust", 5 ], [ "matrix_crystal_pyrokin_dust_refined", 1 ] ]
     ]
   }

--- a/data/mods/MindOverMatter/recipes/weapons.json
+++ b/data/mods/MindOverMatter/recipes/weapons.json
@@ -19,7 +19,7 @@
     "qualities": [ { "id": "SAW_M", "level": 1 }, { "id": "MATRIX_CHANNEL", "level": 1 } ],
     "using": [ [ "volatile_explosive", 20, "LIST" ], [ "explosives_casting_standard", 1 ] ],
     "components": [
-      [ [ "delay_fuze", 1 ] ],
+      [ [ "fuse", 1 ] ],
       [ [ "superglue", 1 ], [ "duct_tape", 75 ], [ "cordage", 1, "LIST" ] ],
       [ [ "can_medium", 1 ] ],
       [ [ "matrix_crystal_pyrokin_dust", 5 ], [ "matrix_crystal_pyrokin_dust_refined", 1 ] ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "[MoM] change Inferno Grenade fuse and casing"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The Inferno Grenade recipe uses the delayed fuze for its recipe. This doesn't make sense to me, because the delayed fuze is a complicated mechanical assembly that can only be acquired by disassembling military explosives, whereas the inferno grenade is clearly an improvised explosive made from duct tape and tin cans. Also, the delayed fuze says its purpose is to directly detonate stable explosives, but the inferno grenade uses volatile explosives to catalyze its psychic firestorm, much more akin to the way e.g. the homemade grenades use volatile explosives to catalyze stable explosives, and those use standard fuses.

e: also, inferno grenades are the size of small homemade grenades and drop empty canisters when used, so they should probably use the casings for small grenades rather than medium tin can in their recipe
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change it to the standard "fuse" item.

e: change it to use the small_grenade_case list instead of medium tin can
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I was gonna ask @Standing-Storm if this was intentional, but it's such a quick change it was easier to just make the PR and let them shoot it down if necessary.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
