### PR TITLE
Fix short workbenches

### DIFF
--- a/data/json/items/vehicle/tables.json
+++ b/data/json/items/vehicle/tables.json
@@ -11,6 +11,7 @@
     "material": [ "wood" ],
     "flags": [ "TRADER_AVOID" ],
     "volume": "13500 ml",
+    "longest_side": "110 cm",
     "category": "veh_parts",
     "price": 20000,
     "price_postapoc": 100,


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
fix #69346
#### Describe the solution
add `"longest_side": "110 cm",` to tables, that workbench inherits
#### Describe alternatives you've considered
Also change the volume, but it is difficult since workbench is very, very bulky item with a lot of empty space