### PR TITLE
Refactor vehicle interaction screen bottom section

### DIFF
--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -311,9 +311,9 @@ void veh_interact::allocate_windows()
 
     const int pane_y = grid.y + mode_h + 1;
 
-    const int pane_w = ( grid_w / 3 ) - 1;
+    pane_w = ( grid_w / 3 ) - 1;
 
-    const int disp_w = grid_w - ( pane_w * 2 ) - 2;
+    disp_w = grid_w - ( pane_w * 2 ) - 2;
     const int disp_h = page_size * 0.45;
     const int parts_h = page_size - disp_h;
     const int parts_y = pane_y + disp_h;
@@ -324,7 +324,6 @@ void veh_interact::allocate_windows()
     const int list_x = grid.x + disp_w + 1;
     const int msg_x  = list_x + pane_w + 1;
 
-    // covers right part of w_name and w_stats in vertical/hybrid
     const int details_y = name_y;
     const int details_x = list_x;
 
@@ -338,9 +337,13 @@ void veh_interact::allocate_windows()
     w_disp  = catacurses::newwin( disp_h,    disp_w, point( grid.x, pane_y ) );
     w_parts = catacurses::newwin( parts_h,   disp_w, point( grid.x, parts_y ) );
     w_list  = catacurses::newwin( page_size, pane_w, point( list_x, pane_y ) );
-    w_stats = catacurses::newwin( stats_h,   grid_w, point( grid.x, stats_y ) );
     w_name  = catacurses::newwin( name_h,    grid_w, point( grid.x, name_y ) );
     w_details = catacurses::newwin( details_h, details_w, point( details_x, details_y ) );
+    w_stats_1 = catacurses::newwin( stats_h, disp_w - 2, point( grid.x + 1, stats_y ) );
+    w_stats_2 = catacurses::newwin( stats_h, pane_w - 2, point( grid.x + disp_w + 2, stats_y ) );
+    w_stats_3 = catacurses::newwin( stats_h, pane_w - 2, point( grid.x + disp_w + pane_w + 3,
+                                    stats_y ) );
+
 }
 
 bool veh_interact::format_reqs( std::string &msg, const requirement_data &reqs,
@@ -2461,15 +2464,20 @@ static std::string wheel_state_description( const vehicle &veh )
  */
 void veh_interact::display_stats() const
 {
-    werase( w_stats );
+    werase( w_stats_1 );
+    werase( w_stats_2 );
+    werase( w_stats_3 );
 
-    // see exec()
-    const int extraw = ( ( TERMX - FULL_SCREEN_WIDTH ) / 4 ) * 2;
+    on_out_of_scope refresh_windows( [&]() {
+        wnoutrefresh( w_stats_1 );
+        wnoutrefresh( w_stats_2 );
+        wnoutrefresh( w_stats_3 );
+    } );
+
     // 3 * stats_h
     const int slots = 24;
-    std::array<int, slots> x;
-    std::array<int, slots> y;
-    std::array<int, slots> w;
+    std::array<const catacurses::window *, slots> win;
+    std::array<int, slots> row;
 
     units::volume total_cargo = 0_ml;
     units::volume free_cargo = 0_ml;
@@ -2479,24 +2487,19 @@ void veh_interact::display_stats() const
         free_cargo += vs.free_volume();
     }
 
-    const int second_column = 33 + ( extraw / 4 );
-    const int third_column = 65 + ( extraw / 2 );
     for( int i = 0; i < slots; i++ ) {
         if( i < stats_h ) {
             // First column
-            x[i] = 1;
-            y[i] = i;
-            w[i] = second_column - 2;
+            win[i] = &w_stats_1;
+            row[i] = i;
         } else if( i < ( 2 * stats_h ) ) {
             // Second column
-            x[i] = second_column;
-            y[i] = i - stats_h;
-            w[i] = third_column - second_column - 1;
+            win[i] = &w_stats_2;
+            row[i] = i - stats_h;
         } else {
             // Third column
-            x[i] = third_column;
-            y[i] = i - 2 * stats_h;
-            w[i] = extraw - third_column - 2;
+            win[i] = &w_stats_3;
+            row[i] = i - 2 * stats_h;
         }
     }
 
@@ -2510,27 +2513,27 @@ void veh_interact::display_stats() const
 
     int i = 0;
     if( is_aircraft ) {
-        fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
+        fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                         _( "Air Safe/Top speed: <color_light_green>%3d</color>/<color_light_red>%3d</color> %s" ),
                         vel_to_int( veh->safe_rotor_velocity( false ) ),
                         vel_to_int( veh->max_rotor_velocity( false ) ),
                         velocity_units( VU_VEHICLE ) );
         i += 1;
-        fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
+        fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                         _( "Air acceleration: <color_light_blue>%3d</color> %s/s" ),
                         vel_to_int( veh->rotor_acceleration( false ) ),
                         velocity_units( VU_VEHICLE ) );
         i += 1;
     } else {
         if( is_ground ) {
-            fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
+            fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                             _( "Safe/Top speed: <color_light_green>%3d</color>/<color_light_red>%3d</color> %s" ),
                             vel_to_int( veh->safe_ground_velocity( false ) ),
                             vel_to_int( veh->max_ground_velocity( false ) ),
                             velocity_units( VU_VEHICLE ) );
             i += 1;
             // TODO: extract accelerations units to its own function
-            fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
+            fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                             //~ /t means per turn
                             _( "Acceleration: <color_light_blue>%3d</color> %s/s" ),
                             vel_to_int( veh->ground_acceleration( false ) ),
@@ -2540,14 +2543,14 @@ void veh_interact::display_stats() const
             i += 2;
         }
         if( is_boat ) {
-            fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
+            fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                             _( "Water Safe/Top speed: <color_light_green>%3d</color>/<color_light_red>%3d</color> %s" ),
                             vel_to_int( veh->safe_water_velocity( false ) ),
                             vel_to_int( veh->max_water_velocity( false ) ),
                             velocity_units( VU_VEHICLE ) );
             i += 1;
             // TODO: extract accelerations units to its own function
-            fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
+            fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                             //~ /t means per turn
                             _( "Water acceleration: <color_light_blue>%3d</color> %s/s" ),
                             vel_to_int( veh->water_acceleration( false ) ),
@@ -2557,31 +2560,41 @@ void veh_interact::display_stats() const
             i += 2;
         }
     }
-    fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
+    fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                     _( "Mass: <color_light_blue>%5.0f</color> %s" ),
                     convert_weight( veh->total_mass() ), weight_units() );
     i += 1;
-    fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
-                    _( "Cargo volume: <color_light_blue>%s</color> / <color_light_blue>%s</color> %s" ),
+    fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
+                    disp_w > 35 ? _( "Cargo volume: <color_light_blue>%s</color> / <color_light_blue>%s</color> %s" ) :
+                    _( "Cargo: <color_light_blue>%s</color> / <color_light_blue>%s</color> %s" ),
                     format_volume( total_cargo - free_cargo ),
                     format_volume( total_cargo ), volume_units_abbr() );
     i += 1;
     // Write the overall damage
-    mvwprintz( w_stats, point( x[i], y[i] ), c_light_gray, _( "Status: " ) );
-    x[i] += utf8_width( _( "Status: " ) );
-    fold_and_print( w_stats, point( x[i], y[i] ), w[i], total_durability_color, total_durability_text );
+    mvwprintz( *win[i], point( 0, row[i] ), c_light_gray, _( "Status: " ) );
+    fold_and_print( *win[i], point( utf8_width( _( "Status: " ) ), row[i] ), getmaxx( *win[i] ),
+                    total_durability_color, total_durability_text );
     i += 1;
 
-    fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
+    fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                     wheel_state_description( *veh ) );
     i += 1;
+
+    if( install_info || remove_info ) {
+        // don't draw the second and third columns which would be overwritten by w_details
+        return;
+    }
+
+    // advance to next column if necessary
+    i = std::max( i, stats_h );
 
     //This lambda handles printing parts in the "Most damaged" and "Needs repair" cases
     //for the veh_interact ui
     const auto print_part = [&]( const std::string & str, int slot, vehicle_part * pt ) {
-        mvwprintz( w_stats, point( x[slot], y[slot] ), c_light_gray, str );
+        mvwprintz( *win[slot], point( 0, row[slot] ), c_light_gray, str );
         int iw = utf8_width( str ) + 1;
-        return fold_and_print( w_stats, point( x[slot] + iw, y[slot] ), w[slot], c_light_gray, pt->name() );
+        return fold_and_print( *win[slot], point( iw, row[slot] ), getmaxx( *win[slot] ), c_light_gray,
+                               pt->name() );
     };
 
     vehicle_part *mostDamagedPart = get_most_damaged_part();
@@ -2605,31 +2618,31 @@ void veh_interact::display_stats() const
         i += 1;
     }
 
-    fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
+    fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                     _( "Air drag:       <color_light_blue>%5.2f</color>" ),
                     veh->coeff_air_drag() );
     i += 1;
 
     if( is_boat ) {
-        fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
+        fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                         _( "Water drag:     <color_light_blue>%5.2f</color>" ),
                         veh->coeff_water_drag() );
     }
     i += 1;
 
     if( is_ground ) {
-        fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
+        fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                         _( "Rolling drag:   <color_light_blue>%5.2f</color>" ),
                         veh->coeff_rolling_drag() );
     }
     i += 1;
 
-    fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
+    fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                     _( "Static drag:    <color_light_blue>%5d</color>" ),
                     units::to_watt( veh->static_drag( false ) ) );
     i += 1;
 
-    fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
+    fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                     _( "Offroad:        <color_light_blue>%4d</color>%%" ),
                     static_cast<int>( veh->k_traction( veh->wheel_area() *
                                       veh->average_offroad_rating() ) * 100 ) );
@@ -2642,31 +2655,20 @@ void veh_interact::display_stats() const
                                    _( "Draft/Clearance:<color_light_blue>%4.2f</color>m/<color_light_blue>%4.2f</color>m" ) :
                                    _( "Draft/Clearance:<color_light_blue>%4.2f</color>m/<color_light_red>%4.2f</color>m" ) ;
 
-        fold_and_print( w_stats, point( x[i], y[i] ), w[i], c_light_gray,
+        fold_and_print( *win[i], point( 0, row[i] ), getmaxx( *win[i] ), c_light_gray,
                         draft_string,
                         veh->water_draft(), water_clearance );
         i += 1;
     }
 
+    // advance to next column if necessary
     i = std::max( i, 2 * stats_h );
 
     // Print fuel percentage & type name only if it fits in the window, 10 is width of "E...F 100%"
-    veh->print_fuel_indicators( w_stats, point( x[i], y[i] ), fuel_index, true,
-                                ( x[ i ] + 10 < getmaxx( w_stats ) ),
-                                ( x[ i ] + 10 < getmaxx( w_stats ) ) );
+    veh->print_fuel_indicators( *win[i], point( 0, row[i] ), fuel_index, true,
+                                ( getmaxx( *win[i] ) > 10 ),
+                                ( getmaxx( *win[i] ) > 10 ) );
 
-    if( install_info || remove_info ) {
-        const int details_w = getmaxx( w_details );
-        // clear rightmost blocks of w_stats to avoid overlap
-        int stats_col_2 = 33;
-        int stats_col_3 = 65 + ( ( TERMX - FULL_SCREEN_WIDTH ) / 4 );
-        int clear_x = getmaxx( w_stats ) - details_w + 1 >= stats_col_3 ? stats_col_3 : stats_col_2;
-        for( int i = 0; i < getmaxy( w_stats ); i++ ) {
-            mvwhline( w_stats, point( clear_x, i ), ' ', getmaxx( w_stats ) - clear_x );
-        }
-    }
-
-    wnoutrefresh( w_stats );
 }
 
 void veh_interact::display_name()

--- a/src/veh_interact.h
+++ b/src/veh_interact.h
@@ -90,12 +90,18 @@ class veh_interact
         int page_size = 0;
         // height of the stats window
         const int stats_h = 8;
+        // element width defaults for 80 column display
+        int disp_w = 26; // width of the left column
+        int pane_w = 25; // width of the center and right columns
         catacurses::window w_border;
         catacurses::window w_mode;
         catacurses::window w_msg;
         catacurses::window w_disp;
         catacurses::window w_parts;
         catacurses::window w_stats;
+        catacurses::window w_stats_1;
+        catacurses::window w_stats_2;
+        catacurses::window w_stats_3;
         catacurses::window w_list;
         catacurses::window w_details;
         catacurses::window w_name;
@@ -277,7 +283,6 @@ class veh_interact
          * Updated whenever the cursor moves. */
         ter_t terrain_here;
 
-        /* called by exec() */
         void cache_tool_availability();
         void allocate_windows();
         void do_main_loop();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Spread out vehicle stats display"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The bottom of the vehicle interaction screen, displaying vehicle stats, is messy. There's wasted space on the right side, text components can overlap, and wrapped text ends up in the wrong column.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Refactored the three column layout from pseudo-columns to three separate windows, each of which can wrap separately to avoid overlapping each other.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Viewed the interface on a few different vehicles in tiles and curses modes at different terminal sizes.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Some outdated comments around the problematic arithmetic were removed, particularly references to the nonexistent `exec()`.
Also made "Cargo volume:" get abbreviated on narrow terminals, one of many fixes the vehicle interaction screen needs for small terminals.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
