### PR TITLE
Boston-chan costume

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/costumes.json
+++ b/data/json/itemgroups/Clothing_Gear/costumes.json
@@ -113,7 +113,8 @@
       { "item": "haori", "prob": 1 },
       { "item": "trenchcoat_steampunk", "prob": 15 },
       { "item": "plaguedoctor_robe", "prob": 15 },
-      { "item": "nun_habit", "prob": 10 }
+      { "item": "nun_habit", "prob": 10 },
+      { "item": "suit_bostonchan", "prob": 20 }
     ]
   },
   {
@@ -192,6 +193,7 @@
       { "item": "hat_hard", "variant": "steampunk_hat_hard", "prob": 10 },
       { "item": "hat_hard_hooded", "variant": "steampunk_hat_hard", "prob": 1 },
       { "item": "clown_wig", "prob": 15 },
+      { "item": "bostonchan_wig", "prob": 20 },
       { "item": "tricorne", "prob": 5 },
       { "item": "wizard_hat_costume", "prob": 25 },
       { "item": "pointed_hat", "prob": 20 },
@@ -298,7 +300,8 @@
       { "item": "cheerleader_skirt", "prob": 15 },
       { "item": "cheerleader_skirt_short", "prob": 15 },
       { "item": "nanoskirt", "prob": 10 },
-      { "item": "skirt_leather", "prob": 15 }
+      { "item": "skirt_leather", "prob": 15 },
+      { "item": "skirt_bostonchan", "prob": 20 }
     ]
   },
   {

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -2281,5 +2281,31 @@
         "append": true
       }
     ]
+  },
+  {
+    "id": "skirt_bostonchan",
+    "type": "ARMOR",
+    "name": { "str": "Boston-Chan skirt" },
+    "description": "A short skirt for the Boston-Chan. costume.",
+    "weight": "230 g",
+    "volume": "250 ml",
+    "price": 9500,
+    "price_postapoc": 50,
+    "material": [ "cotton" ],
+    "symbol": "[",
+    "looks_like": "skirt",
+    "color": "blue",
+    "warmth": 10,
+    "material_thickness": 0.6,
+    "flags": [ "VARSIZE" ],
+    "armor": [
+      {
+        "encumbrance": 5,
+        "coverage": 100,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_hip_l", "leg_hip_r" ]
+      },
+      { "coverage": 38, "covers": [ "leg_l", "leg_r" ], "specifically_covers": [ "leg_upper_l", "leg_upper_r" ] }
+    ]
   }
 ]

--- a/data/json/items/armor/legs_clothes.json
+++ b/data/json/items/armor/legs_clothes.json
@@ -2286,7 +2286,7 @@
     "id": "skirt_bostonchan",
     "type": "ARMOR",
     "name": { "str": "Boston-Chan skirt" },
-    "description": "A short skirt for the Boston-Chan. costume.",
+    "description": "A short skirt for the Boston-Chan costume.",
     "weight": "230 g",
     "volume": "250 ml",
     "price": 9500,

--- a/data/json/items/armor/misc.json
+++ b/data/json/items/armor/misc.json
@@ -312,5 +312,24 @@
     "material_thickness": 1.0,
     "environmental_protection": 0,
     "armor": [ { "encumbrance": 15, "coverage": 10, "covers": [ "head" ] } ]
+  },
+  {
+    "id": "bostonchan_wig",
+    "type": "ARMOR",
+    "name": { "str": "Boston-Chan wig" },
+    "description": "A long blue hair wig for the Boston-Chan costume.",
+    "weight": "125 g",
+    "volume": "0.75 L",
+    "price": 2500,
+    "price_postapoc": 10,
+    "to_hit": -3,
+    "material": [ "cotton" ],
+    "symbol": "[",
+    "color": "blue",
+    "warmth": 10,
+    "material_thickness": 0.2,
+    "environmental_protection": 1,
+    "flags": [ "VARSIZE" ],
+    "armor": [ { "encumbrance": 5, "coverage": 60, "covers": [ "head" ] } ]
   }
 ]

--- a/data/json/items/armor/misc.json
+++ b/data/json/items/armor/misc.json
@@ -319,7 +319,7 @@
     "name": { "str": "Boston-Chan wig" },
     "description": "A long blue hair wig for the Boston-Chan costume.",
     "weight": "125 g",
-    "volume": "0.75 L",
+    "volume": "750 ml",
     "price": 2500,
     "price_postapoc": 10,
     "to_hit": -3,

--- a/data/json/items/armor/torso_clothes.json
+++ b/data/json/items/armor/torso_clothes.json
@@ -2099,5 +2099,49 @@
     "material_thickness": 1,
     "valid_mods": [ "steel_padded" ],
     "flags": [ "VARSIZE", "POCKETS", "HOOD" ]
+  },
+  {
+    "id": "suit_bostonchan",
+    "type": "ARMOR",
+    "name": { "str": "Boston-Chan suit" },
+    "description": "A professional-looking bright blue wool suit for the Boston-Chan costume.",
+    "weight": "680 g",
+    "volume": "3500 ml",
+    "price": 12000,
+    "price_postapoc": 50,
+    "material": [ "wool" ],
+    "symbol": "[",
+    "looks_like": "jacket_light",
+    "color": "blue",
+    "armor": [
+      { "covers": [ "torso" ], "coverage": 85, "encumbrance": [ 5, 10 ] },
+      { "covers": [ "arm_l", "arm_r" ], "coverage": 85, "encumbrance": [ 5, 5 ] }
+    ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "750 ml",
+        "max_contains_weight": "3 kg",
+        "max_item_length": "11 cm",
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "750 ml",
+        "max_contains_weight": "3 kg",
+        "max_item_length": "11 cm",
+        "moves": 80
+      },
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "350 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "9 cm",
+        "moves": 100
+      }
+    ],
+    "warmth": 25,
+    "material_thickness": 1.5,
+    "flags": [ "VARSIZE", "FANCY", "OUTER" ]
   }
 ]


### PR DESCRIPTION


#### Summary
Content "Boston-Chan costume set"


#### Purpose of change
Adds Boston-chan costume set because i have this for the better part of a month now and now having the confidence on adding this into basegame.

#### Describe the solution

Adds Boston-Chan skirt, suit, and wig alongside the costume set's costume itemgroup stuff.

#### Describe alternatives you've considered

Keeping it to myself.

#### Testing

Playing with the costume set as a mod for the better part of the month, i feel like it works as expected.

I also made the sprites for the costume set in MSXotto+
![Screenshot_2023-11-20_05-39-42_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/78019001/3e33b8c9-69ba-43ce-836f-1581c4146784)


#### Additional context

The description and the itemgroup probablity could do with some more work. Tweaks of such things will be appreciated.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
