### PR TITLE
Camps can handle crafting liquid

### DIFF
--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -666,6 +666,7 @@ void basecamp::form_storage_zones( map &here, const tripoint_abs_ms &abspos )
         mgr.cache_vzones();
     }
     tripoint src_loc = here.getlocal( bb_pos ) + point_north;
+    std::vector<tripoint_abs_ms> possible_liquid_dumps;
     if( mgr.has_near( zone_type_CAMP_STORAGE, abspos, 60 ) ) {
         const std::vector<const zone_data *> zones = mgr.get_near_zones( zone_type_CAMP_STORAGE, abspos,
                 60 );
@@ -684,8 +685,20 @@ void basecamp::form_storage_zones( map &here, const tripoint_abs_ms &abspos )
             src_loc = here.getlocal( zones.front()->get_center_point() );
             set_storage_zone( zones );
         }
+        map &here = get_map();
+        for( const zone_data *zone : storage_zones ) {
+            if( zone->get_type() == zone_type_CAMP_STORAGE ) {
+                for( const tripoint_abs_ms &p : tripoint_range<tripoint_abs_ms>(
+                         zone->get_start_point(), zone->get_end_point() ) ) {
+                    if( here.has_flag_ter_or_furn( ter_furn_flag::TFLAG_LIQUIDCONT, here.getlocal( p ) ) ) {
+                        possible_liquid_dumps.emplace_back( p );
+                    }
+                }
+            }
+        }
     }
     set_dumping_spot( here.getglobal( src_loc ) );
+    set_liquid_dumping_spot( possible_liquid_dumps );
 
 }
 void basecamp::form_crafting_inventory( map &target_map )

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -263,9 +263,22 @@ class basecamp
         inline const tripoint_abs_ms &get_dumping_spot() const {
             return dumping_spot;
         }
+        inline const std::vector<tripoint_abs_ms> &get_liquid_dumping_spot() const {
+            return liquid_dumping_spots;
+        }
         // dumping spot in absolute co-ords
         inline void set_dumping_spot( const tripoint_abs_ms &spot ) {
             dumping_spot = spot;
+        }
+        inline void set_liquid_dumping_spot( const std::vector<tripoint_abs_ms> &liquid_dumps ) {
+            // Nowhere qualified to dump liquid? Dump it wherever everything else goes.
+            if( liquid_dumps.empty() ) {
+                liquid_dumping_spots.clear();
+                liquid_dumping_spots.emplace_back( dumping_spot );
+                return;
+            } //else
+            liquid_dumping_spots.clear();
+            liquid_dumping_spots = liquid_dumps;
         }
         void place_results( const item &result );
 
@@ -433,6 +446,8 @@ class basecamp
         comp_list camp_workers; // NOLINT(cata-serialize)
         basecamp_map camp_map; // NOLINT(cata-serialize)
         tripoint_abs_ms dumping_spot;
+        // Tiles inside STORAGE-type zones that have LIQUIDCONT terrain
+        std::vector<tripoint_abs_ms> liquid_dumping_spots;
         std::vector<const zone_data *> storage_zones; // NOLINT(cata-serialize)
         std::unordered_set<tripoint_abs_ms> src_set; // NOLINT(cata-serialize)
         std::set<itype_id> fuel_types; // NOLINT(cata-serialize)

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5409,7 +5409,25 @@ void basecamp::place_results( const item &result )
 {
     map &target_bay = get_camp_map();
     form_storage_zones( target_bay, target_bay.getglobal( target_bay.getlocal( bb_pos ) ) );
-    const tripoint &new_spot = target_bay.getlocal( get_dumping_spot() );
+    tripoint new_spot = target_bay.getlocal( get_dumping_spot() );
+    // Special handling for liquids
+    // find any storage-zoned LIQUIDCONT we can dump them in, set that as the item's destination instead
+    if( result.made_of( phase_id::LIQUID ) ) {
+        for( tripoint_abs_ms potential_spot : get_liquid_dumping_spot() ) {
+            // No items at a potential spot? Set the destination there and stop checking.
+            // We could check if the item at the tile are the same as the item we're placing, but liquids of the same typeid
+            // don't always mix depending on their components...
+            if( target_bay.i_at( target_bay.getlocal( potential_spot ) ).empty() ) {
+                new_spot = target_bay.getlocal( potential_spot );
+                break;
+            }
+            // We've processed the last spot and haven't found anywhere to put it, we'll end up using dumping_spot.
+            // Throw a warning to let players know what's going on. Unfortunately we can't back out of finishing the mission this deep in the process.
+            if( potential_spot == get_liquid_dumping_spot().back() ) {
+                popup( _( "No eligible locations found to place resulting liquids, placing them at random.  \nEligible locations must be a terrain OR furniture (not item) that can contain liquid, and does not already have any items on its tile." ) );
+            }
+        }
+    }
     target_bay.add_item_or_charges( new_spot, result, true );
     apply_camp_ownership( target_bay, new_spot, 10 );
     target_bay.save();

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -5424,7 +5424,7 @@ void basecamp::place_results( const item &result )
             // We've processed the last spot and haven't found anywhere to put it, we'll end up using dumping_spot.
             // Throw a warning to let players know what's going on. Unfortunately we can't back out of finishing the mission this deep in the process.
             if( potential_spot == get_liquid_dumping_spot().back() ) {
-                popup( _( "No eligible locations found to place resulting liquids, placing them at random.  \nEligible locations must be a terrain OR furniture (not item) that can contain liquid, and does not already have any items on its tile." ) );
+                popup( _( "No eligible locations found to place resulting liquids, placing them at random.\n\nEligible locations must be a terrain OR furniture (not item) that can contain liquid, and does not already have any items on its tile." ) );
             }
         }
     }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4395,6 +4395,7 @@ void basecamp::serialize( JsonOut &json ) const
         json.member( "pos", omt_pos );
         json.member( "bb_pos", bb_pos );
         json.member( "dumping_spot", dumping_spot );
+        json.member( "liquid_dumping_spots", liquid_dumping_spots );
         json.member( "hidden_missions" );
         json.start_array();
         for( const std::vector<ui_mission_id> &list : hidden_missions ) {
@@ -4479,6 +4480,7 @@ void basecamp::deserialize( const JsonObject &data )
     data.read( "pos", omt_pos );
     data.read( "bb_pos", bb_pos );
     data.read( "dumping_spot", dumping_spot );
+    data.read( "liquid_dumping_spots", liquid_dumping_spots );
     for( int tab_num = base_camps::TAB_MAIN; tab_num <= base_camps::TAB_NW; tab_num++ ) {
         std::vector<ui_mission_id> temp;
         hidden_missions.push_back( temp );


### PR DESCRIPTION
#### Summary
Features "Liquids crafted at camps will try to be placed inside zoned terrain/furniture that can hold them(LIQUIDCONT)"

#### Purpose of change
Crafting liquids at camps dumped them on the ground (lol)

* Closes #50627

#### Describe the solution
During the camp's zone initialization it registers a vector of absolute tripoints where it can place liquids (furniture or terrain with the LIQUIDCONT flag). These are saved much like the existing `dumping_spot`.

When placing crafting results, it checks if the result is liquid and if so, tries to find an entry in the vector **where there are no items already existing** (most of the time liquids can't mix). Basically, "find an empty barrel and dump it in there".

If it doesn't find one, fine - it just reverts to putting the liquids where everything else goes. It also gives the player a popup explaining why it's dumping their precious crafting results on the ground.

#### Describe alternatives you've considered
Some sort of selectable menu like with personal crafting where you could select a valid container/(terrain/furniture?) to hold your new liquids

#### Testing
3x3 empty storage zone full of bathtubs, places new solid items at the center point (get_dumping_spot always uses the center of the zone), but places liquid items at the first evaluated point that can hold them (top-left):
https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/8f6280cf-ea9c-45ed-aa39-5cdb0856e824

3x3 storage zone with SOME possible containers, some items already in the area, and not all tiles covered in possible containers! Places new solid items at the center point, but places liquid items at the first evaluated point that can hold them (bottom-right, last spot to be evaluated):
https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/84e68b03-9ea9-4e9c-85f0-a50fbe59182b

Warning popup if resulting items would be placed on the ground (placement will still happen, but it lets the player know why):
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/930aebe5-cde9-49d5-aede-d24080271a15)

It successfully handles batch results, placing them all together at once.

#### Additional context
Known deficiencies:

~~-Although furniture can be a LIQUIDCONT I don't think zones are reinitialized unless the player modifies them in some way, so you could go push a toilet into your storage, initialize them, push the toilet out, and the game will happily dump crafted liquids onto the empty tile where it thinks a toilet is. Re-checking the zones is a bit more than I want to bite off here.~~ Haha, they're reset right before the crafting results get placed! Perfect, nothing to worry about here.

~~-I have not touched the save game functions as of this writing so it probably doesn't persist after a save and load cycle.~~
They're reset before placement so I actually don't know why this would need to be serialized to the save except for legacy. This has no legacy equivalent, so it shouldn't matter.

-It cannot handle container *items*. Only furniture and terrain with LIQUIDCONT. This was intentional to KISS.