### PR TITLE
mannequins are now deployable and easily pickable

### DIFF
--- a/data/json/furniture_and_terrain/furniture-decorative.json
+++ b/data/json/furniture_and_terrain/furniture-decorative.json
@@ -136,12 +136,7 @@
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [
-        {
-          "item": "splinter",
-          "count": [ 9, 12 ]
-        }
-      ]
+      "items": [ { "item": "splinter", "count": [ 9, 12 ] } ]
     }
   },
   {

--- a/data/json/furniture_and_terrain/furniture-decorative.json
+++ b/data/json/furniture_and_terrain/furniture-decorative.json
@@ -129,13 +129,19 @@
     "coverage": 40,
     "required_str": 5,
     "flags": [ "PLACE_ITEM", "TRANSPARENT", "FLAMMABLE", "EASY_DECONSTRUCT" ],
-    "deconstruct": { "items": [ { "item": "mannequin", "count": 1 } ] },
+    "deployed_item": "mannequin",
+    "examine_action": "deployed_furniture",
     "bash": {
       "str_min": 6,
       "str_max": 40,
       "sound": "smash!",
       "sound_fail": "whump.",
-      "items": [ { "item": "splinter", "count": [ 9, 12 ] } ]
+      "items": [
+        {
+          "item": "splinter",
+          "count": [ 9, 12 ]
+        }
+      ]
     }
   },
   {

--- a/data/json/items/generic/toys_and_sports.json
+++ b/data/json/items/generic/toys_and_sports.json
@@ -310,9 +310,7 @@
     "longest_side": "180 cm",
     "to_hit": -2,
     "melee_damage": { "bash": 18 },
-    "use_action": [
-      { "type": "deploy_furn", "furn_type": "f_mannequin" }
-    ]
+    "use_action": [ { "type": "deploy_furn", "furn_type": "f_mannequin" } ]
   },
   {
     "type": "TOOL",

--- a/data/json/items/generic/toys_and_sports.json
+++ b/data/json/items/generic/toys_and_sports.json
@@ -309,7 +309,10 @@
     "volume": "62500 ml",
     "longest_side": "180 cm",
     "to_hit": -2,
-    "melee_damage": { "bash": 18 }
+    "melee_damage": { "bash": 18 },
+    "use_action": [
+      { "type": "deploy_furn", "furn_type": "f_mannequin" }
+    ]
   },
   {
     "type": "TOOL",


### PR DESCRIPTION
#### Summary
Features "Mannequins are now deployable"

#### Purpose of change
Closes #69513. Mannequins required deconstructing and couldn't be put down again in their base form. This changes that.

#### Describe the solution
Mannequins can now be taken down simply by interacting ("e") with it. To deploy it again just use ("a") it and pick a direction

#### Describe alternatives you've considered
Keep their take down action in construction menu, do the same with deploying it.

#### Testing
Spawned a mannequin, interacted with it to take it down, deployed it by using it.

