### PR TITLE
Correct closing brackets in COMPILING-VS-VCPKG.md guide

### DIFF
--- a/doc/COMPILING/COMPILING-VS-VCPKG.md
+++ b/doc/COMPILING/COMPILING-VS-VCPKG.md
@@ -146,8 +146,8 @@ It is possible to use `llvm-lib.exe` and `lld-link.exe` to speed up your local b
 <Project>
   <PropertyGroup>
     <CDDA_ENABLE_THIN_ARCHIVES>true</CDDA_ENABLE_THIN_ARCHIVES>
-    <CDDA_LLVM_LIB_PATH>C:\Program Files\LLVM\</CDDA_ENABLE_THIN_ARCHIVES>
-    <CDDA_LLD_LINK_PATH>C:\Program Files\LLVM\</CDDA_ENABLE_THIN_ARCHIVES>
+    <CDDA_LLVM_LIB_PATH>C:\Program Files\LLVM\</CDDA_LLVM_LIB_PATH>
+    <CDDA_LLD_LINK_PATH>C:\Program Files\LLVM\</CDDA_LLD_LINK_PATH>
   </PropertyGroup>
 </Project>
 ```


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

I followed the instructions for compiling and installed LLVM via github. In the process I found that the closing brackets on the documentation for installation were incorrect (maybe? I asked and someone nice verified this).  The closing bracket text didn't match the opening bracket text.

#### Describe the solution

Applied correct bracket text.

#### Describe alternatives you've considered

Letting someone who wouldn't accidently set fire to CDDA do this.

#### Testing

VS Studio stopped yelling at me when I cleaned the solution and let me build with the new corrected Directory.Build.props file.

#### Additional context

If I set fire to CDDA on accident I'm very sorry and promise not to do it again.