### PR TITLE
Make add_msg_debug and variants a macro.

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3687,8 +3687,8 @@ void workout_activity_actor::do_turn( player_activity &act, Character &who )
             who.add_morale( MORALE_FEELING_GOOD, intensity_modifier, 20, 6_hours, 30_minutes );
         }
         if( calendar::once_every( 2_minutes ) ) {
-            add_msg_debug_if_player( who, debugmode::DF_ACT_WORKOUT, who.activity_level_str() );
-            add_msg_debug_if_player( who, debugmode::DF_ACT_WORKOUT, act.id().c_str() );
+            add_msg_debug_if( who.is_avatar(), debugmode::DF_ACT_WORKOUT, who.activity_level_str() );
+            add_msg_debug_if( who.is_avatar(), debugmode::DF_ACT_WORKOUT, act.id().c_str() );
         }
     } else if( !rest_mode ) {
         rest_mode = true;

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3687,8 +3687,8 @@ void workout_activity_actor::do_turn( player_activity &act, Character &who )
             who.add_morale( MORALE_FEELING_GOOD, intensity_modifier, 20, 6_hours, 30_minutes );
         }
         if( calendar::once_every( 2_minutes ) ) {
-            who.add_msg_debug_if_player( debugmode::DF_ACT_WORKOUT, who.activity_level_str() );
-            who.add_msg_debug_if_player( debugmode::DF_ACT_WORKOUT, act.id().c_str() );
+            add_msg_debug_if_player( who, debugmode::DF_ACT_WORKOUT, who.activity_level_str() );
+            add_msg_debug_if_player( who, debugmode::DF_ACT_WORKOUT, act.id().c_str() );
         }
     } else if( !rest_mode ) {
         rest_mode = true;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -873,7 +873,7 @@ void Character::add_msg_if_player( const game_message_params &params, const std:
 void Character::add_msg_debug_if_player( debugmode::debug_filter type,
         const std::string &msg ) const
 {
-    Messages::add_msg_debug( type, msg );
+    add_msg_debug( type, msg );
 }
 
 void Character::add_msg_player_or_npc( const game_message_params &params,
@@ -887,7 +887,7 @@ void Character::add_msg_debug_player_or_npc( debugmode::debug_filter type,
         const std::string &player_msg,
         const std::string &/*npc_msg*/ ) const
 {
-    Messages::add_msg_debug( type, player_msg );
+    add_msg_debug( type, player_msg );
 }
 
 void Character::add_msg_player_or_say( const std::string &player_msg,

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5092,7 +5092,7 @@ needs_rates Character::calc_needs_rates() const
 
     rates.kcal = get_bmr();
 
-    add_msg_debug_if_player( *this, debugmode::DF_CHAR_CALORIES, "Metabolic rate: %.2f", rates.hunger );
+    add_msg_debug_if( is_avatar(), debugmode::DF_CHAR_CALORIES, "Metabolic rate: %.2f", rates.hunger );
 
     static const std::string player_thirst_rate( "PLAYER_THIRST_RATE" );
     rates.thirst = get_option< float >( player_thirst_rate );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -870,24 +870,11 @@ void Character::add_msg_if_player( const game_message_params &params, const std:
     Messages::add_msg( params, msg );
 }
 
-void Character::add_msg_debug_if_player( debugmode::debug_filter type,
-        const std::string &msg ) const
-{
-    add_msg_debug( type, msg );
-}
-
 void Character::add_msg_player_or_npc( const game_message_params &params,
                                        const std::string &player_msg,
                                        const std::string &/*npc_msg*/ ) const
 {
     Messages::add_msg( params, player_msg );
-}
-
-void Character::add_msg_debug_player_or_npc( debugmode::debug_filter type,
-        const std::string &player_msg,
-        const std::string &/*npc_msg*/ ) const
-{
-    add_msg_debug( type, player_msg );
 }
 
 void Character::add_msg_player_or_say( const std::string &player_msg,
@@ -5105,7 +5092,7 @@ needs_rates Character::calc_needs_rates() const
 
     rates.kcal = get_bmr();
 
-    add_msg_debug_if_player( debugmode::DF_CHAR_CALORIES, "Metabolic rate: %.2f", rates.hunger );
+    add_msg_debug_if_player( *this, debugmode::DF_CHAR_CALORIES, "Metabolic rate: %.2f", rates.hunger );
 
     static const std::string player_thirst_rate( "PLAYER_THIRST_RATE" );
     rates.thirst = get_option< float >( player_thirst_rate );

--- a/src/character.h
+++ b/src/character.h
@@ -727,17 +727,11 @@ class Character : public Creature, public visitable
         using Creature::add_msg_if_player;
         void add_msg_if_player( const std::string &msg ) const override;
         void add_msg_if_player( const game_message_params &params, const std::string &msg ) const override;
-        using Creature::add_msg_debug_if_player;
-        void add_msg_debug_if_player( debugmode::debug_filter type,
-                                      const std::string &msg ) const override;
         using Creature::add_msg_player_or_npc;
         void add_msg_player_or_npc( const std::string &player_msg,
                                     const std::string &npc_str ) const override;
         void add_msg_player_or_npc( const game_message_params &params, const std::string &player_msg,
                                     const std::string &npc_msg ) const override;
-        using Creature::add_msg_debug_player_or_npc;
-        void add_msg_debug_player_or_npc( debugmode::debug_filter type, const std::string &player_msg,
-                                          const std::string &npc_msg ) const override;
         using Creature::add_msg_player_or_say;
         void add_msg_player_or_say( const std::string &player_msg,
                                     const std::string &npc_speech ) const override;

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -3144,12 +3144,6 @@ void Creature::add_msg_player_or_npc( const game_message_params &params, const t
     return add_msg_player_or_npc( params, pc.translated(), npc.translated() );
 }
 
-void Creature::add_msg_debug_player_or_npc( debugmode::debug_filter type, const translation &pc,
-        const translation &npc ) const
-{
-    return add_msg_debug_player_or_npc( type, pc.translated(), npc.translated() );
-}
-
 void Creature::add_msg_player_or_say( const translation &pc, const translation &npc ) const
 {
     return add_msg_player_or_say( pc.translated(), npc.translated() );

--- a/src/creature.h
+++ b/src/creature.h
@@ -1111,68 +1111,6 @@ class Creature : public viewer
                                           string_format( npc_msg, std::forward<Args>( args )... ) );
         }
 
-        virtual void add_msg_debug_if_player( debugmode::debug_filter /*type*/,
-                                              const std::string &/*msg*/ ) const {}
-        template<typename ...Args>
-        void add_msg_debug_if_player( debugmode::debug_filter type, const char *const msg,
-                                      Args &&... args ) const {
-            // expanding for string formatting can be expensive
-            if( debug_mode ) {
-                return add_msg_debug_if_player( type, string_format( msg, std::forward<Args>( args )... ) );
-            }
-        }
-        template<typename ...Args>
-        void add_msg_debug_if_player( debugmode::debug_filter type, const std::string &msg,
-                                      Args &&... args ) const {
-            if( debug_mode ) {
-                return add_msg_debug_if_player( type, string_format( msg, std::forward<Args>( args )... ) );
-            }
-        }
-
-        virtual void add_msg_debug_if_npc( debugmode::debug_filter /*type*/,
-                                           const std::string &/*msg*/ ) const {}
-        template<typename ...Args>
-        void add_msg_debug_if_npc( debugmode::debug_filter type, const char *const msg,
-                                   Args &&... args ) const {
-            // expanding for string formatting can be expensive
-            if( debug_mode ) {
-                return add_msg_debug_if_npc( type, string_format( msg, std::forward<Args>( args )... ) );
-            }
-        }
-        template<typename ...Args>
-        void add_msg_debug_if_npc( debugmode::debug_filter type, const std::string &msg,
-                                   Args &&... args ) const {
-            if( debug_mode ) {
-                return add_msg_debug_if_npc( type, string_format( msg, std::forward<Args>( args )... ) );
-            }
-        }
-
-        virtual void add_msg_debug_player_or_npc( debugmode::debug_filter /*type*/,
-                const std::string &/*player_msg*/,
-                const std::string &/*npc_msg*/ ) const {}
-        void add_msg_debug_player_or_npc( debugmode::debug_filter /*type*/,
-                                          const translation &/*player_msg*/,
-                                          const translation &/*npc_msg*/ ) const;
-        template<typename ...Args>
-        void add_msg_debug_player_or_npc( debugmode::debug_filter type, const char *const player_msg,
-                                          const char *const npc_msg, Args &&... args ) const {
-            // expanding for string formatting can be expensive
-            if( debug_mode ) {
-                return add_msg_debug_player_or_npc( type, string_format( player_msg,
-                                                    std::forward<Args>( args )... ),
-                                                    string_format( npc_msg, std::forward<Args>( args )... ) );
-            }
-        }
-        template<typename ...Args>
-        void add_msg_debug_player_or_npc( debugmode::debug_filter type, const std::string &player_msg,
-                                          const std::string &npc_msg, Args &&... args ) const {
-            if( debug_mode ) {
-                return add_msg_debug_player_or_npc( type, string_format( player_msg,
-                                                    std::forward<Args>( args )... ),
-                                                    string_format( npc_msg, std::forward<Args>( args )... ) );
-            }
-        }
-
         virtual void add_msg_player_or_say( const std::string &/*player_msg*/,
                                             const std::string &/*npc_speech*/ ) const {}
         virtual void add_msg_player_or_say( const game_message_params &/*params*/,

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -210,7 +210,7 @@ bool debug_mode = false;
 
 namespace debugmode
 {
-std::list<debug_filter> enabled_filters;
+std::unordered_set<debug_filter> enabled_filters;
 std::string filter_name( debug_filter value )
 {
     // see debug.h for commentary

--- a/src/debug.h
+++ b/src/debug.h
@@ -3,7 +3,7 @@
 #define CATA_SRC_DEBUG_H
 
 #include "string_formatter.h"
-#include <list>
+#include <unordered_set>
 
 /**
  *      debugmsg(msg, ...)

--- a/src/debug.h
+++ b/src/debug.h
@@ -280,7 +280,7 @@ enum debug_filter : int {
     DF_LAST // This is always the last entry
 };
 
-extern std::list<debug_filter> enabled_filters;
+extern std::unordered_set<debug_filter> enabled_filters;
 std::string filter_name( debug_filter value );
 } // namespace debugmode
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5325,8 +5325,8 @@ bool game::spawn_npc( const tripoint &p, const string_id<npc_template> &npc_clas
                       std::vector<trait_id> &traits, std::optional<time_duration> lifespan )
 {
     if( !unique_id.empty() && g->unique_npc_exists( unique_id ) ) {
-        get_avatar().add_msg_debug_if_player( debugmode::DF_NPC, "NPC with unique id %s already exists.",
-                                              unique_id );
+        add_msg_debug_if_player( get_avatar(), debugmode::DF_NPC, "NPC with unique id %s already exists.",
+                                 unique_id );
         return false;
     }
     shared_ptr_fast<npc> tmp = make_shared_fast<npc>();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -5325,8 +5325,7 @@ bool game::spawn_npc( const tripoint &p, const string_id<npc_template> &npc_clas
                       std::vector<trait_id> &traits, std::optional<time_duration> lifespan )
 {
     if( !unique_id.empty() && g->unique_npc_exists( unique_id ) ) {
-        add_msg_debug_if_player( get_avatar(), debugmode::DF_NPC, "NPC with unique id %s already exists.",
-                                 unique_id );
+        add_msg_debug( debugmode::DF_NPC, "NPC with unique id %s already exists.", unique_id );
         return false;
     }
     shared_ptr_fast<npc> tmp = make_shared_fast<npc>();

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -1864,7 +1864,7 @@ static void handle_debug_mode()
         first_time = false;
         debugmode::enabled_filters.clear();
         for( int i = 0; i < debugmode::DF_LAST; ++i ) {
-            debugmode::enabled_filters.emplace_back( static_cast<debugmode::debug_filter>( i ) );
+            debugmode::enabled_filters.emplace( static_cast<debugmode::debug_filter>( i ) );
         }
     }
 
@@ -1891,9 +1891,8 @@ static void handle_debug_mode()
 
         entry.extratxt.left = 1;
 
-        const bool active = std::find(
-                                debugmode::enabled_filters.begin(), debugmode::enabled_filters.end(),
-                                static_cast<debugmode::debug_filter>( i ) ) != debugmode::enabled_filters.end();
+        const bool active = debugmode::enabled_filters.count( static_cast<debugmode::debug_filter>
+                            ( i ) ) == 1;
 
         if( toggle_value && active ) {
             toggle_value = false;
@@ -1926,7 +1925,7 @@ static void handle_debug_mode()
                 debugmode_entry_setup( dbmenu.entries[i + 2], toggle_value );
 
                 if( toggle_value ) {
-                    debugmode::enabled_filters.emplace_back( static_cast<debugmode::debug_filter>( i ) );
+                    debugmode::enabled_filters.emplace( static_cast<debugmode::debug_filter>( i ) );
                 }
             }
 
@@ -1935,9 +1934,8 @@ static void handle_debug_mode()
         } else if( dbmenu.ret > 1 ) {
             uilist_entry &entry = dbmenu.entries[dbmenu.ret];
 
-            const auto filter_iter = std::find(
-                                         debugmode::enabled_filters.begin(), debugmode::enabled_filters.end(),
-                                         static_cast<debugmode::debug_filter>( dbmenu.ret - 2 ) );
+            const auto filter_iter = debugmode::enabled_filters.find( static_cast<debugmode::debug_filter>
+                                     ( dbmenu.ret - 2 ) );
 
             const bool active = filter_iter != debugmode::enabled_filters.end();
 
@@ -1946,7 +1944,7 @@ static void handle_debug_mode()
             if( active ) {
                 debugmode::enabled_filters.erase( filter_iter );
             } else {
-                debugmode::enabled_filters.push_back(
+                debugmode::enabled_filters.emplace(
                     static_cast<debugmode::debug_filter>( dbmenu.ret - 2 ) );
             }
         }

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1830,8 +1830,7 @@ class jmapgen_npc : public jmapgen_piece
                 return;
             }
             if( !unique_id.empty() && g->unique_npc_exists( unique_id ) ) {
-                add_msg_debug_if_player( get_avatar(), debugmode::DF_NPC, "NPC with unique id %s already exists.",
-                                         unique_id );
+                add_msg_debug( debugmode::DF_NPC, "NPC with unique id %s already exists.", unique_id );
                 return;
             }
             tripoint const dst( x.get(), y.get(), dat.m.get_abs_sub().z() );

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -1830,8 +1830,8 @@ class jmapgen_npc : public jmapgen_piece
                 return;
             }
             if( !unique_id.empty() && g->unique_npc_exists( unique_id ) ) {
-                get_avatar().add_msg_debug_if_player( debugmode::DF_NPC, "NPC with unique id %s already exists.",
-                                                      unique_id );
+                add_msg_debug_if_player( get_avatar(), debugmode::DF_NPC, "NPC with unique id %s already exists.",
+                                         unique_id );
                 return;
             }
             tripoint const dst( x.get(), y.get(), dat.m.get_abs_sub().z() );

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -457,18 +457,6 @@ void Messages::add_msg( const game_message_params &params, std::string msg )
     player_messages.add_msg_string( std::move( msg ), params );
 }
 
-void Messages::add_msg_debug( debugmode::debug_filter type, std::string msg )
-{
-    if( debug_mode &&
-        std::find(
-            debugmode::enabled_filters.begin(), debugmode::enabled_filters.end(),
-            type ) == debugmode::enabled_filters.end() ) {
-        return;
-    }
-
-    player_messages.add_msg_string( std::move( msg ), m_debug );
-}
-
 void Messages::clear_messages()
 {
     player_messages.messages.clear();
@@ -1012,11 +1000,6 @@ void add_msg( const game_message_params &params, std::string msg )
     Messages::add_msg( params, std::move( msg ) );
 }
 
-void add_msg_debug( debugmode::debug_filter type, std::string msg )
-{
-    Messages::add_msg_debug( type, std::move( msg ) );
-}
-
 void add_msg_if_player_sees( const tripoint &target, std::string msg )
 {
     if( get_player_view().sees( target ) ) {
@@ -1051,7 +1034,7 @@ void add_msg_debug_if_player_sees( const tripoint &target, debugmode::debug_filt
                                    std::string msg )
 {
     if( get_player_view().sees( target ) ) {
-        Messages::add_msg_debug( type, std::move( msg ) );
+        add_msg_debug( type, std::move( msg ) );
     }
 }
 
@@ -1059,6 +1042,6 @@ void add_msg_debug_if_player_sees( const Creature &target, debugmode::debug_filt
                                    std::string msg )
 {
     if( get_player_view().sees( target ) ) {
-        Messages::add_msg_debug( type, std::move( msg ) );
+        add_msg_debug( type, std::move( msg ) );
     }
 }

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -1034,19 +1034,3 @@ void add_msg_if_player_sees( const Creature &target, const game_message_params &
         Messages::add_msg( params, std::move( msg ) );
     }
 }
-
-void add_msg_debug_if_player_sees( const tripoint &target, debugmode::debug_filter type,
-                                   std::string msg )
-{
-    if( get_player_view().sees( target ) ) {
-        add_msg_debug( type, std::move( msg ) );
-    }
-}
-
-void add_msg_debug_if_player_sees( const Creature &target, debugmode::debug_filter type,
-                                   std::string msg )
-{
-    if( get_player_view().sees( target ) ) {
-        add_msg_debug( type, std::move( msg ) );
-    }
-}

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -427,6 +427,11 @@ std::vector<std::pair<std::string, std::string>> Messages::recent_messages( cons
     return player_messages.recent_messages( count );
 }
 
+bool Messages::has_debug_filter( debugmode::debug_filter type )
+{
+    return debug_mode && debugmode::enabled_filters.count( type ) == 1;
+}
+
 void Messages::serialize( JsonOut &json )
 {
     json.member( "player_messages" );

--- a/src/messages.h
+++ b/src/messages.h
@@ -177,9 +177,6 @@ inline T &&clang_tidy_no_translations( T &&t )
 #define add_msg_debug(type, ...) \
     add_msg_debug_if( true, type, __VA_ARGS__ )
 
-#define add_msg_debug_if_player_sees(target, type, ...) \
-    add_msg_debug_if( get_player_view().sees( target ), type, __VA_ARGS__ )
-
 void modify_msg_with_exclamations( std::string &msg, game_message_type type );
 
 #endif // CATA_SRC_MESSAGES_H

--- a/src/messages.h
+++ b/src/messages.h
@@ -27,10 +27,7 @@ namespace Messages
 {
 
 std::vector<std::pair<std::string, std::string>> recent_messages( size_t count );
-inline bool has_debug_filter( debugmode::debug_filter type )
-{
-    return debug_mode && debugmode::enabled_filters.count( type ) == 1;
-}
+bool has_debug_filter( debugmode::debug_filter type );
 void add_msg( std::string msg );
 void add_msg( const game_message_params &params, std::string msg );
 void clear_messages();

--- a/src/messages.h
+++ b/src/messages.h
@@ -169,7 +169,7 @@ inline T &&clang_tidy_no_translations( T &&t )
 
 #define add_msg_debug_if(condition, type, ...)                                                          \
     do {                                                                                                \
-        if( Messages::has_debug_filter( type ) && ( condition ) ) {                                     \
+        if( debug_mode && Messages::has_debug_filter( type ) && ( condition ) ) {                       \
             Messages::add_msg( m_debug, clang_tidy_no_translations( string_format( __VA_ARGS__ ) ) );   \
         }                                                                                               \
     } while( false )

--- a/src/messages.h
+++ b/src/messages.h
@@ -167,19 +167,24 @@ inline T &&clang_tidy_no_translations( T &&t )
     return std::forward<T>( t );
 }
 
-#define add_msg_debug(type, ...)                                                                        \
+#define add_msg_debug_if(condition, type, ...)                                                          \
     do {                                                                                                \
-        if( Messages::has_debug_filter( type ) ) {                                                      \
+        if( Messages::has_debug_filter( type ) && ( condition ) ) {                                     \
             Messages::add_msg( m_debug, clang_tidy_no_translations( string_format( __VA_ARGS__ ) ) );   \
         }                                                                                               \
     } while( false )
 
-#define add_msg_debug_if_player_sees(target, type, ...)                                                 \
-    do {                                                                                                \
-        if( Messages::has_debug_filter( type ) && get_player_view().sees( target ) ) {                  \
-            Messages::add_msg( m_debug, clang_tidy_no_translations( string_format( __VA_ARGS__ ) ) );   \
-        }                                                                                               \
-    } while( false )
+#define add_msg_debug(type, ...) \
+    add_msg_debug_if( true, type, __VA_ARGS__ )
+
+#define add_msg_debug_if_player(target, type, ...) \
+    add_msg_debug_if( ( target ).is_avatar(), type, __VA_ARGS__ )
+
+#define add_msg_debug_if_npc(target, type, ...) \
+    add_msg_debug_if( ( target ).is_npc(), type, __VA_ARGS__ )
+
+#define add_msg_debug_if_player_sees(target, type, ...) \
+    add_msg_debug_if( get_player_view().sees( target ), type, __VA_ARGS__ )
 
 void modify_msg_with_exclamations( std::string &msg, game_message_type type );
 

--- a/src/messages.h
+++ b/src/messages.h
@@ -177,12 +177,6 @@ inline T &&clang_tidy_no_translations( T &&t )
 #define add_msg_debug(type, ...) \
     add_msg_debug_if( true, type, __VA_ARGS__ )
 
-#define add_msg_debug_if_player(target, type, ...) \
-    add_msg_debug_if( ( target ).is_avatar(), type, __VA_ARGS__ )
-
-#define add_msg_debug_if_npc(target, type, ...) \
-    add_msg_debug_if( ( target ).is_npc(), type, __VA_ARGS__ )
-
 #define add_msg_debug_if_player_sees(target, type, ...) \
     add_msg_debug_if( get_player_view().sees( target ), type, __VA_ARGS__ )
 

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3516,22 +3516,10 @@ void monster::add_msg_if_npc( const game_message_params &params, const std::stri
     add_msg_if_player_sees( *this, params, replace_with_npc_name( msg ) );
 }
 
-void monster::add_msg_debug_if_npc( debugmode::debug_filter type, const std::string &msg ) const
-{
-    add_msg_debug_if_player_sees( *this, type, replace_with_npc_name( msg ) );
-}
-
 void monster::add_msg_player_or_npc( const game_message_params &params,
                                      const std::string &/*player_msg*/, const std::string &npc_msg ) const
 {
     add_msg_if_player_sees( *this, params, replace_with_npc_name( npc_msg ) );
-}
-
-void monster::add_msg_debug_player_or_npc( debugmode::debug_filter type,
-        const std::string &/*player_msg*/,
-        const std::string &npc_msg ) const
-{
-    add_msg_debug_if_player_sees( *this, type, replace_with_npc_name( npc_msg ) );
 }
 
 units::mass monster::get_carried_weight() const

--- a/src/monster.h
+++ b/src/monster.h
@@ -505,16 +505,11 @@ class monster : public Creature
         using Creature::add_msg_if_npc;
         void add_msg_if_npc( const std::string &msg ) const override;
         void add_msg_if_npc( const game_message_params &params, const std::string &msg ) const override;
-        using Creature::add_msg_debug_if_npc;
-        void add_msg_debug_if_npc( debugmode::debug_filter type, const std::string &msg ) const override;
         using Creature::add_msg_player_or_npc;
         void add_msg_player_or_npc( const std::string &player_msg,
                                     const std::string &npc_msg ) const override;
         void add_msg_player_or_npc( const game_message_params &params, const std::string &player_msg,
                                     const std::string &npc_msg ) const override;
-        using Creature::add_msg_debug_player_or_npc;
-        void add_msg_debug_player_or_npc( debugmode::debug_filter type, const std::string &player_msg,
-                                          const std::string &npc_msg ) const override;
 
         // currently grabbed limbs
         std::unordered_set<bodypart_str_id> grabbed_limbs;

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -3157,26 +3157,12 @@ void npc::add_msg_if_npc( const game_message_params &params, const std::string &
     add_msg( params, replace_with_npc_name( msg ) );
 }
 
-void npc::add_msg_debug_if_npc( debugmode::debug_filter type, const std::string &msg ) const
-{
-    add_msg_debug( type, replace_with_npc_name( msg ) );
-}
-
 void npc::add_msg_player_or_npc( const game_message_params &params,
                                  const std::string &/*player_msg*/,
                                  const std::string &npc_msg ) const
 {
     if( get_player_view().sees( *this ) ) {
         add_msg( params, replace_with_npc_name( npc_msg ) );
-    }
-}
-
-void npc::add_msg_debug_player_or_npc( debugmode::debug_filter type,
-                                       const std::string &/*player_msg*/,
-                                       const std::string &npc_msg ) const
-{
-    if( get_player_view().sees( *this ) ) {
-        add_msg_debug( type, replace_with_npc_name( npc_msg ) );
     }
 }
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -1256,23 +1256,15 @@ class npc : public Character
         using Character::add_msg_if_npc;
         void add_msg_if_npc( const std::string &msg ) const override;
         void add_msg_if_npc( const game_message_params &params, const std::string &msg ) const override;
-        using Character::add_msg_debug_if_npc;
-        void add_msg_debug_if_npc( debugmode::debug_filter type, const std::string &msg ) const override;
         using Character::add_msg_player_or_npc;
         void add_msg_player_or_npc( const std::string &player_msg,
                                     const std::string &npc_msg ) const override;
         void add_msg_player_or_npc( const game_message_params &params, const std::string &player_msg,
                                     const std::string &npc_msg ) const override;
-        using Character::add_msg_debug_player_or_npc;
-        void add_msg_debug_player_or_npc( debugmode::debug_filter type, const std::string &player_msg,
-                                          const std::string &npc_msg ) const override;
         using Character::add_msg_if_player;
         void add_msg_if_player( const std::string &/*msg*/ ) const override {}
         void add_msg_if_player( const game_message_params &/*type*/,
                                 const std::string &/*msg*/ ) const override {}
-        using Character::add_msg_debug_if_player;
-        void add_msg_debug_if_player( debugmode::debug_filter /*type*/,
-                                      const std::string &/*msg*/ ) const override {}
         using Character::add_msg_player_or_say;
         void add_msg_player_or_say( const std::string &player_msg,
                                     const std::string &npc_speech ) const override;

--- a/tests/fake_messages.cpp
+++ b/tests/fake_messages.cpp
@@ -82,13 +82,3 @@ void add_msg_if_player_sees( const Creature &, const game_message_params &, std:
 {
     Messages::add_msg( std::move( m ) );
 }
-void add_msg_debug_if_player_sees( const tripoint &, debugmode::debug_filter,
-                                   std::string m )
-{
-    Messages::add_msg( std::move( m ) );
-}
-void add_msg_debug_if_player_sees( const Creature &, debugmode::debug_filter,
-                                   std::string m )
-{
-    Messages::add_msg( std::move( m ) );
-}

--- a/tests/fake_messages.cpp
+++ b/tests/fake_messages.cpp
@@ -28,7 +28,7 @@ std::vector<std::pair<std::string, std::string>> Messages::recent_messages( size
 {
     return messages;
 }
-bool Messages::has_debug_filter( debugmode::debug_filter type )
+bool Messages::has_debug_filter( debugmode::debug_filter )
 {
     return true;
 }

--- a/tests/fake_messages.cpp
+++ b/tests/fake_messages.cpp
@@ -28,17 +28,16 @@ std::vector<std::pair<std::string, std::string>> Messages::recent_messages( size
 {
     return messages;
 }
+bool Messages::has_debug_filter( debugmode::debug_filter type )
+{
+    return true;
+}
 void Messages::add_msg( std::string m )
 {
     messages.emplace_back( to_string_time_of_day( calendar::turn ), std::move( m ) );
 }
 void Messages::add_msg( const game_message_params &, std::string m )
 {
-    add_msg( std::move( m ) );
-}
-void Messages::add_msg_debug( debugmode::debug_filter, std::string m )
-{
-    // cata_test does not need filters
     add_msg( std::move( m ) );
 }
 void Messages::clear_messages()
@@ -64,10 +63,6 @@ void add_msg( std::string m )
     Messages::add_msg( std::move( m ) );
 }
 void add_msg( const game_message_params &, std::string m )
-{
-    Messages::add_msg( std::move( m ) );
-}
-void add_msg_debug( debugmode::debug_filter, std::string m )
 {
     Messages::add_msg( std::move( m ) );
 }

--- a/tools/clang-tidy-plugin/TranslationsInDebugMessagesCheck.cpp
+++ b/tools/clang-tidy-plugin/TranslationsInDebugMessagesCheck.cpp
@@ -48,7 +48,7 @@ void TranslationsInDebugMessagesCheck::check( const MatchFinder::MatchResult &Re
     if( toStringDecl ) {
         diag(
             translationCall->getBeginLoc(),
-            "string arguments to debug message functions should not be translated. This call "
+            "string arguments to debug message functions should not be translated.  This call "
             "to to_string might involve a translation; consider using to_string_writable instead."
         );
     } else {

--- a/tools/clang-tidy-plugin/TranslationsInDebugMessagesCheck.cpp
+++ b/tools/clang-tidy-plugin/TranslationsInDebugMessagesCheck.cpp
@@ -31,7 +31,7 @@ void TranslationsInDebugMessagesCheck::registerMatchers( MatchFinder *Finder )
                     )
                 )
             ),
-            hasAncestor( callExpr( callee( functionDecl( matchesName( "add_msg_debug.*" ) ) ) ) )
+            hasAncestor( callExpr( callee( functionDecl( matchesName( "clang_tidy_no_translations" ) ) ) ) )
         ).bind( "translationCall" ),
         this
     );
@@ -48,15 +48,13 @@ void TranslationsInDebugMessagesCheck::check( const MatchFinder::MatchResult &Re
     if( toStringDecl ) {
         diag(
             translationCall->getBeginLoc(),
-            "string arguments to debug message functions should not be translated, because this "
-            "is an unnecessary performance cost.  This call to to_string might involve a "
-            "translation; consider using to_string_writable instead."
+            "string arguments to debug message functions should not be translated. This call "
+            "to to_string might involve a translation; consider using to_string_writable instead."
         );
     } else {
         diag(
             translationCall->getBeginLoc(),
-            "string arguments to debug message functions should not be translated, because this "
-            "is an unnecessary performance cost."
+            "string arguments to debug message functions should not be translated."
         );
     }
 }

--- a/tools/clang-tidy-plugin/test/translations-in-debug-messages.cpp
+++ b/tools/clang-tidy-plugin/test/translations-in-debug-messages.cpp
@@ -8,19 +8,19 @@
 static void f( const time_duration &duration, Creature &c )
 {
     char *skill_level;
-    add_msg_debug(debugmode::DF_ACT_BUTCHER, _("Skill: %s"), skill_level);
+    add_msg_debug( debugmode::DF_ACT_BUTCHER, _( "Skill: %s" ), skill_level );
     // CHECK-MESSAGES: [[@LINE-1]]:47: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 
-    add_msg_debug(debugmode::DF_ACT_BUTCHER, _("Skill"));
+    add_msg_debug( debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
     // CHECK-MESSAGES: [[@LINE-1]]:47: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 
-    add_msg_debug(debugmode::DF_ACT_BUTCHER, pgettext("Skill", "foo"));
+    add_msg_debug( debugmode::DF_ACT_BUTCHER, pgettext( "Skill", "foo" ) );
     // CHECK-MESSAGES: [[@LINE-1]]:47: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 
-    add_msg_debug(debugmode::DF_ACT_BUTCHER, n_gettext("Skill", "Skills", 0));
+    add_msg_debug( debugmode::DF_ACT_BUTCHER, n_gettext( "Skill", "Skills", 0 ) );
     // CHECK-MESSAGES: [[@LINE-1]]:47: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 
-    add_msg_debug(debugmode::DF_ACT_BUTCHER, "%s", to_translation("Skill"));
+    add_msg_debug( debugmode::DF_ACT_BUTCHER, "%s", to_translation( "Skill" ) );
     // CHECK-MESSAGES: [[@LINE-1]]:53: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 
     add_msg_debug_if_player_sees( c, debugmode::DF_ACT_BUTCHER, _( "Skill: %s" ), skill_level );
@@ -35,6 +35,6 @@ static void f( const time_duration &duration, Creature &c )
     c.add_msg_debug_if_npc( debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
     // CHECK-MESSAGES: [[@LINE-1]]:56: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 
-    add_msg_debug(debugmode::DF_ACT_BUTCHER, "Duration %s", to_string(duration));
+    add_msg_debug( debugmode::DF_ACT_BUTCHER, "Duration %s", to_string( duration ) );
     // CHECK-MESSAGES: [[@LINE-1]]:62: warning: string arguments to debug message functions should not be translated.  This call to to_string might involve a translation; consider using to_string_writable instead. [cata-translations-in-debug-messages]
 }

--- a/tools/clang-tidy-plugin/test/translations-in-debug-messages.cpp
+++ b/tools/clang-tidy-plugin/test/translations-in-debug-messages.cpp
@@ -29,10 +29,7 @@ static void f( const time_duration &duration, Creature &c )
     add_msg_debug_if_player_sees( c, debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
     // CHECK-MESSAGES: [[@LINE-1]]:65: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 
-    add_msg_debug_if_player( c, debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
-    // CHECK-MESSAGES: [[@LINE-1]]:59: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
-
-    add_msg_debug_if_npc( c, debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
+    add_msg_debug_if( true, debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
     // CHECK-MESSAGES: [[@LINE-1]]:56: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 
     add_msg_debug( debugmode::DF_ACT_BUTCHER, "Duration %s", to_string( duration ) );

--- a/tools/clang-tidy-plugin/test/translations-in-debug-messages.cpp
+++ b/tools/clang-tidy-plugin/test/translations-in-debug-messages.cpp
@@ -23,12 +23,6 @@ static void f( const time_duration &duration, Creature &c )
     add_msg_debug( debugmode::DF_ACT_BUTCHER, "%s", to_translation( "Skill" ) );
     // CHECK-MESSAGES: [[@LINE-1]]:53: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 
-    add_msg_debug_if_player_sees( c, debugmode::DF_ACT_BUTCHER, _( "Skill: %s" ), skill_level );
-    // CHECK-MESSAGES: [[@LINE-1]]:65: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
-
-    add_msg_debug_if_player_sees( c, debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
-    // CHECK-MESSAGES: [[@LINE-1]]:65: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
-
     add_msg_debug_if( true, debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
     // CHECK-MESSAGES: [[@LINE-1]]:56: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 

--- a/tools/clang-tidy-plugin/test/translations-in-debug-messages.cpp
+++ b/tools/clang-tidy-plugin/test/translations-in-debug-messages.cpp
@@ -8,21 +8,6 @@
 static void f( const time_duration &duration, Creature &c )
 {
     char *skill_level;
-    add_msg_debug( debugmode::DF_ACT_BUTCHER, _( "Skill: %s" ), skill_level );
-    // CHECK-MESSAGES: [[@LINE-1]]:47: warning: string arguments to debug message functions should not be translated, because this is an unnecessary performance cost. [cata-translations-in-debug-messages]
-
-    add_msg_debug( debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
-    // CHECK-MESSAGES: [[@LINE-1]]:47: warning: string arguments to debug message functions should not be translated, because this is an unnecessary performance cost. [cata-translations-in-debug-messages]
-
-    add_msg_debug( debugmode::DF_ACT_BUTCHER, pgettext( "Skill", "foo" ) );
-    // CHECK-MESSAGES: [[@LINE-1]]:47: warning: string arguments to debug message functions should not be translated, because this is an unnecessary performance cost. [cata-translations-in-debug-messages]
-
-    add_msg_debug( debugmode::DF_ACT_BUTCHER, n_gettext( "Skill", "Skills", 0 ) );
-    // CHECK-MESSAGES: [[@LINE-1]]:47: warning: string arguments to debug message functions should not be translated, because this is an unnecessary performance cost. [cata-translations-in-debug-messages]
-
-    add_msg_debug( debugmode::DF_ACT_BUTCHER, "%s", to_translation( "Skill" ) );
-    // CHECK-MESSAGES: [[@LINE-1]]:53: warning: string arguments to debug message functions should not be translated, because this is an unnecessary performance cost. [cata-translations-in-debug-messages]
-
     add_msg_debug_if_player_sees( c, debugmode::DF_ACT_BUTCHER, _( "Skill: %s" ), skill_level );
     // CHECK-MESSAGES: [[@LINE-1]]:65: warning: string arguments to debug message functions should not be translated, because this is an unnecessary performance cost. [cata-translations-in-debug-messages]
 
@@ -34,7 +19,4 @@ static void f( const time_duration &duration, Creature &c )
 
     c.add_msg_debug_if_npc( debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
     // CHECK-MESSAGES: [[@LINE-1]]:56: warning: string arguments to debug message functions should not be translated, because this is an unnecessary performance cost. [cata-translations-in-debug-messages]
-
-    add_msg_debug( debugmode::DF_ACT_BUTCHER, "Duration %s", to_string( duration ) );
-    // CHECK-MESSAGES: [[@LINE-1]]:62: warning: string arguments to debug message functions should not be translated, because this is an unnecessary performance cost.  This call to to_string might involve a translation; consider using to_string_writable instead. [cata-translations-in-debug-messages]
 }

--- a/tools/clang-tidy-plugin/test/translations-in-debug-messages.cpp
+++ b/tools/clang-tidy-plugin/test/translations-in-debug-messages.cpp
@@ -29,10 +29,10 @@ static void f( const time_duration &duration, Creature &c )
     add_msg_debug_if_player_sees( c, debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
     // CHECK-MESSAGES: [[@LINE-1]]:65: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 
-    c.add_msg_debug_if_player( debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
+    add_msg_debug_if_player( c, debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
     // CHECK-MESSAGES: [[@LINE-1]]:59: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 
-    c.add_msg_debug_if_npc( debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
+    add_msg_debug_if_npc( c, debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
     // CHECK-MESSAGES: [[@LINE-1]]:56: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 
     add_msg_debug( debugmode::DF_ACT_BUTCHER, "Duration %s", to_string( duration ) );

--- a/tools/clang-tidy-plugin/test/translations-in-debug-messages.cpp
+++ b/tools/clang-tidy-plugin/test/translations-in-debug-messages.cpp
@@ -8,15 +8,33 @@
 static void f( const time_duration &duration, Creature &c )
 {
     char *skill_level;
+    add_msg_debug(debugmode::DF_ACT_BUTCHER, _("Skill: %s"), skill_level);
+    // CHECK-MESSAGES: [[@LINE-1]]:47: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
+
+    add_msg_debug(debugmode::DF_ACT_BUTCHER, _("Skill"));
+    // CHECK-MESSAGES: [[@LINE-1]]:47: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
+
+    add_msg_debug(debugmode::DF_ACT_BUTCHER, pgettext("Skill", "foo"));
+    // CHECK-MESSAGES: [[@LINE-1]]:47: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
+
+    add_msg_debug(debugmode::DF_ACT_BUTCHER, n_gettext("Skill", "Skills", 0));
+    // CHECK-MESSAGES: [[@LINE-1]]:47: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
+
+    add_msg_debug(debugmode::DF_ACT_BUTCHER, "%s", to_translation("Skill"));
+    // CHECK-MESSAGES: [[@LINE-1]]:53: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
+
     add_msg_debug_if_player_sees( c, debugmode::DF_ACT_BUTCHER, _( "Skill: %s" ), skill_level );
-    // CHECK-MESSAGES: [[@LINE-1]]:65: warning: string arguments to debug message functions should not be translated, because this is an unnecessary performance cost. [cata-translations-in-debug-messages]
+    // CHECK-MESSAGES: [[@LINE-1]]:65: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 
     add_msg_debug_if_player_sees( c, debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
-    // CHECK-MESSAGES: [[@LINE-1]]:65: warning: string arguments to debug message functions should not be translated, because this is an unnecessary performance cost. [cata-translations-in-debug-messages]
+    // CHECK-MESSAGES: [[@LINE-1]]:65: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 
     c.add_msg_debug_if_player( debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
-    // CHECK-MESSAGES: [[@LINE-1]]:59: warning: string arguments to debug message functions should not be translated, because this is an unnecessary performance cost. [cata-translations-in-debug-messages]
+    // CHECK-MESSAGES: [[@LINE-1]]:59: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
 
     c.add_msg_debug_if_npc( debugmode::DF_ACT_BUTCHER, _( "Skill" ) );
-    // CHECK-MESSAGES: [[@LINE-1]]:56: warning: string arguments to debug message functions should not be translated, because this is an unnecessary performance cost. [cata-translations-in-debug-messages]
+    // CHECK-MESSAGES: [[@LINE-1]]:56: warning: string arguments to debug message functions should not be translated. [cata-translations-in-debug-messages]
+
+    add_msg_debug(debugmode::DF_ACT_BUTCHER, "Duration %s", to_string(duration));
+    // CHECK-MESSAGES: [[@LINE-1]]:62: warning: string arguments to debug message functions should not be translated.  This call to to_string might involve a translation; consider using to_string_writable instead. [cata-translations-in-debug-messages]
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Parameters to `add_msg_debug` can be expensive, notably monster::name which shows up on profiles as taking up a few % of execution time.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Turn `add_msg_debug` into a macro, which allows parameters to be evaluated only if the debug flag is actually enabled.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Verified that debug messages were still working as intended.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
