### PR TITLE
[Xedra Evolved] Adds "All" sub category for Xedra Crafting Category

### DIFF
--- a/data/mods/Xedra_Evolved/recipes/category.json
+++ b/data/mods/Xedra_Evolved/recipes/category.json
@@ -3,6 +3,7 @@
     "type": "recipe_category",
     "id": "CC_XEDRA",
     "recipe_subcategories": [
+      "CSC_ALL",
       "CSC_XEDRA_RESEARCH",
       "CSC_XEDRA_WEAPONS",
       "CSC_XEDRA_ARMOR",


### PR DESCRIPTION

#### Summary
Mods "[Xedra Evolved] Adds "All" recipe subcategory for Xedra recipe category"


#### Purpose of change

Fixes #69495 

#### Describe the solution

See commit.

#### Describe alternatives you've considered

Not doing so.

#### Testing
Adds the thing on my build of the game, it works.
![Screenshot_2023-11-18_14-18-54_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/78019001/24bf100c-06ec-4857-bff6-7951fd103eeb)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
