### PR TITLE
Fix Luliya's dialogue

### DIFF
--- a/data/json/npcs/exodii/exodii_Luliya.json
+++ b/data/json/npcs/exodii/exodii_Luliya.json
@@ -88,7 +88,7 @@
           "and": [
             { "u_has_var": "u_met_luliya", "type": "general", "context": "meeting", "value": "yes" },
             {
-              "not": { "u_has_var": "u_asked_luliya_english", "type": "general", "context": "meeting", "value": "yes" }
+              "not": { "u_has_var": "u_not_english_luliya", "type": "general", "context": "language", "value": "yes" }
             }
           ]
         }
@@ -99,7 +99,7 @@
         "condition": {
           "and": [
             { "u_has_var": "u_met_luliya", "type": "general", "context": "meeting", "value": "yes" },
-            { "not": { "u_has_var": "u_luliya_name", "type": "general", "context": "meeting", "value": "yes" } }
+            { "not": { "u_has_var": "u_luliya_name", "type": "general", "context": "name", "value": "yes" } }
           ]
         }
       },
@@ -107,12 +107,12 @@
         "text": "I heard you playing that.  [You point at the golden harp she holds]  La la la.  Do you like music Luliya?",
         "condition": {
           "and": [
-            { "u_has_var": "u_luliya_name", "type": "general", "context": "meeting", "value": "yes" },
+            { "u_has_var": "u_luliya_name", "type": "general", "context": "name", "value": "yes" },
             {
-              "u_compare_time_since_var": "u_met_luliya",
-              "type": "test",
-              "context": "var_time_test",
-              "op": ">",
+              "u_compare_time_since_var": "luliya_music_timer",
+              "type": "timer",
+              "context": "meeting",
+              "op": ">=",
               "time": "3 days"
             }
           ]
@@ -130,7 +130,12 @@
     "type": "talk_topic",
     "id": "TALK_LULIYA_BUTTON",
     "dynamic_line": "[You hear a loud static discharge, a rough mechanical chugging sound, and then high-pitched shrieking with strange distortions and modulations in the sound.  The golden figure shudders, arms flailing] ቆዳዬ! ቆዳዬ በእሳት ላይ ነው! እየሞትኩ ነው!",
-    "speaker_effect": { "effect": { "u_add_var": "u_met_luliya", "type": "general", "context": "meeting", "value": "yes" } },
+    "speaker_effect": {
+      "effect": [
+        { "u_add_var": "u_met_luliya", "type": "general", "context": "meeting", "value": "yes" },
+        { "u_add_var": "luliya_music_timer", "type": "timer", "context": "meeting", "time": true }
+      ]
+    },
     "responses": [
       { "text": "Hello.  Are you all right?  I just hit the button on your back.", "topic": "TALK_LULIYA" },
       { "text": "I'm not understanding that.  Can you try again?", "topic": "TALK_LULIYA" },
@@ -140,9 +145,9 @@
       },
       { "text": "State your name and function machine.", "topic": "TALK_LULIYA" },
       {
-        "text": "[INT 18]  Huh.  That sounds a little familiar, a little like Arabic.  Earabiun?  [slowly and clearly]  EARABIUN?",
+        "text": "[INT 11]  Huh.  That sounds a little familiar, a little like Arabic.  Earabiun?  [slowly and clearly]  EARABIUN?",
         "topic": "TALK_LULIYA_ARABIC",
-        "condition": { "u_has_intelligence": 18 }
+        "condition": { "u_has_intelligence": 11 }
       },
       { "text": "No, I'm done with this.", "topic": "TALK_DONE" }
     ]
@@ -191,7 +196,7 @@
       {
         "text": "[HAS GUITAR] I happen to have a nice guitar, want to play with me?",
         "topic": "TALK_LULIYA_MUSIC2",
-        "condition": { "u_has_item": "guitar" }
+        "condition": { "u_has_item": "acoustic_guitar" }
       },
       {
         "text": "[HAS TRUMPET] I happen to have a nice trumpet, want to play with me?",
@@ -211,12 +216,12 @@
       {
         "text": "[HAS HARMONICA] I happen to have a nice harmonica, want to play with me?",
         "topic": "TALK_LULIYA_MUSIC2",
-        "condition": { "u_has_item": "harmonica" }
+        "condition": { "u_has_item": "harmonica_holder" }
       },
       {
         "text": "[HAS COWBELL] I happen to have a nice cowbell, want to play with me?",
         "topic": "TALK_LULIYA_MUSIC2",
-        "condition": { "u_has_item": "cowbell" }
+        "condition": { "u_has_item": "cow_bell" }
       },
       {
         "text": "Huh, you know music, good to know.  I'll try and find something to play and come back.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix Luliya's dialogue."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #69359.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Many of the context entries in Luliya's dialogue were not correct, so I had to change those around. The game also tried to track a dialogue variable that wasn't a timer with time, so I added another variable that could be properly tracked. Item ID's for the music dialogue weren't correct, so I changed those too. I also lowered the Intelligence requirement needed to deduce her spoken language from a superhuman 18 to an above-average 11, since most people in New England wouldn't be familiar with spoken Arabic.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Went to the butte and spoke to Luliya, all her dialogue works correctly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Luliya seems like an underdeveloped character in the current state, so I think some work being done on her dialogue tree would be very nice. Also, since she's the head materials manager of the Exodii, I think some quests related to that and/or some way to trade with her could be beneficial to developing this position within the hierarchy.
I also would prefer the language requirement to be tried to proficiencies representing a semi-abstract knowledge of a given language rather than raw intelligence, but that's out of the scope of this PR.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
