### PR TITLE
Can't put in-progress food into faction larder

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5188,6 +5188,10 @@ bool basecamp::distribute_food()
         if( !it.is_comestible() ) {
             return false;
         }
+        // Always reject in-progress craft item
+        if( it.is_craft() ) {
+            return false;
+        }
         // Stuff like butchery refuse and other disgusting stuff
         if( it.get_comestible_fun() < -6 ) {
             return false;


### PR DESCRIPTION
#### Summary
Bugfixes "Can't put in-progress food into faction larder"

#### Purpose of change

* Fixes #59835

#### Describe the solution

Have the lambda check if the food to be consumed is actually an in-progress craft, reject it if it is.

#### Describe alternatives you've considered
We could treat the components of an in-progress craft as if they were discrete items and calculate based off those, but that's a whole lot of juggling which just produces the opposite end of the problem (meat jerky that is 99% done shouldn't be counted as raw meat, etc)

#### Testing
Dropped some in-progress food into storage and tried to distribute it. Could. Compiled with changes, repeated, could not. 

Dropped some fully-crafted crafted food into storage, still added as expected.

#### Additional context

