### PR TITLE
NPC personality hints via dialogue

### DIFF
--- a/data/json/mutations/npc_personality.json
+++ b/data/json/mutations/npc_personality.json
@@ -1,0 +1,153 @@
+[
+  {
+    "//": "This file contains *personality* traits, intended to give players an idea an NPC's decision making via TALK_ASSESS_PERSON and other dialogue.",
+    "//1": "None of them should provide gameplay effects (e.g. more HP or more damage).",
+    "//2": "All of them are reset when the game is loaded, and otherwise applied to any newly generated NPCs at the time of generation.",
+    "id": "personality_ultra_selfish",
+    "type": "mutation",
+    "name": { "str": "Survivor at any cost" },
+    "description": "<npc_name> is certainly a survivor.  You can only wonder how many they've abandoned to save themself.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "//3": "No support for this right now, but maybe in the future? These traits are descriptory, so there's no real problem if the player describes themself however they want.",
+    "vanity": false,
+    "personality_score": { "max_aggression": -3, "max_bravery": -2, "max_altruism": -4 }
+  },
+  {
+    "id": "personality_neg_aggressive",
+    "type": "mutation",
+    "name": { "str": "Timid" },
+    "description": "<npc_name> tries to avoid conflict, even when they have good reason not to.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "max_aggression": -3 }
+  },
+  {
+    "id": "personality_aggressive_mixed",
+    "type": "mutation",
+    "name": { "str": "Hardass" },
+    "description": "<npc_name> loves to fight a good fight, but only for themself.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_bravery": 3, "min_aggression": 3, "max_altruism": -2 }
+  },
+  {
+    "id": "personality_aggressive_plus_mixed",
+    "type": "mutation",
+    "name": { "str": "Freedom fighter" },
+    "description": "<npc_name> believes in fighting… mostly for others, even at risk to their own wellbeing.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_bravery": 1, "min_aggression": 5, "min_altruism": 2 }
+  },
+  {
+    "id": "personality_aggressive_plus",
+    "type": "mutation",
+    "name": { "str": "Volatile" },
+    "description": "<npc_name> is just looking for an excuse.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_aggression": 7 }
+  },
+  {
+    "//": "A straightforward tell for the NPC's bravery, since it has a huge impact on how they engage in combat.",
+    "id": "personality_neg_bravery",
+    "type": "mutation",
+    "name": { "str": "Coward" },
+    "description": "<npc_name> flinches at the thought of fighting, whether it be other people or the undead.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "max_bravery": -4 }
+  },
+  {
+    "//": "A straightforward tell for the NPC's bravery, since it has a huge impact on how they engage in combat.",
+    "id": "personality_neg_bravery_plus",
+    "type": "mutation",
+    "name": { "str": "Craven" },
+    "description": "<npc_name> is afraid of the dark, spiders, and unexplained sounds.  So are you, but only because you've lived through the apocalypse.  <npc_name> has always been like this.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "max_bravery": -7 }
+  },
+  {
+    "//": "A straightforward tell for the NPC's bravery, since it has a huge impact on how they engage in combat.",
+    "id": "personality_brave",
+    "type": "mutation",
+    "name": { "str": "Brave" },
+    "description": "<npc_name> knows the name of fear, but only as a long-defeated foe.  Little can shake them.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_bravery": 4 }
+  },
+  {
+    "id": "personality_brave_plus",
+    "type": "mutation",
+    "name": { "str": "Hero" },
+    "description": "<npc_name> is an ideal ally to those they call friend, always willing to help others.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_bravery": 5, "min_altruism": 2 }
+  },
+  {
+    "id": "personality_collector",
+    "type": "mutation",
+    "name": { "str": "Miser" },
+    "description": "<npc_name> loves their trinkets, and hates giving them away.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_collector": 3, "max_altruism": -1 }
+  },
+  {
+    "id": "personality_collector_plus",
+    "type": "mutation",
+    "name": { "str": "Scrooge" },
+    "description": "<npc_name> collects trash like a RPG protagonist collects potions.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_collector": 6 }
+  },
+  {
+    "id": "personality_altruist",
+    "type": "mutation",
+    "name": { "str": "Kind" },
+    "description": "<npc_name> just wants to help.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "min_altruism": 4 }
+  },
+  {
+    "id": "personality_neg_altruist",
+    "type": "mutation",
+    "name": { "str": "Self-centered" },
+    "description": "<npc_name> steers every interaction into discussing how it will help them.",
+    "points": 0,
+    "valid": false,
+    "purifiable": false,
+    "player_display": true,
+    "personality_score": { "max_altruism": -3 }
+  }
+]

--- a/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
@@ -567,7 +567,7 @@
     ]
   },
   {
-    "id": [ "TALK_SIZE_UP", "TALK_LOOK_AT", "TALK_OPINION", "TALK_SHOUT" ],
+    "id": [ "TALK_SIZE_UP", "TALK_ASSESS_PERSON", "TALK_LOOK_AT", "TALK_OPINION", "TALK_SHOUT" ],
     "type": "talk_topic",
     "responses": [ { "text": "Okay.", "topic": "TALK_NONE" } ]
   },

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -4508,6 +4508,13 @@
   {
     "type": "keybinding",
     "category": "DIALOGUE_CHOOSE_RESPONSE",
+    "id": "ASSESS_PERSONALITY",
+    "name": "Assess personality",
+    "bindings": [ { "input_method": "keyboard_char", "key": "A" }, { "input_method": "keyboard_code", "key": "a", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
+    "category": "DIALOGUE_CHOOSE_RESPONSE",
     "id": "YELL",
     "name": "Yell",
     "bindings": [ { "input_method": "keyboard_char", "key": "Y" }, { "input_method": "keyboard_code", "key": "y", "mod": [ "shift" ] } ]

--- a/doc/MUTATIONS.md
+++ b/doc/MUTATIONS.md
@@ -123,6 +123,18 @@ Note that **all new traits that can be obtained through mutation must be purifia
       "weight": 1                                         // Used to randomly select variant when this is mutated.  Chance of being selected is weight/sum-of-all-weights.  If no weight is specified or weight is 0, variant will not be selected.
     }
   ],
+  "personality_score": [                               // Optional. Defines cosmetic flavor traits for NPCs which can be viewed during dialogue with the NPC.
+    {                                                  // Traits with a defined `personality_score` will be automatically applied to NPCs with personalities that qualify, based
+      "min_aggression": -10,                           // on the min and max values defined. NPC personalities' values are always integers within the range [-10,10].
+      "max_aggression": 10,                            // All mins and maxes are optional, this document contains their default values. (A personality_score trait with no
+      "min_bravery": -10,                              // mins or maxes defined *at all* will be applied to all NPCs.)
+      "max_bravery": 10,                               //
+      "min_collector": -10,                            // As an example, a trait with a `personality_score` which defines only `"min_bravery": -5` will be applied to NPCs with
+      "max_collector": 10,                             // bravery of -5, -1, 0, 2, 7, or 10 (all of them being higher than the minimum), but not to a NPC with -6 (being lower than the
+      "min_altruism": -10,                             // minimum). This can be used to define a range of values for which a trait should be applied (e.g. min 2 max 4 excludes all
+      "max_altruism": 10,                              // numbers except 2, 3, and 4.)
+    }
+  ],
   "category": [ "MUTCAT_BIRD", "MUTCAT_INSECT" ],         // Categories containing this mutation.
       // prereqs and prereqs2 specify prerequisites of the current mutation.
       // Both are optional, but if prereqs2 is specified prereqs must also be specified.

--- a/src/dialogue_win.cpp
+++ b/src/dialogue_win.cpp
@@ -69,6 +69,11 @@ void dialogue_window::draw( const std::string &npc_name )
         print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
                             formatted_text );
         ++ycurrent;
+        formatted_text = formatted_hotkey( ctxt.get_desc( "ASSESS_PERSONALITY", 1 ),
+                                           cur_color ).append( _( "Assess personality" ) );
+        print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
+                            formatted_text );
+        ++ycurrent;
         formatted_text = formatted_hotkey( ctxt.get_desc( "YELL", 1 ), cur_color ).append( _( "Yell" ) );
         print_colored_text( d_win, point( actions_xoffset, ycurrent ), cur_color, c_magenta,
                             formatted_text );
@@ -110,6 +115,7 @@ void dialogue_window::set_up_scrolling( input_context &ctxt ) const
     if( !is_computer && !is_not_conversation ) {
         ctxt.register_action( "LOOK_AT" );
         ctxt.register_action( "SIZE_UP_STATS" );
+        ctxt.register_action( "ASSESS_PERSONALITY" );
         ctxt.register_action( "YELL" );
         ctxt.register_action( "CHECK_OPINION" );
     }

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -94,6 +94,21 @@ struct mut_transform {
     bool load( const JsonObject &jsobj, std::string_view member );
 };
 
+struct mut_personality_score {
+
+    /** bounds within which this trait is applied */
+    int min_aggression = -10;
+    int max_aggression = 10;
+    int min_bravery = -10;
+    int max_bravery = 10;
+    int min_collector = -10;
+    int max_collector = 10;
+    int min_altruism = -10;
+    int max_altruism = 10;
+    mut_personality_score();
+    bool load( const JsonObject &jsobj, std::string_view member );
+};
+
 struct reflex_activation_data {
 
     /**What variable controls the activation*/
@@ -170,8 +185,6 @@ struct mutation_branch {
         bool debug = false;
         // True if the mutation should be displayed in the `@` menu
         bool player_display = true;
-        // True if the mutation is assigned to NPCs based on personality score
-        bool personality_score = false;
         // True if mutation is purely comestic and can be changed anytime without any effect
         bool vanity = false;
         // Dummy mutations are special; they're not gained through normal mutating, and will instead be targeted for the purposes of removing conflicting mutations
@@ -241,6 +254,8 @@ struct mutation_branch {
         int butchering_quality = 0;
 
         cata::value_ptr<mut_transform> transform;
+
+        cata::value_ptr<mut_personality_score> personality_score;
 
         // Cosmetic variants of this mutation
         std::map<std::string, mutation_variant> variants;

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -170,6 +170,8 @@ struct mutation_branch {
         bool debug = false;
         // True if the mutation should be displayed in the `@` menu
         bool player_display = true;
+        // True if the mutation is assigned to NPCs based on personality score
+        bool personality_score = false;
         // True if mutation is purely comestic and can be changed anytime without any effect
         bool vanity = false;
         // Dummy mutations are special; they're not gained through normal mutating, and will instead be targeted for the purposes of removing conflicting mutations

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -239,6 +239,24 @@ bool mut_transform::load( const JsonObject &jsobj, const std::string_view member
     return true;
 }
 
+mut_personality_score::mut_personality_score() = default;
+
+bool mut_personality_score::load( const JsonObject &jsobj, const std::string_view member )
+{
+    JsonObject j = jsobj.get_object( member );
+
+    optional( j, false, "min_aggression", min_aggression, -10 );
+    optional( j, false, "max_aggression", max_aggression, 10 );
+    optional( j, false, "min_bravery", min_bravery, -10 );
+    optional( j, false, "max_bravery", max_bravery, 10 );
+    optional( j, false, "min_collector", min_collector, -10 );
+    optional( j, false, "max_collector", max_collector, 10 );
+    optional( j, false, "min_altruism", min_altruism, -10 );
+    optional( j, false, "max_altruism", max_altruism, 10 );
+
+    return true;
+}
+
 void reflex_activation_data::load( const JsonObject &jsobj )
 {
     read_condition( jsobj, "condition", trigger, false );
@@ -353,6 +371,10 @@ void mutation_branch::load( const JsonObject &jo, const std::string &src )
         transform = cata::make_value<mut_transform>();
         transform->load( jo, "transform" );
     }
+    if( jo.has_object( "personality_score" ) ) {
+        personality_score = cata::make_value<mut_personality_score>();
+        personality_score->load( jo, "personality_score" );
+    }
 
     optional( jo, was_loaded, "triggers", trigger_list );
 
@@ -371,7 +393,6 @@ void mutation_branch::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "profession", profession, false );
     optional( jo, was_loaded, "debug", debug, false );
     optional( jo, was_loaded, "player_display", player_display, true );
-    optional( jo, was_loaded, "personality_score", personality_score, false );
     optional( jo, was_loaded, "vanity", vanity, false );
     optional( jo, was_loaded, "dummy", dummy, false );
 

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -371,6 +371,7 @@ void mutation_branch::load( const JsonObject &jo, const std::string &src )
     optional( jo, was_loaded, "profession", profession, false );
     optional( jo, was_loaded, "debug", debug, false );
     optional( jo, was_loaded, "player_display", player_display, true );
+    optional( jo, was_loaded, "personality_score", personality_score, false );
     optional( jo, was_loaded, "vanity", vanity, false );
     optional( jo, was_loaded, "dummy", dummy, false );
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -898,6 +898,9 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
         set_mutation( tid, tid->variant( var ) );
     }
 
+    // Add personality traits
+    generate_personality_traits();
+
     // Run mutation rounds
     for( const auto &mr : type->mutation_rounds ) {
         int rounds = mr.second.roll();
@@ -929,6 +932,32 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
 
     // Add eocs
     effect_on_conditions::load_new_character( *this );
+}
+
+void npc::clear_personality_traits()
+{
+    for( const trait_id &trait : get_mutations() ) {
+        if( trait.obj().personality_score ) {
+            unset_mutation( trait );
+        }
+    }
+}
+
+void npc::generate_personality_traits()
+{
+    npc_personality &ur = personality;
+    for( const mutation_branch &mdata : mutation_branch::get_all() ) {
+        if( mdata.personality_score ) {
+            auto &required = mdata.personality_score;
+            // This looks intimidating, but it's really just a bounds check, repeated for every personality score.
+            if( ( required->min_aggression <= ur.aggression && ur.aggression <= required->max_aggression ) &&
+                ( required->min_bravery <= ur.bravery && ur.bravery <= required->max_bravery ) &&
+                ( required->min_collector <= ur.collector && ur.collector <= required->max_collector ) &&
+                ( required->min_altruism <= ur.altruism && ur.altruism <= required->max_altruism ) ) {
+                set_mutation( mdata.id );
+            }
+        }
+    }
 }
 
 void npc::learn_ma_styles_from_traits()

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -948,7 +948,7 @@ void npc::generate_personality_traits()
     npc_personality &ur = personality;
     for( const mutation_branch &mdata : mutation_branch::get_all() ) {
         if( mdata.personality_score ) {
-            auto &required = mdata.personality_score;
+            const auto &required = mdata.personality_score;
             // This looks intimidating, but it's really just a bounds check, repeated for every personality score.
             if( ( required->min_aggression <= ur.aggression && ur.aggression <= required->max_aggression ) &&
                 ( required->min_bravery <= ur.bravery && ur.bravery <= required->max_bravery ) &&

--- a/src/npc.h
+++ b/src/npc.h
@@ -749,6 +749,7 @@ enum talk_topic_enum {
     TALK_DEMAND_LEAVE,
 
     TALK_SIZE_UP,
+    TALK_ASSESS_PERSON,
     TALK_LOOK_AT,
     TALK_OPINION,
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -792,6 +792,8 @@ class npc : public Character
                         const npc_template_id &tem_id = npc_template_id::NULL_ID() );
         void randomize_from_faction( faction *fac );
         void apply_ownership_to_inv();
+        void clear_personality_traits();
+        void generate_personality_traits();
         void learn_ma_styles_from_traits();
         // Faction version number
         int get_faction_ver() const;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -1488,6 +1488,8 @@ std::string dialogue::dynamic_line( const talk_topic &the_topic )
         }
     } else if( topic == "TALK_SIZE_UP" ) {
         return actor( true )->evaluation_by( *actor( false ) );
+    } else if( topic == "TALK_ASSESS_PERSON" ) {
+        return actor( true )->view_personality_traits();
     } else if( topic == "TALK_LOOK_AT" ) {
         if( actor( false )->can_see() ) {
             return "&" + actor( true )->short_description();
@@ -1975,7 +1977,7 @@ int topic_category( const talk_topic &the_topic )
         return 9;
     }
     static const std::unordered_set<std::string> topic_99 = { {
-            "TALK_SIZE_UP", "TALK_LOOK_AT", "TALK_OPINION", "TALK_SHOUT"
+            "TALK_SIZE_UP", "TALK_ASSESS_PERSON", "TALK_LOOK_AT", "TALK_OPINION", "TALK_SHOUT"
         }
     };
     if( topic_99.count( topic ) > 0 ) {
@@ -2404,6 +2406,7 @@ const talk_topic &special_talk( const std::string &action )
     static const std::map<std::string, talk_topic> key_map = {{
             { "LOOK_AT", talk_topic( "TALK_LOOK_AT" ) },
             { "SIZE_UP_STATS", talk_topic( "TALK_SIZE_UP" ) },
+            { "ASSESS_PERSONALITY", talk_topic( "TALK_ASSESS_PERSON" ) },
             { "CHECK_OPINION", talk_topic( "TALK_OPINION" ) },
             { "YELL", talk_topic( "TALK_SHOUT" ) },
         }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2365,6 +2365,8 @@ void npc::load( const JsonObject &data )
         complaints.emplace( member.name(), p );
     }
     data.read( "unique_id", unique_id );
+	clear_personality_traits();
+	generate_personality_traits();
 }
 
 /*

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2365,8 +2365,8 @@ void npc::load( const JsonObject &data )
         complaints.emplace( member.name(), p );
     }
     data.read( "unique_id", unique_id );
-	clear_personality_traits();
-	generate_personality_traits();
+    clear_personality_traits();
+    generate_personality_traits();
 }
 
 /*

--- a/src/talker.h
+++ b/src/talker.h
@@ -472,6 +472,9 @@ class talker
         virtual std::string evaluation_by( const talker & ) const {
             return "";
         }
+        virtual std::string view_personality_traits() const {
+            return "";
+        }
         virtual std::string short_description() const {
             return "";
         }

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -706,23 +706,23 @@ std::string talker_npc::get_job_description() const
 
 std::string talker_npc::view_personality_traits() const
 {
-	// Special starting char so it doesn't appear as though the NPC is talking to us
+    // Special starting char so it doesn't appear as though the NPC is talking to us
     std::string assessment = "&";
-	assessment += _( "<npc_name> seems to be:" );
+    assessment += _( "<npc_name> seems to be:" );
     bool found_personality_trait = false;
     for( const auto &trait_data_pairs : me_npc->my_mutations ) {
         const mutation_branch &mdata = trait_data_pairs.first.obj();
         if( mdata.personality_score ) {
             found_personality_trait = true;
-            assessment += ( "\n" );
+            assessment += "\n";
             assessment += me_npc->mutation_name( mdata.id );
-            assessment += ( " - " );
+            assessment += " - ";
             assessment += me_npc->mutation_desc( mdata.id );
             // Example output:
             // John Doe seems to be:
             // Coward - John Doe flinches at the thought of fighting, whether it be other people or the undead.
             // Nice - John Doe has a higher than average altruism.
-			// TRAIT NAME - TRAIT DESCRIPTION
+            // TRAIT NAME - TRAIT DESCRIPTION
         }
     }
     // Fallback

--- a/src/talker_npc.cpp
+++ b/src/talker_npc.cpp
@@ -24,6 +24,7 @@
 #include "messages.h"
 #include "mission.h"
 #include "mission_companion.h"
+#include "mutation.h"
 #include "npc.h"
 #include "npctalk.h"
 #include "npctrade.h"
@@ -701,6 +702,34 @@ void talker_npc::clear_ai_rule( const std::string &, const std::string &rule )
 std::string talker_npc::get_job_description() const
 {
     return me_npc->describe_mission();
+}
+
+std::string talker_npc::view_personality_traits() const
+{
+	// Special starting char so it doesn't appear as though the NPC is talking to us
+    std::string assessment = "&";
+	assessment += _( "<npc_name> seems to be:" );
+    bool found_personality_trait = false;
+    for( const auto &trait_data_pairs : me_npc->my_mutations ) {
+        const mutation_branch &mdata = trait_data_pairs.first.obj();
+        if( mdata.personality_score ) {
+            found_personality_trait = true;
+            assessment += ( "\n" );
+            assessment += me_npc->mutation_name( mdata.id );
+            assessment += ( " - " );
+            assessment += me_npc->mutation_desc( mdata.id );
+            // Example output:
+            // John Doe seems to be:
+            // Coward - John Doe flinches at the thought of fighting, whether it be other people or the undead.
+            // Nice - John Doe has a higher than average altruism.
+			// TRAIT NAME - TRAIT DESCRIPTION
+        }
+    }
+    // Fallback
+    if( !found_personality_trait ) {
+        assessment += _( "\nNormal person - <npc_name> seems to be pretty normal." );
+    }
+    return assessment;
 }
 
 std::string talker_npc::evaluation_by( const talker &alpha ) const

--- a/src/talker_npc.h
+++ b/src/talker_npc.h
@@ -80,6 +80,7 @@ class talker_npc : public talker_cloner<talker_npc, talker_character>
 
         // other descriptors
         std::string get_job_description() const override;
+        std::string view_personality_traits() const override;
         std::string evaluation_by( const talker &alpha ) const override;
         bool has_activity() const override;
         bool is_myclass( const npc_class_id &class_to_check ) const override;


### PR DESCRIPTION
#### Summary
Features "The player can gauge an NPC's personality during dialogue with them"

#### Purpose of change
NPC personality has a lot of effects on how they act, and soon to be a lot more.

It is also a complete black box without opening the debug menu. There is no way to tell why a NPC is acting the way they are without debugging.

#### Describe the solution
Let's fix that. We add a new prompt to dialogue windows, similar to the "Size up stats" option, except this prompt shows specially-added traits the NPC has, dependent on their personality.

Through the magic of programming these traits are applied whenever a NPC is generated(at the end), and when the game is loaded (ensures that these 'hints' are always valid and not stale + gives them to existing NPCs).

More specifically it adds a new optional member (`personality_score`) to mutations/traits which allows conditions to be defined for when the traits will be automatically applied.

#### Describe alternatives you've considered
IDK we could just dump the personality numbers right in the window but this felt more appropriate.

#### Testing
https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/2bf2841e-469d-4e12-806d-8966205e3267

Traits are successfully added to NPCs on load, traits display in the dialog window, everything seems to be working properly.

#### Additional context
The traits as I've added them skew much more towards "flavor" than pure "utility". The values they check are not uniform, although I've tried to give a good representation of all four personality values on both the positive and negative sides. However special attention was given to bravery score, which got multiple one-condition straightforward traits. This is because bravery has an outsized influence on how NPCs act, hopefully it will help players identify whether or not a particular behavior is a bug.
