### PR TITLE
Move the `pocket_type` enum to it's own header

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -877,7 +877,7 @@ void bookbinder_copy_activity_actor::finish( player_activity &act, Character &p 
 
         p.consume_tools( writing_tools, pages );
         book_binder->put_in( item( itype_paper, calendar::turn, pages ),
-                             item_pocket::pocket_type::MAGAZINE );
+                             pocket_type::MAGAZINE );
     } else {
         debugmsg( "Recipe book already has '%s' recipe when it should not.", rec_id.str() );
     }
@@ -2740,7 +2740,7 @@ void ebooksave_activity_actor::completed_scanning_current_book( player_activity 
     item_location scanned_book = books.back();
     books.pop_back();
     if( scanned_book ) {
-        ereader->put_in( *scanned_book, item_pocket::pocket_type::EBOOK );
+        ereader->put_in( *scanned_book, pocket_type::EBOOK );
         if( who.is_avatar() ) {
             if( !who.has_identified( scanned_book->typeId() ) ) {
                 who.identify( *scanned_book );
@@ -3215,10 +3215,10 @@ void unload_activity_actor::unload( Character &who, item_location &target )
         contents_change_handler handler;
         bool changed = false;
 
-        for( item_pocket::pocket_type ptype : {
-                 item_pocket::pocket_type::CONTAINER,
-                 item_pocket::pocket_type::MAGAZINE_WELL,
-                 item_pocket::pocket_type::MAGAZINE
+        for( pocket_type ptype : {
+                 pocket_type::CONTAINER,
+                 pocket_type::MAGAZINE_WELL,
+                 pocket_type::MAGAZINE
              } ) {
 
             for( item *contained : it.all_items_top( ptype, true ) ) {
@@ -4319,7 +4319,7 @@ static ret_val<void> try_insert( item_location &holster, drop_location &holstere
             return ret;
         }
 
-        return holster->put_in( it, item_pocket::pocket_type::CONTAINER, /*unseal_pockets=*/true, carrier );
+        return holster->put_in( it, pocket_type::CONTAINER, /*unseal_pockets=*/true, carrier );
     }
 
     ret = holster->can_contain_partial_directly( it );
@@ -6541,7 +6541,7 @@ void gunmod_add_activity_actor::finish( player_activity &act, Character &who )
     if( rng( 0, 100 ) <= roll ) {
         add_msg( m_good, _( "You successfully attached the %1$s to your %2$s." ), mod.tname(),
                  gun.tname() );
-        gun.put_in( who.i_rem( &mod ), item_pocket::pocket_type::MOD );
+        gun.put_in( who.i_rem( &mod ), pocket_type::MOD );
         gun.on_contents_changed();
 
     } else if( rng( 0, 100 ) <= risk ) {
@@ -6985,13 +6985,13 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
                     !it->first->any_pockets_sealed() ) {
                     std::unordered_map<itype_id, int> item_counts;
                     if( unload_sparse_only ) {
-                        for( item *contained : it->first->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
+                        for( item *contained : it->first->all_items_top( pocket_type::CONTAINER ) ) {
                             if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                                 item_counts[contained->typeId()]++;
                             }
                         }
                     }
-                    for( item *contained : it->first->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
+                    for( item *contained : it->first->all_items_top( pocket_type::CONTAINER ) ) {
                         // no liquids don't want to spill stuff
                         if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                             if( unload_sparse_only &&
@@ -7005,7 +7005,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
                             return;
                         }
                     }
-                    for( item *contained : it->first->all_items_top( item_pocket::pocket_type::MAGAZINE ) ) {
+                    for( item *contained : it->first->all_items_top( pocket_type::MAGAZINE ) ) {
                         // no liquids don't want to spill stuff
                         if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                             if( it->first->is_ammo_belt() ) {
@@ -7035,7 +7035,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
                             return;
                         }
                     }
-                    for( item *contained : it->first->all_items_top( item_pocket::pocket_type::MAGAZINE_WELL ) ) {
+                    for( item *contained : it->first->all_items_top( pocket_type::MAGAZINE_WELL ) ) {
                         // no liquids don't want to spill stuff
                         if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                             move_item( you, *contained, contained->count(), src_loc, src_loc, this_veh, this_part );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -53,7 +53,6 @@
 #include "item.h"
 #include "item_factory.h"
 #include "item_location.h"
-#include "item_pocket.h"
 #include "item_stack.h"
 #include "itype.h"
 #include "iuse.h"
@@ -77,6 +76,7 @@
 #include "overmapbuffer.h"
 #include "pimpl.h"
 #include "player_activity.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "proficiency.h"
 #include "ranged.h"
@@ -901,7 +901,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
     if( action == butcher_type::DISSECT )    {
         int dissectable_practice = 0;
         int dissectable_num = 0;
-        for( item *item : corpse_item->all_items_top( item_pocket::pocket_type::CORPSE ) ) {
+        for( item *item : corpse_item->all_items_top( pocket_type::CORPSE ) ) {
             dissectable_num++;
             const int skill_level = butchery_dissect_skill_level( you, tool_quality,
                                     item->dropped_from );
@@ -1173,7 +1173,7 @@ static bool butchery_drops_harvest( item *corpse_item, const mtype &mt, Characte
     // reveal hidden items / hidden content
     if( action != butcher_type::FIELD_DRESS && action != butcher_type::SKIN &&
         action != butcher_type::BLEED ) {
-        for( item *content : corpse_item->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
+        for( item *content : corpse_item->all_items_top( pocket_type::CONTAINER ) ) {
             if( ( roll_butchery_dissect( round( you.get_average_skill_level( skill_survival ) ), you.dex_cur,
                                          tool_quality ) + 10 ) * 5 > rng( 0, 100 ) ) {
                 //~ %1$s - item name, %2$s - monster name
@@ -2292,7 +2292,7 @@ struct weldrig_hack {
         }
 
         item pseudo_magazine( pseudo.magazine_default() );
-        pseudo.put_in( pseudo_magazine, item_pocket::pocket_type::MAGAZINE_WELL );
+        pseudo.put_in( pseudo_magazine, pocket_type::MAGAZINE_WELL );
         pseudo.ammo_set( itype_battery, part->vehicle().drain( itype_battery,
                          pseudo.ammo_capacity( ammo_battery ) ) );
         return pseudo;
@@ -2656,7 +2656,7 @@ void activity_handlers::toolmod_add_finish( player_activity *act, Character *you
     you->add_msg_if_player( m_good, _( "You successfully attached the %1$s to your %2$s." ),
                             mod.tname(), tool.tname() );
     mod.set_flag( flag_IRREMOVABLE );
-    tool.put_in( mod, item_pocket::pocket_type::MOD );
+    tool.put_in( mod, pocket_type::MOD );
     tool.on_contents_changed();
     act->targets[1].remove_item();
 }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -2230,13 +2230,13 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                         !it->first->any_pockets_sealed() ) {
                         std::unordered_map<itype_id, int> item_counts;
                         if( unload_sparse_only ) {
-                            for( item *contained : it->first->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
+                            for( item *contained : it->first->all_items_top( pocket_type::CONTAINER ) ) {
                                 if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                                     item_counts[contained->typeId()]++;
                                 }
                             }
                         }
-                        for( item *contained : it->first->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
+                        for( item *contained : it->first->all_items_top( pocket_type::CONTAINER ) ) {
                             // no liquids don't want to spill stuff
                             if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                                 if( unload_sparse_only &&
@@ -2247,7 +2247,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                                 it->first->remove_item( *contained );
                             }
                         }
-                        for( item *contained : it->first->all_items_top( item_pocket::pocket_type::MAGAZINE ) ) {
+                        for( item *contained : it->first->all_items_top( pocket_type::MAGAZINE ) ) {
                             // no liquids don't want to spill stuff
                             if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                                 if( it->first->is_ammo_belt() ) {
@@ -2264,7 +2264,7 @@ void activity_on_turn_move_loot( player_activity &act, Character &you )
                                 it->first->remove_item( *contained );
                             }
                         }
-                        for( item *contained : it->first->all_items_top( item_pocket::pocket_type::MAGAZINE_WELL ) ) {
+                        for( item *contained : it->first->all_items_top( pocket_type::MAGAZINE_WELL ) ) {
                             // no liquids don't want to spill stuff
                             if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                                 move_item( you, *contained, contained->count(), src_loc, src_loc, vpr_src );

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -37,7 +37,6 @@
 #include "item.h"
 #include "item_category.h"
 #include "item_location.h"
-#include "item_pocket.h"
 #include "item_stack.h"
 #include "localized_comparator.h"
 #include "map.h"

--- a/src/advanced_inv_pane.cpp
+++ b/src/advanced_inv_pane.cpp
@@ -11,12 +11,12 @@
 #include "cata_assert.h"
 #include "flag.h"
 #include "item.h"
-#include "item_pocket.h"
 #include "item_search.h"
 #include "make_static.h"
 #include "map.h"
 #include "map_selector.h"
 #include "options.h"
+#include "pocket_type.h"
 #include "type_id.h"
 #include "uistate.h"
 #include "units.h"
@@ -137,7 +137,7 @@ std::vector<advanced_inv_listitem> outfit::get_AIM_inventory( size_t &item_index
         }
         for( const std::vector<item_location> &it_stack : item_list_to_stack(
                  item_location( you, &worn_item ),
-                 worn_item.all_items_top( item_pocket::pocket_type::CONTAINER ) ) ) {
+                 worn_item.all_items_top( pocket_type::CONTAINER ) ) ) {
             advanced_inv_listitem adv_it( it_stack, item_index++, square.id, false );
             if( !pane.is_filtered( *adv_it.items.front() ) ) {
                 square.volume += adv_it.volume;
@@ -160,7 +160,7 @@ std::vector<advanced_inv_listitem> avatar::get_AIM_inventory( const advanced_inv
     item_location weapon = get_wielded_item();
     if( weapon && weapon->is_container() ) {
         for( const std::vector<item_location> &it_stack : item_list_to_stack( weapon,
-                weapon->all_items_top( item_pocket::pocket_type::CONTAINER ) ) ) {
+                weapon->all_items_top( pocket_type::CONTAINER ) ) ) {
             advanced_inv_listitem adv_it( it_stack, item_index++, square.id, false );
             if( !pane.is_filtered( *adv_it.items.front() ) ) {
                 square.volume += adv_it.volume;
@@ -258,7 +258,7 @@ void advanced_inventory_pane::add_items_from_area( advanced_inv_area &square,
                 } else {
                     locs.emplace_back( loc_cursor, it );
                     if( it->is_corpse() ) {
-                        for( item *loot : it->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
+                        for( item *loot : it->all_items_top( pocket_type::CONTAINER ) ) {
                             if( !is_filtered( *loot ) ) {
                                 advanced_inv_listitem aim_item( item_location( item_location( loc_cursor, it ), loot ),
                                                                 0, 1, square.id, is_in_vehicle );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1454,7 +1454,7 @@ void Character::burn_fuel( bionic &bio )
             if( fuel_source->ammo_remaining() ) {
                 fuel = &fuel_source->first_ammo();
             } else {
-                fuel = fuel_source->all_items_ptr( item_pocket::pocket_type::CONTAINER ).front();
+                fuel = fuel_source->all_items_ptr( pocket_type::CONTAINER ).front();
             }
             energy_gain = fuel->fuel_energy();
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -3108,7 +3108,7 @@ units::mass Character::weight_carried_with_tweaks( const item_tweaks &tweaks ) c
     units::mass weaponweight = 0_gram;
     if( !without.count( &weapon ) ) {
         weaponweight += weapon.weight();
-        for( const item *i : weapon.all_items_ptr( item_pocket::pocket_type::CONTAINER ) ) {
+        for( const item *i : weapon.all_items_ptr( pocket_type::CONTAINER ) ) {
             if( i->count_by_charges() ) {
                 weaponweight -= get_selected_stack_weight( i, without );
             } else if( without.count( i ) ) {
@@ -10231,7 +10231,7 @@ void Character::place_corpse()
     body.set_item_temperature( units::from_celsius( 37 ) );
     map &here = get_map();
     for( item *itm : tmp ) {
-        body.force_insert_item( *itm, item_pocket::pocket_type::CONTAINER );
+        body.force_insert_item( *itm, pocket_type::CONTAINER );
     }
     for( const bionic &bio : *my_bionics ) {
         if( item::type_is_defined( bio.info().itype() ) ) {
@@ -10240,7 +10240,7 @@ void Character::place_corpse()
             cbm.set_flag( flag_NO_STERILE );
             cbm.set_flag( flag_NO_PACKED );
             cbm.faults.emplace( fault_bionic_salvaged );
-            body.put_in( cbm, item_pocket::pocket_type::CORPSE );
+            body.put_in( cbm, pocket_type::CORPSE );
         }
     }
 
@@ -10271,11 +10271,11 @@ void Character::place_corpse( const tripoint_abs_omt &om_target )
     std::vector<item *> tmp = inv_dump();
     item body = item::make_corpse( mtype_id::NULL_ID(), calendar::turn, get_name() );
     for( item *itm : tmp ) {
-        body.force_insert_item( *itm, item_pocket::pocket_type::CONTAINER );
+        body.force_insert_item( *itm, pocket_type::CONTAINER );
     }
     for( const bionic &bio : *my_bionics ) {
         if( item::type_is_defined( bio.info().itype() ) ) {
-            body.put_in( item( bio.id.str(), calendar::turn ), item_pocket::pocket_type::CORPSE );
+            body.put_in( item( bio.id.str(), calendar::turn ), pocket_type::CORPSE );
         }
     }
 
@@ -11204,10 +11204,10 @@ bool Character::unload( item_location &loc, bool bypass_activity,
         int moves = 0;
         item *prev_contained = nullptr;
 
-        for( item_pocket::pocket_type ptype : {
-                 item_pocket::pocket_type::CONTAINER,
-                 item_pocket::pocket_type::MAGAZINE_WELL,
-                 item_pocket::pocket_type::MAGAZINE
+        for( pocket_type ptype : {
+                 pocket_type::CONTAINER,
+                 pocket_type::MAGAZINE_WELL,
+                 pocket_type::MAGAZINE
              } ) {
 
             for( item *contained : it.all_items_top( ptype, true ) ) {
@@ -12507,10 +12507,10 @@ bool Character::wield_contents( item &container, item *internal_item, bool penal
 }
 
 void Character::store( item &container, item &put, bool penalties, int base_cost,
-                       item_pocket::pocket_type pk_type, bool check_best_pkt )
+                       pocket_type pk_type, bool check_best_pkt )
 {
     moves -= item_store_cost( put, container, penalties, base_cost );
-    if( check_best_pkt && pk_type == item_pocket::pocket_type::CONTAINER &&
+    if( check_best_pkt && pk_type == pocket_type::CONTAINER &&
         container.get_all_contained_pockets().size() > 1 ) {
         // Bypass pocket settings (assuming the item is manually stored)
         container.fill_with( i_rem( &put ), put.count_by_charges() ? put.charges : 1, false, false, true );

--- a/src/character.h
+++ b/src/character.h
@@ -1762,7 +1762,7 @@ class Character : public Creature, public visitable
          */
         void store( item &container, item &put, bool penalties = true,
                     int base_cost = INVENTORY_HANDLING_PENALTY,
-                    item_pocket::pocket_type pk_type = item_pocket::pocket_type::CONTAINER,
+                    pocket_type pk_type = pocket_type::CONTAINER,
                     bool check_best_pkt = false );
         void store( item_pocket *pocket, item &put, bool penalties = true,
                     int base_cost = INVENTORY_HANDLING_PENALTY );
@@ -1853,7 +1853,7 @@ class Character : public Creature, public visitable
             bool operator()( const item &it ) const {
                 return it.mission_id == mission_id || it.has_any_with( [&]( const item & it ) {
                     return it.mission_id == mission_id;
-                }, item_pocket::pocket_type::SOFTWARE );
+                }, pocket_type::SOFTWARE );
             }
         };
 

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -1173,7 +1173,7 @@ units::mass outfit::weight_carried_with_tweaks( const std::map<const item *, int
         if( without.empty() ) {
             ret += i.weight();
         } else if( !without.count( &i ) ) {
-            for( const item *j : i.all_items_ptr( item_pocket::pocket_type::CONTAINER ) ) {
+            for( const item *j : i.all_items_ptr( pocket_type::CONTAINER ) ) {
                 if( j->count_by_charges() ) {
                     ret -= get_selected_stack_weight( j, without );
                 } else if( without.count( j ) ) {
@@ -1915,7 +1915,7 @@ void outfit::absorb_damage( Character &guy, damage_unit &elem, bodypart_id bp,
             destroyed_armor_msg( guy, pre_damage_name );
             armor_destroyed = true;
             armor.on_takeoff( guy );
-            for( const item *it : armor.all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
+            for( const item *it : armor.all_items_top( pocket_type::CONTAINER ) ) {
                 worn_remains.push_back( *it );
             }
             // decltype is the type name of the iterator, note that reverse_iterator::base returns the
@@ -2440,7 +2440,7 @@ void outfit::add_stash( Character &guy, const item &newit, int &remaining_charge
         // Crawl all pockets regardless of priority
         // Crawl First : wielded item
         item_location carried_item = guy.get_wielded_item();
-        if( carried_item && !carried_item->has_pocket_type( item_pocket::pocket_type::MAGAZINE ) &&
+        if( carried_item && !carried_item->has_pocket_type( pocket_type::MAGAZINE ) &&
             carried_item->can_contain_partial( newit ).success() ) {
             int used_charges = carried_item->fill_with( newit, remaining_charges, /*unseal_pockets=*/false,
                                /*allow_sealed=*/false, /*ignore_settings=*/false, /*into_bottom*/false, &guy );

--- a/src/character_inventory.cpp
+++ b/src/character_inventory.cpp
@@ -445,7 +445,7 @@ bool Character::i_drop_at( item &it, int qty )
 
 static void recur_internal_locations( item_location parent, std::vector<item_location> &list )
 {
-    for( item *it : parent->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
+    for( item *it : parent->all_items_top( pocket_type::CONTAINER ) ) {
         item_location child( parent, it );
         recur_internal_locations( child, list );
     }
@@ -654,7 +654,7 @@ void outfit::holster_opts( std::vector<dispose_option> &opts, item_location obj,
                 guy.item_store_cost( *obj, e, false, e.insert_cost( *obj ) ),
                 [&guy, &e, obj] {
                     item &it = *item_location( obj );
-                    guy.store( e, it, false, e.insert_cost( it ), item_pocket::pocket_type::CONTAINER, true );
+                    guy.store( e, it, false, e.insert_cost( it ), pocket_type::CONTAINER, true );
                     return !guy.has_item( it );
                 }
             } );

--- a/src/computer_session.cpp
+++ b/src/computer_session.cpp
@@ -34,7 +34,6 @@
 #include "item.h"
 #include "item_factory.h"
 #include "item_location.h"
-#include "item_pocket.h"
 #include "line.h"
 #include "map.h"
 #include "map_iterator.h"
@@ -48,6 +47,7 @@
 #include "overmap.h"
 #include "overmap_ui.h"
 #include "overmapbuffer.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "ret_val.h"
 #include "rng.h"
@@ -478,7 +478,7 @@ void computer_session::action_sample()
                 }
                 sewage.charges = std::min( sewage.charges, capa );
                 if( elem.can_contain( sewage ).success() ) {
-                    elem.put_in( sewage, item_pocket::pocket_type::CONTAINER );
+                    elem.put_in( sewage, pocket_type::CONTAINER );
                 }
                 found_item = true;
                 break;
@@ -907,7 +907,7 @@ void computer_session::action_download_software()
         item software( miss->get_item_id(), calendar::turn_zero );
         software.mission_id = comp.mission_id;
         usb->clear_items();
-        usb->put_in( software, item_pocket::pocket_type::SOFTWARE );
+        usb->put_in( software, pocket_type::SOFTWARE );
         print_line( _( "Software downloaded." ) );
     } else {
         print_error( _( "USB drive required!" ) );
@@ -948,7 +948,7 @@ void computer_session::action_blood_anal()
                         if( item *const usb = pick_usb() ) {
                             item software( "software_blood_data", calendar::turn_zero );
                             usb->clear_items();
-                            usb->put_in( software, item_pocket::pocket_type::SOFTWARE );
+                            usb->put_in( software, pocket_type::SOFTWARE );
                             print_line( _( "Software downloaded." ) );
                         } else {
                             print_error( _( "USB drive required!" ) );

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -254,7 +254,7 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
         const std::vector<pocket_data> it_pkt = it.comp.type->pockets;
         if( ( item::count_by_charges( it.comp.type ) && it.comp.count > 0 ) ||
         !std::any_of( it_pkt.begin(), it_pkt.end(), []( const pocket_data & p ) {
-        return p.type == item_pocket::pocket_type::CONTAINER && p.watertight;
+        return p.type == pocket_type::CONTAINER && p.watertight;
     } ) ) {
             continue;
         }
@@ -346,7 +346,7 @@ static std::list<item> sane_consume_items( const comp_selection<item_comp> &it, 
     const std::vector<pocket_data> it_pkt = it.comp.type->pockets;
     if( ( item::count_by_charges( it.comp.type ) && it.comp.count > 0 ) ||
     !std::any_of( it_pkt.begin(), it_pkt.end(), []( const pocket_data & p ) {
-    return p.type == item_pocket::pocket_type::CONTAINER && p.watertight;
+    return p.type == pocket_type::CONTAINER && p.watertight;
 } ) ) {
         return crafter->consume_items( it, batch, filter );
     }
@@ -392,9 +392,9 @@ bool craft_command::safe_to_unload_comp( const item &it )
     const std::function<bool( const item &i )> filter = []( const item & i ) {
         return !i.has_flag( flag_ZERO_WEIGHT ) && !i.has_flag( flag_NO_DROP );
     };
-    const bool valid = it.get_contents().has_any_with( filter, item_pocket::pocket_type::CONTAINER ) ||
-                       it.get_contents().has_any_with( filter, item_pocket::pocket_type::MAGAZINE ) ||
-                       it.get_contents().has_any_with( filter, item_pocket::pocket_type::MAGAZINE_WELL );
+    const bool valid = it.get_contents().has_any_with( filter, pocket_type::CONTAINER ) ||
+                       it.get_contents().has_any_with( filter, pocket_type::MAGAZINE ) ||
+                       it.get_contents().has_any_with( filter, pocket_type::MAGAZINE_WELL );
     if( valid ) {
         return true;
     }

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -43,7 +43,6 @@
 #include "inventory.h"
 #include "item.h"
 #include "item_location.h"
-#include "item_pocket.h"
 #include "item_stack.h"
 #include "itype.h"
 #include "iuse.h"
@@ -60,6 +59,7 @@
 #include "output.h"
 #include "pimpl.h"
 #include "player_activity.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "proficiency.h"
 #include "recipe.h"
@@ -504,7 +504,7 @@ static std::vector<const item *> get_eligible_containers_recursive( const item &
     if( is_container_eligible_for_crafting( cont, allow_bucket ) ) {
         ret.push_back( &cont );
     }
-    for( const item *it : cont.all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
+    for( const item *it : cont.all_items_top( pocket_type::CONTAINER ) ) {
         //buckets are never allowed when inside another container
         std::vector<const item *> inside = get_eligible_containers_recursive( *it, false );
         ret.insert( ret.end(), inside.begin(), inside.end() );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -517,7 +517,7 @@ class pickup_inventory_preset : public inventory_selector_preset
                                           bool skip_wield_check = false, bool ignore_liquidcont = false ) : you( you ),
             skip_wield_check( skip_wield_check ), ignore_liquidcont( ignore_liquidcont ) {
             save_state = &pickup_sel_default_state;
-            _pk_type = item_pocket::pocket_type::LAST;
+            _pk_type = pocket_type::LAST;
         }
 
         std::string get_denial( const item_location &loc ) const override {
@@ -1860,7 +1860,7 @@ drop_locations game_menus::inv::unload_container( avatar &you )
 
     drop_locations dropped;
     for( drop_location &droplc : insert_menu.execute() ) {
-        for( item *it : droplc.first->all_items_top( item_pocket::pocket_type::CONTAINER, true ) ) {
+        for( item *it : droplc.first->all_items_top( pocket_type::CONTAINER, true ) ) {
             // no liquids and no items marked as favorite
             if( ( !it->made_of( phase_id::LIQUID ) || ( it->made_of( phase_id::LIQUID ) &&
                     it->is_frozen_liquid() ) ) && !it->is_favorite ) {

--- a/src/gamemode_tutorial.cpp
+++ b/src/gamemode_tutorial.cpp
@@ -338,7 +338,7 @@ void tutorial_game::post_action( action_id act )
             item it( player_character.last_item, calendar::turn_zero );
             if( it.is_holster() ) {
                 add_message( tut_lesson::LESSON_HOLSTERS_ACTIVATE );
-            } else if( it.has_pocket_type( item_pocket::pocket_type::CONTAINER ) ) {
+            } else if( it.has_pocket_type( pocket_type::CONTAINER ) ) {
                 add_message( tut_lesson::LESSON_WORE_STORAGE );
             } else if( it.is_armor() ) {
                 if( it.get_env_resist() >= 2 ) {

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -18,7 +18,6 @@
 #include "flag.h"
 #include "iexamine.h"
 #include "inventory_ui.h" // auto inventory blocking
-#include "item_pocket.h"
 #include "item_stack.h"
 #include "itype.h"
 #include "make_static.h"
@@ -28,6 +27,7 @@
 #include "messages.h" //for rust message
 #include "npc.h"
 #include "options.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "proficiency.h"
 #include "ret_val.h"
@@ -528,7 +528,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
         const furn_t &f = m.furn( p ).obj();
         if( item *furn_item = provide_pseudo_item( f.crafting_pseudo_item ) ) {
             const itype *ammo = f.crafting_ammo_item_type();
-            if( furn_item->has_pocket_type( item_pocket::pocket_type::MAGAZINE ) ) {
+            if( furn_item->has_pocket_type( pocket_type::MAGAZINE ) ) {
                 // NOTE: This only works if the pseudo item has a MAGAZINE pocket, not a MAGAZINE_WELL!
                 const bool using_ammotype = f.has_flag( ter_furn_flag::TFLAG_AMMOTYPE_RELOAD );
                 int amount = 0;
@@ -540,7 +540,7 @@ void inventory::form_from_map( map &m, std::vector<tripoint> pts, const Characte
                     amount = count_charges_in_list( ammo, m.i_at( p ) );
                 }
                 item furn_ammo( ammo_id, calendar::turn, amount );
-                furn_item->put_in( furn_ammo, item_pocket::pocket_type::MAGAZINE );
+                furn_item->put_in( furn_ammo, pocket_type::MAGAZINE );
             }
         }
         if( m.accessible_items( p ) ) {

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -1999,7 +1999,7 @@ bool inventory_selector::add_contained_items( item_location &container, inventor
         return false;
     }
 
-    std::list<item *> const items = preset.get_pocket_type() == item_pocket::pocket_type::LAST
+    std::list<item *> const items = preset.get_pocket_type() == pocket_type::LAST
                                     ? container->all_items_top()
                                     : container->all_items_top( preset.get_pocket_type() );
 

--- a/src/inventory_ui.h
+++ b/src/inventory_ui.h
@@ -23,9 +23,9 @@
 #include "input.h"
 #include "item_category.h"
 #include "item_location.h"
-#include "item_pocket.h"
 #include "map.h"
 #include "memory_fast.h"
+#include "pocket_type.h"
 #include "pimpl.h"
 #include "translations.h"
 #include "units.h"
@@ -258,7 +258,7 @@ class inventory_selector_preset
             return check_components;
         }
 
-        item_pocket::pocket_type get_pocket_type() const {
+        pocket_type get_pocket_type() const {
             return _pk_type;
         }
 
@@ -296,7 +296,7 @@ class inventory_selector_preset
         bool _indent_entries = true;
         bool _collate_entries = false;
 
-        item_pocket::pocket_type _pk_type = item_pocket::pocket_type::CONTAINER;
+        pocket_type _pk_type = pocket_type::CONTAINER;
 
     private:
         class cell_t

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -61,7 +61,6 @@
 #include "item_category.h"
 #include "item_factory.h"
 #include "item_group.h"
-#include "item_pocket.h"
 #include "iteminfo_query.h"
 #include "itype.h"
 #include "iuse.h"
@@ -84,6 +83,7 @@
 #include "output.h"
 #include "overmapbuffer.h"
 #include "pimpl.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "proficiency.h"
 #include "projectile.h"
@@ -332,8 +332,8 @@ item::item( const itype *type, time_point turn, int qty ) : type( type ), bday( 
         }
     } else {
         auto const mag_filter = []( item_pocket const & pck ) {
-            return pck.is_type( item_pocket::pocket_type::MAGAZINE ) ||
-                   pck.is_type( item_pocket::pocket_type::MAGAZINE_WELL );
+            return pck.is_type( pocket_type::MAGAZINE ) ||
+                   pck.is_type( pocket_type::MAGAZINE_WELL );
         };
         for( item_pocket *pocket : contents.get_pockets( mag_filter ) ) {
             pocket->settings.set_collapse( true );
@@ -351,16 +351,16 @@ item::item( const itype *type, time_point turn, int qty ) : type( type ), bday( 
         for( const itype_id &mod : type->gun->built_in_mods ) {
             item it( mod, turn, qty );
             it.set_flag( flag_IRREMOVABLE );
-            put_in( it, item_pocket::pocket_type::MOD );
+            put_in( it, pocket_type::MOD );
         }
         for( const itype_id &mod : type->gun->default_mods ) {
-            put_in( item( mod, turn, qty ), item_pocket::pocket_type::MOD );
+            put_in( item( mod, turn, qty ), pocket_type::MOD );
         }
 
     } else if( type->magazine ) {
         if( type->magazine->count > 0 ) {
             put_in( item( type->magazine->default_ammo, calendar::turn, type->magazine->count ),
-                    item_pocket::pocket_type::MAGAZINE );
+                    pocket_type::MAGAZINE );
         }
 
     } else if( has_temperature() ) {
@@ -632,7 +632,7 @@ item &item::convert( const itype_id &new_type, Character *carrier )
     item temp( *this );
     temp.contents = item_contents( type->pockets );
     for( const item *it : contents.mods() ) {
-        if( !temp.put_in( *it, item_pocket::pocket_type::MOD ).success() ) {
+        if( !temp.put_in( *it, pocket_type::MOD ).success() ) {
             debugmsg( "failed to insert mod" );
         }
     }
@@ -744,7 +744,7 @@ item &item::ammo_set( const itype_id &ammo, int qty )
                 charges = std::min( qty, ammo_capacity( ammo_type ) );
             } else if( is_gun() ) {
                 const item temp_ammo( ammo_default(), calendar::turn, std::min( qty, ammo_capacity( ammo_type ) ) );
-                put_in( temp_ammo, item_pocket::pocket_type::MAGAZINE );
+                put_in( temp_ammo, pocket_type::MAGAZINE );
             }
         }
         return *this;
@@ -768,7 +768,7 @@ item &item::ammo_set( const itype_id &ammo, int qty )
             set_ammo.set_flag( flag_NO_DROP );
             set_ammo.set_flag( flag_IRREMOVABLE );
         }
-        put_in( set_ammo, item_pocket::pocket_type::MAGAZINE );
+        put_in( set_ammo, pocket_type::MAGAZINE );
 
     } else {
         if( !magazine_current() ) {
@@ -814,7 +814,7 @@ item &item::ammo_set( const itype_id &ammo, int qty )
                     mag = opts.back().typeId();
                 }
             }
-            put_in( item( mag ), item_pocket::pocket_type::MAGAZINE_WELL );
+            put_in( item( mag ), pocket_type::MAGAZINE_WELL );
         }
         item *mag_cur = magazine_current();
         if( mag_cur != nullptr ) {
@@ -1247,7 +1247,7 @@ item item::in_container( const itype_id &cont, int qty, const bool sealed ) cons
         container.add_automatic_whitelist();
         return container;
     } else if( is_software() && container.is_software_storage() ) {
-        container.put_in( *this, item_pocket::pocket_type::SOFTWARE );
+        container.put_in( *this, pocket_type::SOFTWARE );
         container.invlet = invlet;
         return container;
     }
@@ -1279,10 +1279,10 @@ void item::update_modified_pockets()
     std::vector<const pocket_data *> container_pockets;
 
     for( const pocket_data &pocket : type->pockets ) {
-        if( pocket.type == item_pocket::pocket_type::CONTAINER ) {
+        if( pocket.type == pocket_type::CONTAINER ) {
             container_pockets.push_back( &pocket );
-        } else if( pocket.type == item_pocket::pocket_type::MAGAZINE ||
-                   pocket.type == item_pocket::pocket_type::MAGAZINE_WELL ) {
+        } else if( pocket.type == pocket_type::MAGAZINE ||
+                   pocket.type == pocket_type::MAGAZINE_WELL ) {
             mag_or_mag_well = &pocket;
         }
     }
@@ -1290,10 +1290,10 @@ void item::update_modified_pockets()
     for( const item *mod : mods() ) {
         if( mod->type->mod ) {
             for( const pocket_data &pocket : mod->type->mod->add_pockets ) {
-                if( pocket.type == item_pocket::pocket_type::CONTAINER ) {
+                if( pocket.type == pocket_type::CONTAINER ) {
                     container_pockets.push_back( &pocket );
-                } else if( pocket.type == item_pocket::pocket_type::MAGAZINE ||
-                           pocket.type == item_pocket::pocket_type::MAGAZINE_WELL ) {
+                } else if( pocket.type == pocket_type::MAGAZINE ||
+                           pocket.type == pocket_type::MAGAZINE_WELL ) {
                     mag_or_mag_well = &pocket;
                 }
             }
@@ -1613,7 +1613,7 @@ int item::insert_cost( const item &it ) const
     return contents.insert_cost( it );
 }
 
-ret_val<void> item::put_in( const item &payload, item_pocket::pocket_type pk_type,
+ret_val<void> item::put_in( const item &payload, pocket_type pk_type,
                             const bool unseal_pockets, Character *carrier )
 {
     ret_val<item *> result = contents.insert_item( payload, pk_type, false, unseal_pockets );
@@ -1622,7 +1622,7 @@ ret_val<void> item::put_in( const item &payload, item_pocket::pocket_type pk_typ
                   payload.typeId().str(), payload.count(), typeId().str(), result.str() );
         return ret_val<void>::make_failure( result.str() );
     }
-    if( pk_type == item_pocket::pocket_type::MOD ) {
+    if( pk_type == pocket_type::MOD ) {
         update_modified_pockets();
     }
     if( carrier ) {
@@ -1632,7 +1632,7 @@ ret_val<void> item::put_in( const item &payload, item_pocket::pocket_type pk_typ
     return ret_val<void>::make_success( result.str() );
 }
 
-void item::force_insert_item( const item &it, item_pocket::pocket_type pk_type )
+void item::force_insert_item( const item &it, pocket_type pk_type )
 {
     contents.force_insert_item( it, pk_type );
     update_inherited_flags();
@@ -2940,7 +2940,7 @@ void item::gun_info( const item *mod, std::vector<iteminfo> &info, const iteminf
 
             item tmp_mag( tmp.magazine_default() );
             tmp_mag.ammo_set( tmp_mag.ammo_default() );
-            tmp.put_in( tmp_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+            tmp.put_in( tmp_mag, pocket_type::MAGAZINE_WELL );
         }
         loaded_mod = &tmp;
         curammo = loaded_mod->ammo_data();
@@ -5132,7 +5132,7 @@ void item::qualities_info( std::vector<iteminfo> &info, const iteminfo_query *pa
     if( parts->test( iteminfo_parts::QUALITIES_CONTAINED ) &&
     contents.has_any_with( []( const item & e ) {
     return !e.type->qualities.empty();
-    }, item_pocket::pocket_type::CONTAINER ) ) {
+    }, pocket_type::CONTAINER ) ) {
 
         info.emplace_back( "QUALITIES", "", _( "Contains items with qualities:" ) );
         std::map<quality_id, int, quality_id::LexCmp> most_quality;
@@ -6069,7 +6069,7 @@ int item::get_free_mod_locations( const gunmod_location &location ) const
         return 0;
     }
     int result = loc->second;
-    for( const item *elem : contents.all_items_top( item_pocket::pocket_type::MOD ) ) {
+    for( const item *elem : contents.all_items_top( pocket_type::MOD ) ) {
         const cata::value_ptr<islot_gunmod> &mod = elem->type->gunmod;
         if( mod && mod->location == location ) {
             result--;
@@ -7786,7 +7786,7 @@ std::vector<item *> item::toolmods()
 {
     std::vector<item *> res;
     if( is_tool() ) {
-        for( item *e : contents.all_items_top( item_pocket::pocket_type::MOD ) ) {
+        for( item *e : contents.all_items_top( pocket_type::MOD ) ) {
             if( e->is_toolmod() ) {
                 res.push_back( e );
             }
@@ -7799,7 +7799,7 @@ std::vector<const item *> item::toolmods() const
 {
     std::vector<const item *> res;
     if( is_tool() ) {
-        for( const item *e : contents.all_items_top( item_pocket::pocket_type::MOD ) ) {
+        for( const item *e : contents.all_items_top( pocket_type::MOD ) ) {
             if( e->is_toolmod() ) {
                 res.push_back( e );
             }
@@ -8599,12 +8599,12 @@ bool item::is_software() const
 
 bool item::is_software_storage() const
 {
-    return contents.has_pocket_type( item_pocket::pocket_type::SOFTWARE );
+    return contents.has_pocket_type( pocket_type::SOFTWARE );
 }
 
 bool item::is_ebook_storage() const
 {
-    return contents.has_pocket_type( item_pocket::pocket_type::EBOOK );
+    return contents.has_pocket_type( pocket_type::EBOOK );
 }
 
 bool item::is_maybe_melee_weapon() const
@@ -9451,7 +9451,7 @@ bool item::is_bionic() const
 
 bool item::is_magazine() const
 {
-    return !!type->magazine || contents.has_pocket_type( item_pocket::pocket_type::MAGAZINE );
+    return !!type->magazine || contents.has_pocket_type( pocket_type::MAGAZINE );
 }
 
 bool item::is_battery() const
@@ -9582,7 +9582,7 @@ bool item::is_ammo_container() const
     return contents.has_any_with(
     []( const item & it ) {
         return it.is_ammo();
-    }, item_pocket::pocket_type::CONTAINER );
+    }, pocket_type::CONTAINER );
 }
 
 bool item::is_melee() const
@@ -9668,7 +9668,7 @@ bool item::any_pockets_sealed() const
 
 bool item::is_container() const
 {
-    return contents.has_pocket_type( item_pocket::pocket_type::CONTAINER );
+    return contents.has_pocket_type( pocket_type::CONTAINER );
 }
 
 bool item::is_container_with_restriction() const
@@ -9684,13 +9684,13 @@ bool item::is_single_container_with_restriction() const
     return contents.is_single_restricted_container();
 }
 
-bool item::has_pocket_type( item_pocket::pocket_type pk_type ) const
+bool item::has_pocket_type( pocket_type pk_type ) const
 {
     return contents.has_pocket_type( pk_type );
 }
 
 bool item::has_any_with( const std::function<bool( const item & )> &filter,
-                         item_pocket::pocket_type pk_type ) const
+                         pocket_type pk_type ) const
 {
     return contents.has_any_with( filter, pk_type );
 }
@@ -10680,7 +10680,7 @@ int item::ammo_remaining( const Character *carrier, const bool include_linked ) 
 
     // Magazines and integral magazines on their own
     if( is_magazine() ) {
-        for( const item *e : contents.all_items_top( item_pocket::pocket_type::MAGAZINE ) ) {
+        for( const item *e : contents.all_items_top( pocket_type::MAGAZINE ) ) {
             if( e->is_ammo() ) {
                 ret += e->charges;
             }
@@ -10689,7 +10689,7 @@ int item::ammo_remaining( const Character *carrier, const bool include_linked ) 
 
     // Handle non-magazines with ammo_restriction in a CONTAINER type pocket (like quivers)
     if( !( mag || is_magazine() || ammo.empty() ) ) {
-        for( const item *e : contents.all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
+        for( const item *e : contents.all_items_top( pocket_type::CONTAINER ) ) {
             if( e->is_ammo() && ammo.find( e->ammo_type() ) != ammo.end() ) {
                 ret += e->charges;
             }
@@ -10742,7 +10742,7 @@ units::energy item::energy_remaining( const Character *carrier ) const
 
     // Battery(ammo) contained within
     if( is_magazine() ) {
-        for( const item *e : contents.all_items_top( item_pocket::pocket_type::MAGAZINE ) ) {
+        for( const item *e : contents.all_items_top( pocket_type::MAGAZINE ) ) {
             if( e->typeId() == itype_battery ) {
                 ret += units::from_kilojoule( e->charges );
             }
@@ -10777,7 +10777,7 @@ int item::ammo_capacity( const ammotype &ammo, bool include_linked ) const
         return units::to_kilojoule( get_player_character().get_max_power_level() );
     }
 
-    if( contents.has_pocket_type( item_pocket::pocket_type::MAGAZINE ) ) {
+    if( contents.has_pocket_type( pocket_type::MAGAZINE ) ) {
         return contents.ammo_capacity( ammo );
     }
     if( is_magazine() ) {
@@ -11142,12 +11142,12 @@ std::string item::ammo_sort_name() const
 
 bool item::magazine_integral() const
 {
-    return contents.has_pocket_type( item_pocket::pocket_type::MAGAZINE );
+    return contents.has_pocket_type( pocket_type::MAGAZINE );
 }
 
 bool item::uses_magazine() const
 {
-    return contents.has_pocket_type( item_pocket::pocket_type::MAGAZINE_WELL );
+    return contents.has_pocket_type( pocket_type::MAGAZINE_WELL );
 }
 
 itype_id item::magazine_default( bool conversion ) const
@@ -11509,7 +11509,7 @@ void item::reload_option::qty( int val )
     bool ammo_in_liquid_container = ammo->is_watertight_container();
     item &ammo_obj = ( ammo_in_container || ammo_in_liquid_container ) ?
                      // this is probably not the right way to do this. there is no guarantee whatsoever that ammo_obj will be an ammo
-                     *ammo->contents.all_items_top( item_pocket::pocket_type::CONTAINER ).front() : *ammo;
+                     *ammo->contents.all_items_top( pocket_type::CONTAINER ).front() : *ammo;
 
     if( ( ammo_in_container && !ammo_obj.is_ammo() ) ||
         ( ammo_in_liquid_container && !ammo_obj.made_of( phase_id::LIQUID ) ) ) {
@@ -11628,7 +11628,7 @@ bool item::reload( Character &u, item_location ammo, int qty )
             item_copy.charges = qty;
         }
 
-        put_in( item_copy, item_pocket::pocket_type::MAGAZINE );
+        put_in( item_copy, pocket_type::MAGAZINE );
 
     } else if( is_watertight_container() && ammo->made_of_from_type( phase_id::LIQUID ) ) {
         item contents( *ammo );
@@ -11650,7 +11650,7 @@ bool item::reload( Character &u, item_location ammo, int qty )
             remove_item( *magazine_current() );
         }
 
-        put_in( *ammo, item_pocket::pocket_type::MAGAZINE_WELL );
+        put_in( *ammo, pocket_type::MAGAZINE_WELL );
         ammo.remove_item();
         if( ammo_from_map ) {
             u.invalidate_weight_carried_cache();
@@ -11976,7 +11976,7 @@ bool item::use_amount( const itype_id &it, int &quantity, std::list<item> &used,
     // Remember quantity so that we can unseal self
     int old_quantity = quantity;
     std::vector<item *> removed_items;
-    for( item *contained : all_items_ptr( item_pocket::pocket_type::CONTAINER ) ) {
+    for( item *contained : all_items_ptr( pocket_type::CONTAINER ) ) {
         if( contained->use_amount_internal( it, quantity, used, filter ) ) {
             removed_items.push_back( contained );
         }
@@ -12313,7 +12313,7 @@ const item_category &item::get_category_shallow() const
 const item_category &item::get_category_of_contents() const
 {
     if( type->category_force == item_category_container ) {
-        const std::list<const item *> items = contents.all_items_top( item_pocket::pocket_type::CONTAINER );
+        const std::list<const item *> items = contents.all_items_top( pocket_type::CONTAINER );
         if( !items.empty() ) {
             const item_category &category_of_first_item = items.front()->get_category_of_contents();
             if( items.size() == 1 ) {
@@ -14170,15 +14170,15 @@ bool item::is_reloadable() const
     }
 
     for( const item_pocket *pocket : contents.get_all_reloadable_pockets() ) {
-        if( pocket->is_type( item_pocket::pocket_type::MAGAZINE_WELL ) ) {
+        if( pocket->is_type( pocket_type::MAGAZINE_WELL ) ) {
             if( pocket->empty() || !pocket->front().is_magazine_full() ) {
                 return true;
             }
-        } else if( pocket->is_type( item_pocket::pocket_type::MAGAZINE ) ) {
+        } else if( pocket->is_type( pocket_type::MAGAZINE ) ) {
             if( remaining_ammo_capacity() > 0 ) {
                 return true;
             }
-        } else if( pocket->is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        } else if( pocket->is_type( pocket_type::CONTAINER ) ) {
             // Container pockets are reloadable only if they are watertight, not full and do not contain non-liquid item
             if( pocket->full( false ) || !pocket->watertight() ) {
                 continue;
@@ -14595,7 +14595,7 @@ units::volume item::check_for_free_space() const
 {
     units::volume volume;
 
-    for( const item *container : contents.all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
+    for( const item *container : contents.all_items_top( pocket_type::CONTAINER ) ) {
         std::vector<const item_pocket *> containedPockets =
             container->contents.get_all_contained_pockets();
         if( !containedPockets.empty() ) {
@@ -14697,12 +14697,12 @@ std::list<item *> item::all_items_top()
     return contents.all_items_top();
 }
 
-std::list<const item *> item::all_items_top( item_pocket::pocket_type pk_type ) const
+std::list<const item *> item::all_items_top( pocket_type pk_type ) const
 {
     return contents.all_items_top( pk_type );
 }
 
-std::list<item *> item::all_items_top( item_pocket::pocket_type pk_type, bool unloading )
+std::list<item *> item::all_items_top( pocket_type pk_type, bool unloading )
 {
     return contents.all_items_top( pk_type, unloading );
 }
@@ -14717,8 +14717,8 @@ item const *item::this_or_single_content() const
 bool item::contents_only_one_type() const
 {
     std::list<const item *> const items = contents.all_items_top( []( item_pocket const & pkt ) {
-        return pkt.is_type( item_pocket::pocket_type::CONTAINER ) ||
-               pkt.is_type( item_pocket::pocket_type::SOFTWARE );
+        return pkt.is_type( pocket_type::CONTAINER ) ||
+               pkt.is_type( pocket_type::SOFTWARE );
     } );
     return items.size() == 1 ||
            ( items.size() > 1 &&
@@ -14730,25 +14730,25 @@ bool item::contents_only_one_type() const
 std::list<const item *> item::all_items_ptr() const
 {
     std::list<const item *> all_items_internal;
-    for( int i = static_cast<int>( item_pocket::pocket_type::CONTAINER );
-         i < static_cast<int>( item_pocket::pocket_type::LAST ); i++ ) {
-        std::list<const item *> inserted{ all_items_top_recursive( static_cast<item_pocket::pocket_type>( i ) ) };
+    for( int i = static_cast<int>( pocket_type::CONTAINER );
+         i < static_cast<int>( pocket_type::LAST ); i++ ) {
+        std::list<const item *> inserted{ all_items_top_recursive( static_cast<pocket_type>( i ) ) };
         all_items_internal.insert( all_items_internal.end(), inserted.begin(), inserted.end() );
     }
     return all_items_internal;
 }
 
-std::list<const item *> item::all_items_ptr( item_pocket::pocket_type pk_type ) const
+std::list<const item *> item::all_items_ptr( pocket_type pk_type ) const
 {
     return all_items_top_recursive( pk_type );
 }
 
-std::list<item *> item::all_items_ptr( item_pocket::pocket_type pk_type )
+std::list<item *> item::all_items_ptr( pocket_type pk_type )
 {
     return all_items_top_recursive( pk_type );
 }
 
-std::list<const item *> item::all_items_top_recursive( item_pocket::pocket_type pk_type )
+std::list<const item *> item::all_items_top_recursive( pocket_type pk_type )
 const
 {
     std::list<const item *> contained = contents.all_items_top( pk_type );
@@ -14762,7 +14762,7 @@ const
     return all_items_internal;
 }
 
-std::list<item *> item::all_items_top_recursive( item_pocket::pocket_type pk_type )
+std::list<item *> item::all_items_top_recursive( pocket_type pk_type )
 {
     std::list<item *> contained = contents.all_items_top( pk_type );
     std::list<item *> all_items_internal{ contained };

--- a/src/item.h
+++ b/src/item.h
@@ -25,7 +25,6 @@
 #include "item_components.h"
 #include "item_contents.h"
 #include "item_location.h"
-#include "item_pocket.h"
 #include "material.h"
 #include "requirements.h"
 #include "safe_reference.h"
@@ -49,6 +48,7 @@ class item;
 class iteminfo_query;
 class monster;
 class nc_color;
+enum class pocket_type;
 class recipe;
 class relic;
 struct part_material;
@@ -816,9 +816,9 @@ class item : public visitable
         /** Whether it is a container with only one pocket, and if it is has some restrictions */
         bool is_single_container_with_restriction() const;
         // whether the contents has a pocket with the associated type
-        bool has_pocket_type( item_pocket::pocket_type pk_type ) const;
+        bool has_pocket_type( pocket_type pk_type ) const;
         bool has_any_with( const std::function<bool( const item & )> &filter,
-                           item_pocket::pocket_type pk_type ) const;
+                           pocket_type pk_type ) const;
 
         /** True if every pocket is rigid or we have no pockets */
         bool all_pockets_rigid() const;
@@ -932,9 +932,9 @@ class item : public visitable
         /**
          * Puts the given item into this one.
          */
-        ret_val<void> put_in( const item &payload, item_pocket::pocket_type pk_type,
+        ret_val<void> put_in( const item &payload, pocket_type pk_type,
                               bool unseal_pockets = false, Character *carrier = nullptr );
-        void force_insert_item( const item &it, item_pocket::pocket_type pk_type );
+        void force_insert_item( const item &it, pocket_type pk_type );
 
         /**
          * Returns this item into its default container. If it does not have a default container,
@@ -2846,11 +2846,11 @@ class item : public visitable
         /** returns a list of pointers to all top-level items that are not mods */
         std::list<item *> all_items_top();
         /** returns a list of pointers to all top-level items */
-        std::list<const item *> all_items_top( item_pocket::pocket_type pk_type ) const;
+        std::list<const item *> all_items_top( pocket_type pk_type ) const;
         /** returns a list of pointers to all top-level items
          *  if unloading is true it ignores items in pockets that are flagged to not unload
          */
-        std::list<item *> all_items_top( item_pocket::pocket_type pk_type, bool unloading = false );
+        std::list<item *> all_items_top( pocket_type pk_type, bool unloading = false );
 
         item const *this_or_single_content() const;
         bool contents_only_one_type() const;
@@ -2861,9 +2861,9 @@ class item : public visitable
          */
         std::list<const item *> all_items_ptr() const;
         /** returns a list of pointers to all items inside recursively */
-        std::list<const item *> all_items_ptr( item_pocket::pocket_type pk_type ) const;
+        std::list<const item *> all_items_ptr( pocket_type pk_type ) const;
         /** returns a list of pointers to all items inside recursively */
-        std::list<item *> all_items_ptr( item_pocket::pocket_type pk_type );
+        std::list<item *> all_items_ptr( pocket_type pk_type );
 
         /** returns a list of pointers to all visible or remembered top-level items */
         std::list<item *> all_known_contents();
@@ -2937,8 +2937,8 @@ class item : public visitable
         /** Update flags associated with temperature */
         void set_temp_flags( units::temperature new_temperature, float freeze_percentage );
 
-        std::list<item *> all_items_top_recursive( item_pocket::pocket_type pk_type );
-        std::list<const item *> all_items_top_recursive( item_pocket::pocket_type pk_type ) const;
+        std::list<item *> all_items_top_recursive( pocket_type pk_type );
+        std::list<const item *> all_items_top_recursive( pocket_type pk_type ) const;
 
         /** Returns true if protection info was printed as well */
         bool armor_full_protection_info( std::vector<iteminfo> &info, const iteminfo_query *parts ) const;

--- a/src/item_action.cpp
+++ b/src/item_action.cpp
@@ -94,7 +94,7 @@ bool item::item_has_uses_recursive( bool contents_only ) const
 bool item_contents::item_has_uses_recursive() const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) &&
+        if( pocket.is_type( pocket_type::CONTAINER ) &&
             pocket.item_has_uses_recursive() ) {
             return true;
         }

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -77,7 +77,7 @@ void pocket_favorite_callback::refresh( uilist *menu )
     for( std::tuple<item_pocket *, int, uilist_entry *> &pocket_val : saved_pockets ) {
         item_pocket *pocket = std::get<0>( pocket_val );
         if( pocket == nullptr || ( pocket->get_pocket_data()  &&
-                                   !pocket->is_type( item_pocket::pocket_type::CONTAINER ) ) ) {
+                                   !pocket->is_type( pocket_type::CONTAINER ) ) ) {
             ++i;
             continue;
         }
@@ -258,7 +258,7 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
     for( std::tuple<item_pocket *, int, uilist_entry *> &pocket_val : saved_pockets ) {
         item_pocket *pocket = std::get<0>( pocket_val );
         if( pocket == nullptr || ( pocket->get_pocket_data()  &&
-                                   !pocket->is_type( item_pocket::pocket_type::CONTAINER ) ) ) {
+                                   !pocket->is_type( pocket_type::CONTAINER ) ) ) {
             ++i;
             continue;
         }
@@ -572,7 +572,7 @@ bool item_contents::empty() const
         return true;
     }
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MOD ) ) {
+        if( pocket.is_type( pocket_type::MOD ) ) {
             // item mods aren't really contents per se
             continue;
         }
@@ -589,7 +589,7 @@ bool item_contents::empty_container() const
         return true;
     }
     for( const item_pocket &pocket : contents ) {
-        if( !pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( !pocket.is_type( pocket_type::CONTAINER ) ) {
             continue;
         }
         if( !pocket.empty() ) {
@@ -602,7 +602,7 @@ bool item_contents::empty_container() const
 bool item_contents::full( bool allow_bucket ) const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER )
+        if( pocket.is_type( pocket_type::CONTAINER )
             && !pocket.full( allow_bucket ) ) {
             return false;
         }
@@ -613,7 +613,7 @@ bool item_contents::full( bool allow_bucket ) const
 bool item_contents::is_magazine_full() const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MAGAZINE )
+        if( pocket.is_type( pocket_type::MAGAZINE )
             && pocket.full( false ) ) {
             return true;
         }
@@ -625,7 +625,7 @@ bool item_contents::bigger_on_the_inside( const units::volume &container_volume 
 {
     units::volume min_logical_volume = 0_ml;
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) ) {
             if( pocket.rigid() ) {
                 min_logical_volume += pocket.max_contains_volume();
             } else {
@@ -644,9 +644,9 @@ size_t item_contents::size() const
 void item_contents::read_mods( const item_contents &read_input )
 {
     for( const item_pocket &pocket : read_input.contents ) {
-        if( pocket.saved_type() == item_pocket::pocket_type::MOD ) {
+        if( pocket.saved_type() == pocket_type::MOD ) {
             for( const item *it : pocket.all_items_top() ) {
-                insert_item( *it, item_pocket::pocket_type::MOD );
+                insert_item( *it, pocket_type::MOD );
             }
         }
     }
@@ -665,28 +665,28 @@ void item_contents::combine( const item_contents &read_input, const bool convert
     for( const item_pocket &pocket : read_input.contents ) {
         if( pocket_index < contents.size() ) {
             if( convert ) {
-                if( pocket.is_type( item_pocket::pocket_type::MIGRATION ) ||
-                    pocket.is_type( item_pocket::pocket_type::CORPSE ) ||
-                    pocket.is_type( item_pocket::pocket_type::MAGAZINE ) ||
-                    pocket.is_type( item_pocket::pocket_type::MAGAZINE_WELL ) ) {
+                if( pocket.is_type( pocket_type::MIGRATION ) ||
+                    pocket.is_type( pocket_type::CORPSE ) ||
+                    pocket.is_type( pocket_type::MAGAZINE ) ||
+                    pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
                     ++pocket_index;
                     for( const item *it : pocket.all_items_top() ) {
                         insert_item( *it, pocket.get_pocket_data()->type, ignore_contents );
                     }
                     continue;
-                } else if( pocket.is_type( item_pocket::pocket_type::MOD ) ) {
+                } else if( pocket.is_type( pocket_type::MOD ) ) {
                     // skipping mod type pocket because using combine this way requires mods to come first
                     // and to call update_mod_pockets
                     ++pocket_index;
                     continue;
                 }
             } else {
-                if( pocket.saved_type() == item_pocket::pocket_type::MOD ) {
+                if( pocket.saved_type() == pocket_type::MOD ) {
                     // this is already handled in item_contents::read_mods
                     ++pocket_index;
                     continue;
-                } else if( pocket.saved_type() == item_pocket::pocket_type::MIGRATION ||
-                           pocket.saved_type() == item_pocket::pocket_type::CORPSE ) {
+                } else if( pocket.saved_type() == pocket_type::MIGRATION ||
+                           pocket.saved_type() == pocket_type::CORPSE ) {
                     for( const item *it : pocket.all_items_top() ) {
                         insert_item( *it, pocket.saved_type(), ignore_contents );
                     }
@@ -720,7 +720,7 @@ void item_contents::combine( const item_contents &read_input, const bool convert
     }
 
     for( const item &uninserted_item : uninserted_items ) {
-        insert_item( uninserted_item, item_pocket::pocket_type::MIGRATION, ignore_contents );
+        insert_item( uninserted_item, pocket_type::MIGRATION, ignore_contents );
     }
 }
 
@@ -728,16 +728,16 @@ struct item_contents::item_contents_helper {
     // Static helper function to implement the const and non-const versions of
     // find_pocket_for with less code duplication
     template<typename ItemContents>
-    using pocket_type = std::conditional_t <
-                        std::is_const_v<ItemContents>,
-                        const item_pocket,
-                        item_pocket
-                        >;
+    using item_pocket_type = std::conditional_t <
+                             std::is_const_v<ItemContents>,
+                             const item_pocket,
+                             item_pocket
+                             >;
 
     template<typename ItemContents>
-    static ret_val<pocket_type<ItemContents>*> find_pocket_for(
-        ItemContents &contents, const item &it, item_pocket::pocket_type pk_type ) {
-        using my_pocket_type = pocket_type<ItemContents>;
+    static ret_val<item_pocket_type<ItemContents>*> find_pocket_for(
+        ItemContents &contents, const item &it, pocket_type pk_type ) {
+        using my_pocket_type = item_pocket_type<ItemContents>;
         static constexpr item_pocket *null_pocket = nullptr;
 
         std::vector<std::string> failure_messages;
@@ -747,9 +747,9 @@ struct item_contents::item_contents_helper {
             if( !pocket.is_type( pk_type ) ) {
                 continue;
             }
-            if( pk_type != item_pocket::pocket_type::CONTAINER &&
-                pk_type != item_pocket::pocket_type::MAGAZINE &&
-                pk_type != item_pocket::pocket_type::MAGAZINE_WELL &&
+            if( pk_type != pocket_type::CONTAINER &&
+                pk_type != pocket_type::MAGAZINE &&
+                pk_type != pocket_type::MAGAZINE_WELL &&
                 pocket.is_type( pk_type ) ) {
                 return ret_val<my_pocket_type *>::make_success(
                            &pocket, "special pocket type override" );
@@ -780,13 +780,13 @@ struct item_contents::item_contents_helper {
 };
 
 ret_val<item_pocket *> item_contents::find_pocket_for( const item &it,
-        item_pocket::pocket_type pk_type )
+        pocket_type pk_type )
 {
     return item_contents_helper::find_pocket_for( *this, it, pk_type );
 }
 
 ret_val<const item_pocket *> item_contents::find_pocket_for( const item &it,
-        item_pocket::pocket_type pk_type ) const
+        pocket_type pk_type ) const
 {
     return item_contents_helper::find_pocket_for( *this, it, pk_type );
 }
@@ -804,7 +804,7 @@ int item_contents::obtain_cost( const item &it ) const
 
 int item_contents::insert_cost( const item &it ) const
 {
-    ret_val<const item_pocket *> pocket = find_pocket_for( it, item_pocket::pocket_type::CONTAINER );
+    ret_val<const item_pocket *> pocket = find_pocket_for( it, pocket_type::CONTAINER );
     if( pocket.success() ) {
         return pocket.value()->moves();
     } else {
@@ -813,11 +813,11 @@ int item_contents::insert_cost( const item &it ) const
 }
 
 ret_val<item *> item_contents::insert_item( const item &it,
-        item_pocket::pocket_type pk_type, bool ignore_contents, const bool unseal_pockets )
+        pocket_type pk_type, bool ignore_contents, const bool unseal_pockets )
 {
-    if( pk_type == item_pocket::pocket_type::LAST ) {
+    if( pk_type == pocket_type::LAST ) {
         // LAST is invalid, so we assume it will be a regular container
-        pk_type = item_pocket::pocket_type::CONTAINER;
+        pk_type = pocket_type::CONTAINER;
     }
 
     ret_val<item_pocket *> pocket = find_pocket_for( it, pk_type );
@@ -838,7 +838,7 @@ ret_val<item *> item_contents::insert_item( const item &it,
     return ret_val<item *>::make_failure( nullptr, inserted.str() );
 }
 
-void item_contents::force_insert_item( const item &it, item_pocket::pocket_type pk_type )
+void item_contents::force_insert_item( const item &it, pocket_type pk_type )
 {
     for( item_pocket &pocket : contents ) {
         if( pocket.is_type( pk_type ) ) {
@@ -858,7 +858,7 @@ std::pair<item_location, item_pocket *> item_contents::best_pocket( const item &
     std::pair<item_location, item_pocket *> ret = { this_loc, nullptr };
     std::vector<item_pocket *> valid_pockets;
     for( item_pocket &pocket : contents ) {
-        if( !pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( !pocket.is_type( pocket_type::CONTAINER ) ) {
             // best pocket is for picking stuff up.
             // containers are the only pockets that are available for such
             continue;
@@ -925,7 +925,7 @@ units::length item_contents::max_containable_length( const bool unrestricted_poc
         if( pocket.is_forbidden() ) {
             continue;
         }
-        bool restriction_condition = !pocket.is_type( item_pocket::pocket_type::CONTAINER ) ||
+        bool restriction_condition = !pocket.is_type( pocket_type::CONTAINER ) ||
                                      pocket.is_ablative() || pocket.holster_full();
         if( unrestricted_pockets_only ) {
             restriction_condition = restriction_condition && pocket.is_restricted();
@@ -945,7 +945,7 @@ units::length item_contents::min_containable_length() const
 {
     units::length ret = 0_mm;
     for( const item_pocket &pocket : contents ) {
-        if( !pocket.is_type( item_pocket::pocket_type::CONTAINER ) || pocket.is_ablative() ||
+        if( !pocket.is_type( pocket_type::CONTAINER ) || pocket.is_ablative() ||
             pocket.holster_full() ) {
             continue;
         }
@@ -961,7 +961,7 @@ std::set<flag_id> item_contents::magazine_flag_restrictions() const
 {
     std::set<flag_id> ret;
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MAGAZINE_WELL ) ) {
+        if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
             ret = pocket.get_pocket_data()->get_flag_restrictions();
         }
     }
@@ -975,7 +975,7 @@ units::volume item_contents::max_containable_volume( const bool unrestricted_poc
         if( pocket.is_forbidden() ) {
             continue;
         }
-        bool restriction_condition = !pocket.is_type( item_pocket::pocket_type::CONTAINER ) ||
+        bool restriction_condition = !pocket.is_type( pocket_type::CONTAINER ) ||
                                      pocket.is_ablative() || pocket.holster_full() ||
                                      pocket.volume_capacity() >= pocket_data::max_volume_for_container;
         if( unrestricted_pockets_only ) {
@@ -1022,9 +1022,9 @@ ret_val<void> item_contents::can_contain_rigid( const item &it, int &copies_rema
 {
     ret_val<void> ret = ret_val<void>::make_failure( _( "is not a container" ) );
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MOD ) ||
-            pocket.is_type( item_pocket::pocket_type::CORPSE ) ||
-            pocket.is_type( item_pocket::pocket_type::MIGRATION ) ) {
+        if( pocket.is_type( pocket_type::MOD ) ||
+            pocket.is_type( pocket_type::CORPSE ) ||
+            pocket.is_type( pocket_type::MIGRATION ) ) {
             continue;
         }
         if( !pocket.rigid() ) {
@@ -1088,7 +1088,7 @@ ret_val<void> item_contents::can_contain( const item &it, int &copies_remaining,
 bool item_contents::can_contain_liquid( bool held_or_ground ) const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) &&
+        if( pocket.is_type( pocket_type::CONTAINER ) &&
             pocket.can_contain_liquid( held_or_ground ) ) {
             return true;
         }
@@ -1099,7 +1099,7 @@ bool item_contents::can_contain_liquid( bool held_or_ground ) const
 bool item_contents::contains_no_solids() const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) &&
+        if( pocket.is_type( pocket_type::CONTAINER ) &&
             pocket.contains_phase( phase_id::SOLID ) ) {
             return false;
         }
@@ -1122,7 +1122,7 @@ bool item_contents::can_reload_with( const item &ammo, const bool now ) const
 bool item_contents::can_unload_liquid() const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) && pocket.can_unload_liquid() ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) && pocket.can_unload_liquid() ) {
             return true;
         }
     }
@@ -1133,9 +1133,9 @@ size_t item_contents::num_item_stacks() const
 {
     size_t num = 0;
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MOD ) ||
-            pocket.is_type( item_pocket::pocket_type::MAGAZINE_WELL ) ||
-            pocket.is_type( item_pocket::pocket_type::CORPSE ) ) {
+        if( pocket.is_type( pocket_type::MOD ) ||
+            pocket.is_type( pocket_type::MAGAZINE_WELL ) ||
+            pocket.is_type( pocket_type::CORPSE ) ) {
             // mods and magazine wells aren't really a contained item, which this function gets
             continue;
         }
@@ -1147,7 +1147,7 @@ size_t item_contents::num_item_stacks() const
 void item_contents::on_pickup( Character &guy, item *avoid )
 {
     for( item_pocket &pocket : contents ) {
-        if( !pocket.is_type( item_pocket::pocket_type::MOD ) ) {
+        if( !pocket.is_type( pocket_type::MOD ) ) {
             pocket.on_pickup( guy, avoid );
         }
     }
@@ -1172,7 +1172,7 @@ void item_contents::overflow( const tripoint &pos, const item_location &loc )
 void item_contents::heat_up()
 {
     for( item_pocket &pocket : contents ) {
-        if( !pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( !pocket.is_type( pocket_type::CONTAINER ) ) {
             continue;
         }
         pocket.heat_up();
@@ -1183,7 +1183,7 @@ int item_contents::ammo_consume( int qty, const tripoint &pos, float fuel_effici
 {
     int consumed = 0;
     for( item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MAGAZINE_WELL ) ) {
+        if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
             // we are assuming only one magazine per well
             if( pocket.empty() ) {
                 return 0;
@@ -1201,7 +1201,7 @@ int item_contents::ammo_consume( int qty, const tripoint &pos, float fuel_effici
             }
             qty -= res;
             consumed += res;
-        } else if( pocket.is_type( item_pocket::pocket_type::MAGAZINE ) ) {
+        } else if( pocket.is_type( pocket_type::MAGAZINE ) ) {
             if( !pocket.empty() && pocket.front().is_fuel() && fuel_efficiency >= 0 ) {
                 // if using fuel instead of battery, everything is in kJ
                 // charges is going to be the energy needed over the energy in 1 unit of fuel * the efficiency of the generator
@@ -1227,7 +1227,7 @@ int item_contents::ammo_consume( int qty, const tripoint &pos, float fuel_effici
 item *item_contents::magazine_current()
 {
     for( item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MAGAZINE_WELL ) ) {
+        if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
             item *mag = pocket.magazine_current();
             if( mag != nullptr ) {
                 return mag;
@@ -1241,7 +1241,7 @@ int item_contents::ammo_capacity( const ammotype &ammo ) const
 {
     int ret = 0;
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MAGAZINE ) ) {
+        if( pocket.is_type( pocket_type::MAGAZINE ) ) {
             ret += pocket.ammo_capacity( ammo );
         }
     }
@@ -1266,10 +1266,10 @@ item &item_contents::first_ammo()
         return null_item_reference();
     }
     for( item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MAGAZINE_WELL ) ) {
+        if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
             return pocket.front().first_ammo();
         }
-        if( !pocket.is_type( item_pocket::pocket_type::MAGAZINE ) || pocket.empty() ) {
+        if( !pocket.is_type( pocket_type::MAGAZINE ) || pocket.empty() ) {
             continue;
         }
         if( pocket.front().has_flag( json_flag_CASING ) ) {
@@ -1292,10 +1292,10 @@ const item &item_contents::first_ammo() const
         return null_item_reference();
     }
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MAGAZINE_WELL ) ) {
+        if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
             return pocket.front().first_ammo();
         }
-        if( !pocket.is_type( item_pocket::pocket_type::MAGAZINE ) || pocket.empty() ) {
+        if( !pocket.is_type( pocket_type::MAGAZINE ) || pocket.empty() ) {
             continue;
         }
         if( pocket.front().has_flag( json_flag_CASING ) ) {
@@ -1314,7 +1314,7 @@ const item &item_contents::first_ammo() const
 bool item_contents::will_spill() const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) && pocket.will_spill() ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) && pocket.will_spill() ) {
             return true;
         }
     }
@@ -1324,7 +1324,7 @@ bool item_contents::will_spill() const
 bool item_contents::will_spill_if_unsealed() const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER )
+        if( pocket.is_type( pocket_type::CONTAINER )
             && pocket.will_spill_if_unsealed() ) {
             return true;
         }
@@ -1335,7 +1335,7 @@ bool item_contents::will_spill_if_unsealed() const
 bool item_contents::spill_open_pockets( Character &guy, const item *avoid )
 {
     for( item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) && pocket.will_spill() ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) && pocket.will_spill() ) {
             pocket.handle_liquid_or_spill( guy, avoid );
             if( !pocket.empty() ) {
                 return false;
@@ -1348,7 +1348,7 @@ bool item_contents::spill_open_pockets( Character &guy, const item *avoid )
 void item_contents::handle_liquid_or_spill( Character &guy, const item *const avoid )
 {
     for( item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) ) {
             pocket.handle_liquid_or_spill( guy, avoid );
         }
     }
@@ -1371,7 +1371,7 @@ void item_contents::clear_items()
 void item_contents::clear_magazines()
 {
     for( item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MAGAZINE ) ) {
+        if( pocket.is_type( pocket_type::MAGAZINE ) ) {
             pocket.clear_items();
         }
     }
@@ -1421,7 +1421,7 @@ bool item_contents::all_pockets_sealed() const
 
     bool all_sealed = false;
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) ) {
             if( !pocket.sealed() ) {
                 return false;
             } else {
@@ -1436,7 +1436,7 @@ bool item_contents::all_pockets_sealed() const
 bool item_contents::any_pockets_sealed() const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) ) {
             if( pocket.sealed() ) {
                 return true;
             }
@@ -1446,7 +1446,7 @@ bool item_contents::any_pockets_sealed() const
     return false;
 }
 
-bool item_contents::has_pocket_type( const item_pocket::pocket_type pk_type ) const
+bool item_contents::has_pocket_type( const pocket_type pk_type ) const
 {
     for( const item_pocket &pocket : contents ) {
         if( pocket.is_type( pk_type ) ) {
@@ -1468,7 +1468,7 @@ bool item_contents::has_unrestricted_pockets() const
 }
 
 bool item_contents::has_any_with( const std::function<bool( const item &it )> &filter,
-                                  item_pocket::pocket_type pk_type ) const
+                                  pocket_type pk_type ) const
 {
     for( const item_pocket &pocket : contents ) {
         if( !pocket.is_type( pk_type ) ) {
@@ -1509,7 +1509,7 @@ bool item_contents::same_contents( const item_contents &rhs ) const
 bool item_contents::is_funnel_container( units::volume &bigger_than ) const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) ) {
             if( pocket.is_funnel_container( bigger_than ) ) {
                 return true;
             }
@@ -1537,7 +1537,7 @@ bool item_contents::is_single_restricted_container() const
 item &item_contents::first_item()
 {
     for( item_pocket &pocket : contents ) {
-        if( pocket.empty() || !pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( pocket.empty() || !pocket.is_type( pocket_type::CONTAINER ) ) {
             continue;
         }
         // the first item we come to is the only one.
@@ -1558,8 +1558,8 @@ item &item_contents::only_item()
 const item &item_contents::first_item() const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.empty() || !( pocket.is_type( item_pocket::pocket_type::CONTAINER ) ||
-                                 pocket.is_type( item_pocket::pocket_type::SOFTWARE ) ) ) {
+        if( pocket.empty() || !( pocket.is_type( pocket_type::CONTAINER ) ||
+                                 pocket.is_type( pocket_type::SOFTWARE ) ) ) {
             continue;
         }
         // the first item we come to is the only one.
@@ -1581,7 +1581,7 @@ const item &item_contents::only_item() const
 item *item_contents::get_item_with( const std::function<bool( const item &it )> &filter )
 {
     for( item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CABLE ) ) {
+        if( pocket.is_type( pocket_type::CABLE ) ) {
             continue;
         }
         item *it = pocket.get_item_with( filter );
@@ -1596,7 +1596,7 @@ const item *item_contents::get_item_with( const std::function<bool( const item &
 const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CABLE ) ) {
+        if( pocket.is_type( pocket_type::CABLE ) ) {
             continue;
         }
         const item *it = pocket.get_item_with( filter );
@@ -1626,7 +1626,7 @@ std::list<item *> item_contents::all_items_top( const std::function<bool( item_p
     return all_items_internal;
 }
 
-std::list<item *> item_contents::all_items_top( item_pocket::pocket_type pk_type,
+std::list<item *> item_contents::all_items_top( pocket_type pk_type,
         bool unloading )
 {
     if( unloading ) {
@@ -1653,7 +1653,7 @@ std::list<const item *> item_contents::all_items_top( const
     return all_items_internal;
 }
 
-std::list<const item *> item_contents::all_items_top( item_pocket::pocket_type pk_type ) const
+std::list<const item *> item_contents::all_items_top( pocket_type pk_type ) const
 {
     return all_items_top( [pk_type]( const item_pocket & pocket ) {
         return pocket.is_type( pk_type );
@@ -1724,7 +1724,7 @@ std::vector<item *> item_contents::gunmods()
 {
     std::vector<item *> mods;
     for( item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MOD ) ) {
+        if( pocket.is_type( pocket_type::MOD ) ) {
             std::vector<item *> internal_mods{ pocket.gunmods() };
             mods.insert( mods.end(), internal_mods.begin(), internal_mods.end() );
         }
@@ -1736,7 +1736,7 @@ std::vector<const item *> item_contents::gunmods() const
 {
     std::vector<const item *> mods;
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MOD ) ) {
+        if( pocket.is_type( pocket_type::MOD ) ) {
             std::vector<const item *> internal_mods{ pocket.gunmods() };
             mods.insert( mods.end(), internal_mods.begin(), internal_mods.end() );
         }
@@ -1747,7 +1747,7 @@ std::vector<const item *> item_contents::gunmods() const
 bool item_contents::allows_speedloader( const itype_id &speedloader_id ) const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MAGAZINE ) ) {
+        if( pocket.is_type( pocket_type::MAGAZINE ) ) {
             return pocket.allows_speedloader( speedloader_id );
         }
     }
@@ -1758,7 +1758,7 @@ std::vector<const item *> item_contents::mods() const
 {
     std::vector<const item *> mods;
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MOD ) ) {
+        if( pocket.is_type( pocket_type::MOD ) ) {
             for( const item *it : pocket.all_items_top() ) {
                 mods.insert( mods.end(), it );
             }
@@ -1771,7 +1771,7 @@ std::vector<const item *> item_contents::softwares() const
 {
     std::vector<const item *> softwares;
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::SOFTWARE ) ) {
+        if( pocket.is_type( pocket_type::SOFTWARE ) ) {
             for( const item *it : pocket.all_items_top() ) {
                 softwares.insert( softwares.end(), it );
             }
@@ -1784,7 +1784,7 @@ std::vector<item *> item_contents::ebooks()
 {
     std::vector<item *> ebooks;
     for( item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::EBOOK ) ) {
+        if( pocket.is_type( pocket_type::EBOOK ) ) {
             for( item *it : pocket.all_items_top() ) {
                 ebooks.emplace_back( it );
             }
@@ -1797,7 +1797,7 @@ std::vector<const item *> item_contents::ebooks() const
 {
     std::vector<const item *> ebooks;
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::EBOOK ) ) {
+        if( pocket.is_type( pocket_type::EBOOK ) ) {
             for( const item *it : pocket.all_items_top() ) {
                 ebooks.emplace_back( it );
             }
@@ -1810,7 +1810,7 @@ std::vector<item *> item_contents::cables()
 {
     std::vector<item *> cables;
     for( item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CABLE ) ) {
+        if( pocket.is_type( pocket_type::CABLE ) ) {
             for( item *it : pocket.all_items_top() ) {
                 cables.emplace_back( it );
             }
@@ -1823,7 +1823,7 @@ std::vector<const item *> item_contents::cables() const
 {
     std::vector<const item *> cables;
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CABLE ) ) {
+        if( pocket.is_type( pocket_type::CABLE ) ) {
             for( const item *it : pocket.all_items_top() ) {
                 // TODO: remove flag check after 0.H
                 if( it->has_flag( STATIC( flag_id( "CABLE_SPOOL" ) ) ) ) {
@@ -1841,7 +1841,7 @@ void item_contents::update_modified_pockets(
 {
     for( auto pocket_iter = contents.begin(); pocket_iter != contents.end(); ) {
         item_pocket &pocket = *pocket_iter;
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) ) {
 
             const pocket_data *current = pocket.get_pocket_data();
             bool found = false;
@@ -1870,8 +1870,8 @@ void item_contents::update_modified_pockets(
                 ++pocket_iter;
             }
 
-        } else if( pocket.is_type( item_pocket::pocket_type::MAGAZINE ) ||
-                   pocket.is_type( item_pocket::pocket_type::MAGAZINE_WELL ) ) {
+        } else if( pocket.is_type( pocket_type::MAGAZINE ) ||
+                   pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
             if( mag_or_mag_well ) {
                 if( pocket.get_pocket_data() != *mag_or_mag_well ) {
                     if( !pocket.empty() ) {
@@ -1903,7 +1903,7 @@ std::set<itype_id> item_contents::magazine_compatible() const
 {
     std::set<itype_id> ret;
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MAGAZINE_WELL ) ) {
+        if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
             for( const itype_id &id : pocket.item_type_restrictions() ) {
                 if( item_is_blacklisted( id ) ) {
                     continue;
@@ -1918,7 +1918,7 @@ std::set<itype_id> item_contents::magazine_compatible() const
 itype_id item_contents::magazine_default() const
 {
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::MAGAZINE_WELL ) ) {
+        if( pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
             return pocket.magazine_default();
         }
     }
@@ -1934,7 +1934,7 @@ const
         if( pocket.is_forbidden() ) {
             continue;
         }
-        bool restriction_condition = pocket.is_type( item_pocket::pocket_type::CONTAINER ) &&
+        bool restriction_condition = pocket.is_type( pocket_type::CONTAINER ) &&
                                      !pocket.is_ablative() && pocket.weight_capacity() < pocket_data::max_weight_for_container;
         if( unrestricted_pockets_only ) {
             restriction_condition = restriction_condition && !pocket.is_restricted();
@@ -1975,14 +1975,14 @@ std::vector<item_pocket *> item_contents::get_pockets( const
 std::vector<const item_pocket *> item_contents::get_all_contained_pockets() const
 {
     return get_pockets( []( item_pocket const & pocket ) {
-        return pocket.is_type( item_pocket::pocket_type::CONTAINER );
+        return pocket.is_type( pocket_type::CONTAINER );
     } );
 }
 
 std::vector<item_pocket *> item_contents::get_all_contained_pockets()
 {
     return get_pockets( []( item_pocket const & pocket ) {
-        return pocket.is_type( item_pocket::pocket_type::CONTAINER );
+        return pocket.is_type( pocket_type::CONTAINER );
     } );
 }
 
@@ -2140,9 +2140,9 @@ std::vector< const item_pocket *> item_contents::get_all_reloadable_pockets() co
     std::vector<const item_pocket *> pockets;
 
     for( const item_pocket &pocket : contents ) {
-        if( ( pocket.is_type( item_pocket::pocket_type::CONTAINER ) && pocket.watertight() ) ||
-            pocket.is_type( item_pocket::pocket_type::MAGAZINE ) ||
-            pocket.is_type( item_pocket::pocket_type::MAGAZINE_WELL ) ) {
+        if( ( pocket.is_type( pocket_type::CONTAINER ) && pocket.watertight() ) ||
+            pocket.is_type( pocket_type::MAGAZINE ) ||
+            pocket.is_type( pocket_type::MAGAZINE_WELL ) ) {
             pockets.push_back( &pocket );
         }
     }
@@ -2153,7 +2153,7 @@ int item_contents::get_used_holsters() const
 {
     int holsters = 0;
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) && pocket.holster_full() ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) && pocket.holster_full() ) {
             holsters++;
         }
     }
@@ -2164,7 +2164,7 @@ int item_contents::get_total_holsters() const
 {
     int holsters = 0;
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) && pocket.is_holster() ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) && pocket.is_holster() ) {
             holsters++;
         }
     }
@@ -2175,7 +2175,7 @@ units::volume item_contents::get_used_holster_volume() const
 {
     units::volume holster_volume = 0_ml;
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) && pocket.holster_full() ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) && pocket.holster_full() ) {
             holster_volume += pocket.volume_capacity();
         }
     }
@@ -2186,7 +2186,7 @@ units::volume item_contents::get_total_holster_volume() const
 {
     units::volume holster_volume = 0_ml;
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) && pocket.is_holster() ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) && pocket.is_holster() ) {
             holster_volume += pocket.volume_capacity();
         }
     }
@@ -2197,7 +2197,7 @@ units::mass item_contents::get_used_holster_weight() const
 {
     units::mass holster_weight = units::mass();
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) && pocket.is_holster() ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) && pocket.is_holster() ) {
             holster_weight += pocket.contains_weight();
         }
     }
@@ -2208,7 +2208,7 @@ units::mass item_contents::get_total_holster_weight() const
 {
     units::mass holster_weight = units::mass();
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) && pocket.is_holster() ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) && pocket.is_holster() ) {
             holster_weight += pocket.weight_capacity();
         }
     }
@@ -2222,7 +2222,7 @@ units::volume item_contents::total_container_capacity( const bool unrestricted_p
         if( pocket.is_forbidden() ) {
             continue;
         }
-        bool restriction_condition = pocket.is_type( item_pocket::pocket_type::CONTAINER );
+        bool restriction_condition = pocket.is_type( pocket_type::CONTAINER );
         if( unrestricted_pockets_only ) {
             restriction_condition = restriction_condition && !pocket.is_restricted();
         }
@@ -2264,7 +2264,7 @@ const
         if( pocket.is_forbidden() ) {
             continue;
         }
-        bool restriction_condition = pocket.is_type( item_pocket::pocket_type::CONTAINER );
+        bool restriction_condition = pocket.is_type( pocket_type::CONTAINER );
         if( unrestricted_pockets_only ) {
             restriction_condition = restriction_condition && !pocket.is_restricted();
         }
@@ -2279,7 +2279,7 @@ units::volume item_contents::total_contained_volume( const bool unrestricted_poc
 {
     units::volume total_vol = 0_ml;
     for( const item_pocket &pocket : contents ) {
-        bool restriction_condition = pocket.is_type( item_pocket::pocket_type::CONTAINER );
+        bool restriction_condition = pocket.is_type( pocket_type::CONTAINER );
         if( unrestricted_pockets_only ) {
             restriction_condition = restriction_condition && !pocket.is_restricted();
         }
@@ -2298,7 +2298,7 @@ units::mass item_contents::remaining_container_capacity_weight( const bool
         if( pocket.is_forbidden() ) {
             continue;
         }
-        bool restriction_condition = pocket.is_type( item_pocket::pocket_type::CONTAINER );
+        bool restriction_condition = pocket.is_type( pocket_type::CONTAINER );
         if( unrestricted_pockets_only ) {
             restriction_condition = restriction_condition && !pocket.is_restricted();
         }
@@ -2313,7 +2313,7 @@ units::mass item_contents::total_contained_weight( const bool unrestricted_pocke
 {
     units::mass total_weight = 0_gram;
     for( const item_pocket &pocket : contents ) {
-        bool restriction_condition = pocket.is_type( item_pocket::pocket_type::CONTAINER );
+        bool restriction_condition = pocket.is_type( pocket_type::CONTAINER );
         if( unrestricted_pockets_only ) {
             restriction_condition = restriction_condition && !pocket.is_restricted();
         }
@@ -2397,7 +2397,7 @@ void item_contents::process( map &here, Character *carrier, const tripoint &pos,
                              temperature_flag flag, float spoil_multiplier_parent )
 {
     for( item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) ) {
             pocket.process( here, carrier, pos, insulation, flag, spoil_multiplier_parent );
         }
     }
@@ -2406,7 +2406,7 @@ void item_contents::process( map &here, Character *carrier, const tripoint &pos,
 void item_contents::leak( map &here, Character *carrier, const tripoint &pos, item_pocket *pocke )
 {
     for( item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) ) {
             pocket.leak( here, carrier, pos, pocke );
         }
     }
@@ -2418,7 +2418,7 @@ int item_contents::remaining_capacity_for_liquid( const item &liquid ) const
     item liquid_copy = liquid;
     liquid_copy.charges = 1;
     for( const item_pocket &pocket : contents ) {
-        if( !pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( !pocket.is_type( pocket_type::CONTAINER ) ) {
             continue;
         }
         charges_of_liquid += pocket.remaining_capacity_for_item( liquid );
@@ -2431,7 +2431,7 @@ float item_contents::relative_encumbrance() const
     units::volume nonrigid_max_volume;
     units::volume nonrigid_volume;
     for( const item_pocket &pocket : contents ) {
-        if( !pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( !pocket.is_type( pocket_type::CONTAINER ) ) {
             continue;
         }
         if( pocket.rigid() ) {
@@ -2455,7 +2455,7 @@ float item_contents::relative_encumbrance() const
 bool item_contents::all_pockets_rigid() const
 {
     for( const item_pocket &pocket : contents ) {
-        if( !pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( !pocket.is_type( pocket_type::CONTAINER ) ) {
             continue;
         }
         if( !pocket.rigid() ) {
@@ -2515,7 +2515,7 @@ void item_contents::info( std::vector<iteminfo> &info, const iteminfo_query *par
     std::vector<item_pocket> found_pockets;
     std::map<int, int> pocket_num; // index, amount
     for( const item_pocket &pocket : contents ) {
-        if( pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( pocket.is_type( pocket_type::CONTAINER ) ) {
             bool found = false;
             int idx = 0;
             for( const item_pocket &found_pocket : found_pockets ) {

--- a/src/item_contents.h
+++ b/src/item_contents.h
@@ -105,9 +105,9 @@ class item_contents
         const;
         /** returns a list of pointers to all top-level items */
         /** if unloading is true it ignores items in pockets that are flagged to not unload */
-        std::list<item *> all_items_top( item_pocket::pocket_type pk_type, bool unloading = false );
+        std::list<item *> all_items_top( pocket_type pk_type, bool unloading = false );
         /** returns a list of pointers to all top-level items */
-        std::list<const item *> all_items_top( item_pocket::pocket_type pk_type ) const;
+        std::list<const item *> all_items_top( pocket_type pk_type ) const;
 
         /** returns a list of pointers to all top-level items that are not mods */
         std::list<item *> all_items_top();
@@ -256,9 +256,9 @@ class item_contents
          * pocket, items will be successfully inserted without regard to volume, length, or any
          * other restrictions, since these pockets are not considered to be normal "containers".
          */
-        ret_val<item *> insert_item( const item &it, item_pocket::pocket_type pk_type,
+        ret_val<item *> insert_item( const item &it, pocket_type pk_type,
                                      bool ignore_contents = false, bool unseal_pockets = false );
-        void force_insert_item( const item &it, item_pocket::pocket_type pk_type );
+        void force_insert_item( const item &it, pocket_type pk_type );
         bool can_unload_liquid() const;
 
         /**
@@ -326,10 +326,10 @@ class item_contents
         void remove_items_if( const std::function<bool( item & )> &filter );
 
         // whether the contents has a pocket with the associated type
-        bool has_pocket_type( item_pocket::pocket_type pk_type ) const;
+        bool has_pocket_type( pocket_type pk_type ) const;
         bool has_unrestricted_pockets() const;
         bool has_any_with( const std::function<bool( const item & )> &filter,
-                           item_pocket::pocket_type pk_type ) const;
+                           pocket_type pk_type ) const;
 
         /**
          * Is part of the recursive call of item::process. see that function for additional comments
@@ -371,10 +371,10 @@ class item_contents
         // this will be where the algorithm picks the best pocket in the contents
         // returns nullptr if none is found
         ret_val<item_pocket *> find_pocket_for( const item &it,
-                                                item_pocket::pocket_type pk_type = item_pocket::pocket_type::CONTAINER );
+                                                pocket_type pk_type = pocket_type::CONTAINER );
 
         ret_val<const item_pocket *> find_pocket_for( const item &it,
-                item_pocket::pocket_type pk_type = item_pocket::pocket_type::CONTAINER ) const;
+                pocket_type pk_type = pocket_type::CONTAINER ) const;
 
         std::list<item_pocket> contents;
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -39,11 +39,11 @@
 #include "item.h"
 #include "item_contents.h"
 #include "item_group.h"
-#include "item_pocket.h"
 #include "iuse_actor.h"
 #include "json.h"
 #include "material.h"
 #include "options.h"
+#include "pocket_type.h"
 #include "proficiency.h"
 #include "recipe.h"
 #include "recipe_dictionary.h"
@@ -449,7 +449,7 @@ void Item_factory::finalize_pre( itype &obj )
         }
 
         for( pocket_data &magazine : obj.pockets ) {
-            if( magazine.type != item_pocket::pocket_type::MAGAZINE ) {
+            if( magazine.type != pocket_type::MAGAZINE ) {
                 continue;
             }
             migrate_ammo_map( magazine.ammo_restriction );
@@ -544,7 +544,7 @@ void Item_factory::finalize_pre( itype &obj )
 
         // generate cached map for [mag type_id] -> [set of compatible guns]
         for( const pocket_data &pocket : obj.pockets ) {
-            if( pocket.type != item_pocket::pocket_type::MAGAZINE_WELL ) {
+            if( pocket.type != pocket_type::MAGAZINE_WELL ) {
                 continue;
             }
             for( const itype_id &mag_type_id : pocket.item_id_restriction ) {
@@ -556,7 +556,7 @@ void Item_factory::finalize_pre( itype &obj )
         }
 
         for( pocket_data &magazine : obj.pockets ) {
-            if( magazine.type != item_pocket::pocket_type::MAGAZINE ) {
+            if( magazine.type != pocket_type::MAGAZINE ) {
                 continue;
             }
             migrate_ammo_map( magazine.ammo_restriction );
@@ -1892,7 +1892,7 @@ void Item_factory::check_definitions() const
     auto is_container = []( const itype * t ) {
         bool am_container = false;
         for( const pocket_data &pocket : t->pockets ) {
-            if( pocket.type == item_pocket::pocket_type::CONTAINER ) {
+            if( pocket.type == pocket_type::CONTAINER ) {
                 am_container = true;
                 // no need to look further
                 break;
@@ -1923,8 +1923,8 @@ void Item_factory::check_definitions() const
 
         int mag_pocket_number = 0;
         for( const pocket_data &data : type->pockets ) {
-            if( data.type == item_pocket::pocket_type::MAGAZINE ||
-                data.type == item_pocket::pocket_type::MAGAZINE_WELL ) {
+            if( data.type == pocket_type::MAGAZINE ||
+                data.type == pocket_type::MAGAZINE_WELL ) {
                 mag_pocket_number++;
             }
             std::string pocket_error = data.check_definition();
@@ -2365,7 +2365,7 @@ void Item_factory::check_definitions() const
                 } else {
                     // Verify that every magazine type can actually be put in
                     // this item
-                    item( type ).put_in( item( magazine ), item_pocket::pocket_type::MAGAZINE_WELL );
+                    item( type ).put_in( item( magazine ), pocket_type::MAGAZINE_WELL );
                 }
             }
         }
@@ -3659,7 +3659,7 @@ void Item_factory::npc_implied_flags( itype &item_template )
     }
 }
 
-static bool has_pocket_type( const std::vector<pocket_data> &data, item_pocket::pocket_type pk )
+static bool has_pocket_type( const std::vector<pocket_data> &data, pocket_type pk )
 {
     for( const pocket_data &pocket : data ) {
         if( pocket.type == pk ) {
@@ -3679,7 +3679,7 @@ static bool has_only_special_pockets( const itype &def )
         return true;
     }
 
-    const std::vector<item_pocket::pocket_type> special_pockets = { item_pocket::pocket_type::CORPSE, item_pocket::pocket_type::MOD, item_pocket::pocket_type::MIGRATION };
+    const std::vector<pocket_type> special_pockets = { pocket_type::CORPSE, pocket_type::MOD, pocket_type::MIGRATION };
 
     for( const pocket_data &pocket : def.pockets ) {
         if( std::find( special_pockets.begin(), special_pockets.end(),
@@ -3731,7 +3731,7 @@ void Item_factory::check_and_create_magazine_pockets( itype &def )
     mag_data.max_item_length = 2_km;
     mag_data.watertight = true;
     if( !def.magazines.empty() ) {
-        mag_data.type = item_pocket::pocket_type::MAGAZINE_WELL;
+        mag_data.type = pocket_type::MAGAZINE_WELL;
         mag_data.rigid = false;
         ammotype default_ammo = ammotype::NULL_ID();
         if( def.tool ) {
@@ -3753,7 +3753,7 @@ void Item_factory::check_and_create_magazine_pockets( itype &def )
             }
         }
     } else {
-        mag_data.type = item_pocket::pocket_type::MAGAZINE;
+        mag_data.type = pocket_type::MAGAZINE;
         mag_data.rigid = true;
         if( def.magazine ) {
             for( const ammotype &amtype : def.magazine->type ) {
@@ -3775,18 +3775,18 @@ void Item_factory::check_and_create_magazine_pockets( itype &def )
 void Item_factory::add_special_pockets( itype &def )
 {
     if( def.has_flag( flag_CORPSE ) &&
-        !has_pocket_type( def.pockets, item_pocket::pocket_type::CORPSE ) ) {
-        def.pockets.emplace_back( item_pocket::pocket_type::CORPSE );
+        !has_pocket_type( def.pockets, pocket_type::CORPSE ) ) {
+        def.pockets.emplace_back( pocket_type::CORPSE );
     }
-    if( ( def.tool || def.gun ) && !has_pocket_type( def.pockets, item_pocket::pocket_type::MOD ) ) {
-        def.pockets.emplace_back( item_pocket::pocket_type::MOD );
+    if( ( def.tool || def.gun ) && !has_pocket_type( def.pockets, pocket_type::MOD ) ) {
+        def.pockets.emplace_back( pocket_type::MOD );
     }
-    if( !has_pocket_type( def.pockets, item_pocket::pocket_type::MIGRATION ) ) {
-        def.pockets.emplace_back( item_pocket::pocket_type::MIGRATION );
+    if( !has_pocket_type( def.pockets, pocket_type::MIGRATION ) ) {
+        def.pockets.emplace_back( pocket_type::MIGRATION );
     }
-    if( !has_pocket_type( def.pockets, item_pocket::pocket_type::CABLE ) &&
+    if( !has_pocket_type( def.pockets, pocket_type::CABLE ) &&
         def.get_use( "link_up" ) != nullptr ) {
-        pocket_data cable_pocket( item_pocket::pocket_type::CABLE );
+        pocket_data cable_pocket( pocket_type::CABLE );
         cable_pocket.rigid = false;
         def.pockets.emplace_back( cable_pocket );
     }
@@ -3985,7 +3985,7 @@ void acc_data::load( const JsonObject &jo )
 static void migrate_mag_from_pockets( itype &def )
 {
     for( const pocket_data &pocket : def.pockets ) {
-        if( pocket.type == item_pocket::pocket_type::MAGAZINE_WELL ) {
+        if( pocket.type == pocket_type::MAGAZINE_WELL ) {
             if( def.gun ) {
                 for( const ammotype &atype : def.gun->ammo ) {
                     def.magazine_default.emplace( atype, pocket.default_magazine );
@@ -4593,8 +4593,8 @@ void Item_factory::migrate_item( const itype_id &id, item &obj )
             count = 1;
         }
         for( ; count > 0; --count ) {
-            if( !obj.put_in( content, item_pocket::pocket_type::CONTAINER ).success() ) {
-                obj.put_in( content, item_pocket::pocket_type::MIGRATION );
+            if( !obj.put_in( content, pocket_type::CONTAINER ).success() ) {
+                obj.put_in( content, pocket_type::MIGRATION );
             }
         }
     }

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -39,19 +39,19 @@ namespace io
 {
 // *INDENT-OFF*
 template<>
-std::string enum_to_string<item_pocket::pocket_type>( item_pocket::pocket_type data )
+std::string enum_to_string<pocket_type>( pocket_type data )
 {
     switch ( data ) {
-    case item_pocket::pocket_type::CONTAINER: return "CONTAINER";
-    case item_pocket::pocket_type::MAGAZINE: return "MAGAZINE";
-    case item_pocket::pocket_type::MAGAZINE_WELL: return "MAGAZINE_WELL";
-    case item_pocket::pocket_type::MOD: return "MOD";
-    case item_pocket::pocket_type::CORPSE: return "CORPSE";
-    case item_pocket::pocket_type::SOFTWARE: return "SOFTWARE";
-    case item_pocket::pocket_type::EBOOK: return "EBOOK";
-    case item_pocket::pocket_type::CABLE: return "CABLE";
-    case item_pocket::pocket_type::MIGRATION: return "MIGRATION";
-    case item_pocket::pocket_type::LAST: break;
+    case pocket_type::CONTAINER: return "CONTAINER";
+    case pocket_type::MAGAZINE: return "MAGAZINE";
+    case pocket_type::MAGAZINE_WELL: return "MAGAZINE_WELL";
+    case pocket_type::MOD: return "MOD";
+    case pocket_type::CORPSE: return "CORPSE";
+    case pocket_type::SOFTWARE: return "SOFTWARE";
+    case pocket_type::EBOOK: return "EBOOK";
+    case pocket_type::CABLE: return "CABLE";
+    case pocket_type::MIGRATION: return "MIGRATION";
+    case pocket_type::LAST: break;
     }
     cata_fatal( "Invalid valid_target" );
 }
@@ -62,9 +62,9 @@ std::vector<item_pocket::favorite_settings> item_pocket::pocket_presets;
 
 std::string pocket_data::check_definition() const
 {
-    if( type == item_pocket::pocket_type::MOD ||
-        type == item_pocket::pocket_type::CORPSE ||
-        type == item_pocket::pocket_type::MIGRATION ) {
+    if( type == pocket_type::MOD ||
+        type == pocket_type::CORPSE ||
+        type == pocket_type::MIGRATION ) {
         return "";
     }
     for( const itype_id &it : item_id_restriction ) {
@@ -119,7 +119,7 @@ std::string pocket_data::check_definition() const
 
 void pocket_data::load( const JsonObject &jo )
 {
-    optional( jo, was_loaded, "pocket_type", type, item_pocket::pocket_type::CONTAINER );
+    optional( jo, was_loaded, "pocket_type", type, pocket_type::CONTAINER );
     optional( jo, was_loaded, "ammo_restriction", ammo_restriction );
     optional( jo, was_loaded, "flag_restriction", flag_restrictions );
     optional( jo, was_loaded, "item_restriction", item_id_restriction );
@@ -246,7 +246,7 @@ void item_pocket::restack()
     if( contents.size() <= 1 ) {
         return;
     }
-    if( is_type( item_pocket::pocket_type::MAGAZINE ) ) {
+    if( is_type( pocket_type::MAGAZINE ) ) {
         // Restack magazine contents in a way that preserves order of items
         for( auto iter = contents.begin(); iter != contents.end(); ) {
             if( !iter->count_by_charges() ) {
@@ -291,7 +291,7 @@ item *item_pocket::restack( /*const*/ item *it )
     if( contents.size() <= 1 ) {
         return ret;
     }
-    if( is_type( item_pocket::pocket_type::MAGAZINE ) ) {
+    if( is_type( pocket_type::MAGAZINE ) ) {
         // Restack magazine contents in a way that preserves order of items
         for( auto iter = contents.begin(); iter != contents.end(); ) {
             if( !iter->count_by_charges() ) {
@@ -489,7 +489,7 @@ std::list<const item *> item_pocket::all_items_top() const
     return items;
 }
 
-std::list<item *> item_pocket::all_items_ptr( item_pocket::pocket_type pk_type )
+std::list<item *> item_pocket::all_items_ptr( pocket_type pk_type )
 {
     if( !is_type( pk_type ) ) {
         return std::list<item *>();
@@ -503,7 +503,7 @@ std::list<item *> item_pocket::all_items_ptr( item_pocket::pocket_type pk_type )
     return all_items_top_level;
 }
 
-std::list<const item *> item_pocket::all_items_ptr( item_pocket::pocket_type pk_type ) const
+std::list<const item *> item_pocket::all_items_ptr( pocket_type pk_type ) const
 {
     if( !is_type( pk_type ) ) {
         return std::list<const item *>();
@@ -608,7 +608,7 @@ units::volume item_pocket::item_size_modifier() const
     }
     units::volume total_vol = 0_ml;
     for( const item &it : contents ) {
-        total_vol += it.volume( is_type( item_pocket::pocket_type::MOD ) );
+        total_vol += it.volume( is_type( pocket_type::MOD ) );
     }
     total_vol -= data->magazine_well;
     total_vol *= data->volume_multiplier;
@@ -619,7 +619,7 @@ units::mass item_pocket::item_weight_modifier() const
 {
     units::mass total_mass = 0_gram;
     for( const item &it : contents ) {
-        if( is_type( item_pocket::pocket_type::MOD ) ) {
+        if( is_type( pocket_type::MOD ) ) {
             total_mass += it.weight( true, true ) * data->weight_multiplier;
         } else {
             total_mass += it.weight() * data->weight_multiplier;
@@ -630,7 +630,7 @@ units::mass item_pocket::item_weight_modifier() const
 
 units::length item_pocket::item_length_modifier() const
 {
-    if( is_type( item_pocket::pocket_type::EBOOK ) ) {
+    if( is_type( pocket_type::EBOOK ) ) {
         return 0_mm;
     }
     units::length total_length = 0_mm;
@@ -697,7 +697,7 @@ item *item_pocket::magazine_current()
 
 itype_id item_pocket::magazine_default() const
 {
-    if( is_type( item_pocket::pocket_type::MAGAZINE_WELL ) ) {
+    if( is_type( pocket_type::MAGAZINE_WELL ) ) {
         return data->default_magazine;
     }
     return itype_id::NULL_ID();
@@ -1333,13 +1333,13 @@ ret_val<item_pocket::contain_code> item_pocket::is_compatible( const item &it ) 
                    contain_code::ERR_MOD, _( "cannot unwield item" ) );
     }
 
-    if( data->type == item_pocket::pocket_type::CORPSE ) {
+    if( data->type == pocket_type::CORPSE ) {
         // corpses can't have items stored in them the normal way,
         // we simply don't want them to "spill"
         return ret_val<item_pocket::contain_code>::make_success();
     }
 
-    if( data->type == item_pocket::pocket_type::EBOOK ) {
+    if( data->type == pocket_type::EBOOK ) {
         if( it.is_book() ) {
             return ret_val<item_pocket::contain_code>::make_success();
         } else {
@@ -1348,7 +1348,7 @@ ret_val<item_pocket::contain_code> item_pocket::is_compatible( const item &it ) 
         }
     }
 
-    if( data->type == item_pocket::pocket_type::CABLE ) {
+    if( data->type == pocket_type::CABLE ) {
         if( it.has_flag( flag_CABLE_SPOOL ) ) {
             return ret_val<item_pocket::contain_code>::make_success();
         } else {
@@ -1357,7 +1357,7 @@ ret_val<item_pocket::contain_code> item_pocket::is_compatible( const item &it ) 
         }
     }
 
-    if( data->type == item_pocket::pocket_type::MOD ) {
+    if( data->type == pocket_type::MOD ) {
         if( it.is_toolmod() || it.is_gunmod() ) {
             return ret_val<item_pocket::contain_code>::make_success();
         } else {
@@ -1453,14 +1453,14 @@ ret_val<item_pocket::contain_code> item_pocket::_can_contain( const item &it,
     if( copies_remaining <= 0 ) {
         return ret_val<item_pocket::contain_code>::make_success();
     }
-    if( data->type == item_pocket::pocket_type::CORPSE ) {
+    if( data->type == pocket_type::CORPSE ) {
         // corpses can't have items stored in them the normal way,
         // we simply don't want them to "spill"
         copies_remaining = 0;
         return ret_val<item_pocket::contain_code>::make_success();
     }
     // To prevent debugmsg. Casings can only be inserted in a magazine during firing.
-    if( data->type == item_pocket::pocket_type::MAGAZINE && it.has_flag( flag_CASING ) ) {
+    if( data->type == pocket_type::MAGAZINE && it.has_flag( flag_CASING ) ) {
         copies_remaining = 0;
         return ret_val<item_pocket::contain_code>::make_success();
     }
@@ -1517,7 +1517,7 @@ ret_val<item_pocket::contain_code> item_pocket::_can_contain( const item &it,
         return ret_val<item_pocket::contain_code>::make_success();
     }
 
-    if( data->type == item_pocket::pocket_type::MAGAZINE && !empty() ) {
+    if( data->type == pocket_type::MAGAZINE && !empty() ) {
         for( const item &contained : contents ) {
             if( contained.has_flag( flag_CASING ) ) {
                 continue;
@@ -1628,7 +1628,7 @@ bool item_pocket::contains_phase( phase_id phase ) const
 
 bool item_pocket::can_reload_with( const item &ammo, const bool now ) const
 {
-    if( is_type( item_pocket::pocket_type::CONTAINER ) ) {
+    if( is_type( pocket_type::CONTAINER ) ) {
         // Only watertight container pockets are reloadable
         if( !watertight() ) {
             return false;
@@ -1673,7 +1673,7 @@ bool item_pocket::can_reload_with( const item &ammo, const bool now ) const
             return true;
         }
 
-        if( is_type( item_pocket::pocket_type::MAGAZINE ) ) {
+        if( is_type( pocket_type::MAGAZINE ) ) {
             // Reloading is refused if
             // Pocket is full of ammo (casings are ignored)
             // Ammos are of different ammo type
@@ -1701,14 +1701,14 @@ bool item_pocket::can_reload_with( const item &ammo, const bool now ) const
 
             return true;
 
-        } else if( is_type( item_pocket::pocket_type::MAGAZINE_WELL ) ) {
+        } else if( is_type( pocket_type::MAGAZINE_WELL ) ) {
             // Reloading is refused if there already is full magazine here
             // Reloading with another identical mag with identical contents is also pointless so it is not allowed
             // Pocket can't know what ammo are compatible with the item so that is checked elsewhere
 
             return !front().is_magazine_full() && !( front().typeId() == ammo.typeId() &&
                     front().same_contents( ammo ) );
-        } else if( is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        } else if( is_type( pocket_type::CONTAINER ) ) {
             // Reloading is possible if liquid combines with old liquid
 
             if( front().can_combine( ammo ) ) {
@@ -2033,7 +2033,7 @@ bool item_pocket::full( bool allow_bucket ) const
         return true;
     }
 
-    if( is_type( item_pocket::pocket_type::MAGAZINE ) && !data->ammo_restriction.empty() ) {
+    if( is_type( pocket_type::MAGAZINE ) && !data->ammo_restriction.empty() ) {
         // Fullness from remaining ammo capacity instead of volume
         for( const item &it : contents ) {
             if( it.has_flag( flag_CASING ) ) {

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -15,6 +15,7 @@
 
 #include "enums.h"
 #include "flat_set.h"
+#include "pocket_type.h"
 #include "ret_val.h"
 #include "type_id.h"
 #include "units.h"
@@ -36,18 +37,6 @@ template <typename E> struct enum_traits;
 class item_pocket
 {
     public:
-        enum class pocket_type : int {
-            CONTAINER,
-            MAGAZINE,
-            MAGAZINE_WELL, //holds magazines
-            MOD, // the gunmods or toolmods
-            CORPSE, // the "corpse" pocket - bionics embedded in a corpse
-            SOFTWARE, // software put into usb or some such
-            EBOOK, // holds electronic books for a device or usb
-            CABLE, // pocket for storing power/data cables and handling their connections
-            MIGRATION, // this allows items to load contents that are too big, in order to spill them later.
-            LAST
-        };
         enum class contain_code : int {
             SUCCESS,
             // only mods can go into the pocket for mods
@@ -468,7 +457,7 @@ class pocket_data
 
         pocket_data() = default;
         // this constructor is used for special types of pockets, not loading
-        explicit pocket_data( item_pocket::pocket_type pk ) : type( pk ) {
+        explicit pocket_data( pocket_type pk ) : type( pk ) {
             rigid = true;
         }
 
@@ -476,7 +465,7 @@ class pocket_data
         static constexpr units::volume max_volume_for_container = 200000000_ml;
         static constexpr units::mass max_weight_for_container = 2000000_kilogram;
 
-        item_pocket::pocket_type type = item_pocket::pocket_type::CONTAINER;
+        pocket_type type = pocket_type::CONTAINER;
         // max volume of stuff the pocket can hold
         units::volume volume_capacity = max_volume_for_container;
         // max volume of item that can be contained, otherwise it spills
@@ -573,8 +562,8 @@ class pocket_data
 };
 
 template<>
-struct enum_traits<item_pocket::pocket_type> {
-    static constexpr item_pocket::pocket_type last = item_pocket::pocket_type::LAST;
+struct enum_traits<pocket_type> {
+    static constexpr pocket_type last = pocket_type::LAST;
 };
 
 template<>

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4669,7 +4669,7 @@ std::optional<int> iuse::blood_draw( Character *p, item *it, const tripoint & )
     if( acid_blood ) {
         item acid( "blood_acid", calendar::turn );
         acid.set_item_temperature( blood_temp );
-        it->put_in( acid, item_pocket::pocket_type::CONTAINER );
+        it->put_in( acid, pocket_type::CONTAINER );
         if( one_in( 3 ) ) {
             if( it->inc_damage() ) {
                 p->add_msg_if_player( m_info, _( "…but acidic blood melts the %s, destroying it!" ),
@@ -4690,7 +4690,7 @@ std::optional<int> iuse::blood_draw( Character *p, item *it, const tripoint & )
     }
 
     blood.set_item_temperature( blood_temp );
-    it->put_in( blood, item_pocket::pocket_type::CONTAINER );
+    it->put_in( blood, pocket_type::CONTAINER );
     p->mod_moves( -to_moves<int>( 5_seconds ) );
     return 1;
 }
@@ -5462,7 +5462,7 @@ std::optional<int> iuse::gunmod_attach( Character *p, item *it, const tripoint &
         const item mod_copy( *it );
         item modded_gun( *loc );
 
-        modded_gun.put_in( mod_copy, item_pocket::pocket_type::MOD );
+        modded_gun.put_in( mod_copy, pocket_type::MOD );
 
         if( !game_menus::inv::compare_items( *loc, modded_gun, _( "Attach modification?" ) ) ) {
             continue;
@@ -7228,7 +7228,7 @@ std::optional<int> iuse::radiocar( Character *p, item *it, const tripoint & )
                 p->moves -= to_moves<int>( 3_seconds );
                 p->add_msg_if_player( _( "You armed your RC car with %s." ),
                                       put.tname() );
-                it->put_in( p->i_rem( &put ), item_pocket::pocket_type::CONTAINER );
+                it->put_in( p->i_rem( &put ), pocket_type::CONTAINER );
             } else if( !put.has_flag( flag_RADIOCARITEM ) ) {
                 p->add_msg_if_player( _( "You want to arm your RC car with %s?  But how?" ),
                                       put.tname() );
@@ -7986,7 +7986,7 @@ std::optional<int> iuse::multicooker_tick( Character *p, item *it, const tripoin
         it->erase_var( "COOKTIME" );
         it->convert( itype_multi_cooker, p );
         if( it->can_contain( meal ).success() ) {
-            it->put_in( meal, item_pocket::pocket_type::CONTAINER );
+            it->put_in( meal, pocket_type::CONTAINER );
         } else {
             add_msg( m_info,
                      _( "Obstruction detected.  Please remove any items lodged in the multi-cooker." ) );
@@ -8752,7 +8752,7 @@ std::optional<int> iuse::electricstorage( Character *p, item *it, const tripoint
     auto filter = [it]( const item & itm ) {
         return !itm.is_broken() &&
                &itm != it &&
-               itm.has_pocket_type( item_pocket::pocket_type::EBOOK );
+               itm.has_pocket_type( pocket_type::EBOOK );
     };
 
     item_location storage_card = game_menus::inv::titled_filter_menu(
@@ -8811,7 +8811,7 @@ std::optional<int> iuse::electricstorage( Character *p, item *it, const tripoint
         books_moved = fromset.size();
         for( const item *ebook : fromset )
         {
-            toit.put_in( *ebook, item_pocket::pocket_type::EBOOK );
+            toit.put_in( *ebook, pocket_type::EBOOK );
         }
     };
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -320,8 +320,8 @@ void iuse_transform::do_transform( Character *p, item &it, const std::string &va
             cont = item( target, calendar::turn );
         }
         for( int i = 0; i < count; i++ ) {
-            if( !it.put_in( cont, item_pocket::pocket_type::CONTAINER ).success() ) {
-                it.put_in( cont, item_pocket::pocket_type::MIGRATION );
+            if( !it.put_in( cont, pocket_type::CONTAINER ).success() ) {
+                it.put_in( cont, pocket_type::MIGRATION );
             }
         }
         if( sealed ) {
@@ -2469,7 +2469,7 @@ bool holster_actor::store( Character &you, item &holster, item &obj ) const
 
     // holsters ignore penalty effects (e.g. GRABBED) when determining number of moves to consume
     you.as_character()->store( holster, obj, false, holster.obtain_cost( obj ),
-                               item_pocket::pocket_type::CONTAINER, true );
+                               pocket_type::CONTAINER, true );
     return true;
 }
 
@@ -2521,7 +2521,7 @@ std::optional<int> holster_actor::use( Character *you, item &it, const tripoint 
     opts.push_back( prompt );
     pos = -1;
     std::list<item *> all_items = it.all_items_top(
-                                      item_pocket::pocket_type::CONTAINER );
+                                      pocket_type::CONTAINER );
     std::transform( all_items.begin(), all_items.end(), std::back_inserter( opts ),
     []( const item * elem ) {
         return string_format( _( "Draw %s" ), elem->display_name() );
@@ -3942,7 +3942,7 @@ std::optional<int> saw_barrel_actor::use( Character *p, item &it, const tripoint
 
     item &obj = *loc.obtain( *p );
     p->add_msg_if_player( _( "You saw down the barrel of your %s." ), obj.tname() );
-    obj.put_in( item( "barrel_small", calendar::turn ), item_pocket::pocket_type::MOD );
+    obj.put_in( item( "barrel_small", calendar::turn ), pocket_type::MOD );
 
     return 0;
 }
@@ -4003,7 +4003,7 @@ std::optional<int> saw_stock_actor::use( Character *p, item &it, const tripoint 
 
     item &obj = *loc.obtain( *p );
     p->add_msg_if_player( _( "You saw down the stock of your %s." ), obj.tname() );
-    obj.put_in( item( "stock_none", calendar::turn ), item_pocket::pocket_type::MOD );
+    obj.put_in( item( "stock_none", calendar::turn ), pocket_type::MOD );
 
     return 0;
 }
@@ -4510,7 +4510,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
         }
         if( !is_cable_item || !can_extend.empty() ) {
             const bool has_extensions = !unspooled &&
-                                        !it.all_items_top( item_pocket::pocket_type::CABLE ).empty();
+                                        !it.all_items_top( pocket_type::CABLE ).empty();
             link_menu.addentry( 30, has_loose_end, -1,
                                 is_cable_item ? _( "Extend another cable" ) : _( "Extend with another cable" ) );
             link_menu.addentry( 31, has_extensions, -1, _( "Remove cable extensions" ) );
@@ -4604,7 +4604,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
         }
         if( !can_extend.empty() ) {
             const bool has_extensions = !unspooled &&
-                                        !it.all_items_top( item_pocket::pocket_type::CABLE ).empty();
+                                        !it.all_items_top( pocket_type::CABLE ).empty();
             link_menu.addentry( 30, has_loose_end, -1, _( "Extend another cable" ) );
             link_menu.addentry( 31, has_extensions, -1, _( "Remove cable extensions" ) );
         }
@@ -5178,7 +5178,7 @@ std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
         item cable_copy( *cable );
         cable_copy.get_contents().clear_items();
         cable_copy.link.reset();
-        if( !extended_ptr->put_in( cable_copy, item_pocket::pocket_type::CABLE ).success() ) {
+        if( !extended_ptr->put_in( cable_copy, pocket_type::CABLE ).success() ) {
             debugmsg( "Failed to put %s inside %s!", cable_copy.type_name(), extended_ptr->type_name() );
         }
     }
@@ -5195,7 +5195,7 @@ std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
         item_location parent = extended.parent_item();
         if( parent->can_contain( *extended_ptr, false, false, false,
                                  item_location(), 10000000_ml, false ).success() ) {
-            if( !parent->put_in( *extended_ptr, item_pocket::pocket_type::CONTAINER ).success() ) {
+            if( !parent->put_in( *extended_ptr, pocket_type::CONTAINER ).success() ) {
                 debugmsg( "Failed to put %s inside %s!", extended_ptr->type_name(),
                           parent->type_name() );
                 return std::nullopt;
@@ -5224,7 +5224,7 @@ std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
 
 std::optional<int> link_up_actor::remove_extensions( Character *p, item &it ) const
 {
-    std::list<item *> all_cables = it.all_items_ptr( item_pocket::pocket_type::CABLE );
+    std::list<item *> all_cables = it.all_items_ptr( pocket_type::CABLE );
     all_cables.remove_if( []( const item * cable ) {
         return !cable->has_flag( flag_CABLE_SPOOL ) || !cable->can_link_up();
     } );
@@ -5232,7 +5232,7 @@ std::optional<int> link_up_actor::remove_extensions( Character *p, item &it ) co
     if( all_cables.empty() ) {
         // Delete any non-cables that somehow got into the pocket.
         it.get_contents().clear_pockets_if( []( item_pocket const & pocket ) {
-            return pocket.is_type( item_pocket::pocket_type::CABLE );
+            return pocket.is_type( pocket_type::CABLE );
         } );
         return 0;
     }
@@ -5244,7 +5244,7 @@ std::optional<int> link_up_actor::remove_extensions( Character *p, item &it ) co
             item cable_copy( *cable );
             cable_copy.get_contents().clear_items();
             cable_copy.link.reset();
-            if( !cable_main_copy.put_in( cable_copy, item_pocket::pocket_type::CABLE ).success() ) {
+            if( !cable_main_copy.put_in( cable_copy, pocket_type::CABLE ).success() ) {
                 debugmsg( "Failed to put %s inside %s!", cable_copy.tname(), cable_main_copy.tname() );
             }
         }
@@ -5253,7 +5253,7 @@ std::optional<int> link_up_actor::remove_extensions( Character *p, item &it ) co
                           cable_main_copy.type_name(), it.type_name() );
 
     it.get_contents().clear_pockets_if( []( item_pocket const & pocket ) {
-        return pocket.is_type( item_pocket::pocket_type::CABLE );
+        return pocket.is_type( pocket_type::CABLE );
     } );
 
     if( it.link ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -56,7 +56,6 @@
 #include "item_factory.h"
 #include "item_group.h"
 #include "item_location.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "iuse.h"
 #include "iuse_actor.h"
@@ -82,6 +81,7 @@
 #include "output.h"
 #include "overmapbuffer.h"
 #include "pathfinding.h"
+#include "pocket_type.h"
 #include "projectile.h"
 #include "ranged.h"
 #include "relic.h"
@@ -5203,7 +5203,7 @@ item &map::add_item( const tripoint &p, item new_item, int copies )
         !new_item.has_var( "spawn_location_omt" ) ) {
         new_item.set_var( "spawn_location_omt", ms_to_omt_copy( getabs( p ) ) );
     }
-    for( item *const it : new_item.all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
+    for( item *const it : new_item.all_items_top( pocket_type::CONTAINER ) ) {
         if( it->has_flag( json_flag_PRESERVE_SPAWN_OMT ) &&
             !it->has_var( "spawn_location_omt" ) ) {
             it->set_var( "spawn_location_omt", ms_to_omt_copy( getabs( p ) ) );
@@ -8356,7 +8356,7 @@ void map::produce_sap( const tripoint &p, const time_duration &time_since_last_a
                 // The environment might have poisoned the sap with animals passing by, insects, leaves or contaminants in the ground
                 sap.poison = one_in( 10 ) ? 1 : 0;
 
-                it.put_in( sap, item_pocket::pocket_type::CONTAINER );
+                it.put_in( sap, pocket_type::CONTAINER );
             }
             // Only fill up the first container.
             break;

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -43,7 +43,6 @@
 #include "item.h"
 #include "item_factory.h"
 #include "item_group.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "json.h"
 #include "level_cache.h"
@@ -66,6 +65,7 @@
 #include "output.h"
 #include "overmap.h"
 #include "overmapbuffer.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "ret_val.h"
 #include "rng.h"
@@ -6510,7 +6510,7 @@ std::vector<item *> map::place_items(
         if( e->is_tool() || e->is_gun() || e->is_magazine() ) {
             if( rng( 0, 99 ) < magazine && e->magazine_default() && !e->magazine_integral() &&
                 !e->magazine_current() ) {
-                e->put_in( item( e->magazine_default(), e->birthday() ), item_pocket::pocket_type::MAGAZINE_WELL );
+                e->put_in( item( e->magazine_default(), e->birthday() ), pocket_type::MAGAZINE_WELL );
             }
             if( rng( 0, 99 ) < ammo && e->ammo_default() && e->ammo_remaining() == 0 ) {
                 e->ammo_set( e->ammo_default() );

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -1232,7 +1232,7 @@ void gun_actor::shoot( monster &z, const tripoint &target, const gun_mode_id &mo
         } else {
             item mag( gun.magazine_default() );
             mag.ammo_set( ammo, z.ammo[ammo_type] );
-            gun.put_in( mag, item_pocket::pocket_type::MAGAZINE_WELL );
+            gun.put_in( mag, pocket_type::MAGAZINE_WELL );
         }
     }
 

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -1859,7 +1859,7 @@ void Character::perform_technique( const ma_technique &technique, Creature &t,
         const itype_id casing = *current_ammo->ammo->casing;
         if( cur_weapon.get_item()->has_flag( flag_RELOAD_EJECT ) ) {
             cur_weapon.get_item()->force_insert_item( item( casing ).set_flag( flag_CASING ),
-                    item_pocket::pocket_type::MAGAZINE );
+                    pocket_type::MAGAZINE );
             cur_weapon.get_item()->on_contents_changed();
         }
     }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2882,14 +2882,14 @@ void monster::die( Creature *nkiller )
                 continue;
             }
             if( corpse ) {
-                corpse->force_insert_item( it, item_pocket::pocket_type::CONTAINER );
+                corpse->force_insert_item( it, pocket_type::CONTAINER );
             } else {
                 get_map().add_item_or_charges( pos(), it );
             }
         }
         for( const item &it : dissectable_inv ) {
             if( corpse ) {
-                corpse->put_in( it, item_pocket::pocket_type::CORPSE );
+                corpse->put_in( it, pocket_type::CORPSE );
             } else {
                 get_map().add_item( pos(), it );
             }
@@ -3028,7 +3028,7 @@ void monster::drop_items_on_death( item *corpse )
 
         // add stuff that could be worn or strapped to the creature
         if( it.is_armor() ) {
-            corpse->force_insert_item( it, item_pocket::pocket_type::CONTAINER );
+            corpse->force_insert_item( it, pocket_type::CONTAINER );
         }
     }
 
@@ -3051,7 +3051,7 @@ void monster::drop_items_on_death( item *corpse )
             if( current_best.second != nullptr ) {
                 current_best.second->insert_item( it );
             } else {
-                corpse->force_insert_item( it, item_pocket::pocket_type::CONTAINER );
+                corpse->force_insert_item( it, pocket_type::CONTAINER );
             }
         }
     }
@@ -3079,7 +3079,7 @@ void monster::spawn_dissectables_on_death( item *corpse )
                 dissectable.faults.emplace( flt );
             }
             if( corpse ) {
-                corpse->put_in( dissectable, item_pocket::pocket_type::CORPSE );
+                corpse->put_in( dissectable, pocket_type::CORPSE );
             } else {
                 get_map().add_item_or_charges( pos(), dissectable );
             }
@@ -3522,7 +3522,7 @@ void monster::init_from_item( item &itm )
         if( !up_time.empty() ) {
             upgrade_time = std::stoi( up_time );
         }
-        for( item *it : itm.all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
+        for( item *it : itm.all_items_top( pocket_type::CONTAINER ) ) {
             if( it->is_armor() ) {
                 it->set_flag( STATIC( flag_id( "FILTHY" ) ) );
             }
@@ -3530,7 +3530,7 @@ void monster::init_from_item( item &itm )
             itm.remove_item( *it );
         }
         //Move dissectables (installed bionics, etc)
-        for( item *dissectable : itm.all_items_top( item_pocket::pocket_type::CORPSE ) ) {
+        for( item *dissectable : itm.all_items_top( pocket_type::CORPSE ) ) {
             dissectable_inv.push_back( *dissectable );
             itm.remove_item( *dissectable );
         }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -47,7 +47,6 @@
 #include "input.h"
 #include "item.h"
 #include "item_category.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "json.h"
 #include "line.h"
@@ -67,6 +66,7 @@
 #include "overmapbuffer.h"
 #include "pimpl.h"
 #include "player_activity.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "popup.h"
 #include "recipe.h"
@@ -2928,7 +2928,7 @@ static void receive_item( itype_id &item_name, int count, std::string_view conta
         item container( std::string( container_name ), calendar::turn );
         new_item.charges = count;
         container.put_in( new_item,
-                          item_pocket::pocket_type::CONTAINER );
+                          pocket_type::CONTAINER );
         if( add_talker ) {
             d.actor( false )->i_add_or_drop( container, force_equip );
         } else {

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -352,7 +352,7 @@ bool npc_trading::npc_can_fit_items( npc const &np, trade_selector::select_t con
             const units::volume pvol = pkt.max_containable_volume();
             const item &i = *it.first;
             if( pkt.can_holster( i ) || ( pkt.can_contain( i ).success() && pvol > i.volume() ) ) {
-                pkt.put_in( i, item_pocket::pocket_type::CONTAINER );
+                pkt.put_in( i, pocket_type::CONTAINER );
                 item_stored = true;
                 break;
             }

--- a/src/npctrade_utils.cpp
+++ b/src/npctrade_utils.cpp
@@ -25,7 +25,7 @@ void _consume_item( item_location elem, consume_queue &consumed, consume_cache &
     if( !elem->is_owned_by( guy ) ) {
         return;
     }
-    std::list<item *> const contents = elem->all_items_top( item_pocket::pocket_type::CONTAINER );
+    std::list<item *> const contents = elem->all_items_top( pocket_type::CONTAINER );
     if( contents.empty() ) {
         auto it = cache.find( elem->typeId() );
         if( it == cache.end() ) {

--- a/src/pocket_type.h
+++ b/src/pocket_type.h
@@ -1,0 +1,18 @@
+#pragma once
+#ifndef CATA_SRC_POCKET_TYPE_H
+#define CATA_SRC_POCKET_TYPE_H
+
+enum class pocket_type : int {
+    CONTAINER,
+    MAGAZINE,
+    MAGAZINE_WELL, //holds magazines
+    MOD, // the gunmods or toolmods
+    CORPSE, // the "corpse" pocket - bionics embedded in a corpse
+    SOFTWARE, // software put into usb or some such
+    EBOOK, // holds electronic books for a device or usb
+    CABLE, // pocket for storing power/data cables and handling their connections
+    MIGRATION, // this allows items to load contents that are too big, in order to spill them later.
+    LAST
+};
+
+#endif // CATA_SRC_POCKET_TYPE_H

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -42,7 +42,6 @@
 #include "input.h"
 #include "item.h"
 #include "item_location.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "line.h"
 #include "magic.h"
@@ -57,6 +56,7 @@
 #include "options.h"
 #include "output.h"
 #include "panels.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "projectile.h"
 #include "ret_val.h"
@@ -2134,11 +2134,11 @@ static void cycle_action( item &weap, const itype_id &ammo, const tripoint &pos 
         }
         if( weap.has_flag( flag_RELOAD_EJECT ) ) {
             weap.force_insert_item( casing.set_flag( flag_CASING ),
-                                    item_pocket::pocket_type::MAGAZINE );
+                                    pocket_type::MAGAZINE );
             weap.on_contents_changed();
         } else {
             if( brass_catcher && brass_catcher->can_contain( casing ).success() ) {
-                brass_catcher->put_in( casing, item_pocket::pocket_type::CONTAINER );
+                brass_catcher->put_in( casing, pocket_type::CONTAINER );
             } else if( ovp_cargo ) {
                 ovp_cargo->vehicle().add_item( ovp_cargo->part(), casing );
             } else {
@@ -2155,7 +2155,7 @@ static void cycle_action( item &weap, const itype_id &ammo, const tripoint &pos 
     if( mag && mag->type->magazine->linkage ) {
         item linkage( *mag->type->magazine->linkage, calendar::turn, 1 );
         if( !( brass_catcher &&
-               brass_catcher->put_in( linkage, item_pocket::pocket_type::CONTAINER ).success() ) ) {
+               brass_catcher->put_in( linkage, pocket_type::CONTAINER ).success() ) ) {
             if( ovp_cargo ) {
                 ovp_cargo->items().insert( linkage );
             } else {

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -991,7 +991,7 @@ nc_color item_comp::get_color( bool has_one, const read_only_visitable &crafting
         const inventory *inv = static_cast<const inventory *>( &crafting_inv );
         // Will use non-empty liquid container
         if( std::any_of( type->pockets.begin(), type->pockets.end(), []( const pocket_data & d ) {
-        return d.type == item_pocket::pocket_type::CONTAINER && d.watertight;
+        return d.type == pocket_type::CONTAINER && d.watertight;
     } ) && inv != nullptr && inv->must_use_liq_container( type, count * batch ) ) {
             return c_magenta;
         }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -257,7 +257,7 @@ void item_pocket::deserialize( const JsonObject &data )
     data.read( "contents", contents );
     int saved_type_int;
     data.read( "pocket_type", saved_type_int );
-    _saved_type = static_cast<item_pocket::pocket_type>( saved_type_int );
+    _saved_type = static_cast<pocket_type>( saved_type_int );
     data.read( "_sealed", _sealed );
     _saved_sealed = _sealed;
     data.read( "no_rigid", no_rigid );
@@ -1184,24 +1184,24 @@ void Character::load( const JsonObject &data )
                         item gasoline( "gasoline" );
                         gasoline.charges = std::stoi( get_value( "gasoline" ) );
                         remove_value( "gasoline" );
-                        pseudo.put_in( gasoline, item_pocket::pocket_type::CONTAINER );
+                        pseudo.put_in( gasoline, pocket_type::CONTAINER );
                     } else if( b_it == itype_internal_ethanol_tank && !get_value( "alcohol" ).empty() ) {
                         item ethanol( "chem_ethanol" );
                         ethanol.charges = std::stoi( get_value( "alcohol" ) );
                         remove_value( "alcohol" );
-                        pseudo.put_in( ethanol, item_pocket::pocket_type::CONTAINER );
+                        pseudo.put_in( ethanol, pocket_type::CONTAINER );
                     } else if( b_it == itype_internal_oil_tank && !get_value( "motor_oil" ).empty() ) {
                         item oil( "motor_oil" );
                         oil.charges = std::stoi( get_value( "motor_oil" ) );
                         remove_value( "motor_oil" );
-                        pseudo.put_in( oil, item_pocket::pocket_type::CONTAINER );
+                        pseudo.put_in( oil, pocket_type::CONTAINER );
                     } else if( b_it == itype_internal_battery_compartment && !get_value( "battery" ).empty() ) {
                         item battery( "medium_battery_cell" );
                         item battery_charge( "battery" );
                         battery_charge.charges = std::min( 500, std::stoi( get_value( "battery" ) ) );
-                        battery.put_in( battery_charge, item_pocket::pocket_type::MAGAZINE );
+                        battery.put_in( battery_charge, pocket_type::MAGAZINE );
                         remove_value( "battery" );
-                        pseudo.put_in( battery, item_pocket::pocket_type::MAGAZINE_WELL );
+                        pseudo.put_in( battery, pocket_type::MAGAZINE_WELL );
                     }
 
                     wear_item( pseudo, false );
@@ -3185,7 +3185,7 @@ void item::io( Archive &archive )
                     still_has_charges = true;
                     copy.charges = 0;
                 }
-                put_in( copy, item_pocket::pocket_type::MIGRATION );
+                put_in( copy, pocket_type::MIGRATION );
             }
             if( still_has_charges ) {
                 debugmsg( "Item %s can't have charges, but still had them after migration.", type->get_id().str() );
@@ -3198,20 +3198,20 @@ void item::io( Archive &archive )
 void item::migrate_content_item( const item &contained )
 {
     if( contained.is_gunmod() || contained.is_toolmod() ) {
-        put_in( contained, item_pocket::pocket_type::MOD );
+        put_in( contained, pocket_type::MOD );
     } else if( typeId() == itype_usb_drive ) {
         // as of this migration, only usb_drive has any software in it.
-        put_in( contained, item_pocket::pocket_type::SOFTWARE );
-    } else if( contents.insert_item( contained, item_pocket::pocket_type::MAGAZINE ).success() ||
-               contents.insert_item( contained, item_pocket::pocket_type::MAGAZINE_WELL ).success() ) {
+        put_in( contained, pocket_type::SOFTWARE );
+    } else if( contents.insert_item( contained, pocket_type::MAGAZINE ).success() ||
+               contents.insert_item( contained, pocket_type::MAGAZINE_WELL ).success() ) {
         // left intentionally blank
     } else if( is_corpse() ) {
-        put_in( contained, item_pocket::pocket_type::CORPSE );
+        put_in( contained, pocket_type::CORPSE );
     } else if( can_contain( contained ).success() ) {
-        put_in( contained, item_pocket::pocket_type::CONTAINER );
+        put_in( contained, pocket_type::CONTAINER );
     } else {
         // we want this to silently fail - the contents will fall out later
-        put_in( contained, item_pocket::pocket_type::MIGRATION );
+        put_in( contained, pocket_type::MIGRATION );
     }
 }
 

--- a/src/turret.cpp
+++ b/src/turret.cpp
@@ -290,7 +290,7 @@ void turret_data::post_fire( Character &you, int shots )
     static const auto clear_mag_wells = []( item & it ) {
         std::vector<item_pocket *> magazine_wells = it.get_contents().get_pockets(
         []( const item_pocket & pocket ) {
-            return pocket.is_type( item_pocket::pocket_type::MAGAZINE_WELL );
+            return pocket.is_type( pocket_type::MAGAZINE_WELL );
         } );
         for( item_pocket *pocket : magazine_wells ) {
             pocket->clear_items();

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -23,10 +23,10 @@
 #include "item.h"
 #include "item_factory.h"
 #include "item_group.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "json.h"
 #include "output.h"
+#include "pocket_type.h"
 #include "requirements.h"
 #include "ret_val.h"
 #include "string_formatter.h"
@@ -1016,7 +1016,7 @@ int vpart_info::format_description( std::string &msg, const nc_color &format_col
             } else if( !base.magazine_default().is_null() ) {
                 class::item tmp_mag( base.magazine_default() );
                 tmp_mag.ammo_set( tmp_mag.ammo_default() );
-                base.put_in( tmp_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+                base.put_in( tmp_mag, pocket_type::MAGAZINE_WELL );
             }
         }
         long_descrip += string_format( _( "\nRange: %1$5d     Damage: %2$5.0f" ),

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -45,7 +45,6 @@
 #include "game.h"
 #include "item.h"
 #include "item_group.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "json.h"
 #include "json_loader.h"
@@ -65,6 +64,7 @@
 #include "overmapbuffer.h"
 #include "pimpl.h"
 #include "player_activity.h"
+#include "pocket_type.h"
 #include "ret_val.h"
 #include "rng.h"
 #include "sounds.h"
@@ -5904,7 +5904,7 @@ void vehicle::place_spawn_items()
                         if( spawn_ammo ) {
                             mag.ammo_set( mag.ammo_default() );
                         }
-                        e.put_in( mag, item_pocket::pocket_type::MAGAZINE_WELL );
+                        e.put_in( mag, pocket_type::MAGAZINE_WELL );
                     } else if( spawn_ammo && e.is_magazine() ) {
                         e.ammo_set( e.ammo_default() );
                     }

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -16,12 +16,12 @@
 #include "flag.h"
 #include "game.h"
 #include "item.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "iuse_actor.h"
 #include "map.h"
 #include "messages.h"
 #include "npc.h"
+#include "pocket_type.h"
 #include "ret_val.h"
 #include "string_formatter.h"
 #include "translations.h"
@@ -305,7 +305,7 @@ int vehicle_part::ammo_set( const itype_id &ammo, int qty )
             const int limit = ammo_capacity( ammo_itype->ammo->type );
             // assuming "ammo" isn't really going into a magazine as this is a vehicle part
             const int amount = qty > 0 ? std::min( qty, limit ) : limit;
-            base.put_in( item( ammo, calendar::turn, amount ), item_pocket::pocket_type::CONTAINER );
+            base.put_in( item( ammo, calendar::turn, amount ), pocket_type::CONTAINER );
             return amount;
         }
     }
@@ -318,7 +318,7 @@ int vehicle_part::ammo_set( const itype_id &ammo, int qty )
         if( mag_type ) {
             item mag( mag_type );
             mag.ammo_set( ammo, qty );
-            base.put_in( mag, item_pocket::pocket_type::MAGAZINE_WELL );
+            base.put_in( mag, pocket_type::MAGAZINE_WELL );
             return base.ammo_remaining();
         }
     }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -28,7 +28,6 @@
 #include "input.h"
 #include "inventory.h"
 #include "item.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "iuse.h"
 #include "game_inventory.h"
@@ -44,6 +43,7 @@
 #include "overmapbuffer.h"
 #include "pickup.h"
 #include "player_activity.h"
+#include "pocket_type.h"
 #include "requirements.h"
 #include "ret_val.h"
 #include "rng.h"
@@ -1779,13 +1779,13 @@ int vehicle::prepare_tool( item &tool ) const
     }
     item mag_mod( "pseudo_magazine_mod" );
     mag_mod.set_flag( STATIC( flag_id( "IRREMOVABLE" ) ) );
-    if( !tool.put_in( mag_mod, item_pocket::pocket_type::MOD ).success() ) {
+    if( !tool.put_in( mag_mod, pocket_type::MOD ).success() ) {
         debugmsg( "tool %s has no space for a %s, this is likely a bug",
                   tool.typeId().str(), mag_mod.type->nname( 1 ) );
     }
     item mag( tool.magazine_default() );
     mag.clear_items(); // no initial ammo
-    if( !tool.put_in( mag, item_pocket::pocket_type::MAGAZINE_WELL ).success() ) {
+    if( !tool.put_in( mag, pocket_type::MAGAZINE_WELL ).success() ) {
         debugmsg( "inserting %s into %s's MAGAZINE_WELL pocket failed",
                   mag.typeId().str(), tool.typeId().str() );
         return 0;

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -373,7 +373,7 @@ VisitResponse item_contents::visit_contents( const std::function<VisitResponse( 
         &func, item *parent )
 {
     for( item_pocket &pocket : contents ) {
-        if( !pocket.is_type( item_pocket::pocket_type::CONTAINER ) ) {
+        if( !pocket.is_type( pocket_type::CONTAINER ) ) {
             // anything that is not CONTAINER is accessible only via its specific accessor
             continue;
         }

--- a/src/weather.cpp
+++ b/src/weather.cpp
@@ -25,7 +25,6 @@
 #include "game.h"
 #include "game_constants.h"
 #include "item.h"
-#include "item_pocket.h"
 #include "line.h"
 #include "map.h"
 #include "map_iterator.h"
@@ -36,6 +35,7 @@
 #include "options.h"
 #include "overmap.h"
 #include "overmapbuffer.h"
+#include "pocket_type.h"
 #include "regional_settings.h"
 #include "ret_val.h"
 #include "rng.h"
@@ -247,7 +247,7 @@ void item::add_rain_to_container( int charges )
         // This is easy. Just add 1 charge of the rain liquid to the container.
         // Funnels aren't always clean enough for water. // TODO: disinfectant squeegie->funnel
         ret.poison = one_in( 10 ) ? 1 : 0;
-        put_in( ret, item_pocket::pocket_type::CONTAINER );
+        put_in( ret, pocket_type::CONTAINER );
     } else {
         static const std::set<itype_id> allowed_liquid_types{
             itype_water

--- a/tests/ammo_set_test.cpp
+++ b/tests/ammo_set_test.cpp
@@ -7,8 +7,8 @@
 #include "cata_catch.h"
 #include "debug.h"
 #include "item.h"
-#include "item_pocket.h"
 #include "itype.h"
+#include "pocket_type.h"
 #include "ret_val.h"
 #include "type_id.h"
 #include "value_ptr.h"
@@ -198,7 +198,7 @@ TEST_CASE( "ammo_set_items_with_MAGAZINE_WELL_pockets_with_magazine",
         REQUIRE( ammo_default_id.str() == ammo9mm_id.str() );
         const ammotype &amtype = ammo9mm_id->ammo->type;
         REQUIRE( cz75mag_20rd.ammo_capacity( amtype ) == 20 );
-        cz75.put_in( cz75mag_20rd, item_pocket::pocket_type::MAGAZINE_WELL );
+        cz75.put_in( cz75mag_20rd, pocket_type::MAGAZINE_WELL );
         REQUIRE( cz75.magazine_current()->typeId().str() == cz75mag_20rd.typeId().str() );
         REQUIRE( cz75.ammo_capacity( amtype ) == 20 );
         WHEN( "set 9mm ammo in the gun with magazine w/o quantity" ) {

--- a/tests/ammo_test.cpp
+++ b/tests/ammo_test.cpp
@@ -210,7 +210,7 @@ TEST_CASE( "barrel_test", "[ammo][weapon]" )
     SECTION( "basic ammo and mod length test" ) {
         item base_gun( "test_glock_super_long" );
         item gun_mod( "barrel_glock_short" );
-        REQUIRE( base_gun.put_in( gun_mod, item_pocket::pocket_type::MOD ).success() );
+        REQUIRE( base_gun.put_in( gun_mod, pocket_type::MOD ).success() );
         REQUIRE( base_gun.barrel_length().value() == 100 );
         CHECK( base_gun.gun_damage( itype_test_100mm_ammo ).total_damage() == 60 );
     }

--- a/tests/battery_mod_test.cpp
+++ b/tests/battery_mod_test.cpp
@@ -10,12 +10,12 @@
 #include "cata_catch.h"
 #include "debug.h"
 #include "item.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "iuse.h"
 #include "iuse_actor.h"
 #include "make_static.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
 #include "ret_val.h"
 #include "type_id.h"
 #include "value_ptr.h"
@@ -107,11 +107,11 @@ TEST_CASE( "battery_tool_mod_test", "[battery][mod]" )
         REQUIRE_FALSE( flashlight.magazine_current() );
         REQUIRE( flashlight.toolmods().empty() );
         // Needs a MOD pocket to allow modding
-        REQUIRE( flashlight.has_pocket_type( item_pocket::pocket_type::MOD ) );
+        REQUIRE( flashlight.has_pocket_type( pocket_type::MOD ) );
 
         WHEN( "medium battery mod is installed" ) {
             med_mod.set_flag( STATIC( flag_id( "IRREMOVABLE" ) ) );
-            flashlight.put_in( med_mod, item_pocket::pocket_type::MOD );
+            flashlight.put_in( med_mod, pocket_type::MOD );
 
             THEN( "tool modification is successful" ) {
                 CHECK_FALSE( flashlight.toolmods().empty() );
@@ -134,7 +134,7 @@ TEST_CASE( "battery_tool_mod_test", "[battery][mod]" )
                 CHECK( flashlight.can_reload_with( item( itype_medium_plus_battery_cell ), true ) );
                 CHECK( flashlight.can_reload_with( item( itype_medium_atomic_battery_cell ), true ) );
                 CHECK( flashlight.can_reload_with( item( itype_medium_disposable_cell ), true ) );
-                CHECK( flashlight.has_pocket_type( item_pocket::pocket_type::MAGAZINE_WELL ) );
+                CHECK( flashlight.has_pocket_type( pocket_type::MAGAZINE_WELL ) );
             }
 
             THEN( "medium battery is now the default" ) {
@@ -150,7 +150,7 @@ TEST_CASE( "battery_tool_mod_test", "[battery][mod]" )
 
             WHEN( "medium battery is installed" ) {
                 item med_battery( "medium_battery_cell" );
-                ret_val<void> result = flashlight.put_in( med_battery, item_pocket::pocket_type::MAGAZINE_WELL );
+                ret_val<void> result = flashlight.put_in( med_battery, pocket_type::MAGAZINE_WELL );
 
                 THEN( "battery installation succeeds" ) {
                     CHECK( result.success() );
@@ -171,7 +171,7 @@ TEST_CASE( "battery_tool_mod_test", "[battery][mod]" )
                 const int bat_charges = med_battery.ammo_capacity( ammo_battery );
                 med_battery.ammo_set( med_battery.ammo_default(), bat_charges );
                 REQUIRE( med_battery.ammo_remaining() == bat_charges );
-                flashlight.put_in( med_battery, item_pocket::pocket_type::MAGAZINE_WELL );
+                flashlight.put_in( med_battery, pocket_type::MAGAZINE_WELL );
 
                 THEN( "the flashlight has charges" ) {
                     CHECK( flashlight.ammo_remaining() == bat_charges );
@@ -338,8 +338,8 @@ TEST_CASE( "installing_battery_in_tool", "[battery][tool][install]" )
         REQUIRE( bat_cell.ammo_remaining() == 0 );
 
         // Put battery in flashlight
-        REQUIRE( flashlight.has_pocket_type( item_pocket::pocket_type::MAGAZINE_WELL ) );
-        ret_val<void> result = flashlight.put_in( bat_cell, item_pocket::pocket_type::MAGAZINE_WELL );
+        REQUIRE( flashlight.has_pocket_type( pocket_type::MAGAZINE_WELL ) );
+        ret_val<void> result = flashlight.put_in( bat_cell, pocket_type::MAGAZINE_WELL );
         CHECK( result.success() );
         CHECK( flashlight.magazine_current() );
 
@@ -353,8 +353,8 @@ TEST_CASE( "installing_battery_in_tool", "[battery][tool][install]" )
         REQUIRE( bat_cell.ammo_remaining() == bat_charges );
 
         // Put battery in flashlight
-        REQUIRE( flashlight.has_pocket_type( item_pocket::pocket_type::MAGAZINE_WELL ) );
-        ret_val<void> result = flashlight.put_in( bat_cell, item_pocket::pocket_type::MAGAZINE_WELL );
+        REQUIRE( flashlight.has_pocket_type( pocket_type::MAGAZINE_WELL ) );
+        ret_val<void> result = flashlight.put_in( bat_cell, pocket_type::MAGAZINE_WELL );
         CHECK( result.success() );
         CHECK( flashlight.magazine_current() );
 
@@ -366,9 +366,9 @@ TEST_CASE( "installing_battery_in_tool", "[battery][tool][install]" )
         item med_bat_cell( "medium_battery_cell" );
 
         // Should fail to install the magazine
-        REQUIRE( flashlight.has_pocket_type( item_pocket::pocket_type::MAGAZINE_WELL ) );
+        REQUIRE( flashlight.has_pocket_type( pocket_type::MAGAZINE_WELL ) );
         std::string dmsg = capture_debugmsg_during( [&flashlight, &med_bat_cell]() {
-            ret_val<void> result = flashlight.put_in( med_bat_cell, item_pocket::pocket_type::MAGAZINE_WELL );
+            ret_val<void> result = flashlight.put_in( med_bat_cell, pocket_type::MAGAZINE_WELL );
             CHECK_FALSE( result.success() );
         } );
         CHECK_THAT( dmsg, Catch::EndsWith( "holster does not accept this item type or form factor" ) );

--- a/tests/behavior_test.cpp
+++ b/tests/behavior_test.cpp
@@ -314,7 +314,7 @@ TEST_CASE( "check_monster_behavior_tree_theoretical_corpse_eater", "[monster][be
         CHECK( monster_goals.tick( &oracle ) == "idle" );
 
         item corpse = item( "corpse" );
-        corpse.force_insert_item( item( "pencil" ), item_pocket::pocket_type::CONTAINER );
+        corpse.force_insert_item( item( "pencil" ), pocket_type::CONTAINER );
 
         here.add_item( test_monster.pos(), corpse );
         CHECK( monster_goals.tick( &oracle ) == "ABSORB_ITEMS" );
@@ -372,7 +372,7 @@ TEST_CASE( "check_monster_behavior_tree_theoretical_absorb", "[monster][behavior
         CHECK( monster_goals.tick( &oracle ) == "idle" );
 
         item corpse = item( "corpse" );
-        corpse.force_insert_item( item( "pencil" ), item_pocket::pocket_type::CONTAINER );
+        corpse.force_insert_item( item( "pencil" ), pocket_type::CONTAINER );
 
         here.add_item( test_monster.pos(), corpse );
         CHECK( monster_goals.tick( &oracle ) == "ABSORB_ITEMS" );

--- a/tests/bionics_test.cpp
+++ b/tests/bionics_test.cpp
@@ -10,12 +10,12 @@
 #include "cata_catch.h"
 #include "game.h"
 #include "item.h"
-#include "item_pocket.h"
 #include "map_helpers.h"
 #include "npc.h"
 #include "options_helpers.h"
 #include "pimpl.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
 #include "ret_val.h"
 #include "type_id.h"
 #include "units.h"
@@ -395,7 +395,7 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         item gasoline = item( "gasoline" );
         gasoline.charges = 2;
         CHECK( gasoline_tank->can_reload_with( gasoline, true ) );
-        gasoline_tank->put_in( gasoline, item_pocket::pocket_type::CONTAINER );
+        gasoline_tank->put_in( gasoline, pocket_type::CONTAINER );
         REQUIRE( gasoline_tank->only_item().charges == 2 );
         CHECK( dummy.activate_bionic( bio ) );
         CHECK_FALSE( dummy.get_bionic_fuels( bio.id ).empty() );
@@ -429,7 +429,7 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         // Add empty battery. Still won't work
         item battery = item( "light_battery_cell" );
         CHECK( bat_compartment->can_reload_with( battery, true ) );
-        bat_compartment->put_in( battery, item_pocket::pocket_type::MAGAZINE_WELL );
+        bat_compartment->put_in( battery, pocket_type::MAGAZINE_WELL );
         REQUIRE( bat_compartment->ammo_remaining() == 0 );
         CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
         CHECK( dummy.get_cable_ups().empty() );
@@ -490,7 +490,7 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
 
         // Put empty battery into ups. Still does not work.
         item ups_mag( ups->magazine_default() );
-        ups->put_in( ups_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+        ups->put_in( ups_mag, pocket_type::MAGAZINE_WELL );
         REQUIRE( ups->ammo_remaining() == 0 );
         CHECK( dummy.get_bionic_fuels( bio.id ).empty() );
         CHECK_FALSE( dummy.activate_bionic( bio ) );
@@ -564,8 +564,8 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         item wood = item( "splinter" );
         item wood_2 = item( "splinter" );
         REQUIRE_FALSE( wood.count_by_charges() );
-        woodshed->put_in( wood, item_pocket::pocket_type::CONTAINER );
-        woodshed->put_in( wood_2, item_pocket::pocket_type::CONTAINER );
+        woodshed->put_in( wood, pocket_type::CONTAINER );
+        woodshed->put_in( wood_2, pocket_type::CONTAINER );
         REQUIRE( woodshed->all_items_ptr().size() == 2 );
         CHECK( dummy.activate_bionic( bio ) );
         CHECK_FALSE( dummy.get_bionic_fuels( bio.id ).empty() );

--- a/tests/clzones_test.cpp
+++ b/tests/clzones_test.cpp
@@ -6,9 +6,9 @@
 #include "clzones.h"
 #include "item.h"
 #include "item_category.h"
-#include "item_pocket.h"
 #include "map_helpers.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "ret_val.h"
 #include "type_id.h"
@@ -189,7 +189,7 @@ TEST_CASE( "zone_sorting_comestibles_", "[zones][items][food][activities]" )
 
             WHEN( "sorting within an unsealed container" ) {
                 item container( "test_watertight_open_sealed_container_250ml" );
-                REQUIRE( container.put_in( nonperishable_food, item_pocket::pocket_type::CONTAINER ).success() );
+                REQUIRE( container.put_in( nonperishable_food, pocket_type::CONTAINER ).success() );
                 REQUIRE( !container.any_pockets_sealed() );
 
                 THEN( "should put in the food zone" ) {
@@ -199,7 +199,7 @@ TEST_CASE( "zone_sorting_comestibles_", "[zones][items][food][activities]" )
 
             WHEN( "sorting within a sealed container" ) {
                 item container( "test_watertight_open_sealed_container_250ml" );
-                REQUIRE( container.put_in( nonperishable_food, item_pocket::pocket_type::CONTAINER ).success() );
+                REQUIRE( container.put_in( nonperishable_food, pocket_type::CONTAINER ).success() );
                 REQUIRE( container.seal() );
                 REQUIRE( container.get_all_contained_pockets().front()->spoil_multiplier() ==
                          0.0f );
@@ -223,7 +223,7 @@ TEST_CASE( "zone_sorting_comestibles_", "[zones][items][food][activities]" )
 
             WHEN( "sorting within an unsealed container" ) {
                 item container( "test_watertight_open_sealed_container_250ml" );
-                REQUIRE( container.put_in( nonperishable_drink, item_pocket::pocket_type::CONTAINER ).success() );
+                REQUIRE( container.put_in( nonperishable_drink, pocket_type::CONTAINER ).success() );
                 REQUIRE( !container.any_pockets_sealed() );
 
                 THEN( "should put in the drink zone" ) {
@@ -233,7 +233,7 @@ TEST_CASE( "zone_sorting_comestibles_", "[zones][items][food][activities]" )
 
             WHEN( "sorting within a sealed container" ) {
                 item container( "test_watertight_open_sealed_container_250ml" );
-                REQUIRE( container.put_in( nonperishable_drink, item_pocket::pocket_type::CONTAINER ).success() );
+                REQUIRE( container.put_in( nonperishable_drink, pocket_type::CONTAINER ).success() );
                 REQUIRE( container.seal() );
                 REQUIRE( container.get_all_contained_pockets().front()->spoil_multiplier() ==
                          0.0f );
@@ -257,7 +257,7 @@ TEST_CASE( "zone_sorting_comestibles_", "[zones][items][food][activities]" )
 
             WHEN( "sorting within an unsealed container" ) {
                 item container( "test_watertight_open_sealed_container_250ml" );
-                REQUIRE( container.put_in( perishable_food, item_pocket::pocket_type::CONTAINER ).success() );
+                REQUIRE( container.put_in( perishable_food, pocket_type::CONTAINER ).success() );
                 REQUIRE( !container.any_pockets_sealed() );
 
                 THEN( "should put in the perishable food zone" ) {
@@ -267,7 +267,7 @@ TEST_CASE( "zone_sorting_comestibles_", "[zones][items][food][activities]" )
 
             WHEN( "sorting within a sealed container" ) {
                 item container( "test_watertight_open_sealed_container_250ml" );
-                REQUIRE( container.put_in( perishable_food, item_pocket::pocket_type::CONTAINER ).success() );
+                REQUIRE( container.put_in( perishable_food, pocket_type::CONTAINER ).success() );
                 REQUIRE( container.seal() );
                 REQUIRE( container.get_all_contained_pockets().front()->spoil_multiplier() ==
                          0.0f );
@@ -291,7 +291,7 @@ TEST_CASE( "zone_sorting_comestibles_", "[zones][items][food][activities]" )
 
             WHEN( "sorting within an unsealed container" ) {
                 item container( "test_watertight_open_sealed_container_250ml" );
-                REQUIRE( container.put_in( perishable_drink, item_pocket::pocket_type::CONTAINER ).success() );
+                REQUIRE( container.put_in( perishable_drink, pocket_type::CONTAINER ).success() );
                 REQUIRE( !container.any_pockets_sealed() );
 
                 THEN( "should put in the perishable drink zone" ) {
@@ -301,7 +301,7 @@ TEST_CASE( "zone_sorting_comestibles_", "[zones][items][food][activities]" )
 
             WHEN( "sorting within a sealed container" ) {
                 item container( "test_watertight_open_sealed_container_250ml" );
-                REQUIRE( container.put_in( perishable_drink, item_pocket::pocket_type::CONTAINER ).success() );
+                REQUIRE( container.put_in( perishable_drink, pocket_type::CONTAINER ).success() );
                 REQUIRE( container.seal() );
                 REQUIRE( container.get_all_contained_pockets().front()->spoil_multiplier() ==
                          0.0f );

--- a/tests/coverage_test.cpp
+++ b/tests/coverage_test.cpp
@@ -223,8 +223,8 @@ TEST_CASE( "Ghost_ablative_vest", "[coverage]" )
 {
     SECTION( "Ablative not covered same limb" ) {
         item full = item( "test_ghost_vest" );
-        full.force_insert_item( item( "test_plate" ), item_pocket::pocket_type::CONTAINER );
-        full.force_insert_item( item( "test_plate" ), item_pocket::pocket_type::CONTAINER );
+        full.force_insert_item( item( "test_plate" ), pocket_type::CONTAINER );
+        full.force_insert_item( item( "test_plate" ), pocket_type::CONTAINER );
         item empty = item( "test_ghost_vest" );
 
         // make sure vest only covers torso_upper when it has armor in it
@@ -241,7 +241,7 @@ TEST_CASE( "Off_Limb_Ghost_ablative_vest", "[coverage]" )
 {
     SECTION( "Ablative not covered seperate limb" ) {
         item full = item( "test_ghost_vest" );
-        full.force_insert_item( item( "test_plate_skirt_super" ), item_pocket::pocket_type::CONTAINER );
+        full.force_insert_item( item( "test_plate_skirt_super" ), pocket_type::CONTAINER );
 
         standard_npc dude( "TestCharacter", dude_pos, {}, 0, 8, 8, 8, 8 );
         dude.wear_item( full, false );

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -20,7 +20,6 @@
 #include "game.h"
 #include "inventory.h"
 #include "item.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "map.h"
 #include "map_helpers.h"
@@ -28,6 +27,7 @@
 #include "pimpl.h"
 #include "player_activity.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "recipe.h"
 #include "recipe_dictionary.h"
@@ -743,7 +743,7 @@ TEST_CASE( "UPS_shows_as_a_crafting_component", "[crafting][ups]" )
     item_location ups = dummy.i_add( item( "UPS_ON" ) );
     item ups_mag( ups->magazine_default() );
     ups_mag.ammo_set( ups_mag.ammo_default(), 500 );
-    ret_val<void> result = ups->put_in( ups_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+    ret_val<void> result = ups->put_in( ups_mag, pocket_type::MAGAZINE_WELL );
     INFO( result.c_str() );
     REQUIRE( result.success() );
     REQUIRE( dummy.has_item( *ups ) );
@@ -776,12 +776,12 @@ TEST_CASE( "UPS_modded_tools", "[crafting][ups]" )
 
     item ups_mag( ups_loc->magazine_default() );
     ups_mag.ammo_set( ups_mag.ammo_default(), ammo_count );
-    ret_val<void> result = ups_loc->put_in( ups_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+    ret_val<void> result = ups_loc->put_in( ups_mag, pocket_type::MAGAZINE_WELL );
     REQUIRE( result.success() );
 
     item_location soldering_iron = dummy.i_add( item( "soldering_iron" ) );
     item battery_ups( "battery_ups" );
-    ret_val<void> ret_solder = soldering_iron->put_in( battery_ups, item_pocket::pocket_type::MOD );
+    ret_val<void> ret_solder = soldering_iron->put_in( battery_ups, pocket_type::MOD );
     REQUIRE( ret_solder.success() );
     REQUIRE( soldering_iron->has_flag( json_flag_USE_UPS ) );
 
@@ -863,15 +863,15 @@ TEST_CASE( "tools_use_charge_to_craft", "[crafting][charge]" )
 
         WHEN( "UPS-modded tools have enough charges" ) {
             item hotplate( "hotplate" );
-            hotplate.put_in( item( "battery_ups" ), item_pocket::pocket_type::MOD );
+            hotplate.put_in( item( "battery_ups" ), pocket_type::MOD );
             tools.push_back( hotplate );
             item soldering_iron( "soldering_iron" );
-            soldering_iron.put_in( item( "battery_ups" ), item_pocket::pocket_type::MOD );
+            soldering_iron.put_in( item( "battery_ups" ), pocket_type::MOD );
             tools.push_back( soldering_iron );
             item UPS( "UPS_off" );
             item UPS_mag( UPS.magazine_default() );
             UPS_mag.ammo_set( UPS_mag.ammo_default(), 1000 );
-            UPS.put_in( UPS_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+            UPS.put_in( UPS_mag, pocket_type::MAGAZINE_WELL );
             tools.emplace_back( UPS );
             tools.push_back( tool_with_ammo( "vac_mold", 4 ) );
 
@@ -886,16 +886,16 @@ TEST_CASE( "tools_use_charge_to_craft", "[crafting][charge]" )
 
         WHEN( "UPS-modded tools do not have enough charges" ) {
             item hotplate( "hotplate" );
-            hotplate.put_in( item( "battery_ups" ), item_pocket::pocket_type::MOD );
+            hotplate.put_in( item( "battery_ups" ), pocket_type::MOD );
             tools.push_back( hotplate );
             item soldering_iron( "soldering_iron" );
-            soldering_iron.put_in( item( "battery_ups" ), item_pocket::pocket_type::MOD );
+            soldering_iron.put_in( item( "battery_ups" ), pocket_type::MOD );
             tools.push_back( soldering_iron );
 
             item ups( "UPS_off" );
             item ups_mag( ups.magazine_default() );
             ups_mag.ammo_set( ups_mag.ammo_default(), 10 );
-            ups.put_in( ups_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+            ups.put_in( ups_mag, pocket_type::MAGAZINE_WELL );
             tools.push_back( ups );
 
             THEN( "crafting fails, and no charges are used" ) {
@@ -913,7 +913,7 @@ TEST_CASE( "tool_use", "[crafting][tool]" )
         tools.push_back( tool_with_ammo( "hotplate", 500 ) );
         item plastic_bottle( "bottle_plastic" );
         plastic_bottle.put_in(
-            item( "water", calendar::turn_zero, 2 ), item_pocket::pocket_type::CONTAINER );
+            item( "water", calendar::turn_zero, 2 ), pocket_type::CONTAINER );
         tools.push_back( plastic_bottle );
         tools.emplace_back( "pot" );
 
@@ -925,7 +925,7 @@ TEST_CASE( "tool_use", "[crafting][tool]" )
         tools.push_back( tool_with_ammo( "hotplate", 500 ) );
         item plastic_bottle( "bottle_plastic" );
         plastic_bottle.put_in(
-            item( "water", calendar::turn_zero, 2 ), item_pocket::pocket_type::CONTAINER );
+            item( "water", calendar::turn_zero, 2 ), pocket_type::CONTAINER );
         tools.push_back( plastic_bottle );
         tools.push_back( tool_with_ammo( "survivor_mess_kit", 500 ) );
 
@@ -937,12 +937,12 @@ TEST_CASE( "tool_use", "[crafting][tool]" )
         tools.push_back( tool_with_ammo( "hotplate", 500 ) );
         item plastic_bottle( "bottle_plastic" );
         plastic_bottle.put_in(
-            item( "water", calendar::turn_zero, 2 ), item_pocket::pocket_type::CONTAINER );
+            item( "water", calendar::turn_zero, 2 ), pocket_type::CONTAINER );
         tools.push_back( plastic_bottle );
         item jar( "jar_glass_sealed" );
         // If it's not watertight the water will spill.
         REQUIRE( jar.is_watertight_container() );
-        jar.put_in( item( "water", calendar::turn_zero, 2 ), item_pocket::pocket_type::CONTAINER );
+        jar.put_in( item( "water", calendar::turn_zero, 2 ), pocket_type::CONTAINER );
         tools.push_back( jar );
 
         prep_craft( recipe_water_clean, tools, false );
@@ -952,7 +952,7 @@ TEST_CASE( "tool_use", "[crafting][tool]" )
         tools.push_back( tool_with_ammo( "hotplate", 500 ) );
         item plastic_bottle( "bottle_plastic" );
         plastic_bottle.put_in(
-            item( "water", calendar::turn_zero, 2 ), item_pocket::pocket_type::CONTAINER );
+            item( "water", calendar::turn_zero, 2 ), pocket_type::CONTAINER );
         tools.push_back( plastic_bottle );
         tools.emplace_back( "pot" );
 
@@ -1446,7 +1446,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_crafting_1_makeshift_funnel", "[craft
         WHEN( "3 full plastic bottles on the ground" ) {
             item plastic_bottle( "bottle_plastic" );
             plastic_bottle.put_in( item( "water", calendar::turn_zero, 2 ),
-                                   item_pocket::pocket_type::CONTAINER );
+                                   pocket_type::CONTAINER );
             REQUIRE( plastic_bottle.is_watertight_container() );
             REQUIRE( !plastic_bottle.empty_container() );
             Character &c = get_player_character();
@@ -1474,7 +1474,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_crafting_1_makeshift_funnel", "[craft
         WHEN( "3 full plastic bottles in inventory" ) {
             item plastic_bottle( "bottle_plastic" );
             plastic_bottle.put_in( item( "water", calendar::turn_zero, 2 ),
-                                   item_pocket::pocket_type::CONTAINER );
+                                   pocket_type::CONTAINER );
             REQUIRE( plastic_bottle.is_watertight_container() );
             REQUIRE( !plastic_bottle.empty_container() );
             Character &c = get_player_character();
@@ -1499,7 +1499,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_crafting_1_makeshift_funnel", "[craft
             item empty_plastic_bottle( "bottle_plastic" );
             item full_plastic_bottle( "bottle_plastic" );
             full_plastic_bottle.put_in( item( "water", calendar::turn_zero, 2 ),
-                                        item_pocket::pocket_type::CONTAINER );
+                                        pocket_type::CONTAINER );
             REQUIRE( empty_plastic_bottle.is_watertight_container() );
             REQUIRE( empty_plastic_bottle.empty_container() );
             REQUIRE( !full_plastic_bottle.empty_container() );
@@ -1523,7 +1523,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_crafting_1_makeshift_funnel", "[craft
             item empty_plastic_bottle( "bottle_plastic" );
             item full_plastic_bottle( "bottle_plastic" );
             full_plastic_bottle.put_in( item( "water", calendar::turn_zero, 2 ),
-                                        item_pocket::pocket_type::CONTAINER );
+                                        pocket_type::CONTAINER );
             REQUIRE( empty_plastic_bottle.is_watertight_container() );
             REQUIRE( empty_plastic_bottle.empty_container() );
             REQUIRE( !full_plastic_bottle.empty_container() );
@@ -1554,7 +1554,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_crafting_1_makeshift_funnel", "[craft
             item empty_plastic_bottle( "bottle_plastic" );
             item full_plastic_bottle( "bottle_plastic" );
             full_plastic_bottle.put_in( item( "water", calendar::turn_zero, 2 ),
-                                        item_pocket::pocket_type::CONTAINER );
+                                        pocket_type::CONTAINER );
             REQUIRE( empty_plastic_bottle.is_watertight_container() );
             REQUIRE( empty_plastic_bottle.empty_container() );
             REQUIRE( !full_plastic_bottle.empty_container() );
@@ -1578,7 +1578,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_crafting_1_makeshift_funnel", "[craft
             item empty_plastic_bottle( "bottle_plastic" );
             item full_plastic_bottle( "bottle_plastic" );
             full_plastic_bottle.put_in( item( "water", calendar::turn_zero, 2 ),
-                                        item_pocket::pocket_type::CONTAINER );
+                                        pocket_type::CONTAINER );
             REQUIRE( empty_plastic_bottle.is_watertight_container() );
             REQUIRE( empty_plastic_bottle.empty_container() );
             REQUIRE( !full_plastic_bottle.empty_container() );
@@ -1661,7 +1661,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_batch_crafting_3_makeshift_funnels", 
         WHEN( "10 full plastic bottles on the ground" ) {
             item plastic_bottle( "bottle_plastic" );
             plastic_bottle.put_in( item( "water", calendar::turn_zero, 2 ),
-                                   item_pocket::pocket_type::CONTAINER );
+                                   pocket_type::CONTAINER );
             REQUIRE( plastic_bottle.is_watertight_container() );
             REQUIRE( !plastic_bottle.empty_container() );
             Character &c = get_player_character();
@@ -1682,7 +1682,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_batch_crafting_3_makeshift_funnels", 
         WHEN( "10 full plastic bottles in inventory" ) {
             item plastic_bottle( "bottle_plastic" );
             plastic_bottle.put_in( item( "water", calendar::turn_zero, 2 ),
-                                   item_pocket::pocket_type::CONTAINER );
+                                   pocket_type::CONTAINER );
             REQUIRE( plastic_bottle.is_watertight_container() );
             REQUIRE( !plastic_bottle.empty_container() );
             Character &c = get_player_character();
@@ -1714,7 +1714,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_batch_crafting_3_makeshift_funnels", 
             item empty_plastic_bottle( "bottle_plastic" );
             item full_plastic_bottle( "bottle_plastic" );
             full_plastic_bottle.put_in( item( "water", calendar::turn_zero, 2 ),
-                                        item_pocket::pocket_type::CONTAINER );
+                                        pocket_type::CONTAINER );
             REQUIRE( empty_plastic_bottle.is_watertight_container() );
             REQUIRE( empty_plastic_bottle.empty_container() );
             REQUIRE( !full_plastic_bottle.empty_container() );
@@ -1738,7 +1738,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_batch_crafting_3_makeshift_funnels", 
             item empty_plastic_bottle( "bottle_plastic" );
             item full_plastic_bottle( "bottle_plastic" );
             full_plastic_bottle.put_in( item( "water", calendar::turn_zero, 2 ),
-                                        item_pocket::pocket_type::CONTAINER );
+                                        pocket_type::CONTAINER );
             REQUIRE( empty_plastic_bottle.is_watertight_container() );
             REQUIRE( empty_plastic_bottle.empty_container() );
             REQUIRE( !full_plastic_bottle.empty_container() );
@@ -1776,7 +1776,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_batch_crafting_3_makeshift_funnels", 
             item empty_plastic_bottle( "bottle_plastic" );
             item full_plastic_bottle( "bottle_plastic" );
             full_plastic_bottle.put_in( item( "water", calendar::turn_zero, 2 ),
-                                        item_pocket::pocket_type::CONTAINER );
+                                        pocket_type::CONTAINER );
             REQUIRE( empty_plastic_bottle.is_watertight_container() );
             REQUIRE( empty_plastic_bottle.empty_container() );
             REQUIRE( !full_plastic_bottle.empty_container() );
@@ -1800,7 +1800,7 @@ TEST_CASE( "prompt_for_liquid_containers_-_batch_crafting_3_makeshift_funnels", 
             item empty_plastic_bottle( "bottle_plastic" );
             item full_plastic_bottle( "bottle_plastic" );
             full_plastic_bottle.put_in( item( "water", calendar::turn_zero, 2 ),
-                                        item_pocket::pocket_type::CONTAINER );
+                                        pocket_type::CONTAINER );
             REQUIRE( empty_plastic_bottle.is_watertight_container() );
             REQUIRE( empty_plastic_bottle.empty_container() );
             REQUIRE( !full_plastic_bottle.empty_container() );
@@ -2036,7 +2036,7 @@ TEST_CASE( "tools_with_charges_as_components", "[crafting]" )
     item thread( "thread" );
     item sheet_cotton( "sheet_cotton" );
     thread.charges = 100;
-    sew_kit.put_in( thread, item_pocket::pocket_type::MAGAZINE );
+    sew_kit.put_in( thread, pocket_type::MAGAZINE );
     REQUIRE( sew_kit.ammo_remaining() == 100 );
     clear_and_setup( c, m, pocketknife );
     c.learn_recipe( &*recipe_balclava );
@@ -2139,7 +2139,7 @@ TEST_CASE( "recipes_inherit_rot_of_components_properly", "[crafting][rot]" )
         tools.insert( tools.end(), 1, macaroni );
         tools.insert( tools.end(), 1, cheese );
         item &bottle = tools.emplace_back( "bottle_plastic" ); // water container
-        bottle.get_contents().insert_item( item( itype_water_clean ), item_pocket::pocket_type::CONTAINER );
+        bottle.get_contents().insert_item( item( itype_water_clean ), pocket_type::CONTAINER );
 
         WHEN( "crafting the mac and cheese" ) {
             prep_craft( recipe_macaroni_cooked, tools, true );
@@ -2166,7 +2166,7 @@ TEST_CASE( "recipes_inherit_rot_of_components_properly", "[crafting][rot]" )
         tools.insert( tools.end(), 1, macaroni );
         tools.insert( tools.end(), 1, cheese );
         item &bottle = tools.emplace_back( "bottle_plastic" ); // water container
-        bottle.get_contents().insert_item( item( itype_water_clean ), item_pocket::pocket_type::CONTAINER );
+        bottle.get_contents().insert_item( item( itype_water_clean ), pocket_type::CONTAINER );
 
         WHEN( "crafting the mac and cheese" ) {
             prep_craft( recipe_macaroni_cooked, tools, true );

--- a/tests/encumbrance_test.cpp
+++ b/tests/encumbrance_test.cpp
@@ -103,14 +103,14 @@ TEST_CASE( "regular_clothing_encumbrance", "[encumbrance]" )
 TEST_CASE( "plate_encumbrance", "[encumbrance]" )
 {
     item with_plates( "test_ballistic_vest" );
-    with_plates.force_insert_item( item( "test_plate" ), item_pocket::pocket_type::CONTAINER );
+    with_plates.force_insert_item( item( "test_plate" ), pocket_type::CONTAINER );
     test_encumbrance_items( { with_plates }, "torso", ballistic + plate );
 }
 
 TEST_CASE( "off_limb_ablative_encumbrance", "[encumbrance]" )
 {
     item with_plates( "test_ghost_vest" );
-    with_plates.force_insert_item( item( "test_plate_skirt" ), item_pocket::pocket_type::CONTAINER );
+    with_plates.force_insert_item( item( "test_plate_skirt" ), pocket_type::CONTAINER );
     test_encumbrance_items( { with_plates }, "leg_l", plate );
 }
 

--- a/tests/faction_price_rules_test.cpp
+++ b/tests/faction_price_rules_test.cpp
@@ -41,12 +41,12 @@ TEST_CASE( "basic_price_check", "[npc][trade]" )
                                adjusted_price( &ammo, ammo_amount, *buyer, *seller ) +
                                adjusted_price( &backpack, 1, *buyer, *seller );
 
-    mag.put_in( ammo, item_pocket::pocket_type::MAGAZINE );
-    m4.put_in( mag, item_pocket::pocket_type::MAGAZINE_WELL );
-    backpack.put_in( m4, item_pocket::pocket_type::CONTAINER );
+    mag.put_in( ammo, pocket_type::MAGAZINE );
+    m4.put_in( mag, pocket_type::MAGAZINE_WELL );
+    backpack.put_in( m4, pocket_type::CONTAINER );
     if( !u_buy ) {
         REQUIRE( !guy.wants_to_buy( bomba ) );
-        backpack.put_in( bomba, item_pocket::pocket_type::CONTAINER );
+        backpack.put_in( bomba, pocket_type::CONTAINER );
     }
 
     trade_selector::entry_t bck_entry{

--- a/tests/item_autopickup_test.cpp
+++ b/tests/item_autopickup_test.cpp
@@ -1,12 +1,12 @@
 #include "avatar.h"
 #include "cata_catch.h"
 #include "item.h"
-#include "item_pocket.h"
 #include "map.h"
 #include "map_helpers.h"
-#include "player_helpers.h"
 #include "options.h"
 #include "pickup.h"
+#include "player_helpers.h"
+#include "pocket_type.h"
 
 static const itype_id itype_aspirin( "aspirin" );
 static const itype_id itype_backpack( "backpack" );
@@ -40,7 +40,7 @@ static const itype_id itype_wallet_leather( "wallet_leather" );
 static const itype_id itype_water_clean( "water_clean" );
 static const itype_id itype_wrapper( "wrapper" );
 
-static const item_pocket::pocket_type pocket_type_container = item_pocket::pocket_type::CONTAINER;
+static const pocket_type pocket_type_container = pocket_type::CONTAINER;
 
 class unique_item
 {

--- a/tests/item_contents_test.cpp
+++ b/tests/item_contents_test.cpp
@@ -3,10 +3,10 @@
 #include "cata_catch.h"
 #include "item.h"
 #include "item_contents.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "ret_val.h"
 #include "type_id.h"
@@ -35,10 +35,10 @@ TEST_CASE( "item_contents" )
     item wrench( "wrench_pocket_test" );
     item crowbar( "crowbar_pocket_test" );
 
-    ret_val<void> i1 = tool_belt.put_in( hammer, item_pocket::pocket_type::CONTAINER );
-    ret_val<void> i2 = tool_belt.put_in( tongs, item_pocket::pocket_type::CONTAINER );
-    ret_val<void> i3 = tool_belt.put_in( wrench, item_pocket::pocket_type::CONTAINER );
-    ret_val<void> i4 = tool_belt.put_in( crowbar, item_pocket::pocket_type::CONTAINER );
+    ret_val<void> i1 = tool_belt.put_in( hammer, pocket_type::CONTAINER );
+    ret_val<void> i2 = tool_belt.put_in( tongs, pocket_type::CONTAINER );
+    ret_val<void> i3 = tool_belt.put_in( wrench, pocket_type::CONTAINER );
+    ret_val<void> i4 = tool_belt.put_in( crowbar, pocket_type::CONTAINER );
 
     {
         CAPTURE( i1.str() );
@@ -70,9 +70,9 @@ TEST_CASE( "item_contents" )
     // check that the tool belt is "full"
     CHECK( !tool_belt.can_contain( crowbar ).success() );
 
-    tool_belt.force_insert_item( crowbar, item_pocket::pocket_type::CONTAINER );
+    tool_belt.force_insert_item( crowbar, pocket_type::CONTAINER );
     CHECK( tool_belt.num_item_stacks() == 5 );
-    tool_belt.force_insert_item( crowbar, item_pocket::pocket_type::CONTAINER );
+    tool_belt.force_insert_item( crowbar, pocket_type::CONTAINER );
     tool_belt.overflow( tripoint_zero );
     CHECK( tool_belt.num_item_stacks() == 4 );
     tool_belt.overflow( tripoint_zero );
@@ -95,7 +95,7 @@ TEST_CASE( "overflow_on_combine", "[item]" )
     item purse( itype_purse );
     item log( itype_log );
     item_contents overfull_contents( purse.type->pockets );
-    overfull_contents.force_insert_item( log, item_pocket::pocket_type::CONTAINER );
+    overfull_contents.force_insert_item( log, pocket_type::CONTAINER );
     capture_debugmsg_during( [&purse, &overfull_contents]() {
         purse.combine( overfull_contents );
     } );
@@ -111,7 +111,7 @@ TEST_CASE( "overflow_test", "[item]" )
     tripoint origin{ 60, 60, 0 };
     item purse( itype_purse );
     item log( itype_log );
-    purse.force_insert_item( log, item_pocket::pocket_type::MIGRATION );
+    purse.force_insert_item( log, pocket_type::MIGRATION );
     map &here = get_map();
     purse.overflow( origin );
     CHECK( here.i_at( origin ).size() == 1 );
@@ -123,8 +123,8 @@ TEST_CASE( "overflow_test_into_parent_item", "[item]" )
     tripoint origin{ 60, 60, 0 };
     item jar( itype_jar_glass_sealed );
     item pickle( itype_pickle );
-    pickle.force_insert_item( pickle, item_pocket::pocket_type::MIGRATION );
-    jar.put_in( pickle, item_pocket::pocket_type::CONTAINER );
+    pickle.force_insert_item( pickle, pocket_type::MIGRATION );
+    jar.put_in( pickle, pocket_type::CONTAINER );
     int contents_pre = 0;
     for( item *it : jar.all_items_top() ) {
         contents_pre += it->count();

--- a/tests/item_location_test.cpp
+++ b/tests/item_location_test.cpp
@@ -6,11 +6,11 @@
 #include "character.h"
 #include "item.h"
 #include "item_location.h"
-#include "item_pocket.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "map_selector.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "ret_val.h"
 #include "rng.h"
@@ -80,7 +80,7 @@ TEST_CASE( "item_in_container", "[item][item_location]" )
 
     REQUIRE( dummy.has_item( *backpack ) );
 
-    backpack->put_in( jeans, item_pocket::pocket_type::CONTAINER );
+    backpack->put_in( jeans, pocket_type::CONTAINER );
 
     item_location backpack_loc( dummy, & **dummy.wear_item( *backpack ) );
 

--- a/tests/item_pickup_test.cpp
+++ b/tests/item_pickup_test.cpp
@@ -64,7 +64,7 @@ TEST_CASE( "putting_items_into_inventory_with_put_in_or_i_add", "[pickup][invent
         }
 
         WHEN( "using put_in to put a rope directly into the backpack" ) {
-            REQUIRE( backpack.put_in( rope_map, item_pocket::pocket_type::CONTAINER ).success() );
+            REQUIRE( backpack.put_in( rope_map, pocket_type::CONTAINER ).success() );
 
             THEN( "the original rope is not in inventory or the backpack" ) {
                 CHECK_FALSE( they.has_item( rope_map ) );

--- a/tests/item_pocket_test.cpp
+++ b/tests/item_pocket_test.cpp
@@ -59,7 +59,7 @@ itype_test_watertight_open_sealed_container_1L( "test_watertight_open_sealed_con
 
 static const nested_mapgen_id nested_mapgen_auto_wl_test( "auto_wl_test" );
 
-static const item_pocket::pocket_type pocket_container = item_pocket::pocket_type::CONTAINER;
+static const pocket_type pocket_container = pocket_type::CONTAINER;
 
 // Pocket Tests
 // ------------
@@ -156,7 +156,7 @@ TEST_CASE( "max_item_length", "[pocket][max_item_length]" )
     item sword( "test_clumsy_sword" );
 
     // Sheath that may contain items
-    pocket_data data_sheath( item_pocket::pocket_type::CONTAINER );
+    pocket_data data_sheath( pocket_type::CONTAINER );
     // Has plenty of weight/ volume, since we're only testing length
     data_sheath.volume_capacity = 10_liter;
     data_sheath.max_contains_weight = 10_kilogram;
@@ -210,7 +210,7 @@ TEST_CASE( "max_item_length", "[pocket][max_item_length]" )
             REQUIRE( rod_14.length() == 14_cm );
 
             REQUIRE( box.is_container_empty() );
-            box.put_in( rod_14, item_pocket::pocket_type::CONTAINER );
+            box.put_in( rod_14, pocket_type::CONTAINER );
             // Item went into the box
             CHECK_FALSE( box.is_container_empty() );
         }
@@ -221,7 +221,7 @@ TEST_CASE( "max_item_length", "[pocket][max_item_length]" )
 
             REQUIRE( box.is_container_empty() );
             std::string dmsg = capture_debugmsg_during( [&box, &rod_15]() {
-                ret_val<void> result = box.put_in( rod_15, item_pocket::pocket_type::CONTAINER );
+                ret_val<void> result = box.put_in( rod_15, pocket_type::CONTAINER );
                 CHECK_FALSE( result.success() );
             } );
             CHECK_THAT( dmsg, Catch::EndsWith( "item is too long" ) );
@@ -253,7 +253,7 @@ TEST_CASE( "max_item_volume", "[pocket][max_item_volume]" )
     item liquid( "test_liquid" );
 
     // Air-tight, water-tight, jug-style container
-    pocket_data data_jug( item_pocket::pocket_type::CONTAINER );
+    pocket_data data_jug( pocket_type::CONTAINER );
     data_jug.airtight = true;
     data_jug.watertight = true;
 
@@ -326,7 +326,7 @@ TEST_CASE( "max_container_volume", "[pocket][max_contains_volume]" )
     // TODO: Add tests for having multiple ammo types in the ammo_restriction
 
     WHEN( "pocket has no ammo_restriction" ) {
-        pocket_data data_box( item_pocket::pocket_type::CONTAINER );
+        pocket_data data_box( pocket_type::CONTAINER );
         // Just a normal 1-liter box
         data_box.volume_capacity = 1_liter;
         REQUIRE( data_box.ammo_restriction.empty() );
@@ -337,7 +337,7 @@ TEST_CASE( "max_container_volume", "[pocket][max_contains_volume]" )
     }
 
     WHEN( "pocket has ammo_restriction" ) {
-        pocket_data data_ammo_box( item_pocket::pocket_type::CONTAINER );
+        pocket_data data_ammo_box( pocket_type::CONTAINER );
 
         // 9mm ammo is 50 rounds per 250ml (or 200 rounds per liter), so this ammo box
         // should be exactly 1 liter in size, so it can contain this much ammo.
@@ -368,7 +368,7 @@ TEST_CASE( "max_container_volume", "[pocket][max_contains_volume]" )
 //
 TEST_CASE( "magazine_with_ammo_restriction", "[pocket][magazine][ammo_restriction]" )
 {
-    pocket_data data_mag( item_pocket::pocket_type::MAGAZINE );
+    pocket_data data_mag( pocket_type::MAGAZINE );
 
     // ammo_restriction takes precedence over volume/length/weight,
     // so it doesn't matter what these are set to - they can even be 0.
@@ -480,7 +480,7 @@ TEST_CASE( "pocket_with_item_flag_restriction", "[pocket][flag_restriction]" )
     REQUIRE( halligan.volume() < axe.volume() );
 
     // Test pocket with BELT_CLIP flag
-    pocket_data data_belt( item_pocket::pocket_type::CONTAINER );
+    pocket_data data_belt( pocket_type::CONTAINER );
 
     // Sonic screwdriver is the smallest item it can hold
     data_belt.min_item_volume = sonic.volume();
@@ -594,7 +594,7 @@ TEST_CASE( "holster_can_contain_one_fitting_item", "[pocket][holster]" )
     item glock( "test_glock" );
 
     // Construct data for a holster to perfectly fit this gun
-    pocket_data data_holster( item_pocket::pocket_type::CONTAINER );
+    pocket_data data_holster( pocket_type::CONTAINER );
     data_holster.holster = true;
     data_holster.volume_capacity = glock.volume();
     data_holster.max_item_length = glock.length();
@@ -687,7 +687,7 @@ TEST_CASE( "pockets_containing_liquids", "[pocket][watertight][liquid]" )
     item glock( "test_glock" );
 
     // Large watertight container
-    pocket_data data_bucket( item_pocket::pocket_type::CONTAINER );
+    pocket_data data_bucket( pocket_type::CONTAINER );
     data_bucket.watertight = true;
     data_bucket.volume_capacity = 10_liter;
     data_bucket.max_item_length = 1_meter;
@@ -781,7 +781,7 @@ TEST_CASE( "pockets_containing_gases", "[pocket][airtight][gas]" )
     item gas( "test_gas", calendar::turn_zero, item::default_charges_tag{} );
 
     // A potentially airtight container
-    pocket_data data_balloon( item_pocket::pocket_type::CONTAINER );
+    pocket_data data_balloon( pocket_type::CONTAINER );
 
     // Has capacity for several charges of gas
     data_balloon.volume_capacity = 4 * gas.volume();
@@ -834,7 +834,7 @@ TEST_CASE( "rigid_and_non-rigid_or_flexible_pockets", "[pocket][rigid][flexible]
     item rock( "test_rock" );
 
     // Pocket with enough space for 2 rocks
-    pocket_data data_sock( item_pocket::pocket_type::CONTAINER );
+    pocket_data data_sock( pocket_type::CONTAINER );
     data_sock.volume_capacity = 2 * rock.volume();
 
     // Can hold plenty of length and weight (we only care about volume here)
@@ -939,7 +939,7 @@ TEST_CASE( "corpse_can_contain_anything", "[pocket][corpse]" )
     item rock( "test_rock" );
     item glock( "test_glock" );
 
-    pocket_data data_corpse( item_pocket::pocket_type::CORPSE );
+    pocket_data data_corpse( pocket_type::CORPSE );
 
     GIVEN( "a corpse" ) {
         item_pocket pocket_corpse( &data_corpse );
@@ -1066,8 +1066,8 @@ TEST_CASE( "when_one_pocket_is_better_than_another", "[pocket][better]" )
     // pockets without ripoff chance should be prioritized (#53162)
 
     // A and B: Two generic sets of pocket data for comparison
-    pocket_data data_a( item_pocket::pocket_type::CONTAINER );
-    pocket_data data_b( item_pocket::pocket_type::CONTAINER );
+    pocket_data data_a( pocket_type::CONTAINER );
+    pocket_data data_b( pocket_type::CONTAINER );
 
     // Candidate items to compare pockets with
     item liquid( "test_liquid" );
@@ -1171,10 +1171,10 @@ TEST_CASE( "best_pocket_in_item_contents", "[pocket][item][best]" )
     SECTION( "non-container pockets cannot be best_pocket" ) {
         // Gun that accepts magazines
         item glock( "test_glock" );
-        REQUIRE( glock.has_pocket_type( item_pocket::pocket_type::MAGAZINE_WELL ) );
+        REQUIRE( glock.has_pocket_type( pocket_type::MAGAZINE_WELL ) );
         // Empty magazine
         item glockmag( "test_glockmag", calendar::turn, 0 );
-        REQUIRE( glockmag.has_pocket_type( item_pocket::pocket_type::MAGAZINE ) );
+        REQUIRE( glockmag.has_pocket_type( pocket_type::MAGAZINE ) );
         REQUIRE( glockmag.ammo_remaining() == 0 );
         // A single 9mm bullet
         item glockammo( "test_9mm_ammo", calendar::turn, 1 );
@@ -1201,7 +1201,7 @@ TEST_CASE( "best_pocket_in_item_contents", "[pocket][item][best]" )
         // Before being sealed, it can be best pocket for liquid
         CHECK( has_best_pocket( can, liquid ) );
         // Fill with liquid, seal it, and ensure success
-        can.put_in( liquid, item_pocket::pocket_type::CONTAINER );
+        can.put_in( liquid, pocket_type::CONTAINER );
         REQUIRE( can.seal() ); // This must succeed, or next assertion is meaningless
         // Now sealed, the can cannot be best_pocket for liquid
         CHECK_FALSE( has_best_pocket( can, liquid ) );
@@ -1731,7 +1731,7 @@ TEST_CASE( "guns_and_gunmods", "[pocket][gunmod]" )
     item strap( "shoulder_strap" );
     // Guns cannot "contain" gunmods, but gunmods can be inserted into guns
     CHECK_FALSE( m4a1.can_contain( strap ).success() );
-    CHECK( m4a1.put_in( strap, item_pocket::pocket_type::MOD ).success() );
+    CHECK( m4a1.put_in( strap, pocket_type::MOD ).success() );
 }
 
 TEST_CASE( "usb_drives_and_software", "[pocket][software]" )
@@ -1740,7 +1740,7 @@ TEST_CASE( "usb_drives_and_software", "[pocket][software]" )
     item software( "software_math" );
     // USB drives aren't containers, and cannot "contain" software, but software can be inserted
     CHECK_FALSE( usb.can_contain( software ).success() );
-    CHECK( usb.put_in( software, item_pocket::pocket_type::SOFTWARE ).success() );
+    CHECK( usb.put_in( software, pocket_type::SOFTWARE ).success() );
 }
 
 static void test_pickup_autoinsert_results( Character &u, bool wear, const item_location &nested,
@@ -2613,7 +2613,7 @@ TEST_CASE( "item_cannot_contain_contents_it_already_has", "[item][pocket]" )
     bottle.fill_with( water, 1 );
     REQUIRE( !bottle.is_container_empty() );
     REQUIRE( bottle.only_item().typeId() == water.typeId() );
-    backpack.put_in( bottle, item_pocket::pocket_type::CONTAINER );
+    backpack.put_in( bottle, pocket_type::CONTAINER );
     REQUIRE( !backpack.is_container_empty() );
     REQUIRE( backpack.only_item().typeId() == bottle.typeId() );
 
@@ -2658,8 +2658,8 @@ TEST_CASE( "Sawed_off_fits_in_large_holster", "[item][pocket]" )
     item large_holster( "XL_holster" );
 
     //add the mods
-    double_barrel.put_in( item( "stock_none", calendar::turn ), item_pocket::pocket_type::MOD );
-    double_barrel.put_in( item( "barrel_small", calendar::turn ), item_pocket::pocket_type::MOD );
+    double_barrel.put_in( item( "stock_none", calendar::turn ), pocket_type::MOD );
+    double_barrel.put_in( item( "barrel_small", calendar::turn ), pocket_type::MOD );
 
     CHECK( large_holster.can_contain( double_barrel ).success() );
 
@@ -2673,7 +2673,7 @@ TEST_CASE( "bag_with_restrictions_and_nested_bag_does_not_fit_too_large_items", 
     item backpack_two( "test_backpack" );
     item mini_backpack( "test_mini_backpack" );
 
-    mini_backpack.put_in( backpack, item_pocket::pocket_type::CONTAINER );
+    mini_backpack.put_in( backpack, pocket_type::CONTAINER );
     REQUIRE( !mini_backpack.is_container_empty() );
     REQUIRE( mini_backpack.only_item().typeId() == backpack.typeId() );
 
@@ -2697,7 +2697,7 @@ TEST_CASE( "pocket_leak" )
     item water( "water" );
     water.set_item_temperature( water.get_freeze_point() );
     REQUIRE( water.is_frozen_liquid() );
-    REQUIRE( backpack.put_in( water, item_pocket::pocket_type::CONTAINER ).success() );
+    REQUIRE( backpack.put_in( water, pocket_type::CONTAINER ).success() );
 
     WHEN( "single container" ) {
         auto backpack_iter = *u.wear_item( backpack );
@@ -2716,7 +2716,7 @@ TEST_CASE( "pocket_leak" )
         CAPTURE( top_watertight );
         item top( top_watertight ? "55gal_drum" : "test_backpack" );
         REQUIRE( top.is_watertight_container() == top_watertight );
-        REQUIRE( top.put_in( backpack, item_pocket::pocket_type::CONTAINER ).success() );
+        REQUIRE( top.put_in( backpack, pocket_type::CONTAINER ).success() );
         u.wield( top );
         item &topit = *u.get_wielded_item();
         item &bkit = topit.only_item();

--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -15,12 +15,12 @@
 #include "game.h"
 #include "item_category.h"
 #include "item_factory.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "math_defines.h"
 #include "monstergenerator.h"
 #include "mtype.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
 #include "ret_val.h"
 #include "test_data.h"
 #include "type_id.h"
@@ -80,7 +80,7 @@ TEST_CASE( "gun_layer", "[item]" )
     item gun( "win70" );
     item mod( "shoulder_strap" );
     CHECK( gun.is_gunmod_compatible( mod ).success() );
-    gun.put_in( mod, item_pocket::pocket_type::MOD );
+    gun.put_in( mod, pocket_type::MOD );
     CHECK( gun.get_layer().front() == layer_level::BELTED );
     CHECK( gun.get_category_of_contents().id == item_category_guns );
 }
@@ -91,8 +91,8 @@ TEST_CASE( "stacking_cash_cards", "[item]" )
     item cash0( "cash_card", calendar::turn_zero );
     item cash1( "cash_card", calendar::turn_zero );
     item cash2( "cash_card", calendar::turn_zero );
-    cash1.put_in( item( "money", calendar::turn_zero, 1 ), item_pocket::pocket_type::MAGAZINE );
-    cash2.put_in( item( "money", calendar::turn_zero, 2 ), item_pocket::pocket_type::MAGAZINE );
+    cash1.put_in( item( "money", calendar::turn_zero, 1 ), pocket_type::MAGAZINE );
+    cash2.put_in( item( "money", calendar::turn_zero, 2 ), pocket_type::MAGAZINE );
     CHECK( !cash0.stacks_with( cash1 ) );
     //CHECK( cash1.stacks_with( cash2 ) ); Enable this once cash card stacking is brought back.
 }
@@ -356,7 +356,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item aspirin( "aspirin" );
             item backpack( "backpack" );
 
-            backpack.put_in( aspirin, item_pocket::pocket_type::CONTAINER );
+            backpack.put_in( aspirin, pocket_type::CONTAINER );
 
             REQUIRE( guy.wear_item( backpack ) );
 
@@ -373,7 +373,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item aspirin( "aspirin" );
             item bottle_small( "bottle_plastic_small" );
 
-            bottle_small.put_in( aspirin, item_pocket::pocket_type::CONTAINER );
+            bottle_small.put_in( aspirin, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( bottle_small ) );
 
@@ -391,8 +391,8 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item backpack( "backpack" );
             item duffelbag( "duffelbag" );
 
-            backpack.put_in( aspirin, item_pocket::pocket_type::CONTAINER );
-            duffelbag.put_in( backpack, item_pocket::pocket_type::CONTAINER );
+            backpack.put_in( aspirin, pocket_type::CONTAINER );
+            duffelbag.put_in( backpack, pocket_type::CONTAINER );
 
             REQUIRE( guy.wear_item( duffelbag ) );
 
@@ -410,8 +410,8 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item backpack( "backpack" );
             item body_bag( "test_waterproof_bag" );
 
-            backpack.put_in( aspirin, item_pocket::pocket_type::CONTAINER );
-            body_bag.put_in( backpack, item_pocket::pocket_type::CONTAINER );
+            backpack.put_in( aspirin, pocket_type::CONTAINER );
+            body_bag.put_in( backpack, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( body_bag ) );
 
@@ -447,7 +447,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item smart_phone( itype_test_smart_phone );
             item backpack( itype_test_backpack );
 
-            backpack.put_in( smart_phone, item_pocket::pocket_type::CONTAINER );
+            backpack.put_in( smart_phone, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( backpack ) );
 
@@ -464,7 +464,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item smart_phone( itype_test_smart_phone );
             item body_bag( "test_waterproof_bag" );
 
-            body_bag.put_in( smart_phone, item_pocket::pocket_type::CONTAINER );
+            body_bag.put_in( smart_phone, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( body_bag ) );
 
@@ -482,8 +482,8 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item backpack( itype_test_backpack );
             item duffelbag( itype_test_duffelbag );
 
-            backpack.put_in( smart_phone, item_pocket::pocket_type::CONTAINER );
-            duffelbag.put_in( backpack, item_pocket::pocket_type::CONTAINER );
+            backpack.put_in( smart_phone, pocket_type::CONTAINER );
+            duffelbag.put_in( backpack, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( duffelbag ) );
 
@@ -501,8 +501,8 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item backpack( itype_test_backpack );
             item body_bag( itype_test_waterproof_bag );
 
-            backpack.put_in( smart_phone, item_pocket::pocket_type::CONTAINER );
-            body_bag.put_in( backpack, item_pocket::pocket_type::CONTAINER );
+            backpack.put_in( smart_phone, pocket_type::CONTAINER );
+            body_bag.put_in( backpack, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( body_bag ) );
 
@@ -538,7 +538,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item mp3( itype_test_mp3 );
             item backpack( itype_test_backpack );
 
-            backpack.put_in( mp3, item_pocket::pocket_type::CONTAINER );
+            backpack.put_in( mp3, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( backpack ) );
 
@@ -557,7 +557,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item mp3( itype_test_mp3 );
             item body_bag( itype_test_waterproof_bag );
 
-            body_bag.put_in( mp3, item_pocket::pocket_type::CONTAINER );
+            body_bag.put_in( mp3, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( body_bag ) );
 
@@ -577,8 +577,8 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item backpack( itype_test_backpack );
             item duffelbag( itype_test_duffelbag );
 
-            backpack.put_in( mp3, item_pocket::pocket_type::CONTAINER );
-            duffelbag.put_in( backpack, item_pocket::pocket_type::CONTAINER );
+            backpack.put_in( mp3, pocket_type::CONTAINER );
+            duffelbag.put_in( backpack, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( duffelbag ) );
 
@@ -598,8 +598,8 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item backpack( itype_test_backpack );
             item body_bag( itype_test_waterproof_bag );
 
-            backpack.put_in( mp3, item_pocket::pocket_type::CONTAINER );
-            body_bag.put_in( backpack, item_pocket::pocket_type::CONTAINER );
+            backpack.put_in( mp3, pocket_type::CONTAINER );
+            body_bag.put_in( backpack, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( body_bag ) );
 
@@ -683,7 +683,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item towel( "towel" );
             item backpack( "backpack" );
 
-            backpack.put_in( towel, item_pocket::pocket_type::CONTAINER );
+            backpack.put_in( towel, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( backpack ) );
 
@@ -700,7 +700,7 @@ TEST_CASE( "water_affect_items_while_swimming_check", "[item][water][swimming]" 
             item towel( "towel" );
             item body_bag( "test_waterproof_bag" );
 
-            body_bag.put_in( towel, item_pocket::pocket_type::CONTAINER );
+            body_bag.put_in( towel, pocket_type::CONTAINER );
 
             REQUIRE( guy.wield( body_bag ) );
 
@@ -807,7 +807,7 @@ TEST_CASE( "module_inheritance", "[item][armor]" )
     item test_exo( "test_modular_exosuit" );
     item test_module( "test_exo_lense_module" );
 
-    test_exo.force_insert_item( test_module, item_pocket::pocket_type::CONTAINER );
+    test_exo.force_insert_item( test_module, pocket_type::CONTAINER );
 
     guy.worn.wear_item( guy, test_exo, false, false, false );
 
@@ -816,7 +816,7 @@ TEST_CASE( "module_inheritance", "[item][armor]" )
     clear_avatar();
     item miner_hat( "miner_hat" );
     item ear_muffs( "attachable_ear_muffs" );
-    REQUIRE( miner_hat.put_in( ear_muffs, item_pocket::pocket_type::CONTAINER ).success() );
+    REQUIRE( miner_hat.put_in( ear_muffs, pocket_type::CONTAINER ).success() );
     REQUIRE( !miner_hat.has_flag( json_flag_DEAF ) );
     guy.wear_item( miner_hat );
     item_location worn_hat = guy.worn.top_items_loc( guy ).front();
@@ -912,20 +912,20 @@ TEST_CASE( "item_single_type_contents", "[item]" )
     int const num = GENERATE( 1, 2 );
     bool ret = true;
     for( int i = 0; i < num; i++ ) {
-        ret &= bag.put_in( walnut, item_pocket::pocket_type::CONTAINER ).success();
+        ret &= bag.put_in( walnut, pocket_type::CONTAINER ).success();
     }
     REQUIRE( ret );
     CAPTURE( num, bag.display_name() );
     CHECK( bag.get_category_of_contents() == *item_category_food );
     REQUIRE( nail.get_category_of_contents().id != walnut.get_category_of_contents().id );
-    REQUIRE( bag.put_in( nail, item_pocket::pocket_type::CONTAINER ).success() );
+    REQUIRE( bag.put_in( nail, pocket_type::CONTAINER ).success() );
     CHECK( bag.get_category_of_contents().id == item_category_container );
 
     SECTION( "clothing" ) {
         item jeans( "jeans" );
         REQUIRE( jeans.get_category_of_contents().id == item_category_clothing );
         REQUIRE( walnut.get_category_of_contents().id == item_category_food );
-        REQUIRE( jeans.put_in( walnut, item_pocket::pocket_type::CONTAINER ).success() );
+        REQUIRE( jeans.put_in( walnut, pocket_type::CONTAINER ).success() );
         CHECK( jeans.get_category_of_contents().id == item_category_clothing );
     }
 
@@ -933,7 +933,7 @@ TEST_CASE( "item_single_type_contents", "[item]" )
         item usb_drive( "usb_drive" );
         item software_hacking( "software_hacking" );
         REQUIRE( usb_drive.get_category_of_contents().id == item_category_tools );
-        REQUIRE( usb_drive.put_in( software_hacking, item_pocket::pocket_type::SOFTWARE ).success() );
+        REQUIRE( usb_drive.put_in( software_hacking, pocket_type::SOFTWARE ).success() );
         CHECK( usb_drive.get_category_of_contents().id == item_category_tools );
     }
 }
@@ -945,15 +945,15 @@ TEST_CASE( "item_nested_contents", "[item]" )
     item inner_bag1( "bag_plastic" );
     item inner_bag2( "bag_plastic" );
 
-    REQUIRE( inner_bag1.put_in( walnut, item_pocket::pocket_type::CONTAINER ).success() );
-    REQUIRE( inner_bag1.put_in( walnut, item_pocket::pocket_type::CONTAINER ).success() );
+    REQUIRE( inner_bag1.put_in( walnut, pocket_type::CONTAINER ).success() );
+    REQUIRE( inner_bag1.put_in( walnut, pocket_type::CONTAINER ).success() );
     CHECK( inner_bag1.get_category_of_contents().id == item_category_food );
 
-    REQUIRE( inner_bag2.put_in( walnut, item_pocket::pocket_type::CONTAINER ).success() );
+    REQUIRE( inner_bag2.put_in( walnut, pocket_type::CONTAINER ).success() );
     CHECK( inner_bag2.get_category_of_contents().id == item_category_food );
 
-    REQUIRE( outer_bag.put_in( inner_bag1, item_pocket::pocket_type::CONTAINER ).success() );
-    REQUIRE( outer_bag.put_in( inner_bag2, item_pocket::pocket_type::CONTAINER ).success() );
+    REQUIRE( outer_bag.put_in( inner_bag1, pocket_type::CONTAINER ).success() );
+    REQUIRE( outer_bag.put_in( inner_bag2, pocket_type::CONTAINER ).success() );
     CAPTURE( outer_bag.display_name() );
     // outer_bag
     //   inner_bag1
@@ -971,14 +971,14 @@ TEST_CASE( "item_rotten_contents", "[item]" )
 
     item butter_rotten( "butter" );
     butter_rotten.set_relative_rot( 1.01 );
-    REQUIRE( wrapper.put_in( butter_rotten, item_pocket::pocket_type::CONTAINER ).success() );
-    REQUIRE( wrapper.put_in( butter_rotten, item_pocket::pocket_type::CONTAINER ).success() );
+    REQUIRE( wrapper.put_in( butter_rotten, pocket_type::CONTAINER ).success() );
+    REQUIRE( wrapper.put_in( butter_rotten, pocket_type::CONTAINER ).success() );
     CAPTURE( wrapper.display_name() );
     CHECK( wrapper.get_category_of_contents().id == item_category_food );
 
     item butter( "butter" );
     butter.set_relative_rot( 0.5 );
-    REQUIRE( wrapper.put_in( butter, item_pocket::pocket_type::CONTAINER ).success() );
+    REQUIRE( wrapper.put_in( butter, pocket_type::CONTAINER ).success() );
     CAPTURE( wrapper.display_name() );
     // wrapper
     //   butter (rotten)

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -8,9 +8,9 @@
 #include "character.h"
 #include "flag.h"
 #include "item.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "options_helpers.h"
+#include "pocket_type.h"
 #include "ret_val.h"
 #include "type_id.h"
 #include "value_ptr.h"
@@ -683,7 +683,7 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
 
     SECTION( "single stack inside" ) {
 
-        backpack_hiking.put_in( rock, item_pocket::pocket_type::CONTAINER );
+        backpack_hiking.put_in( rock, pocket_type::CONTAINER );
 
         std::string const rock_nested_tname = colorize( rock.tname(), rock.color_in_inventory() );
         std::string const rocks_nested_tname = colorize( rock.tname( 2 ), rock.color_in_inventory() );
@@ -693,13 +693,13 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
                    rock_nested_tname );
         }
         SECTION( "several rocks" ) {
-            backpack_hiking.put_in( rock, item_pocket::pocket_type::CONTAINER );
+            backpack_hiking.put_in( rock, pocket_type::CONTAINER );
             CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym +
                    " " + rocks_nested_tname + " (2)" );
         }
         SECTION( "several stacks" ) {
-            backpack_hiking.put_in( rock, item_pocket::pocket_type::CONTAINER );
-            backpack_hiking.put_in( rock2, item_pocket::pocket_type::CONTAINER );
+            backpack_hiking.put_in( rock, pocket_type::CONTAINER );
+            backpack_hiking.put_in( rock2, pocket_type::CONTAINER );
             CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym + " 2 items" );
         }
         SECTION( "container has whitelist" ) {
@@ -722,10 +722,10 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
     std::string const purse_color = get_tag_from_color( purse.color_in_inventory() );
     std::string const color_end_tag = "</color>";
     SECTION( "multi-level nesting" ) {
-        purse.put_in( rock, item_pocket::pocket_type::CONTAINER );
+        purse.put_in( rock, pocket_type::CONTAINER );
 
         SECTION( "single rock" ) {
-            backpack_hiking.put_in( purse, item_pocket::pocket_type::CONTAINER );
+            backpack_hiking.put_in( purse, pocket_type::CONTAINER );
             CHECK( backpack_hiking.tname( 1 ) ==
                    color_pref + "hiking backpack " +
                    nesting_sym + " " + purse_color + color_pref + "purse " +
@@ -734,9 +734,9 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
         }
 
         SECTION( "several rocks" ) {
-            purse.put_in( rock2, item_pocket::pocket_type::CONTAINER );
+            purse.put_in( rock2, pocket_type::CONTAINER );
 
-            backpack_hiking.put_in( purse, item_pocket::pocket_type::CONTAINER );
+            backpack_hiking.put_in( purse, pocket_type::CONTAINER );
 
             CHECK( backpack_hiking.tname( 1 ) ==
                    color_pref + "hiking backpack " +
@@ -746,8 +746,8 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
         }
 
         SECTION( "several purses" ) {
-            backpack_hiking.put_in( purse, item_pocket::pocket_type::CONTAINER );
-            backpack_hiking.put_in( purse, item_pocket::pocket_type::CONTAINER );
+            backpack_hiking.put_in( purse, pocket_type::CONTAINER );
+            backpack_hiking.put_in( purse, pocket_type::CONTAINER );
 
             CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym +
                    " " + purse_color + color_pref + "purses" + color_end_tag + " (2)" );
@@ -762,7 +762,7 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
         REQUIRE( usb_drive.is_software_storage() );
         REQUIRE( medisoft.is_software() );
         REQUIRE( medisoft_nested_tname == "<color_c_light_gray>MediSoft</color>" );
-        usb_drive.put_in( medisoft, item_pocket::pocket_type::SOFTWARE );
+        usb_drive.put_in( medisoft, pocket_type::SOFTWARE );
         CHECK( usb_drive.tname( 1 ) == "USB drive " + nesting_sym + " " + medisoft_nested_tname );
     }
 }

--- a/tests/iteminfo_test.cpp
+++ b/tests/iteminfo_test.cpp
@@ -2288,7 +2288,7 @@ TEST_CASE( "list_of_item_qualities", "[iteminfo][quality]" )
         // With enough charges
         int bat_charges = drill.type->charges_to_use();
         battery.ammo_set( battery.ammo_default(), bat_charges );
-        drill.put_in( battery, item_pocket::pocket_type::MAGAZINE_WELL );
+        drill.put_in( battery, pocket_type::MAGAZINE_WELL );
         REQUIRE( drill.ammo_remaining() == bat_charges );
 
         CHECK( item_info_str( drill, qualities ) ==

--- a/tests/itemname_test.cpp
+++ b/tests/itemname_test.cpp
@@ -7,8 +7,8 @@
 #include "character.h"
 #include "flag.h"
 #include "item.h"
-#include "item_pocket.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
 #include "ret_val.h"
 #include "type_id.h"
 
@@ -148,7 +148,7 @@ TEST_CASE( "display_name_includes_item_contents", "[item][display_name][contents
            "test quiver (0)" );
 
     // Insert one arrow
-    quiver.put_in( arrow, item_pocket::pocket_type::CONTAINER );
+    quiver.put_in( arrow, pocket_type::CONTAINER );
     // Expect 1 arrow remaining and displayed
     CHECK( quiver.ammo_remaining() == 10 );
     std::string const arrow_color = get_tag_from_color( arrow.color_in_inventory() );
@@ -179,15 +179,15 @@ TEST_CASE( "display_name_rotten_food", "[item][display_name][contents]" )
     REQUIRE_FALSE( butter_std.stacks_with( butter_rot1 ) );
     REQUIRE( butter_rot1.stacks_with( butter_rot2 ) );
 
-    REQUIRE( wrapper.put_in( butter_rot1, item_pocket::pocket_type::CONTAINER ).success() );
+    REQUIRE( wrapper.put_in( butter_rot1, pocket_type::CONTAINER ).success() );
     CHECK( wrapper.display_name() ==
            "paper wrapper > " + butter_rot_tname + " hidden" );
 
-    REQUIRE( wrapper.put_in( butter_rot2, item_pocket::pocket_type::CONTAINER ).success() );
+    REQUIRE( wrapper.put_in( butter_rot2, pocket_type::CONTAINER ).success() );
     CHECK( wrapper.display_name() ==
            "paper wrapper > " + butter_rot_tname + " (2) hidden" );
 
-    REQUIRE( wrapper.put_in( butter_std, item_pocket::pocket_type::CONTAINER ).success() );
+    REQUIRE( wrapper.put_in( butter_std, pocket_type::CONTAINER ).success() );
     CHECK( wrapper.display_name() ==
            "paper wrapper > 3 hidden items" );
 }

--- a/tests/iuse_actor_test.cpp
+++ b/tests/iuse_actor_test.cpp
@@ -15,7 +15,6 @@
 #include "game.h"
 #include "item.h"
 #include "item_location.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "iuse.h"
 #include "iuse_actor.h"
@@ -26,6 +25,7 @@
 #include "monster.h"
 #include "mtype.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "ret_val.h"
 #include "type_id.h"
@@ -98,8 +98,8 @@ TEST_CASE( "tool_transform_when_activated", "[iuse][tool][transform]" )
         REQUIRE( bat_cell.ammo_remaining() == bat_charges );
 
         // Put battery in flashlight
-        REQUIRE( flashlight.has_pocket_type( item_pocket::pocket_type::MAGAZINE_WELL ) );
-        ret_val<void> result = flashlight.put_in( bat_cell, item_pocket::pocket_type::MAGAZINE_WELL );
+        REQUIRE( flashlight.has_pocket_type( pocket_type::MAGAZINE_WELL ) );
+        ret_val<void> result = flashlight.put_in( bat_cell, pocket_type::MAGAZINE_WELL );
         REQUIRE( result.success() );
         REQUIRE( flashlight.magazine_current() );
 

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -18,11 +18,11 @@
 #include "game.h"
 #include "game_constants.h"
 #include "item.h"
-#include "item_pocket.h"
 #include "map.h"
 #include "map_iterator.h"
 #include "mapdata.h"
 #include "npc.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "ret_val.h"
 #include "submap.h"
@@ -205,7 +205,7 @@ void player_add_headlamp()
     item headlamp( "wearable_light_on" );
     item battery( "light_battery_cell" );
     battery.ammo_set( battery.ammo_default(), -1 );
-    headlamp.put_in( battery, item_pocket::pocket_type::MAGAZINE_WELL );
+    headlamp.put_in( battery, pocket_type::MAGAZINE_WELL );
     Character &you = get_player_character();
     you.worn.wear_item( you, headlamp, false, true );
 }

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -191,7 +191,7 @@ TEST_CASE( "inactive_container_with_active_contents", "[active_item][map]" )
     REQUIRE( disinfectant.needs_processing() );
 
     ret_val<void> const ret =
-        bottle_plastic.put_in( disinfectant, item_pocket::pocket_type::CONTAINER );
+        bottle_plastic.put_in( disinfectant, pocket_type::CONTAINER );
     REQUIRE( ret.success() );
 
     item &bp = here.add_item( test_loc, bottle_plastic );
@@ -240,7 +240,7 @@ TEST_CASE( "milk_rotting", "[active_item][map]" )
     if( in_container ) {
         sealed = GENERATE( true, false );
         item bottle_plastic( "bottle_plastic" );
-        ret_val<void> const ret = bottle_plastic.put_in( almond_milk, item_pocket::pocket_type::CONTAINER );
+        ret_val<void> const ret = bottle_plastic.put_in( almond_milk, pocket_type::CONTAINER );
         REQUIRE( ret.success() );
 
         bp = &here.add_item( test_loc, bottle_plastic );
@@ -290,7 +290,7 @@ TEST_CASE( "active_monster_drops", "[active_item][map]" )
         cookie.set_relative_rot( 10 );
         REQUIRE( cookie.has_rotten_away() );
     }
-    REQUIRE( bag_plastic.put_in( cookie, item_pocket::pocket_type::CONTAINER ).success() );
+    REQUIRE( bag_plastic.put_in( cookie, pocket_type::CONTAINER ).success() );
 
     monster &zombo = spawn_test_monster( "mon_zombie", start_loc, true );
     zombo.no_extra_death_drops = true;

--- a/tests/npc_attack_test.cpp
+++ b/tests/npc_attack_test.cpp
@@ -164,7 +164,7 @@ TEST_CASE( "NPC_faces_zombies", "[npc_attack]" )
                 item battery( "heavy_plus_battery_cell" );
                 battery.ammo_set( battery.ammo_default(), battery.ammo_capacity( ammo_battery ) );
 
-                ps.put_in( battery, item_pocket::pocket_type::MAGAZINE_WELL );
+                ps.put_in( battery, pocket_type::MAGAZINE_WELL );
 
                 item_location stored_ps = main_npc.try_add( ps );
                 REQUIRE( stored_ps != item_location::nowhere );

--- a/tests/npc_shopkeeper_item_groups_test.cpp
+++ b/tests/npc_shopkeeper_item_groups_test.cpp
@@ -121,7 +121,7 @@ TEST_CASE( "npc_shopkeeper_item_groups", "[npc][trade]" )
         int const num = GENERATE( 1, 2 );
         bool ret = true;
         for( int i = 0; i < num; i++ ) {
-            ret &= bag.put_in( multitool, item_pocket::pocket_type::CONTAINER ).success();
+            ret &= bag.put_in( multitool, pocket_type::CONTAINER ).success();
         }
         CAPTURE( num, bag.display_name() );
         REQUIRE( ret );

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -375,7 +375,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
             battery.ammo_set( battery.ammo_default(), 300 );
 
             item elec_shears( itype_test_shears_off );
-            elec_shears.put_in( battery, item_pocket::pocket_type::MAGAZINE_WELL );
+            elec_shears.put_in( battery, pocket_type::MAGAZINE_WELL );
 
             const use_function *use = elec_shears.type->get_use( "transform" );
             REQUIRE( use != nullptr );
@@ -421,7 +421,7 @@ TEST_CASE( "shearing", "[activity][shearing][animals]" )
             battery.ammo_set( battery.ammo_default(), 5 );
 
             item elec_shears( itype_test_shears_off );
-            elec_shears.put_in( battery, item_pocket::pocket_type::MAGAZINE_WELL );
+            elec_shears.put_in( battery, pocket_type::MAGAZINE_WELL );
 
             const use_function *use = elec_shears.type->get_use( "transform" );
             REQUIRE( use != nullptr );
@@ -691,7 +691,7 @@ TEST_CASE( "boltcut", "[activity][boltcut]" )
             battery.ammo_set( battery.ammo_default(), 2 );
 
             item it_boltcut_elec( itype_test_boltcutter_elec );
-            it_boltcut_elec.put_in( battery, item_pocket::pocket_type::MAGAZINE_WELL );
+            it_boltcut_elec.put_in( battery, pocket_type::MAGAZINE_WELL );
 
             dummy.wield( it_boltcut_elec );
             REQUIRE( dummy.get_wielded_item()->typeId() == itype_test_boltcutter_elec );
@@ -955,7 +955,7 @@ TEST_CASE( "hacksaw", "[activity][hacksaw]" )
             battery.ammo_set( battery.ammo_default() );
 
             item it_hacksaw_elec( itype_test_hacksaw_elec );
-            it_hacksaw_elec.put_in( battery, item_pocket::pocket_type::MAGAZINE_WELL );
+            it_hacksaw_elec.put_in( battery, pocket_type::MAGAZINE_WELL );
 
             dummy.wield( it_hacksaw_elec );
             REQUIRE( dummy.get_wielded_item()->typeId() == itype_test_hacksaw_elec );

--- a/tests/player_helpers.cpp
+++ b/tests/player_helpers.cpp
@@ -14,7 +14,6 @@
 #include "game.h"
 #include "inventory.h"
 #include "item.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "make_static.h"
 #include "map.h"
@@ -22,6 +21,7 @@
 #include "pimpl.h"
 #include "player_activity.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "profession.h"
 #include "ret_val.h"
@@ -194,7 +194,7 @@ void arm_shooter( Character &shooter, const std::string &gun_type,
         gun->reload( shooter, magazine, magazine->ammo_capacity( type_of_ammo ) );
     }
     for( const std::string &mod : mods ) {
-        gun->put_in( item( itype_id( mod ) ), item_pocket::pocket_type::MOD );
+        gun->put_in( item( itype_id( mod ) ), pocket_type::MOD );
     }
     shooter.wield( *gun );
 }
@@ -292,7 +292,7 @@ item tool_with_ammo( const std::string &tool, const int qty )
     } else if( !tool_it.magazine_default().is_null() ) {
         item tool_it_mag( tool_it.magazine_default() );
         tool_it_mag.ammo_set( tool_it_mag.ammo_default(), qty );
-        tool_it.put_in( tool_it_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+        tool_it.put_in( tool_it_mag, pocket_type::MAGAZINE_WELL );
     }
     return tool_it;
 }

--- a/tests/projectile_test.cpp
+++ b/tests/projectile_test.cpp
@@ -11,10 +11,10 @@
 #include "damage.h"
 #include "dispersion.h"
 #include "item.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "projectile.h"
 #include "ret_val.h"
@@ -71,7 +71,7 @@ TEST_CASE( "projectiles_through_obstacles", "[projectile]" )
     item gun( itype_m1a );
     item mag( gun.magazine_default() );
     mag.ammo_set( itype_308, 5 );
-    gun.put_in( mag, item_pocket::pocket_type::MAGAZINE_WELL );
+    gun.put_in( mag, pocket_type::MAGAZINE_WELL );
 
     // Check that a bullet with the correct amount of speed can through obstacles
     CHECK( projectile_end_point( range, gun, 1000, 3 ) == range[2] );

--- a/tests/ranged_balance_test.cpp
+++ b/tests/ranged_balance_test.cpp
@@ -19,7 +19,6 @@
 #include "inventory.h"
 #include "item.h"
 #include "item_location.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "json.h"
 #include "map_helpers.h"

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -491,11 +491,11 @@ TEST_CASE( "reading_a_book_with_an_ebook_reader", "[reading][book][ereader]" )
         item_location ereader = dummy.i_add( item( "test_ebook_reader" ) );
 
         item book{"test_textbook_fabrication"};
-        ereader->put_in( book, item_pocket::pocket_type::EBOOK );
+        ereader->put_in( book, pocket_type::EBOOK );
 
         item battery( "test_battery_disposable" );
         battery.ammo_set( battery.ammo_default(), 100 );
-        ereader->put_in( battery, item_pocket::pocket_type::MAGAZINE_WELL );
+        ereader->put_in( battery, pocket_type::MAGAZINE_WELL );
 
         THEN( "player can read the book" ) {
 

--- a/tests/reload_option_test.cpp
+++ b/tests/reload_option_test.cpp
@@ -6,8 +6,8 @@
 #include "cata_catch.h"
 #include "item.h"
 #include "item_location.h"
-#include "item_pocket.h"
 #include "itype.h"
+#include "pocket_type.h"
 #include "ret_val.h"
 #include "type_id.h"
 #include "value_ptr.h"
@@ -35,7 +35,7 @@ TEST_CASE( "revolver_reload_option", "[reload],[reload_option],[gun]" )
     const item::reload_option speedloader_option( &dummy, speedloader, ammo );
     CHECK( speedloader_option.qty() == speedloader->ammo_capacity( gun_ammo_type ) );
 
-    speedloader->put_in( *ammo, item_pocket::pocket_type::MAGAZINE );
+    speedloader->put_in( *ammo, pocket_type::MAGAZINE );
     const item::reload_option gun_speedloader_option( &dummy, gun, speedloader );
     CHECK( gun_speedloader_option.qty() == speedloader->ammo_capacity( gun_ammo_type ) );
 }
@@ -53,7 +53,7 @@ TEST_CASE( "magazine_reload_option", "[reload],[reload_option],[gun]" )
     const item::reload_option magazine_option( &dummy, magazine, ammo );
     CHECK( magazine_option.qty() == magazine->ammo_capacity( mag_ammo_type ) );
 
-    magazine->put_in( *ammo, item_pocket::pocket_type::MAGAZINE );
+    magazine->put_in( *ammo, pocket_type::MAGAZINE );
     item_location gun = dummy.i_add( item( "glock_19", calendar::turn_zero, 0 ) );
     const item::reload_option gun_option( &dummy, gun, magazine );
     CHECK( gun_option.qty() == 1 );
@@ -77,7 +77,7 @@ TEST_CASE( "belt_reload_option", "[reload],[reload_option],[gun]" )
     const item::reload_option belt_option( &dummy, belt, ammo );
     CHECK( belt_option.qty() == belt->ammo_capacity( belt_ammo_type ) );
 
-    belt->put_in( *ammo, item_pocket::pocket_type::MAGAZINE );
+    belt->put_in( *ammo, pocket_type::MAGAZINE );
     item_location gun = dummy.i_add( item( "m134", calendar::turn_zero, 0 ) );
 
     const item::reload_option gun_option( &dummy, gun, belt );
@@ -95,7 +95,7 @@ TEST_CASE( "canteen_reload_option", "[reload],[reload_option],[liquid]" )
     item water( "water_clean", calendar::turn_zero, 2 );
     // add an extra bottle with water
     item_location water_bottle = dummy.i_add( plastic_bottle );
-    water_bottle->put_in( water, item_pocket::pocket_type::CONTAINER );
+    water_bottle->put_in( water, pocket_type::CONTAINER );
 
     const item::reload_option bottle_option( &dummy, bottle, water_bottle );
     CHECK( bottle_option.qty() == bottle->get_remaining_capacity_for_liquid( water, true ) );

--- a/tests/reloading_test.cpp
+++ b/tests/reloading_test.cpp
@@ -10,12 +10,12 @@
 #include "game.h"
 #include "item.h"
 #include "item_location.h"
-#include "item_pocket.h"
 #include "itype.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "player_activity.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "ret_val.h"
 #include "type_id.h"
@@ -92,7 +92,7 @@ TEST_CASE( "reload_magazines", "[reload]" )
     SECTION( "partially empty magazine" ) {
 
         item mag( "stanag30" );
-        mag.put_in( item( "556", calendar::turn, 1 ), item_pocket::pocket_type::MAGAZINE );
+        mag.put_in( item( "556", calendar::turn, 1 ), pocket_type::MAGAZINE );
         REQUIRE( mag.ammo_remaining() == 1 );
 
         SECTION( "with one round" ) {
@@ -119,7 +119,7 @@ TEST_CASE( "reload_magazines", "[reload]" )
     SECTION( "full magazine" ) {
 
         item mag( "stanag30" );
-        mag.put_in( item( "556", calendar::turn, 30 ), item_pocket::pocket_type::MAGAZINE );
+        mag.put_in( item( "556", calendar::turn, 30 ), pocket_type::MAGAZINE );
         REQUIRE( mag.ammo_remaining() == 30 );
 
         SECTION( "with one round" ) {
@@ -159,9 +159,9 @@ TEST_CASE( "reload_gun_with_casings", "[reload],[gun]" )
 
     SECTION( "gun with casings and ammo" ) {
         item gun( "sw_610" );
-        gun.put_in( item( "40sw", calendar::turn, 3 ), item_pocket::pocket_type::MAGAZINE );
+        gun.put_in( item( "40sw", calendar::turn, 3 ), pocket_type::MAGAZINE );
         gun.force_insert_item( item( "40_casing", calendar::turn, 3 ).set_flag( json_flag_CASING ),
-                               item_pocket::pocket_type::MAGAZINE );
+                               pocket_type::MAGAZINE );
 
         SECTION( "with one round" ) {
             item ammo( "40sw" );
@@ -192,7 +192,7 @@ TEST_CASE( "reload_gun_with_casings", "[reload],[gun]" )
     SECTION( "full of casings" ) {
         item gun( "sw_610" );
         gun.force_insert_item( item( "40_casing", calendar::turn, 6 ).set_flag( json_flag_CASING ),
-                               item_pocket::pocket_type::MAGAZINE );
+                               pocket_type::MAGAZINE );
 
         SECTION( "with one round" ) {
             item ammo( "40sw" );
@@ -223,14 +223,14 @@ TEST_CASE( "reload_gun_with_magazine", "[reload],[gun]" )
 
         SECTION( "with full magazine" ) {
             item mag( "glockmag" );
-            mag.put_in( item( "9mm", calendar::turn, 15 ), item_pocket::pocket_type::MAGAZINE );
+            mag.put_in( item( "9mm", calendar::turn, 15 ), pocket_type::MAGAZINE );
             REQUIRE( mag.ammo_remaining() == 15 );
             test_reloading( gun, mag );
         }
 
         SECTION( "with magazine of wrong ammo" ) {
             item mag( "glockmag" );
-            mag.force_insert_item( item( "556", calendar::turn, 15 ), item_pocket::pocket_type::MAGAZINE );
+            mag.force_insert_item( item( "556", calendar::turn, 15 ), pocket_type::MAGAZINE );
             REQUIRE( mag.ammo_remaining() == 15 );
             test_reloading( gun, mag, false );
         }
@@ -238,7 +238,7 @@ TEST_CASE( "reload_gun_with_magazine", "[reload],[gun]" )
 
     SECTION( "gun with empty magazine" ) {
         item gun( "glock_19" );
-        gun.put_in( item( "glockmag" ), item_pocket::pocket_type::MAGAZINE_WELL );
+        gun.put_in( item( "glockmag" ), pocket_type::MAGAZINE_WELL );
 
         SECTION( "with empty magazine" ) {
             item mag( "glockmag" );
@@ -247,14 +247,14 @@ TEST_CASE( "reload_gun_with_magazine", "[reload],[gun]" )
 
         SECTION( "with full magazine" ) {
             item mag( "glockmag" );
-            mag.put_in( item( "9mm", calendar::turn, 15 ), item_pocket::pocket_type::MAGAZINE );
+            mag.put_in( item( "9mm", calendar::turn, 15 ), pocket_type::MAGAZINE );
             REQUIRE( mag.ammo_remaining() == 15 );
             test_reloading( gun, mag );
         }
 
         SECTION( "with magazine of wrong ammo" ) {
             item mag( "glockmag" );
-            mag.force_insert_item( item( "556", calendar::turn, 15 ), item_pocket::pocket_type::MAGAZINE );
+            mag.force_insert_item( item( "556", calendar::turn, 15 ), pocket_type::MAGAZINE );
             REQUIRE( mag.ammo_remaining() == 15 );
             test_reloading( gun, mag, false );
         }
@@ -263,9 +263,9 @@ TEST_CASE( "reload_gun_with_magazine", "[reload],[gun]" )
     SECTION( "gun with partially empty magazine" ) {
         item gun( "glock_19" );
         item old_mag( "glockmag" );
-        old_mag.put_in( item( "9mm", calendar::turn, 2 ), item_pocket::pocket_type::MAGAZINE );
+        old_mag.put_in( item( "9mm", calendar::turn, 2 ), pocket_type::MAGAZINE );
         REQUIRE( old_mag.ammo_remaining() == 2 );
-        gun.put_in( old_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+        gun.put_in( old_mag, pocket_type::MAGAZINE_WELL );
         REQUIRE( gun.ammo_remaining() == 2 );
 
         SECTION( "with empty magazine" ) {
@@ -275,21 +275,21 @@ TEST_CASE( "reload_gun_with_magazine", "[reload],[gun]" )
 
         SECTION( "with full magazine" ) {
             item mag( "glockmag" );
-            mag.put_in( item( "9mm", calendar::turn, 15 ), item_pocket::pocket_type::MAGAZINE );
+            mag.put_in( item( "9mm", calendar::turn, 15 ), pocket_type::MAGAZINE );
             REQUIRE( mag.ammo_remaining() == 15 );
             test_reloading( gun, mag );
         }
 
         SECTION( "with full magazine with different ammo" ) {
             item mag( "glockmag" );
-            mag.put_in( item( "9mmfmj", calendar::turn, 15 ), item_pocket::pocket_type::MAGAZINE );
+            mag.put_in( item( "9mmfmj", calendar::turn, 15 ), pocket_type::MAGAZINE );
             REQUIRE( mag.ammo_remaining() == 15 );
             test_reloading( gun, mag );
         }
 
         SECTION( "with magazine of wrong ammo" ) {
             item mag( "glockmag" );
-            mag.force_insert_item( item( "556", calendar::turn, 15 ), item_pocket::pocket_type::MAGAZINE );
+            mag.force_insert_item( item( "556", calendar::turn, 15 ), pocket_type::MAGAZINE );
             REQUIRE( mag.ammo_remaining() == 15 );
             test_reloading( gun, mag, false );
         }
@@ -298,9 +298,9 @@ TEST_CASE( "reload_gun_with_magazine", "[reload],[gun]" )
     SECTION( "gun with full magazine" ) {
         item gun( "glock_19" );
         item old_mag( "glockmag" );
-        old_mag.put_in( item( "9mm", calendar::turn, 15 ), item_pocket::pocket_type::MAGAZINE );
+        old_mag.put_in( item( "9mm", calendar::turn, 15 ), pocket_type::MAGAZINE );
         REQUIRE( old_mag.ammo_remaining() == 15 );
-        gun.put_in( old_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+        gun.put_in( old_mag, pocket_type::MAGAZINE_WELL );
         REQUIRE( gun.ammo_remaining() == 15 );
 
         SECTION( "with empty magazine" ) {
@@ -310,21 +310,21 @@ TEST_CASE( "reload_gun_with_magazine", "[reload],[gun]" )
 
         SECTION( "with full magazine" ) {
             item mag( "glockmag" );
-            mag.put_in( item( "9mm", calendar::turn, 15 ), item_pocket::pocket_type::MAGAZINE );
+            mag.put_in( item( "9mm", calendar::turn, 15 ), pocket_type::MAGAZINE );
             REQUIRE( mag.ammo_remaining() == 15 );
             test_reloading( gun, mag, false );
         }
 
         SECTION( "with full magazine with different ammo" ) {
             item mag( "glockmag" );
-            mag.put_in( item( "9mmfmj", calendar::turn, 15 ), item_pocket::pocket_type::MAGAZINE );
+            mag.put_in( item( "9mmfmj", calendar::turn, 15 ), pocket_type::MAGAZINE );
             REQUIRE( mag.ammo_remaining() == 15 );
             test_reloading( gun, mag, false );
         }
 
         SECTION( "with magazine of wrong ammo" ) {
             item mag( "glockmag" );
-            mag.force_insert_item( item( "556", calendar::turn, 15 ), item_pocket::pocket_type::MAGAZINE );
+            mag.force_insert_item( item( "556", calendar::turn, 15 ), pocket_type::MAGAZINE );
             REQUIRE( mag.ammo_remaining() == 15 );
             test_reloading( gun, mag, false );
         }
@@ -338,14 +338,14 @@ TEST_CASE( "liquid_reloading", "[reload]" )
 
         SECTION( "with water" ) {
             item liquid_container( "bottle_plastic" );
-            liquid_container.put_in( item( "water_clean" ), item_pocket::pocket_type::CONTAINER );
+            liquid_container.put_in( item( "water_clean" ), pocket_type::CONTAINER );
             test_reloading( container, liquid_container );
         }
 
         SECTION( "with lots of water" ) {
             item liquid_container( "bottle_twoliter" );
             liquid_container.put_in( item( "water_clean", calendar::turn, 8 ),
-                                     item_pocket::pocket_type::CONTAINER );
+                                     pocket_type::CONTAINER );
             test_reloading( container, liquid_container );
         }
 
@@ -362,7 +362,7 @@ TEST_CASE( "liquid_reloading", "[reload]" )
             REQUIRE( liquid.is_frozen_liquid() );
 
             item liquid_container( "bottle_plastic" );
-            liquid_container.put_in( liquid, item_pocket::pocket_type::CONTAINER );
+            liquid_container.put_in( liquid, pocket_type::CONTAINER );
 
             test_reloading( container, liquid_container, false );
         }
@@ -374,7 +374,7 @@ TEST_CASE( "liquid_reloading", "[reload]" )
 
         SECTION( "with non-liquid from container" ) {
             item liquid_container( "bottle_plastic" );
-            liquid_container.put_in( item( "9mm" ), item_pocket::pocket_type::CONTAINER );
+            liquid_container.put_in( item( "9mm" ), pocket_type::CONTAINER );
             test_reloading( container, liquid_container, false );
         }
     }
@@ -383,20 +383,20 @@ TEST_CASE( "liquid_reloading", "[reload]" )
     SECTION( "partially empty bottle" ) {
 
         item container( "bottle_twoliter" );
-        container.put_in( item( "water_clean", calendar::turn, 1 ), item_pocket::pocket_type::CONTAINER );
+        container.put_in( item( "water_clean", calendar::turn, 1 ), pocket_type::CONTAINER );
         REQUIRE( !container.is_container_empty() );
         REQUIRE( !container.is_container_full() );
 
         SECTION( "with one water" ) {
             item liquid_container( "bottle_plastic" );
-            liquid_container.put_in( item( "water_clean" ), item_pocket::pocket_type::CONTAINER );
+            liquid_container.put_in( item( "water_clean" ), pocket_type::CONTAINER );
             test_reloading( container, liquid_container );
         }
 
         SECTION( "with lots of water" ) {
             item liquid_container( "bottle_twoliter" );
             liquid_container.put_in( item( "water_clean", calendar::turn, 8 ),
-                                     item_pocket::pocket_type::CONTAINER );
+                                     pocket_type::CONTAINER );
             test_reloading( container, liquid_container );
         }
 
@@ -413,14 +413,14 @@ TEST_CASE( "liquid_reloading", "[reload]" )
             REQUIRE( liquid.is_frozen_liquid() );
 
             item liquid_container( "bottle_plastic" );
-            liquid_container.put_in( liquid, item_pocket::pocket_type::CONTAINER );
+            liquid_container.put_in( liquid, pocket_type::CONTAINER );
 
             test_reloading( container, liquid_container, false );
         }
 
         SECTION( "with liquid of different type" ) {
             item liquid_container( "bottle_plastic" );
-            liquid_container.put_in( item( "cranberry_juice" ), item_pocket::pocket_type::CONTAINER );
+            liquid_container.put_in( item( "cranberry_juice" ), pocket_type::CONTAINER );
             test_reloading( container, liquid_container, false );
         }
 
@@ -432,19 +432,19 @@ TEST_CASE( "liquid_reloading", "[reload]" )
 
     SECTION( "full bottle" ) {
         item container( "bottle_plastic" );
-        container.put_in( item( "water_clean", calendar::turn, 2 ), item_pocket::pocket_type::CONTAINER );
+        container.put_in( item( "water_clean", calendar::turn, 2 ), pocket_type::CONTAINER );
         REQUIRE( container.is_container_full() );
 
         SECTION( "with one water" ) {
             item liquid_container( "bottle_plastic_small" );
-            liquid_container.put_in( item( "water_clean" ), item_pocket::pocket_type::CONTAINER );
+            liquid_container.put_in( item( "water_clean" ), pocket_type::CONTAINER );
             test_reloading( container, liquid_container, false );
         }
 
         SECTION( "with lots of water" ) {
             item liquid_container( "bottle_twoliter" );
             liquid_container.put_in( item( "water_clean", calendar::turn, 8 ),
-                                     item_pocket::pocket_type::CONTAINER );
+                                     pocket_type::CONTAINER );
             test_reloading( container, liquid_container, false );
         }
 
@@ -461,14 +461,14 @@ TEST_CASE( "liquid_reloading", "[reload]" )
             REQUIRE( liquid.is_frozen_liquid() );
 
             item liquid_container( "bottle_plastic" );
-            liquid_container.put_in( liquid, item_pocket::pocket_type::CONTAINER );
+            liquid_container.put_in( liquid, pocket_type::CONTAINER );
 
             test_reloading( container, liquid_container, false );
         }
 
         SECTION( "with liquid of different type" ) {
             item liquid_container( "bottle_plastic" );
-            liquid_container.put_in( item( "cranberry_juice" ), item_pocket::pocket_type::CONTAINER );
+            liquid_container.put_in( item( "cranberry_juice" ), pocket_type::CONTAINER );
             test_reloading( container, liquid_container, false );
         }
 
@@ -492,7 +492,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
 
         SECTION( "partially empty speedloader" ) {
             item speedloader( "40_speedloader6" );
-            speedloader.put_in( item( "40sw", calendar::turn, 3 ), item_pocket::pocket_type::MAGAZINE );
+            speedloader.put_in( item( "40sw", calendar::turn, 3 ), pocket_type::MAGAZINE );
 
             REQUIRE( !speedloader.empty() );
             REQUIRE( !speedloader.is_magazine_full() );
@@ -502,7 +502,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
 
         SECTION( "full speedloader" ) {
             item speedloader( "40_speedloader6" );
-            speedloader.put_in( item( "40sw", calendar::turn, 6 ), item_pocket::pocket_type::MAGAZINE );
+            speedloader.put_in( item( "40sw", calendar::turn, 6 ), pocket_type::MAGAZINE );
 
             REQUIRE( speedloader.is_magazine_full() );
 
@@ -512,7 +512,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
         SECTION( "speedloader with wrong ammo" ) {
             item speedloader( "40_speedloader6" );
             speedloader.force_insert_item( item( "9mm", calendar::turn, 6 ),
-                                           item_pocket::pocket_type::MAGAZINE );
+                                           pocket_type::MAGAZINE );
 
             REQUIRE( speedloader.is_magazine_full() );
 
@@ -522,7 +522,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
 
     SECTION( "full gun" ) {
         item gun( "sw_610" );
-        gun.put_in( item( "40sw", calendar::turn, 6 ), item_pocket::pocket_type::MAGAZINE );
+        gun.put_in( item( "40sw", calendar::turn, 6 ), pocket_type::MAGAZINE );
         REQUIRE( gun.is_magazine_full() );
 
         SECTION( "empty speedloader" ) {
@@ -533,7 +533,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
 
         SECTION( "partially empty speedloader" ) {
             item speedloader( "40_speedloader6" );
-            speedloader.put_in( item( "40sw", calendar::turn, 3 ), item_pocket::pocket_type::MAGAZINE );
+            speedloader.put_in( item( "40sw", calendar::turn, 3 ), pocket_type::MAGAZINE );
 
             REQUIRE( !speedloader.empty() );
             REQUIRE( !speedloader.is_magazine_full() );
@@ -543,7 +543,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
 
         SECTION( "full speedloader" ) {
             item speedloader( "40_speedloader6" );
-            speedloader.put_in( item( "40sw", calendar::turn, 6 ), item_pocket::pocket_type::MAGAZINE );
+            speedloader.put_in( item( "40sw", calendar::turn, 6 ), pocket_type::MAGAZINE );
 
             REQUIRE( speedloader.is_magazine_full() );
 
@@ -553,7 +553,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
         SECTION( "speedloader with wrong ammo" ) {
             item speedloader( "40_speedloader6" );
             speedloader.force_insert_item( item( "9mm", calendar::turn, 6 ),
-                                           item_pocket::pocket_type::MAGAZINE );
+                                           pocket_type::MAGAZINE );
 
             REQUIRE( speedloader.is_magazine_full() );
 
@@ -564,7 +564,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
     SECTION( "gun full of casings" ) {
         item gun( "sw_610" );
         gun.force_insert_item( item( "40_casing", calendar::turn, 6 ).set_flag( json_flag_CASING ),
-                               item_pocket::pocket_type::MAGAZINE );
+                               pocket_type::MAGAZINE );
 
         SECTION( "empty speedloader" ) {
             item speedloader( "40_speedloader6" );
@@ -574,7 +574,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
 
         SECTION( "partially empty speedloader" ) {
             item speedloader( "40_speedloader6" );
-            speedloader.put_in( item( "40sw", calendar::turn, 3 ), item_pocket::pocket_type::MAGAZINE );
+            speedloader.put_in( item( "40sw", calendar::turn, 3 ), pocket_type::MAGAZINE );
 
             REQUIRE( !speedloader.empty() );
             REQUIRE( !speedloader.is_magazine_full() );
@@ -584,7 +584,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
 
         SECTION( "full speedloader" ) {
             item speedloader( "40_speedloader6" );
-            speedloader.put_in( item( "40sw", calendar::turn, 6 ), item_pocket::pocket_type::MAGAZINE );
+            speedloader.put_in( item( "40sw", calendar::turn, 6 ), pocket_type::MAGAZINE );
 
             REQUIRE( speedloader.is_magazine_full() );
 
@@ -594,7 +594,7 @@ TEST_CASE( "speedloader_reloading", "[reload],[gun]" )
         SECTION( "speedloader with wrong ammo" ) {
             item speedloader( "40_speedloader6" );
             speedloader.force_insert_item( item( "9mm", calendar::turn, 6 ),
-                                           item_pocket::pocket_type::MAGAZINE );
+                                           pocket_type::MAGAZINE );
 
             REQUIRE( speedloader.is_magazine_full() );
 
@@ -608,7 +608,7 @@ TEST_CASE( "gunmod_reloading", "[reload],[gun]" )
     SECTION( "empty gun and gunmod" ) {
         item gun( "m4_carbine" );
         item mod( "pipe_launcher40mm" );
-        gun.force_insert_item( mod, item_pocket::pocket_type::MOD );
+        gun.force_insert_item( mod, pocket_type::MOD );
 
         SECTION( "wrong ammo" ) {
             item ammo( "9mm" );
@@ -617,7 +617,7 @@ TEST_CASE( "gunmod_reloading", "[reload],[gun]" )
 
         SECTION( "full magazine for the gun" ) {
             item mag( "stanag30" );
-            mag.put_in( item( "556", calendar::turn, 30 ), item_pocket::pocket_type::MAGAZINE );
+            mag.put_in( item( "556", calendar::turn, 30 ), pocket_type::MAGAZINE );
 
             test_reloading( gun, mag );
         }
@@ -633,10 +633,10 @@ TEST_CASE( "gunmod_reloading", "[reload],[gun]" )
         item gun( "m4_carbine" );
         item mod( "pipe_launcher40mm" );
         item mag1( "stanag30" );
-        mag1.put_in( item( "556", calendar::turn, 10 ), item_pocket::pocket_type::MAGAZINE );
+        mag1.put_in( item( "556", calendar::turn, 10 ), pocket_type::MAGAZINE );
 
-        gun.force_insert_item( mod, item_pocket::pocket_type::MOD );
-        gun.put_in( mag1, item_pocket::pocket_type::MAGAZINE_WELL );
+        gun.force_insert_item( mod, pocket_type::MOD );
+        gun.put_in( mag1, pocket_type::MAGAZINE_WELL );
 
         SECTION( "wrong ammo" ) {
             item ammo( "9mm" );
@@ -645,7 +645,7 @@ TEST_CASE( "gunmod_reloading", "[reload],[gun]" )
 
         SECTION( "full magazine for the gun" ) {
             item mag( "stanag30" );
-            mag.put_in( item( "556", calendar::turn, 30 ), item_pocket::pocket_type::MAGAZINE );
+            mag.put_in( item( "556", calendar::turn, 30 ), pocket_type::MAGAZINE );
 
             test_reloading( gun, mag );
         }
@@ -667,11 +667,11 @@ TEST_CASE( "gunmod_reloading", "[reload],[gun]" )
         item gun( "m4_carbine" );
         item mod( "pipe_launcher40mm" );
         item mag1( "stanag30" );
-        mag1.put_in( item( "556", calendar::turn, 10 ), item_pocket::pocket_type::MAGAZINE );
-        mod.put_in( item( "40x46mm_m433", calendar::turn, 1 ), item_pocket::pocket_type::MAGAZINE );
+        mag1.put_in( item( "556", calendar::turn, 10 ), pocket_type::MAGAZINE );
+        mod.put_in( item( "40x46mm_m433", calendar::turn, 1 ), pocket_type::MAGAZINE );
 
-        gun.force_insert_item( mod, item_pocket::pocket_type::MOD );
-        gun.put_in( mag1, item_pocket::pocket_type::MAGAZINE_WELL );
+        gun.force_insert_item( mod, pocket_type::MOD );
+        gun.put_in( mag1, pocket_type::MAGAZINE_WELL );
 
         SECTION( "wrong ammo" ) {
             item ammo( "9mm" );
@@ -680,7 +680,7 @@ TEST_CASE( "gunmod_reloading", "[reload],[gun]" )
 
         SECTION( "full magazine for the gun" ) {
             item mag( "stanag30" );
-            mag.put_in( item( "556", calendar::turn, 30 ), item_pocket::pocket_type::MAGAZINE );
+            mag.put_in( item( "556", calendar::turn, 30 ), pocket_type::MAGAZINE );
 
             test_reloading( gun, mag );
         }
@@ -702,12 +702,12 @@ TEST_CASE( "gunmod_reloading", "[reload],[gun]" )
         item gun( "m4_carbine" );
         item mod( "pipe_launcher40mm" );
         item mag1( "stanag30" );
-        mag1.put_in( item( "556", calendar::turn, 10 ), item_pocket::pocket_type::MAGAZINE );
+        mag1.put_in( item( "556", calendar::turn, 10 ), pocket_type::MAGAZINE );
         mod.force_insert_item( item( "40x46mm_m118_casing" ).set_flag( json_flag_CASING ),
-                               item_pocket::pocket_type::MAGAZINE );
+                               pocket_type::MAGAZINE );
 
-        gun.force_insert_item( mod, item_pocket::pocket_type::MOD );
-        gun.put_in( mag1, item_pocket::pocket_type::MAGAZINE_WELL );
+        gun.force_insert_item( mod, pocket_type::MOD );
+        gun.put_in( mag1, pocket_type::MAGAZINE_WELL );
 
         SECTION( "wrong ammo" ) {
             item ammo( "9mm" );
@@ -716,7 +716,7 @@ TEST_CASE( "gunmod_reloading", "[reload],[gun]" )
 
         SECTION( "full magazine for the gun" ) {
             item mag( "stanag30" );
-            mag.put_in( item( "556", calendar::turn, 30 ), item_pocket::pocket_type::MAGAZINE );
+            mag.put_in( item( "556", calendar::turn, 30 ), pocket_type::MAGAZINE );
 
             test_reloading( gun, mag );
         }
@@ -738,10 +738,10 @@ TEST_CASE( "gunmod_reloading", "[reload],[gun]" )
         item gun( "m4_carbine" );
         item mod( "pipe_launcher40mm" );
         item mag1( "stanag30" );
-        mag1.put_in( item( "556", calendar::turn, 30 ), item_pocket::pocket_type::MAGAZINE );
+        mag1.put_in( item( "556", calendar::turn, 30 ), pocket_type::MAGAZINE );
 
-        gun.force_insert_item( mod, item_pocket::pocket_type::MOD );
-        gun.put_in( mag1, item_pocket::pocket_type::MAGAZINE_WELL );
+        gun.force_insert_item( mod, pocket_type::MOD );
+        gun.put_in( mag1, pocket_type::MAGAZINE_WELL );
 
         SECTION( "wrong ammo" ) {
             item ammo( "9mm" );
@@ -750,7 +750,7 @@ TEST_CASE( "gunmod_reloading", "[reload],[gun]" )
 
         SECTION( "full magazine for the gun" ) {
             item mag( "stanag30" );
-            mag.put_in( item( "556", calendar::turn, 30 ), item_pocket::pocket_type::MAGAZINE );
+            mag.put_in( item( "556", calendar::turn, 30 ), pocket_type::MAGAZINE );
 
             test_reloading( gun, mag, false );
         }
@@ -841,7 +841,7 @@ TEST_CASE( "reload_gun_with_swappable_magazine", "[reload],[gun]" )
     REQUIRE( magazine_type->type.count( ammo_type->type ) != 0 );
 
     item gun( "glock_19" );
-    gun.put_in( mag, item_pocket::pocket_type::MAGAZINE_WELL );
+    gun.put_in( mag, pocket_type::MAGAZINE_WELL );
     REQUIRE( gun.magazine_current() != nullptr );
     REQUIRE( gun.magazine_current()->ammo_types().count( ammo_type->type ) != 0 );
     dummy.i_add( gun );
@@ -1065,7 +1065,7 @@ TEST_CASE( "reload_liquid_container", "[reload],[liquid]" )
 
     item_location ammo_jug = dummy.i_add( item( "jug_plastic" ) );
     ammo_jug->put_in( item( "water_clean", calendar::turn_zero, 2 ),
-                      item_pocket::pocket_type::CONTAINER );
+                      pocket_type::CONTAINER );
     units::volume ammo_volume = ammo_jug->total_contained_volume();
 
     SECTION( "reload liquid into empty container" ) {
@@ -1079,7 +1079,7 @@ TEST_CASE( "reload_liquid_container", "[reload],[liquid]" )
     SECTION( "reload liquid into partially filled container with same type liquid" ) {
         item water_one( "water_clean", calendar::turn_zero, 1 );
         units::volume initial_volume = water_one.volume();
-        dummy.get_wielded_item()->put_in( water_one, item_pocket::pocket_type::CONTAINER );
+        dummy.get_wielded_item()->put_in( water_one, pocket_type::CONTAINER );
         g->reload_wielded();
         REQUIRE( dummy.activity );
         process_activity( dummy );
@@ -1090,7 +1090,7 @@ TEST_CASE( "reload_liquid_container", "[reload],[liquid]" )
     SECTION( "reload liquid into partially filled container with different type liquid" ) {
         item milk_one( "milk", calendar::turn_zero, 1 );
         units::volume initial_volume = milk_one.volume();
-        dummy.get_wielded_item()->put_in( milk_one, item_pocket::pocket_type::CONTAINER );
+        dummy.get_wielded_item()->put_in( milk_one, pocket_type::CONTAINER );
         g->reload_wielded();
         if( !!dummy.activity ) {
             process_activity( dummy );
@@ -1102,7 +1102,7 @@ TEST_CASE( "reload_liquid_container", "[reload],[liquid]" )
     SECTION( "reload liquid into container containing a non-liquid" ) {
         item pebble( "pebble", calendar::turn_zero, 1 );
         units::volume initial_volume = pebble.volume();
-        dummy.get_wielded_item()->put_in( pebble, item_pocket::pocket_type::CONTAINER );
+        dummy.get_wielded_item()->put_in( pebble, pocket_type::CONTAINER );
         g->reload_wielded();
         if( !!dummy.activity ) {
             process_activity( dummy );

--- a/tests/tool_quality_test.cpp
+++ b/tests/tool_quality_test.cpp
@@ -53,7 +53,7 @@ TEST_CASE( "get_quality", "[tool][quality]" )
         }
         SECTION( "get_quality returns INT_MIN for BOIL quality if container is not empty" ) {
             item broth( "test_liquid" );
-            tin_can.put_in( broth, item_pocket::pocket_type::CONTAINER );
+            tin_can.put_in( broth, pocket_type::CONTAINER );
             REQUIRE_FALSE( tin_can.empty_container() );
 
             CHECK( tin_can.get_quality( qual_BOIL ) == INT_MIN );
@@ -101,7 +101,7 @@ TEST_CASE( "battery-powered_tool_qualities", "[tool][battery][quality]" )
         battery.ammo_set( battery.ammo_default(), 0 );
         REQUIRE( battery.ammo_remaining() == 0 );
         // Install the battery in the drill
-        drill.put_in( battery, item_pocket::pocket_type::MAGAZINE_WELL );
+        drill.put_in( battery, pocket_type::MAGAZINE_WELL );
         REQUIRE( drill.magazine_current() );
         REQUIRE( drill.ammo_remaining() == 0 );
 
@@ -120,7 +120,7 @@ TEST_CASE( "battery-powered_tool_qualities", "[tool][battery][quality]" )
         battery.ammo_set( battery.ammo_default(), bat_charges );
         REQUIRE( battery.ammo_remaining() == bat_charges );
         // Install the battery in the drill
-        drill.put_in( battery, item_pocket::pocket_type::MAGAZINE_WELL );
+        drill.put_in( battery, pocket_type::MAGAZINE_WELL );
         REQUIRE( drill.magazine_current() );
         REQUIRE( drill.ammo_remaining() == bat_charges );
 
@@ -140,7 +140,7 @@ TEST_CASE( "battery-powered_tool_qualities", "[tool][battery][quality]" )
         battery.ammo_set( battery.ammo_default(), bat_charges );
         REQUIRE( battery.ammo_remaining() == bat_charges );
         // Install the battery in the drill
-        drill.put_in( battery, item_pocket::pocket_type::MAGAZINE_WELL );
+        drill.put_in( battery, pocket_type::MAGAZINE_WELL );
         REQUIRE( drill.magazine_current() );
         REQUIRE( drill.ammo_remaining() == bat_charges );
 
@@ -176,7 +176,7 @@ TEST_CASE( "battery-powered_tool_qualities", "[tool][battery][quality]" )
             bat_cell->ammo_set( bat_cell->ammo_default(), bat_charges );
             REQUIRE( bat_cell->ammo_remaining() == bat_charges );
             // Install heavy battery into UPS
-            REQUIRE( ups->put_in( *bat_cell, item_pocket::pocket_type::MAGAZINE_WELL ).success() );
+            REQUIRE( ups->put_in( *bat_cell, pocket_type::MAGAZINE_WELL ).success() );
             REQUIRE( ups->ammo_remaining( &they ) == bat_charges );
 
             WHEN( "UPS battery mod is installed into the drill" ) {
@@ -184,7 +184,7 @@ TEST_CASE( "battery-powered_tool_qualities", "[tool][battery][quality]" )
                 REQUIRE( drill->toolmods().empty() );
                 REQUIRE( drill->tname() == "test cordless drill" );
                 // Install the UPS mod and ensure it worked
-                drill->put_in( *ups_mod, item_pocket::pocket_type::MOD );
+                drill->put_in( *ups_mod, pocket_type::MOD );
                 REQUIRE_FALSE( drill->toolmods().empty() );
                 REQUIRE( drill->tname() == "test cordless drill+1 (UPS)" );
                 // Ensure avatar actually has the drill and UPS in possession

--- a/tests/unseal_and_spill_test.cpp
+++ b/tests/unseal_and_spill_test.cpp
@@ -164,7 +164,7 @@ class test_scenario
 void unseal_items_containing( contents_change_handler &handler, item_location &root,
                               const std::set<itype_id> &types )
 {
-    for( item *it : root->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
+    for( item *it : root->all_items_top( pocket_type::CONTAINER ) ) {
         if( it ) {
             item_location content( root, it );
             if( types.count( it->typeId() ) ) {
@@ -190,7 +190,7 @@ item initialize( const initialization &init )
         if( content_init.fill_parent ) {
             REQUIRE( it.fill_with( content ) >= 1 );
         } else {
-            ret_val<void> ret = it.put_in( content, item_pocket::pocket_type::CONTAINER );
+            ret_val<void> ret = it.put_in( content, pocket_type::CONTAINER );
             INFO( ret.str() );
             REQUIRE( ret.success() );
         }
@@ -285,7 +285,7 @@ void match( item_location loc, const final_result &result )
     INFO( "match: id = " << result.id.str() );
     REQUIRE( loc->typeId() == result.id );
     CHECK( result.sealed == loc->any_pockets_sealed() );
-    match( loc, loc->all_items_top( item_pocket::pocket_type::CONTAINER ), result.contents );
+    match( loc, loc->all_items_top( pocket_type::CONTAINER ), result.contents );
 }
 
 void test_scenario::run()
@@ -416,7 +416,7 @@ void test_scenario::run()
             std::optional<std::list<item>::iterator> worn = guy.wear_item( item(
                         itype_test_restricted_container_holder ), false );
             REQUIRE( worn.has_value() );
-            ret_val<void> ret = ( **worn ).put_in( it, item_pocket::pocket_type::CONTAINER );
+            ret_val<void> ret = ( **worn ).put_in( it, pocket_type::CONTAINER );
             INFO( ret.str() );
             REQUIRE( ret.success() );
             item_location worn_loc = item_location( guy, & **worn );

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -8,10 +8,10 @@
 #include "character.h"
 #include "inventory.h"
 #include "item.h"
-#include "item_pocket.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
 #include "point.h"
 #include "requirements.h"
 #include "ret_val.h"
@@ -80,7 +80,7 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
         item welder( "welder" );
         item welder_mag( welder.magazine_default() );
         welder_mag.ammo_set( welder_mag.ammo_default(), 1000 );
-        welder.put_in( welder_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+        welder.put_in( welder_mag, pocket_type::MAGAZINE_WELL );
         tools.push_back( welder );
 
         tools.emplace_back( "goggles_welding" );
@@ -92,13 +92,13 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
     SECTION( "UPS_modded_welder" ) {
         std::vector<item> tools;
         item welder( "welder", calendar::turn_zero, 0 );
-        welder.put_in( item( "battery_ups" ), item_pocket::pocket_type::MOD );
+        welder.put_in( item( "battery_ups" ), pocket_type::MOD );
         tools.push_back( welder );
 
         item ups( "UPS_ON" );
         item ups_mag( ups.magazine_default() );
         ups_mag.ammo_set( ups_mag.ammo_default(), 1000 );
-        ups.put_in( ups_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+        ups.put_in( ups_mag, pocket_type::MAGAZINE_WELL );
         tools.push_back( ups );
 
         tools.emplace_back( "goggles_welding" );
@@ -113,7 +113,7 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
         item welder( "welder" );
         item welder_mag( welder.magazine_default() );
         welder_mag.ammo_set( welder_mag.ammo_default(), 1000 );
-        welder.put_in( welder_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+        welder.put_in( welder_mag, pocket_type::MAGAZINE_WELL );
         tools.push_back( welder );
 
         tools.emplace_back( "hammer" );
@@ -127,7 +127,7 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
         item welder( "welder" );
         item welder_mag( welder.magazine_default() );
         welder_mag.ammo_set( welder_mag.ammo_default(), 500 );
-        welder.put_in( welder_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+        welder.put_in( welder_mag, pocket_type::MAGAZINE_WELL );
         tools.push_back( welder );
 
         tools.emplace_back( "goggles_welding" );
@@ -139,13 +139,13 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
     SECTION( "UPS_modded_welder_missing_charges" ) {
         std::vector<item> tools;
         item welder( "welder", calendar::turn_zero, 0 );
-        welder.put_in( item( "battery_ups" ), item_pocket::pocket_type::MOD );
+        welder.put_in( item( "battery_ups" ), pocket_type::MOD );
         tools.push_back( welder );
 
         item ups( "UPS_ON" );
         item ups_mag( ups.magazine_default() );
         ups_mag.ammo_set( ups_mag.ammo_default(), 500 );
-        ups.put_in( ups_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+        ups.put_in( ups_mag, pocket_type::MAGAZINE_WELL );
         tools.push_back( ups );
 
         tools.emplace_back( "goggles_welding" );
@@ -159,7 +159,7 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
         item welder( "welder" );
         item welder_mag( welder.magazine_default() );
         welder_mag.ammo_set( welder_mag.ammo_default(), 500 );
-        welder.put_in( welder_mag, item_pocket::pocket_type::MAGAZINE_WELL );
+        welder.put_in( welder_mag, pocket_type::MAGAZINE_WELL );
         tools.push_back( welder );
 
         tools.emplace_back( "goggles_welding" );

--- a/tests/visitable_test.cpp
+++ b/tests/visitable_test.cpp
@@ -3,7 +3,7 @@
 #include "calendar.h"
 #include "inventory.h"
 #include "item.h"
-#include "item_pocket.h"
+#include "pocket_type.h"
 #include "ret_val.h"
 #include "type_id.h"
 
@@ -16,7 +16,7 @@ TEST_CASE( "visitable_summation" )
     item bottle_of_water( "bottle_plastic", calendar::turn );
     item water_in_bottle( "water", calendar::turn );
     water_in_bottle.charges = bottle_of_water.get_remaining_capacity_for_liquid( water_in_bottle );
-    bottle_of_water.put_in( water_in_bottle, item_pocket::pocket_type::CONTAINER );
+    bottle_of_water.put_in( water_in_bottle, pocket_type::CONTAINER );
     test_inv.add_item( bottle_of_water );
 
     const item unlimited_water( "water", calendar::turn_zero, item::INFINITE_CHARGES );

--- a/tests/wield_times_test.cpp
+++ b/tests/wield_times_test.cpp
@@ -6,11 +6,11 @@
 #include "calendar.h"
 #include "item.h"
 #include "item_location.h"
-#include "item_pocket.h"
 #include "map.h"
 #include "map_helpers.h"
 #include "map_selector.h"
 #include "player_helpers.h"
+#include "pocket_type.h"
 #include "ret_val.h"
 #include "type_id.h"
 
@@ -29,7 +29,7 @@ static void wield_check_from_inv( avatar &guy, const itype_id &item_name, const 
     REQUIRE( guy.mutation_value( "obtain_cost_multiplier" ) == 1.0 );
 
     item_location backpack_loc( guy, & **item_iter );
-    backpack_loc->put_in( spawned_item, item_pocket::pocket_type::CONTAINER );
+    backpack_loc->put_in( spawned_item, pocket_type::CONTAINER );
     REQUIRE( backpack_loc->num_item_stacks() == 1 );
     item_location item_loc( backpack_loc, &backpack_loc->only_item() );
     CAPTURE( item_name );
@@ -69,20 +69,20 @@ TEST_CASE( "Wield_time_test", "[wield]" )
         guy.set_body();
         auto item_iter = guy.worn.wear_item( guy, backpack, false, false );
         item_location backpack_loc( guy, & **item_iter );
-        backpack_loc->put_in( plastic_bag, item_pocket::pocket_type::CONTAINER );
+        backpack_loc->put_in( plastic_bag, pocket_type::CONTAINER );
         REQUIRE( backpack_loc->num_item_stacks() == 1 );
         REQUIRE( guy.mutation_value( "obtain_cost_multiplier" ) == 1.0 );
 
         item_location plastic_bag_loc( backpack_loc, &backpack_loc->only_item() );
-        plastic_bag_loc->put_in( cargo_pants, item_pocket::pocket_type::CONTAINER );
+        plastic_bag_loc->put_in( cargo_pants, pocket_type::CONTAINER );
         REQUIRE( plastic_bag_loc->num_item_stacks() == 1 );
 
         item_location cargo_pants_loc( plastic_bag_loc, &plastic_bag_loc->only_item() );
-        cargo_pants_loc->put_in( sheath, item_pocket::pocket_type::CONTAINER );
+        cargo_pants_loc->put_in( sheath, pocket_type::CONTAINER );
         REQUIRE( cargo_pants_loc->num_item_stacks() == 1 );
 
         item_location sheath_loc( cargo_pants_loc, &cargo_pants_loc->only_item() );
-        sheath_loc->put_in( knife, item_pocket::pocket_type::CONTAINER );
+        sheath_loc->put_in( knife, pocket_type::CONTAINER );
         REQUIRE( sheath_loc->num_item_stacks() == 1 );
 
         item_location knife_loc( sheath_loc, &sheath_loc->only_item() );

--- a/tests/zones_custom_test.cpp
+++ b/tests/zones_custom_test.cpp
@@ -26,7 +26,7 @@ TEST_CASE( "zones_custom", "[zones]" )
         item nested_batt( "test_battery_disposable" );
         int const num = GENERATE( 1, 2 );
         for( int i = 0; i < num; i++ ) {
-            bag_plastic.put_in( nested_batt, item_pocket::pocket_type::CONTAINER );
+            bag_plastic.put_in( nested_batt, pocket_type::CONTAINER );
         }
         CAPTURE( num, bag_plastic.display_name() );
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

When I wanted to use the pocket_type enum for a test, I noticed that including `item_pocket.h` also made including `item.h` necessary. That's completely overkill for just an enum. The enum is also far more widely used than `item_pocket` or `pocket_data`, so extracting it should be beneficial in general.

#### Describe the solution

- move the enum to a new header file
- replace a lot of `item_pocket.h` includes with the new `pocket_type.h`

#### Describe alternatives you've considered

Possibly a few `item.h` includes are now unnecessary, too, but I didn't have it in me to also check for that.

#### Testing

Everything compiled locally.

#### Additional context

