### PR TITLE
Buttered toast should be able to be made with raw butter, too.

### DIFF
--- a/data/json/recipes/food/bread.json
+++ b/data/json/recipes/food/bread.json
@@ -214,14 +214,14 @@
     "charges": 1,
     "time": "1 m",
     "batch_time_factors": [ 20, 2 ],
-    "components": [ [ [ "toast", 1 ] ], [ [ "butter", 1 ] ] ]
+    "components": [ [ [ "toast", 1 ] ], [ [ "butter", 1 ], ["raw_butter", 1] ] ]
   },
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
     "result": "buttered_toast_wheat_free",
     "copy-from": "buttered_toast",
-    "components": [ [ [ "toast_wheat_free", 1 ] ], [ [ "butter", 1 ] ] ]
+    "components": [ [ [ "toast_wheat_free", 1 ] ], [ [ "butter", 1 ], ["raw_butter", 1] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/food/bread.json
+++ b/data/json/recipes/food/bread.json
@@ -214,7 +214,7 @@
     "charges": 1,
     "time": "1 m",
     "batch_time_factors": [ 20, 2 ],
-    "components": [ [ [ "toast", 1 ] ], [ [ "butter", 1 ], ["raw_butter", 1] ] ]
+    "components": [ [ [ "toast", 1 ] ], [ [ "butter", 1 ], [ "raw_butter", 1 ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/recipes/food/bread.json
+++ b/data/json/recipes/food/bread.json
@@ -221,7 +221,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "result": "buttered_toast_wheat_free",
     "copy-from": "buttered_toast",
-    "components": [ [ [ "toast_wheat_free", 1 ] ], [ [ "butter", 1 ], ["raw_butter", 1] ] ]
+    "components": [ [ [ "toast_wheat_free", 1 ] ], [ [ "butter", 1 ], [ "raw_butter", 1 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

Content "Buttered toast should be craftable with raw butter, too."

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Buttered toast, and wheat-free buttered toast, should also be able to use raw butter for late-game applicability.

"Butter" butter can't be made at a camp, so it previously lost relevancy after the first couple of months or so.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

I simply added the alternative of "raw_butter", which can be made, in line with buttered toast and wheat-free buttered toast's ingredient list, as an alternative to butter.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Can't really think of any other than eating the butter after the toast, which kind of misses the point, no?
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I've played this way on my own game, after a quick JSON edit, and have encountered no issues as of yet.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
