### PR TITLE
Fix Bayonets (remove reach atk. mode flag, and other stuff too)

### DIFF
--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -211,8 +211,9 @@
       "moves": 120
     },
     "location": "underbarrel",
+    "//": "underbarrel to interfere with other stuff in the underbarrel slot on the SKS.",
     "mod_targets": [ "shotgun", "rifle" ],
-    "mode_modifier": [ [ "REACH", "bayonet", 2, [ "MELEE", "REACH_ATTACK" ] ] ],
+    "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
     "qualities": [ [ "CUT", 1 ], [ "COOK", 1 ], [ "BUTCHER", -18 ] ],
     "flags": [ "SLOW_WIELD", "IRREMOVABLE", "ALLOWS_REMOTE_USE" ],
     "melee_damage": { "stab": 10 }
@@ -417,7 +418,7 @@
     "color": "light_red",
     "location": "underbarrel",
     "mod_targets": [ "rifle", "crossbow" ],
-    "blacklist_mod": [ "knife_combat_army", "knife_combat", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
+    "blacklist_mod": [ "knife_combat_army", "knife_combat", "enfield_bayonet", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
     "gun_data": {
       "ammo": "40x46mm",
       "skill": "launcher",
@@ -455,7 +456,7 @@
     "color": "dark_gray",
     "location": "underbarrel",
     "mod_targets": [ "rifle", "crossbow" ],
-    "blacklist_mod": [ "knife_combat_army", "knife_combat", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
+    "blacklist_mod": [ "knife_combat_army", "knife_combat", "enfield_bayonet", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
     "gun_data": {
       "ammo": "40x46mm",
       "skill": "launcher",
@@ -505,9 +506,10 @@
     "longest_side": "12 cm",
     "integral_longest_side": "12 cm",
     "gunmod_data": {
-      "location": "bayonet lug",
+      "location": "underbarrel",
       "mod_targets": [ "shotgun", "rifle", "smg", "launcher", "crossbow" ],
-      "mode_modifier": [ [ "REACH", "bayonet", 2, [ "MELEE", "REACH_ATTACK" ] ] ],
+      "blacklist_mod": [ "knife_combat_army", "knife_combat", "enfield_bayonet", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
+      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
       "install_time": "5 m"
     },
     "extend": { "flags": [ "PUMP_RAIL_COMPATIBLE" ] }
@@ -528,7 +530,7 @@
     "color": "light_red",
     "location": "underbarrel",
     "mod_targets": [ "rifle", "crossbow" ],
-    "blacklist_mod": [ "knife_combat_army", "knife_combat", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
+    "blacklist_mod": [ "knife_combat_army", "knife_combat", "enfield_bayonet", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
     "gun_data": { "ammo": "shot", "skill": "shotgun", "dispersion": 330, "durability": 10, "clip_size": 4 },
     "min_skills": [ [ "weapon", 1 ], [ "shotgun", 1 ] ],
     "flags": [ "RELOAD_ONE" ],
@@ -558,7 +560,7 @@
     "symbol": ":",
     "color": "white",
     "location": "underbarrel",
-    "blacklist_mod": [ "knife_combat_army", "knife_combat", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
+    "blacklist_mod": [ "knife_combat_army", "knife_combat", "enfield_bayonet", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
     "mod_targets": [ "rifle" ],
     "gun_data": { "ammo": "shot", "skill": "shotgun", "dispersion": 310, "durability": 10, "clip_size": 5 },
     "min_skills": [ [ "weapon", 1 ], [ "shotgun", 1 ] ],
@@ -587,7 +589,7 @@
     "symbol": ":",
     "color": "light_gray",
     "location": "underbarrel",
-    "blacklist_mod": [ "knife_combat_army", "knife_combat", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
+    "blacklist_mod": [ "knife_combat_army", "knife_combat", "enfield_bayonet", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
     "mod_targets": [ "smg", "rifle", "shotgun", "launcher", "crossbow" ],
     "gun_data": {
       "ammo": "40x46mm",
@@ -640,7 +642,7 @@
     "symbol": ":",
     "color": "dark_gray",
     "location": "underbarrel",
-    "blacklist_mod": [ "knife_combat_army", "knife_combat", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
+    "blacklist_mod": [ "knife_combat_army", "knife_combat", "enfield_bayonet", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
     "mod_targets": [ "rifle", "crossbow" ],
     "gun_data": { "ammo": "20x66mm", "skill": "shotgun", "dispersion": 320, "durability": 9, "reload": 125 },
     "min_skills": [ [ "weapon", 2 ], [ "shotgun", 2 ] ],
@@ -670,7 +672,7 @@
     "symbol": ":",
     "color": "light_red",
     "location": "underbarrel",
-    "blacklist_mod": [ "knife_combat_army", "knife_combat", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
+    "blacklist_mod": [ "knife_combat_army", "knife_combat", "enfield_bayonet", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
     "mod_targets": [ "rifle", "crossbow" ],
     "gun_data": { "ammo": "shot", "skill": "shotgun", "dispersion": 375, "durability": 10, "clip_size": 2 },
     "min_skills": [ [ "weapon", 1 ], [ "shotgun", 1 ] ],

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -316,7 +316,7 @@
         "u_shotgun",
         "u_shotgun_mod"
       ],
-      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE", "REACH_ATTACK" ] ] ],
+      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
       "install_time": "5 s"
     },
     "min_skills": [ [ "weapon", 2 ], [ "melee", 1 ] ],
@@ -377,7 +377,7 @@
         "u_shotgun",
         "u_shotgun_mod"
       ],
-      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE", "REACH_ATTACK" ] ] ],
+      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
       "install_time": "5 s"
     },
     "min_skills": [ [ "weapon", 2 ], [ "melee", 1 ] ],
@@ -438,7 +438,7 @@
         "u_shotgun",
         "u_shotgun_mod"
       ],
-      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE", "REACH_ATTACK" ] ] ],
+      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
       "install_time": "5 s"
     },
     "min_skills": [ [ "weapon", 2 ], [ "melee", 1 ] ],
@@ -1669,7 +1669,7 @@
         "u_shotgun",
         "u_shotgun_mod"
       ],
-      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE", "REACH_ATTACK" ] ] ],
+      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
       "install_time": "5 s"
     },
     "min_skills": [ [ "weapon", 2 ], [ "melee", 2 ] ],
@@ -2986,7 +2986,7 @@
     "price_postapoc": 3000,
     "melee_damage": { "bash": 7, "stab": 12 },
     "to_hit": { "grip": "solid", "length": "short", "surface": "point", "balance": "neutral" },
-    "//": "VERY not  intended for usage unmounted.",
+    "//": "VERY not intended for usage unmounted.",
     "material": [ "steel" ],
     "symbol": "/",
     "color": "light_gray",
@@ -3016,7 +3016,7 @@
         "u_shotgun",
         "u_shotgun_mod"
       ],
-      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE", "REACH_ATTACK" ] ] ],
+      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
       "install_time": "5 s"
     },
     "min_skills": [ [ "weapon", 2 ], [ "melee", 1 ] ],


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Makeshift bayonet still gave a reach attack. Also I thought about it some more and figure underbarrel was the right home for it afterall, not bayonet lug, as we'd want this to be installed on pretty much everything.
The `mode_modifier` entry in bayonets added an unnecessary `REACH_ATTACK` flag in reachless bayonets.
Also I missed adding the enfield bayonet to all the underbarrel slot conflicting items .


#### Describe the solution

Adds Enfield Bayonet as a conflict on appropriate gunmods.
Removes vestigial reach attack flag.
Removes reach attack range from makeshift bayonet.
Flips makeshift bayonet back to underbarrel slot.

#### Describe alternatives you've considered
None

#### Testing

Loaded game. Made sure bayonets were still adding additional damage and beat up the poor debug monster a bit.

#### Additional context

None.