### PR TITLE
Potentially fix broken build - DO NOT MERGE

### DIFF
--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -170,7 +170,7 @@ Creature &Creature::operator=( Creature && ) noexcept = default;
 
 Creature::~Creature()
 {
-    if( !is_game_destructing ) {
+    if( !is_game_destructing && g ) {
         get_map().remove_creature_from_reachability( this );
     }
 }

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -170,7 +170,7 @@ Creature &Creature::operator=( Creature && ) noexcept = default;
 
 Creature::~Creature()
 {
-    if( g ) {
+    if( !is_game_destructing ) {
         get_map().remove_creature_from_reachability( this );
     }
 }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -357,6 +357,7 @@ extern bool add_key_to_quick_shortcuts( int key, const std::string &category, bo
 
 //The one and only game instance
 std::unique_ptr<game> g;
+bool is_game_destructing = false;
 
 //The one and only uistate instance
 uistatedata uistate;
@@ -440,7 +441,10 @@ game::game() :
     // The reason for this move is so that g is not uninitialized when it gets to installing the parts into vehicles.
 }
 
-game::~game() = default;
+game::~game()
+{
+    is_game_destructing = true;
+}
 
 // Load everything that will not depend on any mods
 void game::load_static_data()

--- a/src/game.h
+++ b/src/game.h
@@ -47,10 +47,19 @@ class viewer;
 
 constexpr int DEFAULT_TILESET_ZOOM = 16;
 
-// The reference to the one and only game instance.
 class game;
 
+// The reference to the one and only game instance.
 extern std::unique_ptr<game> g;
+
+// Game has a non-trivial destructor, so on termination
+// the global variable may become destroyed while other
+// classes are trying to access it.
+//
+// TODO: Check if any destructor is flushing files, if not
+// then it is save to replace the global unique_ptr with a
+// raw pointer, and just let it leak on game close.
+extern bool is_game_destructing;
 
 extern const int savegame_version;
 extern int savegame_loading_version;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Build is broken due to a segfault on exit when running tests.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

This might be the culprit, but I cannot reproduce the issue on my local machine, so I hacked something together to run through the build matrix to check if this is actually the issue.

DO NOT MERGE YET
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
