### PR TITLE
supress an uninitialized variable warning

### DIFF
--- a/src/pickup.cpp
+++ b/src/pickup.cpp
@@ -492,7 +492,7 @@ void Pickup::pick_info::serialize( JsonOut &jsout ) const
 
 void Pickup::pick_info::deserialize( const JsonObject &jsobj )
 {
-    int src_type_;
+    int src_type_ = 0;
     jsobj.read( "total_bulk_volume", total_bulk_volume );
     jsobj.read( "src_type", src_type_ );
     src_type = static_cast<item_location::type>( src_type_ );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Hopefully resolve the build warning that is escalated to an error in the object creator build. 
```
  src/pickup.cpp: In member function 'void Pickup::pick_info::deserialize(const JsonObject&)':
  src/pickup.cpp:498:14: error: 'src_type_' may be used uninitialized [-Werror=maybe-uninitialized]
    498 |     src_type = static_cast<item_location::type>( src_type_ );
        |     ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  src/pickup.cpp:495:9: note: 'src_type_' declared here
    495 |     int src_type_;
        |         ^~~~~~~~~
  ```

#### Describe the solution
Initialize the variable to zero. 

#### Additional context
This is preventing the workflow that publishes releases to cataclysmdda.org from running. 