### PR TITLE
Fix items from losing functionality when manually inserted and/or providing player light when used remotely

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4374,7 +4374,6 @@ void insert_item_activity_actor::finish( player_activity &act, Character &who )
                 //~ %1$s: item to put in the container, %2$s: container to put item in
                 who.add_msg_if_player( string_format( _( "You put your %1$s into the %2$s." ),
                                                       holstered_item.first->display_name(), holster->type->nname( 1 ) ) );
-                who.add_to_inv_search_caches( *holstered_item.first );
                 handler.add_unsealed( holster );
                 handler.unseal_pocket_containing( holstered_item.first );
                 holstered_item.first.remove_item();

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4312,7 +4312,7 @@ void insert_item_activity_actor::start( player_activity &act, Character &who )
 }
 
 static ret_val<void> try_insert( item_location &holster, drop_location &holstered_item,
-                                 int *charges_added )
+                                 int *charges_added, Character *carrier )
 {
     item &it = *holstered_item.first;
     ret_val<void> ret = ret_val<void>::make_failure( _( "item can't be stored there" ) );
@@ -4331,7 +4331,7 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
             return ret;
         }
 
-        return holster->put_in( it, item_pocket::pocket_type::CONTAINER, /*unseal_pockets=*/true );
+        return holster->put_in( it, item_pocket::pocket_type::CONTAINER, /*unseal_pockets=*/true, carrier );
     }
 
     ret = holster->can_contain_partial_directly( it );
@@ -4344,7 +4344,7 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
     }
     int charges_to_insert = std::min( holstered_item.second, max_parent_charges.value() );
     *charges_added = holster->fill_with( it, charges_to_insert, /*unseal_pockets=*/true,
-                                         /*allow_sealed=*/true, /*ignore_settings*/true, /*into_bottom*/true );
+                                         /*allow_sealed=*/true, /*ignore_settings*/true, /*into_bottom*/true, carrier );
     if( *charges_added <= 0 ) {
         return ret_val<void>::make_failure( _( "item can't be stored there" ) );
     }
@@ -4356,6 +4356,7 @@ void insert_item_activity_actor::finish( player_activity &act, Character &who )
 {
     bool success = false;
     bool bulk_load = false;
+    Character *carrier = holster.carrier();
     drop_location &holstered_item = items.front();
     if( holstered_item.first ) {
         success = true;
@@ -4368,7 +4369,7 @@ void insert_item_activity_actor::finish( player_activity &act, Character &who )
         ret_val<void> ret = ret_val<void>::make_failure( _( "item can't be stored there" ) );
 
         if( !it.count_by_charges() ) {
-            ret = try_insert( holster, holstered_item, nullptr );
+            ret = try_insert( holster, holstered_item, nullptr, carrier );
 
             if( ret.success() ) {
                 //~ %1$s: item to put in the container, %2$s: container to put item in
@@ -4380,7 +4381,7 @@ void insert_item_activity_actor::finish( player_activity &act, Character &who )
             }
         } else {
             int charges_added = 0;
-            ret = try_insert( holster, holstered_item, &charges_added );
+            ret = try_insert( holster, holstered_item, &charges_added, carrier );
 
             if( ret.success() ) {
                 item copy( it );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -4595,10 +4595,9 @@ void reload_activity_actor::finish( player_activity &act, Character &who )
         case 2:
         default:
             // In player inventory and player is wielding something.
-            if( loc.held_by( who ) ) {
-                add_msg( m_neutral, _( "The %s no longer fits in your inventory so you drop it instead." ),
-                         reloadable_name );
-            }
+            loc.carrier()->add_msg_if_player( m_neutral,
+                                              _( "The %s no longer fits in your inventory so you drop it instead." ),
+                                              reloadable_name );
             get_map().add_item_or_charges( loc.position(), reloadable );
             loc.remove_item();
             break;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -12461,7 +12461,8 @@ void Character::store( item_pocket *pocket, item &put, bool penalties, int base_
     }
     moves -= std::max( item_store_cost( put, null_item_reference(), penalties, base_cost ),
                        pocket->obtain_cost( put ) );
-    pocket->insert_item( i_rem( &put ) );
+    ret_val<item *> result = pocket->insert_item( i_rem( &put ) );
+    result.value()->on_pickup( *this );
     calc_encumbrance();
 }
 

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2442,7 +2442,8 @@ void outfit::add_stash( Character &guy, const item &newit, int &remaining_charge
         item_location carried_item = guy.get_wielded_item();
         if( carried_item && !carried_item->has_pocket_type( item_pocket::pocket_type::MAGAZINE ) &&
             carried_item->can_contain_partial( newit ).success() ) {
-            int used_charges = carried_item->fill_with( newit, remaining_charges, false, false, false );
+            int used_charges = carried_item->fill_with( newit, remaining_charges, /*unseal_pockets=*/false,
+                               /*allow_sealed=*/false, /*ignore_settings=*/false, /*into_bottom*/false, &guy );
             remaining_charges -= used_charges;
         }
         // Crawl Next : worn items

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -487,13 +487,9 @@ class liquid_inventory_selector_preset : public inventory_selector_preset
             if( location.get_item() == avoid ) {
                 return false;
             }
-            if( location.where() == item_location::type::character ) {
-                Character *character = get_creature_tracker().creature_at<Character>( location.position() );
-                if( character == nullptr ) {
-                    debugmsg( "Invalid location supplied to the liquid filter: no character found." );
-                    return false;
-                }
-                return location->get_remaining_capacity_for_liquid( liquid, *character ) > 0;
+            Character *carrier = location.carrier();
+            if( carrier != nullptr ) {
+                return location->get_remaining_capacity_for_liquid( liquid, *carrier ) > 0;
             }
             const bool allow_buckets = location.where() == item_location::type::map;
             return location->get_remaining_capacity_for_liquid( liquid, allow_buckets ) > 0;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1627,19 +1627,16 @@ ret_val<void> item::put_in( const item &payload, item_pocket::pocket_type pk_typ
     if( !result.success() ) {
         debugmsg( "tried to put an item (%s) count (%d) in a container (%s) that cannot contain it: %s",
                   payload.typeId().str(), payload.count(), typeId().str(), result.str() );
+        return ret_val<void>::make_failure( result.str() );
     }
     if( pk_type == item_pocket::pocket_type::MOD ) {
         update_modified_pockets();
     }
-    if( unseal_pockets && result.success() ) {
+    if( unseal_pockets ) {
         result.value()->unseal();
     }
     on_contents_changed();
-    if( result.success() ) {
-        return ret_val<void>::make_success( result.str() );
-    } else {
-        return ret_val<void>::make_failure( result.str() );
-    }
+    return ret_val<void>::make_success( result.str() );
 }
 
 void item::force_insert_item( const item &it, item_pocket::pocket_type pk_type )

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -655,7 +655,7 @@ item &item::convert( const itype_id &new_type, Character *carrier )
         countdown_point = calendar::turn + type->countdown_interval;
         active = true;
     }
-    if( carrier ) {
+    if( carrier && carrier->has_item( *this ) ) {
         carrier->on_item_acquire( *this );
     }
 

--- a/src/item.h
+++ b/src/item.h
@@ -865,7 +865,8 @@ class item : public visitable
                        bool unseal_pockets = false,
                        bool allow_sealed = false,
                        bool ignore_settings = false,
-                       bool into_bottom = false );
+                       bool into_bottom = false,
+                       Character *carrier = nullptr );
 
         /**
          * How much more of this liquid (in charges) can be put in this container.
@@ -932,7 +933,7 @@ class item : public visitable
          * Puts the given item into this one.
          */
         ret_val<void> put_in( const item &payload, item_pocket::pocket_type pk_type,
-                              bool unseal_pockets = false );
+                              bool unseal_pockets = false, Character *carrier = nullptr );
         void force_insert_item( const item &it, item_pocket::pocket_type pk_type );
 
         /**

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -256,8 +256,8 @@ class item_contents
          * pocket, items will be successfully inserted without regard to volume, length, or any
          * other restrictions, since these pockets are not considered to be normal "containers".
          */
-        ret_val<item_pocket *> insert_item( const item &it, item_pocket::pocket_type pk_type,
-                                            bool ignore_contents = false );
+        ret_val<item *> insert_item( const item &it, item_pocket::pocket_type pk_type,
+                                     bool ignore_contents = false, bool unseal_pockets = false );
         void force_insert_item( const item &it, item_pocket::pocket_type pk_type );
         bool can_unload_liquid() const;
 

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -89,6 +89,7 @@ class item_location::impl
             return nullptr;
         }
         virtual tripoint position() const = 0;
+        virtual Character *carrier() const = 0;
         virtual std::string describe( const Character * ) const = 0;
         virtual item_location obtain( Character &, int ) = 0;
         virtual units::volume volume_capacity() const = 0;
@@ -141,6 +142,10 @@ class item_location::impl::nowhere : public item_location::impl
         tripoint position() const override {
             debugmsg( "invalid use of nowhere item_location" );
             return tripoint_min;
+        }
+
+        Character *carrier() const override {
+            return nullptr;
         }
 
         std::string describe( const Character * ) const override {
@@ -216,6 +221,10 @@ class item_location::impl::item_on_map : public item_location::impl
 
         tripoint position() const override {
             return cur.pos();
+        }
+
+        Character *carrier() const override {
+            return nullptr;
         }
 
         std::string describe( const Character *ch ) const override {
@@ -343,6 +352,13 @@ class item_location::impl::item_on_person : public item_location::impl
             return who->pos();
         }
 
+        Character *carrier() const override {
+            if( !ensure_who_unpacked() ) {
+                return nullptr;
+            }
+            return who;
+        }
+
         std::string describe( const Character *ch ) const override {
             if( !target() || !ensure_who_unpacked() ) {
                 return std::string();
@@ -467,6 +483,10 @@ class item_location::impl::item_on_vehicle : public item_location::impl
 
         tripoint position() const override {
             return cur.veh.global_part_pos3( cur.part );
+        }
+
+        Character *carrier() const override {
+            return nullptr;
         }
 
         std::string describe( const Character *ch ) const override {
@@ -611,6 +631,10 @@ class item_location::impl::item_in_container : public item_location::impl
             } else {
                 return nullptr;
             }
+        }
+
+        Character *carrier() const override {
+            return container.carrier();
         }
 
         std::string describe( const Character * ) const override {
@@ -1074,15 +1098,14 @@ void item_location::set_should_stack( bool should_stack ) const
     ptr->should_stack = should_stack;
 }
 
+Character *item_location::carrier() const
+{
+    return ptr->carrier();
+}
+
 bool item_location::held_by( Character const &who ) const
 {
-    if( where() == type::character &&
-        get_creature_tracker().creature_at<Character>( position() ) == &who ) {
-        return true;
-    } else if( has_parent() ) {
-        return parent_item().held_by( who );
-    }
-    return false;
+    return carrier() == &who;
 }
 
 units::volume item_location::volume_capacity() const

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -1105,7 +1105,13 @@ Character *item_location::carrier() const
 
 bool item_location::held_by( Character const &who ) const
 {
-    return carrier() == &who;
+    if( where() == type::character &&
+        get_creature_tracker().creature_at<Character>( position() ) == &who ) {
+        return true;
+    } else if( has_parent() ) {
+        return parent_item().held_by( who );
+    }
+    return false;
 }
 
 units::volume item_location::volume_capacity() const

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -1105,13 +1105,7 @@ Character *item_location::carrier() const
 
 bool item_location::held_by( Character const &who ) const
 {
-    if( where() == type::character &&
-        get_creature_tracker().creature_at<Character>( position() ) == &who ) {
-        return true;
-    } else if( has_parent() ) {
-        return parent_item().held_by( who );
-    }
-    return false;
+    return carrier() == &who;
 }
 
 units::volume item_location::volume_capacity() const

--- a/src/item_location.h
+++ b/src/item_location.h
@@ -110,6 +110,9 @@ class item_location
         item_location parent_item() const;
         item_pocket *parent_pocket() const;
 
+        /** returns the character whose inventory contains this item, nullptr if none **/
+        Character *carrier() const;
+
         /** returns true if the item is in the inventory of the given character **/
         bool held_by( Character const &who ) const;
 

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1809,8 +1809,7 @@ void item_pocket::overflow( const tripoint &pos, const item_location &loc )
         }
     }
 
-    Character *carrier = loc.where_recursive() != item_location::type::character ? nullptr :
-                         get_creature_tracker().creature_at<Character>( loc.position() );
+    Character *carrier = loc.carrier();
 
     // first remove items that shouldn't be in there anyway
     std::unordered_map<itype_id, bool> contained_type_validity;

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2177,23 +2177,28 @@ std::list<item> &item_pocket::edit_contents()
     return contents;
 }
 
-ret_val<item_pocket::contain_code> item_pocket::insert_item( const item &it,
+ret_val<item *> item_pocket::insert_item( const item &it,
         const bool into_bottom, bool restack_charges, bool ignore_contents )
 {
-    ret_val<item_pocket::contain_code> ret = !is_standard_type() ?
+    ret_val<item_pocket::contain_code> containable = !is_standard_type() ?
             ret_val<item_pocket::contain_code>::make_success() : can_contain( it, ignore_contents );
 
-    if( ret.success() ) {
-        if( !into_bottom ) {
-            contents.push_front( it );
-        } else {
-            contents.push_back( it );
-        }
-        if( restack_charges ) {
-            restack();
-        }
+    if( !containable.success() ) {
+        return ret_val<item *>::make_failure( nullptr, containable.str() );
     }
-    return ret;
+
+    item *inserted = nullptr;
+    if( !into_bottom ) {
+        contents.push_front( it );
+        inserted = &contents.front();
+    } else {
+        contents.push_back( it );
+        inserted = &contents.back();
+    }
+    if( restack_charges ) {
+        restack( inserted );
+    }
+    return ret_val<item *>::make_success( inserted );
 }
 
 std::pair<item_location, item_pocket *> item_pocket::best_pocket_in_contents(

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2160,7 +2160,8 @@ int item_pocket::fill_with( const item &contained, Character &guy, int amount,
     }
 
     contained_item.handle_pickup_ownership( guy );
-    if( !insert_item( contained_item ).success() ) {
+    ret_val<item *> result = insert_item( contained_item );
+    if( !result.success() ) {
         debugmsg( "charges per remaining pocket volume does not fit in that very volume" );
         return 0;
     }
@@ -2169,6 +2170,7 @@ int item_pocket::fill_with( const item &contained, Character &guy, int amount,
     if( allow_unseal ) {
         unseal();
     }
+    result.value()->on_pickup( guy );
     return num_contained;
 }
 

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -329,8 +329,8 @@ class item_pocket
         }
 
         // tries to put an item in the pocket. returns false if failure
-        ret_val<contain_code> insert_item( const item &it, bool into_bottom = false,
-                                           bool restack_charges = true, bool ignore_contents = false );
+        ret_val<item *> insert_item( const item &it, bool into_bottom = false,
+                                     bool restack_charges = true, bool ignore_contents = false );
         /**
           * adds an item to the pocket with no checks
           * may create a new pocket

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -2276,7 +2276,7 @@ class exosuit_interact
                 } );
                 moves += to_moves<int>( 5_seconds );
             }
-            ret_val<item_pocket::contain_code> rval = pkt->insert_item( *candidates[ret] );
+            ret_val<item *> rval = pkt->insert_item( *candidates[ret] );
             if( rval.success() ) {
                 candidates[ret].remove_item();
                 moves += to_moves<int>( 5_seconds );

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -117,10 +117,12 @@ static void expect_cannot_contain( const item_pocket &pocket, const item &it,
 static void expect_can_insert( item_pocket &pocket, const item &it )
 {
     CAPTURE( it.tname() );
-    ret_val<item_pocket::contain_code> rate_can = pocket.insert_item( it );
+    CHECK( pocket.can_contain( it ).value() == item_pocket::contain_code::SUCCESS );
+    ret_val<item *> rate_can = pocket.insert_item( it );
     CHECK( rate_can.success() );
     CHECK( rate_can.str().empty() );
-    CHECK( rate_can.value() == item_pocket::contain_code::SUCCESS );
+    REQUIRE( rate_can.value() != nullptr );
+    CHECK( rate_can.value()->stacks_with( it ) );
 }
 
 // Call pocket.insert_item( it ) and expect it to fail, with an expected reason and contain_code
@@ -129,10 +131,11 @@ static void expect_cannot_insert( item_pocket &pocket, const item &it,
                                   item_pocket::contain_code expect_code )
 {
     CAPTURE( it.tname() );
-    ret_val<item_pocket::contain_code> rate_can = pocket.insert_item( it );
+    CHECK( pocket.can_contain( it ).value() == expect_code );
+    ret_val<item *> rate_can = pocket.insert_item( it );
     CHECK_FALSE( rate_can.success() );
     CHECK( rate_can.str() == expect_reason );
-    CHECK( rate_can.value() == expect_code );
+    CHECK( rate_can.value() == nullptr );
 }
 
 // Max item length

--- a/tests/npc_shopkeeper_item_groups_test.cpp
+++ b/tests/npc_shopkeeper_item_groups_test.cpp
@@ -39,7 +39,7 @@ TEST_CASE( "npc_shopkeeper_item_groups", "[npc][trade]" )
             std::pair<bool, bool> har_pants = has_and_can_restock( guy, pants );
             REQUIRE( har_pants.first == true );
             REQUIRE( har_pants.second == true );
-            REQUIRE( guy.wants_to_sell( { guy, &pants } ) );
+            REQUIRE( guy.wants_to_sell( { map_cursor{ tripoint_zero }, &pants } ) );
         }
     }
 
@@ -49,14 +49,14 @@ TEST_CASE( "npc_shopkeeper_item_groups", "[npc][trade]" )
         REQUIRE( creatures.creature_at<npc>( npc_pos ) != nullptr );
         item backpack( "test_backpack" );
         backpack.set_owner( guy );
-        REQUIRE( guy.wants_to_sell( { map_cursor{ tripoint_zero}, &backpack } ) );
+        REQUIRE( guy.wants_to_sell( { map_cursor{ tripoint_zero }, &backpack } ) );
         WHEN( "backpack is worn - not available for sale" ) {
             auto backpack_iter = *guy.wear_item( backpack );
             item &it = *backpack_iter;
-            REQUIRE( !guy.wants_to_sell( { guy, &it } ) );
+            REQUIRE( !guy.wants_to_sell( { map_cursor{ tripoint_zero }, &it } ) );
             item scrap( "scrap" );
             scrap.set_owner( guy );
-            REQUIRE( guy.wants_to_sell( { map_cursor{ tripoint_zero}, &scrap } ) );
+            REQUIRE( guy.wants_to_sell( { map_cursor{ tripoint_zero }, &scrap } ) );
             item_location const scrap_inv = guy.i_add( scrap );
             REQUIRE( scrap_inv );
             THEN( "sell_belongings is true - item in inventory available for sale" ) {
@@ -79,7 +79,7 @@ TEST_CASE( "npc_shopkeeper_item_groups", "[npc][trade]" )
             THEN( "item is available for restocking but not selling" ) {
                 REQUIRE( har_hammer.first == true );
                 REQUIRE( har_hammer.second == true );
-                REQUIRE( !guy.wants_to_sell( {guy, &hammer } ) );
+                REQUIRE( !guy.wants_to_sell( { map_cursor{ tripoint_zero }, &hammer } ) );
             }
         }
         WHEN( "condition met" ) {
@@ -88,7 +88,7 @@ TEST_CASE( "npc_shopkeeper_item_groups", "[npc][trade]" )
             THEN( "item is available for selling and restocking" ) {
                 REQUIRE( har_hammer.first == true );
                 REQUIRE( har_hammer.second == true );
-                REQUIRE( guy.wants_to_sell( { guy, &hammer } ) );
+                REQUIRE( guy.wants_to_sell( { map_cursor{ tripoint_zero }, &hammer } ) );
             }
         }
     }
@@ -101,7 +101,7 @@ TEST_CASE( "npc_shopkeeper_item_groups", "[npc][trade]" )
             THEN( "item is not available for selling or restocking" ) {
                 REQUIRE( har_multitool.first == true );
                 REQUIRE( har_multitool.second == false );
-                REQUIRE( !guy.wants_to_sell( { guy, &multitool } ) );
+                REQUIRE( !guy.wants_to_sell( { map_cursor{ tripoint_zero }, &multitool } ) );
             }
         }
         WHEN( "condition met" ) {
@@ -110,7 +110,7 @@ TEST_CASE( "npc_shopkeeper_item_groups", "[npc][trade]" )
             THEN( "item is available for selling and restocking" ) {
                 REQUIRE( har_multitool.first == true );
                 REQUIRE( har_multitool.second == true );
-                REQUIRE( guy.wants_to_sell( {guy, &multitool } ) );
+                REQUIRE( guy.wants_to_sell( { map_cursor{ tripoint_zero }, &multitool } ) );
             }
         }
     }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix items from losing functionality when manually inserted and/or providing player light when used remotely"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #68075, #68435, and the first part of #69140.

Also adds the function `carrier()` to item_location, which can be used to easily get the character that's holding an item_location.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Make `insert_item` functions return `ret_val<item *>` so they can return a pointer to the item that was added. Use this to make that newly inserted item call `on_pickup`, which adds it to the now-carrying-character's caches. This is done in `insert_item_activity_actor::finish`, `Character::store`, `item::fill_with`, and `item_pocket::fill_with`. Items with charges should now work as well.

To fix the remote lantern bug, `item::convert` will now check if the provided character is actually holding the item before adding it to the cache.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I originally simplified `item_location::held_by` to use the new function like this:
```
bool item_location::held_by( Character const &who ) const
{
    return carrier() == &who;
}
```
However, this made the game start failing tests in the `npc_shopkeeper_item_groups` test case. I spent a while trying to determine why, but I couldn't find anything concrete. I think it's possible those tests are relying on some sort of buggy interaction with the creature_tracker. I decided I wasn't making progress and reverted the change.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

1. Create a smartphone and a smartphone case, with both in the inventory. Time should be visible.
2. Do the following actions individually and take note that the time will now be correctly shown/hidden as appropriate.
3. Use the insertion menu to put the phone in the case.
4. Use the AIM to insert the phone.
5. Do the previous two again, but with the phone starting outside your inventory on the ground. The clock will properly activate.
6. Use the inventory Organize Contents menu to insert the phone.
7. Click and drag the phone between containers in the inventory menu.
8. Add the "WATCH" flag to an item with charges (I used marbles). Repeat the previous steps but with inserting varying numbers of that item into a held container. The clock should activate and stay active, showing that stack merging doesn't break it.
9. Follow the steps written out in `#68075, #69140, and #68435` and see that they are now fixed.

I also ran the test suite locally and got all green results.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I actually fixed the remote light not illuminating bug too, but I'll make a separate PR for that since it turns out it's not actually related.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
