### PR TITLE
Fix degradation of  removing vehicle parts

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8073,7 +8073,7 @@ item vehicle::part_to_item( const vehicle_part &vp ) const
 
     // quantize damage and degradation to the middle of each damage_level so that items will stack nicely
     tmp.set_damage( ( tmp.damage_level() - 0.5 ) * itype::damage_scale );
-    tmp.set_degradation( ( tmp.damage_level() - 0.5 ) * itype::damage_scale );
+    tmp.set_degradation( ( tmp.degradation() / itype::damage_scale - 0.5 ) * itype::damage_scale );
     return tmp;
 }
 


### PR DESCRIPTION
#### Summary
Bugfixes "Fix degradation of  removing vehicle parts"

#### Purpose of change
The process of degrading vehicle parts when removed was added in #65642.
At this time, degradation is set by referring to the damage value instead of the degradation value.
There's no problem if this is the intended behavior, but based on the content of the PR I don't think it's the case, so I'll fix it.

#### Describe the solution
Quantization of degradation is done by referring to the degradation value instead of damage.

#### Describe alternatives you've considered


#### Testing


#### Additional context
