### PR TITLE
Display vitamins by mass in item descriptions

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -2585,13 +2585,29 @@ void item::food_info( const item *food_item, std::vector<iteminfo> &info,
         const int max_value = v.second;
         const int min_rda = player_character.vitamin_RDA( v.first, min_value );
         const int max_rda = player_character.vitamin_RDA( v.first, max_value );
+        std::pair<std::string, std::string> weight_and_units = v.first->mass_str_from_units( v.second );
+        std::string weight_str;
+        if( !weight_and_units.first.empty() ) {
+            if( min_value != max_value ) {
+                std::pair<std::string, std::string> min_weight_and_units = v.first->mass_str_from_units(
+                            min_nutr.get_vitamin( v.first ) );
+                const bool show_first_unit = ( min_value != 0 ) &&
+                                             ( min_weight_and_units.second != weight_and_units.second );
+                std::string first_string = string_format( !show_first_unit ? "%s" : "%s %s",
+                                           min_weight_and_units.first, min_weight_and_units.second );
+                weight_str = string_format( "%s-%s %s ", first_string, weight_and_units.first,
+                                            weight_and_units.second );
+            } else {
+                weight_str = string_format( "%s %s ", weight_and_units.first, weight_and_units.second );
+            }
+        }
         std::string format;
         if( is_vitamin ) {
-            format = min_value == max_value ? "%s (%i%%)" : "%s (%i-%i%%)";
-            return string_format( format, v.first->name(), min_rda, max_rda );
+            format = min_value == max_value ? "%s%s (%i%%)" : "%s%s (%i-%i%%)";
+            return string_format( format, weight_str, v.first->name(), min_rda, max_rda );
         }
-        format = min_value == max_value ? "%s (%i U)" : "%s (%i-%i U)";
-        return string_format( format, v.first->name(), min_value, max_value );
+        format = min_value == max_value ? "%s%s (%i U)" : "%s%s (%i-%i U)";
+        return string_format( format, weight_str, v.first->name(), min_value, max_value );
     };
 
     const auto max_nutr_vitamins = sorted_lex( max_nutr.vitamins() );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1773,6 +1773,9 @@ void options_manager::add_options_interface()
             { "24h", to_translation( "24h" ) }
         },
         "12h" );
+        add( "SHOW_VITAMIN_MASS", page_id, to_translation( "Show vitamin masses" ),
+             to_translation( "Display the masses of vitamins in addition to units/RDA values in item descriptions." ),
+             true );
     } );
 
     add_empty_line();

--- a/src/units_utility.cpp
+++ b/src/units_utility.cpp
@@ -257,6 +257,21 @@ std::string weight_to_string( const units::mass &weight, const bool compact,
     return string_format( string_to_format, converted_weight, compact ? "" : " ", weight_units() );
 }
 
+std::pair<std::string, std::string> weight_to_string( const
+        units::quantity<int, units::mass_in_microgram_tag> &weight )
+{
+    using high_res_mass = units::quantity<int, units::mass_in_microgram_tag>;
+    static const high_res_mass gram = high_res_mass( 1'000'000, {} );
+    static const high_res_mass milligram = high_res_mass( 1'000, {} );
+
+    if( weight > gram ) {
+        return {string_format( "%.0f", weight.value() / 1'000'000.f ), "g"};
+    } else if( weight > milligram ) {
+        return {string_format( "%.0f", weight.value() / 1'000.f ), "mg"};
+    }
+    return {string_format( "%d", weight.value() ), "μg"};
+}
+
 double convert_volume( int volume )
 {
     return convert_volume( volume, nullptr );

--- a/src/units_utility.h
+++ b/src/units_utility.h
@@ -108,6 +108,13 @@ std::string weight_to_string( const units::mass &weight, bool compact = false,
                               bool remove_trailing_zeroes = false );
 
 /**
+ * Convert high-definition weight/mass to readable format
+ * Always metric units. First is value as string, second is unit
+ */
+std::pair<std::string, std::string> weight_to_string( const
+        units::quantity<int, units::mass_in_microgram_tag> &weight );
+
+/**
  * Convert volume from ml to units defined by user.
  */
 double convert_volume( int volume );

--- a/src/vitamin.cpp
+++ b/src/vitamin.cpp
@@ -8,7 +8,9 @@
 #include "debug.h"
 #include "enum_conversions.h"
 #include "json.h"
+#include "options.h"
 #include "units.h"
+#include "units_utility.h"
 
 static std::map<vitamin_id, vitamin> vitamins_all;
 
@@ -136,6 +138,14 @@ int vitamin::units_from_mass( vitamin_units::mass val ) const
         return 1;
     }
     return val / *weight_per_unit;
+}
+
+std::pair<std::string, std::string> vitamin::mass_str_from_units( int units ) const
+{
+    if( !weight_per_unit.has_value() || !get_option<bool>( "SHOW_VITAMIN_MASS" ) ) {
+        return {"", ""};
+    }
+    return weight_to_string( units * *weight_per_unit );
 }
 
 namespace io

--- a/src/vitamin.h
+++ b/src/vitamin.h
@@ -111,6 +111,8 @@ class vitamin
         float RDA_to_default( int percent ) const;
 
         int units_from_mass( vitamin_units::mass val ) const;
+        // First is value, second is units (g, mg, etc)
+        std::pair<std::string, std::string> mass_str_from_units( int units ) const;
 
     private:
         vitamin_id id_;

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -1903,7 +1903,7 @@ TEST_CASE( "nutrients_in_food", "[iteminfo][food]" )
         // Values end up rounded slightly
         CHECK( item_info_str( ice_cream, { iteminfo_parts::FOOD_VITAMINS } ) ==
                "--\n"
-               "Vitamins (RDA): Calcium (8%)\n" );
+               "Vitamins (RDA): 83 mg Calcium (8%)\n" );
     }
 
     SECTION( "nutrient ranges for recipe exemplars", "[iteminfo]" ) {
@@ -1920,7 +1920,8 @@ TEST_CASE( "nutrients_in_food", "[iteminfo][food]" )
         CHECK( item_info_str( ice_cream, { iteminfo_parts::FOOD_VITAMINS } ) ==
                "--\n"
                "Nutrition will <color_cyan>vary with chosen ingredients</color>.\n"
-               "Vitamins (RDA): Calcium (6-35%), Iron (0-128%), and Vitamin C (0-56%)\n" );
+               "Vitamins (RDA): 63-354 mg Calcium (6-35%), 0-23 mg Iron (0-128%),"
+               " and 0-51 mg Vitamin C (0-56%)\n" );
     }
 }
 


### PR DESCRIPTION

#### Summary
Interface "Show the mass of vitamins in food items"

#### Purpose of change
Use the info added in https://github.com/CleverRaven/Cataclysm-DDA/pull/68988 to display vitamins by mass in items.

#### Describe the solution
Add display of vitamin mass in addition to units/RDA for vitamins that have a weight per unit defined.
Add an option to toggle display of this.

#### Testing
Find some food items, look at them:
![Image of pickled fish. The vitamins display shows "52 mg Calcium (5%), 2 mg Iron (14%), and 938 μg Vitamin C (1%)"](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/e00e33c0-d9cf-4a18-934c-071259d0a24d)
Also works in crafting:
![Image of crafting a boring sandwich. The vitamins display shows "0 μg-3 g Calcium (0-289%), 0 μg-21 mg Iron (0-115%), and 0 μg-397 mg Vitamin C (0-441%)"](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/6ca735ac-1308-4655-80c4-fd6e265c6f91)

Option can be used to turn it off:
![Image of pickled fish. The vitamins display shows "Calcium (5%), Iron (14%), and Vitamin C (1%)"](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/09ae903b-6f65-4301-af0d-ccc8b1d80421)
![Image of crafting a boring sandwich. The vitamins display shows "Calcium (0-289%), Iron (0-115%), and Vitamin C (0-441%)"](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/34e2dfc9-a53c-403c-b065-6db8e8221595)
