### PR TITLE
Convert glass door fridge to appliance

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -5033,6 +5033,18 @@
   },
   {
     "type": "construction",
+    "id": "app_glass_fridge",
+    "group": "place_glass_fridge",
+    "category": "APPLIANCE",
+    "required_skills": [ [ "fabrication", 0 ] ],
+    "time": "5 m",
+    "components": [ [ [ "glass_fridge", 1 ] ] ],
+    "pre_special": "check_empty",
+    "post_special": "done_appliance",
+    "activity_level": "BRISK_EXERCISE"
+  },
+  {
+    "type": "construction",
     "id": "app_stereo",
     "group": "place_stereo",
     "category": "APPLIANCE",

--- a/data/json/construction_group.json
+++ b/data/json/construction_group.json
@@ -1206,6 +1206,11 @@
   },
   {
     "type": "construction_group",
+    "id": "place_glass_fridge",
+    "name": "Place Glass Door Fridge"
+  },
+  {
+    "type": "construction_group",
     "id": "place_stereo",
     "name": "Place Stereo System"
   },

--- a/data/json/furniture_and_terrain/appliances.json
+++ b/data/json/furniture_and_terrain/appliances.json
@@ -55,6 +55,46 @@
   },
   {
     "type": "vehicle_part",
+    "id": "ap_glass_fridge",
+    "name": { "str": "glass door refrigerator" },
+    "looks_like": "f_fridge",
+    "categories": [ "cargo" ],
+    "color": "light_blue",
+    "broken_color": "light_blue",
+    "damage_modifier": 80,
+    "durability": 50,
+    "description": "A standard household refrigerator.  When turned on, it will cool its contents to extend the time before they spoil.",
+    "//": "Use average consumption, not the max on the appliance rating plate. 30W ~ 260kWh per annum",
+    "epower": "-35 W",
+    "size": "500 L",
+    "item": "glass_fridge",
+    "requirements": {
+      "removal": { "time": "2 m" },
+      "repair": {
+        "skills": [ [ "mechanics", 4 ] ],
+        "time": "60 m",
+        "using": [ [ "repair_welding_standard", 3 ], [ "soldering_standard", 5 ] ]
+      }
+    },
+    "flags": [ "CARGO", "OBSTACLE", "FRIDGE", "ENABLED_DRAINS_EPOWER", "APPLIANCE", "CTRL_ELECTRONIC" ],
+    "breaks_into": [
+      { "item": "sheet_metal", "count": [ 2, 5 ] },
+      { "item": "sheet_metal_small", "count": [ 0, 3 ] },
+      { "item": "steel_chunk", "count": [ 2, 3 ] },
+      { "item": "scrap", "count": [ 2, 6 ] },
+      { "item": "cable", "charges": [ 1, 3 ] },
+      { "item": "hose", "count": 1 },
+      { "item": "glass_sheet", "count": 1 },
+      { "item": "cu_pipe", "count": [ 3, 6 ] },
+      { "item": "pipe_fittings", "count": [ 2, 6 ] },
+      { "item": "refrigerant_tank", "count": 1 },
+      { "item": "motor_tiny", "count": 1 }
+    ],
+    "damage_reduction": { "all": 16 },
+    "variants": [ { "symbols": "H", "symbols_broken": "#" } ]
+  },
+  {
+    "type": "vehicle_part",
     "id": "ap_minifridge",
     "flags": [ "CARGO", "OBSTACLE", "FRIDGE", "COVERED", "ENABLED_DRAINS_EPOWER", "APPLIANCE", "CTRL_ELECTRONIC" ],
     "copy-from": "minifridge"

--- a/data/json/furniture_and_terrain/furniture-appliances.json
+++ b/data/json/furniture_and_terrain/furniture-appliances.json
@@ -199,26 +199,13 @@
     "looks_like": "f_fridge",
     "symbol": "{",
     "color": "light_cyan",
-    "description": "A modern refrigerator with a thick sheet of glass in the door, often specially treated to be more insulative.  Allows seeing the contents without letting out the cold air, which used to be a minor convenience, and now saves precious minutes until spoilage.",
+    "description": "A modern refrigerator with a thick sheet of glass in the door, often specially treated to be more insulative.  If powered, it will cool its contents to extend the time before they spoil.",
     "move_cost_mod": -1,
     "coverage": 90,
     "required_str": 10,
-    "flags": [ "PLACE_ITEM", "BLOCKSDOOR", "NO_SELF_CONNECT", "SMALL_HIDE" ],
-    "deconstruct": {
-      "items": [
-        { "item": "sheet_metal", "count": [ 2, 5 ] },
-        { "item": "sheet_metal_small", "count": [ 0, 3 ] },
-        { "item": "steel_chunk", "count": [ 2, 3 ] },
-        { "item": "scrap", "count": [ 2, 6 ] },
-        { "item": "cable", "charges": [ 1, 3 ] },
-        { "item": "hose", "count": 1 },
-        { "item": "glass_sheet", "count": 1 },
-        { "item": "cu_pipe", "count": [ 3, 6 ] },
-        { "item": "pipe_fittings", "count": [ 2, 6 ] },
-        { "item": "refrigerant_tank", "count": 1 },
-        { "item": "motor_tiny", "count": 1 }
-      ]
-    },
+    "examine_action": { "type": "appliance_convert", "furn_set": "f_null", "item": "glass_fridge" },
+    "flags": [ "PLACE_ITEM", "BLOCKSDOOR", "NO_SELF_CONNECT", "EASY_DECONSTRUCT", "SMALL_HIDE" ],
+    "deconstruct": { "items": [ { "item": "glass_fridge", "count": 1 } ] },
     "max_volume": "500 L",
     "bash": {
       "str_min": 12,

--- a/data/json/items/appliances.json
+++ b/data/json/items/appliances.json
@@ -16,6 +16,21 @@
   },
   {
     "type": "GENERIC",
+    "id": "glass_fridge",
+    "looks_like": "minifridge",
+    "symbol": "F",
+    "color": "light_blue",
+    "name": { "str": "disconnected glass door refrigerator" },
+    "description": "A disconnected commercial refrigerator with a glass door.  If connected to a power source, it will cool its contents to extend the time before they spoil.",
+    "longest_side": "1700 mm",
+    "insulation": 9,
+    "material": [ "steel", "glass" ],
+    "volume": "800 L",
+    "weight": "70 kg",
+    "pocket_data": [ { "pocket_type": "CONTAINER", "rigid": true, "max_contains_volume": "500 L", "max_contains_weight": "400 kg" } ]
+  },
+  {
+    "type": "GENERIC",
     "id": "freezer",
     "looks_like": "minifreezer",
     "symbol": "F",

--- a/data/json/items/vehicle/cargo.json
+++ b/data/json/items/vehicle/cargo.json
@@ -151,6 +151,17 @@
     "volume": "800 L"
   },
   {
+    "id": "stowed_glass_fridge",
+    "type": "GENERIC",
+    "name": "tied-down glass door fridge",
+    "symbol": "F",
+    "looks_like": "fridge",
+    "material": [ "steel", "glass" ],
+    "description": "A fridge, secured to the roof for transportation.  Not functional, but easier than carrying it with your hands.",
+    "weight": "75 kg",
+    "volume": "800 L"
+  },
+  {
     "id": "stowed_freezer",
     "type": "GENERIC",
     "name": "tied-down freezer",

--- a/data/json/recipes/other/vehicle.json
+++ b/data/json/recipes/other/vehicle.json
@@ -199,6 +199,17 @@
   {
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",
+    "result": "stowed_glass_fridge",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_VEHICLE",
+    "time": "30 s",
+    "autolearn": true,
+    "reversible": true,
+    "components": [ [ [ "glass_fridge", 1 ] ], [ [ "rope_30", 1 ], [ "rope_6", 5 ] ] ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
     "result": "stowed_freezer",
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_VEHICLE",

--- a/data/json/recipes/recipe_appliance.json
+++ b/data/json/recipes/recipe_appliance.json
@@ -32,6 +32,39 @@
     ]
   },
   {
+    "result": "glass_fridge",
+    "type": "recipe",
+    "activity_level": "MODERATE_EXERCISE",
+    "category": "CC_APPLIANCE",
+    "subcategory": "CSC_APPLIANCE_UTILITY",
+    "copy-from": "minifridge",
+    "skills_required": [ "fabrication", 4 ],
+    "proficiencies": [
+      { "proficiency": "prof_plasticworking", "required": false, "time_multiplier": 1.1, "learning_time_multiplier": 0.1 },
+      { "proficiency": "prof_appliance_repair", "required": false, "skill_penalty": 0 }
+    ],
+    "qualities": [
+      { "id": "HAMMER", "level": 2 },
+      { "id": "SAW_M", "level": 1 },
+      { "id": "DRILL", "level": 1 },
+      { "id": "SCREW", "level": 1 },
+      { "id": "WRENCH", "level": 1 }
+    ],
+    "components": [
+      [ [ "sheet_metal", 15 ] ],
+      [ [ "glass_sheet", 1 ] ],
+      [ [ "condensor_coil", 1 ] ],
+      [ [ "evaporator_coil", 1 ] ],
+      [ [ "cable", 3 ] ],
+      [ [ "hose", 1 ] ],
+      [ [ "pipe_fittings", 6 ] ],
+      [ [ "thermostat", 1 ] ],
+      [ [ "motor_tiny", 1 ] ],
+      [ [ "refrigerant_tank", 1 ] ],
+      [ [ "plastic_chunk", 16 ] ]
+    ]
+  },
+  {
     "result": "freezer",
     "type": "recipe",
     "activity_level": "MODERATE_EXERCISE",

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -3261,6 +3261,33 @@
   },
   {
     "type": "vehicle_part",
+    "id": "stowed_glass_fridge",
+    "name": { "str": "tied-down glass door fridge" },
+    "categories": [ "other" ],
+    "color": "white",
+    "damage_modifier": 5,
+    "durability": 100,
+    "description": "A fridge, secured to the roof for transportation.  Not functional, but easier than carrying it with your hands.  Careful with the glass!",
+    "bonus": 300,
+    "item": "stowed_glass_fridge",
+    "location": "on_roof",
+    "requirements": {
+      "install": { "skills": [ [ "mechanics", 1 ] ], "time": "10 m" },
+      "removal": { "skills": [ [ "mechanics", 1 ] ], "time": "5 m" }
+    },
+    "breaks_into": [
+      { "item": "steel_lump", "count": [ 8, 13 ] },
+      { "item": "steel_chunk", "count": [ 8, 13 ] },
+      { "item": "scrap", "count": [ 8, 13 ] },
+      { "item": "hose", "prob": 50 },
+      { "item": "motor_tiny", "prob": 25 }
+    ],
+    "damage_reduction": { "all": 16 },
+    "flags": [ "EXTRA_DRAG" ],
+    "variants": [ { "symbols": "F", "symbols_broken": "*" } ]
+  },
+  {
+    "type": "vehicle_part",
     "id": "stowed_freezer",
     "name": { "str": "tied-down freezer" },
     "categories": [ "other" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Glass door fridges can now be used as appliances"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Glass door fridges remained legacy furniture with no option to use as appliance.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Copy-paste everything from regular fridge, accounting for difference in material and a token reduction in efficiency.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- [x] Spawn item
- [x] Verify crafting and deconstruction recipe
- [x] Place as appliance and verify it turns on
- [x] Take down appliance
- [x] Craft stowed version
- [x] Install stowed version on vehicle
- [x] Spawn furniture version, verify deconstruction
- [x] Spawn furniture version, verify "connect to grid"
- [x] Bash appliance, verify glass comes out

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
