### PR TITLE
Improve item volume loading

### DIFF
--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -40,21 +40,7 @@ bool assign( const JsonObject &jo, const std::string &name, units::volume &val, 
         }
 
         if( obj.has_string( name ) ) {
-            units::volume::value_type tmp;
-            std::string suffix;
-            std::istringstream str( obj.get_string( name ) );
-            str.imbue( std::locale::classic() );
-            str >> tmp >> suffix;
-            if( str.peek() != std::istringstream::traits_type::eof() ) {
-                obj.throw_error_at( name, "syntax error when specifying volume" );
-            }
-            if( suffix == "ml" ) {
-                out = units::from_milliliter( tmp );
-            } else if( suffix == "L" ) {
-                out = units::from_milliliter( tmp * 1000 );
-            } else {
-                obj.throw_error_at( name, "unrecognized volumetric unit" );
-            }
+            out = read_from_json_string<units::volume>( obj.get_member( name ), units::volume_units );
             return true;
         }
 


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Items can't specify volume like `"40 L 500 ml"`.

#### Describe the solution
Don't roll special quantity parsing code in multiple places, just use the already written code that works better.

#### Testing
All item volumes load as before. Item volumes specified with two units (as above) work.

#### Additional context
When working on https://github.com/CleverRaven/Cataclysm-DDA/pull/68988, I noticed that quantities supported loading in this syntax, and I had been annoyed by the "one unit only" approach items use in the past.

Weight, length, etc already use this style.