### PR TITLE
Bulk loading items saves time cost for generic "pick up(g)" process

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2205,7 +2205,8 @@ void pickup_activity_actor::do_turn( player_activity &, Character &who )
     }
 
     // False indicates that the player canceled pickup when met with some prompt
-    const bool keep_going = Pickup::do_pickup( target_items, quantities, autopickup, stash_successful );
+    const bool keep_going = Pickup::do_pickup( target_items, quantities, autopickup,
+                            stash_successful, info );
 
     // If there are items left we ran out of moves, so continue the activity
     // Otherwise, we are done.
@@ -2238,6 +2239,7 @@ void pickup_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "starting_pos", starting_pos );
     jsout.member( "stash_successful", stash_successful );
     jsout.member( "autopickup", autopickup );
+    jsout.member( "info", info );
 
     jsout.end_object();
 }
@@ -2253,6 +2255,7 @@ std::unique_ptr<activity_actor> pickup_activity_actor::deserialize( JsonValue &j
     data.read( "starting_pos", actor.starting_pos );
     data.read( "stash_successful", actor.stash_successful );
     data.read( "autopickup", actor.autopickup );
+    data.read( "info", actor.info );
 
     return actor.clone();
 }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -20,6 +20,7 @@
 #include "itype.h"
 #include "item_location.h"
 #include "memory_fast.h"
+#include "pickup.h"
 #include "point.h"
 #include "string_id.h"
 #include "type_id.h"
@@ -495,6 +496,7 @@ class pickup_activity_actor : public activity_actor
         /** Target items and the quantities thereof */
         std::vector<item_location> target_items;
         std::vector<int> quantities;
+        Pickup::pick_info info;
 
         /**
          * Position of the character when the activity is started. This is

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -196,7 +196,6 @@ static bool pick_one_up( item_location &loc, int quantity, bool &got_water, bool
     bool picked_up = false;
     bool crushed = false;
     Pickup::pick_info pre_info( info );
-    info = Pickup::pick_info();
 
     pickup_answer option = CANCEL;
 
@@ -295,7 +294,6 @@ static bool pick_one_up( item_location &loc, int quantity, bool &got_water, bool
             ret_val<item_location> ret = player_character.i_add_or_fill( newit, true, nullptr, &it,
                                          /*allow_drop=*/false, /*allow_wield=*/false, false );
             item_location added_it = ret.value();
-            info.dst = added_it;
             if( ret.success() ) {
                 if( added_it == item_location::nowhere ) {
                     newit.charges = last_charges - newit.charges;
@@ -317,6 +315,10 @@ static bool pick_one_up( item_location &loc, int quantity, bool &got_water, bool
                     picked_up = true;
                 }
             }
+            if( picked_up ) {
+                // Update info
+                info.dst = added_it;
+            }
             break;
         }
     }
@@ -326,6 +328,7 @@ static bool pick_one_up( item_location &loc, int quantity, bool &got_water, bool
         info.src_pos = loc.position();
         info.src_container = loc.parent_item();
         info.src_type = loc.where();
+        info.total_bulk_volume += loc->volume( false, false, quantity );
         if( !is_bulk_load( pre_info, info ) ) {
             // Cost to take an item from a container or map
             player_character.moves -= loc.obtain_cost( player_character, quantity );
@@ -361,7 +364,6 @@ bool Pickup::do_pickup( std::vector<item_location> &targets, std::vector<int> &q
     bool got_frozen_liquid = false;
     Character &player_character = get_player_character();
     bool weight_is_okay = ( player_character.weight_carried() <= player_character.weight_capacity() );
-    units::volume total_volume = info.total_bulk_volume;
 
     // Map of items picked up so we can output them all at the end and
     // merge dropping items with the same name.
@@ -380,20 +382,14 @@ bool Pickup::do_pickup( std::vector<item_location> &targets, std::vector<int> &q
             debugmsg( "lost target item of ACT_PICKUP" );
             continue;
         }
-        units::volume target_volume = target->volume( false, false, quantity );
         problem = !pick_one_up( target, quantity, got_water, got_gas, mapPickup, autopickup,
                                 stash_successful, got_frozen_liquid, info );
-        if( !problem ) {
-            total_volume += target_volume;
-            if( total_volume > 200_ml ) {
-                // Bulk loading is not allowed beyond a certain volume
-                info = Pickup::pick_info();
-                total_volume = 0_ml;
-            }
+        if( info.total_bulk_volume > 200_ml ) {
+            // Bulk loading is not allowed beyond a certain volume
+            info = Pickup::pick_info();
         }
     }
     // Remember how much you picked up in total in this section
-    total_volume = info.total_bulk_volume = total_volume;
 
     if( !mapPickup.empty() ) {
         show_pickup_message( mapPickup );

--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -317,17 +317,14 @@ static bool pick_one_up( item_location &loc, int quantity, bool &got_water, bool
             }
             if( picked_up ) {
                 // Update info
-                info.dst = added_it;
+                info.set_dst( added_it );
             }
             break;
         }
     }
 
     if( picked_up ) {
-        // item_location of source may become invalid after the item is moved, so save the information separately.
-        info.src_pos = loc.position();
-        info.src_container = loc.parent_item();
-        info.src_type = loc.where();
+        info.set_src( loc );
         info.total_bulk_volume += loc->volume( false, false, quantity );
         if( !is_bulk_load( pre_info, info ) ) {
             // Cost to take an item from a container or map
@@ -389,7 +386,6 @@ bool Pickup::do_pickup( std::vector<item_location> &targets, std::vector<int> &q
             info = Pickup::pick_info();
         }
     }
-    // Remember how much you picked up in total in this section
 
     if( !mapPickup.empty() ) {
         show_pickup_message( mapPickup );
@@ -503,6 +499,19 @@ void Pickup::pick_info::deserialize( const JsonObject &jsobj )
     jsobj.read( "src_pos", src_pos );
     jsobj.read( "src_container", src_container );
     jsobj.read( "dst", dst );
+}
+
+void Pickup::pick_info::set_src( const item_location &src_ )
+{
+    // item_location of source may become invalid after the item is moved, so save the information separately.
+    src_pos = src_.position();
+    src_container = src_.parent_item();
+    src_type = src_.where();
+}
+
+void Pickup::pick_info::set_dst( const item_location &dst_ )
+{
+    dst = dst_;
 }
 
 std::vector<Pickup::pickup_rect> Pickup::pickup_rect::list;

--- a/src/pickup.h
+++ b/src/pickup.h
@@ -5,20 +5,31 @@
 #include <vector>
 
 #include "cuboid_rectangle.h"
+#include "item_location.h"
 #include "point.h"
 
 class Character;
 class item;
-class item_location;
 
 namespace Pickup
 {
+struct pick_info {
+    pick_info() = default;
+    void serialize( JsonOut &jsout ) const;
+    void deserialize( const JsonObject &jsobj );
+
+    item_location::type src_type = item_location::type::invalid;
+    tripoint src_pos;
+    item_location src_container;
+    item_location dst;
+};
+
 /**
  * Returns `false` if the player was presented a prompt and decided to cancel the pickup.
  * `true` in other cases.
  */
 bool do_pickup( std::vector<item_location> &targets, std::vector<int> &quantities,
-                bool autopickup, bool &stash_successful );
+                bool autopickup, bool &stash_successful, Pickup::pick_info &info );
 bool query_thief();
 
 enum from_where : int {

--- a/src/pickup.h
+++ b/src/pickup.h
@@ -13,11 +13,13 @@ class item;
 
 namespace Pickup
 {
+/** Pick up information reminder for bulk loading */
 struct pick_info {
     pick_info() = default;
     void serialize( JsonOut &jsout ) const;
     void deserialize( const JsonObject &jsobj );
 
+    units::volume total_bulk_volume = 0_ml;
     item_location::type src_type = item_location::type::invalid;
     tripoint src_pos;
     item_location src_container;

--- a/src/pickup.h
+++ b/src/pickup.h
@@ -18,6 +18,8 @@ struct pick_info {
     pick_info() = default;
     void serialize( JsonOut &jsout ) const;
     void deserialize( const JsonObject &jsobj );
+    void set_src( const item_location &src_ );
+    void set_dst( const item_location &dst_ );
 
     units::volume total_bulk_volume = 0_ml;
     item_location::type src_type = item_location::type::invalid;


### PR DESCRIPTION
#### Summary
Balance "Bulk loading items saves time cost for generic pick up(g) process"

#### Purpose of change
Follow up https://github.com/CleverRaven/Cataclysm-DDA/pull/68214

#### Describe the solution
Apply same solution as https://github.com/CleverRaven/Cataclysm-DDA/pull/68214 to "pick up" action
Additionally, in #68214 there was an issue where the cost of moving large items was underestimated.
This time I will address this issue to some extent by placing a limit on the capacity that can be loaded in bulk. Although not implemented in this PR, we plan to backport it later to the Insert action as well.

#### Describe alternatives you've considered
I think it would be better to review the conventional "pick up" processing and redirect it to "insert" processing, but I gave up because the "pick up" processing is very complicated.
Please let me know if there is a better way

#### Testing
Pick up items from adjacent tiles

1000 salts (5 L)
Before: 30:00
After: 00:54

100 apples (23 L)
Before: 3:11
After: 3:11

#### Additional context
