### PR TITLE
Make Aftershock and Aftershock: Exoplanet compatible with Defense Mode

### DIFF
--- a/data/mods/Aftershock/mod_interactions/Defense_Mode/monstergroups.json
+++ b/data/mods/Aftershock/mod_interactions/Defense_Mode/monstergroups.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "monstergroup",
+    "name": "AFS_GROUP_DM",
+    "monsters": [
+      { "monster": "mon_moxie_scavenger_dm", "weight": 350, "cost_multiplier": 1 },
+      { "monster": "mon_moxie_regenerator_dm", "weight": 200, "cost_multiplier": 1 },
+      { "monster": "mon_moxie_grabby_dm", "weight": 100, "cost_multiplier": 1 },
+      { "monster": "mon_human_biomachine_dm", "weight": 50, "cost_multiplier": 1 },
+      { "monster": "afs_titanis_dm", "weight": 350, "cost_multiplier": 0 },
+      { "monster": "afs_venandi_dm", "weight": 250, "cost_multiplier": 0 },
+      { "monster": "afs_mon_boatman_dm", "weight": 200, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_upliftedbear_dm", "weight": 3, "cost_multiplier": 10 },
+      { "monster": "mon_uplifted_ape_zed_dm", "weight": 5, "cost_multiplier": 10 },
+      { "monster": "mon_zombie_upliftedoctopus_dm", "weight": 1, "cost_multiplier": 10 }
+    ]
+  }
+]

--- a/data/mods/Aftershock/mod_interactions/Defense_Mode/monsters.json
+++ b/data/mods/Aftershock/mod_interactions/Defense_Mode/monsters.json
@@ -1,0 +1,117 @@
+[
+  {
+    "id": "mon_moxie_scavenger_dm",
+    "copy-from": "mon_moxie_scavenger",
+    "type": "MONSTER",
+    "species": [ "AFTERSHOCK_DM" ],
+    "default_faction": "aftershock_defense_mode",
+    "regenerates": 1,
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_moxie_regenerator_dm",
+    "copy-from": "mon_moxie_regenerator",
+    "type": "MONSTER",
+    "species": [ "AFTERSHOCK_DM" ],
+    "default_faction": "aftershock_defense_mode",
+    "regenerates": 2,
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_moxie_grabby_dm",
+    "copy-from": "mon_moxie_grabby",
+    "type": "MONSTER",
+    "species": [ "AFTERSHOCK_DM" ],
+    "regenerates": 1,
+    "default_faction": "aftershock_defense_mode",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_human_biomachine_dm",
+    "copy-from": "mon_human_biomachine",
+    "type": "MONSTER",
+    "species": [ "AFTERSHOCK_DM" ],
+    "default_faction": "aftershock_defense_mode",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "afs_venandi_dm",
+    "copy-from": "afs_venandi",
+    "type": "MONSTER",
+    "species": [ "AFTERSHOCK_DM" ],
+    "default_faction": "aftershock_defense_mode",
+    "hp": 80,
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "afs_mon_boatman_dm",
+    "copy-from": "afs_mon_boatman",
+    "type": "MONSTER",
+    "species": [ "AFTERSHOCK_DM" ],
+    "default_faction": "aftershock_defense_mode",
+    "hp": 80,
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_upliftedbear_dm",
+    "copy-from": "mon_zombie_upliftedbear",
+    "type": "MONSTER",
+    "species": [ "AFTERSHOCK_DM" ],
+    "default_faction": "aftershock_defense_mode",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_uplifted_ape_zed_dm",
+    "copy-from": "mon_uplifted_ape_zed",
+    "type": "MONSTER",
+    "species": [ "AFTERSHOCK_DM" ],
+    "default_faction": "aftershock_defense_mode",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_upliftedoctopus_dm",
+    "copy-from": "mon_zombie_upliftedoctopus",
+    "type": "MONSTER",
+    "species": [ "AFTERSHOCK_DM" ],
+    "default_faction": "aftershock_defense_mode",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "afs_titanis_dm",
+    "copy-from": "afs_titanis",
+    "type": "MONSTER",
+    "species": [ "AFTERSHOCK_DM" ],
+    "default_faction": "aftershock_defense_mode",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  }
+]

--- a/data/mods/Aftershock/mod_interactions/Defense_Mode/species.json
+++ b/data/mods/Aftershock/mod_interactions/Defense_Mode/species.json
@@ -1,0 +1,15 @@
+[
+  {
+    "type": "SPECIES",
+    "id": "AFTERSHOCK_DM",
+    "flags": [ "BASHES", "ALL_SEEING", "NEMESIS" ],
+    "description": "a monster"
+  },
+  {
+    "type": "MONSTER_FACTION",
+    "name": "aftershock_defense_mode",
+    "base_faction": "human",
+    "friendly": [ "aftershock_defense_mode" ],
+    "neutral": [  ]
+  }
+]

--- a/data/mods/Defense_Mode/dialogue/menu_screen.json
+++ b/data/mods/Defense_Mode/dialogue/menu_screen.json
@@ -26,7 +26,8 @@
             { "math": [ "candymonsters_allowed", "==", "1" ] },
             { "math": [ "mythos_allowed", "==", "1" ] },
             { "math": [ "exodii_allowed", "==", "1" ] },
-            { "math": [ "xedra_allowed", "==", "1" ] }
+            { "math": [ "xedra_allowed", "==", "1" ] },
+            { "math": [ "aftershock_allowed", "==", "1" ] }
           ]
         },
         "topic": "TALK_DONE"
@@ -245,6 +246,18 @@
         "topic": "TALK_DEFENSE_MODE_ENEMY_SELECTION"
       },
       {
+        "text": "Allow exoplanetary residents.",
+        "condition": { "and": [ { "mod_is_loaded": "aftershock" }, { "math": [ "aftershock_allowed", "==", "0" ] } ] },
+        "effect": { "math": [ "aftershock_allowed", "=", "1" ] },
+        "topic": "TALK_DEFENSE_MODE_ENEMY_SELECTION"
+      },
+      {
+        "text": "Disable exoplanetary residents.",
+        "condition": { "and": [ { "mod_is_loaded": "aftershock" }, { "math": [ "aftershock_allowed", "==", "1" ] } ] },
+        "effect": { "math": [ "aftershock_allowed", "=", "0" ] },
+        "topic": "TALK_DEFENSE_MODE_ENEMY_SELECTION"
+      },
+      {
         "text": "Play!",
         "condition": {
           "or": [
@@ -264,7 +277,8 @@
             { "math": [ "candymonsters_allowed", "==", "1" ] },
             { "math": [ "mythos_allowed", "==", "1" ] },
             { "math": [ "exodii_allowed", "==", "1" ] },
-            { "math": [ "xedra_allowed", "==", "1" ] }
+            { "math": [ "xedra_allowed", "==", "1" ] },
+            { "math": [ "aftershock_allowed", "==", "1" ] }
           ]
         },
         "topic": "TALK_DONE"

--- a/data/mods/Defense_Mode/eocs.json
+++ b/data/mods/Defense_Mode/eocs.json
@@ -110,7 +110,8 @@
           [ "DEFENSE_MODE_WAVE_SPAWN_CANDY", { "const": 1 } ],
           [ "DEFENSE_MODE_WAVE_SPAWN_MYTHOS", { "const": 1 } ],
           [ "DEFENSE_MODE_WAVE_SPAWN_EXODII", { "const": 1 } ],
-          [ "DEFENSE_MODE_WAVE_SPAWN_XEDRA", { "const": 1 } ]
+          [ "DEFENSE_MODE_WAVE_SPAWN_XEDRA", { "const": 1 } ],
+          [ "DEFENSE_MODE_WAVE_SPAWN_AFTERSHOCK", { "const": 1 } ]
         ]
       }
     ]

--- a/data/mods/Defense_Mode/mod_interactions/Aftershock/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Aftershock/eocs.json
@@ -1,0 +1,34 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "DEFENSE_MODE_WAVE_SPAWN_AFTERSHOCK",
+    "condition": { "math": [ "aftershock_allowed", "==", "1" ] },
+    "effect": [
+      {
+        "u_spawn_monster": "AFS_GROUP_DM",
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "outdoor_only": true,
+        "group": true,
+        "min_radius": 20,
+        "max_radius": 40
+      },
+      {
+        "u_spawn_monster": "AFS_GROUP_DM",
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "outdoor_only": true,
+        "group": true,
+        "min_radius": 20,
+        "max_radius": 40
+      },
+      {
+        "u_spawn_monster": "AFS_GROUP_DM",
+        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "outdoor_only": true,
+        "group": true,
+        "min_radius": 20,
+        "max_radius": 40
+      }
+    ],
+    "false_effect": { "run_eocs": "DEFENSE_MODE_WAVE_SPAWN_FALLBACK" }
+  }
+]

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -991,6 +991,7 @@ existentialists
 exobay
 exodii
 exoplanet
+exoplanetary
 exosuit
 exosuits
 expansionary


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Make Aftershock and Aftershock: Exoplanet compatible with Defense Mode."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I think Aftershock is pretty cool, and I decided that it would be quite neat if it was compatible with Defense Mode. As such, I decided to go ahead and make that happen.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Using previous inter-modal infrastructure, I applied that code to Aftershock to add the needed monsters, EOCs, and menu options to make it work.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded into a game and fought off some Aftershock enemies. This works with both regular Aftershock and Aftershock: Exoplanet.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I did have to rebalance some of the `copy-from` monsters to be less powerful because they could easily kill a Day 1 survivor at the game's start. Also, if you stay inside your building and don't go outside too often, Salus IV's harsh atmosphere shouldn't be too much of an issue.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
