### PR TITLE
add integrated_cable pseudo item with link_up to cable charge cbm

### DIFF
--- a/data/json/bionics.json
+++ b/data/json/bionics.json
@@ -562,11 +562,12 @@
     "id": "bio_cable",
     "type": "bionic",
     "name": { "str": "Cable Charger System" },
-    "description": "You have a complex port surgically mounted above your hip.  While active, it will recharge bionic power when connected to a power source via jumper cable.",
+    "description": "You have a complex port surgically mounted above your hip.  While active, it will recharge bionic power when connected to a power source via its integrated cable.",
     "occupied_bodyparts": [ [ "torso", 7 ] ],
     "is_remote_fueled": true,
     "time": "1 s",
     "fuel_efficiency": 1,
+    "passive_pseudo_items": [ "integrated_cable" ],
     "flags": [ "BIONIC_POWER_SOURCE", "BIONIC_SHOCKPROOF", "BIONIC_TOGGLED" ]
   },
   {

--- a/data/json/items/tool/integrated.json
+++ b/data/json/items/tool/integrated.json
@@ -218,5 +218,45 @@
     "charges_per_use": 20,
     "charged_qualities": [ [ "WELD", 2 ] ],
     "melee_damage": { "bash": 2, "cut": -1 }
+  },
+  {
+    "id": "integrated_cable",
+    "type": "TOOL_ARMOR",
+    "category": "armor",
+    "weight": "25 g",
+    "volume": "300 ml",
+    "price": 0,
+    "price_postapoc": 0,
+    "symbol": "s",
+    "color": "brown",
+    "warmth": 0,
+    "environmental_protection": 0,
+    "material_thickness": 0.5,
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "PERSONAL",
+      "WATER_FRIENDLY",
+      "SOFT",
+      "NO_REPAIR",
+      "ALLOWS_NATURAL_ATTACKS",
+      "TRADER_AVOID",
+      "CABLE_SPOOL",
+      "SINGLE_USE"
+    ],
+    "material": [ "superalloy", "copper" ],
+    "name": { "str_sp": "integrated cable" },
+    "description": "Integrated bionic cable for charging.",
+    "to_hit": -1,
+    "use_action": [
+      {
+        "type": "link_up",
+        "menu_text": "Attach / Detach",
+        "is_cable_item": true,
+        "cable_length": 3,
+        "targets": [ "no_link", "bio_cable", "ups", "solarpack", "vehicle_port", "vehicle_battery" ]
+      }
+    ],
+    "melee_damage": { "bash": 1 }
   }
 ]

--- a/data/json/items/tool/integrated.json
+++ b/data/json/items/tool/integrated.json
@@ -252,7 +252,6 @@
       {
         "type": "link_up",
         "menu_text": "Attach / Detach",
-        "is_cable_item": true,
         "cable_length": 3,
         "targets": [ "no_link", "bio_cable", "ups", "solarpack", "vehicle_port", "vehicle_battery" ]
       }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Add link up cables to cable charger cbm"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The cable charger cbm should probably have an integrated cable coiled in there somewhere, most things come with their own cables. Now that link up type cables have been added, it seems to fit.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Created a passive pseudo item like other bionics. Added `link_up` use action. Added `CABLE_SPOOL` flag.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I originally tried to use a normal link_up like most devices, but it seems like there is no way to pass the juice on to the cbm, so I made it a cable spool, which is a bit weird and not that friendly since you have to connect it to yourself. Ideally, it would be already connected to yourself.
Considered, making the pseudo item have a battery and it drains into the cbm, so that the cable management is clean. Doesn't seem like the solution is clean.
Would be nice to make it bi-directional so it can take or give power to stuff, including starting up cars.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
debug installed cable charger cbm and battery. Activated integrated cable, it acted like a jumper cable. Connected it to self, then connected it to car controls. Turned on cable charger system, got power.

~~Was unable to connect directly to a car battery, though. Cable comes loose and gets reeled in.~~
was throwing an error I missed. Removed offending line and now it seems to connect to both batteries and controls correctly.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
![Screenshot (75) - Copy](https://github.com/CleverRaven/Cataclysm-DDA/assets/30750303/e8264cdd-0d1f-407a-8c3b-98f3a25bf32c)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
