### PR TITLE
[MoM] Slightly reduce power ranges

### DIFF
--- a/data/mods/MindOverMatter/powers/clairsentience.json
+++ b/data/mods/MindOverMatter/powers/clairsentience.json
@@ -118,7 +118,7 @@
     "max_level": { "math": [ "int_to_level(1)" ] },
     "min_range": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: clair_spot_weakness') * 1.5) + 1) * (scaling_factor(u_val('intelligence') ) ), 100)"
+        "min( ( (u_val('spell_level', 'spell: clair_spot_weakness') * 1.1) + 1) * (scaling_factor(u_val('intelligence') ) ), 100)"
       ]
     },
     "max_range": 100,
@@ -265,14 +265,12 @@
     "difficulty": 5,
     "max_level": { "math": [ "int_to_level(1)" ] },
     "min_range": {
-      "math": [
-        "min( ( (u_val('spell_level', 'spell: clair_voyance') * 1.5) + 1.5) * (scaling_factor(u_val('intelligence') ) ), 80)"
-      ]
+      "math": [ "min( ( (u_val('spell_level', 'spell: clair_voyance') * 1.2) + 2) * (scaling_factor(u_val('intelligence') ) ), 80)" ]
     },
     "max_range": 80,
     "min_aoe": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: clair_voyance') * 1.5) + 1.5) * (scaling_factor(u_val('intelligence') ) ), 50)"
+        "min( ( (u_val('spell_level', 'spell: clair_voyance') * 1.2) + 1.5) * (scaling_factor(u_val('intelligence') ) ), 50)"
       ]
     },
     "max_aoe": 50,

--- a/data/mods/MindOverMatter/powers/photokinesis.json
+++ b/data/mods/MindOverMatter/powers/photokinesis.json
@@ -541,7 +541,7 @@
     "damage_type": "psi_photokinetic_damage",
     "min_range": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: photokinetic_light_disintegrate') * 2) + 2) * (scaling_factor(u_val('intelligence') ) ), 50)"
+        "min( ( (u_val('spell_level', 'spell: photokinetic_light_disintegrate') * 0.8) + 2) * (scaling_factor(u_val('intelligence') ) ), 50)"
       ]
     },
     "max_range": 50,

--- a/data/mods/MindOverMatter/powers/pyrokinesis.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis.json
@@ -544,7 +544,7 @@
     },
     "min_range": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: pyrokinetic_blast') * 1.2) + 4) * (scaling_factor(u_val('intelligence') ) ), 70)"
+        "min( ( (u_val('spell_level', 'spell: pyrokinetic_blast') * 0.9) + 4) * (scaling_factor(u_val('intelligence') ) ), 70)"
       ]
     },
     "max_range": 80,

--- a/data/mods/MindOverMatter/powers/telekinesis.json
+++ b/data/mods/MindOverMatter/powers/telekinesis.json
@@ -24,7 +24,7 @@
     },
     "min_range": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: telekinetic_pull') * 1.2) + 3) * (scaling_factor(u_val('intelligence') ) ), 40)"
+        "min( ( (u_val('spell_level', 'spell: telekinetic_pull') * 0.9) + 3) * (scaling_factor(u_val('intelligence') ) ), 40)"
       ]
     },
     "max_range": 40,
@@ -63,7 +63,7 @@
     },
     "min_range": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: telekinetic_push') * 1.2) + 1) * (scaling_factor(u_val('intelligence') ) ), 40)"
+        "min( ( (u_val('spell_level', 'spell: telekinetic_push') * 0.9) + 1) * (scaling_factor(u_val('intelligence') ) ), 40)"
       ]
     },
     "max_range": 40,
@@ -280,7 +280,7 @@
     },
     "min_range": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: telekinetic_hammer') * 1.2) + 3) * (scaling_factor(u_val('intelligence') ) ), 70)"
+        "min( ( (u_val('spell_level', 'spell: telekinetic_hammer') * 0.9) + 3) * (scaling_factor(u_val('intelligence') ) ), 70)"
       ]
     },
     "max_range": 70,
@@ -314,6 +314,12 @@
     "max_damage": {
       "math": [ "( (u_val('spell_level', 'spell: telekinetic_hammer') * 2) + 73) * (scaling_factor(u_val('intelligence') ) )" ]
     },
+    "min_range": {
+      "math": [
+        "min( ( (u_val('spell_level', 'spell: telekinetic_hammer') * 0.9) + 3) * (scaling_factor(u_val('intelligence') ) ), 70)"
+      ]
+    },
+    "max_range": 70,
     "ignored_monster_species": [ "PSI_NULL" ]
   },
   {
@@ -419,7 +425,7 @@
     },
     "min_range": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: telekinetic_explosion') * 1.2) + 4) * (scaling_factor(u_val('intelligence') ) ), 60)"
+        "min( ( (u_val('spell_level', 'spell: telekinetic_explosion') * 0.9) + 4) * (scaling_factor(u_val('intelligence') ) ), 60)"
       ]
     },
     "max_range": 60,
@@ -459,6 +465,12 @@
     "max_damage": {
       "math": [ "( (u_val('spell_level', 'spell: telekinetic_explosion') * 5) + 100) * (scaling_factor(u_val('intelligence') ) )" ]
     },
+    "min_range": {
+      "math": [
+        "min( ( (u_val('spell_level', 'spell: telekinetic_explosion') * 0.9) + 4) * (scaling_factor(u_val('intelligence') ) ), 60)"
+      ]
+    },
+    "max_range": 60,
     "min_aoe": {
       "math": [ "( (u_val('spell_level', 'spell: telekinetic_explosion') * 0.3) + 2) * (scaling_factor(u_val('intelligence') ) )" ]
     },

--- a/data/mods/MindOverMatter/powers/telepathy.json
+++ b/data/mods/MindOverMatter/powers/telepathy.json
@@ -165,7 +165,7 @@
     },
     "min_range": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: telepathic_blast') * 1.2) + 3) * (scaling_factor(u_val('intelligence') ) ), 80)"
+        "min( ( (u_val('spell_level', 'spell: telepathic_blast') * 1.1) + 3) * (scaling_factor(u_val('intelligence') ) ), 80)"
       ]
     },
     "max_range": 80,
@@ -208,7 +208,7 @@
     },
     "min_range": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: telepathic_confusion') * 1.2) + 3) * (scaling_factor(u_val('intelligence') ) ), 80)"
+        "min( ( (u_val('spell_level', 'spell: telepathic_confusion') * 1.1) + 3) * (scaling_factor(u_val('intelligence') ) ), 80)"
       ]
     },
     "max_range": 80,
@@ -275,7 +275,7 @@
     },
     "min_range": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: telepathic_fear') * 1.2) + 3) * (scaling_factor(u_val('intelligence') ) ), 80)"
+        "min( ( (u_val('spell_level', 'spell: telepathic_fear') * 1.1) + 3) * (scaling_factor(u_val('intelligence') ) ), 80)"
       ]
     },
     "max_range": 80,
@@ -314,7 +314,7 @@
     },
     "min_range": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: telepathic_fear') * 1.2) + 3) * (scaling_factor(u_val('intelligence') ) ), 80)"
+        "min( ( (u_val('spell_level', 'spell: telepathic_fear') * 1.1) + 3) * (scaling_factor(u_val('intelligence') ) ), 80)"
       ]
     },
     "max_range": 80,
@@ -397,7 +397,7 @@
     },
     "min_aoe": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: telepathic_blast_radius') * 1.2 ) + 2) * (scaling_factor(u_val('intelligence') ) ), 40)"
+        "min( ( (u_val('spell_level', 'spell: telepathic_blast_radius') * 1.1 ) + 2) * (scaling_factor(u_val('intelligence') ) ), 40)"
       ]
     },
     "energy_source": "STAMINA",

--- a/data/mods/MindOverMatter/powers/teleportation.json
+++ b/data/mods/MindOverMatter/powers/teleportation.json
@@ -149,7 +149,7 @@
     "max_level": { "math": [ "int_to_level(1)" ] },
     "min_range": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: teleport_transpose') * 2.5) + 1) * (scaling_factor(u_val('intelligence') ) ), 80)"
+        "min( ( (u_val('spell_level', 'spell: teleport_transpose') * 1.5) + 1) * (scaling_factor(u_val('intelligence') ) ), 80)"
       ]
     },
     "max_range": 80,
@@ -255,7 +255,7 @@
     "aoe_increment": -0.25,
     "min_range": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: teleport_farstep') * 2.5) + 2) * (scaling_factor(u_val('intelligence') ) ), 80)"
+        "min( ( (u_val('spell_level', 'spell: teleport_farstep') * 1.5) + 2) * (scaling_factor(u_val('intelligence') ) ), 80)"
       ]
     },
     "max_range": 80,
@@ -351,7 +351,7 @@
     "min_damage": 1,
     "min_range": {
       "math": [
-        "min( ( (u_val('spell_level', 'spell: teleport_summon') * 1.5) + 2) * (scaling_factor(u_val('intelligence') ) ), 80)"
+        "min( ( (u_val('spell_level', 'spell: teleport_summon') * 1.3) + 2) * (scaling_factor(u_val('intelligence') ) ), 80)"
       ]
     },
     "max_range": 80,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Slightly reduce power ranges"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Powers were scaling a bit faster than is probably good for them
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Slightly reduce the range multiplier on power scaling, generally on the level of 1.2->1.1 or 1.2->0.9.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
