### PR TITLE
Allow sandwiches to be made using toast

### DIFF
--- a/data/json/recipes/food/bread.json
+++ b/data/json/recipes/food/bread.json
@@ -183,7 +183,7 @@
     "qualities": [ { "id": "COOK", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 1, "LIST" ] ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" } ],
-    "components": [ [ [ "bread_sandwich", 1, "LIST" ] ] ]
+    "components": [ [ [ "bread_toastable", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",
@@ -200,7 +200,7 @@
     "qualities": [ { "id": "COOK", "level": 1 } ],
     "tools": [ [ [ "surface_heat", 1, "LIST" ] ] ],
     "proficiencies": [ { "proficiency": "prof_food_prep" } ],
-    "components": [ [ [ "bread_sandwich_wheat_free", 1, "LIST" ] ] ]
+    "components": [ [ [ "bread_toastable_wheat_free", 1, "LIST" ] ] ]
   },
   {
     "type": "recipe",

--- a/data/json/requirements/cooking_components.json
+++ b/data/json/requirements/cooking_components.json
@@ -24,22 +24,32 @@
     ]
   },
   {
+    "id": "bread_toastable",
+    "type": "requirement",
+    "//": "Bread appropriate for toast.",
+    "components": [
+      [
+        [ "bread", 1 ],
+        [ "wastebread", 1 ],
+        [ "sourdough_bread", 1 ],
+        [ "brioche", 1 ],
+        [ "brown_bread", 1 ],
+        [ "hallula", 1 ]
+      ]
+    ]
+  },
+  {
+    "id": "bread_toastable_wheat_free",
+    "type": "requirement",
+    "//": "Wheat free bread appropriate for toast.",
+    "components": [ [ [ "bread_wheat_free", 1 ], [ "brown_bread_wheat_free", 1 ], [ "cornbread", 1 ] ] ]
+  },
+  {
     "id": "bread_sandwich",
     "type": "requirement",
     "//": "Bread appropriate for sandwiches.",
     "components": [
-      [
-        [ "flatbread", 1 ],
-        [ "tortilla_any", 1, "LIST" ],
-        [ "bread", 1 ],
-        [ "wastebread", 1 ],
-        [ "sourdough_bread", 1 ],
-        [ "biscuit", 1 ],
-        [ "brioche", 1 ],
-        [ "crackers", 1 ],
-        [ "brown_bread", 1 ],
-        [ "hallula", 1 ]
-      ]
+      [ [ "bread_toastable", 1, "LIST" ], [ "tortilla_any", 1, "LIST" ], [ "biscuit", 1 ], [ "crackers", 1 ], [ "toast", 1 ] ]
     ]
   },
   {
@@ -48,11 +58,10 @@
     "//": "Wheat free bread appropriate for sandwiches.",
     "components": [
       [
-        [ "cornbread", 1 ],
-        [ "bread_wheat_free", 1 ],
+        [ "bread_toastable_wheat_free", 1, "LIST" ],
         [ "flatbread_wheat_free", 1 ],
         [ "tortilla_corn", 1 ],
-        [ "brown_bread_wheat_free", 1 ]
+        [ "toast_wheat_free", 1 ]
       ]
     ]
   },


### PR DESCRIPTION
#### Summary
Bugfixes "Allow sandwiches to be made using toast"

#### Purpose of change
As sandwiches made with toast are delicious and crunchy, there’s no good reason that I can think of to leave them out of the game.

#### Describe the solution
I divided the breads into two categories. Some have the sugar content to be toasted, while others do not. I left corn bread and hallula in the toastable category. I think it would be weird to toast cornbread, but it usually has enough sugar (at least as made in the modern era). I don’t know anything about hallula, so I just flipped a coin. Meanwhile flatbreads and crackers and such are not toastable.

Of course I maintained the existing separation between breads with wheat and without.

#### Describe alternatives you've considered

I considered several other ways of modifying the recipes, but after sleeping on it realized that adding new ingredient groups was the simpler route.

#### Testing
I toasted bread, made the toast into sandwiches, made the untoasted bread into sandwiches, etc. Of course I didn’t test every single combination, but I figure they’ll all work the same way.

#### Additional context
Fixes #69328