### PR TITLE
Give professions appropriate knives

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1167,7 +1167,7 @@
           { "item": "water_clean", "container-item": "canteen" },
           { "item": "legpouch_large", "contents-group": "army_mags_m4" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "knife_combat_marine", "container-item": "sheath" },
           { "item": "m18", "ammo-item": "9mm", "container-item": "holster", "charges": 17 },
           { "item": "p320mag_17rd_9x19mm", "ammo-item": "9mm", "charges": 17, "count": 2 },
           {
@@ -1529,7 +1529,7 @@
           { "group": "us_ballistic_vest_pristine" },
           { "item": "water_clean", "container-item": "canteen" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "knife_combat_army", "container-item": "sheath" },
           { "item": "shot_00", "count": 2 },
           {
             "item": "mossberg_930",
@@ -1592,7 +1592,7 @@
           { "item": "water_clean", "container-item": "canteen" },
           { "item": "legpouch_large", "contents-group": "army_mags_m4" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "knife_combat_army", "container-item": "sheath" },
           {
             "item": "modular_m4_carbine",
             "variant": "modular_m4a1",
@@ -1654,7 +1654,7 @@
           { "item": "pants_army", "variant": "mil_pants_navy" },
           { "item": "water_clean", "container-item": "canteen" },
           { "item": "legpouch_large", "contents-group": "army_mags_tac338" },
-          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "knife_rm42", "container-item": "sheath" },
           { "item": "p226_9mm", "ammo-item": "9mm", "container-item": "holster", "charges": 15 },
           { "item": "p226mag_15rd_9x19mm", "ammo-item": "9mm", "charges": 15, "count": 2 },
           { "item": "tac338", "ammo-item": "338lapua_fmjbt", "charges": 5, "contents-item": [ "shoulder_strap" ] }
@@ -1716,7 +1716,7 @@
           { "item": "light_battery_cell", "ammo-item": "battery", "charges": 100, "container-item": "goggles_nv" },
           { "item": "water_clean", "container-item": "canteen" },
           { "item": "legpouch_large", "contents-group": "army_mags_m4" },
-          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "knife_rm42", "container-item": "sheath" },
           { "item": "p226_9mm", "ammo-item": "9mm", "container-item": "holster", "charges": 15 },
           { "item": "p226mag_15rd_9x19mm", "ammo-item": "9mm", "charges": 15, "count": 2 },
           {
@@ -3093,7 +3093,7 @@
         "entries": [
           { "group": "charged_cell_phone" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "knife_KABAR", "container-item": "sheath" },
           { "item": "m9", "ammo-item": "9mm", "charges": 15, "container-item": "holster" },
           { "item": "chestrig", "contents-group": "army_mags_m4" },
           { "item": "lighter", "charges": 100 },
@@ -3779,7 +3779,7 @@
       "both": {
         "items": [ "striped_shirt", "striped_pants", "sneakers", "socks" ],
         "entries": [
-          { "item": "knife_combat", "container-item": "gartersheath1" },
+          { "item": "knife_rm42", "container-item": "gartersheath1" },
           { "item": "polaroid_photo", "container-item": "ankle_wallet_pouch" }
         ]
       },
@@ -4468,7 +4468,7 @@
         "entries": [
           { "item": "water_clean", "container-item": "canteen" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "knife_combat_army", "container-item": "sheath" },
           {
             "item": "modular_m4_carbine",
             "variant": "modular_m4a1",
@@ -5400,7 +5400,7 @@
           { "item": "water_clean", "container-item": "canteen" },
           { "item": "legpouch_large", "contents-group": "army_mags_m110" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "knife_combat_army", "container-item": "sheath" },
           { "item": "m110a1", "ammo-item": "762_51", "charges": 20, "contents-item": [ "shoulder_strap" ] },
           { "item": "m17", "ammo-item": "9mmfmj", "charges": 17, "container-item": "holster" },
           { "group": "army_mags_m17" }
@@ -5462,7 +5462,7 @@
             "contents-item": [ "shoulder_strap", "holo_sight", "bipod" ]
           },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "knife_combat_army", "container-item": "sheath" },
           { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
         ]
       },
@@ -5524,7 +5524,7 @@
           },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "grenade_pouch", "contents-group": [ "army_grenades_40x46" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "knife_combat_army", "container-item": "sheath" },
           { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
         ]
       },
@@ -5586,7 +5586,7 @@
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "grenadebandolier", "contents-item": [ "flashbang", "flashbang" ] },
           { "item": "bandolier_shotgun", "contents-group": "bandolier_swat_cqc1" },
-          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "knife_combat_army", "container-item": "sheath" },
           { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
         ]
       },
@@ -5648,7 +5648,7 @@
             "contents-item": [ "shoulder_strap", "rifle_scope" ]
           },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "knife_combat_army", "container-item": "sheath" },
           { "item": "m17", "ammo-item": "9mmfmj", "container-item": "holster", "charges": 17 },
           { "item": "legpouch_large", "contents-group": "army_mags_m17" }
         ]
@@ -5716,7 +5716,7 @@
             "contents-item": [ "shoulder_strap", "holo_sight", "suppressor" ]
           },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "knife_combat_marine", "container-item": "sheath" },
           { "item": "XL_holster", "contents-group": "holster_supp_MEU" },
           { "item": "legpouch_large", "contents-group": "army_mags_1911" }
         ]
@@ -5959,7 +5959,7 @@
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "mask_dust", "variant": "camo_mask_dust", "custom-flags": [ "no_auto_equip" ] },
           { "item": "stethoscope", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat", "container-item": "sheath" },
+          { "item": "knife_combat_army", "container-item": "sheath" },
           {
             "item": "modular_m4_carbine",
             "variant": "modular_m4a1",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -5449,6 +5449,7 @@
           "socks",
           "boots_combat",
           "wristwatch",
+          "pockknife",
           "molle_pack"
         ],
         "entries": [
@@ -5462,7 +5463,6 @@
             "contents-item": [ "shoulder_strap", "holo_sight", "bipod" ]
           },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat_army", "container-item": "sheath" },
           { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
         ]
       },
@@ -5509,6 +5509,7 @@
           "gloves_tactical",
           "socks",
           "boots_combat",
+          "pockknife",
           "wristwatch",
           "molle_pack"
         ],
@@ -5524,7 +5525,6 @@
           },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "grenade_pouch", "contents-group": [ "army_grenades_40x46" ] },
-          { "item": "knife_combat_army", "container-item": "sheath" },
           { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
         ]
       },


### PR DESCRIPTION
#### Summary
Content "Adjusts professions' knives"


#### Purpose of change
I forgot to do a pass on professions to check that they received their correct knives.

#### Describe the solution

Picked some professions for the new knives, based on context. New recruits got  NG bayos, most of the 'army' positions got army bayonets. For-Certain marines got USMC bayonets. Assassin got the FS-K, militia the KABAR, Navy SEAL got the FS-K as well. Military professions whose gear was heavier got pocket knives.

#### Describe alternatives you've considered

Adding a Navy SEAL knife for the SEAL. The FS-K isn't that appropriate for the SEAL; something like the Mk3, SOG 2000, maybe  even Gerber LMF II would be better. Or a (Gasp!) pocket knife. 

The same for the Military Marksman profession - I'd prefer a non-bayonet.
#### Testing
Loaded game. Tried starting as a few professions.

#### Additional context

It is really, REALLY funny that the profession who gets the "best" bayonet never actually gets to deploy with their kit, the national guardsman profession.