### PR TITLE
New enchantment value: `AVOID_FRIENDRY_FIRE`

### DIFF
--- a/doc/MAGIC.md
+++ b/doc/MAGIC.md
@@ -777,6 +777,7 @@ Character status value  | Description
 `ARMOR_STAB`            | 
 `ATTACK_NOISE`          | Affects the amount of noise you make while melee attacking.
 `ATTACK_SPEED`          | Affects attack speed of item even if it's not the one you're wielding.
+`AVOID_FRIENDRY_FIRE`   | Flat chance for your character to avoid friendry fire if there is a friend in the line of fire. From 0.0 (no chance) to 1.0 (never frindly fire).
 `BIONIC_POWER`          |
 `BONUS_BLOCK`           | Affects the number of blocks you can perform.
 `BONUS_DODGE`           | Affects the number of dodges you can perform.

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -424,6 +424,11 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
                 // Or was just IFFing, giving lots of warnings and time to get out of the line of fire
                 continue;
             }
+            // avoid friendly fire
+            if( critter->attitude_to( *origin ) == Creature::Attitude::FRIENDLY &&
+                origin->avoid_friendly_fire() ) {
+                continue;
+            }
             attack.missed_by = cur_missed_by;
             bool print_messages = true;
             // If the attack is shot, once we're past point-blank,

--- a/src/ballistics.cpp
+++ b/src/ballistics.cpp
@@ -426,7 +426,7 @@ dealt_projectile_attack projectile_attack( const projectile &proj_arg, const tri
             }
             // avoid friendly fire
             if( critter->attitude_to( *origin ) == Creature::Attitude::FRIENDLY &&
-                origin->avoid_friendly_fire() ) {
+                origin->check_avoid_friendly_fire() ) {
                 continue;
             }
             attack.missed_by = cur_missed_by;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2015,7 +2015,7 @@ bool Character::uncanny_dodge()
     return false;
 }
 
-bool Character::avoid_friendly_fire() const
+bool Character::check_avoid_friendly_fire() const
 {
     double chance = enchantment_cache->modify_value( enchant_vals::mod::AVOID_FRIENDRY_FIRE, 0.0 );
     return rng( 0, 99 ) < chance * 100.0;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2015,6 +2015,12 @@ bool Character::uncanny_dodge()
     return false;
 }
 
+bool Character::avoid_friendly_fire() const
+{
+    double chance = enchantment_cache->modify_value( enchant_vals::mod::AVOID_FRIENDRY_FIRE, 0.0 );
+    return rng( 0, 99 ) < chance * 100.0;
+}
+
 void Character::handle_skill_warning( const skill_id &id, bool force_warning )
 {
     //remind the player intermittently that no skill gain takes place

--- a/src/character.h
+++ b/src/character.h
@@ -816,7 +816,7 @@ class Character : public Creature, public visitable
         int get_spell_resist() const override;
         /** Handles the uncanny dodge bionic and effects, returns true if the player successfully dodges */
         bool uncanny_dodge() override;
-        bool avoid_friendly_fire() const override;
+        bool check_avoid_friendly_fire() const override;
         float get_hit_base() const override;
 
         /** Returns the player's sight range */

--- a/src/character.h
+++ b/src/character.h
@@ -816,6 +816,7 @@ class Character : public Creature, public visitable
         int get_spell_resist() const override;
         /** Handles the uncanny dodge bionic and effects, returns true if the player successfully dodges */
         bool uncanny_dodge() override;
+        bool avoid_friendly_fire() const override;
         float get_hit_base() const override;
 
         /** Returns the player's sight range */

--- a/src/creature.h
+++ b/src/creature.h
@@ -745,6 +745,9 @@ class Creature : public viewer
         virtual bool uncanny_dodge() {
             return false;
         }
+        virtual bool avoid_friendly_fire() const {
+            return false;
+        }
         void set_reachable_zone( int zone ) {
             reachable_zone = zone;
         }

--- a/src/creature.h
+++ b/src/creature.h
@@ -745,7 +745,7 @@ class Creature : public viewer
         virtual bool uncanny_dodge() {
             return false;
         }
-        virtual bool avoid_friendly_fire() const {
+        virtual bool check_avoid_friendly_fire() const {
             return false;
         }
         void set_reachable_zone( int zone ) {

--- a/src/magic_enchantment.cpp
+++ b/src/magic_enchantment.cpp
@@ -149,6 +149,7 @@ namespace io
             case enchant_vals::mod::EVASION: return "EVASION";
             case enchant_vals::mod::OVERKILL_DAMAGE: return "OVERKILL_DAMAGE";
             case enchant_vals::mod::RANGE: return "RANGE";
+            case enchant_vals::mod::AVOID_FRIENDRY_FIRE: return "AVOID_FRIENDRY_FIRE";
             case enchant_vals::mod::NUM_MOD: break;
         }
         cata_fatal( "Invalid enchant_vals::mod" );

--- a/src/magic_enchantment.h
+++ b/src/magic_enchantment.h
@@ -126,6 +126,7 @@ enum class mod : int {
     EVASION,
     OVERKILL_DAMAGE,
     RANGE,
+    AVOID_FRIENDRY_FIRE,
     NUM_MOD
 };
 } // namespace enchant_vals


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
This game manages the line of fire on a tile-by-tile basis, making it easy for friendly fire to occur.
I think that adding CBM and mutations that avoid friendly fire can motivate players to take on challenges.

#### Describe the solution
Add new enchantment value: `AVOID_FRIENDRY_FIRE`. Setting it to 0.5 gives half a chance to avoid friendly fire, and setting it to 1.0 allows the character to attack enemies beyond their allies without causing friendly fire.

#### Describe alternatives you've considered
I think it would be better to introduce actual use cases along with the features, but I wasn't sure which section (or MOD) would be appropriate to introduce them.

#### Testing
I made the following items and equipped them to characters, and confirmed that friendly fire would not occur even if allies were in the line of fire.

```json
  {
    "type": "TOOL_ARMOR",
    "id": "test_ring_avoid_friendly_fire",
    "weight": "4 g",
    "volume": "1 ml",
    "price": 5000,
    "material": [ "copper" ],
    "symbol": "[",
    "color": "light_red",
    "sided": true,
    "warmth": 0,
    "flags": [ "WATER_FRIENDLY", "ALLOWS_NATURAL_ATTACKS", "FANCY", "ONLY_ONE", "SKINTIGHT" ],
    "name": { "str": "ring of avoid friendy fire", "str_pl": "rings of avoid friendy fire" },
    "description": "A copper ring that makes you a little stronger when you wear it.",
    "relic_data": {
      "passive_effects": [ { "has": "WORN", "condition": "ALWAYS", "values": [ { "value": "AVOID_FRIENDRY_FIRE", "add": 1 } ] } ]
    },
    "armor": [ { "coverage": 0, "covers": [ "hand_l", "hand_r" ] } ]
  }
```

#### Additional context
