### PR TITLE
add pecorino and marscapone to the cheese recipe component

### DIFF
--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -236,7 +236,9 @@
         [ "can_cheese", 1 ],
         [ "cheese_rehydrated", 1 ],
         [ "cottage_cheese", 1 ],
-        [ "mozzarella_cheese", 1 ]
+        [ "mozzarella_cheese", 1 ],
+        [ "mascarpone", 1 ],
+        [ "pecorino_cheese", 1 ]
       ]
     ]
   },


### PR DESCRIPTION
#### Summary
Bugfixes "add pecorino and marscapone to the cheese recipe component"

#### Purpose of change
This allows them to be used in any recipe requiring cheese, such as a deluxe sandwich.

#### Describe alternatives you've considered
Considered just going hungry, or not putting cheese on the sandwich. Rejected.

#### Testing
Made and ate deluxe sandwich with pecorino.