### PR TITLE
Fix shadow encounter teleporting the player

### DIFF
--- a/data/json/monsters/zed_lieutenant.json
+++ b/data/json/monsters/zed_lieutenant.json
@@ -315,7 +315,9 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_LIEUTENANT_ACTIVATE_SHADOW",
-    "recurrence": 1,
+    "recurrence": "1 second",
+    "global": true,
+    "run_for_npcs": false,
     "condition": { "and": [ { "days_since_cataclysm": 7 }, { "math": [ "u_Lieutenants_active", "<", "1" ] } ] },
     "//2": "Integer value instead of bool, so more can be added later and use math for conditions",
     "effect": [ { "u_add_var": "Lieutenants_active", "value": "1" }, { "u_add_var": "Shadow_Lurking", "value": "1" } ],
@@ -325,6 +327,8 @@
     "type": "effect_on_condition",
     "id": "EOC_LIEUTENANT_SPAWN_SHADOW",
     "recurrence": [ "3 hours", "6 hours" ],
+    "global": true,
+    "run_for_npcs": false,
     "//1": "Night time, shadow is active, you are outdoors *and awake*, and you are not likely to be near shelter.",
     "condition": {
       "and": [
@@ -373,7 +377,9 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_LIEUTENANT_SHADOW_WITHDRAWS_FOR_NOW",
-    "recurrence": 1,
+    "recurrence": "1 second",
+    "global": true,
+    "run_for_npcs": false,
     "//1": "Lots of friends nearby, or in base camp, or safely indoors, or the sun has risen. (Sundeath is only a problem after up to 90 minutes after sunrise)",
     "condition": {
       "and": [
@@ -398,7 +404,9 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_LIEUTENANT_SHADOW_CHECK_POS",
-    "recurrence": 1,
+    "recurrence": "1 second",
+    "global": true,
+    "run_for_npcs": false,
     "condition": { "math": [ "u_monsters_nearby('mon_lieutenant_shadow', 'radius': 60)", ">", "0" ] },
     "effect": [
       {

--- a/data/json/monsters/zed_lieutenant.json
+++ b/data/json/monsters/zed_lieutenant.json
@@ -389,7 +389,7 @@
     },
     "//2": "Despawn shadow, adjust var for later to bring him back",
     "effect": [
-      { "math": [ "Shadow_Lurking", "+=", "1" ] },
+      { "math": [ "Shadow_Lurking", "=", "1" ] },
       { "u_message": "The wind laughs through the night", "type": "bad" },
       {
         "u_location_variable": { "global_val": "Shadow_monster" },
@@ -430,25 +430,6 @@
         "success_message": "You can't outrun your own shadow!",
         "force": true
       }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_LIEUTENANT_SHADOW_MIGRATE_VARS",
-    "//1": "FIXME / TODO : Remove this after 0.H",
-    "//2": "Migrate's player character's (ONLY PC's) shadow-related npctalkvars to global ones next time the game is loaded and then never again.",
-    "//3": "Only migrates if player character actually has relevant npctalkvar (expects_vars)",
-    "eoc_type": "EVENT",
-    "required_event": "game_load",
-    "global": true,
-    "run_for_npcs": false,
-    "condition": {
-      "and": [ { "math": [ "Shadow_Vars_Fixed", "!=", "1" ] }, { "expects_vars": [ "u_Shadow_Lurking", "u_Lieutenants_active" ] } ]
-    },
-    "effect": [
-      { "math": [ "Shadow_Vars_Fixed", "=", "1" ] },
-      { "math": [ "Shadow_Lurking", "=", "u_Shadow_Lurking" ] },
-      { "math": [ "Lieutenants_active", "=", "u_Lieutenants_active" ] }
     ]
   }
 ]

--- a/data/json/monsters/zed_lieutenant.json
+++ b/data/json/monsters/zed_lieutenant.json
@@ -318,10 +318,10 @@
     "recurrence": "1 second",
     "global": true,
     "run_for_npcs": false,
-    "condition": { "and": [ { "days_since_cataclysm": 7 }, { "math": [ "u_Lieutenants_active", "<", "1" ] } ] },
+    "condition": { "and": [ { "days_since_cataclysm": 7 }, { "math": [ "Lieutenants_active", "<", "1" ] } ] },
     "//2": "Integer value instead of bool, so more can be added later and use math for conditions",
-    "effect": [ { "u_add_var": "Lieutenants_active", "value": "1" }, { "u_add_var": "Shadow_Lurking", "value": "1" } ],
-    "deactivate_condition": { "math": [ "u_Lieutenants_active", ">=", "1" ] }
+    "effect": [ { "math": [ "Lieutenants_active", "=", "1" ] }, { "math": [ "Shadow_Lurking", "=", "1" ] } ],
+    "deactivate_condition": { "math": [ "Lieutenants_active", ">=", "1" ] }
   },
   {
     "type": "effect_on_condition",
@@ -335,8 +335,8 @@
         { "one_in_chance": 6 },
         { "not": "is_day" },
         { "not": { "u_has_effect": "sleep" } },
-        { "math": [ "u_Lieutenants_active", ">", "0" ] },
-        { "math": [ "u_Shadow_Lurking", ">", "0" ] },
+        { "math": [ "Lieutenants_active", ">", "0" ] },
+        { "math": [ "Shadow_Lurking", ">", "0" ] },
         "u_is_outside",
         {
           "or": [ { "u_at_om_location": "field" }, { "u_at_om_location": "forest" }, { "u_at_om_location": "forest_thick" } ]
@@ -344,7 +344,7 @@
       ]
     },
     "effect": [
-      { "u_adjust_var": "Shadow_Lurking", "adjustment": -1 },
+      { "math": [ "Shadow_Lurking", "-=", "1" ] },
       { "u_spawn_monster": "mon_lieutenant_shadow", "real_count": 1, "min_radius": 10, "max_radius": 15 },
       {
         "u_message": "You shiver as the night closes in…",
@@ -389,7 +389,7 @@
     },
     "//2": "Despawn shadow, adjust var for later to bring him back",
     "effect": [
-      { "u_adjust_var": "Shadow_Lurking", "adjustment": 1 },
+      { "math": [ "Shadow_Lurking", "+=", "1" ] },
       { "u_message": "The wind laughs through the night", "type": "bad" },
       {
         "u_location_variable": { "global_val": "Shadow_monster" },
@@ -430,6 +430,25 @@
         "success_message": "You can't outrun your own shadow!",
         "force": true
       }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_LIEUTENANT_SHADOW_MIGRATE_VARS",
+    "//1": "FIXME / TODO : Remove this after 0.H",
+    "//2": "Migrate's player character's (ONLY PC's) shadow-related npctalkvars to global ones next time the game is loaded and then never again.",
+    "//3": "Only migrates if player character actually has relevant npctalkvar (expects_vars)",
+    "eoc_type": "EVENT",
+    "required_event": "game_load",
+    "global": true,
+    "run_for_npcs": false,
+    "condition": {
+      "and": [ { "math": [ "Shadow_Vars_Fixed", "!=", "1" ] }, { "expects_vars": [ "u_Shadow_Lurking", "u_Lieutenants_active" ] } ]
+    },
+    "effect": [
+      { "math": [ "Shadow_Vars_Fixed", "=", "1" ] },
+      { "math": [ "Shadow_Lurking", "=", "u_Shadow_Lurking" ] },
+      { "math": [ "Lieutenants_active", "=", "u_Lieutenants_active" ] }
     ]
   }
 ]


### PR DESCRIPTION
#### Summary
Bugfixes "A shadow? will not teleport the player and/or nearby NPCs"

#### Purpose of change
* Fixes #68224

#### Describe the solution
Moving the relevant EOCs to the global queue so they only fire once, for the player. (Huge thanks to @lispcoc for identifying the issue and providing a fix to the EOC code to make this possible)

Also migrated related npctalkvars to global ones so that swapping characters won't bring it back to life. (Previously it stayed dead because all the EOCs were firing for all the characters, basically it was a mess with EOCs flying everywhere)

#### Describe alternatives you've considered
~~We have `var_migration` which should, in theory, handle these variable migrations... but I'm not sure it'll only read the *player's* vars when migrating to global. So I went with the bespoke solution.~~ Neither `var_migration` nor my bespoke solution worked. The downsides are relatively minor(players that killed shadow might have him come back, once). Given that this is a bugfix to prevent the player character from being killed arbitrarily, I'm just pushing it without any migration from u_var to global var.

#### Testing
The teleporting is definitely fixed. ~~The npctalkvar migration looks fine, but there are many possible states so I am hesitant to say it's foolproof.~~

~~Please please please help me test the var migration, mergers and otherwise, thank you.~~ If you know why the migrations don't work, let me know.

#### Additional context
