### PR TITLE
[Aftershock: Exoplanet] Revamp the Emergency Evacuation scenario to EOC-based workings.

### DIFF
--- a/data/mods/Aftershock/effects_on_condition.json
+++ b/data/mods/Aftershock/effects_on_condition.json
@@ -65,5 +65,23 @@
       },
       { "u_teleport": { "global_val": "new_map" }, "force": true }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CRASHING_SHIP_SETUP",
+    "eoc_type": "SCENARIO_SPECIFIC",
+    "effect": [ { "queue_eocs": "EOC_CRASHING_SHIP_U_DIE", "time_in_future": "7 minutes" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CRASHING_SHIP_U_DIE",
+    "condition": { "u_near_om_location": "crashing_ship_5", "range": 1 },
+    "effect": [
+      {
+        "u_message": "A large boom rocks the hull, fire engulfs the decks.  You can do nothing but watch as a wall of burning gas rushes towards you, consumes you as fast as it came, and then all is black.",
+        "popup": true
+      },
+      "u_die"
+    ]
   }
 ]

--- a/data/mods/Aftershock/maps/crashing_ship.json
+++ b/data/mods/Aftershock/maps/crashing_ship.json
@@ -202,72 +202,6 @@
         { "group": "afs_escapepod_shootout_corpse", "x": 52, "y": 32 }
       ],
       "place_rubble": [ { "x": [ 1, 4 ], "y": [ 24, 29 ], "repeat": [ 5, 20 ] } ],
-      "place_item": [
-        { "item": "afs_set_us_up_the_bomb_act", "x": 59, "y": 8, "amount": 1, "custom-flags": [ "ACTIVATE_ON_PLACE" ] },
-        {
-          "item": "afs_set_us_up_the_bomb_act",
-          "x": 25,
-          "y": 71,
-          "amount": 1,
-          "custom-flags": [ "ACTIVATE_ON_PLACE" ]
-        },
-        {
-          "item": "afs_set_us_up_the_bomb_act",
-          "x": 1,
-          "y": 16,
-          "amount": 1,
-          "custom-flags": [ "ACTIVATE_ON_PLACE" ]
-        },
-        {
-          "item": "afs_set_us_up_the_bomb_act",
-          "x": 30,
-          "y": 4,
-          "amount": 1,
-          "custom-flags": [ "ACTIVATE_ON_PLACE" ]
-        },
-        {
-          "item": "afs_set_us_up_the_bomb_act",
-          "x": 69,
-          "y": 37,
-          "amount": 1,
-          "custom-flags": [ "ACTIVATE_ON_PLACE" ]
-        },
-        {
-          "item": "afs_set_us_up_the_bomb_act",
-          "x": 41,
-          "y": 62,
-          "amount": 1,
-          "custom-flags": [ "ACTIVATE_ON_PLACE" ]
-        },
-        {
-          "item": "afs_set_us_up_the_bomb_act",
-          "x": 60,
-          "y": 57,
-          "amount": 1,
-          "custom-flags": [ "ACTIVATE_ON_PLACE" ]
-        },
-        {
-          "item": "afs_set_us_up_the_bomb_act",
-          "x": 17,
-          "y": 42,
-          "amount": 1,
-          "custom-flags": [ "ACTIVATE_ON_PLACE" ]
-        },
-        {
-          "item": "afs_set_us_up_the_bomb_act",
-          "x": 7,
-          "y": 68,
-          "amount": 1,
-          "custom-flags": [ "ACTIVATE_ON_PLACE" ]
-        },
-        {
-          "item": "afs_set_us_up_the_bomb_act",
-          "x": 40,
-          "y": 31,
-          "amount": 1,
-          "custom-flags": [ "ACTIVATE_ON_PLACE" ]
-        }
-      ],
       "place_graffiti": [
         { "text": "Barracks", "x": 10, "y": 23 },
         { "text": "Barracks", "x": 13, "y": 23 },
@@ -283,49 +217,5 @@
       "fields": { "F": { "field": "fd_fire", "intensity": 3, "age": 1 }, "x": { "field": "fd_blood", "intensity": 3 } },
       "computers": { "^": { "name": "Escape Pod", "security": 0, "options": [ { "name": "Ready Escape Pod", "action": "unlock" } ] } }
     }
-  },
-  {
-    "id": "afs_set_us_up_the_bomb",
-    "type": "TOOL",
-    "category": "weapons",
-    "name": { "str": "ship self-destruct system" },
-    "description": "You shouldn't be seeing this!",
-    "weight": "1 g",
-    "volume": "1 ml",
-    "price": 0,
-    "material": [ "steel" ],
-    "looks_like": "t_foamcrete_wall_seal",
-    "symbol": " ",
-    "color": "white",
-    "explode_in_fire": false,
-    "explosion": { "power": 90000000, "shrapnel": { "casing_mass": 1200000, "fragment_mass": 60000 } },
-    "use_action": {
-      "target": "afs_set_us_up_the_bomb_act",
-      "target_timer": "420 seconds",
-      "menu_text": "Activate fuze",
-      "type": "transform"
-    },
-    "flags": [ "BOMB", "HIDDEN_ITEM" ]
-  },
-  {
-    "id": "afs_set_us_up_the_bomb_act",
-    "type": "TOOL",
-    "category": "weapons",
-    "name": { "str": "active ship self-destruct system" },
-    "description": "You shouldn't be seeing this!",
-    "weight": "1 g",
-    "volume": "1 ml",
-    "price": 0,
-    "material": [ "steel" ],
-    "looks_like": "t_foamcrete_wall_seal",
-    "symbol": " ",
-    "color": "white",
-    "explode_in_fire": false,
-    "use_action": { "type": "message", "message": "You should be running!" },
-    "countdown_action": {
-      "type": "explosion",
-      "explosion": { "power": 90000000, "shrapnel": { "casing_mass": 1260000, "fragment_mass": 60000 } }
-    },
-    "flags": [ "BOMB", "HIDDEN_ITEM" ]
   }
 ]

--- a/data/mods/Aftershock/scenarios.json
+++ b/data/mods/Aftershock/scenarios.json
@@ -178,6 +178,7 @@
     "allowed_locs": [ "sloc_crashing_ship" ],
     "professions": [ "afs_espatier", "afs_rating", "afs_ship_escape" ],
     "flags": [ "LONE_START", "HELI_CRASH" ],
-    "start_name": "Crashing Ship"
+    "start_name": "Crashing Ship",
+    "eoc": [ "EOC_CRASHING_SHIP_SETUP" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Revamp the Emergency Evacuation scenario to EOC-based workings."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The old explosion items for the Crashing Ship weren't working, and those were causing a bug. I decided that the functionality for this could be done in EOC, and so I made it.  Resolves #69030.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove the old fake bomb items and their spawns and adds a scenario specific EOC which queues for seven minutes after the game starts. In that time, the player can run around the ship like normal and loot, before jumping in the escape pod. If you're still on the ship when this EOC triggers, a stylized death message pops up before the character dies, currently described as a fireball engulfing the interior hull, I would assume from power failures or munitions detonation. Before, the bombs wouldn't explode on time, giving the player infinite time to loot the ship and optimize.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this at all, figuring out why the bombs didn't go off, or increasing the timer from seven to ten minutes.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I went into the game and picked the scenario, stood around for seven minutes. The popup message properly triggered and killed me like I expected it to. I later started again and debug teleported to the surface above the ship, I didn't die that time. Getting off of the ship in time was another story entirely; I have created a bad habit of being a loot goblin in this game, and I died a few times to my own management skills.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
While you should be able to loot if you can manage it, large items that can't fit in your inventory are deleted upon launching by the escape pod; #69449.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
