### PR TITLE
Allow diving into water to remove Mycus spores.

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
@@ -373,5 +373,28 @@
         "unique_ids": [ "GUARD1", "GUARD2", "GUARD3", "GUARD4", "GUARD5", "GUARD6", "GUARD7" ]
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DIVING_INTO_WATER_CHECK",
+    "global": false,
+    "eoc_type": "EVENT",
+    "required_event": "avatar_moves",
+    "condition": "u_is_underwater",
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_REMOVE_HARD_THINGS_CHECK",
+          "global": false,
+          "eoc_type": "EVENT",
+          "required_event": "avatar_moves",
+          "condition": { "x_in_y_chance": { "x": 1, "y": 10 } },
+          "//": "I would assume that Mycus spores are a bit sticky to keep them from coming off, so this has a chance to be removed instead of a garuntee.",
+          "effect": [ { "u_lose_effect": "spores" } ]
+        }
+      },
+      { "u_lose_effect": "boomered" },
+      { "u_lose_effect": "corroding" }
+    ]
   }
 ]

--- a/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
@@ -377,7 +377,8 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_DIVING_INTO_WATER_CHECK",
-    "global": false,
+    "global": true,
+    "run_for_npcs": true,
     "eoc_type": "EVENT",
     "required_event": "avatar_moves",
     "condition": "u_is_underwater",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Allow diving into water to remove Mycus spores."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Resolve #69352, and allow diving to remove a few other effects.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Using an EOC, check for when the player is diving into water and allow that to remove a few effects. This can help a player manage Mycus when water is nearby and adds a new way to prevent Mycus infection.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Dived into some water, the spores went away.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
