### PR TITLE
fix error message in tacoma ranch quest

### DIFF
--- a/data/json/npcs/tacoma_ranch/mission_mapgen_tacoma_commune.json
+++ b/data/json/npcs/tacoma_ranch/mission_mapgen_tacoma_commune.json
@@ -953,6 +953,7 @@
         "W........W  ",
         "WWW....WWW  "
       ],
+      "flags": [ "DISMANTLE_ALL_BEFORE_PLACING_TERRAIN" ],
       "terrain": { "W": "t_wall_log", ".": "t_dirtfloor" }
     }
   },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #68820
#### Describe the solution
Add `DISMANTLE_ALL_BEFORE_PLACING_TERRAIN` flag to erroing location
#### Testing
Tested in attached save, got no errors