### PR TITLE
Discard invalid PO files in pull translations GHA workflow

### DIFF
--- a/.github/workflows/pull-translations.yml
+++ b/.github/workflows/pull-translations.yml
@@ -39,6 +39,8 @@ jobs:
         env:
           TX_TOKEN: ${{ secrets.TX_TOKEN }}
         run: tx pull --force
+      - name: "Discard invalid translations"
+        run: ./lang/discard_invalid_po.sh
       - name: "Update stats"
         run: ./lang/update_stats.sh
       - name: Create Pull Request

--- a/lang/discard_invalid_po.sh
+++ b/lang/discard_invalid_po.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Sometimes PO files pulled from Transifex are not accepted by GNU gettext, for example
+#   lang/po/hu.po:430257: 'msgid' and 'msgstr' entries do not both begin with '\n'
+#   lang/po/hu.po:534682: 'msgid' and 'msgstr' entries do not both end with '\n'
+#   lang/po/hu.po:534692: 'msgid' and 'msgstr' entries do not both end with '\n'
+#
+# This script tries to compile each updated PO file, and revert PO files that cannot be compiled by GNU gettext.
+# So the invalid PO files won't fail Basic Build CI test and block merging the i18n update pull requests.
+
+function discard_po() {
+    echo Discarding $1
+    git restore $1
+}
+
+for i in $(git diff --name-only lang/po/*.po); do
+    msgfmt -o /dev/null $i || discard_po $i
+done
+


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Sometimes PO files pulled from Transifex are not accepted by GNU gettext, cause Basic Build CI test to fail and block merging of the translation update pull requests. This has happened in the last two weeks in a row.

* #69102: https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/6752100752/job/18367343004#step:14:515
* #69252: https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/6831695149/job/18581687695?pr=69252#step:14:869

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added a simple bash script after pulling translations from Transifex, that reverts any PO file that cannot be processed by GNU gettext.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
