### PR TITLE
Fix weapon prof learning EoC

### DIFF
--- a/data/json/effects_on_condition/melee_eocs.json
+++ b/data/json/effects_on_condition/melee_eocs.json
@@ -679,7 +679,9 @@
           }
         ],
         "else": [
-          { "math": [ "u_val('proficiency', 'proficiency_id: prof_thrusting_swords_familiar', 'format: 1600')", "+=", "rand(4)" ] },
+          {
+            "math": [ "u_val('proficiency', 'proficiency_id: prof_thrusting_swords_familiar', 'format: 1600')", "+=", "rand(4)" ]
+          },
           { "math": [ "u_prof_level", "=", "0" ] },
           { "math": [ "u_prof_lowest", "=", "min(u_prof_level, u_prof_lowest)" ] }
         ]

--- a/data/json/effects_on_condition/melee_eocs.json
+++ b/data/json/effects_on_condition/melee_eocs.json
@@ -252,7 +252,7 @@
         "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_maces_familiar', 'format: percent')", ">=", "100" ] },
         "then": [
           {
-            "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_macess_pro', 'format: percent')", ">=", "100" ] },
+            "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_maces_pro', 'format: percent')", ">=", "100" ] },
             "then": [
               {
                 "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_maces_master', 'format: percent')", ">=", "100" ] },
@@ -406,14 +406,14 @@
                 "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_quarterstaves_master', 'format: percent')", ">=", "100" ] },
                 "then": [ { "math": [ "u_prof_level", "=", "3" ] }, { "math": [ "u_prof_lowest", "=", "min(u_prof_level, u_prof_lowest)" ] } ],
                 "else": [
-                  { "math": [ "u_val('proficiency', 'proficiency_id: prof_quaterstaves_master', 'format: 6400')", "+=", "rand(4)" ] },
+                  { "math": [ "u_val('proficiency', 'proficiency_id: prof_quarterstaves_master', 'format: 6400')", "+=", "rand(4)" ] },
                   { "math": [ "u_prof_level", "=", "2" ] },
                   { "math": [ "u_prof_lowest", "=", "min(u_prof_level, u_prof_lowest)" ] }
                 ]
               }
             ],
             "else": [
-              { "math": [ "u_val('proficiency', 'proficiency_id: prof_quaterstaves_pro', 'format: 3200')", "+=", "rand(4)" ] },
+              { "math": [ "u_val('proficiency', 'proficiency_id: prof_quarterstaves_pro', 'format: 3200')", "+=", "rand(4)" ] },
               { "math": [ "u_prof_level", "=", "1" ] },
               { "math": [ "u_prof_lowest", "=", "min(u_prof_level, u_prof_lowest)" ] }
             ]
@@ -622,20 +622,20 @@
         "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_fencing_weapons_familiar', 'format: percent')", ">=", "100" ] },
         "then": [
           {
-            "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_fencing_weaponry_pro', 'format: percent')", ">=", "100" ] },
+            "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_fencing_weapons_pro', 'format: percent')", ">=", "100" ] },
             "then": [
               {
-                "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_fencing_weaponry_master', 'format: percent')", ">=", "100" ] },
+                "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_fencing_weapons_master', 'format: percent')", ">=", "100" ] },
                 "then": [ { "math": [ "u_prof_level", "=", "3" ] }, { "math": [ "u_prof_lowest", "=", "min(u_prof_level, u_prof_lowest)" ] } ],
                 "else": [
-                  { "math": [ "u_val('proficiency', 'proficiency_id: prof_fencing_weaponry_master', 'format: 6400')", "+=", "rand(4)" ] },
+                  { "math": [ "u_val('proficiency', 'proficiency_id: prof_fencing_weapons_master', 'format: 6400')", "+=", "rand(4)" ] },
                   { "math": [ "u_prof_level", "=", "2" ] },
                   { "math": [ "u_prof_lowest", "=", "min(u_prof_level, u_prof_lowest)" ] }
                 ]
               }
             ],
             "else": [
-              { "math": [ "u_val('proficiency', 'proficiency_id: prof_fencing_weaponry_pro', 'format: 3200')", "+=", "rand(4)" ] },
+              { "math": [ "u_val('proficiency', 'proficiency_id: prof_fencing_weapons_pro', 'format: 3200')", "+=", "rand(4)" ] },
               { "math": [ "u_prof_level", "=", "1" ] },
               { "math": [ "u_prof_lowest", "=", "min(u_prof_level, u_prof_lowest)" ] }
             ]
@@ -656,30 +656,30 @@
     "condition": { "u_has_wielded_with_weapon_category": "LONG_THRUSTING_SWORD" },
     "effect": [
       {
-        "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_thrusting_familiar', 'format: percent')", ">=", "100" ] },
+        "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_thrusting_swords_familiar', 'format: percent')", ">=", "100" ] },
         "then": [
           {
-            "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_thrusting_pro', 'format: percent')", ">=", "100" ] },
+            "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_thrusting_swords_pro', 'format: percent')", ">=", "100" ] },
             "then": [
               {
-                "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_thrusting_master', 'format: percent')", ">=", "100" ] },
+                "if": { "math": [ "u_val('proficiency', 'proficiency_id: prof_thrusting_swords_master', 'format: percent')", ">=", "100" ] },
                 "then": [ { "math": [ "u_prof_level", "=", "3" ] }, { "math": [ "u_prof_lowest", "=", "min(u_prof_level, u_prof_lowest)" ] } ],
                 "else": [
-                  { "math": [ "u_val('proficiency', 'proficiency_id: prof_thrusting_master', 'format: 6400')", "+=", "rand(4)" ] },
+                  { "math": [ "u_val('proficiency', 'proficiency_id: prof_thrusting_swords_master', 'format: 6400')", "+=", "rand(4)" ] },
                   { "math": [ "u_prof_level", "=", "2" ] },
                   { "math": [ "u_prof_lowest", "=", "min(u_prof_level, u_prof_lowest)" ] }
                 ]
               }
             ],
             "else": [
-              { "math": [ "u_val('proficiency', 'proficiency_id: prof_thrusting_pro', 'format: 3200')", "+=", "rand(4)" ] },
+              { "math": [ "u_val('proficiency', 'proficiency_id: prof_thrusting_swords_pro', 'format: 3200')", "+=", "rand(4)" ] },
               { "math": [ "u_prof_level", "=", "1" ] },
               { "math": [ "u_prof_lowest", "=", "min(u_prof_level, u_prof_lowest)" ] }
             ]
           }
         ],
         "else": [
-          { "math": [ "u_val('proficiency', 'proficiency_id: prof_thrusting_familiar', 'format: 1600')", "+=", "rand(4)" ] },
+          { "math": [ "u_val('proficiency', 'proficiency_id: prof_thrusting_swords_familiar', 'format: 1600')", "+=", "rand(4)" ] },
           { "math": [ "u_prof_level", "=", "0" ] },
           { "math": [ "u_prof_lowest", "=", "min(u_prof_level, u_prof_lowest)" ] }
         ]


### PR DESCRIPTION
#### Summary
Bugfixes "All weapon proficiencies can be learned by hitting"

#### Purpose of change

Closes #69274

#### Describe the solution

Correct typos in weapon prof EoC so the IDs referenced match with what's in `proficiencies/melee_weapons.json`

#### Describe alternatives you've considered

None

#### Testing

Give character Quarterstaff Familiarity, whack something, see no errors on learning. Repeat for thrusting swords, maces, and fencing.

#### Additional context

~~Can #68990 be merged now 🙏~~ 
Also checked practice recipes to make sure those didn't have typos, they didn't.