### PR TITLE
Balance Mind Over Matter waves for Defense Mode

### DIFF
--- a/data/mods/Defense_Mode/mod_interactions/MindOverMatter/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/MindOverMatter/eocs.json
@@ -13,7 +13,7 @@
         "max_radius": 40
       },
       {
-        "u_spawn_monster": "GROUP_FERAL_PSYCHIC_DM",
+        "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
         "real_count": { "global_val": "wave_number", "default": 1 },
         "outdoor_only": true,
         "group": true,
@@ -21,7 +21,7 @@
         "max_radius": 40
       },
       {
-        "u_spawn_monster": "GROUP_FERAL_PSYCHIC_DM",
+        "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
         "real_count": { "global_val": "wave_number", "default": 1 },
         "outdoor_only": true,
         "group": true,

--- a/data/mods/MindOverMatter/modinteractions/Defense_Mode/monsters.json
+++ b/data/mods/MindOverMatter/modinteractions/Defense_Mode/monsters.json
@@ -34,6 +34,43 @@
     "copy-from": "mon_feral_human_telekin",
     "type": "MONSTER",
     "species": [ "HUMAN" ],
+    "special_attacks": [
+      {
+        "id": "psi_telekin1_telegrab",
+        "type": "spell",
+        "spell_data": { "id": "telekinetic_pull_monster", "min_level": 2 },
+        "cooldown": 15,
+        "monster_message": "%1$s stares at %3$s and %3$s is lifted up and pulled towards them!"
+      },
+      {
+        "type": "gun",
+        "cooldown": 5,
+        "move_cost": 50,
+        "gun_type": "feral_human_thrown_rock",
+        "ammo_type": "rock",
+        "no_ammo_sound": "",
+        "fake_skills": [ [ "throw", 6 ] ],
+        "fake_str": 11,
+        "require_targeting_player": false,
+        "ranges": [ [ 2, 10, "DEFAULT" ] ],
+        "description": "%1$s makes a throwing motion and one of the rocks around them suddenly launches like a bullet!"
+      },
+      {
+        "id": "smash",
+        "move_cost": 80,
+        "cooldown": 10,
+        "damage_max_instance": [ { "damage_type": "psi_telekinetic_damage", "amount": 10, "armor_penetration": 10 } ],
+        "hitsize_min": 12,
+        "range": 6,
+        "throw_strength": 30,
+        "blockable": false,
+        "effects_require_dmg": false,
+        "hit_dmg_u": "%1$s stares at you and a powerful force hurls you through the air!",
+        "hit_dmg_npc": "%1$s stares at <npcname> and a powerful force hurls them through the air!",
+        "miss_msg_u": "%s stares at you, and you feel a crushing pressure for a moment before the feeling vanishes!",
+        "miss_msg_npc": "%s stares at <npcname> but nothing happens!"
+      }
+    ],
     "vision_day": 99,
     "vision_night": 99,
     "aggression": 100,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Balance Mind Over Matter waves for Defense Mode."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #69261, because Mind Over Matter waves are too difficult to enjoy, the psychic powers of the various ferals can overwhelm an early-game survivor.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I decided to mix regular zombies in with the feral psychics, since they usually appear that way within the base game itself. Now, a whole wave won't be entirely composed of psychic creatures, just 1/3 of it. This is still challenging, but not impossible to overcome. You can still ramp up any awakenings you may have with this too; a good deal of psychics will still appear as the game goes on.

I also noticed that, in the quantities spawned, feral telekinetics were simply too powerful for the game mode. Not wanting to exclude telekinesis entirely, I made a few minor nerfs to them to help them better scale with the mode. Just to note, this happened to the `copy-from` monsters that Defense Mode uses, not the base telekinetics that are seen everywhere else in Mind Over Matter.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Simply reducing the number of psychics overall, but still having whole waves of them. Giving the player some psychic armor on game start to balance things, or throwing in a bunch of psychic nulls.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Went into the game and played around with the changes. I think it works better in this state, rather than having whole waves of psychics some and mess you up with magic powers.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I also realized that I need to add psychic nulls into the monster group, but that's a different PR.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
