### PR TITLE
Allow NPCs to teleport without the player

### DIFF
--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -390,10 +390,7 @@
       {
         "if": { "u_query_tile": "anywhere", "target_var": { "context_val": "loc" }, "message": "Select point" },
         "then": {
-          "run_eoc_with": {
-            "id": "EOC_teleport_test_other_do",
-            "effect": { "npc_teleport": { "global_val": "teleport_test_pos" }, "force": false, "safe": false }
-          },
+          "run_eoc_with": { "id": "EOC_teleport_test_other_do", "effect": { "npc_teleport": { "global_val": "teleport_test_pos" } } },
           "beta_loc": { "context_val": "loc" }
         },
         "else": { "u_message": "Canceled" }

--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -353,5 +353,51 @@
         "else": { "u_message": "Canceled" }
       }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_teleport_test",
+    "effect": [
+      {
+        "run_eoc_selector": [ "EOC_teleport_test_setloc", "EOC_teleport_test_do", "EOC_teleport_test_other" ],
+        "names": [ "Set location", "Teleport", "Teleport other" ],
+        "keys": [ "a", "b", "c" ],
+        "descriptions": [ "Set location", "Teleport", "Teleport other" ],
+        "allow_cancel": true
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_teleport_test_setloc",
+    "effect": [
+      {
+        "if": { "u_query_tile": "anywhere", "target_var": { "global_val": "teleport_test_pos" }, "message": "Select point" },
+        "then": { "u_message": "<global_val:pos>" },
+        "else": { "u_message": "Canceled" }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_teleport_test_do",
+    "effect": [ { "u_teleport": { "global_val": "teleport_test_pos" }, "force": false, "safe": false } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_teleport_test_other",
+    "effect": [
+      {
+        "if": { "u_query_tile": "anywhere", "target_var": { "context_val": "loc" }, "message": "Select point" },
+        "then": {
+          "run_eoc_with": {
+            "id": "EOC_teleport_test_other_do",
+            "effect": { "npc_teleport": { "global_val": "teleport_test_pos" }, "force": false, "safe": false }
+          },
+          "beta_loc": { "context_val": "loc" }
+        },
+        "else": { "u_message": "Canceled" }
+      }
+    ]
   }
 ]

--- a/data/json/effects_on_condition/example_eocs.json
+++ b/data/json/effects_on_condition/example_eocs.json
@@ -381,7 +381,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_teleport_test_do",
-    "effect": [ { "u_teleport": { "global_val": "teleport_test_pos" }, "force": false, "safe": false } ]
+    "effect": [ { "u_teleport": { "global_val": "teleport_test_pos" } } ]
   },
   {
     "type": "effect_on_condition",

--- a/src/teleport.cpp
+++ b/src/teleport.cpp
@@ -199,14 +199,17 @@ bool teleport::teleport_to_point( Creature &critter, tripoint target, bool safe,
     }
     //player and npc exclusive teleporting effects
     if( p ) {
-        g->place_player( p->pos() );
         if( add_teleglow ) {
             p->add_effect( effect_teleglow, 30_minutes );
         }
     }
     if( c_is_u ) {
         g->update_map( *p );
-    }
+   } else {
+        if( shifted ) {
+            g->place_player_overmap( project_to<coords::omt>( avatar_pos ), false );
+        }
+   }
     for( const effect &grab : critter.get_effects_with_flag( json_flag_GRAB ) ) {
         critter.remove_effect( grab.get_id() );
     }


### PR DESCRIPTION
#### Summary
Bugfixes "Allow NPCs to teleport without the player"

#### Purpose of change
Allow npcs to teleport without dragging the player with them. 

#### Describe the solution
Code was suggested by lispcoc in issue #69362

#### Testing
Tested to work with the EOCs included in #69364 