### PR TITLE
Optimize mutation_armor & resistances calculations

### DIFF
--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -584,14 +584,6 @@ int dealt_damage_instance::total_damage() const
     } );
 }
 
-resistances::resistances()
-{
-    resist_vals.clear();
-    for( const damage_type &dam : damage_type::get_all() ) {
-        resist_vals.emplace( dam.id, 0.0f );
-    }
-}
-
 resistances::resistances( const item &armor, bool to_self, int roll, const bodypart_id &bp )
 {
     // Armors protect, but all items can resist
@@ -629,18 +621,6 @@ float resistances::get_effective_resist( const damage_unit &du ) const
 {
     return std::max( type_resist( du.type ) - du.res_pen,
                      0.0f ) * du.res_mult * du.unconditional_res_mult;
-}
-
-resistances &resistances::operator+=( const resistances &other )
-{
-    for( const auto &dam : other.resist_vals ) {
-        if( resist_vals.count( dam.first ) <= 0 ) {
-            resist_vals[dam.first] = 0.0f;
-        }
-        resist_vals[dam.first] += dam.second;
-    }
-
-    return *this;
 }
 
 bool resistances::operator==( const resistances &other )
@@ -778,10 +758,10 @@ damage_instance load_damage_instance_inherit( const JsonArray &jarr, const damag
     return di;
 }
 
-std::map<damage_type_id, float> load_damage_map( const JsonObject &jo,
+std::unordered_map<damage_type_id, float> load_damage_map( const JsonObject &jo,
         const std::set<std::string> &ignored_keys )
 {
-    std::map<damage_type_id, float> ret;
+    std::unordered_map<damage_type_id, float> ret;
     for( const JsonMember &jmemb : jo ) {
         if( !ignored_keys.empty() && ignored_keys.count( jmemb.name() ) > 0 ) {
             continue;
@@ -791,7 +771,7 @@ std::map<damage_type_id, float> load_damage_map( const JsonObject &jo,
     return ret;
 }
 
-void finalize_damage_map( std::map<damage_type_id, float> &damage_map, bool force_derive,
+void finalize_damage_map( std::unordered_map<damage_type_id, float> &damage_map, bool force_derive,
                           float default_value )
 {
     const std::vector<damage_type> &dams = damage_type::get_all();

--- a/src/damage.h
+++ b/src/damage.h
@@ -5,6 +5,7 @@
 #include <array>
 #include <iosfwd>
 #include <map>
+#include <unordered_map>
 #include <set>
 #include <vector>
 
@@ -200,9 +201,9 @@ struct dealt_damage_instance {
 };
 
 struct resistances {
-    std::map<damage_type_id, float> resist_vals;
+    std::unordered_map<damage_type_id, float> resist_vals;
 
-    resistances();
+    resistances() = default;
 
     // If to_self is true, we want armor's own resistance, not one it provides to wearer
     explicit resistances( const item &armor, bool to_self = false, int roll = 0,
@@ -214,7 +215,13 @@ struct resistances {
 
     float get_effective_resist( const damage_unit &du ) const;
 
-    resistances &operator+=( const resistances &other );
+    resistances &operator+=( const resistances &other ) {
+        for( const auto &dam : other.resist_vals ) {
+            resist_vals[dam.first] += dam.second;
+        }
+
+        return *this;
+    }
     bool operator==( const resistances &other );
     resistances operator*( float mod ) const;
     resistances operator/( float mod ) const;
@@ -232,9 +239,10 @@ resistances load_resistances_instance( const JsonObject &jo,
 
 // Returns damage or resistance data
 // Handles some shorthands
-std::map<damage_type_id, float> load_damage_map( const JsonObject &jo,
+std::unordered_map<damage_type_id, float> load_damage_map( const JsonObject &jo,
         const std::set<std::string> &ignored_keys = {} );
-void finalize_damage_map( std::map<damage_type_id, float> &damage_map, bool force_derive = false,
+void finalize_damage_map( std::unordered_map<damage_type_id, float> &damage_map,
+                          bool force_derive = false,
                           float default_value = 0.0f );
 
 #endif // CATA_SRC_DAMAGE_H

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9175,6 +9175,7 @@ std::vector<const part_material *> item::armor_made_of( const bodypart_id &bp ) 
             if( bp != bpid ) {
                 continue;
             }
+            matlist.reserve( matlist.size() + d.materials.size() );
             for( const part_material &m : d.materials ) {
                 matlist.emplace_back( &m );
             }

--- a/src/itype.h
+++ b/src/itype.h
@@ -1399,7 +1399,7 @@ struct itype {
 
     public:
         /** Damage output in melee for zero or more damage types */
-        std::map<damage_type_id, float> melee;
+        std::unordered_map<damage_type_id, float> melee;
 
         bool default_container_sealed = true;
 
@@ -1414,10 +1414,10 @@ struct itype {
 
     private:
         // load-only, for applying proportional melee values at load time
-        std::map<damage_type_id, float> melee_proportional;
+        std::unordered_map<damage_type_id, float> melee_proportional;
 
         // load-only, for applying relative melee values at load time
-        std::map<damage_type_id, float> melee_relative;
+        std::unordered_map<damage_type_id, float> melee_relative;
 
         /** Can item be combined with other identical items? */
         bool stackable_ = false;

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -352,7 +352,7 @@ class vpart_info
         item_group_id breaks_into_group = item_group_id( "EMPTY_GROUP" );
 
         /** Flat decrease of damage of a given type. */
-        std::map<damage_type_id, float> damage_reduction = {};
+        std::unordered_map<damage_type_id, float> damage_reduction = {};
 
         /** Tool qualities this vehicle part can provide when installed */
         std::map<quality_id, int> qualities;

--- a/src/weakpoint.h
+++ b/src/weakpoint.h
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <map>
+#include <unordered_map>
 #include <optional>
 #include <string>
 #include <utility>
@@ -124,13 +125,13 @@ struct weakpoint {
     // Percent chance of hitting the weakpoint. Can be increased by skill.
     float coverage = 100.0f;
     // Multiplier for existing armor values. Defaults to 1.
-    std::map<damage_type_id, float> armor_mult;
+    std::unordered_map<damage_type_id, float> armor_mult;
     // Flat penalty to armor values. Applied after the multiplier.
-    std::map<damage_type_id, float> armor_penalty;
+    std::unordered_map<damage_type_id, float> armor_penalty;
     // Damage multipliers. Applied after armor.
-    std::map<damage_type_id, float> damage_mult;
+    std::unordered_map<damage_type_id, float> damage_mult;
     // Critical damage multipliers. Applied after armor instead of damage_mult, if the attack is a crit.
-    std::map<damage_type_id, float> crit_mult;
+    std::unordered_map<damage_type_id, float> crit_mult;
     // A list of required effects.
     std::vector<efftype_id> required_effects;
     // A list of effects that may trigger by hitting this weak point.


### PR DESCRIPTION
`resistances` is a map, but it doesn't need every damage type in it.

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Fix armor resistances hotspot exposed by NPC AI improvements"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Erk's NPC AI overhaul added more calls to evaluate npc/player armor. This exposed some pessimal behavior deep in the damage type resistances logic that was taking up a lot of time for no good reason.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
A few things all together:
- `map` -> `unordered_map` because ordering is not needed.
- Don't default initialize the `resistances` struct with a 0 entry for every damage type, because other functions are O(entries) and O(0-1) is less than O(7+).
- Optimize `resistances::operator+=` marginally to avoid an explicit branch.
- One tight loop adding a vector reserve that popped up in the perf traces.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Before, waiting 1hr in the refugee center with a debug monster in the room:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/883df3e5-1d1c-4f71-bbca-640b78290776)


After:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/24ef0e26-b677-4c1e-bfe5-78c3e7d5c0fc)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
