### PR TITLE
Bugfix: Prevent infinite loop when spawning monsters

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8720,7 +8720,13 @@ void map::spawn_monsters_submap( const tripoint &gp, bool ignore_sight, bool spa
     const tripoint gp_ms = sm_to_ms_copy( gp );
 
     creature_tracker &creatures = get_creature_tracker();
-    for( spawn_point &i : current_submap->spawns ) {
+
+    // The list of spawns on the submap might be updated while we are iterating it.
+    // For example, `monster::on_load` -> `monster::try_reproduce` calls `map::add_spawn`.
+    // Therefore, this intentionally uses old-school indexed for-loop with re-check against `.size()` each step.
+    // NOLINTNEXTLINE(modernize-loop-convert)
+    for( size_t sp_i = 0; sp_i < current_submap->spawns.size(); ++sp_i ) {
+        const spawn_point i = current_submap->spawns[sp_i]; // intentional copy
         const tripoint center = gp_ms + i.pos;
         const tripoint_range<tripoint> points = points_in_radius( center, 3 );
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent infinite loop when spawning monsters"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Prevents game occasionally seemingly hanging when moving to new submaps
* Fixes #69562 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

You know when you find the cause of a particular bug, and you go "how could this *ever* have worked?!". This was such as case for me.

The reason for the previous problem was an infinite loop caused by:
1. `map::spawn_monsters_submap` for-loops the list of `current_submap->spawns`
2. for every spawned monster, it calls `monster::on_load`
3. `monster::on_load` calls `monster::try_reproduce`, which in turn calls `map::add_spawn`
4. So a new spawn is added, thus invalidating the iterator used in step 1
5. Undefined behavior caused by using invaliated iterators.

On my compiler (gcc 13.2.0), the above problem had the following effect:
* The reference `spawn_point &i` pointed to something totally different, so that in particular, `i.count` had garbage values
* Instead of `i.count` being reasonable values such as `3` or `1`, the above undefined behavior made it have values such as `925969776` or `-632214304`
* `i.count` is the upper bound for the inner for-loop in `map::spawn_monsters_submap`, so depending on the garbage value, it might seem like an infinite loop.

Stacktrace of app when frozen and problem happened:
```
 #0  0x000055a1eaf36dcb in creature_tracker::find(coords::coord_point<tripoint, (coords::origin)1, (coords::scale)0> const&) const ()
 #1  0x000055a1eaf39253 in Creature* creature_tracker::creature_at<Creature>(coords::coord_point<tripoint, (coords::origin)1, (coords::scale)0> const&, bool) ()
 #2  0x000055a1eaf393b5 in Creature* creature_tracker::creature_at<Creature>(tripoint const&, bool) ()
 #3  0x000055a1eb357a53 in map::spawn_monsters_submap(tripoint const&, bool, bool)::{lambda(tripoint const&)#1}::operator()(tripoint const&) const ()
 #4  0x000055a1eb3a976e in random_point(tripoint_range<tripoint> const&, std::function<bool (tripoint const&)> const&) ()
 #5  0x000055a1eb37dd2d in map::spawn_monsters_submap(tripoint const&, bool, bool) ()
 #6  0x000055a1eb37de77 in map::spawn_monsters(bool, bool) ()
 #7  0x000055a1eb093981 in game::update_map(int&, int&, bool) ()
 #8  0x000055a1eb094451 in game::update_map(Character&, bool) ()
 #9  0x000055a1eb09530f in game::place_player(tripoint const&, bool) ()
 #10 0x000055a1eb0b3a0e in game::walk_move(tripoint const&, bool, bool) ()
 #11 0x000055a1ead27490 in avatar_action::move(avatar&, map&, tripoint const&) ()
 #12 0x000055a1eb0f338c in game::do_regular_action(action_id&, avatar&, std::optional<tripoint> const&) ()
 #13 0x000055a1eb0f6e63 in game::handle_action() ()
 #14 0x000055a1eafbd9ea in do_turn() ()
 #15 0x000055a1eaa5ec13 in main ()
```

This commit instead changes the loop in step 1 above so that it explicitly *not* uses iterators, but instead old-fashioned indexed loop. The intention with the change is to allow other parts of the code to add items to the vector `current_submap->spawns` while we are iterating it here. If new items are added, they will be handled in later steps of the loop.


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* Could also copy the whole vector `current_submap->spawns` and for-loop iterating the copy instead, but that would cause spawns that are added while iterating to not be processed.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

The above problem only happened very seldom, and there was some part randomness involved in order to reproduce it. To make the problem easier to reproduce, the following steps were made:
* Changed the code in `monster::try_reproduce` so that all randomness is hardcoded (removed calls to `one_in`)
* Visit a new submap that contains monsters that reproduce. In my case, this was `mon_woodlouse`.

The above steps made it possible to reproduce the issue more often, but not always (depending on which garbage values `i.count` got). With the suggested change, the problem does not happen.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
