### PR TITLE
Document Gunmod Blacklist Function

### DIFF
--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -4200,6 +4200,7 @@ Gun mods can be defined like this:
 "cooling_value_multiplier": 0.5,      // Multiply gun's "cooling_value" by this number; works the same as overheat_threshold_multiplier
 "heat_per_shot_modifier":  -2,        //  Add a flat amount to gun's "heat_per_shot"; works the same as overheat_threshold_modifier
 "heat_per_shot_multiplier": 2.0,      // Multiply the gun's "heat_per_shot" by this number; works the same as overheat_threshold_multiplier
+"blacklist_mod ": [ "rail", "underbarrel" ],      // prevents installation of the gunmod if the specified slot(s) are present on the gun.
 ```
 
 Alternately, every item (book, tool, armor, even food) can be used as a gunmod if it has gunmod_data:


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
A functioning JSON field that prevents gunmod installation if certain slots are present on the gun was undocumented. Ref: https://github.com/CleverRaven/Cataclysm-DDA/blob/master/src/item.cpp#L11263

#### Describe the solution

Adds a line in JSON_INFO.md in /doc to describe what the function does.

#### Describe alternatives you've considered
#69221 Turning the function into one that could do the same thing (prevent co-installation with conflicting items, instead of conflicting slots). As I am unable to build, I cannot test the functions that I'd like to implement.

#### Testing

Loaded the document in a markdown viewer.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/7764202/1b55a5fd-1954-45cb-af81-d775f92622a6)
Ensured function actually worked : Pictured is an attempted installation of an m203  that has muzzle listed as a blacklisted slot.

#### Additional context
