### PR TITLE
Cyan reinforced concrete wall name fix

### DIFF
--- a/data/json/furniture_and_terrain/terrain-walls.json
+++ b/data/json/furniture_and_terrain/terrain-walls.json
@@ -1317,7 +1317,7 @@
     "type": "terrain",
     "id": "t_strconc_wall_cyan",
     "alias": [ "t_strconc_h_cyan", "t_strconc_v_cyan" ],
-    "name": "reinforced white concrete wall",
+    "name": "reinforced cyan concrete wall",
     "looks_like": "t_wall_cyan",
     "description": "A reinforced concrete wall, painted cyan.",
     "symbol": "LINE_OXOX",


### PR DESCRIPTION


#### Summary
None

#### Purpose of change

Someone on the devcord pointed out to me that the cyan reinforced concrete wall is named white reinforced concrete wall. this fixes it

#### Describe the solution
see commit.
#### Describe alternatives you've considered
None

#### Testing


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
