### PR TITLE
[MoM] Tinfoil hats protect against telepathy (sometimes) 

### DIFF
--- a/data/mods/MindOverMatter/damage_types.json
+++ b/data/mods/MindOverMatter/damage_types.json
@@ -97,7 +97,7 @@
         "run_eocs": [
           {
             "id": "EOC_TELEPATHIC_DAMAGE_PSYSHIELD_CHECK_2",
-            "condition": { "x_in_y_chance": { "x": 3, "y": 4 } },
+            "condition": { "x_in_y_chance": { "x": 1, "y": 2 } },
             "effect": [
               {
                 "npc_message": "Your head prickles.  It feels like spiders crawling across the surface of your brain.",

--- a/data/mods/MindOverMatter/damage_types.json
+++ b/data/mods/MindOverMatter/damage_types.json
@@ -76,12 +76,36 @@
     "magic_color": "white",
     "name": "telepathic",
     "skill": "metaphysics",
-    "immune_flags": { "character": [ "TEEPSHIELD" ], "monster": [ "TEEP_IMMUNE" ] },
+    "immune_flags": { "character": [ "TEEPSHIELD", "PSYSHIELD_PROTECT" ], "monster": [ "TEEP_IMMUNE" ] },
     "ondamage_eocs": [
-      "EOC_TELEPATHIC_DAMAGE_STUN_CHANCE",
-      "EOC_TELEPATHIC_DAMAGE_DAZED_CHANCE",
-      "EOC_TELEPATHIC_DAMAGE_KNOCKDOWN_CHANCE",
       "EOC_TELEPATHIC_DAMAGE_STUN_HIVE_CHANCE"
+    ]
+  },
+  {
+ "type": "effect_on_condition",
+    "id": "EOC_TELEPATHIC_DAMAGE_PSYSHIELD_CHECK",
+     "condition": {
+      "and": [
+        { "npc_has_worn_with_flag": [ "PSYSHIELD_PARTIAL" ] },
+        { "math": [ "_damage_taken", ">", "-2" ] },
+        { "npc_has_effect": "effect_psyshield_protection" },
+          { "x_in_y_chance": { "x": 5, "y": 6 } },
+        { "not": { "npc_has_flag": "HIVE_MIND" } },
+        { "not": { "npc_has_flag": "TEEP_IMMUNE" } },
+        { "not": { "npc_has_flag": "TEEPSHIELD" } }
+      ]
+    },
+    "effect": [
+      { "npc_message": "Your head prickles.  It feels like spiders crawling across the surface of your brain.", "type": "bad" },
+        { "npc_lose_effect": "effect_psyshield_protection" },
+    ],
+    "false_effect": [
+      
+{
+    "run_eocs": [ "EOC_TELEPATHIC_DAMAGE_STUN_CHANCE",
+      "EOC_TELEPATHIC_DAMAGE_DAZED_CHANCE",
+      "EOC_TELEPATHIC_DAMAGE_KNOCKDOWN_CHANCE" ]
+      }
     ]
   },
   {

--- a/data/mods/MindOverMatter/damage_types.json
+++ b/data/mods/MindOverMatter/damage_types.json
@@ -77,34 +77,46 @@
     "name": "telepathic",
     "skill": "metaphysics",
     "immune_flags": { "character": [ "TEEPSHIELD", "PSYSHIELD_PROTECT" ], "monster": [ "TEEP_IMMUNE" ] },
-    "ondamage_eocs": [
-      "EOC_TELEPATHIC_DAMAGE_STUN_HIVE_CHANCE"
-    ]
+    "ondamage_eocs": [ "EOC_TELEPATHIC_DAMAGE_PSYSHIELD_CHECK", "EOC_TELEPATHIC_DAMAGE_STUN_HIVE_CHANCE" ]
   },
   {
- "type": "effect_on_condition",
+    "type": "effect_on_condition",
     "id": "EOC_TELEPATHIC_DAMAGE_PSYSHIELD_CHECK",
-     "condition": {
+    "condition": {
       "and": [
-        { "npc_has_worn_with_flag": [ "PSYSHIELD_PARTIAL" ] },
+        { "npc_has_worn_with_flag": "PSYSHIELD_PARTIAL" },
         { "math": [ "_damage_taken", ">", "-2" ] },
         { "npc_has_effect": "effect_psyshield_protection" },
-          { "x_in_y_chance": { "x": 5, "y": 6 } },
         { "not": { "npc_has_flag": "HIVE_MIND" } },
         { "not": { "npc_has_flag": "TEEP_IMMUNE" } },
         { "not": { "npc_has_flag": "TEEPSHIELD" } }
       ]
     },
     "effect": [
-      { "npc_message": "Your head prickles.  It feels like spiders crawling across the surface of your brain.", "type": "bad" },
-        { "npc_lose_effect": "effect_psyshield_protection" },
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_TELEPATHIC_DAMAGE_PSYSHIELD_CHECK_2",
+            "condition": { "x_in_y_chance": { "x": 3, "y": 4 } },
+            "effect": [
+              {
+                "npc_message": "Your head prickles.  It feels like spiders crawling across the surface of your brain.",
+                "type": "bad"
+              },
+              { "npc_lose_effect": "effect_psyshield_protection" }
+            ],
+            "false_effect": [
+              { "npc_lose_effect": "effect_psyshield_protection" },
+              { "npc_cast_spell": { "id": "telepathic_self_damage", "hit_self": true } },
+              { "npc_message": "Your minds reels!", "type": "bad" }
+            ]
+          }
+        ]
+      }
     ],
     "false_effect": [
-      
-{
-    "run_eocs": [ "EOC_TELEPATHIC_DAMAGE_STUN_CHANCE",
-      "EOC_TELEPATHIC_DAMAGE_DAZED_CHANCE",
-      "EOC_TELEPATHIC_DAMAGE_KNOCKDOWN_CHANCE" ]
+      {
+        "run_eocs": [ "EOC_TELEPATHIC_DAMAGE_STUN_CHANCE", "EOC_TELEPATHIC_DAMAGE_DAZED_CHANCE", "EOC_TELEPATHIC_DAMAGE_KNOCKDOWN_CHANCE" ]
       }
     ]
   },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_items.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_items.json
@@ -117,5 +117,14 @@
       }
     ],
     "false_effect": [ { "u_message": "Without a matrix crystal to power it, flipping the toggle does nothing.", "type": "bad" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PSYSHIELD_PARTIAL_EFFECT_GRANTER",
+    "recurrence": [ "2 minutes", "8 minutes" ],
+    "condition": { "u_has_worn_with_flag": [ "PSYSHIELD_PARTIAL" ] },
+    "effect": [
+      { "u_add_effect": "effect_psyshield_protection", "duration": "8 minutes" }
+    ]
   }
 ]

--- a/data/mods/MindOverMatter/effectoncondition/eoc_items.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_items.json
@@ -122,9 +122,8 @@
     "type": "effect_on_condition",
     "id": "EOC_PSYSHIELD_PARTIAL_EFFECT_GRANTER",
     "recurrence": [ "2 minutes", "8 minutes" ],
-    "condition": { "u_has_worn_with_flag": [ "PSYSHIELD_PARTIAL" ] },
-    "effect": [
-      { "u_add_effect": "effect_psyshield_protection", "duration": "8 minutes" }
-    ]
+    "condition": { "u_has_worn_with_flag": "PSYSHIELD_PARTIAL" },
+    "effect": [ { "u_add_effect": "effect_psyshield_protection", "duration": "8 minutes" } ],
+    "false_effect": [ { "u_lose_effect": "effect_psyshield_protection" } ]
   }
 ]

--- a/data/mods/MindOverMatter/effects/effects_items.json
+++ b/data/mods/MindOverMatter/effects/effects_items.json
@@ -31,12 +31,13 @@
     "max_duration": "1 minutes",
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "FORCEFIELD", "add": 0.94 } ] } ]
   },
-  { 
+  {
     "id": "effect_psyshield_protection",
     "type": "effect_type",
-    "//": "Blank to create uncertainty", 
+    "//": "Blank to create uncertainty",
     "name": [ "" ],
     "desc": [ "" ],
+    "removes_effects": [ "psi_blind", "psi_deaf", "effect_telepathic_primal_terror", "psi_dazed" ],
     "flags": [ "PSYSHIELD_PROTECT" ]
   }
 ]

--- a/data/mods/MindOverMatter/effects/effects_items.json
+++ b/data/mods/MindOverMatter/effects/effects_items.json
@@ -30,5 +30,13 @@
     "rating": "good",
     "max_duration": "1 minutes",
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "FORCEFIELD", "add": 0.94 } ] } ]
+  },
+  { 
+    "id": "effect_psyshield_protection",
+    "type": "effect_type",
+    "//": "Blank to create uncertainty", 
+    "name": [ "" ],
+    "desc": [ "" ],
+    "flags": [ "PSYSHIELD_PROTECT" ]
   }
 ]

--- a/data/mods/MindOverMatter/json_flags.json
+++ b/data/mods/MindOverMatter/json_flags.json
@@ -20,6 +20,11 @@
     "info": "You are immune to forcible teleportation."
   },
   {
+    "id": "PSYSHIELD_PROTECT",
+    "type": "json_flag",
+    "info": "You are protected against telepathic attack.  Sometimes."
+  },
+  {
     "id": "MATRIX_CRYSTAL_BIOKINESIS",
     "type": "json_flag",
     "info": "This is a matrix crystal attuned to biokinesis."

--- a/data/mods/MindOverMatter/monsters/feral_psychics.json
+++ b/data/mods/MindOverMatter/monsters/feral_psychics.json
@@ -1146,7 +1146,7 @@
         "spell_data": { "id": "telepathic_horror_monster", "min_level": 4 },
         "cooldown": 25,
         "condition": { "not": { "u_has_effect": "effect_psi_null" } },
-        "monster_message": ""
+        "monster_message": "%1$s stares at %3$s!"
       }
     ],
     "flags": [
@@ -1226,7 +1226,7 @@
         "allow_no_target": true,
         "cooldown": 25,
         "condition": { "not": { "u_has_effect": "effect_psi_null" } },
-        "monster_message": ""
+        "monster_message": "%1$s eyes suddenly go wide!"
       },
       {
         "id": "psi_telepath3_freeze",

--- a/data/mods/MindOverMatter/monsters/monsters_spells.json
+++ b/data/mods/MindOverMatter/monsters/monsters_spells.json
@@ -490,6 +490,20 @@
     "ignored_monster_species": [ "ZOMBIE", "ROBOT", "NETHER", "NETHER_EMANATION", "LEECH_PLANT", "WORM", "FUNGUS", "SLIME", "PSI_NULL" ]
   },
   {
+    "id": "telepathic_self_damage",
+    "type": "SPELL",
+    "name": "[Ψ]Telepathic Self Damage",
+    "description": "This spell passes through a bit of damage in case something the PSYSHIELD_PARTIAL flag fails, to simulate the failure.  It's a bug if you have it directly.",
+    "valid_targets": [ "self" ],
+    "flags": [ "CONCENTRATE", "NO_PROJECTILE", "SILENT", "RANDOM_DAMAGE" ],
+    "effect": "attack",
+    "shape": "blast",
+    "affected_body_parts": [ "head" ],
+    "damage_type": "psi_telepathic_damage",
+    "min_damage": 1,
+    "max_damage": 4
+  },
+  {
     "id": "telepathic_shrieking_monster",
     "type": "SPELL",
     "name": "[Ψ]Telepathic Shrieking Monster",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Tinfoil hats protect against telepathy (sometimes) "
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Conversation on Discord made me realize I haven't accounted for PSYSHIELD_PARTIAL yet. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Wearing an item with the PSYSHIELD_PARTIAL flag will give you an hidden effect (caused by recurring EoC). If you are attacked by Telepathic attack while you are still wearing the item and have the hidden effect, it will either completely blocks the damage and then the effect fades (50% chance) or the effect fades and you take a small amount of damage (50% chance). This is simulated by causing a small amount of telepathic damage if the protection roll fails, since the damage was already reduced to zero before the damage EoC runs, thus triggering telepathic damage's chance to daze or stun. This does mean the log messages are a little odd but it does what I want it to.

It also makes you immune to various telepathy-related effects. 

When the effect fades or is penetrated, you get a warning message letting you know you're in trouble. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Put on tinfoil hat and waited--effect appeared. Took off hat and waited--effect disappeared.  Put on hat again and waited--effect appeared again.

Spawned telepathic feral and let it close to attacking range:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/689f8059-1b09-4e3e-b1c6-d14e2b41e88f)

Tested telepathic damage EoCs: Chance of stunning or dazing remains on telepathic attacks and is very common but not automatic (as intended).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
