### PR TITLE
Fixes misstypes for combat weapon proficiencies

### DIFF
--- a/data/json/proficiencies/melee_weapons.json
+++ b/data/json/proficiencies/melee_weapons.json
@@ -125,7 +125,7 @@
     "default_time_multiplier": 1.5,
     "default_skill_penalty": 0.2,
     "time_to_learn": "16 h",
-    "required_proficiencies": [ "prof_knives_familiar" ]
+    "required_proficiencies": [ "prof_shivs_familiar" ]
   },
   {
     "type": "proficiency",
@@ -137,7 +137,7 @@
     "default_time_multiplier": 1.5,
     "default_skill_penalty": 0.2,
     "time_to_learn": "32 h",
-    "required_proficiencies": [ "prof_knives_pro" ]
+    "required_proficiencies": [ "prof_shivs_pro" ]
   },
   {
     "type": "proficiency",
@@ -207,7 +207,7 @@
     "default_time_multiplier": 1.5,
     "default_skill_penalty": 0.2,
     "time_to_learn": "32 h",
-    "required_proficiencies": [ "prof_medium_swords_master" ]
+    "required_proficiencies": [ "prof_medium_swords_pro" ]
   },
   {
     "type": "proficiency",
@@ -440,7 +440,7 @@
     "default_time_multiplier": 1.5,
     "default_skill_penalty": 0.2,
     "time_to_learn": "16 h",
-    "required_proficiencies": [ "prof_claws_familiar" ]
+    "required_proficiencies": [ "prof_bionics_familiar" ]
   },
   {
     "type": "proficiency",
@@ -452,7 +452,7 @@
     "default_time_multiplier": 1.5,
     "default_skill_penalty": 0.2,
     "time_to_learn": "32 h",
-    "required_proficiencies": [ "prof_claws_pro" ]
+    "required_proficiencies": [ "prof_bionics_pro" ]
   },
   {
     "type": "proficiency",
@@ -475,7 +475,7 @@
     "default_time_multiplier": 1.5,
     "default_skill_penalty": 0.2,
     "time_to_learn": "16 h",
-    "required_proficiencies": [ "prof_spear_familiar" ]
+    "required_proficiencies": [ "prof_spears_familiar" ]
   },
   {
     "type": "proficiency",
@@ -487,7 +487,7 @@
     "default_time_multiplier": 1.5,
     "default_skill_penalty": 0.2,
     "time_to_learn": "32 h",
-    "required_proficiencies": [ "prof_spear_pro" ]
+    "required_proficiencies": [ "prof_spears_pro" ]
   },
   {
     "type": "proficiency",


### PR DESCRIPTION
#### Summary
Bugfixes "Fixes typos in the combat weapon proficiencies"

#### Purpose of change
Fixes #69354, there were some typos and misplaced proficiencies that made actually learn them impossible, so it was necessary to correct them.

#### Describe the solution
A quick check for requirements in all the file, spotted some other irregularities that were corrected.

#### Describe alternatives you've considered
Nothing.

#### Testing
Debug learned spear familiarity, tried to learn the next level by the practice recipe, and succeed at it! Also checked the knives and shivs proficiencies and their requirements were corrected.

#### Additional context
![imagen](https://github.com/CleverRaven/Cataclysm-DDA/assets/53200489/bf7ce474-a6e3-4e85-92a1-38f03e98b66e)
It works!
