### PR TITLE
Bashing furniture/terrain gradually gets easier

### DIFF
--- a/data/mods/TEST_DATA/furniture.json
+++ b/data/mods/TEST_DATA/furniture.json
@@ -111,6 +111,17 @@
   },
   {
     "type": "furniture",
+    "id": "test_f_bash_persist",
+    "name": "Bash persistence furniture",
+    "description": "Testing that bashing data does not persist when furniture changes",
+    "symbol": "f",
+    "color": "blue",
+    "bash": { "str_min": 4, "str_max": 100, "sound": "Tests testing!", "sound_fail": "Tests testing!" },
+    "move_cost_mod": 1,
+    "required_str": 8
+  },
+  {
+    "type": "furniture",
     "id": "test_f_eoc",
     "name": "EoC Test Furniture 1",
     "description": "Prying furniture with valid data.",

--- a/data/mods/TEST_DATA/map_bash.json
+++ b/data/mods/TEST_DATA/map_bash.json
@@ -1,0 +1,89 @@
+[
+  {
+    "type": "test_data",
+    "bash_test": {
+      "//furn_str_min": [ 1, 6, 8, 12, 12, 18, 35, 40 ],
+      "//ter_str_min": [ 3, 5, 8, 12, 30, 60, 80, 250 ],
+      "furn": [ "f_trashcan", "f_chair", "f_toilet", "f_bathtub", "f_bed", "f_water_heater", "f_workbench", "f_safe_l" ],
+      "ter": [ "t_window", "t_gutter", "t_door_c", "t_wall_wood", "t_wall", "t_wall_log", "t_door_metal_c", "t_wall_resin" ],
+      "tests": [
+        {
+          "id": "naked",
+          "loadout": { "strength": 8, "expected_ability": 4 },
+          "furn_tries": { "f_trashcan": [ 1, 1 ] },
+          "ter_tries": { "t_window": [ 1, 1 ] }
+        },
+        {
+          "id": "boots",
+          "loadout": { "strength": 8, "expected_ability": 12, "worn": [ "boots_rubber" ] },
+          "furn_tries": { "f_trashcan": [ 1, 1 ], "f_chair": [ 1, 1 ], "f_toilet": [ 1, 1 ], "f_bathtub": [ 1, 1 ], "f_bed": [ 1, 1 ] },
+          "ter_tries": { "t_window": [ 1, 1 ], "t_gutter": [ 1, 1 ], "t_door_c": [ 1, 1 ], "t_wall_wood": [ 1, 1 ] }
+        },
+        {
+          "id": "plank",
+          "loadout": { "strength": 8, "expected_ability": 24, "wielded": "2x4" },
+          "furn_tries": {
+            "f_trashcan": [ 1, 1 ],
+            "f_chair": [ 1, 1 ],
+            "f_toilet": [ 1, 1 ],
+            "f_bathtub": [ 1, 1 ],
+            "f_bed": [ 1, 1 ],
+            "f_water_heater": [ 1, 1 ]
+          },
+          "ter_tries": { "t_window": [ 1, 1 ], "t_gutter": [ 1, 1 ], "t_door_c": [ 1, 1 ], "t_wall_wood": [ 1, 1 ] }
+        },
+        {
+          "id": "crowbar",
+          "loadout": { "strength": 8, "expected_ability": 27, "wielded": "crowbar" },
+          "furn_tries": {
+            "f_trashcan": [ 1, 1 ],
+            "f_chair": [ 1, 1 ],
+            "f_toilet": [ 1, 1 ],
+            "f_bathtub": [ 1, 1 ],
+            "f_bed": [ 1, 1 ],
+            "f_water_heater": [ 1, 1 ]
+          },
+          "ter_tries": { "t_window": [ 1, 1 ], "t_gutter": [ 1, 1 ], "t_door_c": [ 1, 1 ], "t_wall_wood": [ 1, 1 ] }
+        },
+        {
+          "id": "mace",
+          "loadout": { "strength": 8, "expected_ability": 48, "wielded": "mace" },
+          "furn_tries": {
+            "f_trashcan": [ 1, 1 ],
+            "f_chair": [ 1, 1 ],
+            "f_toilet": [ 1, 1 ],
+            "f_bathtub": [ 1, 1 ],
+            "f_bed": [ 1, 1 ],
+            "f_water_heater": [ 1, 1 ],
+            "f_workbench": [ 1, 1 ],
+            "f_safe_l": [ 1, 1 ]
+          },
+          "ter_tries": { "t_window": [ 1, 1 ], "t_gutter": [ 1, 1 ], "t_door_c": [ 1, 1 ], "t_wall_wood": [ 1, 1 ], "t_wall": [ 1, 1 ] }
+        },
+        {
+          "id": "sledgehammer",
+          "loadout": { "strength": 8, "expected_ability": 88, "wielded": "hammer_sledge_heavy" },
+          "furn_tries": {
+            "f_trashcan": [ 1, 1 ],
+            "f_chair": [ 1, 1 ],
+            "f_toilet": [ 1, 1 ],
+            "f_bathtub": [ 1, 1 ],
+            "f_bed": [ 1, 1 ],
+            "f_water_heater": [ 1, 1 ],
+            "f_workbench": [ 1, 1 ],
+            "f_safe_l": [ 1, 1 ]
+          },
+          "ter_tries": {
+            "t_window": [ 1, 1 ],
+            "t_gutter": [ 1, 1 ],
+            "t_door_c": [ 1, 1 ],
+            "t_wall_wood": [ 1, 1 ],
+            "t_wall": [ 1, 1 ],
+            "t_wall_log": [ 1, 1 ],
+            "t_door_metal_c": [ 1, 1 ]
+          }
+        }
+      ]
+    }
+  }
+]

--- a/data/mods/TEST_DATA/map_bash.json
+++ b/data/mods/TEST_DATA/map_bash.json
@@ -11,26 +11,26 @@
           "id": "naked",
           "loadout": { "strength": 8, "expected_ability": 4 },
           "furn_tries": { "f_trashcan": [ 1, 1 ] },
-          "ter_tries": { "t_window": [ 1, 1 ] }
+          "ter_tries": { "t_window": [ 1, 3 ] }
         },
         {
           "id": "boots",
           "loadout": { "strength": 8, "expected_ability": 12, "worn": [ "boots_rubber" ] },
-          "furn_tries": { "f_trashcan": [ 1, 1 ], "f_chair": [ 1, 1 ], "f_toilet": [ 1, 1 ], "f_bathtub": [ 1, 1 ], "f_bed": [ 1, 1 ] },
-          "ter_tries": { "t_window": [ 1, 1 ], "t_gutter": [ 1, 1 ], "t_door_c": [ 1, 1 ], "t_wall_wood": [ 1, 1 ] }
+          "furn_tries": { "f_trashcan": [ 1, 1 ], "f_chair": [ 1, 20 ], "f_toilet": [ 1, 23 ], "f_bathtub": [ 1, 39 ], "f_bed": [ 1, 29 ] },
+          "ter_tries": { "t_window": [ 1, 1 ], "t_gutter": [ 1, 1 ], "t_door_c": [ 1, 73 ], "t_wall_wood": [ 1, 139 ] }
         },
         {
           "id": "plank",
           "loadout": { "strength": 8, "expected_ability": 24, "wielded": "2x4" },
           "furn_tries": {
             "f_trashcan": [ 1, 1 ],
-            "f_chair": [ 1, 1 ],
-            "f_toilet": [ 1, 1 ],
-            "f_bathtub": [ 1, 1 ],
-            "f_bed": [ 1, 1 ],
-            "f_water_heater": [ 1, 1 ]
+            "f_chair": [ 1, 20 ],
+            "f_toilet": [ 1, 23 ],
+            "f_bathtub": [ 1, 39 ],
+            "f_bed": [ 1, 29 ],
+            "f_water_heater": [ 1, 63 ]
           },
-          "ter_tries": { "t_window": [ 1, 1 ], "t_gutter": [ 1, 1 ], "t_door_c": [ 1, 1 ], "t_wall_wood": [ 1, 1 ] }
+          "ter_tries": { "t_window": [ 1, 1 ], "t_gutter": [ 1, 1 ], "t_door_c": [ 1, 73 ], "t_wall_wood": [ 1, 139 ] }
         },
         {
           "id": "crowbar",
@@ -38,12 +38,12 @@
           "furn_tries": {
             "f_trashcan": [ 1, 1 ],
             "f_chair": [ 1, 1 ],
-            "f_toilet": [ 1, 1 ],
-            "f_bathtub": [ 1, 1 ],
-            "f_bed": [ 1, 1 ],
-            "f_water_heater": [ 1, 1 ]
+            "f_toilet": [ 1, 23 ],
+            "f_bathtub": [ 1, 39 ],
+            "f_bed": [ 1, 29 ],
+            "f_water_heater": [ 1, 63 ]
           },
-          "ter_tries": { "t_window": [ 1, 1 ], "t_gutter": [ 1, 1 ], "t_door_c": [ 1, 1 ], "t_wall_wood": [ 1, 1 ] }
+          "ter_tries": { "t_window": [ 1, 1 ], "t_gutter": [ 1, 1 ], "t_door_c": [ 1, 73 ], "t_wall_wood": [ 1, 139 ] }
         },
         {
           "id": "mace",
@@ -52,13 +52,13 @@
             "f_trashcan": [ 1, 1 ],
             "f_chair": [ 1, 1 ],
             "f_toilet": [ 1, 1 ],
-            "f_bathtub": [ 1, 1 ],
+            "f_bathtub": [ 1, 33 ],
             "f_bed": [ 1, 1 ],
-            "f_water_heater": [ 1, 1 ],
-            "f_workbench": [ 1, 1 ],
-            "f_safe_l": [ 1, 1 ]
+            "f_water_heater": [ 1, 63 ],
+            "f_workbench": [ 1, 46 ],
+            "f_safe_l": [ 1, 161 ]
           },
-          "ter_tries": { "t_window": [ 1, 1 ], "t_gutter": [ 1, 1 ], "t_door_c": [ 1, 1 ], "t_wall_wood": [ 1, 1 ], "t_wall": [ 1, 1 ] }
+          "ter_tries": { "t_window": [ 1, 1 ], "t_gutter": [ 1, 1 ], "t_door_c": [ 1, 73 ], "t_wall_wood": [ 1, 139 ], "t_wall": [ 1, 181 ] }
         },
         {
           "id": "sledgehammer",
@@ -71,16 +71,16 @@
             "f_bed": [ 1, 1 ],
             "f_water_heater": [ 1, 1 ],
             "f_workbench": [ 1, 1 ],
-            "f_safe_l": [ 1, 1 ]
+            "f_safe_l": [ 1, 161 ]
           },
           "ter_tries": {
             "t_window": [ 1, 1 ],
             "t_gutter": [ 1, 1 ],
             "t_door_c": [ 1, 1 ],
-            "t_wall_wood": [ 1, 1 ],
-            "t_wall": [ 1, 1 ],
-            "t_wall_log": [ 1, 1 ],
-            "t_door_metal_c": [ 1, 1 ]
+            "t_wall_wood": [ 1, 139 ],
+            "t_wall": [ 1, 181 ],
+            "t_wall_log": [ 1, 121 ],
+            "t_door_metal_c": [ 1, 171 ]
           }
         }
       ]

--- a/data/mods/TEST_DATA/terrain.json
+++ b/data/mods/TEST_DATA/terrain.json
@@ -137,6 +137,22 @@
   },
   {
     "type": "terrain",
+    "id": "test_t_bash_persist",
+    "name": "Bash persistence furniture",
+    "description": "Testing that bashing data does not persist when terrain changes",
+    "symbol": "t",
+    "color": "blue",
+    "bash": {
+      "str_min": 4,
+      "str_max": 100,
+      "sound": "Tests testing!",
+      "sound_fail": "Tests testing!",
+      "ter_set": "test_t_pit_shallow"
+    },
+    "move_cost": 1
+  },
+  {
+    "type": "terrain",
     "id": "test_t_pit_shallow",
     "name": "shallow pit",
     "description": "test shallow pit",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3571,6 +3571,48 @@ void Character::apply_skill_boost()
     }
 }
 
+std::pair<bodypart_id, int> Character::best_part_to_smash() const
+{
+    const bodypart_id bp_null( "bp_null" );
+    std::pair<bodypart_id, int> best_part_to_smash = {bp_null, 0};
+    int tmp_bash_armor = 0;
+    for( const bodypart_id &bp : get_all_body_parts() ) {
+        tmp_bash_armor += worn.damage_resist( damage_bash, bp );
+        for( const trait_id &mut : get_mutations() ) {
+            const resistances &res = mut->damage_resistance( bp );
+            tmp_bash_armor += std::floor( res.type_resist( damage_bash ) );
+        }
+        if( tmp_bash_armor > best_part_to_smash.second ) {
+            best_part_to_smash = {bp, tmp_bash_armor};
+        }
+    }
+
+    return best_part_to_smash;
+}
+
+int Character::smash_ability() const
+{
+    int ret = get_arm_str();
+    ///\EFFECT_STR increases smashing capability
+    if( is_mounted() ) {
+        auto *mon = mounted_creature.get();
+        ret += mon->mech_str_addition() + mon->type->melee_dice * mon->type->melee_sides;
+    } else if( get_wielded_item() ) {
+        ret += get_wielded_item()->damage_melee( damage_bash );
+        ret = calculate_by_enchantment( ret, enchant_vals::mod::ITEM_DAMAGE_BASH, true );
+    }
+
+    if( !has_weapon() ) {
+        std::pair<bodypart_id, int> best_part = best_part_to_smash();
+        const int min_ret = ret * best_part.first->smash_efficiency;
+        const int max_ret = ret * ( 1.0f + best_part.first->smash_efficiency );
+        ret = std::min( best_part.second + min_ret, max_ret );
+    }
+    ret = calculate_by_enchantment( ret, enchant_vals::mod::MELEE_DAMAGE, true );
+
+    return ret;
+}
+
 void Character::do_skill_rust()
 {
     for( std::pair<const skill_id, SkillLevel> &pair : *_skills ) {

--- a/src/character.h
+++ b/src/character.h
@@ -2488,6 +2488,9 @@ class Character : public Creature, public visitable
         }
         virtual bool query_yn( const std::string &msg ) const = 0;
 
+        std::pair<bodypart_id, int> best_part_to_smash() const;
+        virtual int smash_ability() const;
+
         // checks if your character is immune to an effect or field based on field_immunity_data
         bool check_immunity_data( const field_immunity_data &ft ) const override;
         bool is_immune_field( const field_type_id &fid ) const override;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1720,6 +1720,7 @@ bool map::furn_set( const tripoint &p, const furn_id &new_furniture, const bool 
     }
 
     current_submap->set_furn( l, new_target_furniture );
+    current_submap->set_map_damage( point_sm_ms( l ), 0 );
 
     // Set the dirty flags
     const furn_t &old_f = old_id.obj();
@@ -1888,6 +1889,36 @@ ter_id map::ter( const tripoint &p ) const
 ter_id map::ter( const tripoint_bub_ms &p ) const
 {
     return ter( p.raw() );
+}
+
+int map::get_map_damage( const tripoint_bub_ms &p ) const
+{
+    if( !inbounds( p ) ) {
+        return 0;
+    }
+
+    point_sm_ms l;
+    const submap *const current_submap = unsafe_get_submap_at( p, l );
+    if( current_submap == nullptr ) {
+        debugmsg( "Called get_map_damage for unloaded submap" );
+        return 0;
+    }
+    return current_submap->get_map_damage( l );
+}
+
+void map::set_map_damage( const tripoint_bub_ms &p, int dmg )
+{
+    if( !inbounds( p ) ) {
+        return;
+    }
+
+    point_sm_ms l;
+    submap *const current_submap = unsafe_get_submap_at( p, l );
+    if( current_submap == nullptr ) {
+        debugmsg( "Called set_map_damage for unloaded submap" );
+        return;
+    }
+    return current_submap->set_map_damage( l, dmg );
 }
 
 uint8_t map::get_known_connections( const tripoint &p,
@@ -2168,6 +2199,7 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_crea
     }
 
     current_submap->set_ter( l, new_terrain );
+    current_submap->set_map_damage( point_sm_ms( l ), 0 );
 
     // Set the dirty flags
     const ter_t &old_t = old_id.obj();
@@ -3973,11 +4005,22 @@ void map::bash_ter_furn( const tripoint &p, bash_params &params )
                 }
             }
         }
-        // Linear interpolation from str_min to str_max
-        const int resistance = smin + ( params.roll * ( smax - smin ) );
-        if( params.strength >= resistance ) {
+        // Semi-persistant map damage. Increment by one for each bash over smin
+        // Gradually makes hard bashes easier
+        int damage = get_map_damage( tripoint_bub_ms( p ) );
+        add_msg_debug( debugmode::DF_MAP,
+                       "Bashing difficulty %d, threshold is %d. Strength is %d + %d, added damage %d", smax, smin,
+                       params.strength, damage, std::max( ( params.strength - smin ) * params.roll, 0.f ) );
+        if( params.strength + damage >= smax ) {
+            damage = 0;
             success = true;
+        } else if( params.strength >= smin ) {
+            // Add at least one damage per unsuccessful bash will ensure that if we exceed str_min,
+            // we will destroy it in str_max - str_min bashes. As the amount we exceed it by increases,
+            // we'll take less time to destroy it
+            damage += std::max( ( params.strength - smin ) * params.roll, 1.f );
         }
+        set_map_damage( tripoint_bub_ms( p ), damage );
     }
 
     if( smash_furn ) {

--- a/src/map.h
+++ b/src/map.h
@@ -809,6 +809,9 @@ class map
             return ter( tripoint( p, abs_sub.z() ) );
         }
 
+        int get_map_damage( const tripoint_bub_ms &p ) const;
+        void set_map_damage( const tripoint_bub_ms &p, int dmg );
+
         // Return a bitfield of the adjacent tiles which connect to the given
         // connect_group.  From least-significant bit the order is south, east,
         // west, north (because that's what cata_tiles expects).

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2675,15 +2675,12 @@ void npc::npc_dismount()
 
 int npc::smash_ability() const
 {
-    if( !is_hallucination() && ( !is_player_ally() || rules.has_flag( ally_rule::allow_bash ) ) ) {
-        ///\EFFECT_STR_NPC increases smash ability
-        int dmg = get_wielded_item() ? get_wielded_item()->damage_melee( STATIC(
-                      damage_type_id( "bash" ) ) ) : 0;
-        return str_cur + dmg;
+    if( is_hallucination() || ( is_player_ally() && !rules.has_flag( ally_rule::allow_bash ) ) ) {
+        // Not allowed to bash
+        return 0;
     }
 
-    // Not allowed to bash
-    return 0;
+    return Character::smash_ability();
 }
 
 float npc::danger_assessment() const

--- a/src/npc.h
+++ b/src/npc.h
@@ -1018,7 +1018,7 @@ class npc : public Character
         bool is_dead() const;
         void prevent_death() override;
         // How well we smash terrain (not corpses!)
-        int smash_ability() const;
+        int smash_ability() const override;
 
         /*
          *  CBM management functions

--- a/src/submap.h
+++ b/src/submap.h
@@ -123,6 +123,17 @@ class submap
             ensure_nonuniform();
             std::uninitialized_fill_n( &m->frn[0][0], elements, furn );
         }
+        int get_map_damage( const point_sm_ms &p ) const {
+            auto it = ephemeral_data.find( p );
+            if( it != ephemeral_data.end() ) {
+                return it->second.damage;
+            }
+            return 0;
+        }
+
+        void set_map_damage( const point_sm_ms &p, int dmg ) {
+            ephemeral_data[p] = { dmg };
+        }
 
         ter_id get_ter( const point &p ) const {
             if( is_uniform() ) {
@@ -294,7 +305,12 @@ class submap
         std::map<tripoint_sm_ms, partial_con> partial_constructions;
         std::unique_ptr<basecamp> camp;  // only allowing one basecamp per submap
 
+        struct tile_data {
+            int damage;
+        };
+
     private:
+        std::map<point_sm_ms, tile_data> ephemeral_data;
         std::map<point, computer> computers;
         std::unique_ptr<computer> legacy_computer;
         std::unique_ptr<maptile_soa> m;

--- a/src/test_data.cpp
+++ b/src/test_data.cpp
@@ -1,6 +1,7 @@
 #include "test_data.h"
 
 #include "flexbuffer_json.h"
+#include "generic_factory.h"
 
 std::set<itype_id> test_data::known_bad;
 std::map<vproto_id, std::vector<double>> test_data::drag_data;
@@ -8,6 +9,7 @@ std::map<vproto_id, efficiency_data> test_data::eff_data;
 std::map<itype_id, double> test_data::expected_dps;
 std::map<spawn_type, std::vector<container_spawn_test_data>> test_data::container_spawn_data;
 std::map<std::string, npc_boarding_test_data> test_data::npc_boarding_data;
+std::vector<bash_test_set> test_data::bash_tests;
 
 void efficiency_data::deserialize( const JsonObject &jo )
 {
@@ -48,6 +50,29 @@ void npc_boarding_test_data::deserialize( const JsonObject &jo )
     jo.read( "npc_target", npc_target );
 }
 
+void bash_test_loadout::deserialize( const JsonObject &jo )
+{
+    mandatory( jo, false, "strength", strength );
+    mandatory( jo, false, "expected_ability", expected_smash_ability );
+    optional( jo, false, "worn", worn );
+    optional( jo, false, "wielded", wielded, std::nullopt );
+}
+
+void single_bash_test::deserialize( const JsonObject &jo )
+{
+    mandatory( jo, false, "id", id );
+    mandatory( jo, false, "loadout", loadout );
+    optional( jo, false, "furn_tries", furn_tries );
+    optional( jo, false, "ter_tries", ter_tries );
+}
+
+void bash_test_set::deserialize( const JsonObject &jo )
+{
+    optional( jo, false, "furn", tested_furn );
+    optional( jo, false, "ter", tested_ter );
+    mandatory( jo, false, "tests", tests );
+}
+
 void test_data::load( const JsonObject &jo )
 {
     // It's probably not necessary, but these are set up to
@@ -74,6 +99,12 @@ void test_data::load( const JsonObject &jo )
         std::map<itype_id, double> new_expected_dps;
         jo.read( "expected_dps", new_expected_dps );
         expected_dps.insert( new_expected_dps.begin(), new_expected_dps.end() );
+    }
+
+    if( jo.has_object( "bash_test" ) ) {
+        bash_test_set loaded;
+        optional( jo, false, "bash_test", loaded );
+        bash_tests.push_back( loaded );
     }
 
     if( jo.has_object( "spawn_data" ) )  {

--- a/src/test_data.h
+++ b/src/test_data.h
@@ -3,12 +3,14 @@
 #define CATA_TEST_DATA_H
 
 #include <map>
+#include <optional>
 #include <set>
 #include <vector>
 
 #include "point.h"
 #include "type_id.h"
 
+class Character;
 class JsonObject;
 
 struct efficiency_data {
@@ -49,6 +51,35 @@ struct npc_boarding_test_data {
     void deserialize( const JsonObject &jo );
 };
 
+// TODO: Support mounts
+struct bash_test_loadout {
+    int strength;
+    int expected_smash_ability;
+    std::vector<itype_id> worn;
+    std::optional<itype_id> wielded;
+
+    void apply( Character &guy ) const;
+    void deserialize( const JsonObject &jo );
+};
+
+struct single_bash_test {
+    std::string id;
+    bash_test_loadout loadout;
+    std::map<furn_id, std::pair<int, int>> furn_tries;
+    std::map<ter_id, std::pair<int, int>> ter_tries;
+
+    void deserialize( const JsonObject &jo );
+};
+
+struct bash_test_set {
+    std::vector<furn_id> tested_furn;
+    std::vector<ter_id> tested_ter;
+
+    std::vector<single_bash_test> tests;
+
+    void deserialize( const JsonObject &jo );
+};
+
 class test_data
 {
     public:
@@ -59,6 +90,7 @@ class test_data
         static std::map<itype_id, double> expected_dps;
         static std::map<spawn_type, std::vector<container_spawn_test_data>> container_spawn_data;
         static std::map<std::string, npc_boarding_test_data> npc_boarding_data;
+        static std::vector<bash_test_set> bash_tests;
 
         static void load( const JsonObject &jo );
 };

--- a/tests/map_bash_test.cpp
+++ b/tests/map_bash_test.cpp
@@ -6,6 +6,12 @@
 #include "player_helpers.h"
 #include "test_data.h"
 
+static const furn_str_id furn_test_f_bash_persist( "test_f_bash_persist" );
+static const furn_str_id furn_test_f_eoc( "test_f_eoc" );
+
+static const ter_str_id ter_test_t_bash_persist( "test_t_bash_persist" );
+static const ter_str_id ter_test_t_pit_shallow( "test_t_pit_shallow" );
+
 void bash_test_loadout::apply( Character &guy ) const
 {
     clear_character( guy );
@@ -51,10 +57,8 @@ static void test_bash_set( const bash_test_set &set )
             if( it == test.furn_tries.end() ) {
                 CHECK( tries == max_tries );
             } else {
-                // TODO: make bashing deterministic, this is just a "can bash" test right now
-                // CHECK( tries >= it->second.first );
-                // CHECK( tries <= it->second.second );
-                CHECK( tries != max_tries );
+                CHECK( tries >= it->second.first );
+                CHECK( tries <= it->second.second );
             }
         }
         for( const ter_id &ter : set.tested_ter ) {
@@ -70,10 +74,8 @@ static void test_bash_set( const bash_test_set &set )
             if( it == test.ter_tries.end() ) {
                 CHECK( tries == max_tries );
             } else {
-                // TODO: make bashing deterministic, this is just a "can bash" test right now
-                // CHECK( tries >= it->second.first );
-                // CHECK( tries <= it->second.second );
-                CHECK( tries != max_tries );
+                CHECK( tries >= it->second.first );
+                CHECK( tries <= it->second.second );
             }
         }
     }
@@ -85,5 +87,88 @@ TEST_CASE( "map_bash_chances", "[map][bash]" )
 
     for( const bash_test_set &set : test_data::bash_tests ) {
         test_bash_set( set );
+    }
+}
+
+TEST_CASE( "map_bash_ephemeral_persistence", "[map][bash]" )
+{
+    clear_map();
+    map &here = get_map();
+
+    const tripoint_bub_ms test_pt( 40, 40, 0 );
+
+    // Assumptions
+    REQUIRE( furn_test_f_bash_persist->bash.str_min == 4 );
+    REQUIRE( furn_test_f_bash_persist->bash.str_max == 100 );
+    REQUIRE( ter_test_t_bash_persist->bash.str_min == 4 );
+    REQUIRE( ter_test_t_bash_persist->bash.str_max == 100 );
+
+    SECTION( "bashing a furniture to completion leaves behind no map bash info" ) {
+        here.furn_set( test_pt, furn_test_f_bash_persist );
+
+        REQUIRE( here.furn( test_pt ) == furn_test_f_bash_persist );
+        REQUIRE( here.get_map_damage( test_pt ) == 0 );
+        // One above str_min, but well below str_max
+        here.bash( test_pt.raw(), 5 );
+        // Does not destroy it
+        CHECK( here.furn( test_pt ) == furn_test_f_bash_persist );
+        // There is any map damage
+        CHECK( here.get_map_damage( test_pt ) > 0 );
+        // Bash it again to destroy it
+        here.bash( test_pt.raw(), 999 );
+        CHECK( here.furn( test_pt ) != furn_test_f_bash_persist );
+        // Then, it is gone and there is no map damage
+        CHECK( here.furn( test_pt ) != furn_test_f_bash_persist );
+        CHECK( here.get_map_damage( test_pt ) == 0 );
+    }
+    SECTION( "bashing a terrain to completion leaves behind no map bash info" ) {
+        here.ter_set( test_pt, ter_test_t_bash_persist );
+
+        REQUIRE( here.ter( test_pt ) == ter_test_t_bash_persist );
+        REQUIRE( here.get_map_damage( test_pt ) == 0 );
+        // One above str_min, but well below str_max
+        here.bash( test_pt.raw(), 5 );
+        // Does not destroy the terrain
+        CHECK( here.ter( test_pt ) == ter_test_t_bash_persist );
+        // There is any map damage
+        CHECK( here.get_map_damage( test_pt ) > 0 );
+        // Bash it again to destroy it
+        here.bash( test_pt.raw(), 999 );
+        CHECK( here.ter( test_pt ) != ter_test_t_bash_persist );
+        // Then, it is gone and there is no map damage
+        CHECK( here.ter( test_pt ) != ter_test_t_bash_persist );
+        CHECK( here.get_map_damage( test_pt ) == 0 );
+    }
+    SECTION( "when a terrain changes, map damage is lost" ) {
+        here.ter_set( test_pt, ter_test_t_bash_persist );
+
+        REQUIRE( here.ter( test_pt ) == ter_test_t_bash_persist );
+        REQUIRE( here.get_map_damage( test_pt ) == 0 );
+        // One above str_min, but well below str_max
+        here.bash( test_pt.raw(), 5 );
+        // Does not destroy the terrain
+        CHECK( here.ter( test_pt ) == ter_test_t_bash_persist );
+        // There is any map damage
+        CHECK( here.get_map_damage( test_pt ) > 0 );
+        // Change the terrain
+        here.ter_set( test_pt, ter_test_t_pit_shallow );
+        CHECK( here.ter( test_pt ) == ter_test_t_pit_shallow );
+        CHECK( here.get_map_damage( test_pt ) == 0 );
+    }
+    SECTION( "when a furniture changes, map damage is lost" ) {
+        here.furn_set( test_pt, furn_test_f_bash_persist );
+
+        REQUIRE( here.furn( test_pt ) == furn_test_f_bash_persist );
+        REQUIRE( here.get_map_damage( test_pt ) == 0 );
+        // One above str_min, but well below str_max
+        here.bash( test_pt.raw(), 5 );
+        // Does not destroy the terrain
+        CHECK( here.furn( test_pt ) == furn_test_f_bash_persist );
+        // There is any map damage
+        CHECK( here.get_map_damage( test_pt ) > 0 );
+        // Change the terrain
+        here.furn_set( test_pt, furn_test_f_eoc );
+        CHECK( here.furn( test_pt ) == furn_test_f_eoc );
+        CHECK( here.get_map_damage( test_pt ) == 0 );
     }
 }

--- a/tests/map_bash_test.cpp
+++ b/tests/map_bash_test.cpp
@@ -1,0 +1,89 @@
+#include "cata_catch.h"
+#include "character.h"
+#include "map.h"
+#include "mapdata.h"
+#include "map_helpers.h"
+#include "player_helpers.h"
+#include "test_data.h"
+
+void bash_test_loadout::apply( Character &guy ) const
+{
+    clear_character( guy );
+
+    guy.str_max = strength;
+    guy.reset_stats();
+    REQUIRE( guy.str_cur == strength );
+
+    for( const itype_id &it : worn ) {
+        REQUIRE( guy.wear_item( item( it ), false, false ).has_value() );
+    }
+    guy.calc_encumbrance();
+
+    if( wielded.has_value() ) {
+        item to_wield( wielded.value() );
+        REQUIRE( guy.wield( to_wield ) );
+    }
+
+    REQUIRE( guy.smash_ability() == expected_smash_ability );
+}
+
+static void test_bash_set( const bash_test_set &set )
+{
+    map &here = get_map();
+    Character &guy = get_player_character();
+    // Arbitrary point on the map
+    const tripoint_bub_ms test_pt( 40, 40, 0 );
+
+    for( const single_bash_test &test : set.tests ) {
+        test.loadout.apply( guy );
+
+        constexpr int max_tries = 999;
+        for( const furn_id &furn : set.tested_furn ) {
+            INFO( string_format( "%s bashing %s", test.id, furn.id().str() ) );
+            here.ter_set( test_pt, t_floor );
+            here.furn_set( test_pt, furn );
+            int tries = 0;
+            while( here.furn( test_pt ) == furn && tries < max_tries ) {
+                ++tries;
+                here.bash( test_pt.raw(), guy.smash_ability() );
+            }
+            auto it = test.furn_tries.find( furn );
+            if( it == test.furn_tries.end() ) {
+                CHECK( tries == max_tries );
+            } else {
+                // TODO: make bashing deterministic, this is just a "can bash" test right now
+                // CHECK( tries >= it->second.first );
+                // CHECK( tries <= it->second.second );
+                CHECK( tries != max_tries );
+            }
+        }
+        for( const ter_id &ter : set.tested_ter ) {
+            INFO( string_format( "%s bashing %s", test.id, ter.id().str() ) );
+            here.ter_set( test_pt, ter );
+            here.furn_set( test_pt, f_null );
+            int tries = 0;
+            while( here.ter( test_pt ) == ter && tries < max_tries ) {
+                ++tries;
+                here.bash( test_pt.raw(), guy.smash_ability() );
+            }
+            auto it = test.ter_tries.find( ter );
+            if( it == test.ter_tries.end() ) {
+                CHECK( tries == max_tries );
+            } else {
+                // TODO: make bashing deterministic, this is just a "can bash" test right now
+                // CHECK( tries >= it->second.first );
+                // CHECK( tries <= it->second.second );
+                CHECK( tries != max_tries );
+            }
+        }
+    }
+}
+
+TEST_CASE( "map_bash_chances", "[map][bash]" )
+{
+    clear_map();
+
+    for( const bash_test_set &set : test_data::bash_tests ) {
+        test_bash_set( set );
+    }
+}


### PR DESCRIPTION
#### Summary
Features "Furniture/terrain have semi-persistent damage from being bashed"

#### Purpose of change
Bashing is very non-deterministic and frustrating,  with destroying an object being random chance once you've exceeded it's min strength. For objects with a large difference between the min strength and the max strength, this just turns into successively rolling the dice until you manage to get a good roll.

This one-or-none style also makes it hard (and frustrating to the player) to represent that some objects could be destroyed with bashing, but only with significant effort.

#### Describe the solution
This is a proof-of-concept solution. It adds this data to submaps, accessors to maps, and changes the map bashing function to gradually increase the bash strength for each bash that has strength over the min bash strength.

When bashing something:
If you exceed or equal the max strength, the bash succeeds.
If you exceed or equal the min strength, damage is added to the bashed tile based on how much exceed the min strength and RNG, with a minimum of 1. This damage is added to your strength in subsequent bashes.
If you are under the min strength, the bash fails.

Results:
If you beat the `str_min`, you will bash something down in at most `str_max - str_min` bashes.
It will take at least `ceil((str score - str_min) / str_max)` bashes to bash something. 

#### Testing
See tests.

Some history in https://github.com/CleverRaven/Cataclysm-DDA/pull/69209 https://github.com/CleverRaven/Cataclysm-DDA/pull/69107