### PR TITLE
[Xedra Evolved] Maintained spell message grammar improvements

### DIFF
--- a/data/mods/Xedra_Evolved/spells/spell_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/spell_eocs.json
@@ -7,7 +7,7 @@
       { "u_spawn_item": "dreamer_artifact", "use_item_group": true, "suppress_message": true },
       { "math": [ "u_val('vitamin', 'name:dreamer_vit')", "-=", "600" ] },
       {
-        "u_message": "You pulled your powers into this world and something from outside placed an object in your hand.",
+        "u_message": "You pull your power into this world and something from the outside places an object in your hand.",
         "type": "info"
       }
     ],
@@ -29,21 +29,21 @@
         {
           "case": 150,
           "effect": {
-            "u_message": "You try to connect the item with another dimensions, but everything went wrong from the very beginning.  You feel you need much more patience to finish it.",
+            "u_message": "You try to connect the item with another dimension, but everything goes wrong from the very beginning.  You feel you need much more patience to finish this.",
             "type": "bad"
           }
         },
         {
           "case": 300,
           "effect": {
-            "u_message": "You try to connect the item with another dimensions, but something interrupted you in the middle.  You need just a bit of time to afford it.",
+            "u_message": "You try to connect the item with another dimension, but something interupts you in the middle of your attempt.  You need just a bit more time to make this work.",
             "type": "bad"
           }
         },
         {
           "case": 450,
           "effect": {
-            "u_message": "You try to connect the item with another dimensions, but in the end it failed.  It was close enough, so you think you need to try it again in a day.",
+            "u_message": "You try to connect the item with another dimension, but in the end it fails.  It was close though, so you think you need to try it again tomorrow.",
             "type": "bad"
           }
         }
@@ -88,7 +88,7 @@
     "condition": { "and": [ { "u_has_trait": "karma_arms" }, { "math": [ "u_val('mana')", ">=", "200" ] } ] },
     "effect": [
       { "math": [ "u_val('mana')", "-=", "200" ] },
-      { "u_message": "Floating arms behind you flicker a bit, but still glow.", "type": "good" },
+      { "u_message": "The floating arms behind you slightly flicker, but they soon resume their steady glow.", "type": "good" },
       {
         "queue_eocs": "EOC_KARMA_ARMS_CONTINUE",
         "time_in_future": { "math": [ "((u_spell_level('spell_karma_arms')+1)*500)" ] }
@@ -111,7 +111,7 @@
         "time_in_future": { "math": [ "((u_spell_level('spell_devil_tail')+1)*900)" ] }
       }
     ],
-    "false_effect": [ { "u_lose_trait": "devil_tail" }, { "u_message": "Your devil tail disappear in the air.", "type": "neutral" } ]
+    "false_effect": [ { "u_lose_trait": "devil_tail" }, { "u_message": "Your devil tail fades away.", "type": "neutral" } ]
   },
   {
     "type": "effect_on_condition",
@@ -119,13 +119,13 @@
     "condition": { "and": [ { "u_has_trait": "devil_tail" }, { "math": [ "u_val('mana')", ">=", "100" ] } ] },
     "effect": [
       { "math": [ "u_val('mana')", "-=", "100" ] },
-      { "u_message": "Your devilish tail stretches and twist playfully.", "type": "good" },
+      { "u_message": "Your devilish tail stretches and twists playfully.", "type": "good" },
       {
         "queue_eocs": "EOC_DEVIL_TAIL_CONTINUE",
         "time_in_future": { "math": [ "((u_spell_level('spell_devil_tail')+1)*900)" ] }
       }
     ],
-    "false_effect": [ { "u_lose_trait": "devil_tail" }, { "u_message": "Your devil tail disappear in the air.", "type": "neutral" } ]
+    "false_effect": [ { "u_lose_trait": "devil_tail" }, { "u_message": "Your devil tail fades away.", "type": "neutral" } ]
   },
   {
     "type": "effect_on_condition",
@@ -133,7 +133,7 @@
     "condition": { "not": { "u_has_trait": "stalker_eyes" } },
     "effect": [
       {
-        "u_message": "Your vision gets dark for a moment, and in a second, a whole new world is revealed under your eyes.",
+        "u_message": "Your vision grows dark for a moment, but a second later a whole new world is revealed under your eyes.",
         "type": "good"
       },
       { "u_add_trait": "stalker_eyes" },
@@ -144,7 +144,7 @@
     ],
     "false_effect": [
       { "u_lose_trait": "stalker_eyes" },
-      { "u_message": "A great new world under your eyes disappears.", "type": "neutral" }
+      { "u_message": "The great new world visible to your eyes disappears.", "type": "neutral" }
     ]
   },
   {
@@ -153,7 +153,7 @@
     "condition": { "and": [ { "u_has_trait": "stalker_eyes" }, { "math": [ "u_val('mana')", ">=", "200" ] } ] },
     "effect": [
       { "math": [ "u_val('mana')", "-=", "200" ] },
-      { "u_message": "Your sight darkens for a second, but then turn back.", "type": "good" },
+      { "u_message": "Your sight darkens for a second, but it quickly turns back.", "type": "good" },
       {
         "queue_eocs": "EOC_STALKER_EYES_CONTINUE",
         "time_in_future": { "math": [ "((u_spell_level('spell_stalker_eyes')+1)*1300)" ] }
@@ -161,7 +161,7 @@
     ],
     "false_effect": [
       { "u_lose_trait": "stalker_eyes" },
-      { "u_message": "A great new world under your eyes disappears.", "type": "neutral" }
+      { "u_message": "The great new world visible to your eyes disappears.", "type": "neutral" }
     ]
   }
 ]

--- a/data/mods/Xedra_Evolved/spells/spell_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/spell_eocs.json
@@ -88,7 +88,10 @@
     "condition": { "and": [ { "u_has_trait": "karma_arms" }, { "math": [ "u_val('mana')", ">=", "200" ] } ] },
     "effect": [
       { "math": [ "u_val('mana')", "-=", "200" ] },
-      { "u_message": "The floating arms behind you slightly flicker, but they soon resume their steady glow.", "type": "good" },
+      {
+        "u_message": "The floating arms behind you slightly flicker, but they soon resume their steady glow.",
+        "type": "good"
+      },
       {
         "queue_eocs": "EOC_KARMA_ARMS_CONTINUE",
         "time_in_future": { "math": [ "((u_spell_level('spell_karma_arms')+1)*500)" ] }

--- a/data/mods/Xedra_Evolved/spells/spell_eocs.json
+++ b/data/mods/Xedra_Evolved/spells/spell_eocs.json
@@ -7,7 +7,7 @@
       { "u_spawn_item": "dreamer_artifact", "use_item_group": true, "suppress_message": true },
       { "math": [ "u_val('vitamin', 'name:dreamer_vit')", "-=", "600" ] },
       {
-        "u_message": "You pull your power into this world and something from the outside places an object in your hand.",
+        "u_message": "You pull your power into this world, and something outside of it places an object in your hand.",
         "type": "info"
       }
     ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None 
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
"Grammar / wording improvements for maintained spells" There was a couple of grammar issues I saw with the karma arms maintain message in game that I see frequently, so I gave the whole file a parse through.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fixes some grammar issues and aims for present tense in the messages.  One or two other slight wording changes that I feel work better.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
N/A
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
