### PR TITLE
math_parser: implement support for array arguments

### DIFF
--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -1400,7 +1400,8 @@ These functions support keyword-value pairs as optional arguments (kwargs) of th
 
 This section is a work in progress as functions are ported from `arithmetic` to `math`.
 
-_function arguments are `d`oubles (or sub-expressions), `s`trings, or `v`[ariables](#variables)_
+_function arguments are `d`oubles (or sub-expressions), `s`trings, or `v`[ariables](#variables)_<br/>
+_some functions support array arguments or kwargs, denoted with square brackets [] (ex: [`d`/`v`])_
 
 | Function | Eval | Assign |Scopes | Description |
 |----------|------|--------|-------|-------------|

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -116,6 +116,8 @@ struct parse_state {
         operand,
         lparen,  // operand alias used for functions
         rparen,
+        lbracket,
+        rbracket,
         string,
         eof,     // oper alias used for EOF
     };
@@ -126,6 +128,8 @@ struct parse_state {
             case expect::operand: return "operand";
             case expect::lparen: return "left parenthesis";
             case expect::rparen: return "right parenthesis";
+            case expect::lbracket: return "left bracket";
+            case expect::rbracket: return "right bracket";
             case expect::string: return "string delimiter";
             case expect::eof: return "EOF";
             // *INDENT-ON*
@@ -134,11 +138,15 @@ struct parse_state {
     }
 
     void validate( expect next ) const {
-        if( previous == expect::lparen && next == expect::rparen ) {
+        if( ( previous == expect::lparen && next == expect::rparen ) ||
+            ( previous == expect::operand && next == expect::rbracket ) ) {
             return;
         }
-        expect const alias = next == expect::rparen ? expect::oper : next;
-        if( expected != alias && ( expected != expect::operand || alias != expect::lparen ) &&
+        expect const alias =
+            next == expect::rparen || next == expect::rbracket ? expect::oper : next;
+        if( expected != alias &&
+            ( expected != expect::operand ||
+              ( alias != expect::lparen && alias != expect::lbracket ) ) &&
             ( expected != expect::oper || alias != expect::eof ) ) {
             throw std::invalid_argument( string_format(
                                              "Expected %s, got %s",
@@ -146,17 +154,15 @@ struct parse_state {
                                              expect_to_string( next ) ) );
         }
     }
-    void set( expect current, bool unary_ok = false, bool kwargs_ok = false ) {
+    void set( expect current, bool unary_ok = false ) {
         previous = expected;
         expected = current;
         allows_prefix_unary = unary_ok;
-        allows_kwargs = kwargs_ok;
     }
 
     expect expected = expect::operand;
     expect previous = expect::eof;
     bool allows_prefix_unary = true;
-    bool allows_kwargs = false;
     bool instring = false;
     std::string_view strpos;
 };
@@ -185,12 +191,15 @@ std::vector<double> _eval_params( std::vector<thingie> const &params, dialogue &
     return elems;
 }
 
-template<typename T>
-void _validate_operand( thingie const &thing, T op )
+constexpr void _validate_operand( thingie const &thing, std::string_view symbol )
 {
     if( std::holds_alternative<std::string>( thing.data ) ) {
         throw std::invalid_argument( string_format(
-                                         R"(Operator "%s" does not support string operands)", op->symbol ) );
+                                         R"(Operator "%s" does not support string operands)", symbol ) );
+    }
+    if( std::holds_alternative<array>( thing.data ) ) {
+        throw std::invalid_argument( string_format(
+                                         R"(Operator "%s" does not support array operands)", symbol ) );
     }
 }
 
@@ -311,7 +320,9 @@ class math_exp::math_exp_impl
         struct arity_t {
             enum class type_t {
                 func = 0,
-                bracket,
+                parens,
+                array,
+                ternary,
             };
             arity_t( std::string_view sym_, int expected_, type_t type_, bool stringy_ = false ) : sym( sym_ ),
                 expected( expected_ ), type( type_ ), stringy( stringy_ ) {}
@@ -321,6 +332,10 @@ class math_exp::math_exp_impl
             int expected{};
             type_t type{};
             bool stringy{};
+
+            bool allows_comma() const {
+                return type == type_t::func || type == type_t::array;
+            }
         };
         std::stack<arity_t> arity;
         thingie tree{ 0.0 };
@@ -328,18 +343,21 @@ class math_exp::math_exp_impl
         parse_state state;
 
         void _parse( std::string_view str, bool assignment );
-        void parse_string( std::string_view token, std::string_view full, parse_state &state );
-        void parse_bin_op( pbin_op const &op, parse_state &state );
+        void parse_string( std::string_view token, std::string_view full );
+        void parse_bin_op( pbin_op const &op );
         template<typename T>
-        void parse_diag_f( std::string_view symbol, T const &token, parse_state &state );
-        void parse_comma( parse_state &state );
-        void parse_lparen( parse_state &state );
-        void parse_rparen( parse_state &state );
+        void parse_diag_f( std::string_view symbol, T const &token );
+        void parse_comma();
+        void parse_lparen( arity_t::type_t type = arity_t::type_t::parens );
+        void parse_rparen();
+        void parse_lbracket();
+        void parse_rbracket();
         void new_func();
         void new_oper();
         void new_var( std::string_view str );
         void new_kwarg( thingie &lhs, thingie &rhs );
         void new_ternary( thingie &lhs, thingie &rhs );
+        void new_array();
         void maybe_first_argument();
         void error( std::string_view str, std::string_view what );
         void validate_string( std::string_view str, std::string_view label, std::string_view badlist );
@@ -349,64 +367,70 @@ class math_exp::math_exp_impl
 
 void math_exp::math_exp_impl::maybe_first_argument()
 {
-    if( !arity.empty() && arity.top().type == arity_t::type_t::func && arity.top().current == 0 ) {
+    if( !arity.empty() && arity.top().allows_comma() && arity.top().current == 0 ) {
         arity.top().current++;
     }
 }
 
 void math_exp::math_exp_impl::_parse( std::string_view str, bool assignment )
 {
-    constexpr std::string_view expression_separators = "+-*/^,()%':><=!?";
+    constexpr std::string_view expression_separators = "+-*/^,()[]%':><=!?";
     state = {};
     for( std::string_view const token : tokenize( str, expression_separators ) ) {
         last_token = token;
         if( state.instring || token == "'" ) {
-            parse_string( token, str, state );
+            parse_string( token, str );
 
         } else if( std::optional<double> val = get_number( token ); val ) {
             state.validate( parse_state::expect::operand );
             maybe_first_argument();
             output.emplace( *val );
-            state.set( parse_state::expect::oper, false );
+            state.set( parse_state::expect::oper );
 
         } else if( std::optional<pmath_func> ftoken = get_function( token ); ftoken ) {
             state.validate( parse_state::expect::operand );
             maybe_first_argument();
             ops.emplace( *ftoken );
             arity.emplace( ( *ftoken )->symbol, ( *ftoken )->num_params, arity_t::type_t::func );
-            state.set( parse_state::expect::lparen, false );
+            state.set( parse_state::expect::lparen );
 
         } else if( jmath_func_id jmfid( token ); jmfid.is_valid() ) {
             state.validate( parse_state::expect::operand );
             maybe_first_argument();
             ops.emplace( jmfid );
             arity.emplace( token, jmfid->num_params, arity_t::type_t::func );
-            state.set( parse_state::expect::lparen, false );
+            state.set( parse_state::expect::lparen );
 
         } else if( std::optional<scoped_diag_eval> feval = get_dialogue_eval( token ); feval &&
                    !assignment ) {
-            parse_diag_f( token, *feval, state );
+            parse_diag_f( token, *feval );
 
         } else if( std::optional<scoped_diag_ass> fass = get_dialogue_ass( token ); fass &&
                    assignment ) {
-            parse_diag_f( token, *fass, state );
+            parse_diag_f( token, *fass );
 
         } else if( std::optional<punary_op> op = get_unary_op( token ); op && state.allows_prefix_unary ) {
             state.validate( parse_state::expect::operand );
             ops.emplace( *op );
-            state.set( parse_state::expect::operand, false );
+            state.set( parse_state::expect::operand );
 
         } else if( std::optional<pbin_op> op = get_binary_op( token ); op ) {
-            parse_bin_op( *op, state );
+            parse_bin_op( *op );
 
         } else if( token == "," ) {
-            parse_comma( state );
+            parse_comma();
 
         } else if( token == "(" ) {
-            parse_lparen( state );
+            parse_lparen();
 
         } else if( token == ")" ) {
-            parse_rparen( state );
+            parse_rparen();
+
+        } else if( token == "[" ) {
+            parse_lbracket();
+
+        } else if( token == "]" ) {
+            parse_rbracket();
 
         } else if( token == "=" ) {
             throw std::invalid_argument( R"(Misplaced "=".  Did you mean "=="?)" );
@@ -415,13 +439,16 @@ void math_exp::math_exp_impl::_parse( std::string_view str, bool assignment )
             state.validate( parse_state::expect::operand );
             maybe_first_argument();
             new_var( token );
-            state.set( parse_state::expect::oper, false );
+            state.set( parse_state::expect::oper );
         }
     }
     state.validate( parse_state::expect::eof );
     while( !ops.empty() ) {
         if( std::holds_alternative<paren>( ops.top() ) && std::get<paren>( ops.top() ) == paren::left ) {
             throw std::invalid_argument( "Unterminated left paranthesis" );
+        }
+        if( std::holds_alternative<paren>( ops.top() ) && std::get<paren>( ops.top() ) == paren::left_sq ) {
+            throw std::invalid_argument( "Unterminated left bracket" );
         }
         new_oper();
     }
@@ -437,8 +464,7 @@ void math_exp::math_exp_impl::_parse( std::string_view str, bool assignment )
     output.pop();
 }
 
-void math_exp::math_exp_impl::parse_string( std::string_view token, std::string_view full,
-        parse_state &state )
+void math_exp::math_exp_impl::parse_string( std::string_view token, std::string_view full )
 {
     if( !state.instring ) {
         state.validate( parse_state::expect::operand );
@@ -448,23 +474,23 @@ void math_exp::math_exp_impl::parse_string( std::string_view token, std::string_
         }
         state.instring = true;
         state.strpos = token;
-        state.set( parse_state::expect::string, false, state.allows_kwargs );
+        state.set( parse_state::expect::string, false );
     } else if( token == "'" ) {
         // FIXME: write a better tokenizer that returns the entire quoted string as a single token
         output.emplace( std::in_place_type_t<std::string>(), full, state.strpos.data() - full.data() + 1,
                         token.data() - state.strpos.data() - 1 );
         state.instring = false;
-        state.set( parse_state::expect::oper, false, state.allows_kwargs );
+        state.set( parse_state::expect::oper, false );
     } else {
         // skip tokens inside string
     }
 }
 
-void math_exp::math_exp_impl::parse_bin_op( pbin_op const &op, parse_state &state )
+void math_exp::math_exp_impl::parse_bin_op( pbin_op const &op )
 {
-    if( op->symbol == ":" && !state.allows_kwargs ) {
+    if( op->symbol == ":" && !arity.empty() && arity.top().type == arity_t::type_t::ternary ) {
         // insert a pair of parens to help resolve nested ternaries like 0?0?-1:-2:1
-        parse_rparen( state );
+        parse_rparen();
     }
     state.validate( parse_state::expect::oper );
     while( !ops.empty() && ops.top() > *op ) {
@@ -473,44 +499,43 @@ void math_exp::math_exp_impl::parse_bin_op( pbin_op const &op, parse_state &stat
     ops.emplace( op );
     state.set( parse_state::expect::operand, true );
     if( op->symbol == "?" ) {
-        parse_lparen( state );
+        parse_lparen( arity_t::type_t::ternary );
     }
 }
 
 template<typename T>
-void math_exp::math_exp_impl::parse_diag_f( std::string_view symbol, T const &token,
-        parse_state &state )
+void math_exp::math_exp_impl::parse_diag_f( std::string_view symbol, T const &token )
 {
     state.validate( parse_state::expect::operand );
     ops.emplace( token );
     arity.emplace( symbol, token.df->num_params, arity_t::type_t::func, true );
-    state.set( parse_state::expect::lparen, false, true );
+    state.set( parse_state::expect::lparen, false );
 }
 
-void math_exp::math_exp_impl::parse_comma( parse_state &state )
+void math_exp::math_exp_impl::parse_comma()
 {
     state.validate( parse_state::expect::oper );
-    if( arity.empty() || arity.top().type == arity_t::type_t::bracket ) {
+    if( arity.empty() || !arity.top().allows_comma() ) {
         throw std::invalid_argument( "Misplaced comma" );
     }
     while( ops.top() > paren::left ) {
         new_oper();
     }
     arity.top().current++;
-    state.set( parse_state::expect::operand, true, arity.top().stringy );
+    state.set( parse_state::expect::operand, true );
 }
 
-void math_exp::math_exp_impl::parse_lparen( parse_state &state )
+void math_exp::math_exp_impl::parse_lparen( arity_t::type_t type )
 {
     state.validate( parse_state::expect::lparen );
     if( ops.empty() || !is_function( ops.top() ) ) {
-        arity.emplace( std::string_view{}, 0, arity_t::type_t::bracket );
+        arity.emplace( std::string_view{}, 0, type, !arity.empty() && arity.top().stringy );
     }
     ops.emplace( paren::left );
-    state.set( parse_state::expect::operand, true, state.allows_kwargs );
+    state.set( parse_state::expect::operand, true );
 }
 
-void math_exp::math_exp_impl::parse_rparen( parse_state &state )
+void math_exp::math_exp_impl::parse_rparen()
 {
     state.validate( parse_state::expect::rparen );
     while( !ops.empty() && ops.top() > paren::left ) {
@@ -525,6 +550,34 @@ void math_exp::math_exp_impl::parse_rparen( parse_state &state )
     arity.pop();
     maybe_first_argument();
     state.set( parse_state::expect::oper, false );
+}
+
+void math_exp::math_exp_impl::parse_lbracket()
+{
+    state.validate( parse_state::expect::lbracket );
+    if( arity.empty() || !arity.top().stringy ) {
+        throw std::invalid_argument( "Arrays can only be used as arguments for dialogue functions" );
+    }
+    arity.emplace( std::string_view{}, 0, arity_t::type_t::array,
+                   !arity.empty() && arity.top().stringy );
+    ops.emplace( paren::left_sq );
+    state.set( parse_state::expect::operand, true );
+}
+
+void math_exp::math_exp_impl::parse_rbracket()
+{
+    state.validate( parse_state::expect::rbracket );
+    if( arity.empty() || arity.top().type != arity_t::type_t::array ) {
+        throw std::invalid_argument( "Misplaced right bracket" );
+    }
+    while( !ops.empty() && ops.top() > paren::left_sq ) {
+        new_oper();
+    }
+    ops.pop();
+    new_array();
+    arity.pop();
+    maybe_first_argument();
+    state.set( parse_state::expect::oper );
 }
 
 void math_exp::math_exp_impl::new_func()
@@ -603,6 +656,15 @@ diag_value math_exp::math_exp_impl::_get_diag_value( thingie &param )
         {
             val.data.emplace<var_info>( std::move( v.varinfo ) );
         },
+        [&val]( array & v )
+        {
+            diag_array arr;
+            arr.reserve( v.params.size() );
+            for( thingie &t : v.params ) {
+                arr.emplace_back( _get_diag_value( t ) );
+            }
+            val.data.emplace<diag_array>( std::move( arr ) );
+        },
         [&val, &param]( auto const &/* v */ )
         {
             val.data.emplace<math_exp>( math_exp_impl{ std::move( param ) } );
@@ -623,6 +685,12 @@ std::vector<diag_value> math_exp::math_exp_impl::_get_diag_vals( std::vector<thi
 
 void math_exp::math_exp_impl::new_kwarg( thingie &lhs, thingie &rhs )
 {
+    if( arity.top().type != arity_t::type_t::func || !arity.top().stringy ) {
+        throw std::invalid_argument( "kwargs are not supported in this scope" );
+    }
+    if( !std::holds_alternative<std::string>( lhs.data ) ) {
+        throw std::invalid_argument( "kwarg key must be a string" );
+    }
     output.emplace( std::in_place_type_t<kwarg>(), std::get<std::string>( lhs.data ), rhs );
     arity.top().current--;
     arity.top().nkwargs++;
@@ -630,18 +698,30 @@ void math_exp::math_exp_impl::new_kwarg( thingie &lhs, thingie &rhs )
 
 void math_exp::math_exp_impl::new_ternary( thingie &lhs, thingie &rhs )
 {
+    _validate_operand( lhs, "?:" );
+    _validate_operand( rhs, "?:" );
     ops.pop();
-    if( !std::holds_alternative<pbin_op>( ops.top() ) ||
-        std::get<pbin_op>( ops.top() )->symbol != "?" ) {
-        throw std::invalid_argument( "Misplaced colon" );
-    }
     thingie cond = std::move( output.top() );
+    _validate_operand( cond, "?:" );
     output.pop();
     output.emplace( std::in_place_type_t<ternary>(), cond, lhs, rhs );
 }
 
+void math_exp::math_exp_impl::new_array()
+{
+    std::vector<thingie>::size_type const nparams = arity.top().current;
+    std::vector<thingie> params( nparams );
+    for( std::vector<thingie>::size_type i = 0; i < nparams; i++ ) {
+        params[nparams - i - 1] = std::move( output.top() );
+        output.pop();
+    }
+    output.emplace( std::in_place_type_t<array>(), std::move( params ) );
+}
+
 void math_exp::math_exp_impl::new_oper()
 {
+    op_t op( ops.top() );
+    ops.pop();
     std::visit( overloaded{
         [this]( pbin_op v )
         {
@@ -654,17 +734,23 @@ void math_exp::math_exp_impl::new_oper()
                 throw std::invalid_argument( "Unterminated ternary" );
             }
             if( v->symbol == ":" ) {
-                if( !arity.empty() && arity.top().stringy && arity.top().current > 0 &&
-                    std::holds_alternative<std::string>( lhs.data ) ) {
-                    new_kwarg( lhs, rhs );
-                } else if( ops.size() >= 2 && !output.empty() ) {
+                std::string_view top_sym =
+                    !ops.empty() && std::holds_alternative<pbin_op>( ops.top() )
+                    ? std::get<pbin_op>( ops.top() )->symbol
+                    : std::string_view{};
+
+                if( !output.empty() && top_sym == "?" ) {
                     new_ternary( lhs, rhs );
+
+                } else if( !arity.empty() && arity.top().current > 0 ) {
+                    new_kwarg( lhs, rhs );
+
                 } else {
-                    throw std::invalid_argument( "Misplaced colon or kwarg key is not string" );
+                    throw std::invalid_argument( "Misplaced colon" );
                 }
             } else {
-                _validate_operand( lhs, v );
-                _validate_operand( rhs, v );
+                _validate_operand( lhs, v->symbol );
+                _validate_operand( rhs, v->symbol );
                 output.emplace( std::in_place_type_t<oper>(), lhs, rhs, v->f );
             }
         },
@@ -673,7 +759,7 @@ void math_exp::math_exp_impl::new_oper()
             cata_assert( !output.empty() );
             thingie rhs = std::move( output.top() );
             output.pop();
-            _validate_operand( rhs, v );
+            _validate_operand( rhs, v->symbol );
             output.emplace( std::in_place_type_t<oper>(), thingie { 0.0 }, rhs, v->f );
         },
         []( auto /* v */ )
@@ -682,9 +768,7 @@ void math_exp::math_exp_impl::new_oper()
             throw std::invalid_argument( "Internal oper error.  That's all we know." );
         }
     },
-    ops.top() );
-
-    ops.pop();
+    op );
 }
 
 void math_exp::math_exp_impl::new_var( std::string_view str )

--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -23,7 +23,7 @@
 #include "dialogue.h"
 #include "dialogue_helpers.h"
 #include "global_vars.h"
-#include "math_parser_diag.h"
+#include "math_parser_diag_value.h"
 #include "math_parser_func.h"
 #include "math_parser_impl.h"
 #include "math_parser_jmath.h"

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -2,10 +2,8 @@
 
 #include <functional>
 #include <string>
-#include <type_traits>
 #include <vector>
 
-#include "cata_utility.h"
 #include "condition.h"
 #include "dialogue.h"
 #include "field.h"
@@ -30,111 +28,7 @@ bool is_beta( char scope )
     }
 }
 
-template<typename T>
-constexpr std::string_view _str_type_of( T /* t */ )
-{
-    if constexpr( std::is_same_v<T, double> ) {
-        return "double";
-    } else if constexpr( std::is_same_v<T, std::string> ) {
-        return "string";
-    } else if constexpr( std::is_same_v<T, var_info> ) {
-        return "variable";
-    } else if constexpr( std::is_same_v<T, math_exp> ) {
-        return "sub-expression";
-    }
-    return "cookies";
-}
-
-template<class C, class R = C>
-constexpr R _diag_value_at_parse_time( diag_value::impl_t const &data )
-{
-    return std::visit( overloaded{
-        []( C const & v ) -> R
-        {
-            return v;
-        },
-        []( auto const & v ) -> R
-        {
-            throw std::invalid_argument( string_format( "Expected %s, got %s", _str_type_of( C{} ), _str_type_of( v ) ) );
-        },
-    },
-    data );
-}
-
 } // namespace
-
-double diag_value::dbl() const
-{
-    return _diag_value_at_parse_time<double>( data );
-}
-
-double diag_value::dbl( dialogue const &d ) const
-{
-    return std::visit( overloaded{
-        []( double v )
-        {
-            return v;
-        },
-        []( std::string const & v )
-        {
-            if( std::optional<double> ret = svtod( v ); ret ) {
-                return *ret;
-            }
-            debugmsg( R"(Could not convert string "%s" to double)", v );
-            return 0.0;
-        },
-        [&d]( var_info const & v )
-        {
-            std::string const val = read_var_value( v, d );
-            if( std::optional<double> ret = svtod( val ); ret ) {
-                return *ret;
-            }
-            debugmsg( R"(Could not convert variable "%s" with value "%s" to double)", v.name, val );
-            return 0.0;
-        },
-        [&d]( math_exp const & v )
-        {
-            // FIXME: maybe re-constify eval paths?
-            return v.eval( const_cast<dialogue &>( d ) );
-        }
-    },
-    data );
-}
-
-std::string_view diag_value::str() const
-{
-    return _diag_value_at_parse_time<std::string, std::string_view>( data );
-}
-
-std::string diag_value::str( dialogue const &d ) const
-{
-    return std::visit( overloaded{
-        []( double v )
-        {
-            // NOLINTNEXTLINE(cata-translate-string-literal)
-            return string_format( "%g", v );
-        },
-        []( std::string const & v )
-        {
-            return v;
-        },
-        [&d]( var_info const & v )
-        {
-            return read_var_value( v, d );
-        },
-        [&d]( math_exp const & v )
-        {
-            // NOLINTNEXTLINE(cata-translate-string-literal)
-            return string_format( "%g", v.eval( const_cast<dialogue &>( d ) ) );
-        }
-    },
-    data );
-}
-
-var_info diag_value::var() const
-{
-    return _diag_value_at_parse_time<var_info>( data );
-}
 
 std::function<double( dialogue & )> u_val( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )

--- a/src/math_parser_diag.h
+++ b/src/math_parser_diag.h
@@ -83,6 +83,7 @@ decl_diag_ass spell_level_adjustment_ass;
 decl_diag_eval proficiency_eval;
 decl_diag_ass proficiency_ass;
 decl_diag_eval test_diag;
+decl_diag_eval test_str_len;
 decl_diag_eval u_val;
 decl_diag_ass u_val_ass;
 decl_diag_eval vitamin_eval;
@@ -127,6 +128,7 @@ std::function<double( dialogue & )> myfunction_eval( char scope,
 // kwargs are not included in num_args
 inline std::map<std::string_view, dialogue_func_eval> const dialogue_eval_f{
     { "_test_diag_", { "g", -1, test_diag } },
+    { "_test_str_len_", { "g", -1, test_str_len } },
     { "addiction_intensity", { "un", 1, addiction_intensity_eval } },
     { "addiction_turns", { "un", 1, addiction_turns_eval } },
     { "armor", { "un", 2, armor_eval } },

--- a/src/math_parser_diag.h
+++ b/src/math_parser_diag.h
@@ -4,14 +4,11 @@
 
 #include <functional>
 #include <map>
-#include <string>
 #include <string_view>
-#include <variant>
 #include <vector>
 
-#include "dialogue_helpers.h"
+#include "math_parser_diag_value.h"
 
-class math_exp;
 struct dialogue;
 struct dialogue_func {
     dialogue_func( std::string_view sc_, int n_ ) :
@@ -19,57 +16,6 @@ struct dialogue_func {
     std::string_view scopes;
     int num_params{};
 };
-
-struct diag_value {
-    diag_value() = default;
-    template <class U>
-    explicit diag_value( U u ) : data( std::in_place_type<U>, std::forward<U>( u ) ) {}
-    template <class T, class... Args>
-    explicit diag_value( std::in_place_type_t<T> /*t*/, Args &&...args )
-        : data( std::in_place_type<T>, std::forward<Args>( args )... ) {}
-
-    // these functions can be used at parse time if the parameter needs to be of exactly this type
-    // with no conversion. These throw so they should *NOT* be used at runtime.
-    double dbl() const;
-    std::string_view str() const;
-    var_info var() const;
-
-    // evaluate and possibly convert the parameter to this type
-    double dbl( dialogue const &d ) const;
-    std::string str( dialogue const &d ) const;
-
-    using impl_t = std::variant<double, std::string, var_info, math_exp>;
-    impl_t data;
-};
-
-constexpr bool operator==( diag_value const &lhs, std::string_view rhs )
-{
-    return std::holds_alternative<std::string>( lhs.data ) && std::get<std::string>( lhs.data ) == rhs;
-}
-
-// helper struct that makes it easy to determine whether a kwarg's value has been used
-struct deref_diag_value {
-    public:
-        deref_diag_value() = default;
-        explicit deref_diag_value( diag_value &&dv ) : _val( dv ) {}
-        diag_value const *operator->() const {
-            _used = true;
-            return &_val;
-        }
-        diag_value const &operator*() const {
-            _used = true;
-            return _val;
-        }
-        bool was_used() const {
-            return _used;
-        }
-    private:
-        bool mutable _used = false;
-        diag_value _val;
-};
-
-using diag_kwargs = std::map<std::string, deref_diag_value>;
-
 struct dialogue_func_eval : dialogue_func {
     using f_t = std::function<double( dialogue & )> ( * )( char scope,
                 std::vector<diag_value> const &, diag_kwargs const & );

--- a/src/math_parser_diag_value.cpp
+++ b/src/math_parser_diag_value.cpp
@@ -1,0 +1,120 @@
+#include "math_parser_diag_value.h"
+
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+#include "cata_utility.h"
+#include "debug.h"
+#include "math_parser.h"
+#include "string_formatter.h"
+
+namespace
+{
+template<typename T>
+constexpr std::string_view _str_type_of( T /* t */ )
+{
+    if constexpr( std::is_same_v<T, double> ) {
+        return "double";
+    } else if constexpr( std::is_same_v<T, std::string> ) {
+        return "string";
+    } else if constexpr( std::is_same_v<T, var_info> ) {
+        return "variable";
+    } else if constexpr( std::is_same_v<T, math_exp> ) {
+        return "sub-expression";
+    }
+    return "cookies";
+}
+
+template<class C, class R = C>
+constexpr R _diag_value_at_parse_time( diag_value::impl_t const &data )
+{
+    return std::visit( overloaded{
+        []( C const & v ) -> R
+        {
+            return v;
+        },
+        []( auto const & v ) -> R
+        {
+            throw std::invalid_argument( string_format( "Expected %s, got %s", _str_type_of( C{} ), _str_type_of( v ) ) );
+        },
+    },
+    data );
+}
+
+} // namespace
+
+double diag_value::dbl() const
+{
+    return _diag_value_at_parse_time<double>( data );
+}
+
+double diag_value::dbl( dialogue const &d ) const
+{
+    return std::visit( overloaded{
+        []( double v )
+        {
+            return v;
+        },
+        []( std::string const & v )
+        {
+            if( std::optional<double> ret = svtod( v ); ret ) {
+                return *ret;
+            }
+            debugmsg( R"(Could not convert string "%s" to double)", v );
+            return 0.0;
+        },
+        [&d]( var_info const & v )
+        {
+            std::string const val = read_var_value( v, d );
+            if( std::optional<double> ret = svtod( val ); ret ) {
+                return *ret;
+            }
+            debugmsg( R"(Could not convert variable "%s" with value "%s" to double)", v.name, val );
+            return 0.0;
+        },
+        [&d]( math_exp const & v )
+        {
+            // FIXME: maybe re-constify eval paths?
+            return v.eval( const_cast<dialogue &>( d ) );
+        },
+    },
+    data );
+}
+
+std::string_view diag_value::str() const
+{
+    return _diag_value_at_parse_time<std::string, std::string_view>( data );
+}
+
+std::string diag_value::str( dialogue const &d ) const
+{
+    return std::visit( overloaded{
+        []( double v )
+        {
+            // NOLINTNEXTLINE(cata-translate-string-literal)
+            return string_format( "%g", v );
+        },
+        []( std::string const & v )
+        {
+            return v;
+        },
+        [&d]( var_info const & v )
+        {
+            return read_var_value( v, d );
+        },
+        [&d]( math_exp const & v )
+        {
+            // NOLINTNEXTLINE(cata-translate-string-literal)
+            return string_format( "%g", v.eval( const_cast<dialogue &>( d ) ) );
+        },
+    },
+    data );
+}
+
+var_info diag_value::var() const
+{
+    return _diag_value_at_parse_time<var_info>( data );
+}

--- a/src/math_parser_diag_value.h
+++ b/src/math_parser_diag_value.h
@@ -1,0 +1,65 @@
+#pragma once
+#ifndef CATA_SRC_MATH_PARSER_DIAG_VALUE_H
+#define CATA_SRC_MATH_PARSER_DIAG_VALUE_H
+
+#include <map>
+#include <string>
+#include <string_view>
+#include <variant>
+#include <vector>
+
+#include "dialogue_helpers.h"
+
+class math_exp;
+struct dialogue;
+struct diag_value {
+    diag_value() = default;
+    template <class U>
+    explicit diag_value( U u ) : data( std::in_place_type<U>, std::forward<U>( u ) ) {}
+    template <class T, class... Args>
+    explicit diag_value( std::in_place_type_t<T> /*t*/, Args &&...args )
+        : data( std::in_place_type<T>, std::forward<Args>( args )... ) {}
+
+    // these functions can be used at parse time if the parameter needs to be of exactly this type
+    // with no conversion. These throw so they should *NOT* be used at runtime.
+    double dbl() const;
+    std::string_view str() const;
+    var_info var() const;
+
+    // evaluate and possibly convert the parameter to this type
+    double dbl( dialogue const &d ) const;
+    std::string str( dialogue const &d ) const;
+
+    using impl_t = std::variant<double, std::string, var_info, math_exp>;
+    impl_t data;
+};
+
+constexpr bool operator==( diag_value const &lhs, std::string_view rhs )
+{
+    return std::holds_alternative<std::string>( lhs.data ) && std::get<std::string>( lhs.data ) == rhs;
+}
+
+// helper struct that makes it easy to determine whether a kwarg's value has been used
+struct deref_diag_value {
+    public:
+        deref_diag_value() = default;
+        explicit deref_diag_value( diag_value &&dv ) : _val( dv ) {}
+        diag_value const *operator->() const {
+            _used = true;
+            return &_val;
+        }
+        diag_value const &operator*() const {
+            _used = true;
+            return _val;
+        }
+        bool was_used() const {
+            return _used;
+        }
+    private:
+        bool mutable _used = false;
+        diag_value _val;
+};
+
+using diag_kwargs = std::map<std::string, deref_diag_value>;
+
+#endif // CATA_SRC_MATH_PARSER_DIAG_VALUE_H

--- a/src/math_parser_diag_value.h
+++ b/src/math_parser_diag_value.h
@@ -12,6 +12,8 @@
 
 class math_exp;
 struct dialogue;
+struct diag_value;
+using diag_array = std::vector<diag_value>;
 struct diag_value {
     diag_value() = default;
     template <class U>
@@ -25,12 +27,15 @@ struct diag_value {
     double dbl() const;
     std::string_view str() const;
     var_info var() const;
+    bool is_array() const;
+    diag_array const &array() const;
 
     // evaluate and possibly convert the parameter to this type
     double dbl( dialogue const &d ) const;
     std::string str( dialogue const &d ) const;
+    diag_array const &array( dialogue const &/* d */ ) const;
 
-    using impl_t = std::variant<double, std::string, var_info, math_exp>;
+    using impl_t = std::variant<double, std::string, var_info, math_exp, diag_array>;
     impl_t data;
 };
 

--- a/src/math_parser_impl.h
+++ b/src/math_parser_impl.h
@@ -39,7 +39,9 @@ constexpr bool operator>( binary_op const &lhs, binary_op const &rhs )
            ( lhs.precedence == rhs.precedence && lhs.assoc == binary_op::associativity::left );
 }
 enum class paren {
-    left = 0,
+    left_sq = 0,
+    right_sq,
+    left,
     right,
 };
 
@@ -118,6 +120,10 @@ struct kwarg {
     std::string key;
     std::shared_ptr<thingie> val;
 };
+struct array {
+    explicit array( std::vector<thingie> &&params_ ): params( params_ ) {}
+    std::vector<thingie> params;
+};
 struct ternary {
     ternary() = default;
     explicit ternary( thingie cond_, thingie mhs_, thingie rhs_ );
@@ -138,7 +144,7 @@ struct thingie {
     constexpr double eval( dialogue &d ) const;
 
     using impl_t =
-        std::variant<double, std::string, oper, func, func_jmath, func_diag_eval, func_diag_ass, var, kwarg, ternary>;
+        std::variant<double, std::string, oper, func, func_jmath, func_diag_eval, func_diag_ass, var, kwarg, ternary, array>;
     impl_t data;
 };
 
@@ -158,6 +164,11 @@ constexpr double thingie::eval( dialogue &d ) const
         []( kwarg const & v )
         {
             debugmsg( "Unexpected kwarg %s", v.key );
+            return 0.0;
+        },
+        []( array const & /* v */ )
+        {
+            debugmsg( "Unexpected array" );
             return 0.0;
         },
         [&d]( auto const & v ) -> double


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Light-Wave asked for array arguments in math [here ](https://github.com/CleverRaven/Cataclysm-DDA/pull/69473#issuecomment-1817639038)

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Implement!

Array arguments are accepted for dialogue functions, either as positional arguments or as kwargs.

Quick example with both: `"_test_diag_([1,1+1,3], 'blorg': [3+1,5,6])"`
Also works with string arguments: `"_test_str_len_(['1','2'], 'test_str_arr': ['one','two'])"`

Also had to clean up parsing of ternaries and kwargs because it was a little sketchy and conflicted with arrays, leading to unhelpful error messages.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Updated test unit

I fuzzed for about a day with [this fuzz target](https://github.com/andrei8l/Cataclysm-DDA/commit/869e7246cc8d56fc7056ddbaaa3b9daa636466ec) (with an updated seed corpus and disabled shim).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
e20d54bfbf69f9d3b1c5e42494f5fd5a95d67905 just moves some code around with no changes

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
