### PR TITLE
Update formatter tools for color support

### DIFF
--- a/src/json.h
+++ b/src/json.h
@@ -94,11 +94,15 @@ struct json_source_location {
     int offset = 0;
 };
 
-enum class json_error_output_colors_t {
-    unset,        // default value, will print a warning
-    no_colors,    // use when error output is a redirected pipe
-    color_tags,   // use when debugmsg will handle the errors in either SDL or curses mode
-    ansi_escapes, // use when error output will end up in stdout: in tooling, formatters or CI
+// careful when deleting values from this enum; they're used outside cdda code (in formatter tools)
+// please make sure to update or file an issue that an update is needed for:
+// * in CDDA repository; tools/format_emscripten/shell.html
+// * VS Code extension; https://github.com/cdda-toys/cdda-json-formatter-vscode-extension/issues/
+enum class json_error_output_colors_t : int32_t {
+    unset = 0,        // default value, will print a warning
+    no_colors = 1,    // use when error output is a redirected pipe
+    color_tags = 2,   // use when debugmsg will handle the errors in either SDL or curses mode
+    ansi_escapes = 3, // use when error output will end up in stdout: in tooling, formatters or CI
 };
 
 extern json_error_output_colors_t json_error_output_colors;

--- a/tools/format_emscripten/format_emscripten.cpp
+++ b/tools/format_emscripten/format_emscripten.cpp
@@ -5,8 +5,10 @@ extern constexpr error_log_format_t error_log_format = error_log_format_t::human
 #include "format.h"
 
 extern "C" {
-    const char *json_format( const char *input )
+    const char *json_format( const char *input, int colors )
     {
+        json_error_output_colors = static_cast<json_error_output_colors_t>( colors );
+
         // we can do the malloc/free game with emscripten
         // or just leave the buffer in place and realloc
         // to make sure the strings fit

--- a/tools/format_emscripten/shell.html
+++ b/tools/format_emscripten/shell.html
@@ -113,7 +113,11 @@
             "\n    and a modern browser.";
 
         json_formatter().then(function (module) {
-            let json_format = module.cwrap("json_format", "string", ["string"]);
+            // parameters are the unformatted input string and an int representing json_error_output_colors_t
+            // for possible values see the enum definition in json.h, return value is the formatted string or
+            // error message
+            let json_format = module.cwrap("json_format", "string", ["string", "int"]);
+            const json_error_output_colors_t_no_colors = 1;
 
             json_output.placeholder =
                 "\n\n    Formatter ready."
@@ -131,7 +135,7 @@
                     // https://stackoverflow.com/a/20392392
                     let o = JSON.parse(json_input.value);
                     if (o && typeof o === "object") {
-                        let formatted = json_format(json_input.value);
+                        let formatted = json_format(json_input.value, json_error_output_colors_t_no_colors);
                         json_error_alert.style.display =
                             (formatted.startsWith("Json error")
                                 ? "block" : "none");


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Make formatters based on emscripten output work with colors from https://github.com/CleverRaven/Cataclysm-DDA/pull/66623

#### Describe the solution

Put an extra parameter into emscripten glue to allow overriding `json_error_output_colors`

#### Describe alternatives you've considered

#### Testing

Use `tools/format_emscripten/build.sh` to build the html-based formatter, remove the code that invokes validation using the browser's json parser (lines 132-133 and closing bracket), json with an error shouldn't print out a warning any more

#### Additional context
