### PR TITLE
allow sandwiches to be made with tortillas

### DIFF
--- a/data/json/recipes/recipe_food.json
+++ b/data/json/recipes/recipe_food.json
@@ -9806,7 +9806,7 @@
     "tools": [ [ [ "surface_heat", 12, "LIST" ] ] ],
     "components": [
       [ [ "meat_cooked", 1, "LIST" ], [ "dry_meat", 1 ], [ "can_chicken", 1 ], [ "meat_smoked", 1 ] ],
-      [ [ "tortilla_corn", 3 ] ],
+      [ [ "tortilla_any", 3, "LIST" ] ],
       [
         [ "dry_beans", 1 ],
         [ "raw_beans", 1 ],

--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -11,7 +11,7 @@
         [ "cornmeal", 1 ],
         [ "flatbread", 1 ],
         [ "flatbread_wheat_free", 1 ],
-        [ "tortilla_corn", 1 ],
+        [ "tortilla_any", 1, "LIST" ],
         [ "bread", 1 ],
         [ "bread_wheat_free", 1 ],
         [ "wastebread", 1 ],
@@ -30,6 +30,7 @@
     "components": [
       [
         [ "flatbread", 1 ],
+        [ "tortilla_any", 1, "LIST" ],
         [ "bread", 1 ],
         [ "wastebread", 1 ],
         [ "sourdough_bread", 1 ],
@@ -45,7 +46,15 @@
     "id": "bread_sandwich_wheat_free",
     "type": "requirement",
     "//": "Wheat free bread appropriate for sandwiches.",
-    "components": [ [ [ "cornbread", 1 ], [ "bread_wheat_free", 1 ], [ "flatbread_wheat_free", 1 ], [ "brown_bread_wheat_free", 1 ] ] ]
+    "components": [
+      [
+        [ "cornbread", 1 ],
+        [ "bread_wheat_free", 1 ],
+        [ "flatbread_wheat_free", 1 ],
+        [ "tortilla_corn", 1 ],
+        [ "brown_bread_wheat_free", 1 ]
+      ]
+    ]
   },
   {
     "id": "any_bread",


### PR DESCRIPTION
#### Summary
Bugfixes "allow sandwiches to be made with tortillas"
#### Purpose of change
Maybe it’s not as good as sourdough or whatever, but in a pinch a tortilla will hold the meat and cheese together long enough for you to eat it.

#### Describe the solution

You can now use 2 corn or flour tortillas in the sandwich recipes, if you want.

#### Describe alternatives you've considered

Considered adding wraps instead. But ultimately aside from the choice of bread the recipe is exactly the same, so what's the point.

#### Testing

My character was hungry and had tortillas and other ingredients, so I made deluxe sandwiches with them. And then ate them.

#### Additional context

Still cannot make sandwiches using toast, but that’s a separate problem.