### PR TITLE
Rewrite how NPCs evaluate threats.

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -246,6 +246,7 @@ std::string filter_name( debug_filter value )
         case DF_MONSTER: return "DF_MONSTER";
         case DF_MUTATION: return "DF_MUTATION";
         case DF_NPC: return "DF_NPC";
+        case DF_NPC_COMBATAI: return "DF_NPC_COMBATAI";
         case DF_NPC_ITEMAI: return "DF_NPC_ITEMAI";
         case DF_OVERMAP: return "DF_OVERMAP";
         case DF_RADIO: return "DF_RADIO";

--- a/src/debug.h
+++ b/src/debug.h
@@ -264,7 +264,8 @@ enum debug_filter : int {
     DF_MONMOVE, // movement/pathfinding-related
     DF_MONSTER, // monster generic
     DF_MUTATION, // mutation/purification logic
-    DF_NPC, // npc generic
+    DF_NPC, // npc generic, less verbose comments
+    DF_NPC_COMBATAI, // npc combat and danger assessment logic
     DF_NPC_ITEMAI, // npc weapon/item logic - weapon choices, decision to reload, etc.
     DF_OVERMAP, // overmap generic
     DF_RADIO, // radio stuff

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -2761,8 +2761,18 @@ double Character::weapon_value( const item &weap, int ammo ) const
             return cached_value->second;
         }
     }
-    const double val_gun = gun_value( weap, ammo );
-    const double val_melee = melee_value( weap );
+    double val_gun = gun_value( weap, ammo );
+    val_gun = val_gun /
+              5.0f; // This is an emergency patch to get melee and ranged in approximate parity, if you're looking at it in 2025 or later and it's still here... I'm sorry.  Kill it with fire.  Tear it all down, and rebuild a glorious castle from the ashes.
+    add_msg_debug( debugmode::DF_NPC_ITEMAI,
+                   "<color_magenta>weapon_value</color>%s %s valued at <color_light_cyan>%1.2f as a ranged weapon</color>.",
+                   disp_name( true ), weap.type->get_id().str(), val_gun );
+    double val_melee = melee_value( weap );
+    val_melee *=
+        val_melee; // Same emergency patch.  Same purple prose descriptors, you already saw them above.
+    add_msg_debug( debugmode::DF_NPC_ITEMAI,
+                   "%s %s valued at <color_light_cyan>%1.2f as a melee weapon</color>.", disp_name( true ),
+                   weap.type->get_id().str(), val_melee );
     const double more = std::max( val_gun, val_melee );
     const double less = std::min( val_gun, val_melee );
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -1084,7 +1084,7 @@ class npc : public Character
         bool invoke_item( item * ) override;
 
         /** rates how dangerous a target is */
-        float evaluate_monster( const Creature &target ) const;
+        float evaluate_monster( const monster &target, int dist ) const;
         float evaluate_character( const Character &candidate, bool my_gun, bool enemy ) const;
         float evaluate_self( bool my_gun ) const;
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -1085,8 +1085,8 @@ class npc : public Character
 
         /** rates how dangerous a target is */
         float evaluate_monster( const Creature &target ) const;
-        float evaluate_character( const Character &candidate, bool enemy ) const;
-        float evaluate_self() const;
+        float evaluate_character( const Character &candidate, bool my_gun, bool enemy ) const;
+        float evaluate_self( bool my_gun ) const;
 
         void assess_danger();
         bool is_safe() const;
@@ -1097,6 +1097,7 @@ class npc : public Character
         // picks among melee, guns, spells, etc.
         // updates the ai_cache
         void evaluate_best_weapon( const Creature *target );
+        float estimate_armour( const Character &candidate ) const;
 
         static std::array<std::pair<std::string, overmap_location_str_id>, npc_need::num_needs> need_data;
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -1083,8 +1083,10 @@ class npc : public Character
         bool invoke_item( item *used, const std::string &method ) override;
         bool invoke_item( item * ) override;
 
-        /** rates how dangerous a target is from 0 (harmless) to 1 (max danger) */
-        float evaluate_enemy( const Creature &target ) const;
+        /** rates how dangerous a target is */
+        float evaluate_monster( const Creature &target ) const;
+        float evaluate_character( const Creature &target, bool enemy ) const;
+        float evaluate_self() const;
 
         void assess_danger();
         bool is_safe() const;

--- a/src/npc.h
+++ b/src/npc.h
@@ -1085,7 +1085,7 @@ class npc : public Character
 
         /** rates how dangerous a target is */
         float evaluate_monster( const Creature &target ) const;
-        float evaluate_character( const Creature &target, bool enemy ) const;
+        float evaluate_character( const Character &candidate, bool enemy ) const;
         float evaluate_self() const;
 
         void assess_danger();

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -475,12 +475,14 @@ float npc::evaluate_self( bool my_gun ) const
     float threat = 0.0f;
     const double &my_weap_val = ai_cache.my_weapon_value;
     // the worse pain the NPC is in, the more likely they are to overestimate the severity of their injuries.
-    float pain_factor = rng( 0.0f, static_cast<float>( get_pain() / 10.0f ) );
+    // the more perceptive they are, the more they're able to see how bad it really is.
+    float pain_factor = rng( 0.0f,
+                             static_cast<float>( get_pain() ) / static_cast<float>( get_per() ) ) );
     float my_health = ( hp_percentage() - pain_factor ) / 100.0f;
     float armour = estimate_armour( dynamic_cast<const Character &>( *this ) );
     float speed = std::max( 0.5f, get_speed() / 100.0f );
     if( my_gun ) {
-        speed = std::max( speed, 0.75f );
+    speed = std::max( speed, 0.75f );
     }
 
     threat += get_dodge();
@@ -520,7 +522,7 @@ float npc::estimate_armour( const Character &candidate ) const
         armour_step += candidate.get_armor_type( damage_stab, part_id );
         armour_step += candidate.get_armor_type( damage_bullet, part_id );
         add_msg_debug( debugmode::DF_NPC_ITEMAI, "%s: %s armour value for %s rated as %i.", name,
-                       candidate.disp_name(), body_part_name( part_id ), armour_step );
+                       candidate.disp_name( true ), body_part_name( part_id ), armour_step );
         if( part_id == bodypart_id( "head" ) || part_id == bodypart_id( "torso" ) ) {
             armour_step *= 3;
             number_of_parts += 2;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -437,7 +437,7 @@ float npc::evaluate_character( const Character &candidate, bool my_gun, bool ene
     if( enemy && candidate_gun && !my_gun ) {
         add_msg_debug( debugmode::DF_NPC_COMBATAI,
                        "%s has a gun and %s doesn't; %s adjusts threat accordingly.",
-                       candidate.disp_name( true ), name, name );
+                       candidate.disp_name(), name, name );
         candidate_weap_val *= 1.5f;
     }
     threat += candidate_weap_val;
@@ -477,12 +477,12 @@ float npc::evaluate_self( bool my_gun ) const
     // the worse pain the NPC is in, the more likely they are to overestimate the severity of their injuries.
     // the more perceptive they are, the more they're able to see how bad it really is.
     float pain_factor = rng( 0.0f,
-                             static_cast<float>( get_pain() ) / static_cast<float>( get_per() ) ) );
+                             static_cast<float>( get_pain() ) / static_cast<float>( get_per() ) );
     float my_health = ( hp_percentage() - pain_factor ) / 100.0f;
     float armour = estimate_armour( dynamic_cast<const Character &>( *this ) );
     float speed = std::max( 0.5f, get_speed() / 100.0f );
     if( my_gun ) {
-    speed = std::max( speed, 0.75f );
+        speed = std::max( speed, 0.75f );
     }
 
     threat += get_dodge();
@@ -503,7 +503,8 @@ float npc::evaluate_self( bool my_gun ) const
                    name, speed * 100.0f );
     threat *= my_health;
     add_msg_debug( debugmode::DF_NPC_COMBATAI,
-                   "%s scales own threat by %1.0f%% based on remaining health.", name, my_health * 100.0f );
+                   "%s scales own threat by %1.0f%% based on remaining health (reduced by %1.2f%% due to pain).", name,
+                   my_health * 100.0f, pain_factor );
     add_msg_debug( debugmode::DF_NPC, "%s assesses own threat as %1.2f", name, threat );
     return std::min( threat, NPC_CHARACTER_DANGER_MAX );
 }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -939,12 +939,13 @@ void npc::assess_danger()
     }
 
     assessment *= NPC_COWARDICE_MODIFIER;
+    assess_ally *= NPC_COWARDICE_MODIFIER;
     if( !has_effect( effect_npc_run_away ) && !has_effect( effect_npc_fire_bad ) ) {
         float my_diff = evaluate_self( npc_ranged ) * 0.5f;
         add_msg_debug( debugmode::DF_NPC_COMBATAI,
                        "%s assesses own final strength as %1.2f.", name, my_diff );
         assess_ally += my_diff;
-        add_msg_debug( debugmode::DF_NPC,
+        add_msg_debug( debugmode::DF_NPC_COMBATAI,
                        "%s rates total <color_yellow>enemy strength %1.2f</color>, <color_light_green>ally strength %1.2f</color>.",
                        name,
                        assessment, assess_ally );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -408,7 +408,7 @@ float npc::evaluate_monster( const monster &target, int dist ) const
 {
     float speed = target.speed_rating();
     float scaled_distance = std::max( 1.0f, dist * dist / ( target.speed_rating() + 10 ) );
-    float hp_percent = 1.0f - static_cast<float>( target.get_hp() ) / target.get_hp_max();
+    float hp_percent = static_cast<float>( target.get_hp() ) / target.get_hp_max();
     float diff = std::min( static_cast<float>( target.type->difficulty ), NPC_DANGER_VERY_LOW );
     add_msg_debug( debugmode::DF_NPC_COMBATAI,
                    "<color_yellow>evaluate_monster </color><color_light_gray>%s thinks %s threat level is %1.2f before considering situation.</color>",
@@ -853,7 +853,7 @@ void npc::assess_danger()
             }
         }
         add_msg_debug( debugmode::DF_NPC_COMBATAI,
-                       "<color_light_gray>%s assessed threat of enemy %s as %1.2f.  With distance vs speed ratio %i, final relative threat is </color>%1.2f",
+                       "<color_light_gray>%s assessed threat of enemy %s as %1.2f.  With distance vs speed ratio %i, final relative threat is </color><color_red>%1.2f</color>",
                        name, bogey, foe_threat, scaled_distance, foe_threat / scaled_distance );
         return foe_threat;
     };
@@ -868,7 +868,7 @@ void npc::assess_danger()
         }
     }
     add_msg_debug( debugmode::DF_NPC_COMBATAI,
-                   "Before checking allies+player, %s assesses danger level as %1.2f.", name,
+                   "Before checking allies+player, %s assesses danger level as <color_light_red>%1.2f</color>.", name,
                    assessment );
     for( const weak_ptr_fast<Creature> &guy : ai_cache.friends ) {
         if( !( guy.lock() && guy.lock()->is_npc() ) ) {
@@ -878,11 +878,11 @@ void npc::assess_danger()
                                      npc_ranged, false ), NPC_DANGER_VERY_LOW );
         assess_ally += guy_threat * 0.5f;
         add_msg_debug( debugmode::DF_NPC_COMBATAI,
-                       "<color_light_gray>%s assessed friendly %s at threat level %1.2f.</color>",
+                       "<color_light_gray>%s assessed friendly %s at threat level </color><color_light_blue>%1.2f.</color>",
                        name, guy.lock()->disp_name(), guy_threat );
     }
     add_msg_debug( debugmode::DF_NPC_COMBATAI,
-                   "Total of %s NPC ally threat: %1.2f.",
+                   "Total of <color_green>%s NPC ally threat</color>: <color_light_green>%1.2f</color>.",
                    name, assess_ally );
 
     if( sees( player_character.pos() ) ) {
@@ -908,7 +908,7 @@ void npc::assess_danger()
                 player_diff = player_diff * ( 4 - dist ) / 2;
                 assess_ally += player_diff;
                 add_msg_debug( debugmode::DF_NPC_COMBATAI,
-                               "<color_light_green>Player is %i tiles from %s.</color><color_light_gray>  Adding %1.2f to ally strength and bolstering morale.</color>",
+                               "<color_green>Player is %i tiles from %s.</color><color_light_gray>  Adding </color><color_light_green>%1.2f to ally strength</color><color_light_gray> and bolstering morale.</color>",
                                dist, name,
                                player_diff );
                 swarm_count = 0;
@@ -934,7 +934,7 @@ void npc::assess_danger()
     if( hostile_count > friendly_count ) {
         assessment *= std::max( hostile_count / static_cast<float>( friendly_count ), 1.0f );
         add_msg_debug( debugmode::DF_NPC_COMBATAI,
-                       "Crowd adjustment: <color_light_gray>%s set danger level to %1.2f after counting %i major hostiles vs %i friendlies.</color>",
+                       "Crowd adjustment: <color_light_gray>%s set danger level to </color>%1.2f<color_light_gray> after counting </color><color_yellow>%i major hostiles</color><color_light_gray> vs </color><color_light_green>%i friendlies.</color>",
                        name, assessment, hostile_count, friendly_count );
     }
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2410,7 +2410,7 @@ double Character::gun_value( const item &weap, int ammo ) const
             { 10.0f, 4.0f },
             { 25.0f, 3.0f },
             { 100.0f, 1.0f },
-            { 500.0f, 5.0f },
+            { 500.0f, 0.5f },
         }
     };
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Accidentally winds up rewriting how NPCs assess danger."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

So, um.

This all started when I decided to refactor `npc::assess_danger()` and add some comments to it. I started noting that NPCs' assessments of how tough their friends were weird:
1. They didn't make sense. A weak ally was getting scores of like 100, saying they could take on a hulk with their fists.
2. They were rapidly changing in a large fight, in what seemed unpredictable patterns, bouncing between 30 and 120 in about five turns at one point.

I finally decided to track down where these numbers came from, and here we are.

Before reading on, be aware that I have the utmost respect for the people who originally coded this. They're two of the people whose code I go to when I want to understand how to do something right. However, well, pobody's nerfect.

The old method for estimating how tough a non-monster target is... it, uh, had a few flaws.
- If the target had a gun, and the assessor didn't, the target was considered more threatening, even if they were an ally. That meant that an NPC swapping from a gun to a sword would then rate its team as having become much stronger.
- Assessment of the target would register it as *more* dangerous the more HP the *assessor* has, and also the more max HP they had on their torso. Not the current HP, the max HP. So as they got hurt they rated themselves, and their enemies, lower. If they got a mutation that increased their max HP, they rated their enemies higher.
- the assessment was also *less* dangerous the stronger the assessor's weapon was. Note that this is also how the assessor rated themselves and their allies, so if they had a stronger weapon they rated themselves and their friends lower. Since they'd also be adding their own weapon into this, the math got complex but basically it meant that the lower their HP got, the more they weighted the value of their weapon. This is a big part of why I saw the numbers jumping all over the place.

While I was at this, I noticed that monsters HP and distance weren't factoring into their difficulty in most regards either, and I rewrote a lot of the calculations there

Basically, I am not sure how NPCs managed to even resemble functionality with this. It's utterly nonsensical, I think the bit about HP is a combination of both incorrect logic and some typos in the implementation of that incorrect logic in the first place. Fixing it is probably going to make a lot of differences in how NPCs assess danger, and also allow us to use those danger assessments in new ways now that they make sense.


#### Describe the solution
1. Refactor the `npc::evaluate_enemy()` and `character_danger()` functions into three functions: `evaluate_monster()`, `evaluate_character()`, and `evaluate_self()`. OK, I didn't so much refactor `character_danger()` as nuke it from orbit and then pick up the pieces and superglue them together into something new.
- `evaluate_monster()` is, for now, basically the same as `evaluate_enemy` used to be, but it only works for monsters. I have some ideas for how to adjust this later, but first let's get this whole deal out.
- `evaluate_character()` can be used to evaluate friends, neutrals, and enemies; other NPCs, or the player character.
- `evaluate_self()` only assesses yourself.
2. Create `npc::estimate_armour()`, which calculates a weighted average of bullet, blunt, cut, and stab armour ratings across all body parts on the target Character, with the torso and head counting 3x as much as other parts. This function should be reasonably futureproofed against adding new body parts.
3. Revise threat calculations. Here is the core threat calculation I started with:
- `threat = ( dodge + armour + weapon value ) * speed * %health remaining`
- When evaluating others, the NPC's perception "fuzzes" their result. The higher the perception, the more accurate it is.  Personality also figures in here.
- If an NPC is running away, their threat is dropped to 50% of its total.
- When evaluating themself, the NPC's own stats are affected by internal stats that they're unaware of on other characters, such as their current level of pain. The amount these affect them is randomized and reduced by perception: a more perceptive NPC is less likely to get overwhelmed by the pain and will keep a more accurate assessment of their wounds.
- a character's bleeding figures into their health assessment. When assessing anyone other than themselves, the NPC assessing can only spot intense bleeding, influenced by their perception score.
- Speed assessment varies slightly depending on if the NPC and/or the target have a gun. Speed matters a bit less for targets wielding guns and a bit less if NPC is wielding a gun.
- Aggression and bravery personality scores also influence assessments, and later I'd like NPC opinions to factor in as well, so if they trust you they'll score you higher.
4. Add the CombatAI debug message category and adds commentary in this category and in the ItemAI category I created in #69420. It's through these categories that I realized this function was broken, and I truly cannot over-emphasize how important it is that we improve logic reporting so that these numbers can be seen and noticed when they don't make sense. This has sat, totally and utterly broken, for seven years because it was quietly happening in a spot where the calculations were too complex to see that they were nonsensical without seeing the numbers. Instead, NPCs have just seemed unpredictable and strange.
- My plan here is to use the NPC_whateverAI message categories for the "nitty gritty" detailed reports, and save the basic DF_NPC reports for just basic updates on the most important stuff. So if you see an NPC making weird combat decisions you can break the details down by turning on CombatAI reports.
5. Adjust how monster difficulty is rated.
- Monsters no longer have a hard lower cap on how low their threat can be. The cap does figure in, but it figures in *before* calculation of distance and HP are added, so a monster's overall threat floors at 5, but if it's far away and injured the NPC can rate it lower than that.
- Distance reduces threat as an inverse square, starting around 10 tiles away (adjusted by monster speed). So after ~10 tiles away a human-speed monster starts getting exponentially less threatening. I need to review the math on this and make sure it's sound, but early tests look good.
- TO DO: Needs some adjustment for monsters that have not yet noticed the assessing NPC vs. monsters that are on alert. Won't happen this PR because I'd like to add it along with some logic about what to do about un-alert monsters.
6. This is a lateral change, but I changed how the `assessment` score works when assessing danger. This used to add in all the enemies and subtract the allies, then compare the result to the assessing NPC's difficulty. Now, I add up all the enemies and add up all the allies, and include the NPC as an ally. The math is the same, I just found it easier to error check this way and it let me remove some 'do not hit zero' checks because there's no subtraction now.

Still TO DO besides that: I would like to have the NPC rate their own weapon value lower if their weapon uses ammo, based on how much ammo they have left and how much they have in inventory. I may not add that in this PR as I have already got 220 lines of diff.

#### Describe alternatives you've considered
I considered some more robust ways to calculate armour and damage, and may still implement these, but for now I think this is working OK and I have other things I want to get done.

I'd still like to add things like the target's strength and weapon skill to its assessed threat, influenced by the NPC's own skill with that weapon, but that's a little ways off and might be too much for this PR. If I get there, I'm worried I'll wind up looking at `weapon_value()` and I'm afraid of what I might see. I'm supposed to be adding memory to NPCs, not rewriting their entire basic logic stuff.

Finally, I really think we should have some CI testing here but I don't know how to add that.

#### Testing

Playtest resutls: It's very hard to do enough play testing to get a real feel for this since it's going to vary wildly with different players, loadouts, and scenarios, but the initial tests are veyr promising
- npc fleeing behaviour seems to be much more predictable.
- My npc with a fire axe did a really good job of ditching combat when the zombie threat got too great
- He actually ran away before the point of no return death stuff, which was great
- then he activated my "don't stray too far from player" caveat, came back, saw I was nearby, bolstered his morale, and ran in and died at my side, which was pretty stupid. I have fixes for this planned next.

Weapon assessments feel OK, the role of armour makes a big difference now, and NPCs notice various important things that are helpful to them. I didn't do a lot of ranged weapon testing except to ensure they were valued more appropriately. I don't want to get in the weeds there, there's a lot of work still to be done with rnaged (but at least they can reload their magazines now, nice)

I could use some help testing against more than just crowds of zombies, and testing things like bandits. I will try to get some more work done on those, but the issue with AI changes is that they are so situational that it's hard to guess what things could go wrong.

---
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/affd9a4d-4a7c-4754-b17e-094f3ec97547)
A slightly outdated shot showing the more verbose combat reports. In this example, the NPC has a gun, and is far away from threats so they're rated very low... and you can see that logic happening, what a concept.

---

Final or semifinal testing:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/fa349914-c4b3-4075-925b-961beaa7575a)
Monster threat assessment report

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/1ebed054-7a12-49e7-a76c-8c5c18a63008)
Armour and dodge assessment report

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/2736ba3e-5b61-419d-a34b-7875b2c6debc)
Further fuzz of assessment based on NPC perception, I'm quite pleased about this one.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/c6985d0f-074b-4de9-9d7b-3aea4bfb6314)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/cddb4b55-5ef3-4203-843a-25644db1adb9)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/daf9f1c5-8f3a-4c8b-ae52-3e988a835d01)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/b953debb-ef13-4d70-9bc1-be9670ecb92c)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/a7699455-1169-424b-a4fa-75abe20a1f9e)
Some examples of the new verbose combat reporting that makes this much easier to debug and assess, and basically opens up the black box of the NPC brain to prying eyes.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/3357e243-d57c-484f-bdef-7a3886cd02cf)
This is another NPC in the exact same combat, she's got lower bravery and is more hurt so she's deciding to run away, frankly it's the better solution. Especially since the player has been standing a little ways away just watching their friends die for several turns and taking notes on a clipboard.

#### Additional context
In this process I learned that melee and ranged weapons are valued on a totally different scale, one where a slingshot counts as a score of 11, and a tempered nodachi counts as a score of 8. I added a quick, very dirty scalar fix to weapon_value() to get the numbers into a comparative scale that at least keeps NPCs working a bit, but this is going to need a much closer look, one I have no capacity for within this PR.