### PR TITLE
Decrease range  on Feral Marine Bayonet attack (and adjust its mondrops)

### DIFF
--- a/data/json/monster_special_attacks/feral_weapon_attacks.json
+++ b/data/json/monster_special_attacks/feral_weapon_attacks.json
@@ -467,7 +467,6 @@
     "cooldown": 1,
     "move_cost": 196,
     "accuracy": 3,
-    "range": 1,
     "//1": "Feral melee skill + weapon's to hit, so 4-1=3",
     "damage_max_instance": [ { "damage_type": "bash", "amount": 12 }, { "damage_type": "stab", "amount": 22 } ],
     "condition": { "and": [ { "not": { "u_has_effect": "maimed_arm" } }, { "not": { "u_has_effect": "disarmed" } } ] },

--- a/data/json/monster_special_attacks/feral_weapon_attacks.json
+++ b/data/json/monster_special_attacks/feral_weapon_attacks.json
@@ -467,7 +467,7 @@
     "cooldown": 1,
     "move_cost": 196,
     "accuracy": 3,
-    "range": 2,
+    "range": 1,
     "//1": "Feral melee skill + weapon's to hit, so 4-1=3",
     "damage_max_instance": [ { "damage_type": "bash", "amount": 12 }, { "damage_type": "stab", "amount": 22 } ],
     "condition": { "and": [ { "not": { "u_has_effect": "maimed_arm" } }, { "not": { "u_has_effect": "disarmed" } } ] },

--- a/data/json/monsterdrops/feral_humans.json
+++ b/data/json/monsterdrops/feral_humans.json
@@ -796,16 +796,11 @@
       { "item": "pants_army", "variant": "apants_MARPAT", "damage": [ 0, 4 ] },
       { "item": "boots_combat", "damage": [ 0, 4 ] },
       {
-        "distribution": [
-          {
-            "group": "military_standard_assault_rifles",
-            "contents-item": "knife_combat_marine",
-            "prob": 100,
-            "damage": [ 0, 4 ],
-            "dirt": [ 0, 6000 ]
-          }
-        ],
-        "prob": 100
+        "group": "military_standard_assault_rifles",
+        "contents-item": "knife_combat_marine",
+        "prob": 100,
+        "damage": [ 0, 4 ],
+        "dirt": [ 0, 6000 ]
       },
       { "group": "military_standard_grenades", "count": [ 1, 3 ], "prob": 20 },
       { "group": "military_patrol_food" },

--- a/data/json/monsterdrops/feral_humans.json
+++ b/data/json/monsterdrops/feral_humans.json
@@ -800,11 +800,10 @@
           {
             "group": "military_standard_assault_rifles",
             "contents-item": "knife_combat_marine",
-            "prob": 75,
+            "prob": 100,
             "damage": [ 0, 4 ],
             "dirt": [ 0, 6000 ]
-          },
-          { "group": "military_standard_lmgs", "prob": 10, "damage": [ 0, 4 ], "dirt": [ 0, 6000 ] }
+          }
         ],
         "prob": 100
       },


### PR DESCRIPTION
#### Summary
Bugfixes "Decreases the Range  on Feral Marine Bayonet attacks and ensures it always drops a Bayonet"

#### Purpose of change

https://github.com/CleverRaven/Cataclysm-DDA/issues/68775 describes an issue in which feral marines have a bayonet reach attack (which should no longer be the case) and also in which they don't drop the bayonet (and rifle) they were attacking with.

#### Describe the solution

Decrease range to 1 on their attack. Ensure they always drop a rifle with a bayonet attached, not a SAW or something else.

#### Describe alternatives you've considered

None.

#### Testing

Spawned a BUNCH of feral jarheads and killed them all. Yep, a big pile of groty bayonets+rifles.
Spawned another and let it try to stab me. it did so adjacent to me.

#### Additional context
None.