### PR TITLE
Add last stand scenario based on the map extra

### DIFF
--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -1327,7 +1327,7 @@
   {
     "type": "scenario",
     "id": "road_start",
-    "name": "Middle of nowhere",
+    "name": "Middle of Nowhere",
     "points": 1,
     "description": "During your escape you got lost and ended up at the wrong location.  Get your bearings and make a plan.  You'll need it.",
     "start_name": "Middle of Nowhere",
@@ -1343,5 +1343,17 @@
     "start_name": "Underground",
     "allowed_locs": [ "sloc_sewer" ],
     "reveal_locale": false
+  },
+  {
+    "type": "scenario",
+    "id": "last_stand_start",
+    "name": "Challenge - Last Stand",
+    "points": -1,
+    "description": "Together with some others you decided to take up arms against the horde.  Now you are reconsidering whether that was a wise choice.",
+    "start_name": "Intersection",
+    "allowed_locs": [ "sloc_nesw_manhole" ],
+    "requirement": "achievement_kill_10_monsters",
+    "map_extra": "mx_laststand",
+    "flags": [ "CITY_START", "LONE_START" ]
   }
 ]

--- a/data/json/start_locations.json
+++ b/data/json/start_locations.json
@@ -805,5 +805,12 @@
     "id": "sloc_sewer",
     "name": "Sewer",
     "terrain": [ "sewer" ]
+  },
+  {
+    "type": "start_location",
+    "id": "sloc_nesw_manhole",
+    "name": "Intersection",
+    "terrain": [ { "om_terrain": "road_nesw_manhole", "om_terrain_match_type": "PREFIX" } ],
+    "flags": [ "ALLOW_OUTSIDE" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "New Scenario: Last Stand"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

People suggested that in https://github.com/CleverRaven/Cataclysm-DDA/pull/68458#issuecomment-1743100878 and I did not forget about it.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Really just a simple scenario.

Also fixes capitalization of "Middle of Nowhere" for consistency. It bothered me.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

It does not guarantee being close to the city center and the city may also be small if you are (un)lucky, so the density of zombies varies dramatically.
I could have modified the last stand map extra, as was also commented in the linked PR, to include zeds so even after some days it is not suspiciously empty, but there are technical limitations related to evolution.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Applied changes locally. Without `ALLOW_OUTSIDE` in the sloc it would magically beam me into a random house nearby. That was super weird.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
