### PR TITLE
Fix pink-white varsity jacket variant id

### DIFF
--- a/data/json/items/armor/coats.json
+++ b/data/json/items/armor/coats.json
@@ -1675,7 +1675,7 @@
         "append": true
       },
       {
-        "id": "black_red_varsity_jacket",
+        "id": "pink_white_varsity_jacket",
         "name": { "str": "pink and white varsity jacket" },
         "description": "This one has a pink torso and white arms.  Somone has sewn an equally pink heart on its front right.",
         "color": "pink",


### PR DESCRIPTION


#### Summary
None


#### Purpose of change

I noticed pink-white varsity jacket variant have the same id as black-red varsity jacket variant, so im fixing it.

#### Describe the solution

Giving it the proper different id

#### Describe alternatives you've considered

Not doing so

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
