### PR TITLE
Apply clang-tidy check modernize-type-traits auto-fix

### DIFF
--- a/src/assign.h
+++ b/src/assign.h
@@ -29,14 +29,14 @@ class is_optional_helper<std::optional<T>> : public std::true_type
 };
 } // namespace detail
 template<typename T>
-class is_optional : public detail::is_optional_helper<typename std::decay<T>::type>
+class is_optional : public detail::is_optional_helper<std::decay_t<T>>
 {
 };
 
 void report_strict_violation( const JsonObject &jo, const std::string &message,
                               std::string_view name );
 
-template <typename T, typename std::enable_if<std::is_arithmetic<T>::value, int>::type = 0>
+template <typename T, std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
 bool assign( const JsonObject &jo, std::string_view name, T &val, bool strict = false,
              T lo = std::numeric_limits<T>::lowest(), T hi = std::numeric_limits<T>::max() )
 {
@@ -88,7 +88,7 @@ bool assign( const JsonObject &jo, std::string_view name, T &val, bool strict = 
 // and also to avoid potentially nonsensical interactions between relative and proportional.
 bool assign( const JsonObject &jo, std::string_view name, bool &val, bool strict = false );
 
-template <typename T, typename std::enable_if<std::is_arithmetic<T>::value, int>::type = 0>
+template <typename T, std::enable_if_t<std::is_arithmetic_v<T>, int> = 0>
 bool assign( const JsonObject &jo, const std::string_view name, std::pair<T, T> &val,
              bool strict = false, T lo = std::numeric_limits<T>::lowest(), T hi = std::numeric_limits<T>::max() )
 {
@@ -126,8 +126,8 @@ bool assign( const JsonObject &jo, const std::string_view name, std::pair<T, T> 
 
 // Note: is_optional excludes any types based on std::optional, which is
 // handled below in a separate function.
-template < typename T, typename std::enable_if < std::is_class<T>::value &&!is_optional<T>::value,
-           int >::type = 0 >
+template < typename T, std::enable_if_t < std::is_class_v<T> &&!is_optional<T>::value,
+           int > = 0 >
 bool assign( const JsonObject &jo, std::string_view name, T &val, bool strict = false )
 {
     T out;
@@ -186,14 +186,14 @@ bool assign_set( const JsonObject &jo, const std::string_view name, Set &val )
 } // namespace details
 
 template <typename T>
-typename std::enable_if<std::is_constructible<T, std::string>::value, bool>::type assign(
+std::enable_if_t<std::is_constructible_v<T, std::string>, bool>assign(
     const JsonObject &jo, const std::string_view name, std::set<T> &val, bool = false )
 {
     return details::assign_set<T, std::set<T>>( jo, name, val );
 }
 
 template <typename T>
-typename std::enable_if<std::is_constructible<T, std::string>::value, bool>::type assign(
+std::enable_if_t<std::is_constructible_v<T, std::string>, bool>assign(
     const JsonObject &jo, const std::string_view name, cata::flat_set<T> &val, bool = false )
 {
     return details::assign_set<T, cata::flat_set<T>>( jo, name, val );
@@ -235,8 +235,8 @@ bool assign( const JsonObject &jo, const std::string &name, nc_color &val,
 class time_duration;
 
 template<typename T>
-inline typename
-std::enable_if<std::is_same<typename std::decay<T>::type, time_duration>::value, bool>::type
+inline
+std::enable_if_t<std::is_same_v<std::decay_t<T>, time_duration>, bool>
 read_with_factor( const JsonObject &jo, const std::string_view name, T &val, const T &factor )
 {
     int tmp;
@@ -258,8 +258,8 @@ read_with_factor( const JsonObject &jo, const std::string_view name, T &val, con
 // will be ignored. If it is called with time_duration, it is available and the
 // *caller* is responsible for including the "calendar.h" header.
 template<typename T>
-inline typename
-std::enable_if<std::is_same<typename std::decay<T>::type, time_duration>::value, bool>::type assign(
+inline
+std::enable_if_t<std::is_same_v<std::decay_t<T>, time_duration>, bool>assign(
     const JsonObject &jo, const std::string &name, T &val, bool strict, const T &factor )
 {
     T out{};

--- a/src/cata_io.h
+++ b/src/cata_io.h
@@ -131,15 +131,15 @@ struct enable_if_type {
  */
 template<class T, class E = void>
 struct has_archive_tag : std::false_type {
-    template < typename S,
-               std::enable_if_t < std::is_enum_v<T> &&std::is_same_v<S, T> > * = nullptr >
+    template < typename S, typename TT = T,
+               std::enable_if_t < std::is_enum_v<TT> &&std::is_same_v<S, TT> > * = nullptr >
     static void write( JsonOut &stream, const S &value ) {
         // TODO: When writing strings as enums is the default, this overload of
         // write can be removed
         stream.write_as_string( value );
     }
-    template < typename S,
-               std::enable_if_t < !std::is_enum_v<T> &&std::is_same_v<S, T> > * = nullptr >
+    template < typename S, typename TT = T,
+               std::enable_if_t < !std::is_enum_v<TT> &&std::is_same_v<S, TT> > * = nullptr >
     static void write( JsonOut &stream, const S &value ) {
         stream.write( value );
     }

--- a/src/cata_io.h
+++ b/src/cata_io.h
@@ -132,14 +132,14 @@ struct enable_if_type {
 template<class T, class E = void>
 struct has_archive_tag : std::false_type {
     template < typename S,
-               std::enable_if_t < std::is_enum<T>::value &&std::is_same<S, T>::value > * = nullptr >
+               std::enable_if_t < std::is_enum_v<T> &&std::is_same_v<S, T> > * = nullptr >
     static void write( JsonOut &stream, const S &value ) {
         // TODO: When writing strings as enums is the default, this overload of
         // write can be removed
         stream.write_as_string( value );
     }
     template < typename S,
-               std::enable_if_t < !std::is_enum<T>::value &&std::is_same<S, T>::value > * = nullptr >
+               std::enable_if_t < !std::is_enum_v<T> &&std::is_same_v<S, T> > * = nullptr >
     static void write( JsonOut &stream, const S &value ) {
         stream.write( value );
     }

--- a/src/cata_small_literal_vector.h
+++ b/src/cata_small_literal_vector.h
@@ -90,7 +90,7 @@ struct alignas( T * ) small_literal_vector {
         *end() = t;
         len_ += 1;
     }
-    template<typename ...US, typename std::enable_if<std::is_constructible<T, US...>::value>::type * = 0>
+    template<typename ...US, std::enable_if_t<std::is_constructible_v<T, US...>> * = 0>
     void push_back( US && ...us ) {
         ensure_capacity_for( size() + 1 );
         *end() = T( std::forward < US && > ( us )... );

--- a/src/cata_type_traits.h
+++ b/src/cata_type_traits.h
@@ -9,7 +9,7 @@ namespace cata
 // I think something similar is proposed for a future std library version, but
 // I can't find it.
 template<typename CopyFrom, typename CopyTo>
-using copy_const = std::conditional_t<std::is_const<CopyFrom>::value, const CopyTo, CopyTo>;
+using copy_const = std::conditional_t<std::is_const_v<CopyFrom>, const CopyTo, CopyTo>;
 
 } // namespace cata
 

--- a/src/cata_utility.h
+++ b/src/cata_utility.h
@@ -75,7 +75,7 @@ double round_up( double val, unsigned int dp );
 *
 * @p num must be non-negative, @p den must be positive, and @c num+den must not overflow.
 */
-template<typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+template<typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
 T divide_round_up( T num, T den )
 {
     return ( num + den - 1 ) / den;
@@ -668,7 +668,7 @@ void set_title( const std::string &title );
 /**
  * Convenience function to get the aggregate value for a list of values.
  */
-template<typename T, typename std::enable_if<std::is_integral<T>::value, int>::type = 0>
+template<typename T, std::enable_if_t<std::is_integral_v<T>, int> = 0>
 T aggregate( const std::vector<T> &values, aggregate_type agg_func )
 {
     if( values.empty() ) {

--- a/src/cata_variant.h
+++ b/src/cata_variant.h
@@ -109,7 +109,7 @@ constexpr cata_variant_type type_for_impl( std::index_sequence<I...> )
 {
     constexpr size_t num_types = static_cast<size_t>( cata_variant_type::num_types );
     constexpr std::array<bool, num_types> matches = {{
-            std::is_same<T, typename convert<static_cast<cata_variant_type>( I )>::type>::value...
+            std::is_same_v<T, typename convert<static_cast<cata_variant_type>( I )>::type>...
         }
     };
     for( size_t i = 0; i < num_types; ++i ) {
@@ -126,7 +126,7 @@ constexpr cata_variant_type type_for_impl( std::index_sequence<I...> )
 template<typename T>
 struct convert_string {
     using type = T;
-    static_assert( std::is_same<T, std::string>::value,
+    static_assert( std::is_same_v<T, std::string>,
                    "Intended for use only with string typedefs" );
     static std::string to_string( const T &v ) {
         return v;

--- a/src/colony.h
+++ b/src/colony.h
@@ -81,9 +81,9 @@ class colony : private element_allocator_type
         using skipfield_type = element_skipfield_type;
 
         // NOLINTNEXTLINE(bugprone-sizeof-expression)
-        using aligned_element_type = typename std::aligned_storage < sizeof( element_type ),
+        using aligned_element_type = std::aligned_storage_t < sizeof( element_type ),
               ( alignof( element_type ) > ( sizeof( element_skipfield_type ) * 2 ) ) ? alignof( element_type ) :
-              ( sizeof( element_skipfield_type ) * 2 ) >::type;
+              ( sizeof( element_skipfield_type ) * 2 ) >;
 
         using size_type = typename std::allocator_traits<element_allocator_type>::size_type;
         using difference_type = typename std::allocator_traits<element_allocator_type>::difference_type;

--- a/src/common_types.h
+++ b/src/common_types.h
@@ -9,7 +9,7 @@
  * An interval of numeric values between @ref min and @ref max (including both).
  * By default it's [0, 0].
  */
-template<typename T, typename = typename std::enable_if<std::is_arithmetic<T>::value, T>::type>
+template<typename T, typename = std::enable_if_t<std::is_arithmetic_v<T>, T>>
 struct numeric_interval {
     T min = static_cast<T>( 0 );
     T max = static_cast<T>( 0 );

--- a/src/compatibility.h
+++ b/src/compatibility.h
@@ -13,18 +13,18 @@
 // Some of our classes can't be in that case, so we need to know when we're in
 // that situation.  Can probably get rid of this once we're on C++17.
 // std::list is a problem on clang-3.8 on Travis CI Ubuntu Xenial.
-constexpr bool list_is_noexcept = std::is_nothrow_move_assignable<std::list<int>>::value;
+constexpr bool list_is_noexcept = std::is_nothrow_move_assignable_v<std::list<int>>;
 // std::string is a problem on gcc-5.3 on Travis CI Ubuntu Xenial.
-constexpr bool string_is_noexcept = std::is_nothrow_move_assignable<std::string>::value;
+constexpr bool string_is_noexcept = std::is_nothrow_move_assignable_v<std::string>;
 // std::set is a problem in Visual Studio
-constexpr bool set_is_noexcept = std::is_nothrow_move_constructible<std::set<std::string>>::value;
+constexpr bool set_is_noexcept = std::is_nothrow_move_constructible_v<std::set<std::string>>;
 // as is std::map
-constexpr bool map_is_noexcept = std::is_nothrow_move_constructible<std::map<int, int>>::value;
+constexpr bool map_is_noexcept = std::is_nothrow_move_constructible_v<std::map<int, int>>;
 // std::basic_ifstream<char> and std::basic_ofstream<char> is not noexcept on clang-6
 constexpr bool basic_ifstream_is_noexcept =
-    std::is_nothrow_move_constructible<std::basic_ifstream<char>>::value;
+    std::is_nothrow_move_constructible_v<std::basic_ifstream<char>>;
 constexpr bool basic_ofstream_is_noexcept =
-    std::is_nothrow_move_constructible<std::basic_ofstream<char>>::value;
+    std::is_nothrow_move_constructible_v<std::basic_ofstream<char>>;
 
 // Due to a bug in MinGW we have to manually reset FPU or SSE floating point mode on Windows
 void reset_floating_point_mode();

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -420,7 +420,7 @@ struct time_info {
         using char_t = typename Stream::char_type;
         using base   = std::basic_ostream<char_t>;
 
-        static_assert( std::is_base_of<base, Stream>::value );
+        static_assert( std::is_base_of_v<base, Stream> );
 
         out << std::setfill( '0' );
         out << std::setw( 2 ) << t.hours << ':' << std::setw( 2 ) << t.minutes << ':' <<

--- a/src/dialogue.h
+++ b/src/dialogue.h
@@ -43,8 +43,8 @@ enum dialogue_consequence : unsigned char {
     action
 };
 
-using talkfunction_ptr = std::add_pointer<void ( npc & )>::type;
-using dialogue_fun_ptr = std::add_pointer<void( npc & )>::type;
+using talkfunction_ptr = std::add_pointer_t<void ( npc & )>;
+using dialogue_fun_ptr = std::add_pointer_t<void( npc & )>;
 
 using trial_mod = std::pair<std::string, int>;
 

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -14,8 +14,8 @@
 struct dialogue;
 class npc;
 
-using talkfunction_ptr = std::add_pointer<void ( npc & )>::type;
-using dialogue_fun_ptr = std::add_pointer<void( npc & )>::type;
+using talkfunction_ptr = std::add_pointer_t<void ( npc & )>;
+using dialogue_fun_ptr = std::add_pointer_t<void( npc & )>;
 
 using trial_mod = std::pair<std::string, int>;
 

--- a/src/enum_bitset.h
+++ b/src/enum_bitset.h
@@ -11,7 +11,7 @@
 template<typename E>
 class enum_bitset
 {
-        static_assert( std::is_enum<E>::value, "the template argument is not an enum." );
+        static_assert( std::is_enum_v<E>, "the template argument is not an enum." );
         static_assert( has_enum_traits<E>::value,
                        "a specialization of 'enum_traits<E>' template containing 'last' element of the enum must be defined somewhere.  "
                        "The `last` constant must be of the same type as the enum itself."
@@ -81,7 +81,7 @@ class enum_bitset
         }
     private:
         static constexpr size_t get_pos( E e ) noexcept {
-            return static_cast<size_t>( static_cast<typename std::underlying_type<E>::type>( e ) );
+            return static_cast<size_t>( static_cast<std::underlying_type_t<E>>( e ) );
         }
 
         std::bitset<enum_bitset<E>::size()> bits;

--- a/src/enum_conversions.h
+++ b/src/enum_conversions.h
@@ -42,7 +42,7 @@ std::string enum_to_string( E );
 template<typename E>
 std::unordered_map<std::string, E> build_enum_lookup_map()
 {
-    static_assert( std::is_enum<E>::value, "E should be an enum type" );
+    static_assert( std::is_enum_v<E>, "E should be an enum type" );
     static_assert( has_enum_traits<E>::value, "enum E needs a specialization of enum_traits" );
     std::unordered_map<std::string, E> result;
 

--- a/src/enum_traits.h
+++ b/src/enum_traits.h
@@ -48,7 +48,7 @@ namespace enum_traits_detail
 {
 
 template<typename E>
-using last_type = typename std::decay<decltype( enum_traits<E>::last )>::type;
+using last_type = std::decay_t<decltype( enum_traits<E>::last )>;
 
 } // namespace enum_traits_detail
 

--- a/src/event.h
+++ b/src/event.h
@@ -888,7 +888,7 @@ class event
             using Spec = event_detail::event_spec<Type>;
             // Using is_empty mostly just to verify that the type is defined at
             // all, but it so happens that it ought to be empty too.
-            static_assert( std::is_empty<Spec>::value,
+            static_assert( std::is_empty_v<Spec>,
                            "spec for this event type must be defined and empty" );
             static_assert( sizeof...( Args ) == Spec::fields.size(),
                            "wrong number of arguments for event type" );

--- a/src/flexbuffer_json-inl.h
+++ b/src/flexbuffer_json-inl.h
@@ -326,7 +326,7 @@ auto JsonValue::read( T &v, bool throw_on_error ) const -> decltype( v.deseriali
     }
 }
 
-template<typename T, std::enable_if_t<std::is_enum<T>::value, int>>
+template<typename T, std::enable_if_t<std::is_enum_v<T>, int>>
 bool JsonValue::read( T &val, bool throw_on_error ) const
 {
     int i;
@@ -369,8 +369,8 @@ bool JsonValue::read( std::pair<T, U> &p, bool throw_on_error ) const
 }
 
 // array ~> vector, deque, list
-template < typename T, typename std::enable_if <
-               !std::is_same<void, typename T::value_type>::value >::type * >
+template < typename T, std::enable_if_t <
+               !std::is_same_v<void, typename T::value_type> > * >
 auto JsonValue::read( T &v, bool throw_on_error ) const -> decltype( v.front(), true )
 {
     if( !test_array() ) {
@@ -428,8 +428,8 @@ bool JsonValue::read( std::array<T, N> &v, bool throw_on_error ) const
 
 // object ~> containers with matching key_type and value_type
 // set, unordered_set ~> object
-template <typename T, typename std::enable_if<
-              std::is_same<typename T::key_type, typename T::value_type>::value>::type *>
+template <typename T, std::enable_if_t<
+              std::is_same_v<typename T::key_type, typename T::value_type>> *>
 bool JsonValue::read( T &v, bool throw_on_error ) const
 {
     if( !test_array() ) {
@@ -485,7 +485,7 @@ bool JsonValue::read( enum_bitset<T> &v, bool throw_on_error ) const
 
 // special case for colony<item> as it supports RLE
 // see corresponding `write` for details
-template <typename T, std::enable_if_t<std::is_same<T, item>::value>* >
+template <typename T, std::enable_if_t<std::is_same_v<T, item>>* >
 bool JsonValue::read( cata::colony<T> &v, bool throw_on_error ) const
 {
     if( !test_array() ) {
@@ -533,7 +533,7 @@ bool JsonValue::read( cata::colony<T> &v, bool throw_on_error ) const
 // special case for colony as it uses `insert()` instead of `push_back()`
 // and therefore doesn't fit with vector/deque/list
 // for colony of items there is another specialization with RLE
-template < typename T, std::enable_if_t < !std::is_same<T, item>::value > * >
+template < typename T, std::enable_if_t < !std::is_same_v<T, item> > * >
 bool JsonValue::read( cata::colony<T> &v, bool throw_on_error ) const
 {
     if( !test_array() ) {
@@ -559,8 +559,8 @@ bool JsonValue::read( cata::colony<T> &v, bool throw_on_error ) const
 
 // object ~> containers with unmatching key_type and value_type
 // map, unordered_map ~> object
-template < typename T, typename std::enable_if <
-               !std::is_same<typename T::key_type, typename T::value_type>::value >::type * >
+template < typename T, std::enable_if_t <
+               !std::is_same_v<typename T::key_type, typename T::value_type> > * >
 bool JsonValue::read( T &m, bool throw_on_error ) const
 {
     if( !test_object() ) {
@@ -587,8 +587,8 @@ bool JsonValue::read( T &m, bool throw_on_error ) const
 }
 
 // array ~> vector, deque, list
-template < typename T, typename std::enable_if <
-               !std::is_same<void, typename T::value_type>::value >::type * >
+template < typename T, std::enable_if_t <
+               !std::is_same_v<void, typename T::value_type> > * >
 auto JsonArray::read( T &v, bool throw_on_error ) const -> decltype( v.front(), true )
 {
     try {
@@ -819,13 +819,13 @@ inline std::string JsonObject::get_string( const char *key ) const
     return get_member( key );
 }
 
-template<typename T, typename std::enable_if_t<std::is_convertible<T, std::string>::value>*>
+template<typename T, typename std::enable_if_t<std::is_convertible_v<T, std::string>>*>
 std::string JsonObject::get_string( const std::string &key, T &&fallback ) const
 {
     return get_string( key.c_str(), std::forward<T>( fallback ) );
 }
 
-template<typename T, typename std::enable_if_t<std::is_convertible<T, std::string>::value>*>
+template<typename T, typename std::enable_if_t<std::is_convertible_v<T, std::string>>*>
 std::string JsonObject::get_string( const char *key, T &&fallback ) const
 {
     size_t idx = 0;

--- a/src/flexbuffer_json.h
+++ b/src/flexbuffer_json.h
@@ -253,7 +253,7 @@ class JsonValue : Json
         template<typename T>
         auto read( T &v, bool throw_on_error = false ) const -> decltype( v.deserialize( *this ), true );
 
-        template<typename T, std::enable_if_t<std::is_enum<T>::value, int> = 0>
+        template<typename T, std::enable_if_t<std::is_enum_v<T>, int> = 0>
         bool read( T &val, bool throw_on_error = false ) const;
 
         /// Overload for std::pair
@@ -261,8 +261,8 @@ class JsonValue : Json
         bool read( std::pair<T, U> &p, bool throw_on_error = false ) const;
 
         // array ~> vector, deque, list
-        template < typename T, typename std::enable_if <
-                       !std::is_same<void, typename T::value_type>::value >::type * = nullptr
+        template < typename T, std::enable_if_t <
+                       !std::is_same_v<void, typename T::value_type> > * = nullptr
                    >
         auto read( T &v, bool throw_on_error = false ) const -> decltype( v.front(), true );
 
@@ -272,8 +272,8 @@ class JsonValue : Json
 
         // object ~> containers with matching key_type and value_type
         // set, unordered_set ~> object
-        template <typename T, typename std::enable_if<
-                      std::is_same<typename T::key_type, typename T::value_type>::value>::type * = nullptr
+        template <typename T, std::enable_if_t<
+                      std::is_same_v<typename T::key_type, typename T::value_type>> * = nullptr
                   >
         bool read( T &v, bool throw_on_error = false ) const;
 
@@ -283,19 +283,19 @@ class JsonValue : Json
 
         // special case for colony<item> as it supports RLE
         // see corresponding `write` for details
-        template <typename T, std::enable_if_t<std::is_same<T, item>::value>* = nullptr >
+        template <typename T, std::enable_if_t<std::is_same_v<T, item>>* = nullptr >
         bool read( cata::colony<T> &v, bool throw_on_error = false ) const;
 
         // special case for colony as it uses `insert()` instead of `push_back()`
         // and therefore doesn't fit with vector/deque/list
         // for colony of items there is another specialization with RLE
-        template < typename T, std::enable_if_t < !std::is_same<T, item>::value > * = nullptr >
+        template < typename T, std::enable_if_t < !std::is_same_v<T, item> > * = nullptr >
         bool read( cata::colony<T> &v, bool throw_on_error = false ) const;
 
         // object ~> containers with unmatching key_type and value_type
         // map, unordered_map ~> object
-        template < typename T, typename std::enable_if <
-                       !std::is_same<typename T::key_type, typename T::value_type>::value >::type * = nullptr
+        template < typename T, std::enable_if_t <
+                       !std::is_same_v<typename T::key_type, typename T::value_type> > * = nullptr
                    >
         bool read( T &m, bool throw_on_error = true ) const;
 
@@ -440,25 +440,25 @@ class JsonArray : JsonWithPath
 
         JsonValue next_value();
 
-        template<typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-        E next_enum_value() ;
+        template<typename E, typename = std::enable_if_t<std::is_enum_v<E>>>
+                 E next_enum_value() ;
 
-        // array ~> vector, deque, list
-        template < typename T, typename std::enable_if <
-                       !std::is_same<void, typename T::value_type>::value >::type * = nullptr
-                   >
-        auto read( T &v, bool throw_on_error = false ) const -> decltype( v.front(), true );
+                 // array ~> vector, deque, list
+                 template < typename T, std::enable_if_t <
+                                !std::is_same_v<void, typename T::value_type> > * = nullptr
+                            >
+                 auto read( T &v, bool throw_on_error = false ) const -> decltype( v.front(), true );
 
-        // random-access read values by reference
-        template <typename T> bool read_next( T &t, bool throw_on_error = false );
+                 // random-access read values by reference
+                 template <typename T> bool read_next( T &t, bool throw_on_error = false );
 
-        // random-access read values by reference
-        template <typename T> bool read( size_t idx, T &t, bool throw_on_error = false ) const;
+                 // random-access read values by reference
+                 template <typename T> bool read( size_t idx, T &t, bool throw_on_error = false ) const;
 
-        template <typename T = std::string, typename Res = std::set<T>>
-        Res get_tags( size_t idx ) const;
+                 template <typename T = std::string, typename Res = std::set<T>>
+                 Res get_tags( size_t idx ) const;
 
-        [[noreturn]] void string_error( size_t idx, int offset, const std::string &message ) const;
+                 [[noreturn]] void string_error( size_t idx, int offset, const std::string &message ) const;
 
         bool has_more() const {
             return next_ < size_;
@@ -599,10 +599,10 @@ class JsonObject : JsonWithPath
         std::string get_string( const std::string &key ) const;
         std::string get_string( const char *key ) const;
 
-        template<typename T, typename std::enable_if_t<std::is_convertible<T, std::string>::value>* = nullptr>
+        template<typename T, typename std::enable_if_t<std::is_convertible_v<T, std::string>>* = nullptr>
         std::string get_string( const std::string &key, T && fallback ) const;
 
-        template<typename T, typename std::enable_if_t<std::is_convertible<T, std::string>::value>* = nullptr>
+        template<typename T, typename std::enable_if_t<std::is_convertible_v<T, std::string>>* = nullptr>
         std::string get_string( const char *key, T && fallback ) const;
 
         // Vanilla accessors. Just return the named member and use it's conversion function.
@@ -612,52 +612,52 @@ class JsonObject : JsonWithPath
         JsonArray get_array( std::string_view key ) const;
         JsonObject get_object( std::string_view key ) const;
 
-        template<typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-        E get_enum_value( const std::string &name ) const;
-        template<typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-        E get_enum_value( const char *name ) const;
+        template<typename E, typename = std::enable_if_t<std::is_enum_v<E>>>
+                 E get_enum_value( const std::string &name ) const;
+                 template<typename E, typename = std::enable_if_t<std::is_enum_v<E>>>
+                          E get_enum_value( const char *name ) const;
 
-        template<typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-        E get_enum_value( const std::string &name, E fallback ) const;
-        template<typename E, typename = typename std::enable_if<std::is_enum<E>::value>::type>
-        E get_enum_value( const char *name, E fallback ) const;
+                          template<typename E, typename = std::enable_if_t<std::is_enum_v<E>>>
+                                   E get_enum_value( const std::string &name, E fallback ) const;
+                                   template<typename E, typename = std::enable_if_t<std::is_enum_v<E>>>
+                                            E get_enum_value( const char *name, E fallback ) const;
 
-        // Sigh.
-        std::vector<int> get_int_array( std::string_view name ) const;
-        std::vector<std::string> get_string_array( std::string_view name ) const;
-        std::vector<std::string> get_as_string_array( const std::string &name ) const;
+                                            // Sigh.
+                                            std::vector<int> get_int_array( std::string_view name ) const;
+                                            std::vector<std::string> get_string_array( std::string_view name ) const;
+                                            std::vector<std::string> get_as_string_array( const std::string &name ) const;
 
-        bool has_member( std::string_view key ) const;
-        bool has_null( std::string_view key ) const;
-        bool has_string( std::string_view key ) const;
-        bool has_bool( std::string_view key ) const;
-        bool has_number( std::string_view key ) const;
-        bool has_int( std::string_view key ) const;
-        bool has_float( std::string_view key ) const;
-        bool has_array( std::string_view key ) const;
-        bool has_object( std::string_view key ) const;
+                                            bool has_member( std::string_view key ) const;
+                                            bool has_null( std::string_view key ) const;
+                                            bool has_string( std::string_view key ) const;
+                                            bool has_bool( std::string_view key ) const;
+                                            bool has_number( std::string_view key ) const;
+                                            bool has_int( std::string_view key ) const;
+                                            bool has_float( std::string_view key ) const;
+                                            bool has_array( std::string_view key ) const;
+                                            bool has_object( std::string_view key ) const;
 
-        // Fallback accessors. Test if the named member exists, and if yes, return it,
-        // else will return the fallback value. Does *not* test the member is the type
-        // being requested.
-        bool get_bool( std::string_view key, bool fallback ) const;
-        int get_int( std::string_view key, int fallback ) const;
-        double get_float( std::string_view key, double fallback ) const;
+                                            // Fallback accessors. Test if the named member exists, and if yes, return it,
+                                            // else will return the fallback value. Does *not* test the member is the type
+                                            // being requested.
+                                            bool get_bool( std::string_view key, bool fallback ) const;
+                                            int get_int( std::string_view key, int fallback ) const;
+                                            double get_float( std::string_view key, double fallback ) const;
 
-        // Tries to get the member, and if found, calls it visited.
-        std::optional<JsonValue> get_member_opt( std::string_view key ) const;
-        JsonValue get_member( std::string_view key ) const;
-        JsonValue operator[]( std::string_view key ) const;
+                                            // Tries to get the member, and if found, calls it visited.
+                                            std::optional<JsonValue> get_member_opt( std::string_view key ) const;
+                                            JsonValue get_member( std::string_view key ) const;
+                                            JsonValue operator[]( std::string_view key ) const;
 
-        // Schwillions of read overloads
-        template <typename T>
-        bool read( std::string_view name, T &t, bool throw_on_error = true ) const;
+                                            // Schwillions of read overloads
+                                            template <typename T>
+                                            bool read( std::string_view name, T &t, bool throw_on_error = true ) const;
 
-        template <typename T = std::string, typename Res = std::set<T>>
-        Res get_tags( std::string_view name ) const;
+                                            template <typename T = std::string, typename Res = std::set<T>>
+                                            Res get_tags( std::string_view name ) const;
 
-        [[noreturn]] void throw_error( const std::string &err ) const;
-        [[noreturn]] void throw_error_at( std::string_view member, const std::string &err ) const;
+                                            [[noreturn]] void throw_error( const std::string &err ) const;
+                                            [[noreturn]] void throw_error_at( std::string_view member, const std::string &err ) const;
 
         void allow_omitted_members() const {
             visited_fields_bitset_.set_all();
@@ -693,8 +693,8 @@ class JsonObject : JsonWithPath
         static bool find_map_key_idx( const std::string_view key, const flexbuffers::TypedVector &keys,
                                       size_t &idx ) {
             // Handlrolled binary search because the STL does not provide a version that just uses indexes.
-            typename std::make_signed<size_t>::type low = 0;
-            typename std::make_signed<size_t>::type high = keys.size() - 1;
+            std::make_signed_t<size_t>low = 0;
+            std::make_signed_t<size_t>high = keys.size() - 1;
             while( low <= high ) {
                 std::make_signed_t<size_t> mid = ( high - low ) / 2 + low;
 

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -843,9 +843,9 @@ If the 5. parameter can be used to construct a `MemberType`, it is assumed to be
 otherwise it is assumed to be the reader.
 */
 template<typename MemberType, typename DefaultType = MemberType,
-         typename = typename std::enable_if<std::is_constructible<MemberType, const DefaultType &>::value>::type>
-inline void optional( const JsonObject &jo, const bool was_loaded, const std::string_view name,
-                      MemberType &member, const DefaultType &default_value )
+         typename = std::enable_if_t<std::is_constructible_v<MemberType, const DefaultType &>>>
+                                     inline void optional( const JsonObject &jo, const bool was_loaded, const std::string_view name,
+                                             MemberType &member, const DefaultType &default_value )
 {
     if( !jo.read( name, member ) && !handle_proportional( jo, name, member ) &&
         !handle_relative( jo, name, member ) ) {
@@ -855,8 +855,8 @@ inline void optional( const JsonObject &jo, const bool was_loaded, const std::st
     }
 }
 template < typename MemberType, typename ReaderType, typename DefaultType = MemberType,
-           typename = typename std::enable_if <
-               !std::is_constructible<MemberType, const ReaderType &>::value >::type >
+           typename = std::enable_if_t <
+               !std::is_constructible_v<MemberType, const ReaderType &> > >
 inline void optional( const JsonObject &jo, const bool was_loaded, const std::string_view name,
                       MemberType &member, const ReaderType &reader )
 {
@@ -1007,156 +1007,156 @@ struct handler<std::vector<T>> {
 template<typename Derived>
 class generic_typed_reader
 {
-    public:
-        template<typename C>
-        void insert_values_from( const JsonObject &jo, const std::string_view member_name,
-                                 C &container ) const {
-            const Derived &derived = static_cast<const Derived &>( *this );
-            if( !jo.has_member( member_name ) ) {
-                return;
-            }
-            JsonValue jv = jo.get_member( member_name );
-            // We allow either a single value or an array of values. Note that this will not work
-            // correctly if the thing we load from JSON is itself an array.
-            if( jv.test_array() ) {
-                for( JsonValue jav : jv.get_array() ) {
-                    derived.insert_next( jav, container );
-                }
-            } else {
-                derived.insert_next( jv, container );
-            }
+public:
+    template<typename C>
+    void insert_values_from( const JsonObject &jo, const std::string_view member_name,
+                             C &container ) const {
+        const Derived &derived = static_cast<const Derived &>( *this );
+        if( !jo.has_member( member_name ) ) {
+            return;
         }
+        JsonValue jv = jo.get_member( member_name );
+        // We allow either a single value or an array of values. Note that this will not work
+        // correctly if the thing we load from JSON is itself an array.
+        if( jv.test_array() ) {
+            for( JsonValue jav : jv.get_array() ) {
+                derived.insert_next( jav, container );
+            }
+        } else {
+            derived.insert_next( jv, container );
+        }
+    }
 
-        template<typename C>
-        void insert_next( JsonValue &jv, C &container ) const {
-            const Derived &derived = static_cast<const Derived &>( *this );
-            reader_detail::handler<C>().insert( container, derived.get_next( jv ) );
-        }
+    template<typename C>
+    void insert_next( JsonValue &jv, C &container ) const {
+        const Derived &derived = static_cast<const Derived &>( *this );
+        reader_detail::handler<C>().insert( container, derived.get_next( jv ) );
+    }
 
-        template<typename C>
-        void erase_values_from( const JsonObject &jo, const std::string_view member_name,
-                                C &container ) const {
-            const Derived &derived = static_cast<const Derived &>( *this );
-            if( !jo.has_member( member_name ) ) {
-                return;
-            }
-            JsonValue jv = jo.get_member( member_name );
-            // Same as for inserting: either an array or a single value, same caveat applies.
-            if( jv.test_array() ) {
-                for( JsonValue jav : jv.get_array() ) {
-                    derived.erase_next( jav, container );
-                }
-            } else {
-                derived.erase_next( jv, container );
-            }
+    template<typename C>
+    void erase_values_from( const JsonObject &jo, const std::string_view member_name,
+                            C &container ) const {
+        const Derived &derived = static_cast<const Derived &>( *this );
+        if( !jo.has_member( member_name ) ) {
+            return;
         }
-        template<typename C>
-        void erase_next( JsonValue &jv, C &container ) const {
-            const Derived &derived = static_cast<const Derived &>( *this );
-            reader_detail::handler<C>().erase( container, derived.get_next( jv ) );
+        JsonValue jv = jo.get_member( member_name );
+        // Same as for inserting: either an array or a single value, same caveat applies.
+        if( jv.test_array() ) {
+            for( JsonValue jav : jv.get_array() ) {
+                derived.erase_next( jav, container );
+            }
+        } else {
+            derived.erase_next( jv, container );
         }
+    }
+    template<typename C>
+    void erase_next( JsonValue &jv, C &container ) const {
+        const Derived &derived = static_cast<const Derived &>( *this );
+        reader_detail::handler<C>().erase( container, derived.get_next( jv ) );
+    }
 
-        /**
-         * Implements the reader interface, handles members that are containers of flags.
-         * The functions forwards the actual changes to assign(), insert()
-         * and erase(), which are specialized for various container types.
-         * The `enable_if` is here to prevent the compiler from considering it
-         * when called on a simple data member, the other `operator()` will be used.
-         */
-        template<typename C, typename std::enable_if<reader_detail::handler<C>::is_container, int>::type = 0>
-        bool operator()( const JsonObject &jo, const std::string_view member_name,
-                         C &container, bool was_loaded ) const {
-            const Derived &derived = static_cast<const Derived &>( *this );
-            // If you get an error about "incomplete type 'struct reader_detail::handler...",
-            // you have to implement a specialization of your container type, so above for
-            // existing specializations in namespace reader_detail.
-            if( jo.has_member( member_name ) ) {
-                reader_detail::handler<C>().clear( container );
-                derived.insert_values_from( jo, member_name, container );
-                return true;
-            } else if( !was_loaded ) {
+    /**
+     * Implements the reader interface, handles members that are containers of flags.
+     * The functions forwards the actual changes to assign(), insert()
+     * and erase(), which are specialized for various container types.
+     * The `enable_if` is here to prevent the compiler from considering it
+     * when called on a simple data member, the other `operator()` will be used.
+     */
+    template<typename C, std::enable_if_t<reader_detail::handler<C>::is_container, int> = 0>
+    bool operator()( const JsonObject &jo, const std::string_view member_name,
+                     C &container, bool was_loaded ) const {
+        const Derived &derived = static_cast<const Derived &>( *this );
+        // If you get an error about "incomplete type 'struct reader_detail::handler...",
+        // you have to implement a specialization of your container type, so above for
+        // existing specializations in namespace reader_detail.
+        if( jo.has_member( member_name ) ) {
+            reader_detail::handler<C>().clear( container );
+            derived.insert_values_from( jo, member_name, container );
+            return true;
+        } else if( !was_loaded ) {
+            return false;
+        } else {
+            if( jo.has_object( "extend" ) ) {
+                JsonObject tmp = jo.get_object( "extend" );
+                tmp.allow_omitted_members();
+                derived.insert_values_from( tmp, member_name, container );
+            }
+            if( jo.has_object( "delete" ) ) {
+                JsonObject tmp = jo.get_object( "delete" );
+                tmp.allow_omitted_members();
+                derived.erase_values_from( tmp, member_name, container );
+            }
+            return true;
+        }
+    }
+
+    /*
+     * These two functions are effectively handle_relative but they need to
+     * use the reader, so they must be here.
+     * proportional does not need these, because it's only reading a float
+     * whereas these are reading values of the same type.
+     */
+    // Type does not support relative
+    template < typename C, std::enable_if_t < !reader_detail::handler<C>::is_container,
+               int > = 0,
+               std::enable_if_t < !supports_relative<C>::value > * = nullptr
+               >
+    bool do_relative( const JsonObject &jo, const std::string_view name, C & ) const {
+        if( jo.has_object( "relative" ) ) {
+            JsonObject relative = jo.get_object( "relative" );
+            relative.allow_omitted_members();
+            if( !relative.has_member( name ) ) {
                 return false;
-            } else {
-                if( jo.has_object( "extend" ) ) {
-                    JsonObject tmp = jo.get_object( "extend" );
-                    tmp.allow_omitted_members();
-                    derived.insert_values_from( tmp, member_name, container );
-                }
-                if( jo.has_object( "delete" ) ) {
-                    JsonObject tmp = jo.get_object( "delete" );
-                    tmp.allow_omitted_members();
-                    derived.erase_values_from( tmp, member_name, container );
-                }
-                return true;
             }
+            debugmsg( "Member %s of type %s does not support relative",
+                      name, demangle( typeid( C ).name() ) );
         }
+        return false;
+    }
 
-        /*
-         * These two functions are effectively handle_relative but they need to
-         * use the reader, so they must be here.
-         * proportional does not need these, because it's only reading a float
-         * whereas these are reading values of the same type.
-         */
-        // Type does not support relative
-        template < typename C, typename std::enable_if < !reader_detail::handler<C>::is_container,
-                   int >::type = 0,
-                   std::enable_if_t < !supports_relative<C>::value > * = nullptr
-                   >
-        bool do_relative( const JsonObject &jo, const std::string_view name, C & ) const {
-            if( jo.has_object( "relative" ) ) {
-                JsonObject relative = jo.get_object( "relative" );
-                relative.allow_omitted_members();
-                if( !relative.has_member( name ) ) {
-                    return false;
-                }
-                debugmsg( "Member %s of type %s does not support relative",
-                          name, demangle( typeid( C ).name() ) );
+    // Type supports relative
+    template < typename C, std::enable_if_t < !reader_detail::handler<C>::is_container,
+               int > = 0, std::enable_if_t<supports_relative<C>::value> * = nullptr >
+    bool do_relative( const JsonObject &jo, const std::string_view name, C &member ) const {
+        if( jo.has_object( "relative" ) ) {
+            JsonObject relative = jo.get_object( "relative" );
+            relative.allow_omitted_members();
+            const Derived &derived = static_cast<const Derived &>( *this );
+            // This needs to happen here, otherwise we get unvisited members
+            if( !relative.has_member( name ) ) {
+                return false;
             }
-            return false;
+            C adder = derived.get_next( relative.get_member( name ) );
+            member += adder;
+            return true;
         }
+        return false;
+    }
 
-        // Type supports relative
-        template < typename C, typename std::enable_if < !reader_detail::handler<C>::is_container,
-                   int >::type = 0, std::enable_if_t<supports_relative<C>::value> * = nullptr >
-        bool do_relative( const JsonObject &jo, const std::string_view name, C &member ) const {
-            if( jo.has_object( "relative" ) ) {
-                JsonObject relative = jo.get_object( "relative" );
-                relative.allow_omitted_members();
-                const Derived &derived = static_cast<const Derived &>( *this );
-                // This needs to happen here, otherwise we get unvisited members
-                if( !relative.has_member( name ) ) {
-                    return false;
-                }
-                C adder = derived.get_next( relative.get_member( name ) );
-                member += adder;
-                return true;
-            }
-            return false;
+    template<typename C>
+    bool read_normal( const JsonObject &jo, const std::string_view name, C &member ) const {
+        if( jo.has_member( name ) ) {
+            const Derived &derived = static_cast<const Derived &>( *this );
+            member = derived.get_next( jo.get_member( name ) );
+            return true;
         }
+        return false;
+    }
 
-        template<typename C>
-        bool read_normal( const JsonObject &jo, const std::string_view name, C &member ) const {
-            if( jo.has_member( name ) ) {
-                const Derived &derived = static_cast<const Derived &>( *this );
-                member = derived.get_next( jo.get_member( name ) );
-                return true;
-            }
-            return false;
-        }
-
-        /**
-         * Implements the reader interface, handles a simple data member.
-         */
-        // was_loaded is ignored here, if the value is not found in JSON, report to
-        // the caller, which will take action on their own.
-        template < typename C, typename std::enable_if < !reader_detail::handler<C>::is_container,
-                   int >::type = 0 >
-        bool operator()( const JsonObject &jo, const std::string_view member_name,
-                         C &member, bool /*was_loaded*/ ) const {
-            return read_normal( jo, member_name, member ) ||
-                   handle_proportional( jo, member_name, member ) ||
-                   do_relative( jo, member_name, member );
-        }
+    /**
+     * Implements the reader interface, handles a simple data member.
+     */
+    // was_loaded is ignored here, if the value is not found in JSON, report to
+    // the caller, which will take action on their own.
+    template < typename C, std::enable_if_t < !reader_detail::handler<C>::is_container,
+               int > = 0 >
+    bool operator()( const JsonObject &jo, const std::string_view member_name,
+                     C &member, bool /*was_loaded*/ ) const {
+        return read_normal( jo, member_name, member ) ||
+        handle_proportional( jo, member_name, member ) ||
+        do_relative( jo, member_name, member );
+    }
 };
 
 /**
@@ -1174,10 +1174,10 @@ class generic_typed_reader
 template<typename FlagType = std::string>
 class auto_flags_reader : public generic_typed_reader<auto_flags_reader<FlagType>>
 {
-    public:
-        FlagType get_next( std::string &&str ) const {
-            return FlagType( std::move( str ) );
-        }
+public:
+    FlagType get_next( std::string &&str ) const {
+        return FlagType( std::move( str ) );
+    }
 };
 
 using string_reader = auto_flags_reader<>;
@@ -1246,33 +1246,33 @@ class money_reader : public generic_typed_reader<units::money>
 template<typename T>
 class typed_flag_reader : public generic_typed_reader<typed_flag_reader<T>>
 {
-    private:
-        using map_t = std::unordered_map<std::string, T>;
+private:
+    using map_t = std::unordered_map<std::string, T>;
 
-        const map_t &flag_map;
-        const std::string flag_type;
+    const map_t &flag_map;
+    const std::string flag_type;
 
-    public:
-        typed_flag_reader( const map_t &flag_map, const std::string_view flag_type )
-            : flag_map( flag_map )
-            , flag_type( flag_type ) {
+public:
+    typed_flag_reader( const map_t &flag_map, const std::string_view flag_type )
+        : flag_map( flag_map )
+        , flag_type( flag_type ) {
+    }
+
+    explicit typed_flag_reader( const std::string_view flag_type )
+        : flag_map( io::get_enum_lookup_map<T>() )
+        , flag_type( flag_type ) {
+    }
+
+    T get_next( const JsonValue &jv ) const {
+        const std::string flag = jv;
+        const auto iter = flag_map.find( flag );
+
+        if( iter == flag_map.cend() ) {
+            jv.throw_error( string_format( "invalid %s: \"%s\"", flag_type, flag ) );
         }
 
-        explicit typed_flag_reader( const std::string_view flag_type )
-            : flag_map( io::get_enum_lookup_map<T>() )
-            , flag_type( flag_type ) {
-        }
-
-        T get_next( const JsonValue &jv ) const {
-            const std::string flag = jv;
-            const auto iter = flag_map.find( flag );
-
-            if( iter == flag_map.cend() ) {
-                jv.throw_error( string_format( "invalid %s: \"%s\"", flag_type, flag ) );
-            }
-
-            return iter->second;
-        }
+        return iter->second;
+    }
 };
 
 template<typename T>
@@ -1288,22 +1288,22 @@ typed_flag_reader<T> make_flag_reader( const std::unordered_map<std::string, T> 
 template<typename E>
 class enum_flags_reader : public generic_typed_reader<enum_flags_reader<E>>
 {
-    private:
-        const std::string flag_type;
+private:
+    const std::string flag_type;
 
-    public:
-        explicit enum_flags_reader( const std::string &flag_type ) : flag_type( flag_type ) {
-        }
+public:
+    explicit enum_flags_reader( const std::string &flag_type ) : flag_type( flag_type ) {
+    }
 
-        E get_next( const JsonValue &jv ) const {
-            const std::string flag = jv.get_string();
-            try {
-                return io::string_to_enum<E>( flag );
-            } catch( const io::InvalidEnumString & ) {
-                jv.throw_error( string_format( "invalid %s: \"%s\"", flag_type, flag ) );
-                throw; // ^^ throws already
-            }
+    E get_next( const JsonValue &jv ) const {
+        const std::string flag = jv.get_string();
+        try {
+            return io::string_to_enum<E>( flag );
+        } catch( const io::InvalidEnumString & ) {
+            jv.throw_error( string_format( "invalid %s: \"%s\"", flag_type, flag ) );
+            throw; // ^^ throws already
         }
+    }
 };
 
 /**
@@ -1312,10 +1312,10 @@ class enum_flags_reader : public generic_typed_reader<enum_flags_reader<E>>
 template<typename T>
 class string_id_reader : public generic_typed_reader<string_id_reader<T>>
 {
-    public:
-        string_id<T> get_next( std::string &&str ) const {
-            return string_id<T>( std::move( str ) );
-        }
+public:
+    string_id<T> get_next( std::string &&str ) const {
+        return string_id<T>( std::move( str ) );
+    }
 };
 
 /**

--- a/src/int_id.h
+++ b/src/int_id.h
@@ -32,7 +32,7 @@ class int_id
         /**
          * Prevent accidental construction from other int ids.
          */
-        template < typename S, typename std::enable_if_t < !std::is_same<S, T>::value, int > = 0 >
+        template < typename S, typename std::enable_if_t < !std::is_same_v<S, T>, int > = 0 >
         int_id( const int_id<S> &id ) = delete;
 
         /**
@@ -55,7 +55,7 @@ class int_id
          * and std::strings to be used.
          */
         template<typename S, class =
-                 typename std::enable_if< std::is_convertible<S, std::string >::value>::type >
+                 std::enable_if_t< std::is_convertible_v<S, std::string >> >
         explicit int_id( S && id ) : int_id( string_id<T>( std::forward<S>( id ) ) ) {}
 
         /**

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -729,7 +729,7 @@ struct item_contents::item_contents_helper {
     // find_pocket_for with less code duplication
     template<typename ItemContents>
     using pocket_type = std::conditional_t <
-                        std::is_const<ItemContents>::value,
+                        std::is_const_v<ItemContents>,
                         const item_pocket,
                         item_pocket
                         >;

--- a/src/make_static.h
+++ b/src/make_static.h
@@ -31,7 +31,7 @@ inline const T &static_argument_identity( const T &t )
 #define STATIC(expr) \
     (([]()-> const auto &{ \
         using ExprType = std::decay_t<decltype(static_argument_identity( expr ))>; \
-        using CachedType = std::conditional_t<std::is_same<ExprType, const char*>::value, \
+        using CachedType = std::conditional_t<std::is_same_v<ExprType, const char*>, \
                            std::string, ExprType>; \
         static const CachedType _cached_expr = static_argument_identity( expr ); \
         return _cached_expr; \

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1144,7 +1144,7 @@ class mapgen_value
         using StringId = to_string_id_t<Id>;
         struct void_;
         using Id_unless_string =
-            std::conditional_t<std::is_same<Id, std::string>::value, void_, Id>;
+            std::conditional_t<std::is_same_v<Id, std::string>, void_, Id>;
 
         struct value_source {
             virtual ~value_source() = default;

--- a/src/mapgendata.h
+++ b/src/mapgendata.h
@@ -29,12 +29,12 @@ struct mapgen_arguments {
     template <
         typename InputRange,
         std::enable_if_t <
-            std::is_same <
+            std::is_same_v <
                 typename InputRange::value_type, std::pair<std::string, cata_variant>
-                >::value ||
-            std::is_same <
+                > ||
+            std::is_same_v <
                 typename InputRange::value_type, std::pair<const std::string, cata_variant>
-                >::value
+                >
             > * = nullptr >
     explicit mapgen_arguments( const InputRange &map_ )
         : map( map_.begin(), map_.end() )

--- a/src/output.h
+++ b/src/output.h
@@ -795,10 +795,10 @@ std::map<std::string, inclusive_rectangle<point>> draw_tabs( const catacurses::w
 // };
 // draw_tabs( w, tabs, current_tab );
 template<typename TabList, typename CurrentTab, typename = std::enable_if_t<
-             std::is_same<CurrentTab,
-                          std::remove_const_t<typename TabList::value_type::first_type>>::value>>
-std::map<CurrentTab, inclusive_rectangle<point>> draw_tabs( const catacurses::window &w,
-        const TabList &tab_list, const CurrentTab &current_tab )
+             std::is_same_v<CurrentTab,
+                            std::remove_const_t<typename TabList::value_type::first_type>>>>
+             std::map<CurrentTab, inclusive_rectangle<point>> draw_tabs( const catacurses::window &w,
+                     const TabList &tab_list, const CurrentTab &current_tab )
 {
     std::vector<std::string> tab_text;
     std::transform( tab_list.begin(), tab_list.end(), std::back_inserter( tab_text ),
@@ -827,10 +827,10 @@ std::map<CurrentTab, inclusive_rectangle<point>> draw_tabs( const catacurses::wi
 // Similar to the above, but where the order of tabs is specified separately
 // TabList is expected to be a map type.
 template<typename TabList, typename TabKeys, typename CurrentTab, typename = std::enable_if_t<
-             std::is_same<CurrentTab,
-                          std::remove_const_t<typename TabList::value_type::first_type>>::value>>
-std::map<CurrentTab, inclusive_rectangle<point>> draw_tabs( const catacurses::window &w,
-        const TabList &tab_list, const TabKeys &keys, const CurrentTab &current_tab )
+             std::is_same_v<CurrentTab,
+                            std::remove_const_t<typename TabList::value_type::first_type>>>>
+             std::map<CurrentTab, inclusive_rectangle<point>> draw_tabs( const catacurses::window &w,
+                     const TabList &tab_list, const TabKeys &keys, const CurrentTab &current_tab )
 {
     std::vector<typename TabList::value_type> ordered_tab_list;
     for( const auto &key : keys ) {

--- a/src/pimpl.h
+++ b/src/pimpl.h
@@ -19,7 +19,7 @@ class is_pimpl_helper<pimpl<T>> : public std::true_type
 {
 };
 template<typename T>
-class is_pimpl : public is_pimpl_helper<typename std::decay<T>::type>
+class is_pimpl : public is_pimpl_helper<std::decay_t<T>>
 {
 };
 /**
@@ -43,7 +43,7 @@ class pimpl : private std::unique_ptr<T>
         // argument is a `pimpl` itself (the other copy constructors should be used instead).
         explicit pimpl() : std::unique_ptr<T>( new T() ) { }
         template < typename P, typename ...Args,
-                   typename = typename std::enable_if < !is_pimpl<P>::value >::type >
+                   typename = std::enable_if_t < !is_pimpl<P>::value > >
         explicit pimpl( P && head, Args &&
                         ... args ) : std::unique_ptr<T>( new T( std::forward<P>( head ), std::forward<Args>( args )... ) ) { }
 

--- a/src/point_traits.h
+++ b/src/point_traits.h
@@ -32,7 +32,7 @@ struct point_traits {
 template<typename Point>
 struct point_traits <
     Point,
-    std::enable_if_t < std::is_same<Point, point>::value || std::is_same<Point, tripoint>::value >
+    std::enable_if_t < std::is_same_v<Point, point> || std::is_same_v<Point, tripoint> >
     >  {
     static int &x( Point &p ) {
         return p.x;

--- a/src/requirements.h
+++ b/src/requirements.h
@@ -231,10 +231,10 @@ struct requirement_data {
         template <
             typename Container,
             typename = std::enable_if_t <
-                std::is_same <
-                    typename Container::value_type, std::pair<requirement_id, int >>::value ||
-                std::is_same <
-                    typename Container::value_type, std::pair<const requirement_id, int >>::value
+                std::is_same_v <
+                    typename Container::value_type, std::pair<requirement_id, int >> ||
+                std::is_same_v <
+                    typename Container::value_type, std::pair<const requirement_id, int >>
                 >
             >
         explicit requirement_data( const Container &cont ) :

--- a/src/ret_val.h
+++ b/src/ret_val.h
@@ -23,9 +23,9 @@ class ret_val_common
         }
     protected:
         template<typename S>
-        using is_convertible_to_string = typename std::enable_if <
-                                         !std::is_same<S, std::nullptr_t>::value
-                                         && std::is_convertible<S, std::string>::value >::type;
+        using is_convertible_to_string = std::enable_if_t <
+                                         !std::is_same_v<S, std::nullptr_t>
+                                         &&std::is_convertible_v<S, std::string> >;
 
         ret_val_common( const std::string &msg, bool succ )
             : msg( msg ), succ( succ )
@@ -47,7 +47,7 @@ class ret_val_common
 template<typename T>
 class ret_val : public ret_val_common
 {
-        static_assert( !std::is_convertible<T, std::string>::value, "string values aren't allowed" );
+        static_assert( !std::is_convertible_v<T, std::string>, "string values aren't allowed" );
 
     public:
         /**

--- a/src/rng.h
+++ b/src/rng.h
@@ -150,7 +150,7 @@ class is_std_array_helper<std::array<T, N>> : public std::true_type
 {
 };
 template<typename T>
-class is_std_array : public is_std_array_helper<typename std::decay<T>::type>
+class is_std_array : public is_std_array_helper<std::decay_t<T>>
 {
 };
 
@@ -160,8 +160,8 @@ class is_std_array : public is_std_array_helper<typename std::decay<T>::type>
  * or to the default value.
  */
 template<typename C, typename V = typename C::value_type>
-inline typename std::enable_if < !is_std_array<C>::value,
-       const V & >::type random_entry_ref( const C &container )
+inline std::enable_if_t < !is_std_array<C>::value,
+       const V & > random_entry_ref( const C &container )
 {
     if( container.empty() ) {
         static const V default_value = V();

--- a/src/safe_reference.cpp
+++ b/src/safe_reference.cpp
@@ -1,7 +1,7 @@
 #include "safe_reference.h"
 
-static_assert( std::is_nothrow_move_constructible<safe_reference_anchor>::value );
-static_assert( std::is_nothrow_move_assignable<safe_reference_anchor>::value );
+static_assert( std::is_nothrow_move_constructible_v<safe_reference_anchor> );
+static_assert( std::is_nothrow_move_assignable_v<safe_reference_anchor> );
 
 safe_reference_anchor::safe_reference_anchor()
 {

--- a/src/savegame.cpp
+++ b/src/savegame.cpp
@@ -932,7 +932,7 @@ void overmap::unserialize_view( const JsonObject &jsobj )
 template<typename MdArray>
 static void serialize_array_to_compacted_sequence( JsonOut &json, const MdArray &array )
 {
-    static_assert( std::is_same<typename MdArray::value_type, bool>::value,
+    static_assert( std::is_same_v<typename MdArray::value_type, bool>,
                    "This implementation assumes bool, in that the initial value of lastval has "
                    "to not be a valid value of the content" );
     int count = 0;

--- a/src/shadowcasting.h
+++ b/src/shadowcasting.h
@@ -127,7 +127,7 @@ void castLightAll( cata::mdarray<Out, point_bub_ms> &output_cache,
 template<typename T>
 using array_of_grids_of =
     std::conditional_t <
-    std::is_const<T>::value,
+    std::is_const_v<T>,
     std::array<const cata::mdarray<std::remove_const_t<T>, point_bub_ms>*, OVERMAP_LAYERS>,
     std::array<cata::mdarray<T, point_bub_ms>*, OVERMAP_LAYERS>
     >;

--- a/src/stats_tracker.h
+++ b/src/stats_tracker.h
@@ -135,7 +135,7 @@ class event_multiset_watcher : public base_watcher
 template<typename Watcher>
 class watcher_set
 {
-        static_assert( std::is_base_of<base_watcher, Watcher>::value,
+        static_assert( std::is_base_of_v<base_watcher, Watcher>,
                        "Watcher must be derived from base_watcher" );
     public:
         void insert( Watcher *watcher ) {

--- a/src/string_id.h
+++ b/src/string_id.h
@@ -128,9 +128,9 @@ class string_identity_static
 #endif
         {}
 
-        template<typename S, class = std::enable_if_t<std::is_convertible<S, std::string>::value>>
-        explicit string_identity_static( S && id )
-            : _id( string_id_intern( std::forward<S>( id ) ) )
+        template<typename S, class = std::enable_if_t<std::is_convertible_v<S, std::string>>>
+                 explicit string_identity_static( S && id )
+                     : _id( string_id_intern( std::forward<S>( id ) ) )
 #ifdef CATA_STRING_ID_DEBUGGING
             , _string_id( str().c_str() )
 #endif
@@ -175,8 +175,8 @@ class string_identity_dynamic
 
         string_identity_dynamic() = default;
 
-        template<typename S, class = std::enable_if_t<std::is_convertible<S, std::string>::value>>
-        explicit string_identity_dynamic( S && id ) : _id( std::forward<S>( id ) )  {}
+        template<typename S, class = std::enable_if_t<std::is_convertible_v<S, std::string>>>
+                 explicit string_identity_dynamic( S && id ) : _id( std::forward<S>( id ) )  {}
 
         inline const std::string &str() const {
             return _id;
@@ -196,169 +196,169 @@ class string_identity_dynamic
 template<typename T>
 class string_id
 {
-    public:
-        using value_type = T;
-        using This = string_id<T>;
-        // type of internal identity representation
-        using Identity = std::conditional_t<string_id_params<T>::dynamic,
-              string_identity_dynamic, string_identity_static>;
-        // type of lexicographic comparator for this string_id
-        using LexCmp = lexicographic<T>;
+public:
+    using value_type = T;
+    using This = string_id<T>;
+    // type of internal identity representation
+    using Identity = std::conditional_t<string_id_params<T>::dynamic,
+          string_identity_dynamic, string_identity_static>;
+    // type of lexicographic comparator for this string_id
+    using LexCmp = lexicographic<T>;
 
-        /**
-         * Forwarding constructor, forwards any parameter to the std::string
-         * constructor to create the id string. This allows plain C-strings,
-         * and std::strings to be used.
-         */
-        // Beautiful C++11: enable_if makes sure that S is always something that can be used to constructor
-        // a std::string, otherwise a "no matching function to call..." error is generated.
-        template<typename S, class = std::enable_if_t<std::is_convertible<S, std::string>::value>>
-        explicit string_id( S && id ) : _id( std::forward<S>( id ) ) {}
+    /**
+     * Forwarding constructor, forwards any parameter to the std::string
+     * constructor to create the id string. This allows plain C-strings,
+     * and std::strings to be used.
+     */
+    // Beautiful C++11: enable_if makes sure that S is always something that can be used to constructor
+    // a std::string, otherwise a "no matching function to call..." error is generated.
+    template<typename S, class = std::enable_if_t<std::is_convertible_v<S, std::string>>>
+             explicit string_id( S && id ) : _id( std::forward<S>( id ) ) {}
 
-        // string_view is not implicitly convertible to std::string, so need a
-        // separate constructor for that
-        explicit string_id( const std::string_view id ) : string_id( std::string( id ) ) {}
-        /**
-         * Default constructor constructs an empty id string.
-         * Note that this id class does not enforce empty id strings (or any specific string at all)
-         * to be special. Every string (including the empty one) may be a valid id.
-         */
-        string_id() : _id() {} // NOLINT(clang-analyzer-optin.cplusplus.UninitializedObject)
-        /**
-         * Comparison, only useful when the id is used in std::map or std::set as key.
-         * Guarantees total order, but DOESN'T guarantee the same order after process restart!
-         * To have a predictable lexicographic order, use `LexCmp` (much slower!)
-         */
-        bool operator<( const This &rhs ) const {
-            return _id._id < rhs._id._id;
-        }
-        /**
-         * The usual comparator, compares the string id as usual.
-         */
-        bool operator==( const This &rhs ) const {
-            return _id._id == rhs._id._id;
-        }
-        /**
-         * The usual comparator, compares the string id as usual.
-         */
-        bool operator!=( const This &rhs ) const {
-            return ! operator==( rhs );
-        }
-        /**
-         * Interface to the plain C-string of the id. This function mimics the std::string
-         * object. Ids are often used in debug messages, where they are forwarded as C-strings
-         * to be included in the format string, e.g. debugmsg("invalid id: %s", id.c_str())
-         */
-        const char *c_str() const {
-            return _id.str().c_str();
-        }
-        /**
-         * Returns the identifier as plain std::string. Use with care, the plain string does not
-         * have any information as what type of object it refers to (the T template parameter of
-         * the class).
-         */
-        const std::string &str() const {
-            return _id.str();
-        }
+    // string_view is not implicitly convertible to std::string, so need a
+    // separate constructor for that
+    explicit string_id( const std::string_view id ) : string_id( std::string( id ) ) {}
+    /**
+     * Default constructor constructs an empty id string.
+     * Note that this id class does not enforce empty id strings (or any specific string at all)
+     * to be special. Every string (including the empty one) may be a valid id.
+     */
+    string_id() : _id() {} // NOLINT(clang-analyzer-optin.cplusplus.UninitializedObject)
+    /**
+     * Comparison, only useful when the id is used in std::map or std::set as key.
+     * Guarantees total order, but DOESN'T guarantee the same order after process restart!
+     * To have a predictable lexicographic order, use `LexCmp` (much slower!)
+     */
+    bool operator<( const This &rhs ) const {
+        return _id._id < rhs._id._id;
+    }
+    /**
+     * The usual comparator, compares the string id as usual.
+     */
+    bool operator==( const This &rhs ) const {
+        return _id._id == rhs._id._id;
+    }
+    /**
+     * The usual comparator, compares the string id as usual.
+     */
+    bool operator!=( const This &rhs ) const {
+        return ! operator==( rhs );
+    }
+    /**
+     * Interface to the plain C-string of the id. This function mimics the std::string
+     * object. Ids are often used in debug messages, where they are forwarded as C-strings
+     * to be included in the format string, e.g. debugmsg("invalid id: %s", id.c_str())
+     */
+    const char *c_str() const {
+        return _id.str().c_str();
+    }
+    /**
+     * Returns the identifier as plain std::string. Use with care, the plain string does not
+     * have any information as what type of object it refers to (the T template parameter of
+     * the class).
+     */
+    const std::string &str() const {
+        return _id.str();
+    }
 
-        explicit operator std::string() const {
-            return _id.str();
-        }
+    explicit operator std::string() const {
+        return _id.str();
+    }
 
-        // Those are optional, you need to implement them on your own if you want to use them.
-        // If you don't implement them, but use them, you'll get a linker error.
-        /**
-         * Translate the string based it to the matching integer based id.
-         * This may issue a debug message if the string is not a valid id.
-         */
-        int_id<T> id() const;
-        /**
-         * Translate the string based it to the matching integer based id.
-         * If this string_id is not valid, returns `fallback`.
-         * Does not produce debug message.
-         */
-        int_id<T> id_or( const int_id<T> &fallback ) const;
-        /**
-         * Returns the actual object this id refers to. May show a debug message if the id is invalid.
-         */
-        const T &obj() const;
+    // Those are optional, you need to implement them on your own if you want to use them.
+    // If you don't implement them, but use them, you'll get a linker error.
+    /**
+     * Translate the string based it to the matching integer based id.
+     * This may issue a debug message if the string is not a valid id.
+     */
+    int_id<T> id() const;
+    /**
+     * Translate the string based it to the matching integer based id.
+     * If this string_id is not valid, returns `fallback`.
+     * Does not produce debug message.
+     */
+    int_id<T> id_or( const int_id<T> &fallback ) const;
+    /**
+     * Returns the actual object this id refers to. May show a debug message if the id is invalid.
+     */
+    const T &obj() const;
 
-        const T &operator*() const {
-            return obj();
+    const T &operator*() const {
+        return obj();
 
-        }
-        const T *operator->() const {
-            return &obj();
-        }
+    }
+    const T *operator->() const {
+        return &obj();
+    }
 
-        /**
-         * Returns whether this id is valid, that means whether it refers to an existing object.
-         */
-        bool is_valid() const;
-        /**
-         * Returns whether this id is empty. An empty id can still be valid,
-         * and emptiness does not mean that it's null. Named is_empty() to
-         * keep consistency with the rest is_.. functions
-         */
-        bool is_empty() const {
-            return _id.is_empty();
-        }
-        /**
-         * Returns a null id whose `string_id<T>::is_null()` must always return true. See @ref is_null.
-         * Specializations are defined in string_id_null_ids.cpp to avoid instantiation ordering issues.
-         */
-        static const string_id<T> &NULL_ID();
-        /**
-         * Returns whether this represents the id of the null-object (in which case it's the null-id).
-         * Note that not all types assigned to T may have a null-object. As such, there won't be a
-         * definition of @ref NULL_ID and if you use any of the related functions, you'll get
-         * errors during the linking.
-         *
-         * Example: "mon_null" is the id of the null-object of monster type.
-         *
-         * Note: per definition the null-id shall be valid. This allows to use it in places
-         * that require a (valid) id, but it can still represent a "don't use it" value.
-         */
-        bool is_null() const {
-            return operator==( NULL_ID() );
-        }
-        /**
-         * Same as `!is_null`, basically one can use it to check for the id referring to an actual
-         * object. This avoids explicitly comparing it with NULL_ID. The id may still be invalid,
-         * but that should have been checked when the world data was loaded.
-         * \code
-         * string_id<X> id = ...;
-         * if( id ) {
-         *     apply_id( id );
-         * } else {
-         *     // was the null-id, ignore it.
-         * }
-         * \endcode
-         */
-        explicit operator bool() const {
-            return !is_null();
-        }
+    /**
+     * Returns whether this id is valid, that means whether it refers to an existing object.
+     */
+    bool is_valid() const;
+    /**
+     * Returns whether this id is empty. An empty id can still be valid,
+     * and emptiness does not mean that it's null. Named is_empty() to
+     * keep consistency with the rest is_.. functions
+     */
+    bool is_empty() const {
+        return _id.is_empty();
+    }
+    /**
+     * Returns a null id whose `string_id<T>::is_null()` must always return true. See @ref is_null.
+     * Specializations are defined in string_id_null_ids.cpp to avoid instantiation ordering issues.
+     */
+    static const string_id<T> &NULL_ID();
+    /**
+     * Returns whether this represents the id of the null-object (in which case it's the null-id).
+     * Note that not all types assigned to T may have a null-object. As such, there won't be a
+     * definition of @ref NULL_ID and if you use any of the related functions, you'll get
+     * errors during the linking.
+     *
+     * Example: "mon_null" is the id of the null-object of monster type.
+     *
+     * Note: per definition the null-id shall be valid. This allows to use it in places
+     * that require a (valid) id, but it can still represent a "don't use it" value.
+     */
+    bool is_null() const {
+        return operator==( NULL_ID() );
+    }
+    /**
+     * Same as `!is_null`, basically one can use it to check for the id referring to an actual
+     * object. This avoids explicitly comparing it with NULL_ID. The id may still be invalid,
+     * but that should have been checked when the world data was loaded.
+     * \code
+     * string_id<X> id = ...;
+     * if( id ) {
+     *     apply_id( id );
+     * } else {
+     *     // was the null-id, ignore it.
+     * }
+     * \endcode
+     */
+    explicit operator bool() const {
+        return !is_null();
+    }
 
-        friend std::ostream &operator<<( std::ostream &os, const string_id &s ) {
-            os << s.str();
-            return os;
-        }
+    friend std::ostream &operator<<( std::ostream &os, const string_id &s ) {
+        os << s.str();
+        return os;
+    }
 
-    private:
-        // generic_factory version that corresponds to the _cid
-        mutable int64_t _version = INVALID_VERSION;
-        // cached int_id counterpart of this string_id
-        mutable int _cid = INVALID_CID;
-        // structure that captures the actual "identity" of this string_id
-        Identity _id;
+private:
+    // generic_factory version that corresponds to the _cid
+    mutable int64_t _version = INVALID_VERSION;
+    // cached int_id counterpart of this string_id
+    mutable int _cid = INVALID_CID;
+    // structure that captures the actual "identity" of this string_id
+    Identity _id;
 
-        inline void set_cid_version( int cid, int64_t version ) const {
-            _cid = cid;
-            _version = version;
-        }
+    inline void set_cid_version( int cid, int64_t version ) const {
+        _cid = cid;
+        _version = version;
+    }
 
-        friend class generic_factory<T>;
-        friend struct std::hash<string_id<T>>;
+    friend class generic_factory<T>;
+    friend struct std::hash<string_id<T>>;
 };
 
 // Support hashing of string based ids by forwarding the hash of the string.

--- a/src/string_id_utils.h
+++ b/src/string_id_utils.h
@@ -18,7 +18,7 @@ template<typename Col,
          typename El = std::decay_t<decltype( *std::declval<const Col &>().begin() )>,
          typename K =  std::decay_t<typename El::first_type>,
          typename V = std::decay_t<typename El::second_type>,
-         std::enable_if_t<std::is_same<K, string_id<typename K::value_type>>::value, int> = 0>
+         std::enable_if_t<std::is_same_v<K, string_id<typename K::value_type>>, int> = 0>
 std::vector<std::pair<K, V>> sorted_lex( Col col )
 {
     std::vector<std::pair<K, V>> ret;
@@ -36,7 +36,7 @@ std::vector<std::pair<K, V>> sorted_lex( Col col )
  */
 template<typename Col,
          typename El = std::decay_t<decltype( *std::declval<const Col &>().begin() )>,
-         std::enable_if_t<std::is_same<El, string_id<typename El::value_type>>::value, int> = 0>
+         std::enable_if_t<std::is_same_v<El, string_id<typename El::value_type>>, int> = 0>
 std::vector<El> sorted_lex( Col col )
 {
     std::vector<El> ret;

--- a/src/submap.h
+++ b/src/submap.h
@@ -317,7 +317,7 @@ class submap
 template<typename Submap>
 class maptile_impl
 {
-        static_assert( std::is_same<std::remove_const_t<Submap>, submap>::value,
+        static_assert( std::is_same_v<std::remove_const_t<Submap>, submap>,
                        "Submap should be either submap or const submap" );
     private:
         friend map; // To allow "sliding" the tile in x/y without bounds checks

--- a/src/ui.h
+++ b/src/ui.h
@@ -164,9 +164,9 @@ struct uilist_entry {
     uilist_entry( int retval, bool enabled, int key, const std::string &txt,
                   const nc_color &keycolor, const nc_color &txtcolor );
     template<typename Enum, typename... Args,
-             typename = std::enable_if_t<std::is_enum<Enum>::value>>
-    explicit uilist_entry( Enum e, Args && ... args ) :
-        uilist_entry( static_cast<int>( e ), std::forward<Args>( args )... )
+             typename = std::enable_if_t<std::is_enum_v<Enum>>>
+                                         explicit uilist_entry( Enum e, Args && ... args ) :
+                                             uilist_entry( static_cast<int>( e ), std::forward<Args>( args )... )
     {}
 
     std::optional<inclusive_rectangle<point>> drawn_rect;
@@ -593,7 +593,7 @@ void kill_advanced_inv();
  * Add delta to val. If on bounds, wrap to other bound, otherwise clamp to the range [0,size)
  */
 template<typename V, typename S>
-inline typename std::enable_if < !std::is_enum<V>::value, V >::type
+inline std::enable_if_t < !std::is_enum_v<V>, V >
 inc_clamp_wrap( V val, int delta, S size )
 {
     if( size == 0 ) {
@@ -617,7 +617,7 @@ inc_clamp_wrap( V val, int delta, S size )
  * Add 1/-1 to val, then wrap to the range [0,size)
  */
 template<typename V, typename S>
-inline typename std::enable_if < !std::is_enum<V>::value, V >::type
+inline std::enable_if_t < !std::is_enum_v<V>, V >
 inc_clamp_wrap( V val, bool inc, S size )
 {
     return inc_clamp_wrap( val, static_cast<int>( inc ? 1 : -1 ), size );
@@ -629,7 +629,7 @@ inc_clamp_wrap( V val, bool inc, S size )
  * Add 1/-1 to val, then wrap to the range [0,size)
  */
 template<typename T, typename I>
-inline typename std::enable_if<std::is_enum<T>::value, T>::type
+inline std::enable_if_t<std::is_enum_v<T>, T>
 inc_clamp_wrap( T val, I inc, T size )
 {
     return static_cast<T>( inc_clamp_wrap( static_cast<int>( val ), inc, static_cast<int>( size ) ) );
@@ -640,7 +640,7 @@ inc_clamp_wrap( T val, I inc, T size )
  * Add delta to val, then clamp to the range [min,max]
  */
 template<typename V, typename S>
-inline typename std::enable_if < !std::is_enum<V>::value, V >::type
+inline std::enable_if_t < !std::is_enum_v<V>, V >
 inc_clamp( V val, int delta, S min, S max )
 {
     // Templating of existing `unsigned int` triggers linter rules against `unsigned long`
@@ -658,7 +658,7 @@ inc_clamp( V val, int delta, S min, S max )
  * Add 1/-1 to val, then clamp to the range [0,max]
  */
 template<typename V, typename S>
-inline typename std::enable_if < !std::is_enum<V>::value, V >::type
+inline std::enable_if_t < !std::is_enum_v<V>, V >
 inc_clamp( V val, bool inc, S max )
 {
     // NOLINTNEXTLINE(cata-no-long)
@@ -670,7 +670,7 @@ inc_clamp( V val, bool inc, S max )
  * Add delta to val, then clamp to the range [0,max]
  */
 template<typename V, typename S>
-inline typename std::enable_if < !std::is_enum<V>::value, V >::type
+inline std::enable_if_t < !std::is_enum_v<V>, V >
 inc_clamp( V val, int delta, S max )
 {
     // NOLINTNEXTLINE(cata-no-long)
@@ -682,7 +682,7 @@ inc_clamp( V val, int delta, S max )
  * Add 1/-1 to val, then clamp to the range [min,max]
  */
 template<typename V, typename S>
-inline typename std::enable_if < !std::is_enum<V>::value, V >::type
+inline std::enable_if_t < !std::is_enum_v<V>, V >
 inc_clamp( V val, bool inc, S min, S max )
 {
     return inc_clamp( val, inc ? 1 : -1, min, max );
@@ -694,7 +694,7 @@ inc_clamp( V val, bool inc, S min, S max )
  * Add 1/-1 to val, then clamp to the range [0,max]
  */
 template<typename T, typename I>
-inline typename std::enable_if<std::is_enum<T>::value, T>::type
+inline std::enable_if_t<std::is_enum_v<T>, T>
 inc_clamp( T val, I inc, T size )
 {
     return static_cast<T>( inc_clamp( static_cast<int>( val ), inc, static_cast<int>( size ) ) );

--- a/src/units.h
+++ b/src/units.h
@@ -197,29 +197,29 @@ inline quantity<V, U> fmod( quantity<V, U> num, quantity<V, U> den )
 // "quantity / scalar" or "quantity / other_quanity" is meant.
 
 // scalar * quantity<foo, unit> == quantity<decltype(foo * scalar), unit>
-template<typename lvt, typename ut, typename st, typename = typename std::enable_if<std::is_arithmetic<st>::value>::type>
-inline constexpr quantity<decltype( std::declval<lvt>() * std::declval<st>() ), ut>
-operator*( const st &factor, const quantity<lvt, ut> &rhs )
+template<typename lvt, typename ut, typename st, typename = std::enable_if_t<std::is_arithmetic_v<st>>>
+         inline constexpr quantity<decltype( std::declval<lvt>() * std::declval<st>() ), ut>
+         operator*( const st &factor, const quantity<lvt, ut> &rhs )
 {
     return { factor * rhs.value(), ut{} };
 }
 
 // same as above only with inverse order of operands: quantity * scalar
-template<typename lvt, typename ut, typename st, typename = typename std::enable_if<std::is_arithmetic<st>::value>::type>
-inline constexpr quantity<decltype( std::declval<st>() * std::declval<lvt>() ), ut>
-operator*( const quantity<lvt, ut> &lhs, const st &factor )
+template<typename lvt, typename ut, typename st, typename = std::enable_if_t<std::is_arithmetic_v<st>>>
+         inline constexpr quantity<decltype( std::declval<st>() * std::declval<lvt>() ), ut>
+         operator*( const quantity<lvt, ut> &lhs, const st &factor )
 {
     return { lhs.value() *factor, ut{} };
 }
 
 // quantity<foo, unit> * quantity<bar, unit> is not supported
-template<typename lvt, typename ut, typename rvt, typename = typename std::enable_if<std::is_arithmetic<lvt>::value>::type>
-inline void operator*( quantity<lvt, ut>, quantity<rvt, ut> ) = delete;
+template<typename lvt, typename ut, typename rvt, typename = std::enable_if_t<std::is_arithmetic_v<lvt>>>
+         inline void operator*( quantity<lvt, ut>, quantity<rvt, ut> ) = delete;
 
-// operator *=
-template<typename lvt, typename ut, typename st, typename = typename std::enable_if<std::is_arithmetic<st>::value>::type>
-inline quantity<lvt, ut> &
-operator*=( quantity<lvt, ut> &lhs, const st &factor )
+         // operator *=
+         template<typename lvt, typename ut, typename st, typename = std::enable_if_t<std::is_arithmetic_v<st>>>
+                  inline quantity<lvt, ut> &
+                  operator*=( quantity<lvt, ut> &lhs, const st &factor )
 {
     lhs = lhs * factor;
     return lhs;
@@ -227,29 +227,29 @@ operator*=( quantity<lvt, ut> &lhs, const st &factor )
 
 // and the revers of the multiplication above:
 // quantity<foo, unit> / scalar == quantity<decltype(foo / scalar), unit>
-template<typename lvt, typename ut, typename rvt, typename = typename std::enable_if<std::is_arithmetic<rvt>::value>::type>
-inline constexpr quantity<decltype( std::declval<lvt>() * std::declval<rvt>() ), ut>
-operator/( const quantity<lvt, ut> &lhs, const rvt &divisor )
+template<typename lvt, typename ut, typename rvt, typename = std::enable_if_t<std::is_arithmetic_v<rvt>>>
+         inline constexpr quantity<decltype( std::declval<lvt>() * std::declval<rvt>() ), ut>
+         operator/( const quantity<lvt, ut> &lhs, const rvt &divisor )
 {
     return { lhs.value() / divisor, ut{} };
 }
 
 // scalar / quantity<foo, unit> is not supported
-template<typename lvt, typename ut, typename rvt, typename = typename std::enable_if<std::is_arithmetic<lvt>::value>::type>
-inline void operator/( lvt, quantity<rvt, ut> ) = delete;
+template<typename lvt, typename ut, typename rvt, typename = std::enable_if_t<std::is_arithmetic_v<lvt>>>
+         inline void operator/( lvt, quantity<rvt, ut> ) = delete;
 
-// quantity<foo, unit> / quantity<bar, unit> == decltype(foo / bar)
-template<typename lvt, typename ut, typename rvt>
-inline constexpr decltype( std::declval<lvt>() / std::declval<rvt>() )
-operator/( const quantity<lvt, ut> &lhs, const quantity<rvt, ut> &rhs )
+         // quantity<foo, unit> / quantity<bar, unit> == decltype(foo / bar)
+         template<typename lvt, typename ut, typename rvt>
+         inline constexpr decltype( std::declval<lvt>() / std::declval<rvt>() )
+         operator/( const quantity<lvt, ut> &lhs, const quantity<rvt, ut> &rhs )
 {
     return lhs.value() / rhs.value();
 }
 
 // operator /=
-template<typename lvt, typename ut, typename st, typename = typename std::enable_if<std::is_arithmetic<st>::value>::type>
-inline quantity<lvt, ut> &
-operator/=( quantity<lvt, ut> &lhs, const st &divisor )
+template<typename lvt, typename ut, typename st, typename = std::enable_if_t<std::is_arithmetic_v<st>>>
+         inline quantity<lvt, ut> &
+         operator/=( quantity<lvt, ut> &lhs, const st &divisor )
 {
     lhs = lhs / divisor;
     return lhs;
@@ -257,29 +257,29 @@ operator/=( quantity<lvt, ut> &lhs, const st &divisor )
 
 // remainder:
 // quantity<foo, unit> % scalar == quantity<decltype(foo % scalar), unit>
-template<typename lvt, typename ut, typename rvt, typename = typename std::enable_if<std::is_arithmetic<rvt>::value>::type>
-inline constexpr quantity < decltype( std::declval<lvt>() % std::declval<rvt>() ), ut >
-operator%( const quantity<lvt, ut> &lhs, const rvt &divisor )
+template<typename lvt, typename ut, typename rvt, typename = std::enable_if_t<std::is_arithmetic_v<rvt>>>
+         inline constexpr quantity < decltype( std::declval<lvt>() % std::declval<rvt>() ), ut >
+         operator%( const quantity<lvt, ut> &lhs, const rvt &divisor )
 {
     return { lhs.value() % divisor, ut{} };
 }
 
 // scalar % quantity<foo, unit> is not supported
-template<typename lvt, typename ut, typename rvt, typename = typename std::enable_if<std::is_arithmetic<lvt>::value>::type>
-inline void operator%( lvt, quantity<rvt, ut> ) = delete;
+template<typename lvt, typename ut, typename rvt, typename = std::enable_if_t<std::is_arithmetic_v<lvt>>>
+         inline void operator%( lvt, quantity<rvt, ut> ) = delete;
 
-// quantity<foo, unit> % quantity<bar, unit> == decltype(foo % bar)
-template<typename lvt, typename ut, typename rvt>
-inline constexpr quantity < decltype( std::declval<lvt>() % std::declval<rvt>() ), ut >
-operator%( const quantity<lvt, ut> &lhs, const quantity<rvt, ut> &rhs )
+         // quantity<foo, unit> % quantity<bar, unit> == decltype(foo % bar)
+         template<typename lvt, typename ut, typename rvt>
+         inline constexpr quantity < decltype( std::declval<lvt>() % std::declval<rvt>() ), ut >
+         operator%( const quantity<lvt, ut> &lhs, const quantity<rvt, ut> &rhs )
 {
     return { lhs.value() % rhs.value(), ut{} };
 }
 
 // operator %=
-template<typename lvt, typename ut, typename st, typename = typename std::enable_if<std::is_arithmetic<st>::value>::type>
-inline quantity<lvt, ut> &
-operator%=( quantity<lvt, ut> &lhs, const st &divisor )
+template<typename lvt, typename ut, typename st, typename = std::enable_if_t<std::is_arithmetic_v<st>>>
+         inline quantity<lvt, ut> &
+         operator%=( quantity<lvt, ut> &lhs, const st &divisor )
 {
     lhs = lhs % divisor;
     return lhs;
@@ -776,8 +776,8 @@ inline constexpr quantity<value_type, length_in_millimeter_tag> default_length_f
     const quantity<value_type, volume_in_milliliter_tag> &v )
 {
     return units::from_centimeter<int>(
-               std::round(
-                   std::cbrt( units::to_milliliter( v ) ) ) );
+        std::round(
+            std::cbrt( units::to_milliliter( v ) ) ) );
 }
 
 // Streaming operators for debugging and tests
@@ -829,8 +829,8 @@ inline std::ostream &operator<<( std::ostream &o, const quantity<value_type, tag
     return o << v.value() << tag_type{};
 }
 
-template<typename value_type, typename tag_type>
-inline std::string quantity_to_string( const quantity<value_type, tag_type> &v )
+          template<typename value_type, typename tag_type>
+          inline std::string quantity_to_string( const quantity<value_type, tag_type> &v )
 {
     std::ostringstream os;
     os << v;

--- a/src/units_utility.h
+++ b/src/units_utility.h
@@ -37,7 +37,7 @@ int angle_to_dir4( units::angle direction );
 // convert angle to nearest of 0=north 1=NE 2=east 3=SE...
 int angle_to_dir8( units::angle direction );
 
-template<typename T, typename U, std::enable_if_t<std::is_floating_point<T>::value>* = nullptr>
+template<typename T, typename U, std::enable_if_t<std::is_floating_point_v<T>>* = nullptr>
 units::quantity<T, U> round_to_multiple_of( units::quantity<T, U> val, units::quantity<T, U> of )
 {
     int multiple = std::lround( val / of );

--- a/src/value_ptr.h
+++ b/src/value_ptr.h
@@ -38,7 +38,7 @@ class value_ptr : public std::unique_ptr<T>
                 jsout.write_null();
             }
         }
-        template<typename Value = JsonValue, std::enable_if_t<std::is_same<std::decay_t<Value>, JsonValue>::value>* = nullptr>
+        template<typename Value = JsonValue, std::enable_if_t<std::is_same_v<std::decay_t<Value>, JsonValue>>* = nullptr>
         void deserialize( const Value &jsin ) {
             if( jsin.test_null() ) {
                 this->reset();

--- a/src/weighted_list.h
+++ b/src/weighted_list.h
@@ -266,7 +266,7 @@ template <typename T> struct weighted_int_list : public weighted_list<int, T> {
         std::vector<int> precalc_array;
 };
 
-static_assert( std::is_nothrow_move_constructible<weighted_int_list<int>>::value );
+static_assert( std::is_nothrow_move_constructible_v<weighted_int_list<int>> );
 
 template <typename T> struct weighted_float_list : public weighted_list<double, T> {
 

--- a/tests/make_static_test.cpp
+++ b/tests/make_static_test.cpp
@@ -28,7 +28,7 @@ TEST_CASE( "make_static_macro_test", "[make_static_macro]" )
 
     // NOLINTNEXTLINE(cata-almost-never-auto)
     const auto test11 = STATIC( "test11" );
-    static_assert( std::is_same<std::decay_t<decltype( test11 )>, std::string>::value,
+    static_assert( std::is_same_v<std::decay_t<decltype( test11 )>, std::string>,
                    "type must be std::string" );
 
     CHECK( test11 == "test11" );

--- a/tests/test_statistics.h
+++ b/tests/test_statistics.h
@@ -80,7 +80,7 @@ class statistics
         // Outside of this class, this should only be used for debugging
         // purposes.
         template<typename U = T>
-        typename std::enable_if< std::is_same< U, bool >::value, double >::type
+        std::enable_if_t< std::is_same_v< U, bool >, double >
         margin_of_error() const {
             if( _error != invalid_err ) {
                 return _error;
@@ -102,7 +102,7 @@ class statistics
         // Outside of this class, this should only be used for debugging purposes.
         // https://measuringu.com/ci-five-steps/
         template<typename U = T>
-        typename std::enable_if < ! std::is_same< U, bool >::value, double >::type
+        std::enable_if_t < ! std::is_same_v< U, bool >, double >
         margin_of_error() const {
             if( _error != invalid_err ) {
                 return _error;

--- a/tests/unseal_and_spill_test.cpp
+++ b/tests/unseal_and_spill_test.cpp
@@ -224,7 +224,7 @@ item *item_pointer( item_location it )
 }
 
 template < typename Parent,
-           std::enable_if_t < !std::is_same<std::decay_t<Parent>, item_location>::value, int > = 0 >
+           std::enable_if_t < !std::is_same_v<std::decay_t<Parent>, item_location>, int > = 0 >
 item_location container_from_parent( Parent && )
 {
     return item_location::nowhere;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Appeases the clang-tidy check `modernize-type-traits`.

https://clang.llvm.org/extra/clang-tidy/checks/modernize/type-traits.html
TL;DR:
```cpp
std::enable_if<...>::type -> std::enable_if_t<...>;
std::is_same<T, U>::value -> std::is_same_v<T, U>;
```
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Apply auto-fix from clang-tidy, and then run AStyle.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Should be good as long as it compiles.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Note that this is not an exhaustive replacement of all pre-C++17 standard type traits. There are still some usages of old type traits (e.g. `std::is_same<T, U>::type`) that are not reported by this clang-tidy check and not auto-fixed in this pull request. I don't know if these are false negatives. Will leave them for a subsequent pull request.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
