### PR TITLE
change quick panel switch keys in @ menu

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4391,49 +4391,49 @@
     "category": "PLAYER_INFO",
     "id": "SELECT_STATS_TAB",
     "name": "Select stats tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F1" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "w" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_ENCUMBRANCE_TAB",
     "name": "Select encumbrance tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F2" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "e" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_SKILLS_TAB",
     "name": "Select skills tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F3" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "r" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_TRAITS_TAB",
     "name": "Select traits tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F4" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "t" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_BIONICS_TAB",
     "name": "Select bionics tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F5" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "x" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_EFFECTS_TAB",
     "name": "Select effects tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F6" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "c" } ]
   },
   {
     "type": "keybinding",
     "category": "PLAYER_INFO",
     "id": "SELECT_PROFICIENCIES_TAB",
     "name": "Select proficiencies tab",
-    "bindings": [ { "input_method": "keyboard_any", "key": "F7" } ]
+    "bindings": [ { "input_method": "keyboard_any", "key": "v" } ]
   },
   {
     "type": "keybinding",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I do not like using F1-F7 as hotkeys to change panel in the @ menu, when I ported the feature I didn't think of better keys, since I guess the ones that came to mind were already used; well just make the best out of what is available, use w, e, r, t, x, c and v for quick panel change; they make sense in the context of the qwerty keyboard, as in they are located on the left end of the keyboard and are very close to the home row to hit any of them easily with one hand


<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![Screenshot from 2023-11-17 16-58-06](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/9d88dc6f-b059-4006-b7d5-eca195aa84c7)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
