### PR TITLE
Adjust seed paste requirements

### DIFF
--- a/data/json/recipes/food/other.json
+++ b/data/json/recipes/food/other.json
@@ -356,12 +356,12 @@
     "tools": [ [ [ "clay_quern", -1 ], [ "rock_quern", -1 ] ] ],
     "components": [
       [
-        [ "seed_cotton_boll", 50 ],
-        [ "seed_pumpkin", 50 ],
-        [ "seed_sunflower", 50 ],
-        [ "seed_canola", 50 ],
-        [ "seed_grapes", 50 ],
-        [ "seed_weed", 50 ]
+        [ "seed_cotton_boll", 2 ],
+        [ "seed_pumpkin", 2 ],
+        [ "seed_sunflower", 2 ],
+        [ "seed_canola", 2 ],
+        [ "seed_grapes", 2 ],
+        [ "seed_weed", 2 ]
       ]
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Adjust seed paste requirements"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
#65924 and #67711 changed seed yields and volumes of most crops. A "seeds" is now meant to be a fairly large pile and consequentially you get a lot fewer of them, but the seed paste recipe hadn't changed to account for this.

Fixes #69309 

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
For seeds which are measured at 250ml (pumpkin, sunflower, canola), the recipe now only requires 2. For smaller seeds (grape, cannabis, cotton) it requires 20. There's still some abstraction happening there, but it should feel a lot more reasonable now.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
We might want to halve pumpkin and sunflower seed pile sizes and double their yield, but a part of the reason they're currently set up as they are is that food crops require zero effort from the player to grow. I recommend waiting until irrigation, blight, soil quality, and sunlight are tracked so that players can't get exponential amounts of free zero labor food - in real life, many plants can be lost to attrition while farming, and once this is tracked we don't need to worry about oversized yields as much.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
