### PR TITLE
Refactor vehicle crash starts. Damage monsters in crash.

### DIFF
--- a/data/json/mapgen/map_extras/mayhem.json
+++ b/data/json/mapgen/map_extras/mayhem.json
@@ -11,6 +11,15 @@
   {
     "type": "mapgen",
     "method": "json",
+    "update_mapgen_id": "mx_mayhem_crash",
+    "object": {
+      "flags": [ "ALLOW_TERRAIN_UNDER_OTHER_DATA" ],
+      "place_nested": [ { "chunks": [ "24x24_mayhem_crash" ], "x": 0, "y": 0 } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "nested_mapgen_id": "24x24_mayhem_crash",
     "object": {
       "mapgensize": [ 24, 24 ],

--- a/data/json/overmap/map_extras.json
+++ b/data/json/overmap/map_extras.json
@@ -59,6 +59,18 @@
     "flags": [ "MAN_MADE" ]
   },
   {
+    "id": "mx_mayhem_crash",
+    "type": "map_extra",
+    "name": { "str": "Crash Site" },
+    "description": "Where you lost control.",
+    "generator": { "generator_method": "update_mapgen", "generator_id": "mx_mayhem_crash" },
+    "min_max_zlevel": [ 0, 0 ],
+    "sym": "M",
+    "color": "light_red",
+    "autonote": true,
+    "flags": [ "MAN_MADE" ]
+  },
+  {
     "id": "mx_roadblock",
     "type": "map_extra",
     "name": { "str": "Roadblock (Police)" },

--- a/data/json/scenarios.json
+++ b/data/json/scenarios.json
@@ -842,7 +842,7 @@
       "combat-engineer"
     ],
     "map_extra": "mx_helicopter",
-    "flags": [ "HELI_CRASH", "LONE_START" ],
+    "flags": [ "LIMB_WOUNDS", "LONE_START", "VEHICLE_CRASH" ],
     "missions": [ "MISSION_HELICOPTER_CRASH" ]
   },
   {
@@ -938,8 +938,8 @@
     "description": "You decided the open road would be a better prospect than the zombie-filled cities.  While en route to your destination, you were involved in a crash that totaled your vehicle.  Injured and alone, you'll need to think fast if you want to survive.",
     "allowed_locs": [ "sloc_road" ],
     "start_name": "Crash Site",
-    "map_extra": "mx_mayhem",
-    "flags": [ "CHALLENGE", "HELI_CRASH", "LONE_START" ]
+    "map_extra": "mx_mayhem_crash",
+    "flags": [ "CHALLENGE", "LIMB_WOUNDS", "LONE_START", "VEHICLE_CRASH" ]
   },
   {
     "type": "scenario",
@@ -1124,7 +1124,7 @@
     "type": "scenario",
     "name": "Challenge - Close Encounter",
     "description": "You don't know what it was but you managed to lose it for the time being.  Now you are injured, surrounded and the building is on fire.  You hope you have some time before it returns to finish the job.",
-    "flags": [ "CITY_START", "CHALLENGE", "LONE_START", "HELI_CRASH" ],
+    "flags": [ "CITY_START", "CHALLENGE", "LONE_START", "LIMB_WOUNDS" ],
     "id": "close_encounter_start",
     "points": -5,
     "start_name": "In Town",

--- a/data/json/vehicles/helicopters.json
+++ b/data/json/vehicles/helicopters.json
@@ -398,7 +398,7 @@
   {
     "id": "SmallFlier2_Wreck",
     "type": "vehicle",
-    "name": "SmallFlier2 Wreck",
+    "name": "Small helicopter",
     "parts": [
       { "x": 0, "y": 0, "parts": [ "frame#cross", "seat", "dashboard", "controls", "seatbelt" ] },
       { "x": 0, "y": 0, "parts": [ "small_storage_battery", "roof" ] },

--- a/data/mods/Aftershock/scenarios.json
+++ b/data/mods/Aftershock/scenarios.json
@@ -177,7 +177,7 @@
     "description": "You must have hit your head when the first explosion happened.  You sit up and realize everyone is gone, that the air smells like smoke, and that the ship's computer is calmly announcing in a posh English voice 'Abandon the vessel immediately.', and then counting down from seven minutes.  Time to grab what you can and find an escape pod.",
     "allowed_locs": [ "sloc_crashing_ship" ],
     "professions": [ "afs_espatier", "afs_rating", "afs_ship_escape" ],
-    "flags": [ "LONE_START", "HELI_CRASH" ],
+    "flags": [ "LONE_START", "LIMB_WOUNDS" ],
     "start_name": "Crashing Ship",
     "eoc": [ "EOC_CRASHING_SHIP_SETUP" ]
   }

--- a/data/mods/innawood/scenarios.json
+++ b/data/mods/innawood/scenarios.json
@@ -396,8 +396,8 @@
     "//": "Came from a portal storm, so future tech/professions are allowed",
     "allowed_locs": [ "sloc_field" ],
     "start_name": "Crash Site",
-    "map_extra": "mx_mayhem",
-    "flags": [ "CHALLENGE", "HELI_CRASH", "LONE_START" ],
+    "map_extra": "mx_mayhem_crash",
+    "flags": [ "CHALLENGE", "LIMB_WOUNDS", "LONE_START" ],
     "reveal_locale": false
   },
   {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3183,7 +3183,8 @@ static std::string assemble_scenario_details( const avatar &u, const input_conte
     const std::vector<std::pair<std::string, std::string>> flag_descriptions = {
         { "FIRE_START", translate_marker( "Fire nearby" ) },
         { "SUR_START", translate_marker( "Zombies nearby" ) },
-        { "HELI_CRASH", translate_marker( "Various limb wounds" ) },
+        { "VEHICLE_CRASH", translate_marker( "Vehicle crash" ) },
+        { "LIMB_WOUNDS", translate_marker( "Various limb wounds" ) },
         { "LONE_START", translate_marker( "No starting NPC" ) },
         { "BORDERED", translate_marker( "Starting location is bordered by an immense wall" ) },
     };

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -480,7 +480,7 @@ void start_location::add_map_extra( const tripoint_abs_omt &omtstart,
     m.save();
 }
 
-void start_location::handle_heli_crash( avatar &you ) const
+void start_location::handle_limb_wounds( Creature &you ) const
 {
     for( const bodypart_id &bp : you.get_all_body_parts( get_body_part_flags::only_main ) ) {
         if( bp == bodypart_id( "head" ) || bp == bodypart_id( "torso" ) ) {
@@ -491,11 +491,11 @@ void start_location::handle_heli_crash( avatar &you ) const
             // Damage + Bleed
             case 1:
             case 2:
-                you.add_effect( effect_bleed, 6_minutes, bp );
+                you.add_effect( effect_bleed, 4_minutes * roll, bp );
             /* fallthrough */
+            // Just damage
             case 3:
             case 4:
-            // Just damage
             case 5: {
                 const int maxHp = you.get_hp_max( bp );
                 // Body part health will range from 33% to 66% with occasional bleed
@@ -507,6 +507,31 @@ void start_location::handle_heli_crash( avatar &you ) const
             default:
                 break;
         }
+    }
+}
+
+void start_location::wound_monster( monster *mon ) const
+{
+    const int roll = static_cast<int>( rng( 1, 8 ) );
+    switch( roll ) {
+        // Damage + Bleed
+        case 1:
+        case 2:
+            mon->make_bleed( effect_source(), 4_minutes * roll );
+        /* fallthrough */
+        // Just damage
+        case 3:
+        case 4:
+        case 5: {
+            const int maxHp = mon->get_hp_max();
+            // Health will range from 33% to 66% with occasional bleed
+            const int dmg = static_cast<int>( rng( maxHp / 3, maxHp * 2 / 3 ) );
+            mon->apply_damage( nullptr, bodypart_id( "bp_null" ), dmg );
+            break;
+        }
+        // No damage
+        default:
+            break;
     }
 }
 

--- a/src/start_location.h
+++ b/src/start_location.h
@@ -78,7 +78,8 @@ class start_location
          */
         void add_map_extra( const tripoint_abs_omt &omtstart, const map_extra_id &map_extra ) const;
 
-        void handle_heli_crash( avatar &you ) const;
+        void handle_limb_wounds( Creature &you ) const;
+        void wound_monster( monster *mon ) const;
 
         /**
          * Adds surround start monsters.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Monsters might take damage from vehicle crash scenarios"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
In a vehicle crash, the player often starts with damaged/bleeding limbs, but monsters start with full health even though they were involved in the same crash.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Apply similar amount of damage to monsters and NPCs riding the vehicles in the starting location.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
An EOC to cast a generic damage spell could damage the monsters at spawn.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
I am continuously starting new games and checking the results as I work on this PR.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Further comments on specific changes will be made within the PR files.

#### Outstanding problems

Sometimes monsters in the vehicle don't show up as part of the vehicle `riders`, so they don't get damaged.

Sometimes the heli_crash start spawns the player in a non-helicopter vehicle.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
