### PR TITLE
Refactor action portion out of assess_danger

### DIFF
--- a/src/npc.h
+++ b/src/npc.h
@@ -259,12 +259,13 @@ struct npc_opinion {
 // npc_combat_memory should store short-term trackers that don't really need to be saved if
 // the player exits the game. Minor logic behaviour changes might occur, but nothing serious.
 struct npc_combat_memory {
-    int panic = 0; // Tracks how many times NPC has had to try to run and how bad the threat
-    int swarm_count =
-        0; //so you can tell if you're getting away over multiple turns
-    int failing_to_reposition = 0; // Increases as NPC tries to flee/move and doesn't change situation
-    int reposition_countdown = 0; // set when reposition fails so that we don't keep trying for a bit.
-    int assessment_before_repos = 0; // assessment of enemy threat level at the start of repositioning.
+    float assess_ally = 0.0f;
+    float assess_enemy = 0.0f;
+    int panic = 0;
+    int swarm_count = 0; //so you can tell if you're getting away over multiple turns
+    int failing_to_reposition = 0; // Inc. when tries to flee/move and doesn't change assess
+    int reposition_countdown = 0; // set when repos fails so that we don't keep trying.
+    int assessment_before_repos = 0; // assessment of enemy threat level at the start of repos
     float my_health = 1.0f; // saved when we evaluate_self.  Health 1.0 means 100% unhurt.
     bool repositioning = false; // is NPC running away or just moving around / kiting.
 };
@@ -1105,6 +1106,7 @@ class npc : public Character
         float evaluate_self( bool my_gun );
 
         void assess_danger();
+        void act_on_danger_assessment();
         bool is_safe() const;
         // Functions which choose an action for a particular goal
         npc_action method_of_fleeing();

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -616,7 +616,7 @@ float npc::evaluate_self( bool my_gun )
         }
         mem_combat.my_health *= std::max( 1.0f - bleed_intensity / 10.0f, 0.25f );
         add_msg_debug( debugmode::DF_NPC_COMBATAI,
-                       "<color_red>%s is bleeeeeeding...</color>, intensity %i", name, bleed_intensity );
+                       "<color_red>%s is bleeeeeeding…</color>, intensity %i", name, bleed_intensity );
         if( mem_combat.my_health < 0.25f ) {
             mem_combat.panic += 1;
         }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -712,15 +712,12 @@ std::optional<int> npc_short_term_cache::closest_enemy_to_friendly_distance() co
 
 void npc::assess_danger()
 {
-    float assessment = 0.0f;
-    float assess_ally = 0.0f;
     float highest_priority = 1.0f;
     int hostile_count = 0; // for tallying nearby threatening enemies
     int friendly_count = 1; // count yourself as a friendly
     int def_radius = rules.has_flag( ally_rule::follow_close ) ? follow_distance() : 6;
     float bravery_vs_pain = static_cast<float>( personality.bravery ) - get_pain() / 10.0f;
     bool npc_ranged = get_wielded_item() && get_wielded_item()->is_gun();
-    mem_combat.swarm_count = 0;
 
     if( !confident_range_cache ) {
         invalidate_range_cache();
@@ -814,7 +811,7 @@ void npc::assess_danger()
     }
     if( is_friendly( player_character ) && sees_player ) {
         ai_cache.friends.emplace_back( g->shared_from( player_character ) );
-    } else if( is_enemy() && sees( player_character ) ) {
+    } else if( sees_player && is_enemy() && sees( player_character ) ) {
         // Unlike allies, hostile npcs should not see invisible players
         ai_cache.hostile_guys.emplace_back( g->shared_from( player_character ) );
     }
@@ -861,7 +858,7 @@ void npc::assess_danger()
         }
 
         if( is_enemy() || !critter.friendly ) {
-            assessment += critter_threat;
+            mem_combat.assess_enemy += critter_threat;
             if( critter_threat > ( 8.0f + personality.bravery + rng( 0, 5 ) ) ) {
                 warn_about( "monster", 10_minutes, critter.type->nname(), dist, critter.pos() );
             }
@@ -921,11 +918,11 @@ void npc::assess_danger()
         }
     }
 
-    if( assessment == 0.0 && ai_cache.hostile_guys.empty() ) {
+    if( mem_combat.assess_enemy == 0.0 && ai_cache.hostile_guys.empty() ) {
         if( mem_combat.panic > 0 ) {
             mem_combat.panic -= 1;
         }
-        ai_cache.danger_assessment = assessment;
+        ai_cache.danger_assessment = mem_combat.assess_enemy;
         return;
     }
 
@@ -987,28 +984,28 @@ void npc::assess_danger()
     for( const weak_ptr_fast<Creature> &guy : ai_cache.hostile_guys ) {
         Character *foe = dynamic_cast<Character *>( guy.lock().get() );
         if( foe && foe->is_npc() ) {
-            assessment += handle_hostile( *foe, evaluate_character( *foe, npc_ranged ),
+            mem_combat.assess_enemy += handle_hostile( *foe, evaluate_character( *foe, npc_ranged ),
                                           translate_marker( "bandit" ),
                                           "kill_npc" );
         }
     }
     add_msg_debug( debugmode::DF_NPC_COMBATAI,
                    "Before checking allies+player, %s assesses danger level as <color_light_red>%1.2f</color>.", name,
-                   assessment );
+                   mem_combat.assess_enemy );
     for( const weak_ptr_fast<Creature> &guy : ai_cache.friends ) {
         if( !( guy.lock() && guy.lock()->is_npc() ) ) {
             continue;
         }
         float guy_threat = std::max( evaluate_character( dynamic_cast<const Character &>( *guy.lock() ),
                                      npc_ranged, false ), NPC_DANGER_VERY_LOW );
-        assess_ally += guy_threat * 0.5f;
+        mem_combat.assess_ally += guy_threat * 0.5f;
         add_msg_debug( debugmode::DF_NPC_COMBATAI,
                        "<color_light_gray>%s assessed friendly %s at threat level </color><color_light_blue>%1.2f.</color>",
                        name, guy.lock()->disp_name(), guy_threat );
     }
     add_msg_debug( debugmode::DF_NPC_COMBATAI,
                    "Total of <color_green>%s NPC ally threat</color>: <color_light_green>%1.2f</color>.",
-                   name, assess_ally );
+                   name, mem_combat.assess_ally );
 
     if( sees_player ) {
         // Mod for the player's danger level, weight it higher if player is very close
@@ -1023,7 +1020,7 @@ void npc::assess_danger()
             add_msg_debug( debugmode::DF_NPC_COMBATAI,
                            "<color_light_gray>%s identified player as an</color> <color_red>enemy</color> <color_light_gray>of threat level %1.2f</color>",
                            name, player_diff );
-            assessment += handle_hostile( player_character, player_diff, translate_marker( "maniac" ),
+            mem_combat.assess_enemy += handle_hostile( player_character, player_diff, translate_marker( "maniac" ),
                                           "kill_player" );
         } else if( is_friendly( player_character ) ) {
             add_msg_debug( debugmode::DF_NPC_COMBATAI,
@@ -1032,7 +1029,7 @@ void npc::assess_danger()
             if( dist <= 3 ) {
                 player_diff = player_diff * ( 4 - dist ) / 2;
                 mem_combat.swarm_count = 0;
-                assess_ally += player_diff;
+                mem_combat.assess_ally += player_diff;
                 add_msg_debug( debugmode::DF_NPC_COMBATAI,
                                "<color_green>Player is %i tiles from %s.</color><color_light_gray>  Adding </color><color_light_green>%1.2f to ally strength</color><color_light_gray> and bolstering morale.</color>",
                                dist, name,
@@ -1046,32 +1043,32 @@ void npc::assess_danger()
                 add_msg_debug( debugmode::DF_NPC_COMBATAI,
                                "<color_light_gray>%s sees friendly player,</color> <color_light_green>adding %1.2f</color><color_light_gray> to ally strength.</color>",
                                name, player_diff * 0.5f );
-                assess_ally += player_diff * 0.5f;
+                mem_combat.assess_ally += player_diff * 0.5f;
             }
             ai_cache.friends.emplace_back( g->shared_from( player_character ) );
         }
     }
     add_msg_debug( debugmode::DF_NPC_COMBATAI,
                    "<color_light_blue>After checking player</color><color_light_gray>, %s assesses enemy level as </color><color_yellow>%1.2f</color><color_light_gray>, ally level at </color><color_light_green>%1.2f</color>",
-                   name, assessment, assess_ally );
+                   name, mem_combat.assess_enemy, mem_combat.assess_ally );
 
 
     // gotta rename cowardice modifier now.
     // This bit scales the assessments of enemies and allies so that the NPC weights their own skills a little higher.
     // It's likely to get deprecated in a while?
-    assessment *= NPC_COWARDICE_MODIFIER;
+    mem_combat.assess_enemy *= NPC_COWARDICE_MODIFIER;
     //Figure our own health more heavily here, because it doens't matter how tough our friends are if we're dying.
-    assess_ally *= mem_combat.my_health * NPC_COWARDICE_MODIFIER;
+    mem_combat.assess_ally *= mem_combat.my_health * NPC_COWARDICE_MODIFIER;
 
     // Swarm assessment.  Do a flat scale up your assessment if you're outnumbered.
     // Hostile_count counts enemies within a range of 8 who exceed the NPC's bravery, mitigated
     // how much pain they're currently experiencing. This means a very brave NPC might ignore
     // large crowds of minor creatures, until they start getting hurt.
     if( hostile_count > friendly_count ) {
-        assessment *= std::max( hostile_count / static_cast<float>( friendly_count ), 1.0f );
+        mem_combat.assess_enemy *= std::max( hostile_count / static_cast<float>( friendly_count ), 1.0f );
         add_msg_debug( debugmode::DF_NPC_COMBATAI,
                        "Crowd adjustment: <color_light_gray>%s set danger level to </color>%1.2f<color_light_gray> after counting </color><color_yellow>%i major hostiles</color><color_light_gray> vs </color><color_light_green>%i friendlies.</color>",
-                       name, assessment, hostile_count, friendly_count );
+                       name, mem_combat.assess_enemy, hostile_count, friendly_count );
     }
 
     bool failed_reposition = false;
@@ -1079,10 +1076,10 @@ void npc::assess_danger()
         // this check runs each turn that the NPC is repositioning and assesses if the situation is getting any better.
         // The longer they try to move without improving, the more likely they become to stop and stand their ground.
         const bool melee_reposition_fail = !npc_ranged &&
-                                           mem_combat.assessment_before_repos + rng( 0, 5 ) <= assessment;
+                                           mem_combat.assessment_before_repos + rng( 0, 5 ) <= mem_combat.assess_enemy;
         const bool range_reposition_fail = npc_ranged &&
                                            mem_combat.assessment_before_repos * mem_combat.swarm_count + rng( 0,
-                                                   5 ) <= assessment * mem_combat.swarm_count;
+                                                   5 ) <= mem_combat.assess_enemy * mem_combat.swarm_count;
         if( melee_reposition_fail || range_reposition_fail ) {
             add_msg_debug( debugmode::DF_NPC_COMBATAI,
                            "<color_light_red>%s tried to reposition last turn, and the situation has not improved.</color>",
@@ -1098,18 +1095,36 @@ void npc::assess_danger()
     }
 
     if( !has_effect( effect_npc_run_away ) && !has_effect( effect_npc_fire_bad ) ) {
-        mem_combat.assessment_before_repos = static_cast<int>( assessment );
+        mem_combat.assessment_before_repos = std::round( mem_combat.assess_enemy );
         float my_diff = evaluate_self( npc_ranged ) * 0.5f;
         add_msg_debug( debugmode::DF_NPC_COMBATAI,
                        "%s assesses own final strength as %1.2f.", name, my_diff );
-        assess_ally += my_diff;
+        mem_combat.assess_ally += my_diff;
         add_msg_debug( debugmode::DF_NPC_COMBATAI,
                        "%s rates total <color_yellow>enemy strength %1.2f</color>, <color_light_green>ally strength %1.2f</color>.",
-                       name, assessment, assess_ally );
-        add_msg_debug( debugmode::DF_NPC, "Enemy Danger: %1f, Ally Strength: %2f.", assessment,
-                       assess_ally );
+                       name, mem_combat.assess_enemy, mem_combat.assess_ally );
+        add_msg_debug( debugmode::DF_NPC, "Enemy Danger: %1f, Ally Strength: %2f.", mem_combat.assess_enemy,
+                       mem_combat.assess_ally );
+    }
+    // update the threat cache
+    for( size_t i = 0; i < 8; i++ ) {
+        direction threat_dir = npc_threat_dir[i];
+        direction dir_right = npc_threat_dir[( i + 1 ) % 8];
+        direction dir_left = npc_threat_dir[( i + 7 ) % 8 ];
+        ai_cache.threat_map[threat_dir] = cur_threat_map[threat_dir] + 0.1f *
+                                          ( cur_threat_map[dir_right] + cur_threat_map[dir_left] );
+    }
+    if( mem_combat.assess_enemy <= 2.0f ) {
+        ai_cache.danger_assessment = -10.0f + 5.0f * mem_combat.assess_enemy; // Low danger if no monsters around
+    } else {
+        ai_cache.danger_assessment = mem_combat.assess_enemy;
+    }
+}
 
-        if( assess_ally < assessment ) {
+void act_on_danger_assessment(){
+    bool npc_ranged = get_wielded_item() && get_wielded_item()->is_gun();
+    if( !has_effect( effect_npc_run_away ) && !has_effect( effect_npc_fire_bad ) ) {
+        if( mem_combat.assess_ally < mem_combat.assess_enemy ) {
             // Each time NPC decides to run away, their panic increases, which increases likelihood
             // and duration of running away.
             // if they run to a more advantageous position, they'll reassess and rally.
@@ -1126,12 +1141,11 @@ void npc::assess_danger()
                                name );
                 mem_combat.reposition_countdown --;
             }
-
-            mem_combat.panic *= ( assessment / ( assess_ally + 0.5f ) );
+            mem_combat.panic *= ( mem_combat.assess_enemy / ( mem_combat.assess_ally + 0.5f ) );
             mem_combat.panic += std::min(
                                     rng( 1, 3 ) + ( get_pain() / 5 ) - personality.bravery, 1 );
 
-            if( my_diff * 5 < assessment ) {
+            if( my_diff * 5 < mem_combat.assess_enemy ) {
                 // Things are looking more than a little grim, NPC should remember to keep running even
                 // if the worst baddy goes out of LOS.
                 mem_combat.panic += 10;
@@ -1141,7 +1155,7 @@ void npc::assess_danger()
                 add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s upgrades reposition to flat out retreat.", name );
                 mem_combat.repositioning = false; // we're not just moving, we're running.
                 warn_about( "run_away", run_away_for );
-                if( mem_combat.panic > 5 && sees_player && is_player_ally() ) {
+                if( mem_combat.panic > 5 && is_player_ally() && sees( player_character.pos() ) {
                     // consider warning player about panic
                     int panic_alert = rl_dist( pos(), player_character.pos() ) - player_character.get_per();
                     if( mem_combat.panic - personality.bravery > panic_alert ) {
@@ -1152,13 +1166,12 @@ void npc::assess_danger()
                         }
                     }
                 }
-            }
-        } else if( failed_reposition || ( npc_ranged &&
-                                          assess_ally < assessment * mem_combat.swarm_count ) ) {
+            } else if( mem_combat.failed_reposition || ( npc_ranged &&
+                                          mem_combat.assess_ally < mem_combat.assess_enemy * mem_combat.swarm_count ) ) {
             add_msg_debug( debugmode::DF_NPC_COMBATAI,
                            "<color_light_gray>Due to ranged weapon, %s considers </color>repositioning<color_light_gray> from swarming enemies.</color>",
                            name );
-            if( failed_reposition ) {
+            if( mem_combat.failed_reposition ) {
                 add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s failed repositioning, trying again." );
                 mem_combat.failing_to_reposition++;
             } else {
@@ -1179,26 +1192,9 @@ void npc::assess_danger()
             }
             mem_combat.failing_to_reposition = 0;
         }
-
     }
     add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s <color_magenta>panic level</color> is up to %i.",
-                   name,
-                   mem_combat.panic );
-
-    // update the threat cache
-    for( size_t i = 0; i < 8; i++ ) {
-        direction threat_dir = npc_threat_dir[i];
-        direction dir_right = npc_threat_dir[( i + 1 ) % 8];
-        direction dir_left = npc_threat_dir[( i + 7 ) % 8 ];
-        ai_cache.threat_map[threat_dir] = cur_threat_map[threat_dir] + 0.1f *
-                                          ( cur_threat_map[dir_right] + cur_threat_map[dir_left] );
-    }
-    if( assessment <= 2.0f ) {
-        assessment = -10.0f + 5.0f * assessment; // Low danger if no monsters around
-    }
-    //should also cache ally strength here?
-    ai_cache.danger_assessment = assessment;
-
+                   name, mem_combat.panic );
     if( mem_combat.failing_to_reposition > 2 && has_effect( effect_npc_run_away ) &&
         !has_effect( effect_npc_fire_bad ) ) {
         // NPC is fleeing, but hasn't been able to reposition safely.
@@ -1259,6 +1255,9 @@ void npc::regen_ai_cache()
     ai_cache.my_weapon_value = weapon_value( weapon );
     ai_cache.dangerous_explosives = find_dangerous_explosives();
 
+    mem_combat.assess_enemy = 0.0f;
+    mem_combat.assess_ally = 0.0f;
+    mem_combat.swarm_count = 0;
     assess_danger();
     if( old_assessment > NPC_DANGER_VERY_LOW && ai_cache.danger_assessment <= 0 ) {
         warn_about( "relax", 30_minutes );
@@ -1303,7 +1302,7 @@ void npc::move()
         execute_action( npc_player_activity );
         return;
     }
-
+    act_on_danger_assessment();
     npc_action action = npc_undecided;
 
     const item_location weapon = get_wielded_item();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Remove action portion out of assess_danger into a dedicated method"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Infrastructure only, should not have significant logic changes (some small concessions were made to suit the new structure but nothing important).

When I started messing around, npc::assess_danger() first assessed the danger and then decided to stick around or run away.

As the decision to run away has morphed into a complex decision tree this has become less appropriate for an assessment function.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Move some of the core variables to the new mem_combat struct so that they can be accessed elsewhere in npc, then create a new method, act_on_assessed_danger(), called from within npc::move

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I could do more refactoring but I also don't want to have another big batch of PR feature creep.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Compiles, runs without errors. Not much to test, the logic shouldn't be much different.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I'd also like to refactor the evaluation functions to cache information at the Character level, which I'll start doing in another PR in a second.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
