### PR TITLE
Fix chocoloate-covered coffee bean calories

### DIFF
--- a/data/json/items/comestibles/junkfood.json
+++ b/data/json/items/comestibles/junkfood.json
@@ -569,7 +569,7 @@
     "symbol": "%",
     "quench": -1,
     "addiction_potential": 2,
-    "calories": 140,
+    "calories": 160,
     "description": "Roasted coffee beans coated with dark chocolate, a natural source of concentrated caffeine.",
     "price": "10 cent",
     "price_postapoc": "10 cent",


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Increased realism and accuracy.

#### Describe the solution

Literally just changing a single value, backed by both a Google search (Claims that the comestible in question is 549kcal per 100 grams, which is 3.33 portions in-game equating to approximately 166kcal per portion) and the nutritional information on a package of chocolate-covered coffee beans which claims that the energy per 100 grams is 533kcal, which would make the accurate in-game value 160 kcal with a negligible difference. I consider the latter more accurate than Google, that is why I have chosen that value.

#### Describe alternatives you've considered

Literally none.

#### Testing

Not required in this case due to the sheer simplicity of the change.

#### Additional context
![20231121_174105](https://github.com/CleverRaven/Cataclysm-DDA/assets/67743918/5180038c-94e8-475f-b95e-8bdc22047adf)

![20231121_171048](https://github.com/CleverRaven/Cataclysm-DDA/assets/67743918/8e653893-fda4-4c69-9f29-42158ef55d38)

The above are images of the chocolate-covered coffee beans I have purchased and on which I am basing this change. Packaging in Slovak, but it matches the in-game description (of being coffee beans covered in a layer of dark chocolate.)

