### PR TITLE
Performance: Improve creature visitor and optimize away parrot_at_danger. DO NOT MERGE

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -10325,7 +10325,7 @@ void map::flood_fill_zone( const Creature &origin )
         Creature *creature = tracker.creature_at<Creature>( loc );
         if( creature ) {
             const int n = zone_number * zone_tick;
-            creatures_by_zone[n].push_back( creature );
+            creatures_by_zone_and_faction[n][creature->get_monster_faction()].push_back( creature );
             creature->set_reachable_zone( n );
         }
     } );

--- a/src/map.h
+++ b/src/map.h
@@ -2299,7 +2299,7 @@ class map
         template <typename CreaturePredicate>
         Creature *find_reachable_creature( const Creature &origin, CreaturePredicate f ) {
             return find_reachable_creature_matching_faction_and_creature_predicate( origin, [](
-            const mfaction_id & faction ) {
+            const mfaction_id & ) {
                 return true;
             }, std::move( f ) );
         }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4505,13 +4505,12 @@ bool mattack::parrot( monster *z )
 
 bool mattack::parrot_at_danger( monster *parrot )
 {
-    for( Creature &creature : g->all_creatures() ) {
-        if( !creature.is_hallucination() ) {
+    if( get_map().find_reachable_creature( *parrot, [parrot]( Creature & creature ) {
+    if( !creature.is_hallucination() ) {
             if( creature.is_avatar() || creature.is_npc() ) {
                 Character *character = creature.as_character();
                 if( one_in( 20 ) && character->attitude_to( *parrot ) == Creature::Attitude::HOSTILE &&
                     parrot->sees( *character ) ) {
-                    parrot_common( parrot );
                     return true;
                 }
             } else {
@@ -4520,11 +4519,13 @@ bool mattack::parrot_at_danger( monster *parrot )
                                       ( monster->anger > 0 &&
                                         monster->faction->attitude( parrot->faction ) == mf_attitude::MFA_BY_MOOD ) ) &&
                     parrot->sees( *monster ) ) {
-                    parrot_common( parrot );
                     return true;
                 }
             }
         }
+    } ) ) {
+        parrot_common( parrot );
+        return true;
     }
 
     return false;

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4523,6 +4523,7 @@ bool mattack::parrot_at_danger( monster *parrot )
                 }
             }
         }
+        return false;
     } ) ) {
         parrot_common( parrot );
         return true;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "More monster planner optimizations."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The `parrot_at_danger` function was iterating over all monsters, and was taking way longer than it should.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change the reachable creatures visitor into a a search that can be terminated, and include faction information. This also improves the original use of this function in the monster planner.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tests pass, game seems to run fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Flame graph before:
<img width="1007" alt="parrot" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/2677507/029c8b87-0edd-46f4-ab08-451a1a7465cc">

Flame graph after (`parrot_at_danger` is gone)
<img width="1008" alt="parrot_after_2" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/2677507/36adb264-e2a2-43f3-aa14-de9b09602a6c">


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
