### PR TITLE
Add more options for naming monsters in mapgen

### DIFF
--- a/doc/MAPGEN.md
+++ b/doc/MAPGEN.md
@@ -559,6 +559,7 @@ Value: `[ array of {objects} ]: [ { "monster": ... } ]`
 | one_or_none | Do not allow more than one to spawn due to high spawn density. If repeat is not defined or pack size is defined this defaults to true, otherwise this defaults to false. Ignored when spawning from a group.
 | friendly    | Set true to make the monster friendly. Default false.
 | name        | Extra name to display on the monster.
+| random_name | Options for generating a name for this monster. If not set, the value of name will be used. If set to "random", "female", or "male", a random unisex/female/male given name will be used. If set to "snippet", any snippets in `name` will be expanded, and that will be the name given.
 | target      | Set to true to make this into mission target. Only works when the monster is spawned from a mission.
 | spawn_data  | An optional object that contains additional details for spawning the monster.
 | use_pack_size | An optional bool, defaults to false.  If it is true and `group` is used then pack_size values from the monster group will be used.


### PR DESCRIPTION
#### Summary
Infrastructure "Provide more options to name monsters placed via mapgen"

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/69210
If you want to give a monster that is place in mapgen a name, it must be preset, and the same each time. This is limiting, particularly for quests.

#### Describe the solution
Add options to spawn monsters with random given names, as well as to expand snippets in monster names.

#### Describe alternatives you've considered
I don't love the use of a string for this, but it's a quick and easy way to do it. It'd be great to give access to the full range of nameFlags, though.

#### Testing
Changed `Sean McLaughlin`'s (refugee center quest zombie) name to utilize each of the options, verified they work. Specified an invalid `random_name` string, got an error on load. Removed the name, and place monster worked normally. The name was given without modification when `random_name` was not specified.
