### PR TITLE
Avoid unnecessary copies in lambda captures

### DIFF
--- a/src/mission_util.cpp
+++ b/src/mission_util.cpp
@@ -439,10 +439,10 @@ mission_target_params mission_util::parse_mission_om_target( const JsonObject &j
 void mission_util::set_reveal( const std::string &terrain,
                                std::vector<std::function<void( mission *miss )>> &funcs )
 {
-    const auto mission_func = [ terrain ]( mission * miss ) {
+    auto mission_func = [ terrain ]( mission * miss ) {
         reveal_target( miss, terrain );
     };
-    funcs.emplace_back( mission_func );
+    funcs.emplace_back( std::move( mission_func ) );
 }
 
 void mission_util::set_reveal_any( const JsonArray &ja,
@@ -452,23 +452,22 @@ void mission_util::set_reveal_any( const JsonArray &ja,
     for( const std::string terrain : ja ) {
         terrains.push_back( terrain );
     }
-    const auto mission_func = [ terrains ]( mission * miss ) {
+    auto mission_func = [ terrains = std::move( terrains ) ]( mission * miss ) {
         reveal_any_target( miss, terrains );
     };
-    funcs.emplace_back( mission_func );
+    funcs.emplace_back( std::move( mission_func ) );
 }
 
 void mission_util::set_assign_om_target( const JsonObject &jo,
         std::vector<std::function<void( mission *miss )>> &funcs )
 {
     mission_target_params p = parse_mission_om_target( jo );
-    const auto mission_func = [p]( mission * miss ) {
-        mission_target_params mtp = p;
-        mtp.mission_pointer = miss;
+    auto mission_func = [p = std::move( p )]( mission * miss ) mutable {
+        p.mission_pointer = miss;
         dialogue d( get_talker_for( get_avatar() ), nullptr );
-        assign_mission_target( mtp, d );
+        assign_mission_target( p, d );
     };
-    funcs.emplace_back( mission_func );
+    funcs.emplace_back( std::move( mission_func ) );
 }
 
 bool mission_util::set_update_mapgen( const JsonObject &jo,
@@ -483,17 +482,17 @@ bool mission_util::set_update_mapgen( const JsonObject &jo,
 
     if( jo.has_member( "om_terrain" ) ) {
         const std::string om_terrain = jo.get_string( "om_terrain" );
-        const auto mission_func = [update_map, om_terrain]( mission * miss ) {
+        auto mission_func = [update_map = std::move( update_map ), om_terrain]( mission * miss ) {
             tripoint_abs_omt update_pos3 = mission_util::reveal_om_ter( om_terrain, 1, false );
             update_map( update_pos3, miss );
         };
-        funcs.emplace_back( mission_func );
+        funcs.emplace_back( std::move( mission_func ) );
     } else {
-        const auto mission_func = [update_map]( mission * miss ) {
+        auto mission_func = [update_map = std::move( update_map )]( mission * miss ) {
             tripoint_abs_omt update_pos3 = miss->get_target();
             update_map( update_pos3, miss );
         };
-        funcs.emplace_back( mission_func );
+        funcs.emplace_back( std::move( mission_func ) );
     }
     return true;
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
While trying to fix `performance-no-automatic-move` clang-tidy warning (LLVM 17), incidentally I found some lambdas have quite expensive captures by copy.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This pull request changes them to capture by move if possible. Also move lambdas instead of copying lambdas if possible.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Started a new game in Address Sanitizer, no error reported in mapgen and accepting missions.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
