### PR TITLE
Fix vehicle being mergeable into powergrids

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1189,12 +1189,10 @@ std::optional<tripoint> choose_adjacent_highlight( const tripoint &pos, const st
         g->add_draw_callback( hilite_cb );
     }
 
-
-    const std::optional<tripoint> dir = choose_direction( message, allow_vertical );
-    const std::optional<tripoint> chosen = dir ? *dir + pos : dir;
-
+    const std::optional<tripoint> chosen = choose_adjacent( pos, message, allow_vertical );
     if( std::find( valid.begin(), valid.end(), chosen ) != valid.end() ) {
         return chosen;
     }
+
     return std::nullopt;
 }

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1189,5 +1189,12 @@ std::optional<tripoint> choose_adjacent_highlight( const tripoint &pos, const st
         g->add_draw_callback( hilite_cb );
     }
 
-    return choose_adjacent( pos, message, allow_vertical );
+
+    const std::optional<tripoint> dir = choose_direction( message, allow_vertical );
+    const std::optional<tripoint> chosen = dir ? *dir + pos : dir;
+
+    if( std::find( valid.begin(), valid.end(), chosen ) != valid.end() ) {
+        return chosen;
+    }
+    return std::nullopt;
 }

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -527,7 +527,7 @@ void veh_app_interact::merge()
             return false;
         }
         vehicle &target_veh = target_vp->vehicle();
-        if( !target_veh.has_tag( flag_APPLIANCE ) || !target_veh.is_powergrid() ) {
+        if( !target_veh.is_powergrid() ) {
             return false;
         }
         return true;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix vehicle being mergeable into powergrids

#### Describe the solution

- add checks in `choose_adjacent_highlight` to forbid chosing a non highlighted position

#### Describe alternatives you've considered

Don't touch `choose_adjacent_highlight` and instead re-check that the vehicle chosen is a power grid

#### Testing

- can't merge vehicle in grid
- can merge aplliances in grid

#### Additional context

- Merging still gives you no message that something happened or not. Should that change? Maybe in this PR?
- Maybe we should slate the merging option to desapear after stable? Since you can only merge adjacent appliances and mergeable appliances automatically merge when you place them, manually merging won't make sense once there's no appliances placed down from before the option to merge was a thing

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
