### PR TITLE
fix a typo in NPC doc

### DIFF
--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -198,7 +198,7 @@ Two topics are special:
 - `TALK_DONE` ends the dialogue immediately.
 - `TALK_NONE` goes to the previously talked about topic.
 
-If `npc` has the follows fields, the game will display a dialogue with the indicated topic instead of default topic.
+If `npc` has the following fields, the game will display a dialogue with the indicated topic instead of default topic.
 
 Field | Default topic ID  | Uses for...
 ---|---|---


### PR DESCRIPTION


#### Summary
None


#### Purpose of change

While i was reading through the npc doc trying to make sense of the dialogue stuff, i was nearly thrown off by a typo, so imma fix said typo.
#### Describe the solution

See commit.

#### Describe alternatives you've considered

Let it be unchanged.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I wonder if someone else got thrown by this.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
