### PR TITLE
[MoM] Change Pyrokinesis passive trait

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_awakening.json
@@ -223,8 +223,7 @@
         "popup": true
       },
       { "u_add_trait": "PYROKINETIC" },
-      { "u_add_trait": "PYROGLOW_WEAK" },
-      { "u_add_trait": "PYROGLOW_STRONG" },
+      { "u_add_trait": "PYROKIN_ADAPTATION" },
       { "u_add_effect": "effect_pyrokinetic_cloak", "duration": "5 minutes" },
       { "u_add_effect": "effect_pyrokinetic_aura", "duration": "5 minutes" },
       { "run_eocs": "EOC_TEACH_PYROKIN_CONTEMPLATE_RECIPES" },
@@ -1139,8 +1138,7 @@
         "popup": true
       },
       { "u_add_trait": "PYROKINETIC" },
-      { "u_add_trait": "PYROGLOW_WEAK" },
-      { "u_add_trait": "PYROGLOW_STRONG" },
+      { "u_add_trait": "PYROKIN_ADAPTATION" },
       { "run_eocs": "EOC_TEACH_PYROKIN_CONTEMPLATE_RECIPES" },
       { "u_add_effect": "psionic_awakened", "duration": { "math": [ "ps_str * u_val('time: 2 h')" ] } },
       { "math": [ "awakening_countup", "+=", "1" ] },

--- a/data/mods/MindOverMatter/hobbies.json
+++ b/data/mods/MindOverMatter/hobbies.json
@@ -42,7 +42,7 @@
     "name": "Newly-Awakened Pyrokinetic",
     "description": "Something happened during the storms that raged during the Cataclysm, and now you can do things that would have once seemed impossible.  With just a thought, you can start a fire or make light radiate from the very air.  It's already saved your life once when you burned a zombie while scavenging in a ruined house to ash.  Sure, the house burned down too, but you'll definitely get more control as time goes on, right?",
     "points": 5,
-    "traits": [ "PYROKINETIC", "PYROGLOW_WEAK", "PYROGLOW_STRONG" ]
+    "traits": [ "PYROKINETIC", "PYROKIN_ADAPTATION" ]
   },
   {
     "type": "profession",

--- a/data/mods/MindOverMatter/mutations/psi_passives.json
+++ b/data/mods/MindOverMatter/mutations/psi_passives.json
@@ -75,7 +75,7 @@
   {
     "type": "mutation",
     "id": "PYROKIN_ADAPTATION",
-    "name": { "str": "Fire Within" },
+    "name": { "str": "Internal Fire" },
     "points": 0,
     "description": "You naturally heat the air around you slightly, making it more comfortable in the cold.  It also helps prevent you from getting too wet.",
     "bodytemp_modifiers": [ 250, 750 ],

--- a/data/mods/MindOverMatter/mutations/psi_passives.json
+++ b/data/mods/MindOverMatter/mutations/psi_passives.json
@@ -11,8 +11,8 @@
     "cancels": [
       "BIOKIN_NEEDS",
       "CLAIR_SENSES",
-      "PYROGLOW_WEAK",
-      "PYROGLOW_STRONG",
+      "PHOTO_EYES",
+      "PYROKIN_ADAPTATION",
       "TELEKINETIC_CARRY",
       "TELEPATHIC_SUGGESTION",
       "TELEPORTER_PROTECT",
@@ -67,68 +67,33 @@
     "id": "PHOTO_EYES",
     "name": { "str": "Photon Regulation" },
     "points": 0,
-    "description": "Your powers adapt the amount of photons your eyes receive.",
+    "description": "Your powers passively filter the amount of photons your eyes receive.",
     "flags": [ "FLASH_PROTECTION", "SEESLEEP", "GLARE_RESIST" ],
     "player_display": true,
     "purifiable": false
   },
   {
     "type": "mutation",
-    "id": "PYROGLOW_WEAK",
-    "name": { "str": "Pyrokinetic Radiance [soft]" },
+    "id": "PYROKIN_ADAPTATION",
+    "name": { "str": "Fire Within" },
     "points": 0,
-    "description": "You can make the air around you emit light.",
-    "active": true,
+    "description": "You naturally heat the air around you slightly, making it more comfortable in the cold.  It also helps prevent you from getting too wet.",
+    "bodytemp_modifiers": [ 250, 750 ],
+    "bodytemp_sleep": 500,
+    "wet_protection": [
+      { "part": "head", "ignored": 10 },
+      { "part": "leg_l", "ignored": 10 },
+      { "part": "leg_r", "ignored": 10 },
+      { "part": "foot_l", "ignored": 10 },
+      { "part": "foot_r", "ignored": 10 },
+      { "part": "arm_l", "ignored": 10 },
+      { "part": "arm_r", "ignored": 10 },
+      { "part": "hand_l", "ignored": 10 },
+      { "part": "hand_r", "ignored": 10 },
+      { "part": "torso", "ignored": 10 }
+    ],
     "player_display": true,
-    "purifiable": false,
-    "cost": 0,
-    "transform": {
-      "target": "PYROGLOW_WEAK_A",
-      "msg_transform": "The air around you starts glowing softly.",
-      "active": true,
-      "moves": 10
-    }
-  },
-  {
-    "type": "mutation",
-    "id": "PYROGLOW_WEAK_A",
-    "name": { "str": "Pyrokinetic Radiance [soft] (on)" },
-    "description": "The air around you is emitting light.",
-    "copy-from": "PYROGLOW_WEAK",
-    "valid": false,
-    "transform": { "target": "PYROGLOW_WEAK", "msg_transform": "The air around you loses its radiance.", "active": false, "moves": 10 },
-    "enchantments": [ { "values": [ { "value": "LUMINATION", "add": 20 } ] } ]
-  },
-  {
-    "type": "mutation",
-    "id": "PYROGLOW_STRONG",
-    "name": { "str": "Pyrokinetic Radiance [bright]" },
-    "points": 0,
-    "description": "You can make the air around you emit a strong light.",
-    "active": true,
-    "player_display": true,
-    "purifiable": false,
-    "cost": 0,
-    "transform": {
-      "target": "PYROGLOW_STRONG_A",
-      "msg_transform": "The air around you starts glowing brightly.",
-      "active": true,
-      "moves": 10
-    }
-  },
-  {
-    "type": "mutation",
-    "id": "PYROGLOW_STRONG_A",
-    "name": { "str": "Pyrokinetic Radiance [bright] (on)" },
-    "description": "The air around you is emitting a bright light.",
-    "copy-from": "PYROGLOW_STRONG",
-    "valid": false,
-    "transform": { "target": "PYROGLOW_STRONG", "msg_transform": "The air around you loses its radiance.", "active": false, "moves": 10 },
-    "enchantments": [
-      {
-        "values": [ { "value": "LUMINATION", "add": { "math": [ "(50 + (20 * u_val('spell_level', 'school: PYROKINETIC')))" ] } } ]
-      }
-    ]
+    "purifiable": false
   },
   {
     "type": "mutation",

--- a/data/mods/MindOverMatter/obsolete/trait_migration.json
+++ b/data/mods/MindOverMatter/obsolete/trait_migration.json
@@ -1,0 +1,22 @@
+[
+  {
+    "type": "TRAIT_MIGRATION",
+    "id": "PYROGLOW_WEAK",
+    "trait": "PYROKIN_ADAPTATION"
+  },
+  {
+    "type": "TRAIT_MIGRATION",
+    "id": "PYROGLOW_WEAK_A",
+    "trait": "PYROKIN_ADAPTATION"
+  },
+  {
+    "type": "TRAIT_MIGRATION",
+    "id": "PYROGLOW_STRONG",
+    "remove": true
+  },
+  {
+    "type": "TRAIT_MIGRATION",
+    "id": "PYROGLOW_STRONG_A",
+    "remove": true
+  }
+]

--- a/data/mods/MindOverMatter/professions.json
+++ b/data/mods/MindOverMatter/professions.json
@@ -100,7 +100,7 @@
     "description": "Fire always fascinated you.  The fires you set almost got you arrested a few times, but the urge was just too powerful.  It was like they were calling to you, urging you to create them.  And ever since the sky broke, you can create fire with merely a thought.",
     "points": 4,
     "skills": [ { "level": 2, "name": "cooking" }, { "level": 1, "name": "driving" }, { "level": 2, "name": "metaphysics" } ],
-    "traits": [ "PYROMANIA", "PYROKINETIC", "PYROGLOW_WEAK", "PYROGLOW_STRONG" ],
+    "traits": [ "PYROMANIA", "PYROKINETIC", "PYROKIN_ADAPTATION" ],
     "spells": [
       { "id": "pyrokinetic_eruption", "level": 4 },
       { "id": "pyrokinetic_quell_flames", "level": 2 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Change Pyrokinesis passive trait"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

With Photokinesis being a possible path, Pyrokinesis should have a more distinct passive trait than just "creating light." Also, through the Banked Flames power they can create light at will anyway now.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Migrate Pyrokinetic Radiance into Internal Fire, which heats the pyrokinetic slightly when cold (even more when sleeping), and prevents getting wet from bothering them as much. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Created a pyrokinetic, then applied changes to make sure the migration was successful and with no errors. Trait appears.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
