### PR TITLE
The effect "corroding" should only be added when causing damage

### DIFF
--- a/data/json/monster_special_attacks/monster_attacks.json
+++ b/data/json/monster_special_attacks/monster_attacks.json
@@ -23,7 +23,7 @@
     "move_cost": 100,
     "damage_max_instance": [ { "damage_type": "cut", "amount": 15 }, { "damage_type": "acid", "amount": 16 } ],
     "effects": [ { "id": "corroding", "duration": [ 10, 30 ], "affect_hit_bp": true } ],
-    "effects_require_dmg": false,
+    "effects_require_dmg": true,
     "self_effects_always": [ { "id": "maimed_acid_gland", "duration": 5 } ],
     "condition": {
       "and": [


### PR DESCRIPTION
#### Summary

Bugfixes "The effect "corroding" should only be added when causing damage"

#### Purpose of change

Fix https://github.com/CleverRaven/Cataclysm-DDA/issues/68082#issue-1889264763

#### Describe the solution

Modify the attribute “effects_require_dmg” of “acid_slash” to true.

#### Describe alternatives you've considered

None.

#### Testing

1.Put on phase immersion suit (on)
2.Summon a caustic amalgamation
3.Let it attack me
4.The effect "corroding" only be added when "acid slash" causing damage

#### Additional context

None.













