### PR TITLE
[Xedra Evolved] Mad Inventor Wide-Shot Choke

### DIFF
--- a/data/mods/Xedra_Evolved/eocs/inventor.json
+++ b/data/mods/Xedra_Evolved/eocs/inventor.json
@@ -60,6 +60,7 @@
           "trinket_damage",
           "trinket_range",
           "trinket_sound",
+          "choke_wideshot",
           "mod_inv_pistol_booster",
           "inventor_research_base_3",
           "inventor_research_energy_1",

--- a/data/mods/Xedra_Evolved/items/inventor/gunmods.json
+++ b/data/mods/Xedra_Evolved/items/inventor/gunmods.json
@@ -54,6 +54,27 @@
     "min_skills": [ [ "weapon", 4 ], [ "deduction", 4 ] ]
   },
   {
+    "id": "choke_wideshot",
+    "type": "GUNMOD",
+    "name": { "str": "wide-shot shotgun choke" },
+    "description": "A choke that makes the pellets spread out wide to hit multiple enemies. The pellets will have shorter range but somehow deals higher damage.",
+    "weight": "300 g",
+    "volume": "150 ml",
+    "longest_side": "4 cm",
+    "integral_longest_side": "4 cm",
+    "material": [ "steel" ],
+    "symbol": ":",
+    "color": "yellow",
+    "location": "muzzle",
+    "mod_targets": [ "shotgun" ],
+    "install_time": "60 m",
+    "shot_spread_multiplier_modifier": 3,
+    "damage_modifier": { "damage_type": "bullet", "amount": 25 },
+    "range_modifier": -6,
+    "flags": [ "CHOKE" ],
+    "min_skills": [ [ "weapon", 4 ], [ "deduction", 4 ] ]
+  },
+  {
     "id": "mod_inv_pistol_booster",
     "type": "GUNMOD",
     "name": { "str": "pistol booster" },

--- a/data/mods/Xedra_Evolved/items/inventor/gunmods.json
+++ b/data/mods/Xedra_Evolved/items/inventor/gunmods.json
@@ -57,7 +57,7 @@
     "id": "choke_wideshot",
     "type": "GUNMOD",
     "name": { "str": "wide-shot shotgun choke" },
-    "description": "A choke that makes the pellets spread out wide to hit multiple enemies. The pellets will have shorter range but somehow deals higher damage.",
+    "description": "A choke that makes the pellets spread out wide to hit multiple enemies.  The pellets will have shorter range but somehow deals higher damage.",
     "weight": "300 g",
     "volume": "150 ml",
     "longest_side": "4 cm",

--- a/data/mods/Xedra_Evolved/recipes/inventor/gunmods.json
+++ b/data/mods/Xedra_Evolved/recipes/inventor/gunmods.json
@@ -92,6 +92,36 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
+    "result": "choke_wideshot",
+    "using": [ [ "soldering_standard", 20 ] ],
+    "qualities": [ { "id": "SAW_M", "level": 2 }, { "id": "SAW_M_FINE", "level": 1 }, { "id": "GRIND", "level": 1 } ],
+    "proficiencies": [
+      { "proficiency": "prof_elec_soldering", "time_multiplier": 3, "skill_penalty": -100, "learning_time_multiplier": 0.3 },
+      {
+        "proficiency": "prof_metalworking",
+        "time_multiplier": 3,
+        "skill_penalty": -100,
+        "learning_time_multiplier": 0.3
+      },
+      {
+        "proficiency": "prof_gunsmithing_improv",
+        "time_multiplier": 3,
+        "skill_penalty": -100,
+        "learning_time_multiplier": 0.3
+      }
+    ],
+    "components": [ [ [ "pipe", 1 ] ], [ [ "scrap", 1 ] ], [ [ "sheet_metal_small", 1 ] ], [ [ "amplifier", 1 ] ], [ [ "cable", 100 ] ], [ [ "circuit", 1 ] ] ],
+    "time": "18 h",
+    "skill_used": "deduction",
+    "difficulty": 7,
+    "skills_required": [ "fabrication", 3 ],
+    "flags": [ "SECRET" ],
+    "category": "CC_XEDRA",
+    "subcategory": "CSC_XEDRA_MISC"
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
     "result": "mod_inv_pistol_booster",
     "using": [ [ "soldering_standard", 20 ] ],
     "qualities": [ { "id": "SAW_M", "level": 2 }, { "id": "SAW_M_FINE", "level": 1 }, { "id": "GRIND", "level": 1 } ],

--- a/data/mods/Xedra_Evolved/recipes/inventor/gunmods.json
+++ b/data/mods/Xedra_Evolved/recipes/inventor/gunmods.json
@@ -110,7 +110,14 @@
         "learning_time_multiplier": 0.3
       }
     ],
-    "components": [ [ [ "pipe", 1 ] ], [ [ "scrap", 1 ] ], [ [ "sheet_metal_small", 1 ] ], [ [ "amplifier", 1 ] ], [ [ "cable", 100 ] ], [ [ "circuit", 1 ] ] ],
+    "components": [
+      [ [ "pipe", 1 ] ],
+      [ [ "scrap", 1 ] ],
+      [ [ "sheet_metal_small", 1 ] ],
+      [ [ "amplifier", 1 ] ],
+      [ [ "cable", 100 ] ],
+      [ [ "circuit", 1 ] ]
+    ],
     "time": "18 h",
     "skill_used": "deduction",
     "difficulty": 7,


### PR DESCRIPTION
#### Summary
Mods "Wide-Shot Shotgun Choke for Xedra Evolved's Mad Genius Gunmods"


#### Purpose of change

While i was chatting in the devcord, a questiom has crossed my mind: "What if there's a gun mod that makes the pellets spreads wide?". So i'm adding one as a gunmod Xedra Evolved's Mad Genius can craft because the spread is rather exaggerated.

#### Describe the solution

Adds a gunmod i named "Wide-shot shotgun choke", a gun mod that makes the pellets spreads wide, reduced range by 6, and increase in damage by 25.

#### Describe alternatives you've considered

Not adding so.

#### Testing

I tested the gun mod proper but havent tested the recipe for it, so TBD.

Update: I tested the eoc for it by giving meself a lotta creative sparks and run the reseach eoc bunch of times. it appears as expected.

#### Additional context

I've been playing a bit too much crimsonland, so much so that i'll blame it for giving me the idea in the first place.

Besides that, any suggestion on this stuff will be appreciated.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
