### PR TITLE
Hauling overhaul

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -2364,6 +2364,12 @@
   },
   {
     "type": "keybinding",
+    "name": "Quick toggle hauling",
+    "category": "DEFAULTMODE",
+    "id": "haul_toggle"
+  },
+  {
+    "type": "keybinding",
     "name": "Zone activities",
     "category": "DEFAULTMODE",
     "id": "loot",

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -193,6 +193,8 @@ std::string action_ident( action_id act )
             return "grab";
         case ACTION_HAUL:
             return "haul";
+        case ACTION_HAUL_TOGGLE:
+            return "haul_toggle";
         case ACTION_BUTCHER:
             return "butcher";
         case ACTION_CHAT:
@@ -943,6 +945,7 @@ action_id handle_action_menu()
             REGISTER_ACTION( ACTION_PICKUP_ALL );
             REGISTER_ACTION( ACTION_GRAB );
             REGISTER_ACTION( ACTION_HAUL );
+            REGISTER_ACTION( ACTION_HAUL_TOGGLE );
             REGISTER_ACTION( ACTION_BUTCHER );
             REGISTER_ACTION( ACTION_LOOT );
         } else if( category == _( "Combat" ) ) {

--- a/src/action.h
+++ b/src/action.h
@@ -118,6 +118,8 @@ enum action_id : int {
     ACTION_GRAB,
     /** Haul pile of items, or let go of them */
     ACTION_HAUL,
+    /** Quickly toggle hauling on/off */
+    ACTION_HAUL_TOGGLE,
     /** Butcher or disassemble objects in current square */
     ACTION_BUTCHER,
     /** Chat with something */

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2110,7 +2110,7 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
                 std::vector<item_location> dropped_items = drop_on_map( who, item_drop_reason::deliberate, { newit },
                         dest );
                 if( save_moved_items ) {
-                    who.items_hauled.insert( who.items_hauled.end(), dropped_items.begin(), dropped_items.end() );
+                    who.haul_list.insert( who.haul_list.end(), dropped_items.begin(), dropped_items.end() );
                 }
             }
             // If we picked up a whole stack, remove the leftover item

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2107,7 +2107,11 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
             if( to_vehicle ) {
                 put_into_vehicle_or_drop( who, item_drop_reason::deliberate, { newit }, dest );
             } else {
-                drop_on_map( who, item_drop_reason::deliberate, { newit }, dest );
+                std::vector<item_location> dropped_items = drop_on_map( who, item_drop_reason::deliberate, { newit },
+                        dest );
+                if( save_moved_items ) {
+                    who.items_hauled.insert( who.items_hauled.end(), dropped_items.begin(), dropped_items.end() );
+                }
             }
             // If we picked up a whole stack, remove the leftover item
             if( leftovers.charges <= 0 ) {
@@ -2133,6 +2137,7 @@ void move_items_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "quantities", quantities );
     jsout.member( "to_vehicle", to_vehicle );
     jsout.member( "relative_destination", relative_destination );
+    jsout.member( "save_moved_items", save_moved_items );
 
     jsout.end_object();
 }
@@ -2147,6 +2152,7 @@ std::unique_ptr<activity_actor> move_items_activity_actor::deserialize( JsonValu
     data.read( "quantities", actor.quantities );
     data.read( "to_vehicle", actor.to_vehicle );
     data.read( "relative_destination", actor.relative_destination );
+    data.read( "save_moved_items", actor.save_moved_items );
 
     return actor.clone();
 }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -462,15 +462,13 @@ class move_items_activity_actor : public activity_actor
         std::vector<int> quantities;
         bool to_vehicle;
         tripoint relative_destination;
-        bool save_moved_items;
 
     public:
         move_items_activity_actor( std::vector<item_location> target_items, std::vector<int> quantities,
-                                   bool to_vehicle, tripoint relative_destination, bool save_moved_items = false ) :
+                                   bool to_vehicle, tripoint relative_destination ) :
             target_items( std::move( target_items ) ), quantities( std::move( quantities ) ),
             to_vehicle( to_vehicle ),
-            relative_destination( relative_destination ),
-            save_moved_items( save_moved_items ) {}
+            relative_destination( relative_destination ) {}
 
         activity_id get_type() const override {
             return activity_id( "ACT_MOVE_ITEMS" );

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -462,13 +462,15 @@ class move_items_activity_actor : public activity_actor
         std::vector<int> quantities;
         bool to_vehicle;
         tripoint relative_destination;
+        bool save_moved_items;
 
     public:
         move_items_activity_actor( std::vector<item_location> target_items, std::vector<int> quantities,
-                                   bool to_vehicle, tripoint relative_destination ) :
+                                   bool to_vehicle, tripoint relative_destination, bool save_moved_items = false ) :
             target_items( std::move( target_items ) ), quantities( std::move( quantities ) ),
             to_vehicle( to_vehicle ),
-            relative_destination( relative_destination ) {}
+            relative_destination( relative_destination ),
+            save_moved_items( save_moved_items ) {}
 
         activity_id get_type() const override {
             return activity_id( "ACT_MOVE_ITEMS" );

--- a/src/activity_handlers.h
+++ b/src/activity_handlers.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "coordinates.h"
+#include "item_location.h"
 #include "type_id.h"
 #include "requirements.h"
 
@@ -143,8 +144,9 @@ enum class item_drop_reason : int {
 void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items );
 void put_into_vehicle_or_drop( Character &you, item_drop_reason, const std::list<item> &items,
                                const tripoint_bub_ms &where, bool force_ground = false );
-void drop_on_map( Character &you, item_drop_reason reason, const std::list<item> &items,
-                  const tripoint_bub_ms &where );
+std::vector<item_location> drop_on_map( Character &you, item_drop_reason reason,
+                                        const std::list<item> &items,
+                                        const tripoint_bub_ms &where );
 // used in unit tests to avoid triggering user input
 void repair_item_finish( player_activity *act, Character *you, bool no_menu );
 

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -327,11 +327,12 @@ static void put_into_vehicle( Character &c, item_drop_reason reason, const std::
     }
 }
 
-void drop_on_map( Character &you, item_drop_reason reason, const std::list<item> &items,
-                  const tripoint_bub_ms &where )
+std::vector<item_location> drop_on_map( Character &you, item_drop_reason reason,
+                                        const std::list<item> &items,
+                                        const tripoint_bub_ms &where )
 {
     if( items.empty() ) {
-        return;
+        return {};
     }
     map &here = get_map();
     const std::string ter_name = here.name( where );
@@ -418,12 +419,15 @@ void drop_on_map( Character &you, item_drop_reason reason, const std::list<item>
                 break;
         }
     }
+    std::vector<item_location> items_dropped;
     for( const item &it : items ) {
-        here.add_item_or_charges( where, it );
+        item &dropped_item = here.add_item_or_charges( where, it );
+        items_dropped.push_back( item_location( map_cursor( where.raw() ), &dropped_item ) );
         item( it ).handle_pickup_ownership( you );
     }
 
     you.recoil = MAX_RECOIL;
+    return items_dropped;
 }
 
 void put_into_vehicle_or_drop( Character &you, item_drop_reason reason,

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -422,7 +422,7 @@ std::vector<item_location> drop_on_map( Character &you, item_drop_reason reason,
     std::vector<item_location> items_dropped;
     for( const item &it : items ) {
         item &dropped_item = here.add_item_or_charges( where, it );
-        items_dropped.push_back( item_location( map_cursor( where.raw() ), &dropped_item ) );
+        items_dropped.emplace_back( map_cursor( where.raw() ), &dropped_item );
         item( it ).handle_pickup_ownership( you );
     }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8622,6 +8622,27 @@ units::volume Character::volume_carried() const
     return volume_capacity() - free_space();
 }
 
+void Character::toggle_hauling()
+{
+    map &here = get_map();
+
+    if( hauling ) {
+        stop_hauling();
+    } else {
+        if( here.veh_at( pos() ) ) {
+            add_msg( m_info, _( "You cannot haul inside vehicles." ) );
+        } else if( here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, pos() ) ) {
+            add_msg( m_info, _( "You cannot haul while in deep water." ) );
+        } else if( !here.can_put_items( pos() ) ) {
+            add_msg( m_info, _( "You cannot haul items here." ) );
+        } else if( !here.has_haulable_items( pos() ) ) {
+            add_msg( m_info, _( "There are no items to haul here." ) );
+        } else {
+            start_hauling();
+        }
+    }
+}
+
 void Character::start_hauling()
 {
     add_msg( _( "You start hauling items along the ground." ) );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8692,6 +8692,9 @@ void Character::start_autohaul()
 void Character::stop_autohaul()
 {
     autohaul = false;
+    if( haul_list.empty() ) {
+        stop_hauling();
+    }
 }
 
 bool Character::is_autohauling() const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8702,12 +8702,15 @@ bool Character::is_autohauling() const
     return autohaul;
 }
 
-void Character::trim_haul_list( const std::vector<item_location> &valid_items )
+bool Character::trim_haul_list( const std::vector<item_location> &valid_items )
 {
+    size_t qty_before = haul_list.size();
     haul_list.erase( std::remove_if( haul_list.begin(),
     haul_list.end(), [&valid_items]( const item_location & it ) {
         return std::count( valid_items.begin(), valid_items.end(), it ) == 0;
     } ), haul_list.end() );
+
+    return qty_before != haul_list.size();
 }
 
 bool Character::knows_creature_type( const Creature *c ) const

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8629,7 +8629,12 @@ void Character::toggle_hauling()
     if( hauling ) {
         stop_hauling();
     } else {
-        start_hauling( here.get_haulable_items( pos() ) );
+        std::vector<item_location> items = here.get_haulable_items( pos() );
+        if( items.empty() ) {
+            add_msg( m_info, _( "There are no items to haul here." ) );
+            return;
+        }
+        start_hauling( items );
         start_autohaul();
     }
 }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8702,6 +8702,14 @@ bool Character::is_autohauling() const
     return autohaul;
 }
 
+void Character::trim_haul_list( const std::vector<item_location> &valid_items )
+{
+    haul_list.erase( std::remove_if( haul_list.begin(),
+    haul_list.end(), [&valid_items]( const item_location & it ) {
+        return std::count( valid_items.begin(), valid_items.end(), it ) == 0;
+    } ), haul_list.end() );
+}
+
 bool Character::knows_creature_type( const Creature *c ) const
 {
     if( const monster *mon = dynamic_cast<const monster *>( c ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8636,6 +8636,8 @@ void Character::stop_hauling()
     if( hauling ) {
         add_msg( _( "You stop hauling items." ) );
         hauling = false;
+        hauling_selectively = false;
+        items_hauled.clear();
     }
     if( has_activity( ACT_MOVE_ITEMS ) ) {
         cancel_activity();
@@ -8645,6 +8647,25 @@ void Character::stop_hauling()
 bool Character::is_hauling() const
 {
     return hauling;
+}
+
+void Character::start_hauling_selectively()
+{
+    add_msg( _( "You are now ignoring new items as you haul." ) );
+    items_hauled = get_map().get_haulable_items( pos() );
+    hauling_selectively = true;
+}
+
+void Character::stop_hauling_selectively()
+{
+    add_msg( _( "You are now adding new items to the haul as you encounter them." ) );
+    items_hauled.clear();
+    hauling_selectively = false;
+}
+
+bool Character::is_hauling_selectively() const
+{
+    return hauling_selectively;
 }
 
 bool Character::knows_creature_type( const Creature *c ) const

--- a/src/character.h
+++ b/src/character.h
@@ -2636,6 +2636,8 @@ class Character : public Creature, public visitable
         bool hauling = false;
         // Means player is automatically including new items in the haul
         bool autohaul = false;
+        // Skip autohaul on the stop the hauling selection is modified manually
+        bool suppress_autohaul = false;
         std::string hauling_filter;
         // Items currently being hauled
         std::vector<item_location> haul_list;

--- a/src/character.h
+++ b/src/character.h
@@ -2631,12 +2631,14 @@ class Character : public Creature, public visitable
         bool nv_cached = false;
         // Means player sit inside vehicle on the tile he is now
         bool in_vehicle = false;
-        bool hauling = false;
-        // Means player is hauling only specific items
-        bool hauling_selectively = false;
-        std::string hauling_filter;
 
-        std::vector<item_location> items_hauled;
+        // Means player is hauling items along the ground
+        bool hauling = false;
+        // Means player is automatically including new items in the haul
+        bool autohaul = false;
+        std::string hauling_filter;
+        // Items currently being hauled
+        std::vector<item_location> haul_list;
 
         tripoint view_offset;
 
@@ -2740,13 +2742,13 @@ class Character : public Creature, public visitable
 
         // Hauling items on the ground
         void toggle_hauling();
-        void start_hauling();
+        void start_hauling( const std::vector<item_location> &items_to_haul );
         void stop_hauling();
         bool is_hauling() const;
 
-        void start_hauling_selectively();
-        void stop_hauling_selectively();
-        bool is_hauling_selectively() const;
+        void start_autohaul();
+        void stop_autohaul();
+        bool is_autohauling() const;
 
         /**
          * @brief Applies a lambda function on all items with the given flag and/or that pass the given boolean item function, using or creating caches from @ref inv_search_caches.

--- a/src/character.h
+++ b/src/character.h
@@ -2751,6 +2751,7 @@ class Character : public Creature, public visitable
         void start_autohaul();
         void stop_autohaul();
         bool is_autohauling() const;
+        void trim_haul_list( const std::vector<item_location> &valid_items );
 
         /**
          * @brief Applies a lambda function on all items with the given flag and/or that pass the given boolean item function, using or creating caches from @ref inv_search_caches.

--- a/src/character.h
+++ b/src/character.h
@@ -2751,7 +2751,8 @@ class Character : public Creature, public visitable
         void start_autohaul();
         void stop_autohaul();
         bool is_autohauling() const;
-        void trim_haul_list( const std::vector<item_location> &valid_items );
+        // Remove items from haul list which are not in valid_items. Returns true if anything was trimmed
+        bool trim_haul_list( const std::vector<item_location> &valid_items );
 
         /**
          * @brief Applies a lambda function on all items with the given flag and/or that pass the given boolean item function, using or creating caches from @ref inv_search_caches.

--- a/src/character.h
+++ b/src/character.h
@@ -2739,6 +2739,7 @@ class Character : public Creature, public visitable
         int activity_vehicle_part_index = -1;
 
         // Hauling items on the ground
+        void toggle_hauling();
         void start_hauling();
         void stop_hauling();
         bool is_hauling() const;

--- a/src/character.h
+++ b/src/character.h
@@ -2632,6 +2632,12 @@ class Character : public Creature, public visitable
         // Means player sit inside vehicle on the tile he is now
         bool in_vehicle = false;
         bool hauling = false;
+        // Means player is hauling only specific items
+        bool hauling_selectively = false;
+        std::string hauling_filter;
+
+        std::vector<item_location> items_hauled;
+
         tripoint view_offset;
 
         player_activity stashed_outbounds_activity;
@@ -2736,6 +2742,10 @@ class Character : public Creature, public visitable
         void start_hauling();
         void stop_hauling();
         bool is_hauling() const;
+
+        void start_hauling_selectively();
+        void stop_hauling_selectively();
+        bool is_hauling_selectively() const;
 
         /**
          * @brief Applies a lambda function on all items with the given flag and/or that pass the given boolean item function, using or creating caches from @ref inv_search_caches.

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12117,7 +12117,7 @@ void game::start_hauling( const tripoint &pos )
     // Find target items and quantities thereof for the new activity
     std::vector<item_location> target_items = u.haul_list;
 
-    if( u.is_autohauling() ) {
+    if( u.is_autohauling() && !u.suppress_autohaul ) {
         for( const item_location &item : u.haul_list ) {
             candidate_items.erase( std::remove( candidate_items.begin(), candidate_items.end(), item ),
                                    candidate_items.end() );
@@ -12133,6 +12133,7 @@ void game::start_hauling( const tripoint &pos )
         }
     }
 
+    u.suppress_autohaul = false;
     u.haul_list.clear();
 
     // Quantity of 0 means move all

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2467,6 +2467,7 @@ input_context get_default_mode_input_context()
     ctxt.register_action( "pickup_all" );
     ctxt.register_action( "grab" );
     ctxt.register_action( "haul" );
+    ctxt.register_action( "haul_toggle" );
     ctxt.register_action( "butcher" );
     ctxt.register_action( "chat" );
     ctxt.register_action( "look" );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12109,8 +12109,6 @@ void game::vertical_move( int movez, bool force, bool peeking )
 void game::start_hauling( const tripoint &pos )
 {
     std::vector<item_location> candidate_items = m.get_haulable_items( pos );
-    // Forget about items that didn't actually end up on the previous tile (e.g. because they overflowed)
-    u.trim_haul_list( candidate_items );
     // Find target items and quantities thereof for the new activity
     std::vector<item_location> target_items = u.haul_list;
 
@@ -12149,8 +12147,7 @@ void game::start_hauling( const tripoint &pos )
     // Destination relative to the player
     const tripoint relative_destination{};
 
-    const move_items_activity_actor actor( target_items, quantities, to_vehicle, relative_destination,
-                                           true );
+    const move_items_activity_actor actor( target_items, quantities, to_vehicle, relative_destination );
     u.assign_activity( actor );
 }
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12110,10 +12110,7 @@ void game::start_hauling( const tripoint &pos )
 {
     std::vector<item_location> candidate_items = m.get_haulable_items( pos );
     // Forget about items that didn't actually end up on the previous tile (e.g. because they overflowed)
-    u.haul_list.erase( std::remove_if( u.haul_list.begin(),
-    u.haul_list.end(), [&candidate_items]( const item_location & it ) {
-        return std::count( candidate_items.begin(), candidate_items.end(), it ) == 0;
-    } ), u.haul_list.end() );
+    u.trim_haul_list( candidate_items );
     // Find target items and quantities thereof for the new activity
     std::vector<item_location> target_items = u.haul_list;
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12108,11 +12108,16 @@ void game::vertical_move( int movez, bool force, bool peeking )
 
 void game::start_hauling( const tripoint &pos )
 {
+    std::vector<item_location> candidate_items = m.get_haulable_items( pos );
+    // Forget about items that didn't actually end up on the previous tile (e.g. because they overflowed)
+    u.haul_list.erase( std::remove_if( u.haul_list.begin(),
+    u.haul_list.end(), [&candidate_items]( const item_location & it ) {
+        return std::count( candidate_items.begin(), candidate_items.end(), it ) == 0;
+    } ), u.haul_list.end() );
     // Find target items and quantities thereof for the new activity
     std::vector<item_location> target_items = u.haul_list;
 
     if( u.is_autohauling() ) {
-        std::vector<item_location> candidate_items = m.get_haulable_items( pos );
         for( const item_location &item : u.haul_list ) {
             candidate_items.erase( std::remove( candidate_items.begin(), candidate_items.end(), item ),
                                    candidate_items.end() );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -777,8 +777,12 @@ static void haul()
 
     menu.text = help_header + "\n\n" + status_header;
 
-    menu.entries.emplace_back( 0, hauling, hauling ? '\\' : 'h', _( "Stop hauling" ) );
-    menu.entries.emplace_back( 1, !haulable_items.empty(), !hauling ? '\\' : 'h',
+    input_context ctxt = get_default_mode_input_context();
+    std::vector<input_event> haul_keys = ctxt.keys_bound_to( "haul" );
+    int haul_key = haul_keys.empty() ? '\\' : haul_keys.front().sequence.front();
+
+    menu.entries.emplace_back( 0, hauling, hauling ? haul_key : 'h', _( "Stop hauling" ) );
+    menu.entries.emplace_back( 1, !haulable_items.empty(), !hauling ? haul_key : 'h',
                                _( "Haul everything here" ) );
     menu.entries.emplace_back( 2, !haulable_items.empty(), 'p', _( "Choose items to haul" ) );
     menu.entries.emplace_back( 3, true, 'a',

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -735,7 +735,6 @@ static void haul()
     bool autohaul = player_character.is_autohauling();
     std::vector<item_location> &haul_list = player_character.haul_list;
     std::vector<item_location> haulable_items = get_map().get_haulable_items( player_character.pos() );
-    player_character.trim_haul_list( haulable_items );
     int haul_qty = haul_list.size();
     std::string &haul_filter = player_character.hauling_filter;
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -805,6 +805,9 @@ static void haul()
             for( const drop_location &dl : result ) {
                 haulable_items.push_back( dl.first );
             }
+            if( haulable_items != player_character.haul_list ) {
+                player_character.suppress_autohaul = true;
+            }
             if( !haulable_items.empty() ) {
                 player_character.start_hauling( haulable_items );
             }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -728,7 +728,6 @@ static void grab()
 static void haul()
 {
     Character &player_character = get_player_character();
-    map &here = get_map();
 
     bool exit = false;
     do {
@@ -771,21 +770,7 @@ static void haul()
 
         switch( menu.ret ) {
             case 0:
-                if( hauling ) {
-                    player_character.stop_hauling();
-                } else {
-                    if( here.veh_at( player_character.pos() ) ) {
-                        add_msg( m_info, _( "You cannot haul inside vehicles." ) );
-                    } else if( here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, player_character.pos() ) ) {
-                        add_msg( m_info, _( "You cannot haul while in deep water." ) );
-                    } else if( !here.can_put_items( player_character.pos() ) ) {
-                        add_msg( m_info, _( "You cannot haul items here." ) );
-                    } else if( !here.has_haulable_items( player_character.pos() ) ) {
-                        add_msg( m_info, _( "There are no items to haul here." ) );
-                    } else {
-                        player_character.start_hauling();
-                    }
-                }
+                player_character.toggle_hauling();
                 exit = true;
                 break;
             case 1:
@@ -808,6 +793,11 @@ static void haul()
                 return;
         }
     } while( !exit );
+}
+
+static void haul_toggle()
+{
+    get_avatar().toggle_hauling();
 }
 
 static void smash()
@@ -2015,6 +2005,7 @@ static std::map<action_id, std::string> get_actions_disabled_in_shell()
         { ACTION_PICKUP_ALL,         _( "You can't pick anything up while you're in your shell." ) },
         { ACTION_GRAB,               _( "You can't grab things while you're in your shell." ) },
         { ACTION_HAUL,               _( "You can't haul things while you're in your shell." ) },
+        { ACTION_HAUL_TOGGLE,        _( "You can't haul things while you're in your shell." ) },
         { ACTION_BUTCHER,            _( "You can't butcher while you're in your shell." ) },
         { ACTION_PEEK,               _( "You can't peek around corners while you're in your shell." ) },
         { ACTION_DROP,               _( "You can't drop things while you're in your shell." ) },
@@ -2036,6 +2027,7 @@ static const std::set<action_id> actions_disabled_in_incorporeal {
     ACTION_PICKUP_ALL,
     ACTION_GRAB,
     ACTION_HAUL,
+    ACTION_HAUL_TOGGLE,
     ACTION_BUTCHER,
     ACTION_CRAFT,
     ACTION_RECRAFT,
@@ -2056,6 +2048,7 @@ static std::map<action_id, std::string> get_actions_disabled_mounted()
         { ACTION_PICKUP_ALL,         _( "You can't pick anything up while you're riding." ) },
         { ACTION_GRAB,               _( "You can't grab things while you're riding." ) },
         { ACTION_HAUL,               _( "You can't haul things while you're riding." ) },
+        { ACTION_HAUL_TOGGLE,        _( "You can't haul things while you're riding." ) },
         { ACTION_BUTCHER,            _( "You can't butcher while you're riding." ) },
         { ACTION_PEEK,               _( "You can't peek around corners while you're riding." ) },
         { ACTION_CRAFT,              _( "You can't craft while you're riding." ) },
@@ -2331,6 +2324,10 @@ bool game::do_regular_action( action_id &act, avatar &player_character,
 
         case ACTION_HAUL:
             haul();
+            break;
+
+        case ACTION_HAUL_TOGGLE:
+            haul_toggle();
             break;
 
         case ACTION_BUTCHER:

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -794,10 +794,22 @@ static void haul()
         case 1:
             player_character.start_hauling( haulable_items );
             break;
-        case 2:
-            //TODO: Query player to trim haulable_items
-            player_character.start_hauling( haulable_items );
-            break;
+        case 2: {
+            inventory_haul_selector selector( player_character );
+            selector.add_map_items( player_character.pos() );
+            selector.apply_selection( player_character.haul_list );
+            selector.set_title( _( "Select items to haul" ) );
+            selector.set_hint( _( "To select x items, type a number before selecting." ) );
+            drop_locations result = selector.execute();
+            haulable_items.clear();
+            for( const drop_location &dl : result ) {
+                haulable_items.push_back( dl.first );
+            }
+            if( !haulable_items.empty() ) {
+                player_character.start_hauling( haulable_items );
+            }
+        }
+        break;
         case 3:
             autohaul ? player_character.stop_autohaul() : player_character.start_autohaul();
             break;

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -734,9 +734,11 @@ static void haul()
     bool hauling = player_character.is_hauling();
     bool autohaul = player_character.is_autohauling();
     std::vector<item_location> &haul_list = player_character.haul_list;
+    std::vector<item_location> haulable_items = get_map().get_haulable_items( player_character.pos() );
+    player_character.trim_haul_list( haulable_items );
     int haul_qty = haul_list.size();
     std::string &haul_filter = player_character.hauling_filter;
-    std::vector<item_location> haulable_items = get_map().get_haulable_items( player_character.pos() );
+
 
     std::string help_header =
         _( "Select items on current tile to haul with you as you move.\nIf autohaul is enabled, you will automatically add encountered items to the haul.\nYou can set a filter to limit which items are automatically added." );

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -801,7 +801,7 @@ static void haul()
             selector.apply_selection( player_character.haul_list );
             selector.set_title( _( "Select items to haul" ) );
             selector.set_hint( _( "To select x items, type a number before selecting." ) );
-            drop_locations result = selector.execute();
+            drop_locations result = selector.execute( true );
             haulable_items.clear();
             for( const drop_location &dl : result ) {
                 haulable_items.push_back( dl.first );
@@ -809,9 +809,7 @@ static void haul()
             if( haulable_items != player_character.haul_list ) {
                 player_character.suppress_autohaul = true;
             }
-            if( !haulable_items.empty() ) {
-                player_character.start_hauling( haulable_items );
-            }
+            player_character.start_hauling( haulable_items );
         }
         break;
         case 3:

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3764,8 +3764,10 @@ void inventory_multiselector::on_input( const inventory_input &input )
     }
 }
 
+static const haul_selector_preset haul_preset {};
+
 inventory_haul_selector::inventory_haul_selector( Character &p ) :
-    inventory_multiselector( p, default_preset, _( "ITEMS TO HAUL" ) ) {}
+    inventory_multiselector( p, haul_preset, _( "ITEMS TO HAUL" ) ) {}
 
 void inventory_haul_selector::apply_selection( std::vector<item_location> &items )
 {
@@ -3777,6 +3779,23 @@ void inventory_haul_selector::apply_selection( std::vector<item_location> &items
             set_chosen_count( *entry, entry->chosen_count + 1 );
         }
     }
+}
+
+bool haul_selector_preset::is_shown( const item_location &item ) const
+{
+    if( item.where() == item_location::type::container ) {
+        return false;
+    }
+
+    return true;
+}
+
+std::string haul_selector_preset::get_denial( const item_location &item ) const
+{
+    if( item.where() == item_location::type::container ) {
+        return _( "Cannot haul contents of containers" );
+    }
+    return "";
 }
 
 drop_locations inventory_drop_selector::execute()

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3521,7 +3521,7 @@ void inventory_multiselector::toggle_entries( int &count, const toggle_mode mode
     on_toggle();
 }
 
-drop_locations inventory_multiselector::execute()
+drop_locations inventory_multiselector::execute( bool allow_empty )
 {
     shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();
     debug_print_timer( tp_start );
@@ -3531,7 +3531,7 @@ drop_locations inventory_multiselector::execute()
         const inventory_input input = get_input();
 
         if( input.action == "CONFIRM" ) {
-            if( to_use.empty() ) {
+            if( to_use.empty() && !allow_empty ) {
                 popup_getkey( _( "No items were selected.  Use %s to select them." ),
                               ctxt.get_desc( "TOGGLE_ENTRY" ) );
                 continue;

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3764,6 +3764,21 @@ void inventory_multiselector::on_input( const inventory_input &input )
     }
 }
 
+inventory_haul_selector::inventory_haul_selector( Character &p ) :
+    inventory_multiselector( p, default_preset, _( "ITEMS TO HAUL" ) ) {}
+
+void inventory_haul_selector::apply_selection( std::vector<item_location> &items )
+{
+    for( item_location &item : items ) {
+        inventory_entry *entry = find_entry_by_location( item );
+        if( entry->locations.size() == 1 && entry->locations[0]->count_by_charges() ) {
+            set_chosen_count( *entry, inventory_multiselector::max_chosen_count );
+        } else {
+            set_chosen_count( *entry, entry->chosen_count + 1 );
+        }
+    }
+}
+
 drop_locations inventory_drop_selector::execute()
 {
     shared_ptr_fast<ui_adaptor> ui = create_or_get_ui_adaptor();

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -954,7 +954,7 @@ class inventory_multiselector : public inventory_selector
                                           const std::string &selection_column_title = "",
                                           const GetStats & = {},
                                           bool allow_select_contained = false );
-        drop_locations execute();
+        drop_locations execute( bool allow_empty = false );
         void toggle_entry( inventory_entry &entry, size_t count );
     protected:
         void rearrange_columns( size_t client_width ) override;

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -982,6 +982,13 @@ class inventory_haul_selector : public inventory_multiselector
         void apply_selection( std::vector<item_location> &items );
 };
 
+class haul_selector_preset : public inventory_selector_preset
+{
+    public:
+        bool is_shown( const item_location &item ) const override;
+        std::string get_denial( const item_location &item ) const override;
+};
+
 class inventory_compare_selector : public inventory_multiselector
 {
     public:

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -975,6 +975,13 @@ class inventory_multiselector : public inventory_selector
         GetStats get_stats;
 };
 
+class inventory_haul_selector : public inventory_multiselector
+{
+    public:
+        explicit inventory_haul_selector( Character &p );
+        void apply_selection( std::vector<item_location> &items );
+};
+
 class inventory_compare_selector : public inventory_multiselector
 {
     public:

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1256,6 +1256,12 @@ void Character::load( const JsonObject &data )
         bcdata.read( "pos", bcpt );
         camps.insert( bcpt );
     }
+
+    data.read( "hauling", hauling );
+    data.read( "autohaul", autohaul );
+    data.read( "hauling_filter", hauling_filter );
+    data.read( "haul_list", haul_list );
+
     //load queued_eocs
     for( JsonObject elem : data.get_array( "queued_effect_on_conditions" ) ) {
         queued_eoc temp;
@@ -1487,6 +1493,12 @@ void Character::store( JsonOut &json ) const
         json.end_object();
     }
     json.end_array();
+
+    // Hauling state
+    json.member( "hauling", hauling );
+    json.member( "autohaul", autohaul );
+    json.member( "hauling_filter", hauling_filter );
+    json.member( "haul_list", haul_list );
 
     //save queued effect_on_conditions
     queued_eocs temp_queued( queued_effect_on_conditions );

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -1261,6 +1261,7 @@ void Character::load( const JsonObject &data )
     data.read( "autohaul", autohaul );
     data.read( "hauling_filter", hauling_filter );
     data.read( "haul_list", haul_list );
+    data.read( "suppress_autohaul", suppress_autohaul );
 
     //load queued_eocs
     for( JsonObject elem : data.get_array( "queued_effect_on_conditions" ) ) {
@@ -1499,6 +1500,7 @@ void Character::store( JsonOut &json ) const
     json.member( "autohaul", autohaul );
     json.member( "hauling_filter", hauling_filter );
     json.member( "haul_list", haul_list );
+    json.member( "suppress_autohaul", suppress_autohaul );
 
     //save queued effect_on_conditions
     queued_eocs temp_queued( queued_effect_on_conditions );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Hauling overhaul: you can choose which specific items to haul, whether to automatically haul new items, or haul items by filter"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Hauling picks up every item stepped on, which causes some usability issues. If you want to haul only some specific items, you may need to navigate around anything on the floor, or stop to untangle piles. When used unattended (e.g. while autotravelling) there is risk that it will pick up junk along the way and slow you down unnecessarily. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/102094270/0015e88c-acb8-4619-83e7-f2ee6066ca65)

Pressing the haul button now brings up a little UI where items to be hauled can be chosen, automatically including new items to haul can be enabled/disabled and a filter for the automatic haul can be set. An action to replicate old behavior (not bound by default) is available. Start/stop hauling is always hotkeyed to the same button as the key to open the menu, so a quick double-tap can be used for the most common action.

Caveats:
* this feature does not support `count_by_charges`. It will haul those safely, but it's not possible to haul part of a charge stack, and any stacks of a charge item already hauled will be merged into the haul even with autohaul off. I'm choosing to leave it like this weighing this minor inconvenience against the significant effort of supporting charges in light of them being a feature on the way out.
* hauling will lose track of items that spill to other tiles due to the destination tile being full. They are handled safely but it's up to the player to sort out the mess; there is a warning message in the log when it happens.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- [x] basic hauling of a handful of items
- [x] hauling one stack over another with autohaul off does not mix them up
- [x] hauling one stack over another with autohaul on gathers them together
- [x] partially combine stacks with autohaul and filter
- [x] choose part of a stack with the selector
- [x] combine chosen part of a stack with another stack, confirm selector state makes sense
- [x] overflowing a tile produces a warning and doesn't lose any items


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
