### PR TITLE
Defense Mode: Custom Options and Difficulty Modifiers

### DIFF
--- a/data/mods/Defense_Mode/dialogue/TALK_DM_MERCHANT.json
+++ b/data/mods/Defense_Mode/dialogue/TALK_DM_MERCHANT.json
@@ -7,6 +7,7 @@
       {
         "text": "I'll buy something.",
         "topic": "TALK_DM_MERCHANT_2",
+        "condition": { "math": [ "trading_allowed", "==", "0" ] },
         "effect": [ { "run_eocs": "defense_mode_money_add_npc" }, "start_trade" ]
       },
       { "text": "What'll it cost me to get some help around here?", "topic": "TALK_DM_MERCHANT_HIRE_COST" },
@@ -29,6 +30,7 @@
       {
         "text": "I'll buy something.",
         "topic": "TALK_DM_MERCHANT_2",
+        "condition": { "math": [ "trading_allowed", "==", "0" ] },
         "effect": [ { "run_eocs": "defense_mode_money_add_npc" }, "start_trade" ]
       },
       {
@@ -50,6 +52,7 @@
       {
         "text": "I'll buy something.",
         "topic": "TALK_DM_MERCHANT_2",
+        "condition": { "math": [ "trading_allowed", "==", "0" ] },
         "effect": [ { "run_eocs": "defense_mode_money_add_npc" }, "start_trade" ]
       },
       { "text": "What'll it cost me to get some help around here?", "topic": "TALK_DM_MERCHANT_HIRE_COST" },

--- a/data/mods/Defense_Mode/dialogue/menu_screen.json
+++ b/data/mods/Defense_Mode/dialogue/menu_screen.json
@@ -1,11 +1,14 @@
 [
   {
     "type": "talk_topic",
-    "id": "TALK_DEFENSE_MODE_MAIN_MENU",
-    "dynamic_line": "Hello, and welcome to Defense Mode!  Please alter the options as you desire, then we'll get started!",
+    "id": [
+      "TALK_DEFENSE_MODE_MAIN_MENU",
+      "TALK_DEFENSE_MODE_ENEMY_SELECTION",
+      "TALK_DEFENSE_MODE_ADVANCED_GAME_OPTIONS",
+      "TALK_DEFENSE_MODE_DIFFICULTY_SELECTION_MENU",
+      "TALK_DEFENSE_MODE_CUSTOM_DIFFICULTY_MENU"
+    ],
     "responses": [
-      { "text": "Enemy Options", "topic": "TALK_DEFENSE_MODE_ENEMY_SELECTION" },
-      { "text": "Preset Game Options", "topic": "TALK_DEFENSE_MODE_PRESET_GAME_MENU" },
       {
         "text": "Play!",
         "condition": {
@@ -30,8 +33,20 @@
             { "math": [ "aftershock_allowed", "==", "1" ] }
           ]
         },
+        "effect": { "run_eocs": "defense_mode_game_start_final_setup" },
         "topic": "TALK_DONE"
       }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_DEFENSE_MODE_MAIN_MENU",
+    "dynamic_line": "Hello, and welcome to Defense Mode!  Please alter the options as you desire, then we'll get started!",
+    "responses": [
+      { "text": "Enemy Options", "topic": "TALK_DEFENSE_MODE_ENEMY_SELECTION" },
+      { "text": "Preset Game Options", "topic": "TALK_DEFENSE_MODE_PRESET_GAME_MENU" },
+      { "text": "Advanced Game Options", "topic": "TALK_DEFENSE_MODE_ADVANCED_GAME_OPTIONS" },
+      { "text": "Difficulty Options", "topic": "TALK_DEFENSE_MODE_DIFFICULTY_SELECTION_MENU" }
     ]
   },
   {
@@ -257,32 +272,6 @@
         "effect": { "math": [ "aftershock_allowed", "=", "0" ] },
         "topic": "TALK_DEFENSE_MODE_ENEMY_SELECTION"
       },
-      {
-        "text": "Play!",
-        "condition": {
-          "or": [
-            { "math": [ "regular_zombies_allowed", "==", "1" ] },
-            { "math": [ "special_zombies_allowed", "==", "1" ] },
-            { "math": [ "spiders_allowed", "==", "1" ] },
-            { "math": [ "triffids_allowed", "==", "1" ] },
-            { "math": [ "robots_allowed", "==", "1" ] },
-            { "math": [ "subspace_allowed", "==", "1" ] },
-            { "math": [ "dinos_allowed", "==", "1" ] },
-            { "math": [ "lizardfolk_allowed", "==", "1" ] },
-            { "math": [ "goblins_allowed", "==", "1" ] },
-            { "math": [ "golems_allowed", "==", "1" ] },
-            { "math": [ "orcs_allowed", "==", "1" ] },
-            { "math": [ "megafauna_allowed", "==", "1" ] },
-            { "math": [ "mindovermatter_allowed", "==", "1" ] },
-            { "math": [ "candymonsters_allowed", "==", "1" ] },
-            { "math": [ "mythos_allowed", "==", "1" ] },
-            { "math": [ "exodii_allowed", "==", "1" ] },
-            { "math": [ "xedra_allowed", "==", "1" ] },
-            { "math": [ "aftershock_allowed", "==", "1" ] }
-          ]
-        },
-        "topic": "TALK_DONE"
-      },
       { "text": "Return to main menu.", "topic": "TALK_DEFENSE_MODE_MAIN_MENU" }
     ]
   },
@@ -305,7 +294,8 @@
             "target_params": { "om_terrain": "bar", "search_range": 500, "z": 0 }
           },
           { "u_teleport": { "global_val": "your_spawnpoint" } },
-          { "mapgen_update": "shaun_of_the_dead_spawns" }
+          { "mapgen_update": "shaun_of_the_dead_spawns" },
+          { "run_eocs": "defense_mode_game_start_final_setup" }
         ],
         "topic": "TALK_DONE"
       },
@@ -317,7 +307,8 @@
           { "math": [ "spiders_allowed", "=", "0" ] },
           { "math": [ "triffids_allowed", "=", "0" ] },
           { "math": [ "robots_allowed", "=", "0" ] },
-          { "math": [ "subspace_allowed", "=", "0" ] }
+          { "math": [ "subspace_allowed", "=", "0" ] },
+          { "run_eocs": "defense_mode_game_start_final_setup" }
         ],
         "topic": "TALK_DONE"
       },
@@ -329,7 +320,8 @@
           { "math": [ "spiders_allowed", "=", "1" ] },
           { "math": [ "triffids_allowed", "=", "0" ] },
           { "math": [ "robots_allowed", "=", "0" ] },
-          { "math": [ "subspace_allowed", "=", "0" ] }
+          { "math": [ "subspace_allowed", "=", "0" ] },
+          { "run_eocs": "defense_mode_game_start_final_setup" }
         ],
         "topic": "TALK_DONE"
       },
@@ -346,7 +338,8 @@
             "u_location_variable": { "global_val": "your_spawnpoint" },
             "target_params": { "om_terrain": "dm_mansion_e2", "search_range": 500, "z": 0 }
           },
-          { "u_teleport": { "global_val": "your_spawnpoint" } }
+          { "u_teleport": { "global_val": "your_spawnpoint" } },
+          { "run_eocs": "defense_mode_game_start_final_setup" }
         ],
         "topic": "TALK_DONE"
       },
@@ -358,7 +351,8 @@
           { "math": [ "spiders_allowed", "=", "0" ] },
           { "math": [ "triffids_allowed", "=", "0" ] },
           { "math": [ "robots_allowed", "=", "1" ] },
-          { "math": [ "subspace_allowed", "=", "0" ] }
+          { "math": [ "subspace_allowed", "=", "0" ] },
+          { "run_eocs": "defense_mode_game_start_final_setup" }
         ],
         "topic": "TALK_DONE"
       },
@@ -370,10 +364,135 @@
           { "math": [ "spiders_allowed", "=", "0" ] },
           { "math": [ "triffids_allowed", "=", "0" ] },
           { "math": [ "robots_allowed", "=", "0" ] },
-          { "math": [ "subspace_allowed", "=", "1" ] }
+          { "math": [ "subspace_allowed", "=", "1" ] },
+          { "run_eocs": "defense_mode_game_start_final_setup" }
         ],
         "topic": "TALK_DONE"
       },
+      { "text": "Return to main menu.", "topic": "TALK_DEFENSE_MODE_MAIN_MENU" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_DEFENSE_MODE_ADVANCED_GAME_OPTIONS",
+    "dynamic_line": "Please alter these game options as you wish, make the experience just like you want it.",
+    "responses": [
+      {
+        "text": "Disable merchant trading.",
+        "condition": { "math": [ "trading_allowed", "==", "0" ] },
+        "effect": { "math": [ "trading_allowed", "=", "1" ] },
+        "topic": "TALK_DEFENSE_MODE_ADVANCED_GAME_OPTIONS"
+      },
+      {
+        "text": "Enable merchant trading.",
+        "condition": { "math": [ "trading_allowed", "==", "1" ] },
+        "effect": { "math": [ "trading_allowed", "=", "0" ] },
+        "topic": "TALK_DEFENSE_MODE_ADVANCED_GAME_OPTIONS"
+      },
+      {
+        "text": "Disable special waves.",
+        "condition": { "math": [ "special_waves_allowed", "==", "0" ] },
+        "effect": { "math": [ "special_waves_allowed", "=", "1" ] },
+        "topic": "TALK_DEFENSE_MODE_ADVANCED_GAME_OPTIONS"
+      },
+      {
+        "text": "Enable special waves.",
+        "condition": { "math": [ "special_waves_allowed", "==", "1" ] },
+        "effect": { "math": [ "special_waves_allowed", "=", "0" ] },
+        "topic": "TALK_DEFENSE_MODE_ADVANCED_GAME_OPTIONS"
+      },
+      {
+        "text": "Disable portal storms.",
+        "condition": { "math": [ "portal_storms_allowed", "==", "0" ] },
+        "effect": { "math": [ "portal_storms_allowed", "=", "1" ] },
+        "topic": "TALK_DEFENSE_MODE_ADVANCED_GAME_OPTIONS"
+      },
+      {
+        "text": "Enable portal storms.",
+        "condition": { "math": [ "portal_storms_allowed", "==", "1" ] },
+        "effect": { "math": [ "portal_storms_allowed", "=", "0" ] },
+        "topic": "TALK_DEFENSE_MODE_ADVANCED_GAME_OPTIONS"
+      },
+      {
+        "text": "Disable random events.",
+        "condition": { "math": [ "random_events_allowed", "==", "0" ] },
+        "effect": { "math": [ "random_events_allowed", "=", "1" ] },
+        "topic": "TALK_DEFENSE_MODE_ADVANCED_GAME_OPTIONS"
+      },
+      {
+        "text": "Enable random events.",
+        "condition": { "math": [ "random_events_allowed", "==", "1" ] },
+        "effect": { "math": [ "random_events_allowed", "=", "0" ] },
+        "topic": "TALK_DEFENSE_MODE_ADVANCED_GAME_OPTIONS"
+      },
+      { "text": "Return to main menu.", "topic": "TALK_DEFENSE_MODE_MAIN_MENU" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_DEFENSE_MODE_DIFFICULTY_SELECTION_MENU",
+    "dynamic_line": "How hard do you want your game to be?",
+    "responses": [
+      {
+        "text": "<color_yellow>Easy</color>: No additional enemies spawn per wave, and you get a second chance when you die the first time.  Good for newcomers or those not familiar with isometric horde fighters.",
+        "effect": [ { "math": [ "diffulty_modifier", "=", "1" ] }, { "math": [ "revivication_counter", "=", "1" ] } ],
+        "topic": "TALK_DEFENSE_MODE_DIFFICULTY_SELECTION_MENU"
+      },
+      {
+        "text": "<color_yellow>Normal</color>: The basic way to play, no additional enemies, with no safety nets.  This is considered the default.",
+        "effect": { "math": [ "diffulty_modifier", "=", "1" ] },
+        "topic": "TALK_DEFENSE_MODE_DIFFICULTY_SELECTION_MENU"
+      },
+      {
+        "text": "<color_yellow>Difficult</color>: More enemies spawn per wave, but nothing too extreme.  You'll have to fight harder to live, but more loot comes with it too.",
+        "effect": { "math": [ "diffulty_modifier", "=", "1.5" ] },
+        "topic": "TALK_DEFENSE_MODE_DIFFICULTY_SELECTION_MENU"
+      },
+      {
+        "text": "<color_yellow>Hard</color>: Twice the number of enemies will spawn per wave.  A true challenge to test your metal.",
+        "effect": { "math": [ "diffulty_modifier", "=", "2" ] },
+        "topic": "TALK_DEFENSE_MODE_DIFFICULTY_SELECTION_MENU"
+      },
+      {
+        "text": "<color_yellow>Nightmare</color>: Three times the number of enemies will attack you, making things a long and brutal slog though guts and blood.  Come prepared to possibly fail a few times.",
+        "effect": { "math": [ "diffulty_modifier", "=", "3" ] },
+        "topic": "TALK_DEFENSE_MODE_DIFFICULTY_SELECTION_MENU"
+      },
+      {
+        "text": "<color_yellow>DOOM</color>: Fives times the number of enemies will attack you.  Armies will come to your door, and what they will be met with is up to you to decide.  Incredibly difficult.",
+        "effect": { "math": [ "diffulty_modifier", "=", "5" ] },
+        "topic": "TALK_DEFENSE_MODE_DIFFICULTY_SELECTION_MENU"
+      },
+      { "text": "Make a custom difficulty.", "topic": "TALK_DEFENSE_MODE_CUSTOM_DIFFICULTY_MENU" },
+      { "text": "Return to main menu.", "topic": "TALK_DEFENSE_MODE_MAIN_MENU" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_DEFENSE_MODE_CUSTOM_DIFFICULTY_MENU",
+    "dynamic_line": "What difficulty modifier would you prefer?  Current modifier: <global_val:diffulty_modifier>.",
+    "responses": [
+      {
+        "text": "Increase by 1",
+        "effect": { "math": [ "diffulty_modifier", "++" ] },
+        "topic": "TALK_DEFENSE_MODE_CUSTOM_DIFFICULTY_MENU"
+      },
+      {
+        "text": "Increase by 5",
+        "effect": { "math": [ "diffulty_modifier", "+=", "5" ] },
+        "topic": "TALK_DEFENSE_MODE_CUSTOM_DIFFICULTY_MENU"
+      },
+      {
+        "text": "Decrease by 1",
+        "effect": { "math": [ "diffulty_modifier", "--" ] },
+        "topic": "TALK_DEFENSE_MODE_CUSTOM_DIFFICULTY_MENU"
+      },
+      {
+        "text": "Decrease by 5",
+        "effect": { "math": [ "diffulty_modifier", "-=", "5" ] },
+        "topic": "TALK_DEFENSE_MODE_CUSTOM_DIFFICULTY_MENU"
+      },
+      { "text": "Choose a preset difficulty.", "topic": "TALK_DEFENSE_MODE_DIFFICULTY_SELECTION_MENU" },
       { "text": "Return to main menu.", "topic": "TALK_DEFENSE_MODE_MAIN_MENU" }
     ]
   }

--- a/data/mods/Defense_Mode/effects_on_condition/altered_eocs.json
+++ b/data/mods/Defense_Mode/effects_on_condition/altered_eocs.json
@@ -1,0 +1,35 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CAUSE_EARLY_PORTAL_STORM",
+    "global": true,
+    "//": "This sets up all the variables for the start of an early portal storm.",
+    "condition": {
+      "and": [
+        { "math": [ "portal_storms_allowed", "==", "0" ] },
+        {
+          "not": {
+            "or": [
+              { "is_weather": "portal_storm" },
+              { "is_weather": "early_portal_storm" },
+              { "math": [ "cause_portal_storm", "==", "1" ] },
+              { "math": [ "cause_early_portal_storm", "==", "1" ] }
+            ]
+          }
+        }
+      ]
+    },
+    "effect": [
+      { "u_location_variable": { "global_val": "portal_storm_center" }, "min_radius": 30, "max_radius": 75 },
+      { "math": [ "cause_early_portal_storm", "=", "1" ] },
+      "next_weather",
+      { "queue_eocs": "EOC_CAUSE_PORTAL_STORM", "time_in_future": [ "30 seconds", "1 minutes" ] },
+      { "assign_mission": "MISSION_INVESTIGATE_PORTAL_STORM_CENTER" },
+      {
+        "u_message": "You suddenly register a buzzing in your senses.  It's getting louder, and your head starts to throb.  Somewhere nearby, a tiny cataclysm has begun (check mission log for details).",
+        "type": "bad",
+        "popup": true
+      }
+    ]
+  }
+]

--- a/data/mods/Defense_Mode/effects_on_condition/backend_eocs.json
+++ b/data/mods/Defense_Mode/effects_on_condition/backend_eocs.json
@@ -1,0 +1,101 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "scenario_defense_mode",
+    "eoc_type": "SCENARIO_SPECIFIC",
+    "deactivate_condition": { "math": [ "wave_number", ">=", "1" ] },
+    "effect": [
+      { "math": [ "diffulty_modifier", "=", "1" ] },
+      { "open_dialogue": { "topic": "TALK_DEFENSE_MODE_MAIN_MENU" } },
+      {
+        "u_location_variable": { "global_val": "your_spawnpoint" },
+        "target_max_radius": 2,
+        "min_radius": 0,
+        "max_radius": 0
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "defense_mode_game_start_final_setup",
+    "//": "This is what really starts the game for the player.",
+    "effect": [
+      { "u_message": "Get ready for the first wave, it's not that far away!", "type": "good", "popup": true },
+      { "run_eocs": "DEFENSE_MODE_WAVE_CONTROL" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "defense_mode_caravan_spawn",
+    "recurrence": [ "2 days", "4 days" ],
+    "global": true,
+    "condition": { "math": [ "u_monsters_nearby('radius': u_search_radius == 3)", "<=", "0" ] },
+    "effect": [
+      { "u_spawn_npc": "defense_mode_merchant", "lifespan": "2 hours", "real_count": 1, "min_radius": 2, "max_radius": 3 },
+      { "u_message": "A caravan approaches!", "type": "good", "popup": false }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "defense_mode_hire_merc_true",
+    "global": true,
+    "effect": [ { "u_spawn_npc": "follower_mercenary", "real_count": 1, "min_radius": 2, "max_radius": 3 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "defense_mode_money_add_npc",
+    "global": false,
+    "condition": { "not": { "npc_has_var": "u_got_money", "type": "general", "context": "trade", "value": "yes" } },
+    "effect": [
+      { "u_spend_cash": { "math": [ "wave_number * -1000" ] } },
+      { "npc_add_var": "u_got_money", "type": "general", "context": "trade", "value": "yes" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "DEFENSE_MODE_FORTRESS_TRAP",
+    "//": "Keeps you from running away from your hideout.",
+    "global": true,
+    "recurrence": 100,
+    "condition": {
+      "or": [
+        { "u_near_om_location": "field", "range": 0 },
+        { "u_near_om_location": "forest", "range": 0 },
+        { "u_near_om_location": "forest_thick", "range": 0 },
+        { "u_near_om_location": "lake_shore", "range": 0 },
+        { "u_near_om_location": "lake_surface", "range": 0 }
+      ]
+    },
+    "effect": [
+      { "u_message": "You can't leave your fortress behind!", "type": "bad", "popup": false },
+      { "u_teleport": { "global_val": "your_spawnpoint" } }
+    ]
+  },
+  {
+    "id": "EOC_DEFENSE_MODE_PREVENT_DEATH",
+    "type": "effect_on_condition",
+    "eoc_type": "PREVENT_DEATH",
+    "condition": { "math": [ "revivication_counter", ">=", "1" ] },
+    "effect": [
+      { "u_lose_effect": "hypovolemia" },
+      { "u_lose_effect": "redcells_anemia" },
+      { "u_lose_effect": "grabbed" },
+      { "u_lose_effect": "staggered" },
+      { "u_lose_effect": "bite" },
+      { "math": [ "u_val('stored_kcal')", "=", "u_val('stored_kcal')" ] },
+      { "math": [ "u_val('pkill')", "=", "u_val('pkill')" ] },
+      { "math": [ "u_val('stim')", "=", "u_val('stim')" ] },
+      { "math": [ "u_pain()", "=", "0" ] },
+      { "math": [ "u_val('thirst')", "=", "0" ] },
+      { "math": [ "u_val('fatigue')", "=", "0" ] },
+      { "math": [ "u_val('stamina')", "=", "8500" ] },
+      { "math": [ "revivication_counter", "--" ] },
+      { "u_cast_spell": { "id": "remove_opponents" } },
+      {
+        "u_message": "For an instant that is also an eternity, you exist only in an empty void.  Then you feel something vast, alien, and merciless reach through a preexisting connection to give you just enough energy to exist.  Its motives for doing so are not likely to be benign.",
+        "popup": true
+      },
+      { "u_set_hp": 100, "only_increase": true, "main_only": true }
+    ]
+  }
+]

--- a/data/mods/Defense_Mode/effects_on_condition/random_event_eocs.json
+++ b/data/mods/Defense_Mode/effects_on_condition/random_event_eocs.json
@@ -1,0 +1,47 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "DEFENSE_MODE_RANDOM_EVENT",
+    "recurrence": [ "2 days", "4 days" ],
+    "//": "A general EOC for selecting a random event.  Can and should be expanded.",
+    "condition": {
+      "and": [
+        { "math": [ "random_events_allowed", "==", "0" ] },
+        { "not": { "is_weather": "portal_storm" } },
+        { "x_in_y_chance": { "x": 7, "y": 10 } }
+      ]
+    },
+    "effect": [
+      {
+        "weighted_list_eocs": [
+          [ "EOC_DEFENSE_MODE_RANDOM_NPC", { "const": 10 } ],
+          [ "EOC_DEFENSE_MODE_RANDOM_NPC_ROBBER", { "const": 6 } ],
+          [ "EOC_DEFENSE_MODE_BANDIT_ATTACK", { "const": 1 } ]
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DEFENSE_MODE_RANDOM_NPC",
+    "effect": [ { "u_spawn_npc": "random_survivor", "outdoor_only": true, "real_count": 1, "min_radius": 15, "max_radius": 40 } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DEFENSE_MODE_RANDOM_NPC_ROBBER",
+    "effect": [
+      {
+        "u_spawn_npc": "random_survivor_nefarious",
+        "outdoor_only": true,
+        "real_count": 1,
+        "min_radius": 15,
+        "max_radius": 40
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DEFENSE_MODE_BANDIT_ATTACK",
+    "effect": [ { "u_spawn_npc": "defense_mode_raider", "outdoor_only": true, "real_count": 5, "min_radius": 15, "max_radius": 25 } ]
+  }
+]

--- a/data/mods/Defense_Mode/effects_on_condition/wave_eocs.json
+++ b/data/mods/Defense_Mode/effects_on_condition/wave_eocs.json
@@ -1,50 +1,6 @@
 [
   {
     "type": "effect_on_condition",
-    "id": "scenario_defense_mode",
-    "eoc_type": "SCENARIO_SPECIFIC",
-    "deactivate_condition": { "math": [ "wave_number", ">=", "1" ] },
-    "effect": [
-      { "open_dialogue": { "topic": "TALK_DEFENSE_MODE_MAIN_MENU" } },
-      { "u_message": "Get ready for the first wave, it's not that far away!", "type": "good", "popup": true },
-      { "run_eocs": "DEFENSE_MODE_WAVE_CONTROL" },
-      {
-        "u_location_variable": { "global_val": "your_spawnpoint" },
-        "target_max_radius": 2,
-        "min_radius": 0,
-        "max_radius": 0
-      }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "defense_mode_caravan_spawn",
-    "recurrence": [ "2 days", "4 days" ],
-    "global": true,
-    "condition": { "math": [ "u_monsters_nearby('radius': u_search_radius == 3)", "<=", "0" ] },
-    "effect": [
-      { "u_spawn_npc": "defense_mode_merchant", "lifespan": "2 hours", "real_count": 1, "min_radius": 2, "max_radius": 3 },
-      { "u_message": "A caravan approaches!", "type": "good", "popup": false }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "defense_mode_hire_merc_true",
-    "global": true,
-    "effect": [ { "u_spawn_npc": "follower_mercenary", "real_count": 1, "min_radius": 2, "max_radius": 3 } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "defense_mode_money_add_npc",
-    "global": false,
-    "condition": { "not": { "npc_has_var": "u_got_money", "type": "general", "context": "trade", "value": "yes" } },
-    "effect": [
-      { "u_spend_cash": { "math": [ "wave_number * -1000" ] } },
-      { "npc_add_var": "u_got_money", "type": "general", "context": "trade", "value": "yes" }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "DEFENSE_MODE_WAVE_CONTROL",
     "recurrence": "1 day",
     "global": true,
@@ -61,11 +17,16 @@
     "global": true,
     "//": "This is used to decide for special waves, like shadow spawns and ultimate victory.",
     "condition": {
-      "or": [
-        { "math": [ "wave_number", "==", "5" ] },
-        { "math": [ "wave_number", "==", "15" ] },
-        { "math": [ "wave_number", "==", "30" ] },
-        { "math": [ "wave_number", "==", "50" ] }
+      "and": [
+        { "math": [ "special_waves_allowed", "==", "0" ] },
+        {
+          "or": [
+            { "math": [ "wave_number", "==", "5" ] },
+            { "math": [ "wave_number", "==", "15" ] },
+            { "math": [ "wave_number", "==", "30" ] },
+            { "math": [ "wave_number", "==", "50" ] }
+          ]
+        }
       ]
     },
     "effect": [
@@ -116,7 +77,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -124,7 +85,7 @@
       },
       {
         "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -132,7 +93,7 @@
       },
       {
         "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -148,7 +109,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_ZOMBIE",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -156,7 +117,7 @@
       },
       {
         "u_spawn_monster": "GROUP_ZOMBIE",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -164,7 +125,7 @@
       },
       {
         "u_spawn_monster": "GROUP_ZOMBIE",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -180,7 +141,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_SPIDER_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -188,7 +149,7 @@
       },
       {
         "u_spawn_monster": "GROUP_SPIDER_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -196,7 +157,7 @@
       },
       {
         "u_spawn_monster": "GROUP_SPIDER_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -212,7 +173,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_ROBOT_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -220,7 +181,7 @@
       },
       {
         "u_spawn_monster": "GROUP_ROBOT_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -228,7 +189,7 @@
       },
       {
         "u_spawn_monster": "GROUP_ROBOT_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -244,7 +205,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_TRIFFID_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -252,7 +213,7 @@
       },
       {
         "u_spawn_monster": "GROUP_TRIFFID_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -260,7 +221,7 @@
       },
       {
         "u_spawn_monster": "GROUP_TRIFFID_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -276,7 +237,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_NETHER_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -284,7 +245,7 @@
       },
       {
         "u_spawn_monster": "GROUP_NETHER_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -292,7 +253,7 @@
       },
       {
         "u_spawn_monster": "GROUP_NETHER_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -308,7 +269,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_FERAL",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -316,7 +277,7 @@
       },
       {
         "u_spawn_monster": "GROUP_FERAL",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -324,7 +285,7 @@
       },
       {
         "u_spawn_monster": "GROUP_FERAL",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -344,7 +305,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_RATKIN_EVOLVED",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -352,7 +313,7 @@
       },
       {
         "u_spawn_monster": "GROUP_RATKIN_EVOLVED",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -360,7 +321,7 @@
       },
       {
         "u_spawn_monster": "GROUP_RATKIN_EVOLVED",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -380,7 +341,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_MIL_HELIPAD",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -388,7 +349,7 @@
       },
       {
         "u_spawn_monster": "GROUP_MIL_HELIPAD",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -396,7 +357,7 @@
       },
       {
         "u_spawn_monster": "GROUP_MIL_HELIPAD",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -421,64 +382,5 @@
         "popup": true
       }
     ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "DEFENSE_MODE_FORTRESS_TRAP",
-    "//": "Keeps you from running away from your hideout.",
-    "global": true,
-    "recurrence": 100,
-    "condition": {
-      "or": [
-        { "u_near_om_location": "field", "range": 0 },
-        { "u_near_om_location": "forest", "range": 0 },
-        { "u_near_om_location": "forest_thick", "range": 0 },
-        { "u_near_om_location": "lake_shore", "range": 0 },
-        { "u_near_om_location": "lake_surface", "range": 0 }
-      ]
-    },
-    "effect": [
-      { "u_message": "You can't leave your fortress behind!", "type": "bad", "popup": false },
-      { "u_teleport": { "global_val": "your_spawnpoint" } }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "DEFENSE_MODE_RANDOM_EVENT",
-    "recurrence": [ "2 days", "4 days" ],
-    "//": "A general EOC for selecting a random event.  Can and should be expanded.",
-    "condition": { "and": [ { "not": { "is_weather": "portal_storm" } }, { "x_in_y_chance": { "x": 7, "y": 10 } } ] },
-    "effect": [
-      {
-        "weighted_list_eocs": [
-          [ "EOC_DEFENSE_MODE_RANDOM_NPC", { "const": 10 } ],
-          [ "EOC_DEFENSE_MODE_RANDOM_NPC_ROBBER", { "const": 6 } ],
-          [ "EOC_DEFENSE_MODE_BANDIT_ATTACK", { "const": 1 } ]
-        ]
-      }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_DEFENSE_MODE_RANDOM_NPC",
-    "effect": [ { "u_spawn_npc": "random_survivor", "outdoor_only": true, "real_count": 1, "min_radius": 15, "max_radius": 40 } ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_DEFENSE_MODE_RANDOM_NPC_ROBBER",
-    "effect": [
-      {
-        "u_spawn_npc": "random_survivor_nefarious",
-        "outdoor_only": true,
-        "real_count": 1,
-        "min_radius": 15,
-        "max_radius": 40
-      }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_DEFENSE_MODE_BANDIT_ATTACK",
-    "effect": [ { "u_spawn_npc": "defense_mode_raider", "outdoor_only": true, "real_count": 5, "min_radius": 15, "max_radius": 25 } ]
   }
 ]

--- a/data/mods/Defense_Mode/jmath.json
+++ b/data/mods/Defense_Mode/jmath.json
@@ -1,0 +1,8 @@
+[
+  {
+    "type": "jmath_function",
+    "id": "wave_spawn_number",
+    "num_args": 0,
+    "return": "wave_number * diffulty_modifier"
+  }
+]

--- a/data/mods/Defense_Mode/mod_interactions/Aftershock/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Aftershock/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "AFS_GROUP_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "AFS_GROUP_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
       },
       {
         "u_spawn_monster": "AFS_GROUP_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/DinoMod/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/DinoMod/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_DINOSAUR_DANGEROUS",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_DINOSAUR_DANGEROUS",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
       },
       {
         "u_spawn_monster": "GROUP_DINOSAUR_DANGEROUS",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Magiclysm/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Magiclysm/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_LIZARDFOLK_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_LIZARDFOLK_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
       },
       {
         "u_spawn_monster": "GROUP_LIZARDFOLK_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -38,7 +38,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_GOLEM_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -46,7 +46,7 @@
       },
       {
         "u_spawn_monster": "GROUP_GOLEM_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -54,7 +54,7 @@
       },
       {
         "u_spawn_monster": "GROUP_GOLEM_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -70,7 +70,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_GOBLIN_STANDARD",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -78,7 +78,7 @@
       },
       {
         "u_spawn_monster": "GROUP_GOBLIN_STANDARD",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -86,7 +86,7 @@
       },
       {
         "u_spawn_monster": "GROUP_GOBLIN_STANDARD",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -102,7 +102,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_ORC_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -110,7 +110,7 @@
       },
       {
         "u_spawn_monster": "GROUP_ORC_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -118,7 +118,7 @@
       },
       {
         "u_spawn_monster": "GROUP_ORC_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Megafauna/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Megafauna/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_MEGAFAUNA_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_MEGAFAUNA_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
       },
       {
         "u_spawn_monster": "GROUP_MEGAFAUNA_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/MindOverMatter/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/MindOverMatter/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_FERAL_PSYCHIC_DM",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
       },
       {
         "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/My_Sweet_Cataclysm/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/My_Sweet_Cataclysm/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_SWEET_HORDE",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_SWEET_HORDE",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
       },
       {
         "u_spawn_monster": "GROUP_SWEET_HORDE",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Mythos/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Mythos/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_MYTHOS_SPAWN",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_MYTHOS_SPAWN",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
       },
       {
         "u_spawn_monster": "GROUP_MYTHOS_SPAWN",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Xedra_Evolved/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Xedra_Evolved/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_EXODII",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_EXODII",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
       },
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_EXODII",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -38,7 +38,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_XEDRA",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -46,7 +46,7 @@
       },
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_XEDRA",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -54,7 +54,7 @@
       },
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_XEDRA",
-        "real_count": { "math": [ "wave_number" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/spells.json
+++ b/data/mods/Defense_Mode/spells.json
@@ -1,0 +1,19 @@
+[
+  {
+    "id": "remove_opponents",
+    "type": "SPELL",
+    "name": "Debug Opponent Kill",
+    "description": ".",
+    "effect": "attack",
+    "shape": "blast",
+    "valid_targets": [ "hostile" ],
+    "flags": [ "NO_LEGS" ],
+    "min_damage": 300,
+    "max_damage": 300,
+    "min_aoe": 5,
+    "max_aoe": 5,
+    "min_range": 0,
+    "max_range": 0,
+    "damage_type": "null"
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Add more customizable options to Defense Mode."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Considering how you could customize games in the previous C++ iteration of Defense Mode, I thought that it would be a good idea to expand more on this principle for the new mod version of it. It's also pretty cool to be able to alter the game to how you'd like it. Resolve #69262, too.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add more customizable options to the start menu in Defense Mode, including advanced game controls, a new difficulty modifier, and several preset difficulty options. Advanced game controls allow the user to toggle merchant trading (#69262), special waves, random events, and portal storms within the game world. The introduction of a difficulty modifier lets the user make their game easier or harder as they please, by affecting the quantity of enemies within a wave. There are a few preset options for this; Easy (one extra life for the player, no extra enemies), Normal (how the game is right now, default), Difficult (1.5 times more enemies overall), Hard (Twice the enemies), Nightmare (Three times the enemies), and Doom (Five times the enemies). Players can also customize the difficulty within a new menu, with no maximum limit to it. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I played the game a good deal when making these, everything works well.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I plan on extending difficulty to merchant trading and wave money after this, so you can get more or less money per wave and/or to start with.

I also understand that toggleable portal storms can be a bit touchy, since they've come a long way in the scope of content. Considering that players cannot outrun portal storms in Defense Mode, I simply thought that some individuals would not like them like that. If need be, I can change this. I did intend for Defense Mode to have portal storms and the toggleable content, so they are on by default.

Turning off special waves also defaults the game to endless mode, since the shadow of reality never spawns and lets you win. I haven't decided yet if I should change the starting mission to account for this or not. I also decided to go ahead and split up the EOCs file for the mod, since I plan on a lot more getting added in the future.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
