### PR TITLE
Allow overmap autotravel to evac center & hub01

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain.json
@@ -46,6 +46,7 @@
     "sym": "#",
     "color": "brown",
     "see_cost": 5,
+    "travel_cost_type": "impassable",
     "flags": [ "NO_ROTATE" ]
   },
   {
@@ -57,6 +58,7 @@
     "sym": "%",
     "color": "dark_gray",
     "see_cost": 5,
+    "travel_cost_type": "impassable",
     "flags": [ "NO_ROTATE" ]
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_agricultural.json
@@ -4,6 +4,7 @@
     "abstract": "generic_rural_road",
     "name": "rural road",
     "color": "brown",
+    "travel_cost_type": "dirt_road",
     "see_cost": 2,
     "mondensity": 2
   },

--- a/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_hardcoded.json
@@ -5,6 +5,7 @@
     "name": "open air",
     "sym": ".",
     "color": "blue",
+    "travel_cost_type": "air",
     "flags": [ "NO_ROTATE" ]
   },
   {
@@ -17,6 +18,7 @@
     "see_cost": 2,
     "extras": "field",
     "spawns": { "group": "GROUP_FOREST", "population": [ 0, 1 ], "chance": 13 },
+    "travel_cost_type": "field",
     "flags": [ "NO_ROTATE" ]
   },
   {
@@ -29,6 +31,7 @@
     "see_cost": 3,
     "extras": "forest",
     "spawns": { "group": "GROUP_FOREST", "population": [ 0, 3 ], "chance": 13 },
+    "travel_cost_type": "forest",
     "flags": [ "NO_ROTATE", "SOURCE_FORAGE" ]
   },
   {
@@ -55,6 +58,7 @@
     "extras": "forest_water",
     "spawns": { "group": "GROUP_SWAMP", "population": [ 2, 6 ], "chance": 50 },
     "mapgen": [ { "method": "builtin", "name": "forest" } ],
+    "travel_cost_type": "swamp",
     "flags": [ "NO_ROTATE", "SOURCE_FORAGE", "RISK_HIGH" ]
   },
   {
@@ -159,6 +163,7 @@
     "sym": "%",
     "color": "dark_gray",
     "see_cost": 5,
+    "travel_cost_type": "impassable",
     "flags": [ "NO_ROTATE" ]
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_microlab.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_microlab.json
@@ -16,6 +16,7 @@
     "sym": "%",
     "color": "dark_gray",
     "see_cost": 5,
+    "travel_cost_type": "impassable",
     "flags": [ "NO_ROTATE", "RISK_HIGH", "SOURCE_CHEMISTRY", "SOURCE_MEDICINE" ]
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_river.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_river.json
@@ -13,6 +13,7 @@
     "type": "overmap_terrain",
     "abstract": "generic_river_bank",
     "copy-from": "generic_river",
+    "travel_cost_type": "shore",
     "name": "river bank",
     "color": "light_blue"
   },
@@ -20,6 +21,7 @@
     "type": "overmap_terrain",
     "id": "river_center",
     "copy-from": "generic_river",
+    "travel_cost_type": "water",
     "mapgen": [ { "method": "builtin", "name": "river_center" } ]
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_robofachq.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_robofachq.json
@@ -29,7 +29,8 @@
     "name": "meteorology station",
     "sym": "─",
     "color": "dark_gray",
-    "see_cost": 1
+    "see_cost": 1,
+    "travel_cost_type": "road"
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_special.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_special.json
@@ -146,7 +146,8 @@
     "name": "road",
     "looks_like": "road",
     "color": "dark_gray",
-    "see_cost": 1
+    "see_cost": 1,
+    "travel_cost_type": "road"
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -6,6 +6,7 @@
     "copy-from": "generic_transportation",
     "color": "dark_gray",
     "see_cost": 2,
+    "travel_cost_type": "road",
     "extras": "road",
     "flags": [ "LINEAR", "REQUIRES_PREDECESSOR" ]
   },
@@ -17,6 +18,7 @@
     "sym": "┼",
     "color": "yellow",
     "see_cost": 2,
+    "travel_cost_type": "road",
     "extras": "road_nesw_manhole",
     "flags": [ "KNOWN_DOWN", "NO_ROTATE" ]
   },
@@ -28,6 +30,7 @@
     "sym": "┼",
     "color": "dark_gray",
     "see_cost": 2,
+    "travel_cost_type": "road",
     "extras": "city_center",
     "flags": [ "NO_ROTATE" ]
   },
@@ -45,12 +48,14 @@
     "id": "bridge",
     "copy-from": "generic_bridge",
     "color": "blue",
+    "travel_cost_type": "water",
     "flags": [ "RIVER" ]
   },
   {
     "type": "overmap_terrain",
     "id": "bridge_road",
     "copy-from": "generic_bridge",
+    "travel_cost_type": "road",
     "name": "bridge (overpass)"
   },
   {
@@ -59,6 +64,7 @@
     "copy-from": "generic_bridge",
     "name": "bridgehead (ground)",
     "sym": "v",
+    "travel_cost_type": "road",
     "extras": "bridgehead_ground"
   },
   {
@@ -72,6 +78,7 @@
     "type": "overmap_terrain",
     "id": "bridgehead_ramp",
     "copy-from": "generic_bridge",
+    "travel_cost_type": "road",
     "name": "bridgehead (ramp)",
     "sym": "^"
   },
@@ -109,6 +116,7 @@
     "mapgen_end": [ { "method": "builtin", "name": "forest_trail_straight" } ],
     "mapgen_tee": [ { "method": "builtin", "name": "forest_trail_tee" } ],
     "mapgen_four_way": [ { "method": "builtin", "name": "forest_trail_four_way" } ],
+    "travel_cost_type": "trail",
     "flags": [ "LINEAR" ],
     "land_use_code": "forest"
   },
@@ -180,6 +188,7 @@
     "mapgen_tee": [ { "method": "builtin", "name": "subway_tee" } ],
     "mapgen_four_way": [ { "method": "builtin", "name": "subway_four_way" } ],
     "spawns": { "group": "GROUP_SUBWAY", "population": [ 1, 3 ], "chance": 66 },
+    "travel_cost_type": "dirt_road",
     "flags": [ "LINEAR" ]
   },
   {
@@ -195,6 +204,7 @@
     "mapgen_tee": [ { "method": "builtin", "name": "subway_tee" } ],
     "mapgen_four_way": [ { "method": "builtin", "name": "subway_four_way" } ],
     "spawns": { "group": "GROUP_SUBWAY_LAB", "population": [ 1, 3 ], "chance": 50 },
+    "travel_cost_type": "dirt_road",
     "flags": [ "LINEAR" ]
   },
   {

--- a/data/json/overmap/overmap_terrain/overmap_terrain_waterbody.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_waterbody.json
@@ -18,12 +18,14 @@
     "delete": { "flags": [ "LAKE" ] },
     "extend": { "flags": [ "LAKE_SHORE" ] },
     "extras": "lake_shore",
+    "travel_cost_type": "shore",
     "mapgen": [ { "method": "builtin", "name": "lake_shore" } ]
   },
   {
     "type": "overmap_terrain",
     "id": "lake_surface",
-    "copy-from": "generic_lake"
+    "copy-from": "generic_lake",
+    "travel_cost_type": "water"
   },
   {
     "type": "overmap_terrain",

--- a/doc/OVERMAP.md
+++ b/doc/OVERMAP.md
@@ -233,7 +233,7 @@ rotation for the referenced overmap terrains (e.g. the `_north` version for all)
 | `looks_like`      | Id of another overmap terrain to be used for the graphical tile, if this doesn't have one.       |
 | `connect_group`   | Specify that this overmap terrain might be graphically connected to its neighbours, should a tileset wish to.  It will connect to any other `overmap_terrain` with the same `connect_group`. |
 | `see_cost`        | Affects player vision on overmap. Higher values obstruct vision more.                            |
-| `travel_cost`     | Affects pathfinding cost. Higher values are harder to travel through (reference: Forest = 10 )   |
+| `travel_cost_type` | How to treat this location when planning a route using autotravel on the overmap. Valid values are `road`,`field`,`dirt_road`,`trail`,`forest`,`shore`,`swamp`,`water`,`air`,`impassable`,`other`. Some types are harder to travel through with different types of vehicles, or on foot. |
 | `extras`          | Reference to a named `map_extras` in region_settings, defines which map extras can be applied.   |
 | `mondensity`      | Summed with values for adjacent overmap terrains to influence density of monsters spawned here.  |
 | `spawns`          | Spawns added once at mapgen. Monster group, % chance, population range (min/max).                |
@@ -272,6 +272,7 @@ an exhaustive example...
     "mapgen_end": [ { "method": "builtin", "name": "road_end" } ],
     "mapgen_tee": [ { "method": "builtin", "name": "road_tee" } ],
     "mapgen_four_way": [ { "method": "builtin", "name": "road_four_way" } ],
+    "travel_cost_type": "field",
     "eoc": {
       "id": "EOC_REFUGEE_CENTER_GENERATE",
       "condition": { "compare_num": [ { "global_val": "var", "var_name": "refugee_centers", "default": 0 }, "<", { "const": 1 } ] },

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -217,6 +217,26 @@ struct enum_traits<oter_flags> {
     static constexpr oter_flags last = oter_flags::num_oter_flags;
 };
 
+enum class oter_travel_cost_type : int {
+    other,
+    impassable,
+    road,
+    field,
+    dirt_road,
+    trail,
+    forest,
+    shore,
+    swamp,
+    water,
+    air,
+    last
+};
+
+template<>
+struct enum_traits<oter_travel_cost_type> {
+    static constexpr oter_travel_cost_type last = oter_travel_cost_type::last;
+};
+
 struct oter_type_t {
     public:
         static const oter_type_t null_type;
@@ -229,7 +249,8 @@ struct oter_type_t {
         overmap_land_use_code_id land_use_code = overmap_land_use_code_id::NULL_ID();
         std::vector<std::string> looks_like;
         unsigned char see_cost = 0;     // Affects how far the player can see in the overmap
-        unsigned char travel_cost = 5;  // Affects the pathfinding and travel times
+        oter_travel_cost_type travel_cost_type =
+            oter_travel_cost_type::other;  // Affects the pathfinding and travel times
         std::string extras = "none";
         int mondensity = 0;
         effect_on_condition_id entry_EOC;
@@ -334,8 +355,8 @@ struct oter_t {
         unsigned char get_see_cost() const {
             return type->see_cost;
         }
-        unsigned char get_travel_cost() const {
-            return type->travel_cost;
+        oter_travel_cost_type get_travel_cost_type() const {
+            return type->travel_cost_type;
         }
 
         const std::string &get_extras() const {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -725,6 +725,32 @@ std::string oter_type_t::get_symbol() const
     return utf32_to_utf8( symbol );
 }
 
+namespace io
+{
+template<>
+std::string enum_to_string<oter_travel_cost_type>( oter_travel_cost_type data )
+{
+    switch( data ) {
+        // *INDENT-OFF*
+        case oter_travel_cost_type::other: return "other";
+        case oter_travel_cost_type::road: return "road";
+        case oter_travel_cost_type::field: return "field";
+        case oter_travel_cost_type::dirt_road: return "dirt_road";
+        case oter_travel_cost_type::trail: return "trail";
+        case oter_travel_cost_type::forest: return "forest";
+        case oter_travel_cost_type::shore: return "shore";
+        case oter_travel_cost_type::swamp: return "swamp";
+        case oter_travel_cost_type::water: return "water";
+        case oter_travel_cost_type::air: return "air";
+        case oter_travel_cost_type::impassable: return "impassable";
+        // *INDENT-ON*
+        case oter_travel_cost_type::last:
+            break;
+    }
+    cata_fatal( "Invalid oter_travel_cost_type" );
+}
+} // namespace io
+
 void oter_type_t::load( const JsonObject &jo, const std::string &src )
 {
     const bool strict = src == "dda";
@@ -733,7 +759,6 @@ void oter_type_t::load( const JsonObject &jo, const std::string &src )
 
     assign( jo, "name", name, strict );
     assign( jo, "see_cost", see_cost, strict );
-    assign( jo, "travel_cost", travel_cost, strict );
     assign( jo, "extras", extras, strict );
     assign( jo, "mondensity", mondensity, strict );
     assign( jo, "entry_eoc", entry_EOC, strict );
@@ -759,6 +784,7 @@ void oter_type_t::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "flags", flags, flag_reader );
 
     optional( jo, was_loaded, "connect_group", connect_group, string_reader{} );
+    optional( jo, was_loaded, "travel_cost_type", travel_cost_type, oter_travel_cost_type::other );
 
     if( has_flag( oter_flags::line_drawing ) ) {
         if( has_flag( oter_flags::no_rotate ) ) {

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -1698,7 +1698,7 @@ static std::vector<tripoint_abs_omt> get_overmap_path_to( const tripoint_abs_omt
         // already in water or going to a water tile
         if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, player_character.pos() ) ||
             is_river_or_lake( dest_ter ) ) {
-            params.water_cost = 100;
+            params.set_cost( oter_travel_cost_type::water, 100 );
         }
     }
     // literal "edge" case: the vehicle may be in a different OMT than the player

--- a/src/overmapbuffer.h
+++ b/src/overmapbuffer.h
@@ -38,20 +38,17 @@ struct radio_tower;
 struct regional_settings;
 
 struct overmap_path_params {
-    int road_cost = -1;
-    int field_cost = -1;
-    int dirt_road_cost = -1;
-    int trail_cost = -1;
-    int forest_cost = -1;
-    int small_building_cost = -1;
-    int shore_cost = -1;
-    int swamp_cost = -1;
-    int water_cost = -1;
-    int air_cost = -1;
-    int other_cost = -1;
+    std::map<oter_travel_cost_type, int> travel_cost_per_type;
     bool avoid_danger = true;
     bool only_known_by_player = true;
 
+    void set_cost( const oter_travel_cost_type &type, int v ) {
+        travel_cost_per_type.emplace( type, v );
+    }
+    int get_cost( const oter_travel_cost_type &type ) const {
+        auto it = travel_cost_per_type.find( type );
+        return it != travel_cost_per_type.end() ? it->second : -1;
+    }
     static constexpr int standard_cost = 10;
     static overmap_path_params for_player();
     static overmap_path_params for_npc();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Allow overmap autotravel to evac center & hub01"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Allows overmap autotravel pathfinder to find a path on the road segments leading into evac center, and the four road segments on hub01.
* Unhardcodes list of selected overmap terrains that affected autotravel cost. Instead, the cost type is moved to a new json field `travel_cost_type`.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The new overmap_terrain json field `travel_cost_type` specifies how the terrain will be handled by the overmap autotravel pathfinder. It replaces previous (unused) json field `travel_cost`. It's worth noting that the actual travel cost for a particular type of terrain depends on the type of vehicle being used, or if on foot. Hence the suggested name `travel_cost_type` instead of just `travel_cost`.
    
This change moves the previously hardcoded list of terrain ids in `overmapbuffer.cpp` function `get_terrain_cost` so that those terrains instead specify a corresponding `travel_cost_type` in json.

This change is split into two commits: one that unhardcodes the above function, and another one that makes the evac-center & hub01 roads work as regular roads for the overmap autotravel pathfinder.

Intended effect is also to prepare for terrains that we will create in the future, so that it's possible to make them work well with the overmap autotravel pathfinder. The second commit in this change shows how we can do that for other terrains (by only adding `travel_cost_type` to json).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* Not particularly satisfied with the name `oter_travel_cost_type` for the enum, the name feels a bit long. Could have used some abbreviations perhaps?

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Verifying that the new things work:
* Using a car. Used overmap autotravel pathfinder to plan a route that uses the road leading into the evac center. ✔
* Using a car. Used overmap autotravel pathfinder to plan a route to the road tile outside hub01 intercom ✔

Verifying that existing things did not break:
* Drove around in a car a bit on regular roads. Works as before. ✔
* Drove around in a car a bit on farmland dirt roads. Works as before. ✔
* Drove around in a car a bit on fields and used pathfinder to plan a route using both fields, dirt roads and regular roads. Works as before. ✔
* Rode a canoe on a lake. It only finds paths on the lake (not on land). Works as before. ✔
* Planned an autotravel path on a river in a canoe. It correctly chooses a path on the river tiles and avoids shores. ✔
* Rode the canoe under a bridge. It correctly plans an autotravel path under the bridge. ✔

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
