### PR TITLE
Update soundpack doc

### DIFF
--- a/doc/SOUNDPACKS.md
+++ b/doc/SOUNDPACKS.md
@@ -189,10 +189,10 @@ Divided by sections for clarity.
 
 Triggered by seeing large numbers of zombies.
 
-* `danger_low`
-* `danger_medium`
-* `danger_high`
-* `danger_extreme`
+* `danger_low` when seeing 5-9 enemies.
+* `danger_medium` when seeing 10-14 enemies.
+* `danger_high` when seeing 15-19 enemies.
+* `danger_extreme` when seeing ≥ 20 enemies.
 
 ### Chainsaw pack
 


### PR DESCRIPTION

#### Summary
None


#### Purpose of change

I discovered the exact numbers for the ambient danger theme for soundpacks a long time ago, so i add it.

#### Describe the solution

Document the exact number of enemies for the ambient danger theme.
#### Describe alternatives you've considered

Not doing so
#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I shouldve done this back then.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
