### PR TITLE
Add Faction editing to Debug menu

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -252,6 +252,7 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
 		case debug_menu::debug_menu_index::TOGGLE_SETUP_MUTATION: return "TOGGLE_SETUP_MUTATION";
 		case debug_menu::debug_menu_index::NORMALIZE_BODY_STAT: return "NORMALIZE_BODY_STAT";
 		case debug_menu::debug_menu_index::SIX_MILLION_DOLLAR_SURVIVOR: return "SIX_MILLION_DOLLAR_SURVIVOR";
+		case debug_menu::debug_menu_index::EDIT_FACTION: return "EDIT_FACTION";
         // *INDENT-ON*
         case debug_menu::debug_menu_index::last:
             break;
@@ -491,7 +492,7 @@ static int info_uilist( bool display_all_entries = true )
             { uilist_entry( debug_menu_index::TRAIT_GROUP, true, 't', _( "Test trait group" ) ) },
             { uilist_entry( debug_menu_index::DISPLAY_NPC_PATH, true, 'n', _( "Toggle NPC pathfinding on map" ) ) },
             { uilist_entry( debug_menu_index::DISPLAY_NPC_ATTACK, true, 'A', _( "Toggle NPC attack potential values on map" ) ) },
-            { uilist_entry( debug_menu_index::PRINT_FACTION_INFO, true, 'f', _( "Print faction info to console" ) ) },
+            { uilist_entry( debug_menu_index::PRINT_FACTION_INFO, true, 'f', _( "Print factions info to console" ) ) },
             { uilist_entry( debug_menu_index::PRINT_NPC_MAGIC, true, 'M', _( "Print NPC magic info to console" ) ) },
             { uilist_entry( debug_menu_index::TEST_WEATHER, true, 'W', _( "Test weather" ) ) },
             { uilist_entry( debug_menu_index::WRITE_GLOBAL_EOCS, true, 'C', _( "Write global effect_on_condition(s) to eocs.output" ) ) },
@@ -601,6 +602,18 @@ static int quick_setup_uilist()
     return uilist( _( "Quick setup…" ), uilist_initializer );
 }
 
+static int faction_uilist()
+{
+    const std::vector<uilist_entry> uilist_initializer = {
+        { uilist_entry( debug_menu_index::EDIT_FACTION, true, 'e', _( "Edit faction" ) ) },
+        { uilist_entry( debug_menu_index::PRINT_FACTION_INFO, true, 'p', _( "Print factions info to console" ) ) },
+    };
+
+    return uilist( _( "Faction" ), uilist_initializer );
+}
+
+
+
 /**
  * Create the debug menu UI list.
  * @param display_all_entries: `true` if all entries should be displayed, `false` is some entries should be hidden (for ex. when the debug menu is called from the main menu).
@@ -609,19 +622,24 @@ static int quick_setup_uilist()
  */
 static std::optional<debug_menu_index> debug_menu_uilist( bool display_all_entries = true )
 {
+    enum {
+        D_INFO, D_GAME, D_SPAWNING, D_PLAYER, D_FACTION, D_VEHICLE, D_TELEPORT, D_MAP, D_QUICK_SETUP
+    };
+
     std::vector<uilist_entry> menu = {
-        { uilist_entry( 1, true, 'i', _( "Info…" ) ) },
+        { uilist_entry( D_INFO, true, 'i', _( "Info…" ) ) },
     };
 
     if( display_all_entries ) {
         const std::vector<uilist_entry> debug_menu = {
-            { uilist_entry( 6, true, 'g', _( "Game…" ) ) },
-            { uilist_entry( 2, true, 's', _( "Spawning…" ) ) },
-            { uilist_entry( 3, true, 'p', _( "Player…" ) ) },
-            { uilist_entry( 7, true, 'v', _( "Vehicle…" ) ) },
-            { uilist_entry( 4, true, 't', _( "Teleport…" ) ) },
-            { uilist_entry( 5, true, 'm', _( "Map…" ) ) },
-            { uilist_entry( 8, true, 'q', _( "Quick setup…" ) ) },
+            { uilist_entry( D_GAME,        true, 'g', _( "Game…" ) ) },
+            { uilist_entry( D_SPAWNING,    true, 's', _( "Spawning…" ) ) },
+            { uilist_entry( D_PLAYER,      true, 'p', _( "Player…" ) ) },
+            { uilist_entry( D_FACTION,     true, 'f', _( "Faction…" ) ) },
+            { uilist_entry( D_VEHICLE,     true, 'v', _( "Vehicle…" ) ) },
+            { uilist_entry( D_TELEPORT,    true, 't', _( "Teleport…" ) ) },
+            { uilist_entry( D_MAP,         true, 'm', _( "Map…" ) ) },
+            { uilist_entry( D_QUICK_SETUP, true, 'q', _( "Quick setup…" ) ) },
         };
 
         // insert debug-only menu right after "Info".
@@ -641,28 +659,31 @@ static std::optional<debug_menu_index> debug_menu_uilist( bool display_all_entri
         int action;
 
         switch( group ) {
-            case 1:
+            case D_INFO:
                 action = info_uilist( display_all_entries );
                 break;
-            case 2:
+            case D_SPAWNING:
                 action = spawning_uilist();
                 break;
-            case 3:
+            case D_PLAYER:
                 action = player_uilist();
                 break;
-            case 4:
+            case D_FACTION:
+                action = faction_uilist();
+                break;
+            case D_TELEPORT:
                 action = teleport_uilist();
                 break;
-            case 5:
+            case D_MAP:
                 action = map_uilist();
                 break;
-            case 6:
+            case D_GAME:
                 action = game_uilist();
                 break;
-            case 7:
+            case D_VEHICLE:
                 action = vehicle_uilist();
                 break;
-            case 8:
+            case D_QUICK_SETUP:
                 action = quick_setup_uilist();
                 break;
 
@@ -1658,12 +1679,12 @@ static void character_edit_hp_menu( Character &you )
 static void character_edit_opinion_menu( npc *np )
 {
     uilist smenu;
-    smenu.addentry( 0, true, 'h', "%s: %d", _( "trust" ), np->op_of_u.trust );
-    smenu.addentry( 1, true, 's', "%s: %d", _( "fear" ), np->op_of_u.fear );
-    smenu.addentry( 2, true, 't', "%s: %d", _( "value" ), np->op_of_u.value );
-    smenu.addentry( 3, true, 'f', "%s: %d", _( "anger" ), np->op_of_u.anger );
-    smenu.addentry( 4, true, 'd', "%s: %d", _( "owed" ), np->op_of_u.owed );
-    smenu.addentry( 5, true, 'd', "%s: %d", _( "sold" ), np->op_of_u.sold );
+    smenu.addentry( 0, true, 't', "%s: %d", _( "trust" ), np->op_of_u.trust );
+    smenu.addentry( 1, true, 'f', "%s: %d", _( "fear" ), np->op_of_u.fear );
+    smenu.addentry( 2, true, 'v', "%s: %d", _( "value" ), np->op_of_u.value );
+    smenu.addentry( 3, true, 'a', "%s: %d", _( "anger" ), np->op_of_u.anger );
+    smenu.addentry( 4, true, 'o', "%s: %d", _( "owed" ), np->op_of_u.owed );
+    smenu.addentry( 5, true, 's', "%s: %d", _( "sold" ), np->op_of_u.sold );
 
     smenu.query();
     int value;
@@ -1941,7 +1962,7 @@ static void character_edit_menu()
         nmenu.addentry( D_MISSION_ADD, true, 'm', "%s", _( "Add mission" ) );
         nmenu.addentry( D_CLASS, true, 'c', "%s", _( "Randomize with class" ) );
         nmenu.addentry( D_ATTITUDE, true, 'A', "%s", _( "Set attitude" ) );
-        nmenu.addentry( D_OPINION, true, 'O', "%s", _( "Set opinion" ) );
+        nmenu.addentry( D_OPINION, true, 'O', "%s", _( "Set opinions" ) );
         nmenu.addentry( D_PERSONALITY, true, 'P', "%s", _( "Set personality" ) );
     }
     nmenu.query();
@@ -2240,6 +2261,126 @@ static void character_edit_menu()
             you.set_value( "npctalk_var_" + key, value );
             break;
         }
+    }
+}
+
+static void faction_edit_opinion_menu( faction *fac )
+{
+    uilist smenu;
+    smenu.addentry( 0, true, 'l', "%s: %d", _( "Like" ), fac->likes_u );
+    smenu.addentry( 1, true, 'r', "%s: %d", _( "Respect" ), fac->respects_u );
+    smenu.addentry( 2, true, 't', "%s: %d", _( "Trust" ), fac->trusts_u );
+
+    smenu.query();
+    int value;
+    switch( smenu.ret ) {
+        case 0:
+            if( query_int( value, _( "Change like from %d to: " ), fac->likes_u ) ) {
+                fac->likes_u = value;
+            }
+            break;
+        case 1:
+            if( query_int( value, _( "Change respect from %d to: " ), fac->respects_u ) ) {
+                fac->respects_u = value;
+            }
+            break;
+        case 2:
+            if( query_int( value, _( "Change trust from %d to: " ), fac->trusts_u ) ) {
+                fac->trusts_u = value;
+            }
+            break;
+    }
+}
+
+static void faction_edit_menu()
+{
+
+    std::vector<faction *> factions; // Factions that we know of.
+    for( const auto &elem : g->faction_manager_ptr->all() ) {
+        factions.push_back( g->faction_manager_ptr->get( elem.first ) );
+    }
+
+    if( factions.size() == 0 ) {
+        return;
+    }
+
+    uilist factionlist;
+    int facnum = 0;
+    for( const auto &faction : factions ) {
+        factionlist.addentry( facnum++, true, MENU_AUTOASSIGN, "%s", faction->name.c_str() );
+    }
+
+    factionlist.w_y_setup = 0;
+    factionlist.query();
+    if( factionlist.ret < 0 || static_cast<size_t>( factionlist.ret ) >= factions.size() ) {
+        return;
+    }
+    const size_t index = factionlist.ret;
+
+    uilist nmenu;
+
+    auto &fac = factions[index];
+
+    std::stringstream data;
+    data << fac->name << std::endl;
+    data << fac->describe() << std::endl;
+    data << string_format( _( "Id: %s" ), fac->id.c_str() ) << std::endl;
+    data << string_format( _( "Wealth: %d" ), fac->wealth ) << " | "
+         << string_format( _( "Currency: %s" ), fac->currency.obj().nname( fac->wealth ) ) << std::endl;
+    data << string_format( _( "Size: %d" ), fac->size ) << " | "
+         << string_format( _( "Power: %d" ), fac->power ) << " | "
+         << string_format( _( "Food Supply: %d" ), fac->food_supply ) << std::endl;
+    data << string_format( _( "Like: %d" ), fac->likes_u ) << " | "
+         << string_format( _( "Respect: %d" ), fac->respects_u ) << " | "
+         << string_format( _( "Trust: %d" ), fac->trusts_u ) << std::endl;
+    data << string_format( _( "Known by you: %s" ), fac->known_by_u ? "true" : "false" ) << " | "
+         << string_format( _( "Lone wolf: %s" ), fac->lone_wolf_faction ? "true" : "false" ) << std::endl;
+
+    nmenu.text = data.str();
+
+    enum {
+        D_WEALTH, D_SIZE, D_POWER, D_FOOD, D_OPINION, D_KNOWN, D_LONE
+    };
+    nmenu.addentry( D_WEALTH, true, 'w', "%s", _( "Set wealth" ) );
+    nmenu.addentry( D_SIZE, true, 's', "%s", _( "Set size" ) );
+    nmenu.addentry( D_POWER, true, 'p', "%s", _( "Set power" ) );
+    nmenu.addentry( D_FOOD, true, 'f', "%s", _( "Set food supply" ) );
+    nmenu.addentry( D_OPINION, true, 'o', "%s", _( "Set opinions" ) );
+    nmenu.addentry( D_KNOWN, true, 'k', "%s", _( "Toggle Known by you" ) );
+    nmenu.addentry( D_LONE, true, 'l', "%s", _( "Toggle Lone wolf" ) );
+
+    nmenu.query();
+    int value;
+    switch( nmenu.ret ) {
+        case D_WEALTH:
+            if( query_int( value, _( "Change wealth from %d to: " ), fac->wealth ) ) {
+                fac->wealth = value;
+            }
+            break;
+        case D_SIZE:
+            if( query_int( value, _( "Change size from %d to: " ), fac->size ) ) {
+                fac->size = value;
+            }
+            break;
+        case D_POWER:
+            if( query_int( value, _( "Change power from %d to: " ), fac->power ) ) {
+                fac->power = value;
+            }
+            break;
+        case D_FOOD:
+            if( query_int( value, _( "Change food from %d to: " ), fac->food_supply ) ) {
+                fac->food_supply = value;
+            }
+            break;
+        case D_OPINION:
+            faction_edit_opinion_menu( fac );
+            break;
+        case D_KNOWN:
+            fac->known_by_u = !fac->known_by_u;
+            break;
+        case D_LONE:
+            fac->lone_wolf_faction = !fac->lone_wolf_faction;
+            break;
     }
 }
 
@@ -3591,6 +3732,10 @@ void debug()
             u.set_power_level( 2500_kJ );
             break;
         }
+
+        case debug_menu_index::EDIT_FACTION:
+            faction_edit_menu();
+            break;
 
         case debug_menu_index::last:
             return;

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -240,7 +240,6 @@ std::string enum_to_string<debug_menu::debug_menu_index>( debug_menu::debug_menu
         case debug_menu::debug_menu_index::TEST_MAP_EXTRA_DISTRIBUTION: return "TEST_MAP_EXTRA_DISTRIBUTION";
         case debug_menu::debug_menu_index::NESTED_MAPGEN: return "NESTED_MAPGEN";
         case debug_menu::debug_menu_index::VEHICLE_EXPORT: return "VEHICLE_EXPORT";
-        case debug_menu::debug_menu_index::EDIT_CAMP_LARDER: return "EDIT_CAMP_LARDER";
         case debug_menu::debug_menu_index::VEHICLE_DELETE: return "VEHICLE_DELETE";
         case debug_menu::debug_menu_index::VEHICLE_BATTERY_CHARGE: return "VEHICLE_BATTERY_CHARGE";
         case debug_menu::debug_menu_index::GENERATE_EFFECT_LIST: return "GENERATE_EFFECT_LIST";
@@ -584,7 +583,6 @@ static int map_uilist()
         { uilist_entry( debug_menu_index::OM_EDITOR, true, 'O', _( "Overmap editor" ) ) },
         { uilist_entry( debug_menu_index::MAP_EXTRA, true, 'm', _( "Spawn map extra" ) ) },
         { uilist_entry( debug_menu_index::NESTED_MAPGEN, true, 'n', _( "Spawn nested mapgen" ) ) },
-        { uilist_entry( debug_menu_index::EDIT_CAMP_LARDER, true, 'l', _( "Edit the faction camp larder" ) ) },
     };
 
     return uilist( _( "Map…" ), uilist_initializer );
@@ -2300,13 +2298,13 @@ static void faction_edit_menu()
         factions.push_back( g->faction_manager_ptr->get( elem.first ) );
     }
 
-    if( factions.size() == 0 ) {
+    if( factions.empty() ) {
         return;
     }
 
     uilist factionlist;
     int facnum = 0;
-    for( const auto &faction : factions ) {
+    for( const faction *faction : factions ) {
         factionlist.addentry( facnum++, true, MENU_AUTOASSIGN, "%s", faction->name.c_str() );
     }
 
@@ -3631,16 +3629,6 @@ void debug()
                 break;
             }
             add_msg( m_bad, _( "There's no vehicle there." ) );
-            break;
-        }
-
-        case debug_menu_index::EDIT_CAMP_LARDER: {
-            faction *your_faction = get_player_character().get_faction();
-            int larder;
-            if( query_int( larder, _( "Set camp larder kCals to?  Currently: %d" ),
-                           your_faction->food_supply ) ) {
-                your_faction->food_supply = larder;
-            }
             break;
         }
 

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -105,6 +105,7 @@ enum class debug_menu_index : int {
     TOGGLE_SETUP_MUTATION,
     NORMALIZE_BODY_STAT,
     SIX_MILLION_DOLLAR_SURVIVOR,
+    EDIT_FACTION,
     last
 };
 

--- a/src/debug_menu.h
+++ b/src/debug_menu.h
@@ -91,7 +91,6 @@ enum class debug_menu_index : int {
     VEHICLE_DELETE,
     VEHICLE_EXPORT,
     GENERATE_EFFECT_LIST,
-    EDIT_CAMP_LARDER,
     WRITE_GLOBAL_EOCS,
     WRITE_GLOBAL_VARS,
     EDIT_GLOBAL_VARS,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Faction editing on Debug menu"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Currently when faction stats become problematic, through a bug or just poor choices, players resort to editing the save files to fix them.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Add a new Debug menu to edit faction info (like, respect, trust, wealth, food, etc).
Also replicate the "print factions info to console" debug info item.
Also removed Edit Camp Larder debug menu item, it can now be done the same as editing any other faction's food.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Used the new menu to edit factions.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Also made some updates/fixes to a few other debug menu areas, such as mismatched and duplicate hotkeys.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/121299/80da3265-66b7-449c-8614-3b3f5b23439c)


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
