### PR TITLE
[Aftershock: Exoplanet] Allow escape pods to carry loot planetside

### DIFF
--- a/data/mods/Aftershock/effects_on_condition.json
+++ b/data/mods/Aftershock/effects_on_condition.json
@@ -52,15 +52,20 @@
     "id": "EOC_ESCAPE_POD_CHAIR",
     "effect": [
       {
-        "u_location_variable": { "global_val": "new_map" },
-        "target_params": { "om_terrain": "afs_crashed_escape_pod", "search_range": 500, "z": 0 },
-        "terrain": "t_metal_floor",
-        "target_max_radius": 30,
-        "min_radius": 0,
-        "max_radius": 0
+        "u_location_variable": { "context_val": "escape_pod_crate" },
+        "target_params": { "om_terrain": "crashing_ship_4", "search_range": 10, "z": -10 },
+        "terrain": "t_escape_pod_floor",
+        "target_max_radius": 24
       },
       {
-        "u_message": "You make sure there are no lose items in the pod that would become projectiles during launch before you strap yourself into the escape pod seat and press the launch button.  With an incredibly loud roar and a massive acceleration that presses you into the seat, the escape pod fires from the ship, plummeting towards the planet below.",
+        "u_map_run_item_eocs": "all",
+        "loc": { "context_val": "escape_pod_crate" },
+        "min_radius": 0,
+        "max_radius": 0,
+        "true_eocs": [ { "id": "EOC_AFS_ESCAPE_POD_CARGO_TP", "effect": [ { "npc_teleport": { "global_val": "new_map" } } ] } ]
+      },
+      {
+        "u_message": "You make sure there are no lose items in the pod outside the cargo space that would become projectiles during launch before you strap yourself into the escape pod seat and press the launch button.  With an incredibly loud roar and a massive acceleration that presses you into the seat, the escape pod fires from the ship, plummeting towards the planet below.",
         "popup": true
       },
       { "u_teleport": { "global_val": "new_map" }, "force": true }
@@ -68,9 +73,24 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_AFS_ESCAPE_POD_CARGO_TP",
+    "effect": [ { "u_teleport": { "global_val": "new_map" }, "force": true } ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_CRASHING_SHIP_SETUP",
     "eoc_type": "SCENARIO_SPECIFIC",
-    "effect": [ { "queue_eocs": "EOC_CRASHING_SHIP_U_DIE", "time_in_future": "7 minutes" } ]
+    "effect": [
+      {
+        "u_location_variable": { "global_val": "new_map" },
+        "target_params": { "om_terrain": "afs_crashed_escape_pod", "search_range": 500, "z": 0 },
+        "terrain": "t_metal_floor",
+        "target_max_radius": 30,
+        "min_radius": 0,
+        "max_radius": 0
+      },
+      { "queue_eocs": "EOC_CRASHING_SHIP_U_DIE", "time_in_future": "7 minutes" }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/Aftershock/effects_on_condition.json
+++ b/data/mods/Aftershock/effects_on_condition.json
@@ -65,7 +65,7 @@
         "true_eocs": [ { "id": "EOC_AFS_ESCAPE_POD_CARGO_TP", "effect": [ { "npc_teleport": { "global_val": "new_map" } } ] } ]
       },
       {
-        "u_message": "You make sure there are no lose items in the pod outside the cargo space that would become projectiles during launch before you strap yourself into the escape pod seat and press the launch button.  With an incredibly loud roar and a massive acceleration that presses you into the seat, the escape pod fires from the ship, plummeting towards the planet below.",
+        "u_message": "You make sure that all equipment is strapped down and loose items are put away to avoid projectiles during launch before you strap yourself into the escape pod seat and press the launch button.  With an incredibly loud roar and a massive acceleration that presses you into the seat, the escape pod fires from the ship, plummeting towards the planet below.",
         "popup": true
       },
       { "u_teleport": { "global_val": "new_map" }, "force": true }

--- a/data/mods/Aftershock/maps/crashing_ship.json
+++ b/data/mods/Aftershock/maps/crashing_ship.json
@@ -150,7 +150,8 @@
         "j": "t_chaingate_l",
         "W": "t_reinforced_glass_shutter",
         "P": "t_foamcrete_wall_seal",
-        "p": "t_foamcrete_floor_seal"
+        "p": "t_foamcrete_floor_seal",
+        "z": "t_escape_pod_floor"
       },
       "place_zones": [ { "type": "ZONE_START_POINT", "faction": "your_followers", "x": 19, "y": 14 } ],
       "set": [ { "point": "trap", "id": "tr_escape_pod", "x": 68, "y": 42 } ],

--- a/data/mods/Aftershock/maps/furniture_and_terrain/terrain_spaceship.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/terrain_spaceship.json
@@ -67,6 +67,19 @@
   },
   {
     "type": "terrain",
+    "id": "t_escape_pod_floor",
+    "name": "escape pod floor",
+    "description": "A relatively flat slab of heat-treated metal, designed to withstand the crushing pressure of space and the searing heat of reentry.",
+    "symbol": ".",
+    "color": "light_gray",
+    "looks_like": "t_rock_floor",
+    "move_cost": 2,
+    "roof": "t_open_air",
+    "flags": [ "TRANSPARENT", "FLAT", "ROAD" ],
+    "bash": { "ter_set": "t_null", "str_min": 75, "str_max": 400, "str_min_supported": 30, "bash_below": true }
+  },
+  {
+    "type": "terrain",
     "id": "t_afs_space_ship_hatch_c",
     "name": "closed spaceship hatch",
     "description": "An armored and airtight spaceship hatch.  A side mounted lever allows for its manual operation.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Allow escape pods to carry loot planetside."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Resolve #69449, and up the looting aspect of the scenario.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Using the code that @John-Candlebury recommended me in #69364, I refurbished the scenario EOC to assign the mission target prior to launch, and ~stole~ borrowed some of the Augustmoon EOCs to properly transport items within the pod. Now, the player can throw some things in there and take them planetside.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Started the game, ran like a chicken without a head to loot, and took some tools with me to Salus IV within the escape pod.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Having loose items inside a high-velocity pod is quite problematic, so I assumed that it came with equipment straps and storage boxes to tie them down; the Type II Survival Kit had to go somewhere. I'm also not sure if having a Type II Survival Kit in addition to the loot you can grab off of the ship is too much for a balanced start, but since Salus IV is an extremely unforgiving environment, I guess it should balance out.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
