### PR TITLE
Adding memory to NPC retreat code

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -246,6 +246,7 @@ std::string filter_name( debug_filter value )
         case DF_MONSTER: return "DF_MONSTER";
         case DF_MUTATION: return "DF_MUTATION";
         case DF_NPC: return "DF_NPC";
+        case DF_NPC_COMBATAI: return "DF_NPC_COMBATAI";
         case DF_OVERMAP: return "DF_OVERMAP";
         case DF_RADIO: return "DF_RADIO";
         case DF_RANGED: return "DF_RANGED";

--- a/src/debug.h
+++ b/src/debug.h
@@ -265,6 +265,7 @@ enum debug_filter : int {
     DF_MONSTER, // monster generic
     DF_MUTATION, // mutation/purification logic
     DF_NPC, // npc generic
+    DF_NPC_COMBATAI, // npc combat logic decisions
     DF_OVERMAP, // overmap generic
     DF_RADIO, // radio stuff
     DF_RANGED, // ranged generic

--- a/src/npc.h
+++ b/src/npc.h
@@ -258,8 +258,14 @@ struct npc_opinion {
 
 struct npc_logic_token {
     int panic; // Tracks how many times NPC has had to try to run
+    int hostile_count; // for tallying nearby threatening enemies
+    int swarm_count; // for tallying swarming enemies if you're using a ranged weapon
+    int friendly_count; // for counting how many allies are nearby
     npc_logic_token_reset() {
         panic = 0;
+        hostile_count = 0;
+        swarm_count = 0;
+        friendly_count = 1; // count yourself as a friendly
     }
 };
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -256,12 +256,12 @@ struct npc_opinion {
     void deserialize( const JsonObject &data );
 };
 
-struct npc_logic_token {
+struct npc_combat_logic {
     int panic; // Tracks how many times NPC has had to try to run
     int hostile_count; // for tallying nearby threatening enemies
     int swarm_count; // for tallying swarming enemies if you're using a ranged weapon
     int friendly_count; // for counting how many allies are nearby
-    npc_logic_token_reset() {
+    npc_combat_logic_reset() {
         panic = 0;
         hostile_count = 0;
         swarm_count = 0;
@@ -1364,6 +1364,7 @@ class npc : public Character
         npc_mission previous_mission = NPC_MISSION_NULL;
         npc_personality personality;
         npc_opinion op_of_u;
+        npc_logic_combat remember_combat;
         dialogue_chatbin chatbin;
         int patience = 0; // Used when we expect the player to leave the area
         npc_follower_rules rules;

--- a/src/npc.h
+++ b/src/npc.h
@@ -1366,7 +1366,7 @@ class npc : public Character
         npc_mission previous_mission = NPC_MISSION_NULL;
         npc_personality personality;
         npc_opinion op_of_u;
-        npc_logic_combat mem_combat;
+        npc_combat_logic mem_combat;
         dialogue_chatbin chatbin;
         int patience = 0; // Used when we expect the player to leave the area
         npc_follower_rules rules;

--- a/src/npc.h
+++ b/src/npc.h
@@ -256,6 +256,13 @@ struct npc_opinion {
     void deserialize( const JsonObject &data );
 };
 
+struct npc_logic_token {
+    int panic; // Tracks how many times NPC has had to try to run
+    npc_logic_token_reset() {
+        panic = 0;
+    }
+};
+
 enum class combat_engagement : int {
     NONE = 0,
     CLOSE,

--- a/src/npc.h
+++ b/src/npc.h
@@ -262,7 +262,7 @@ struct npc_combat_logic {
     int swarm_count; // for tallying swarming enemies if you're using a ranged weapon
     int friendly_count; // for counting how many allies are nearby
     float old_danger_assessment; // keep track of recent danger levels to see if they change
-    npc_combat_logic_reset() {
+    npc_combat_logic() {
         panic = 0;
         hostile_count = 0;
         swarm_count = 0;

--- a/src/npc.h
+++ b/src/npc.h
@@ -261,13 +261,17 @@ struct npc_combat_logic {
     int hostile_count; // for tallying nearby threatening enemies
     int swarm_count; // for tallying swarming enemies if you're using a ranged weapon
     int friendly_count; // for counting how many allies are nearby
+    int failed_repositions;
     float old_danger_assessment; // keep track of recent danger levels to see if they change
+    bool repositioning;
     npc_combat_logic() {
         panic = 0;
         hostile_count = 0;
         swarm_count = 0;
         friendly_count = 1; // count yourself as a friendly
+        failed_repositions = true;
         old_danger_assessment = 0.0f;
+        repositioning = false;
     }
 };
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -1364,7 +1364,7 @@ class npc : public Character
         npc_mission previous_mission = NPC_MISSION_NULL;
         npc_personality personality;
         npc_opinion op_of_u;
-        npc_logic_combat remember_combat;
+        npc_logic_combat mem_combat;
         dialogue_chatbin chatbin;
         int patience = 0; // Used when we expect the player to leave the area
         npc_follower_rules rules;

--- a/src/npc.h
+++ b/src/npc.h
@@ -873,7 +873,7 @@ class npc : public Character
         npc_opinion get_opinion_values( const Character &you ) const;
         std::string pick_talk_topic( const Character &u );
         std::string const &get_specified_talk_topic( std::string const &topic_id );
-        float character_danger( const Character &u ) const;
+        float character_danger( const Character &u, bool self, bool enemy ) const;
         float vehicle_danger( int radius ) const;
         void pretend_fire( npc *source, int shots, item &gun ); // fake ranged attack for hallucination
         // True if our anger is at least equal to...
@@ -1103,7 +1103,7 @@ class npc : public Character
         bool invoke_item( item * ) override;
 
         /** rates how dangerous a target is from 0 (harmless) to 1 (max danger) */
-        float evaluate_enemy( const Creature &target ) const;
+        float evaluate_enemy( const Creature &target, bool self, bool enemy ) const;
 
         void assess_danger();
         bool is_safe() const;

--- a/src/npc.h
+++ b/src/npc.h
@@ -261,11 +261,13 @@ struct npc_combat_logic {
     int hostile_count; // for tallying nearby threatening enemies
     int swarm_count; // for tallying swarming enemies if you're using a ranged weapon
     int friendly_count; // for counting how many allies are nearby
+    float old_danger_assessment; // keep track of recent danger levels to see if they change
     npc_combat_logic_reset() {
         panic = 0;
         hostile_count = 0;
         swarm_count = 0;
         friendly_count = 1; // count yourself as a friendly
+        old_danger_assessment = 0.0f;
     }
 };
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -552,12 +552,13 @@ void npc::assess_danger()
         ai_cache.hostile_guys.emplace_back( g->shared_from( critter ) );
 
         // ignore targets behind glass even if we can see them.
-        if( !obstacle_in_between( pos(), critter.pos(), false ) ) {
+        if( obstacle_in_between( pos(), critter.pos(), false ) ) {
             if( is_enemy() || !critter.friendly ) {
                 // still warn about enemies behind impassable glass walls, but not as often.
                 if( critter_threat > 2 * ( 8.0f + personality.bravery + rng( 0, 5 ) ) ) {
                     warn_about( "monster", 10_minutes, critter.type->nname(), dist, critter.pos() );
                 }
+            }
             continue;
         } else {
             add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s ignored %s because there's an obstacle in between.", name, critter.type->nname() );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -770,12 +770,11 @@ void npc::assess_danger()
         add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s semi-randomly adjusted ally strength to %i.", 
             name, static_cast<int>( my_diff ) );
         if( my_diff < assessment ) {
-            time_duration run_away_for = std::max( 1_turns, 5_turns - 1_turns * personality.bravery
-                                         + 1_turns * ( static_cast<int>( get_pain() / 5 ) + mem_combat.panic );
+            time_duration run_away_for = std::max( 2_turns + 1_turns * mem_combat.panic, 20_turns );
             // Each time NPC decides to run away, their panic increases, which increases likelihood
             // and duration of running away.
             // if they run to a more advantageous position, they'll reassess and rally.
-            mem_combat.panic += rng ( 1, 3 );
+            mem_combat.panic += std::min( rng ( 1, 3 ) + static_cast<int>( get_pain() / 5 ) - personality.bravery, 1 );
             if( my_diff * 5 < assessment ){
                 // Things are looking more than a little grim, NPC should remember to keep running even
                 // if the worst baddy goes out of LOS.

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -255,7 +255,7 @@ static bool obstacle_in_between( const tripoint &from, const tripoint &to, bool 
     std::vector<tripoint> path = line_to( from, to );
     path.pop_back();
     creature_tracker &creatures = get_creature_tracker();
-	map &here = get_map();
+    map &here = get_map();
     for( const tripoint &candidate : path ) {
         Creature *inter = creatures.creature_at( candidate );
         if( ignore_soft && here.( has_flag( ter_furn_flag::TFLAG_THIN_OBSTACLE ) ) ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -254,13 +254,11 @@ static bool obstacle_in_between( const tripoint &from, const tripoint &to, bool 
 {
     std::vector<tripoint> path = line_to( from, to );
     path.pop_back();
-    creature_tracker &creatures = get_creature_tracker();
     map &here = get_map();
     for( const tripoint &candidate : path ) {
-        Creature *inter = creatures.creature_at( candidate );
-        if( ignore_soft && here.( has_flag( ter_furn_flag::TFLAG_THIN_OBSTACLE ) ) ) {
-            // if the terrain is a thin obstacle and can be shot or attacked through, it doesn't matter if it's impassible,
-            // it's still not an obstacle.
+        if( ignore_soft && here.( has_flag( ter_furn_flag::TFLAG_THIN_OBSTACLE, candidate ) ) ) {
+            // if the terrain is a thin obstacle and can be shot or attacked through, 
+            // it doesn't matter if it's impassible, it's still not an obstacle.
             return false;
         } else if( here.impassable( candidate ) ) {
             return true;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -486,8 +486,8 @@ void npc::assess_danger()
                 return false;
             case combat_engagement::CLOSE:
                 // Either close to player or close enough that we can reach it and close to us
-                if( dist <= max_range && scaled_dist <= def_radius * 0.5 ) ||
-                    too_close( foe.pos(), player_character.pos(), def_radius ) {
+                if( ( dist <= max_range && scaled_dist <= def_radius * 0.5 ) ||
+                    too_close( foe.pos(), player_character.pos(), def_radius ) ) {
                     add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s identified a CLOSE opponent: %s.", name,
                                    foe.type->nname() );
                     return true;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -451,7 +451,7 @@ void npc::assess_danger()
     mem_combat.swarm_count = 0;
     mem_combat.friendly_count = 1;
 
-    if ( blind ) {
+    if( blind ) {
         assessment = mem_combat.old_danger_assessment;
     }
 
@@ -478,7 +478,6 @@ void npc::assess_danger()
         }
     }
     add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s set their def_radius to %i.", name, def_radius );
-    
 
     const auto ok_by_rules = [max_range, def_radius, this, &player_character]( const Creature & foe,
     int dist, int scaled_dist ) {
@@ -491,20 +490,23 @@ void npc::assess_danger()
                 return false;
             case combat_engagement::CLOSE:
                 // Either close to player or close enough that we can reach it and close to us
-                if  ( dist <= max_range && scaled_dist <= def_radius * 0.5 ) ||
-                       too_close( foe.pos(), player_character.pos(), def_radius ){
-                    add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s identified a CLOSE opponent: %s.", name, foe.type->nname() );
+                if( dist <= max_range && scaled_dist <= def_radius * 0.5 ) ||
+                    too_close( foe.pos(), player_character.pos(), def_radius ) {
+                    add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s identified a CLOSE opponent: %s.", name,
+                                   foe.type->nname() );
                     return true;
                 }
             case combat_engagement::WEAK:
-                if ( foe.get_hp() <= average_damage_dealt() ){
-                    add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s identified a WEAK opponent: %s.", name, foe.type->nname() );
+                if( foe.get_hp() <= average_damage_dealt() ) {
+                    add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s identified a WEAK opponent: %s.", name,
+                                   foe.type->nname() );
                     return true;
                 }
                 return foe.get_hp() <= average_damage_dealt();
             case combat_engagement::HIT:
-                if ( foe.has_effect( effect_hit_by_player ) ){
-                    add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s identified an opponent that was HIT: %s.", name, foe.type->nname() );
+                if( foe.has_effect( effect_hit_by_player ) ) {
+                    add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s identified an opponent that was HIT: %s.", name,
+                                   foe.type->nname() );
                     return true;
                 }
             case combat_engagement::NO_MOVE:
@@ -516,7 +518,6 @@ void npc::assess_danger()
 
         return true;
     };
-    
     std::map<direction, float> cur_threat_map;
     // start with a decayed version of last turn's map
     for( direction threat_dir : npc_threat_dir ) {
@@ -524,12 +525,11 @@ void npc::assess_danger()
     }
     map &here = get_map();
     // cache string_id -> int_id conversion before hot loop
-    
     // first, check if we're about to be consumed by fire
     npc_danger_fire( cur_threat_map, here );
 
     // find our Character's friends and enemies
-    if ( !blind ) {
+    if( !blind ) {
         npc_count_friend_or_foe( player_character, here );
     }
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -443,7 +443,7 @@ void npc::assess_danger()
     float highest_priority = 1.0f;
     int def_radius = rules.has_flag( ally_rule::follow_close ) ? follow_distance() : 6;
     bool npc_ranged = get_wielded_item() && get_wielded_item()->is_gun();
-    bool npc_blind = is_blind();
+    bool blind = is_blind();
     if( !blind ){
         // reset memory counters at the beginning of danger assessment
         mem_combat.hostile_count = 0;
@@ -764,7 +764,6 @@ void npc::assess_danger()
         bool range_reposition_fail = npc_ranged && mem_combat.old_danger_assessment * mem_combat.swarm_count <= assessment * mem_combat.swarm_count;
         if( melee_reposition_fail || range_reposition_fail ){
             add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s tried to reposition last turn, and the situation has not improved.", name );
-            mem_combat.panic += 1;
             failed_reposition = true;
             mem_combat.failed_repositions += 1;
         } else {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -650,6 +650,14 @@ void npc::assess_danger()
         if( foe_threat > ( 8.0f + personality.bravery + rng( 0, 5 ) ) ) {
             warn_about( "monster", 10_minutes, bogey, dist, foe.pos() );
         }
+        if( dist < 8 && foe_threat > bravery_vs_pain ) {
+            add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s added %s to nearby hostile count.", name, bogey );
+            mem_combat.hostile_count += 1;
+        }
+        if( dist < 4 && npc_ranged ) {
+            add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s added %s to swarming enemies count.", name, bogey );
+            mem_combat.swarm_count += 1;
+        }
 
         int scaled_distance = std::max( 1, ( 100 * dist ) / foe.get_speed() );
         ai_cache.total_danger += foe_threat / scaled_distance;
@@ -695,6 +703,10 @@ void npc::assess_danger()
             continue;
         }
         float guy_threat = evaluate_enemy( *guy.lock() );
+        add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s assessed friendly %s at threat level %i.",
+                                          name, guy.lock()->name, static_cast<int>( guy_threat );
+        // TODO: pick the strongest friendly guy around and declare them the leader
+        // if you don't have a player character, regroup on them instead of the player
         float min_danger = assessment >= NPC_DANGER_VERY_LOW ? NPC_DANGER_VERY_LOW : -10.0f;
         assessment = std::max( min_danger, assessment - guy_threat * 0.5f );
     }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -636,7 +636,7 @@ void npc::assess_danger()
     const std::string & bogey, const std::string & warning ) {
         int dist = rl_dist( pos(), foe.pos() );
         
-        if( !obstacle_in_between( pos(), foe.pos(), true ) ) {
+        if( obstacle_in_between( pos(), foe.pos(), true ) ) {
             // still warn about enemies behind impassable glass walls, but not as often.
             // since NPC threats have a higher chance of ignoring soft obstacles, we'll ignore them here.
             if( foe_threat > 2 * ( 8.0f + personality.bravery + rng( 0, 5 ) ) ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -257,7 +257,7 @@ static bool obstacle_in_between( const tripoint &from, const tripoint &to, bool 
     map &here = get_map();
     for( const tripoint &candidate : path ) {
         if( ignore_soft && here.( has_flag( ter_furn_flag::TFLAG_THIN_OBSTACLE, candidate ) ) ) {
-            // if the terrain is a thin obstacle and can be shot or attacked through, 
+            // if the terrain is a thin obstacle and can be shot or attacked through,
             // it doesn't matter if it's impassible, it's still not an obstacle.
             return false;
         } else if( here.impassable( candidate ) ) {
@@ -444,7 +444,7 @@ void npc::assess_danger()
     int def_radius = rules.has_flag( ally_rule::follow_close ) ? follow_distance() : 6;
     bool npc_ranged = get_wielded_item() && get_wielded_item()->is_gun();
     bool blind = is_blind();
-    if( !blind ){
+    if( !blind ) {
         // reset memory counters at the beginning of danger assessment
         mem_combat.hostile_count = 0;
         mem_combat.swarm_count = 0;
@@ -749,11 +749,11 @@ void npc::assess_danger()
     // how much pain they're currently experiencing. This means a very brave NPC might ignore
     // large crowds of minor creatures, until they start getting hurt.
     if( mem_combat.hostile_count > mem_combat.friendly_count ) {
-        assessment *= std::min( mem_combat.hostile_count / static_cast<float>( mem_combat.friendly_count ), 1.0f );
+        assessment *= std::min( mem_combat.hostile_count / static_cast<float>( mem_combat.friendly_count ),
+                                1.0f );
         add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s adjusted danger level to %i after counting %i major hostiles vs %i friendlies.", 
                         name, static_cast<int>( assessment ), mem_combat.hostile_count, mem_combat.friendly_count );
     }
-    
     bool failed_reposition = false;
     if( mem_combat.repositioning ) {
         // this check runs each turn that the NPC is fleeing and assesses if the situation is 
@@ -846,7 +846,7 @@ void npc::assess_danger()
     }
 }
 
-void npc::npc_danger_fire( std::map<direction, float> cur_threat_map, map &here ) 
+void npc::npc_danger_fire( std::map<direction, float> cur_threat_map, map &here )
 {
     // `map::get_field` uses `field_cache`, so in general case (no fire) it provides an early exit
     const field_type_id fd_fire = ::fd_fire;
@@ -867,7 +867,6 @@ void npc::npc_danger_fire( std::map<direction, float> cur_threat_map, map &here 
 
 void npc::npc_count_friend_or_foe( Character &player_character, map &here ) {
     const bool clairvoyant = clairvoyance();
-    
     for( const npc &guy : g->all_npcs() ) {
         if( &guy == this ) {
             continue;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -446,7 +446,6 @@ void npc::assess_danger()
     int def_radius = rules.has_flag( ally_rule::follow_close ) ? follow_distance() : 6;
     bool npc_ranged = get_wielded_item() && get_wielded_item()->is_gun();
     bool npc_blind = is_blind();
-    
     // reset memory counters at the beginning of danger assessment
     mem_combat.hostile_count = 0;
     mem_combat.swarm_count = 0;


### PR DESCRIPTION
#### Summary
Features "adds short term memory to NPC danger assessments"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I started out trying to refactor assess_danger() but in the process I wound up gradually being more excited about adding more features to it instead. The features I'm adding are peppered through the function, so in the process I added more debug messages and did some cleanup.

#### Describe the solution

1. Adds a new NPC struct, npc_logic_token, which saves short term memory for the NPC. Should be reset fairly regularly, I may not add that this time. For now, I am using this to store some of the NPC's counts and tallies so that I can easily pass and modify them between the new separate methods in assess_danger().
2. Renames at least one out-of-date method that no longer does what it says it does, to avoid confusion.
3. Adds a new debug message category, "combatai", and numerous messages in this category to allow easier debugging and tracking of the combat decision making process.
4. Adds a new variable, `panic`, which is tracked in the short term and resets out of combat. Whenever an NPC makes the decision to run away from a fight, their panic increases, raising the chance that they'll decide to run next time and also increasing the duration they'll run for. If they are doing okay and decide not to run, panic decreases. The idea here is that NPCs may run for just a few squares, reassess the situation, and decide that now that they're in a better position it's worth staying and fighting.
5. Tracks if an NPC has attempted to flee or reposition on previous turns, and if this has resulted in them being in a more safe position. If it has not, they have a chance to abort attempting to flee and instead stay and fight, which rises the longer they try to flee and wind up not making any difference.

#### Describe alternatives you've considered
I still think assess_danger() could use some refactoring but I have a large enough diff here as it is.

#### Testing
Getting actual debug data reports is nice. One thing I've found out already is that assess_danger() is running *constantly* and we may be able to reduce it.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/aae37e19-8b48-4ca1-8591-bb583db3339d)

#### Additional context
