### PR TITLE
Fragile armor is fragile

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -8960,6 +8960,10 @@ item::armor_status item::damage_armor_durability( damage_unit &du, const bodypar
         // This is some weird type that doesn't damage armors
         return armor_status::UNDAMAGED;
     }
+    // Fragile items take damage if the block more than 15% of their armor value
+    if( has_flag( flag_FRAGILE ) && du.amount / armors_own_resist > 0.15f ) {
+        return mod_damage( itype::damage_scale ) ? armor_status::DESTROYED : armor_status::DAMAGED;
+    }
 
     // Scale chance of article taking damage based on the number of parts it covers.
     // This represents large articles being able to take more punishment
@@ -8990,11 +8994,7 @@ item::armor_status item::damage_armor_durability( damage_unit &du, const bodypar
         }
     }
 
-    const int damage = has_flag( flag_FRAGILE )
-                       ? rng( 2 * itype::damage_scale, 3 * itype::damage_scale )
-                       : itype::damage_scale;
-
-    return mod_damage( damage ) ? armor_status::DESTROYED : armor_status::DAMAGED;
+    return mod_damage( itype::damage_scale ) ? armor_status::DESTROYED : armor_status::DAMAGED;
 }
 
 item::armor_status item::damage_armor_transforms( damage_unit &du ) const


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Fragile Clothing will degrade if its dealt damage larger than 15% its armor value."

#### Purpose of change
The Aftershock Armors added in #69010 are intended to rely on fast degradation to balance its high armor values. However due to the way the degradation code was previously structured, fragile only  mattered when items rolled to take chip damage (at a flat 1 in 200 chance). Which meant that the armor pieces weren't really that fragile at all.

#### Describe the solution
Just like ballistic armor plates, fragile armors will now degrade if dealt damage larger than 15% their protection, no matter if they completely protected you from harm or not. As a result they actually break rather fast.
 
Since vanilla doenst really have fragile armors beyond glasses or high tech headsets, the effect on balance outside aftershock should be pretty minimal.

#### Testing
Got my character shot and generally thrashed around for a while.

#### Additional context
The rest of the degradation logic is actually broken,  normal items dont degrade at all if they let any damage through even when they are meant to.  Erk offered to write a better formula that I'll later implement, but that's a Saga for another day.