### PR TITLE
Brigandine ALLOWS_TAIL adjustments

### DIFF
--- a/data/json/items/armor/brigandine.json
+++ b/data/json/items/armor/brigandine.json
@@ -140,7 +140,7 @@
     "looks_like": "armor_larmor",
     "color": "light_gray",
     "longest_side": "60 cm",
-    "flags": [ "OUTER", "STURDY", "ABLATIVE_CHAINMAIL_TORSO", "VARSIZE" ],
+    "flags": [ "OUTER", "STURDY", "ABLATIVE_CHAINMAIL_TORSO", "VARSIZE", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [
@@ -212,7 +212,7 @@
     "looks_like": "armor_larmor",
     "color": "light_gray",
     "longest_side": "60 cm",
-    "flags": [ "OUTER", "STURDY", "ABLATIVE_CHAINMAIL_TORSO", "VARSIZE" ],
+    "flags": [ "OUTER", "STURDY", "ABLATIVE_CHAINMAIL_TORSO", "VARSIZE", "ALLOWS_TAIL" ],
     "armor": [
       {
         "material": [
@@ -860,7 +860,7 @@
     "looks_like": "legguard_lightplate",
     "color": "light_gray",
     "environmental_protection": 1,
-    "flags": [ "OUTER", "ALLOWS_TAIL", "STURDY", "ABLATIVE_CHAINMAIL_LEGS", "VARSIZE" ],
+    "flags": [ "OUTER", "STURDY", "ABLATIVE_CHAINMAIL_LEGS", "VARSIZE" ],
     "armor": [
       {
         "material": [
@@ -1151,7 +1151,7 @@
     "looks_like": "legguard_metal",
     "color": "light_gray",
     "environmental_protection": 1,
-    "flags": [ "OUTER", "ALLOWS_TAIL", "STURDY", "ABLATIVE_CHAINMAIL_LEGS", "VARSIZE" ],
+    "flags": [ "OUTER", "STURDY", "ABLATIVE_CHAINMAIL_LEGS", "VARSIZE" ],
     "armor": [
       {
         "material": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Brigandine coat allows tail"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Brigandine coat has only 85% hip coverage, it's both believable and not a balance issue if it can be worn by tailed characters. This will help somewhat with the dearth of hip armor options for them (obviously their options should be inferior compared to what someone with normal anatomy can wear, but there should be options. 85% is inferior enough.)

`ALLOWS_TAIL` on splint leg guards and greaves is redundant as those items don't have hip coverage, so they wouldn't conflict with tails anyway.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add `ALLOWS_TAIL` to brigandine coat, remove from greaves and leg guards.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I thought about splitting out the skirt/tasset part of the coat as a separate item but I don't see a way to make this work with the chainmail attachment system. If I added another pocket for the skirt there would be nothing preventing stacking them, and if I didn't the inability to wear it with chainmail would be glaring.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- [x] Verify coats can be worn with tail
- [x] Verify leg guards and greaves can still be worn with tail

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
