### PR TITLE
Fully `math`-ify Defense Mode 

### DIFF
--- a/data/mods/Defense_Mode/eocs.json
+++ b/data/mods/Defense_Mode/eocs.json
@@ -3,7 +3,7 @@
     "type": "effect_on_condition",
     "id": "scenario_defense_mode",
     "eoc_type": "SCENARIO_SPECIFIC",
-    "deactivate_condition": { "compare_num": [ { "global_val": "var", "var_name": "wave_number" }, ">=", { "const": 1 } ] },
+    "deactivate_condition": { "math": [ "wave_number", ">=", "1" ] },
     "effect": [
       { "open_dialogue": { "topic": "TALK_DEFENSE_MODE_MAIN_MENU" } },
       { "u_message": "Get ready for the first wave, it's not that far away!", "type": "good", "popup": true },
@@ -35,17 +35,11 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "defense_mode_money_add",
-    "global": true,
-    "effect": [ { "math": [ "wave_cash", "=", "wave_cash_number * -1000" ] } ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "defense_mode_money_add_npc",
     "global": false,
     "condition": { "not": { "npc_has_var": "u_got_money", "type": "general", "context": "trade", "value": "yes" } },
     "effect": [
-      { "u_spend_cash": { "global_val": "wave_cash" } },
+      { "u_spend_cash": { "math": [ "wave_number * -1000" ] } },
       { "npc_add_var": "u_got_money", "type": "general", "context": "trade", "value": "yes" }
     ]
   },
@@ -56,10 +50,9 @@
     "global": true,
     "effect": [
       { "u_teleport": { "global_val": "your_spawnpoint" } },
-      { "arithmetic": [ { "global_val": "var", "var_name": "wave_number" }, "+=", { "const": 1 } ] },
-      { "math": [ "wave_cash_number", "++" ] },
+      { "math": [ "wave_number", "++" ] },
       { "u_message": "Welcome to wave <global_val:wave_number>!", "type": "bad", "popup": false },
-      { "run_eocs": [ "defense_mode_money_add", "DEFENSE_MODE_WAVE_SPECIAL_DECIDER" ] }
+      { "run_eocs": "DEFENSE_MODE_WAVE_SPECIAL_DECIDER" }
     ]
   },
   {
@@ -69,10 +62,10 @@
     "//": "This is used to decide for special waves, like shadow spawns and ultimate victory.",
     "condition": {
       "or": [
-        { "compare_num": [ { "global_val": "var", "var_name": "wave_number" }, "==", { "const": 5 } ] },
-        { "compare_num": [ { "global_val": "var", "var_name": "wave_number" }, "==", { "const": 15 } ] },
-        { "compare_num": [ { "global_val": "var", "var_name": "wave_number" }, "==", { "const": 30 } ] },
-        { "compare_num": [ { "global_val": "var", "var_name": "wave_number" }, "==", { "const": 50 } ] }
+        { "math": [ "wave_number", "==", "5" ] },
+        { "math": [ "wave_number", "==", "15" ] },
+        { "math": [ "wave_number", "==", "30" ] },
+        { "math": [ "wave_number", "==", "50" ] }
       ]
     },
     "effect": [
@@ -122,7 +115,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -130,7 +123,7 @@
       },
       {
         "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -138,7 +131,7 @@
       },
       {
         "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -154,7 +147,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_ZOMBIE",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -162,7 +155,7 @@
       },
       {
         "u_spawn_monster": "GROUP_ZOMBIE",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -170,7 +163,7 @@
       },
       {
         "u_spawn_monster": "GROUP_ZOMBIE",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -186,7 +179,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_SPIDER_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -194,7 +187,7 @@
       },
       {
         "u_spawn_monster": "GROUP_SPIDER_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -202,7 +195,7 @@
       },
       {
         "u_spawn_monster": "GROUP_SPIDER_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -218,7 +211,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_ROBOT_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -226,7 +219,7 @@
       },
       {
         "u_spawn_monster": "GROUP_ROBOT_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -234,7 +227,7 @@
       },
       {
         "u_spawn_monster": "GROUP_ROBOT_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -250,7 +243,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_TRIFFID_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -258,7 +251,7 @@
       },
       {
         "u_spawn_monster": "GROUP_TRIFFID_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -266,7 +259,7 @@
       },
       {
         "u_spawn_monster": "GROUP_TRIFFID_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -282,7 +275,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_NETHER_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -290,7 +283,7 @@
       },
       {
         "u_spawn_monster": "GROUP_NETHER_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -298,7 +291,7 @@
       },
       {
         "u_spawn_monster": "GROUP_NETHER_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -310,11 +303,11 @@
   {
     "type": "effect_on_condition",
     "id": "DEFENSE_MODE_WAVE_SPECIAL_FERALS",
-    "condition": { "compare_num": [ { "global_val": "var", "var_name": "wave_number" }, "==", { "const": 5 } ] },
+    "condition": { "math": [ "wave_number", "==", "5" ] },
     "effect": [
       {
         "u_spawn_monster": "GROUP_FERAL",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -322,7 +315,7 @@
       },
       {
         "u_spawn_monster": "GROUP_FERAL",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -330,7 +323,7 @@
       },
       {
         "u_spawn_monster": "GROUP_FERAL",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -346,11 +339,11 @@
   {
     "type": "effect_on_condition",
     "id": "DEFENSE_MODE_WAVE_SPECIAL_RATKIN",
-    "condition": { "compare_num": [ { "global_val": "var", "var_name": "wave_number" }, "==", { "const": 15 } ] },
+    "condition": { "math": [ "wave_number", "==", "15" ] },
     "effect": [
       {
         "u_spawn_monster": "GROUP_RATKIN_EVOLVED",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -358,7 +351,7 @@
       },
       {
         "u_spawn_monster": "GROUP_RATKIN_EVOLVED",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -366,7 +359,7 @@
       },
       {
         "u_spawn_monster": "GROUP_RATKIN_EVOLVED",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -382,11 +375,11 @@
   {
     "type": "effect_on_condition",
     "id": "DEFENSE_MODE_WAVE_SPECIAL_MILITARY",
-    "condition": { "compare_num": [ { "global_val": "var", "var_name": "wave_number" }, "==", { "const": 30 } ] },
+    "condition": { "math": [ "wave_number", "==", "30" ] },
     "effect": [
       {
         "u_spawn_monster": "GROUP_MIL_HELIPAD",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -394,7 +387,7 @@
       },
       {
         "u_spawn_monster": "GROUP_MIL_HELIPAD",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -402,7 +395,7 @@
       },
       {
         "u_spawn_monster": "GROUP_MIL_HELIPAD",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -418,7 +411,7 @@
   {
     "type": "effect_on_condition",
     "id": "DEFENSE_MODE_WAVE_SPECIAL_SHADOW",
-    "condition": { "compare_num": [ { "global_val": "var", "var_name": "wave_number" }, "==", { "const": 50 } ] },
+    "condition": { "math": [ "wave_number", "==", "50" ] },
     "effect": [
       { "u_spawn_monster": "mon_boss_shadow", "real_count": 1, "outdoor_only": true, "min_radius": 20, "max_radius": 40 },
       {

--- a/data/mods/Defense_Mode/mod_interactions/DinoMod/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/DinoMod/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_DINOSAUR_DANGEROUS",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_DINOSAUR_DANGEROUS",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
       },
       {
         "u_spawn_monster": "GROUP_DINOSAUR_DANGEROUS",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Magiclysm/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Magiclysm/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_LIZARDFOLK_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_LIZARDFOLK_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
       },
       {
         "u_spawn_monster": "GROUP_LIZARDFOLK_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -38,7 +38,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_GOLEM_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -46,7 +46,7 @@
       },
       {
         "u_spawn_monster": "GROUP_GOLEM_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -54,7 +54,7 @@
       },
       {
         "u_spawn_monster": "GROUP_GOLEM_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -70,7 +70,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_GOBLIN_STANDARD",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -78,7 +78,7 @@
       },
       {
         "u_spawn_monster": "GROUP_GOBLIN_STANDARD",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -86,7 +86,7 @@
       },
       {
         "u_spawn_monster": "GROUP_GOBLIN_STANDARD",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -102,7 +102,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_ORC_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -110,7 +110,7 @@
       },
       {
         "u_spawn_monster": "GROUP_ORC_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -118,7 +118,7 @@
       },
       {
         "u_spawn_monster": "GROUP_ORC_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Megafauna/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Megafauna/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_MEGAFAUNA_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_MEGAFAUNA_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
       },
       {
         "u_spawn_monster": "GROUP_MEGAFAUNA_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/MindOverMatter/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/MindOverMatter/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_FERAL_PSYCHIC_DM",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
       },
       {
         "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/My_Sweet_Cataclysm/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/My_Sweet_Cataclysm/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_SWEET_HORDE",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_SWEET_HORDE",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
       },
       {
         "u_spawn_monster": "GROUP_SWEET_HORDE",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Mythos/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Mythos/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_MYTHOS_SPAWN",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_MYTHOS_SPAWN",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
       },
       {
         "u_spawn_monster": "GROUP_MYTHOS_SPAWN",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Xedra_Evolved/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Xedra_Evolved/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_EXODII",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_EXODII",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
       },
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_EXODII",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -38,7 +38,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_XEDRA",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -46,7 +46,7 @@
       },
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_XEDRA",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -54,7 +54,7 @@
       },
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_XEDRA",
-        "real_count": { "global_val": "wave_number", "default": 1 },
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/MindOverMatter/modinteractions/Defense_Mode/premonition_instances.json
+++ b/data/mods/MindOverMatter/modinteractions/Defense_Mode/premonition_instances.json
@@ -36,10 +36,9 @@
     "global": true,
     "effect": [
       { "u_teleport": { "global_val": "your_spawnpoint" } },
-      { "arithmetic": [ { "global_val": "var", "var_name": "wave_number" }, "+=", { "const": 1 } ] },
-      { "math": [ "wave_cash_number", "++" ] },
+      { "math": [ "wave_number", "++" ] },
       { "u_message": "Welcome to wave <global_val:wave_number>!", "type": "bad", "popup": false },
-      { "run_eocs": [ "defense_mode_money_add", "DEFENSE_MODE_WAVE_SPECIAL_DECIDER" ] }
+      { "run_eocs": "DEFENSE_MODE_WAVE_SPECIAL_DECIDER" }
     ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Fully math-ify Defense Mode. "
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Defense Mode still relied on a bunch of functions that were slated for obsoletion, like `arithmetic`, `compare_num`, and `compare_int`. Now that I know how to define global variables with `math`, I decided to change this and update the syntax to modern standards.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Replace all the remaining `arithmetic`, `compare_num`, and `compare_int` functions with `math` equivalents and update some old EOCs to work better with `math`.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this and keeping the outdated syntax.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Played the game, everything ran as normal. Merchants got their cash, waves spawned, and characters died.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None at this time.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
