### PR TITLE
[EoC] Some monster and map related update

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -675,6 +675,17 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_character_kills_monster_event_test",
+    "eoc_type": "EVENT",
+    "required_event": "character_kills_monster",
+    "effect": [
+      { "u_add_var": "last_event", "type": "test", "context": "event", "value": "character_kills_monster" },
+      { "set_string_var": { "context_val": "victim_type" }, "target_var": { "global_val": "victim_type" } },
+      { "math": [ "test_exp", "=", "_exp" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_character_wields_item_event_test",
     "eoc_type": "EVENT",
     "required_event": "character_wields_item",

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1057,7 +1057,7 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | character_gets_headshot |  | { "character", `character_id` } | character / NONE |
 | character_heals_damage |  | { "character", `character_id` },<br/> { "damage", `int` }, | character / NONE |
 | character_kills_character |  | { "killer", `character_id` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character / NONE |
-| character_kills_monster |  | { "killer", `character_id` },<br/> { "victim_type", `mtype_id` }, | character / NONE |
+| character_kills_monster |  | { "killer", `character_id` },<br/> { "victim_type", `mtype_id` },<br/> { "exp", `int` }, | character / monster |
 | character_learns_spell |  | { "character", `character_id` },<br/> { "spell", `spell_id` } | character / NONE |
 | character_loses_effect |  | { "character", `character_id` },<br/> { "effect", `efftype_id` }, | character / NONE |
 | character_melee_attacks_character |  | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "hits", `bool` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character (attacker) / character (victim) |

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -2427,11 +2427,14 @@ Search a specific coordinates of map around `u_`, `npc_` or `target_params` and 
 | "u_location_variable" / "npc_location_variable" | **mandatory** | [variable object](##variable-object) | variable, where the location would be saved | 
 | "min_radius", "max_radius" | optional | int, float or [variable object](##variable-object) | default 0; radius around the player or NPC, where the location would be searched | 
 | "outdoor_only" | optional | boolean | default false; if true, only outdoor values would be picked | 
+| "passable_only" | optional | boolean | default false; if true, only passable values would be picked | 
 | "target_params" | optional | assign_mission_target | if used, the search would be performed not from `u_` or `npc_` location, but from `mission_target`. it uses an [assign_mission_target](MISSIONS_JSON.md) syntax | 
 | "x_adjust", "y_adjust", "z_adjust" | optional | int, float or [variable object](##variable-object) | add this amount to `x`, `y` or `z` coordinate in the end; `"x_adjust": 2` would save the coordinate with 2 tile shift to the right from targeted | 
 | "z_override" | optional | boolean | default is false; if true, instead of adding up to `z` level, override it with absolute value; `"z_adjust": 3` with `"z_override": true` turn the value of `z` to `3` | 
 | "terrain" / "furniture" / "trap" / "monster" / "zone" / "npc" | optional | string or [variable object](##variable-object) | if used, search the entity with corresponding id between `target_min_radius` and `target_max_radius`; if empty string is used (e.g. `"monster": ""`), return any entity from the same radius  | 
 | "target_min_radius", "target_max_radius" | optional | int, float or [variable object](##variable-object) | default 0, min and max radius for search, if previous field was used | 
+| "true_eocs" | optional | string, [variable object](##variable-object), `effect_on_condition` or range of all of them | if the location was found, all EoCs from this field would be triggered; | 
+| "false_eocs" | optional | string, [variable object](##variable-object), `effect_on_condition` or range of all of them | if the location was not found, all EoCs from this field would be triggered | 
 
 ##### Valid talkers:
 

--- a/src/event.h
+++ b/src/event.h
@@ -342,7 +342,7 @@ struct event_spec<event_type::character_heals_damage> {
 
 template<>
 struct event_spec<event_type::character_kills_monster> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = {{
             { "killer", cata_variant_type::character_id },
             { "victim_type", cata_variant_type::mtype_id },
             { "xp", cata_variant_type::int_},

--- a/src/event.h
+++ b/src/event.h
@@ -345,6 +345,7 @@ struct event_spec<event_type::character_kills_monster> {
     static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
             { "killer", cata_variant_type::character_id },
             { "victim_type", cata_variant_type::mtype_id },
+            { "xp", cata_variant_type::int_},
         }
     };
 };

--- a/src/event.h
+++ b/src/event.h
@@ -345,7 +345,7 @@ struct event_spec<event_type::character_kills_monster> {
     static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = {{
             { "killer", cata_variant_type::character_id },
             { "victim_type", cata_variant_type::mtype_id },
-            { "xp", cata_variant_type::int_},
+            { "exp", cata_variant_type::int_},
         }
     };
 };

--- a/src/kill_tracker.cpp
+++ b/src/kill_tracker.cpp
@@ -130,11 +130,6 @@ static Character *get_avatar_or_follower( const character_id &id )
     return nullptr;
 }
 
-static int compute_kill_xp( const mtype_id &mon_type )
-{
-    return mon_type->difficulty + mon_type->difficulty_base;
-}
-
 static constexpr int npc_kill_xp = 10;
 
 void kill_tracker::notify( const cata::event &e )
@@ -145,7 +140,7 @@ void kill_tracker::notify( const cata::event &e )
             if( Character *killer = get_avatar_or_follower( killer_id ) ) {
                 const mtype_id victim_type = e.get<mtype_id>( "victim_type" );
                 kills[victim_type]++;
-                killer->kill_xp += compute_kill_xp( victim_type );
+                killer->kill_xp += e.get<int>( "xp" );
                 victim_type.obj().families.practice_kill( *killer );
             }
             break;

--- a/src/kill_tracker.cpp
+++ b/src/kill_tracker.cpp
@@ -140,7 +140,7 @@ void kill_tracker::notify( const cata::event &e )
             if( Character *killer = get_avatar_or_follower( killer_id ) ) {
                 const mtype_id victim_type = e.get<mtype_id>( "victim_type" );
                 kills[victim_type]++;
-                killer->kill_xp += e.get<int>( "xp" );
+                killer->kill_xp += e.get<int>( "exp" );
                 victim_type.obj().families.practice_kill( *killer );
             }
             break;

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2724,7 +2724,8 @@ void monster::die( Creature *nkiller )
     if( get_killer() != nullptr ) {
         Character *ch = get_killer()->as_character();
         if( !is_hallucination() && ch != nullptr ) {
-            cata::event e = cata::event::make<event_type::character_kills_monster>( ch->getID(), type->id, compute_kill_xp( type->id ) );
+            cata::event e = cata::event::make<event_type::character_kills_monster>( ch->getID(), type->id,
+                            compute_kill_xp( type->id ) );
             get_event_bus().send_with_talker( ch, this, e );
             if( ch->is_avatar() && ch->has_trait( trait_KILLER ) ) {
                 if( one_in( 4 ) ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -263,6 +263,11 @@ static const std::map<monster_attitude, std::pair<std::string, color_id>> attitu
     {monster_attitude::MATT_NULL, {translate_marker( "BUG: Behavior unnamed." ), def_h_red}},
 };
 
+static int compute_kill_xp( const mtype_id &mon_type )
+{
+    return mon_type->difficulty + mon_type->difficulty_base;
+}
+
 monster::monster()
 {
     unset_dest();
@@ -2719,7 +2724,8 @@ void monster::die( Creature *nkiller )
     if( get_killer() != nullptr ) {
         Character *ch = get_killer()->as_character();
         if( !is_hallucination() && ch != nullptr ) {
-            get_event_bus().send<event_type::character_kills_monster>( ch->getID(), type->id );
+            cata::event e = cata::event::make<event_type::character_kills_monster>( ch->getID(), type->id, compute_kill_xp( type->id ) );
+            get_event_bus().send_with_talker( ch, this, e );
             if( ch->is_avatar() && ch->has_trait( trait_KILLER ) ) {
                 if( one_in( 4 ) ) {
                     const translation snip = SNIPPET.random_from_category( "killer_on_kill" ).value_or( translation() );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3255,6 +3255,7 @@ void talk_effect_fun_t::set_location_variable( const JsonObject &jo, std::string
     dbl_or_var dov_y_adjust = get_dbl_or_var( jo, "y_adjust", false, 0 );
     bool z_override = jo.get_bool( "z_override", false );
     const bool outdoor_only = jo.get_bool( "outdoor_only", false );
+    const bool passable_only = jo.get_bool( "passable_only", false );
     std::optional<mission_target_params> target_params;
     if( jo.has_object( "target_params" ) ) {
         JsonObject target_obj = jo.get_object( "target_params" );
@@ -3303,9 +3304,9 @@ void talk_effect_fun_t::set_location_variable( const JsonObject &jo, std::string
     std::vector<effect_on_condition_id> true_eocs = load_eoc_vector( jo, "true_eocs" );
     std::vector<effect_on_condition_id> false_eocs = load_eoc_vector( jo, "false_eocs" );
 
-    function = [dov_min_radius, dov_max_radius, var_name, outdoor_only, target_params, is_npc, type,
-                                dov_x_adjust, dov_y_adjust, dov_z_adjust, z_override, true_eocs, false_eocs, search_target,
-                    search_type, dov_target_min_radius, dov_target_max_radius]( dialogue & d ) {
+    function = [dov_min_radius, dov_max_radius, var_name, outdoor_only, passable_only, target_params,
+                                is_npc, type, dov_x_adjust, dov_y_adjust, dov_z_adjust, z_override, true_eocs, false_eocs,
+                    search_target, search_type, dov_target_min_radius, dov_target_max_radius]( dialogue & d ) {
         talker *target = d.actor( is_npc );
         tripoint talker_pos = get_map().getabs( target->pos() );
         tripoint target_pos = talker_pos;
@@ -3403,6 +3404,7 @@ void talk_effect_fun_t::set_location_variable( const JsonObject &jo, std::string
                 target_pos = talker_pos + tripoint( rng( -max_radius, max_radius ), rng( -max_radius, max_radius ),
                                                     0 );
                 if( ( !outdoor_only || here.is_outside( target_pos ) ) &&
+                    ( !passable_only || here.passable( target_pos ) ) &&
                     rl_dist( target_pos, talker_pos ) >= min_radius ) {
                     found = true;
                     break;

--- a/src/talker_monster.cpp
+++ b/src/talker_monster.cpp
@@ -23,6 +23,11 @@ std::string talker_monster_const::disp_name() const
     return me_mon_const->disp_name();
 }
 
+std::string talker_monster_const::get_name() const
+{
+    return me_mon_const->get_name();
+}
+
 int talker_monster_const::posx() const
 {
     return me_mon_const->posx();
@@ -208,6 +213,11 @@ int talker_monster_const::get_cur_hp( const bodypart_id & ) const
 int talker_monster_const::get_hp_max( const bodypart_id & ) const
 {
     return me_mon_const->get_hp_max();
+}
+
+double talker_monster_const::armor_at( damage_type_id &dt, bodypart_id &bp ) const
+{
+    return me_mon_const->get_armor_type( dt, bp );
 }
 
 bool talker_monster_const::will_talk_to_u( const Character &you, bool )

--- a/src/talker_monster.h
+++ b/src/talker_monster.h
@@ -32,6 +32,7 @@ class talker_monster_const: public talker_cloner<talker_monster_const>
 
         // identity and location
         std::string disp_name() const override;
+        std::string get_name() const override;
 
         int posx() const override;
         int posy() const override;
@@ -62,6 +63,7 @@ class talker_monster_const: public talker_cloner<talker_monster_const>
         std::vector<std::string> get_topics( bool radio_contact ) override;
         int get_cur_hp( const bodypart_id & ) const override;
         int get_hp_max( const bodypart_id & ) const override;
+        double armor_at( damage_type_id &dt, bodypart_id &bp ) const override;
 
         int get_volume() const override;
         int get_weight() const override;

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -1070,6 +1070,15 @@ TEST_CASE( "EOC_combat_event_test", "[eoc]" )
            "character_ranged_attacks_monster" );
     CHECK( globvars.get_global_value( "npctalk_var_weapon" ) == "shotgun_s" );
     CHECK( globvars.get_global_value( "npctalk_var_victim_type" ) == "mon_zombie" );
+
+    // character_kills_monster
+    clear_map();
+    monster &victim = spawn_test_monster( "mon_zombie", target_pos );
+    victim.die( &get_avatar() );
+
+    CHECK( get_avatar().get_value( "npctalk_var_test_event_last_event" ) == "character_kills_monster" );
+    CHECK( globvars.get_global_value( "npctalk_var_victim_type" ) == "mon_zombie" );
+    CHECK( globvars.get_global_value( "npctalk_var_test_exp" ) == "4" );
 }
 
 TEST_CASE( "EOC_spell_exp", "[eoc]" )

--- a/tests/event_test.cpp
+++ b/tests/event_test.cpp
@@ -15,13 +15,15 @@ static const mtype_id zombie( "zombie" );
 TEST_CASE( "construct_event", "[event]" )
 {
     cata::event e = cata::event::make<event_type::character_kills_monster>(
-                        character_id( 7 ), zombie );
+                        character_id( 7 ), zombie, 100 );
     CHECK( e.type() == event_type::character_kills_monster );
     CHECK( e.time() == calendar::turn );
     CHECK( e.get<cata_variant_type::character_id>( "killer" ) == character_id( 7 ) );
     CHECK( e.get<cata_variant_type::mtype_id>( "victim_type" ) == zombie );
+    CHECK( e.get<cata_variant_type::int_>( "xp" ) == 100 );
     CHECK( e.get<character_id>( "killer" ) == character_id( 7 ) );
     CHECK( e.get<mtype_id>( "victim_type" ) == zombie );
+    CHECK( e.get<int>( "xp" ) == 100 );
 }
 
 struct test_subscriber : public event_subscriber {
@@ -37,7 +39,7 @@ TEST_CASE( "push_event_on_vector", "[event]" )
 {
     std::vector<cata::event> test_events;
     cata::event original_event = cata::event::make<event_type::character_kills_monster>(
-                                     character_id( 5 ), zombie );
+                                     character_id( 5 ), zombie, 0 );
     test_events.push_back( original_event );
     REQUIRE( test_events.size() == 1 );
 }
@@ -46,7 +48,7 @@ TEST_CASE( "notify_subscriber", "[event]" )
 {
     test_subscriber sub;
     cata::event original_event = cata::event::make<event_type::character_kills_monster>(
-                                     character_id( 5 ), zombie );
+                                     character_id( 5 ), zombie, 0 );
     sub.notify( original_event );
     REQUIRE( sub.events.size() == 1 );
 }
@@ -58,7 +60,7 @@ TEST_CASE( "send_event_through_bus", "[event]" )
     bus.subscribe( &sub );
 
     bus.send( cata::event::make<event_type::character_kills_monster>(
-                  character_id( 5 ), zombie ) );
+                  character_id( 5 ), zombie, 0 ) );
     REQUIRE( sub.events.size() == 1 );
     const cata::event &e = sub.events[0];
     CHECK( e.type() == event_type::character_kills_monster );
@@ -74,7 +76,7 @@ TEST_CASE( "destroy_bus_before_subscriber", "[event]" )
     bus.subscribe( &sub );
 
     bus.send( cata::event::make<event_type::character_kills_monster>(
-                  character_id( 5 ), zombie ) );
+                  character_id( 5 ), zombie, 0 ) );
     CHECK( sub.events.size() == 1 );
 }
 
@@ -89,7 +91,7 @@ struct expect_subscriber : public event_subscriber {
 TEST_CASE( "notify_subscriber_2", "[event]" )
 {
     cata::event original_event = cata::event::make<event_type::character_kills_monster>(
-                                     character_id( 5 ), zombie );
+                                     character_id( 5 ), zombie, 0 );
     expect_subscriber sub;
 
     sub.notify( original_event );

--- a/tests/event_test.cpp
+++ b/tests/event_test.cpp
@@ -20,10 +20,10 @@ TEST_CASE( "construct_event", "[event]" )
     CHECK( e.time() == calendar::turn );
     CHECK( e.get<cata_variant_type::character_id>( "killer" ) == character_id( 7 ) );
     CHECK( e.get<cata_variant_type::mtype_id>( "victim_type" ) == zombie );
-    CHECK( e.get<cata_variant_type::int_>( "xp" ) == 100 );
+    CHECK( e.get<cata_variant_type::int_>( "exp" ) == 100 );
     CHECK( e.get<character_id>( "killer" ) == character_id( 7 ) );
     CHECK( e.get<mtype_id>( "victim_type" ) == zombie );
-    CHECK( e.get<int>( "xp" ) == 100 );
+    CHECK( e.get<int>( "exp" ) == 100 );
 }
 
 struct test_subscriber : public event_subscriber {

--- a/tests/memorial_test.cpp
+++ b/tests/memorial_test.cpp
@@ -130,7 +130,7 @@ TEST_CASE( "memorials", "[memorial]" )
         "afterwards.", ch, ch2, "victim_name" );
 
     check_memorial<event_type::character_kills_monster>(
-        m, b, "Killed a Kevlar hulk.", ch, mon );
+        m, b, "Killed a Kevlar hulk.", ch, mon, 0 );
 
     check_memorial<event_type::character_loses_effect>(
         m, b, "Put out the fire.", ch, eff );

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -1245,7 +1245,7 @@ TEST_CASE( "npc_compare_int", "[npc_talk]" )
     player_character.inv->add_item( item( itype_bottle_glass ) );
     player_character.inv->add_item( item( itype_bottle_glass ) );
     cata::event e = cata::event::make<event_type::character_kills_monster>(
-                        get_player_character().getID(), mon_zombie_bio_op );
+                        get_player_character().getID(), mon_zombie_bio_op, 0 );
     get_event_bus().send( e );
     player_character.magic->learn_spell( spell_test_spell_json, player_character, false );
     player_character.set_mutation( trait_test_trait ); // Give the player the spell scool test_trait

--- a/tests/stats_tracker_test.cpp
+++ b/tests/stats_tracker_test.cpp
@@ -81,9 +81,9 @@ TEST_CASE( "stats_tracker_count_events", "[stats]" )
 
     const character_id u_id = get_player_character().getID();
     const cata::event kill1 =
-        cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie );
+        cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie, 0 );
     const cata::event kill2 = cata::event::make<event_type::character_kills_monster>( u_id,
-                              mon_zombie_brute );
+                              mon_zombie_brute, 0 );
     const cata::event::data_type char_is_player{ { "killer", cata_variant( u_id ) } };
 
     CHECK( s.get_events( kill1.type() ).count( kill1.data() ) == 0 );
@@ -310,11 +310,11 @@ TEST_CASE( "stats_tracker_with_event_statistics", "[stats]" )
         character_id other_id = u_id;
         ++other_id;
         const cata::event avatar_zombie_kill =
-            cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie );
+            cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie, 0 );
         const cata::event avatar_dog_kill =
-            cata::event::make<event_type::character_kills_monster>( u_id, mon_dog );
+            cata::event::make<event_type::character_kills_monster>( u_id, mon_dog, 0 );
         const cata::event other_kill =
-            cata::event::make<event_type::character_kills_monster>( other_id, mon_zombie );
+            cata::event::make<event_type::character_kills_monster>( other_id, mon_zombie, 0 );
 
         send_game_start( b, u_id );
         CHECK( event_statistic_avatar_id->value( s ) == cata_variant( u_id ) );
@@ -526,11 +526,11 @@ TEST_CASE( "stats_tracker_watchers", "[stats]" )
         character_id other_id = u_id;
         ++other_id;
         const cata::event avatar_zombie_kill =
-            cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie );
+            cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie, 0 );
         const cata::event avatar_dog_kill =
-            cata::event::make<event_type::character_kills_monster>( u_id, mon_dog );
+            cata::event::make<event_type::character_kills_monster>( u_id, mon_dog, 0 );
         const cata::event other_kill =
-            cata::event::make<event_type::character_kills_monster>( other_id, mon_zombie );
+            cata::event::make<event_type::character_kills_monster>( other_id, mon_zombie, 0 );
 
         watch_stat kills_watcher;
         watch_stat zombie_kills_watcher;
@@ -651,7 +651,7 @@ TEST_CASE( "achievements_tracker", "[stats]" )
 
     SECTION( "hidden_kills" ) {
         const cata::event avatar_zombie_kill =
-            cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie );
+            cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie, 0 );
 
         achievement_id a_kill_10( "achievement_kill_10_monsters" );
         achievement_id a_kill_100( "achievement_kill_100_monsters" );
@@ -679,7 +679,7 @@ TEST_CASE( "achievements_tracker", "[stats]" )
         calendar::turn = calendar::start_of_game + time_since_game_start;
 
         const cata::event avatar_zombie_kill =
-            cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie );
+            cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie, 0 );
 
         achievement_id c_pacifist( "conduct_zero_kills" );
         achievement_id c_merciful( "conduct_zero_character_kills" );
@@ -933,7 +933,7 @@ TEST_CASE( "achievements_tracker_in_game", "[stats]" )
     send_game_start( get_event_bus(), u_id );
 
     const cata::event avatar_zombie_kill =
-        cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie );
+        cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie, 0 );
     get_event_bus().send( avatar_zombie_kill );
 
     achievement_id c_pacifist( "conduct_zero_kills" );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Some monster and map related update of EoC

#### Describe the solution
- `<npc_name>` can parse monster name
- Add experience value to `character_kills_monster` event
- Add beta talker to `character_kills_monster` event
- math `armor()` can get monsters armor value
- Add `passable_only` option to `u_location_variable`

#### Describe alternatives you've considered


#### Testing
Add CI test

#### Additional context
