### PR TITLE
[Defense Mode] Fix Zombie Hostility and Remove Panicked Civilians

### DIFF
--- a/data/mods/Defense_Mode/monster_factions.json
+++ b/data/mods/Defense_Mode/monster_factions.json
@@ -1,0 +1,27 @@
+[
+  {
+    "type": "MONSTER_FACTION",
+    "name": "zombie",
+    "friendly": [
+      "slime",
+      "zombie",
+      "animal",
+      "mutant",
+      "insect",
+      "bot",
+      "nether",
+      "spider",
+      "stag_beetle",
+      "small_animal",
+      "plant",
+      "triffid",
+      "cult",
+      "fish",
+      "aquatic_predator",
+      "nether_player_hate",
+      "attack_player_only"
+    ],
+    "by_mood": [  ],
+    "hate": [ "player", "human" ]
+  }
+]

--- a/data/mods/Defense_Mode/monstergroups.json
+++ b/data/mods/Defense_Mode/monstergroups.json
@@ -48,5 +48,42 @@
     "default": "mon_zombie_nemesis",
     "//": "nemesis squad, exists here to remove them from Defense Mode",
     "monsters": [ { "monster": "mon_zombie", "weight": 1000, "cost_multiplier": 0 } ]
+  },
+  {
+    "type": "monstergroup",
+    "name": "GROUP_ZOMBIE",
+    "monsters": [
+      { "monster": "mon_zombie", "weight": 10, "cost_multiplier": 7, "pack_size": [ 5, 20 ] },
+      { "monster": "mon_zombie", "weight": 10, "cost_multiplier": 13, "pack_size": [ 15, 40 ] },
+      { "monster": "mon_zombie", "weight": 10, "cost_multiplier": 20, "pack_size": [ 25, 60 ] },
+      { "monster": "mon_zombie", "weight": 4720, "cost_multiplier": 0 },
+      { "monster": "mon_zombie_fat", "weight": 750, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_fat", "weight": 30, "cost_multiplier": 7, "pack_size": [ 3, 5 ] },
+      { "monster": "mon_zombie_tough", "weight": 750, "cost_multiplier": 3 },
+      { "monster": "mon_zombie_child", "weight": 750 },
+      { "monster": "mon_zombie_rot", "weight": 500, "cost_multiplier": 3 },
+      { "monster": "mon_zombie_crawler", "weight": 250, "cost_multiplier": 3 },
+      { "monster": "mon_zombie_dog", "weight": 200, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_dog", "weight": 10, "cost_multiplier": 4, "pack_size": [ 3, 5 ] },
+      { "monster": "mon_zombie_dog", "weight": 10, "cost_multiplier": 16, "pack_size": [ 5, 8 ] },
+      { "monster": "mon_zombie_dog", "weight": 10, "cost_multiplier": 24, "pack_size": [ 8, 12 ] },
+      { "monster": "mon_dog_zombie_cop", "weight": 50, "cost_multiplier": 4 },
+      { "monster": "mon_dog_zombie_rot", "weight": 50, "cost_multiplier": 5 },
+      { "monster": "mon_zombie_cop", "weight": 200, "cost_multiplier": 3 },
+      { "monster": "mon_zombie_fursuit", "weight": 1, "cost_multiplier": 3 },
+      { "monster": "mon_zombie_swat", "weight": 100, "cost_multiplier": 3 },
+      { "monster": "mon_zombie_medical", "weight": 100, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_hazmat", "weight": 100, "cost_multiplier": 3 },
+      { "monster": "mon_zombie_fireman", "weight": 100, "cost_multiplier": 2 },
+      { "monster": "mon_zombie_swimmer_base", "weight": 100, "cost_multiplier": 5 },
+      { "monster": "mon_zombie_static", "weight": 100, "cost_multiplier": 5 },
+      { "monster": "mon_zombie_paramilitary", "weight": 10, "cost_multiplier": 25 },
+      { "monster": "mon_zombie_survivor", "weight": 10, "cost_multiplier": 25, "starts": "30 days" },
+      { "monster": "mon_zombie_survivor_elite", "weight": 10, "cost_multiplier": 25, "starts": "40 days" },
+      { "group": "GROUP_FERAL", "weight": 13 },
+      { "monster": "mon_beekeeper", "weight": 10, "cost_multiplier": 5 },
+      { "monster": "mon_zombie_technician", "weight": 10, "cost_multiplier": 12 },
+      { "monster": "mon_zombie_runner", "weight": 200, "cost_multiplier": 5, "pack_size": [ 1, 4 ] }
+    ]
   }
 ]

--- a/data/mods/Defense_Mode/monsters.json
+++ b/data/mods/Defense_Mode/monsters.json
@@ -282,6 +282,7 @@
     "id": "mon_zap_rat",
     "copy-from": "mon_zap_rat",
     "type": "MONSTER",
+    "aggro_character": true,
     "vision_day": 99,
     "vision_night": 99,
     "aggression": 100,
@@ -291,6 +292,7 @@
     "id": "mon_tunnel_rat",
     "copy-from": "mon_tunnel_rat",
     "type": "MONSTER",
+    "aggro_character": true,
     "vision_day": 99,
     "vision_night": 99,
     "aggression": 100,
@@ -300,6 +302,7 @@
     "id": "mon_pack_rat",
     "copy-from": "mon_pack_rat",
     "type": "MONSTER",
+    "aggro_character": true,
     "vision_day": 99,
     "vision_night": 99,
     "aggression": 100,
@@ -309,6 +312,7 @@
     "id": "mon_teke_mouse",
     "copy-from": "mon_teke_mouse",
     "type": "MONSTER",
+    "aggro_character": true,
     "vision_day": 99,
     "vision_night": 99,
     "aggression": 100,
@@ -317,6 +321,304 @@
   {
     "id": "mon_mausketeer",
     "copy-from": "mon_mausketeer",
+    "type": "MONSTER",
+    "aggro_character": true,
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie",
+    "copy-from": "mon_zombie",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_fat",
+    "copy-from": "mon_zombie_fat",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_tough",
+    "copy-from": "mon_zombie_tough",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_child",
+    "copy-from": "mon_zombie_child",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_rot",
+    "copy-from": "mon_zombie_rot",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_crawler",
+    "copy-from": "mon_zombie_crawler",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_dog",
+    "copy-from": "mon_zombie_dog",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_dog_zombie_cop",
+    "copy-from": "mon_dog_zombie_cop",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_dog_zombie_rot",
+    "copy-from": "mon_dog_zombie_rot",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_cop",
+    "copy-from": "mon_zombie_cop",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_fursuit",
+    "copy-from": "mon_zombie_fursuit",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_swat",
+    "copy-from": "mon_zombie_swat",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_medical",
+    "copy-from": "mon_zombie_medical",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_hazmat",
+    "copy-from": "mon_zombie_hazmat",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_fireman",
+    "copy-from": "mon_zombie_fireman",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_swimmer_base",
+    "copy-from": "mon_zombie_swimmer_base",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_static",
+    "copy-from": "mon_zombie_static",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_paramilitary",
+    "copy-from": "mon_zombie_paramilitary",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_survivor",
+    "copy-from": "mon_zombie_survivor",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_survivor_elite",
+    "copy-from": "mon_zombie_survivor_elite",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_beekeeper",
+    "copy-from": "mon_beekeeper",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_technician",
+    "copy-from": "mon_zombie_technician",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_runner",
+    "copy-from": "mon_zombie_runner",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_soldier",
+    "copy-from": "mon_zombie_soldier",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_milbase_personnel",
+    "copy-from": "mon_zombie_milbase_personnel",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_zombie_military_pilot",
+    "copy-from": "mon_zombie_military_pilot",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_feral_human_crowbar",
+    "copy-from": "mon_feral_human_crowbar",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_feral_cop",
+    "copy-from": "mon_feral_cop",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_feral_human_pipe",
+    "copy-from": "mon_feral_human_pipe",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_feral_human_axe",
+    "copy-from": "mon_feral_human_axe",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_feral_human_tool",
+    "copy-from": "mon_feral_human_tool",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_feral_sapien_spear",
+    "copy-from": "mon_feral_sapien_spear",
+    "type": "MONSTER",
+    "vision_day": 99,
+    "vision_night": 99,
+    "aggression": 100,
+    "morale": 100
+  },
+  {
+    "id": "mon_feral_soldier",
+    "copy-from": "mon_feral_soldier",
     "type": "MONSTER",
     "vision_day": 99,
     "vision_night": 99,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Fix zombie hostility and remove panicked civilians from Defense Mode."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This has been a known issue for some time now, so I decided to fix it. Most zombies that spawned within waves didn't have proper sight ranges with their all-seeing nature, and as such wouldn't chase the player. They also still had their hostility towards animals and were known to chase after local wildlife, abandoning the attack wholesale. Panicked civilians would also spawn in a wave, and being non-hostile would distract the horde.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Using the magic of `copy-from`, I set the sight range of zombies to 99 tiles and edited the faction info to make them friendly to everything except for the player. I also removed the civilian group from `GROUP_ZOMBIES` to keep them from appearing.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spawned a bunch of cats outside my house and let the horde come. Nobody ran off, no civilians appeared, and they didn't attack the local wildlife.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
With this, Defense Mode should be working flawlessly, I think. Now to expand it!
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
