### PR TITLE
Randomized characters will now have the default background on them

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -587,6 +587,8 @@ void avatar::randomize( const bool random_scenario, bool play_now )
 
     // Restart cardio accumulator
     reset_cardio_acc();
+
+    add_default_background();
 }
 
 void avatar::randomize_cosmetics()
@@ -690,6 +692,7 @@ bool avatar::create( character_type type, const std::string &tempname )
     switch( type ) {
         case character_type::CUSTOM:
             randomize_cosmetics();
+            add_default_background();
             break;
         case character_type::RANDOM:
             //random scenario, default name if exist
@@ -717,11 +720,6 @@ bool avatar::create( character_type type, const std::string &tempname )
             }
             tabs.position.last();
             break;
-    }
-
-    // Don't apply the default backgrounds on a template
-    if( type != character_type::TEMPLATE ) {
-        add_default_background();
     }
 
     auto nameExists = [&]( const std::string & name ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Randomizing a character with the default % or ^ keys in the character creator menu will now apply the default background on them."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Selecting a random character when creating a new character will give you the default background, but pressing the randomize keys (% and ^) to further randomize your character will erase the default background and not re-add it after. 
<!-- With a few sentences, describe your reasons for making this change.  If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.  If your pull request *fully* resolves an issue, include the word "Fix" or "Fixes" before the issue number, like: Fixes #xxxx
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
This just makes it so that the adding of the default background happens when `randomize` is called or the custom character type is selected rather than when the character creator menu is first opened. To keep as consistent as possible before and reduce any side-effects, it happens at the end of `randomize()`

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Could maybe call this after the randomize function is called for % and ^, but it would lead to a lot of code duplication, it just seems to be better to do it in the randomize function directly.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Compiled the code, ran it and saw that it worked as randomizing my character with % and ^
Also tested with loading a template, template loaded fine; default backgrounds turned off stayed off

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
