### PR TITLE
Remove charges from grain seed recipes

### DIFF
--- a/data/json/recipes/food/seed.json
+++ b/data/json/recipes/food/seed.json
@@ -461,7 +461,7 @@
     "id_suffix": "seed_designation",
     "type": "recipe",
     "copy-from": "seed_extraction_designation",
-    "components": [ [ [ "seed_lentils",  ] ] ]
+    "components": [ [ [ "seed_lentils", 1  ] ] ]
   },
   {
     "result": "seed_chamomile",

--- a/data/json/recipes/food/seed.json
+++ b/data/json/recipes/food/seed.json
@@ -125,16 +125,14 @@
     "result": "seed_barley",
     "type": "recipe",
     "copy-from": "seed_extraction_designation",
-    "components": [ [ [ "barley", 1 ] ] ],
-    "charges": 4
+    "components": [ [ [ "barley", 1 ] ] ]
   },
   {
     "result": "barley",
     "type": "recipe",
     "id_suffix": "seed_designation",
     "copy-from": "seed_extraction_designation",
-    "components": [ [ [ "seed_barley", 4 ] ] ],
-    "charges": 1
+    "components": [ [ [ "seed_barley", 1 ] ] ]
   },
   {
     "result": "seed_tomato",
@@ -253,16 +251,14 @@
     "result": "seed_buckwheat",
     "type": "recipe",
     "copy-from": "seed_extraction_designation",
-    "components": [ [ [ "buckwheat", 1 ] ] ],
-    "charges": 2
+    "components": [ [ [ "buckwheat", 1 ] ] ]
   },
   {
     "result": "buckwheat",
     "type": "recipe",
     "id_suffix": "seed_designation",
     "copy-from": "seed_extraction_base",
-    "components": [ [ [ "seed_buckwheat", 2 ] ] ],
-    "charges": 1
+    "components": [ [ [ "seed_buckwheat", 1 ] ] ]
   },
   {
     "result": "seed_dogbane",
@@ -432,16 +428,14 @@
     "result": "seed_beans",
     "type": "recipe",
     "copy-from": "seed_extraction_designation",
-    "components": [ [ [ "dry_beans", 6 ] ] ],
-    "charges": 6
+    "components": [ [ [ "dry_beans", 1 ] ] ]
   },
   {
     "result": "dry_beans",
     "id_suffix": "seed_designation",
     "type": "recipe",
     "copy-from": "seed_extraction_designation",
-    "components": [ [ [ "seed_beans", 6 ] ] ],
-    "charges": 6
+    "components": [ [ [ "seed_beans", 1 ] ] ]
   },
   {
     "result": "soybean_seed",
@@ -460,16 +454,14 @@
     "result": "seed_lentils",
     "type": "recipe",
     "copy-from": "seed_extraction_designation",
-    "components": [ [ [ "dry_lentils", 2 ] ] ],
-    "charges": 2
+    "components": [ [ [ "dry_lentils", 1 ] ] ]
   },
   {
     "result": "dry_lentils",
     "id_suffix": "seed_designation",
     "type": "recipe",
     "copy-from": "seed_extraction_designation",
-    "components": [ [ [ "seed_lentils", 2 ] ] ],
-    "charges": 2
+    "components": [ [ [ "seed_lentils",  ] ] ]
   },
   {
     "result": "seed_chamomile",

--- a/data/json/recipes/food/seed.json
+++ b/data/json/recipes/food/seed.json
@@ -461,7 +461,7 @@
     "id_suffix": "seed_designation",
     "type": "recipe",
     "copy-from": "seed_extraction_designation",
-    "components": [ [ [ "seed_lentils", 1  ] ] ]
+    "components": [ [ [ "seed_lentils", 1 ] ] ]
   },
   {
     "result": "seed_chamomile",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Remove charges from grain seed recipes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

 Lingering references to charges in some grain and bean seed recipes were causing issues. These items and their seeds are interchangeable and are supposed to always be 1:1 with each other.

Closes #69433 

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Remove charges from the seed designation recipes, so it's all 1:1 with grains.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Loaded the game, planted some grains, saw that they grew and gave the right amount of produce, crafted seeds into grains and vice versa.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/94415528/35e0d860-9261-495e-9680-9c05d13c30e1)
Caviar and egg sandwich no longer shows wacky values in its calorie estimate.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
