### PR TITLE
Reset camera after struggling with aiming

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -299,7 +299,7 @@ void aim_activity_actor::do_turn( player_activity &act, Character &who )
     // We need to make sure RAS weapon is loaded/reloaded in case the aim activity was temp. suspended
     // therefore the order of evaluation matters here
     if( gun->has_flag( flag_RELOAD_AND_SHOOT ) && !gun->ammo_remaining() && !load_RAS_weapon() &&
-            first_turn ) {
+        first_turn ) {
         aborted = true;
         act.moves_left = 0;
         return;
@@ -554,20 +554,20 @@ void autodrive_activity_actor::do_turn( player_activity &act, Character &who )
             return;
         }
         switch( player_vehicle->do_autodrive( who ) ) {
-        case autodrive_result::ok:
-            if( who.moves > 0 ) {
-                // if do_autodrive() didn't eat up all our moves, end the turn
-                // equivalent to player pressing the "pause" button
-                who.moves = 0;
-            }
-            sounds::reset_markers();
-            break;
-        case autodrive_result::abort:
-            who.cancel_activity();
-            break;
-        case autodrive_result::finished:
-            act.moves_left = 0;
-            break;
+            case autodrive_result::ok:
+                if( who.moves > 0 ) {
+                    // if do_autodrive() didn't eat up all our moves, end the turn
+                    // equivalent to player pressing the "pause" button
+                    who.moves = 0;
+                }
+                sounds::reset_markers();
+                break;
+            case autodrive_result::abort:
+                who.cancel_activity();
+                break;
+            case autodrive_result::finished:
+                act.moves_left = 0;
+                break;
         }
     } else {
         who.cancel_activity();
@@ -770,53 +770,53 @@ void hacking_activity_actor::finish( player_activity &act, Character &who )
     tripoint examp = get_map().getlocal( act.placement );
     hack_type type = get_hack_type( examp );
     switch( hack_attempt( who ) ) {
-    case hack_result::UNABLE:
-        who.add_msg_if_player( _( "You cannot hack this." ) );
-        break;
-    case hack_result::FAIL:
-        // currently all things that can be hacked have equivalent alarm failure states.
-        // this may not always be the case with new hackable things.
-        get_event_bus().send<event_type::triggers_alarm>( who.getID() );
-        sounds::sound( who.pos(), 60, sounds::sound_t::music, _( "an alarm sound!" ), true, "environment",
-                       "alarm" );
-        break;
-    case hack_result::NOTHING:
-        who.add_msg_if_player( _( "You fail the hack, but no alarms are triggered." ) );
-        break;
-    case hack_result::SUCCESS:
-        map &here = get_map();
-        if( type == hack_type::GAS ) {
-            int tankUnits;
-            fuel_station_fuel_type fuelType;
-            const std::optional<tripoint> pTank_ = iexamine::getNearFilledGasTank( examp, tankUnits,
-                                                   fuelType );
-            if( !pTank_ ) {
-                break;
-            }
-            const tripoint pTank = *pTank_;
-            const std::optional<tripoint> pGasPump = iexamine::getGasPumpByNumber( examp,
-                    uistate.ags_pay_gas_selected_pump );
-            if( pGasPump && iexamine::toPumpFuel( pTank, *pGasPump, tankUnits ) ) {
-                who.add_msg_if_player( _( "You hack the terminal and route all available fuel to your pump!" ) );
-                sounds::sound( examp, 6, sounds::sound_t::activity,
-                               _( "Glug Glug Glug Glug Glug Glug Glug Glug Glug" ), true, "tool", "gaspump" );
-            } else {
-                who.add_msg_if_player( _( "Nothing happens." ) );
-            }
-        } else if( type == hack_type::SAFE ) {
-            who.add_msg_if_player( m_good, _( "The door on the safe swings open." ) );
-            here.furn_set( examp, furn_f_safe_o );
-        } else if( type == hack_type::DOOR ) {
-            who.add_msg_if_player( _( "You activate the panel!" ) );
-            who.add_msg_if_player( m_good, _( "The nearby doors unlock." ) );
-            here.ter_set( examp, t_card_reader_broken );
-            for( const tripoint &tmp : here.points_in_radius( examp, 3 ) ) {
-                if( here.ter( tmp ) == t_door_metal_locked ) {
-                    here.ter_set( tmp, t_door_metal_c );
+        case hack_result::UNABLE:
+            who.add_msg_if_player( _( "You cannot hack this." ) );
+            break;
+        case hack_result::FAIL:
+            // currently all things that can be hacked have equivalent alarm failure states.
+            // this may not always be the case with new hackable things.
+            get_event_bus().send<event_type::triggers_alarm>( who.getID() );
+            sounds::sound( who.pos(), 60, sounds::sound_t::music, _( "an alarm sound!" ), true, "environment",
+                           "alarm" );
+            break;
+        case hack_result::NOTHING:
+            who.add_msg_if_player( _( "You fail the hack, but no alarms are triggered." ) );
+            break;
+        case hack_result::SUCCESS:
+            map &here = get_map();
+            if( type == hack_type::GAS ) {
+                int tankUnits;
+                fuel_station_fuel_type fuelType;
+                const std::optional<tripoint> pTank_ = iexamine::getNearFilledGasTank( examp, tankUnits,
+                                                       fuelType );
+                if( !pTank_ ) {
+                    break;
+                }
+                const tripoint pTank = *pTank_;
+                const std::optional<tripoint> pGasPump = iexamine::getGasPumpByNumber( examp,
+                        uistate.ags_pay_gas_selected_pump );
+                if( pGasPump && iexamine::toPumpFuel( pTank, *pGasPump, tankUnits ) ) {
+                    who.add_msg_if_player( _( "You hack the terminal and route all available fuel to your pump!" ) );
+                    sounds::sound( examp, 6, sounds::sound_t::activity,
+                                   _( "Glug Glug Glug Glug Glug Glug Glug Glug Glug" ), true, "tool", "gaspump" );
+                } else {
+                    who.add_msg_if_player( _( "Nothing happens." ) );
+                }
+            } else if( type == hack_type::SAFE ) {
+                who.add_msg_if_player( m_good, _( "The door on the safe swings open." ) );
+                here.furn_set( examp, furn_f_safe_o );
+            } else if( type == hack_type::DOOR ) {
+                who.add_msg_if_player( _( "You activate the panel!" ) );
+                who.add_msg_if_player( m_good, _( "The nearby doors unlock." ) );
+                here.ter_set( examp, t_card_reader_broken );
+                for( const tripoint &tmp : here.points_in_radius( examp, 3 ) ) {
+                    if( here.ter( tmp ) == t_door_metal_locked ) {
+                        here.ter_set( tmp, t_door_metal_c );
+                    }
                 }
             }
-        }
-        break;
+            break;
     }
     act.set_to_null();
 }
@@ -1027,9 +1027,9 @@ void data_handling_activity_actor::do_turn( player_activity &act, Character &p )
         std::set<recipe_id> candidates;
         for( const auto& [rid, r] : recipe_dict ) {
             if( r.never_learn || r.obsolete || mmd->recipes_categories.count( r.category ) == 0 ||
-                    saved_recipes.count( rid ) ||
-                    r.difficulty > mmd->recipes_level_max || r.difficulty < mmd->recipes_level_min ||
-                    ( r.has_flag( "SECRET" ) && !mmd->secret_recipes ) ) {
+                saved_recipes.count( rid ) ||
+                r.difficulty > mmd->recipes_level_max || r.difficulty < mmd->recipes_level_min ||
+                ( r.has_flag( "SECRET" ) && !mmd->secret_recipes ) ) {
                 continue;
             }
             candidates.emplace( rid );
@@ -1719,8 +1719,8 @@ bool read_activity_actor::player_read( avatar &you )
         }
 
         if( skill &&
-                learner->get_knowledge_level( skill ) < islotbook->level &&
-                learner->get_skill_level_object( skill ).can_train() ) {
+            learner->get_knowledge_level( skill ) < islotbook->level &&
+            learner->get_skill_level_object( skill ).can_train() ) {
 
             SkillLevel &skill_level = learner->get_skill_level_object( skill );
             std::string skill_name = skill.obj().name();
@@ -1756,8 +1756,8 @@ bool read_activity_actor::player_read( avatar &you )
             }
 
             if( ( skill_level == islotbook->level || !skill_level.can_train() ) ||
-                    ( learner->has_trait( trait_SCHIZOPHRENIC ) && !learner->has_effect( effect_took_thorazine ) &&
-                      one_in( 25 ) ) ) {
+                ( learner->has_trait( trait_SCHIZOPHRENIC ) && !learner->has_effect( effect_took_thorazine ) &&
+                  one_in( 25 ) ) ) {
                 if( learner->is_avatar() ) {
                     add_msg( m_info, _( "You can no longer learn from %s." ), book->type_name() );
                 } else {
@@ -1822,22 +1822,22 @@ bool read_activity_actor::player_readma( avatar &you )
         return true;
     } else if( continuous ) {
         switch( rng( 1, 5 ) ) {
-        case 1:
-            add_msg( m_info,
-                     _( "You train the moves according to the book, but can't get a grasp of the style, so you start from the beginning." ) );
-            break;
-        case 2:
-            add_msg( m_info,
-                     _( "This martial art is not easy to grasp.  You start training the moves from the beginning." ) );
-            break;
-        case 3:
-            add_msg( m_info,
-                     _( "You decide to read the manual and train even more.  In martial arts, patience leads to mastery." ) );
-            break;
-        case 4: // intentionally empty
-        case 5:
-            add_msg( m_info, _( "You try again.  This training will finally pay off." ) );
-            break;
+            case 1:
+                add_msg( m_info,
+                         _( "You train the moves according to the book, but can't get a grasp of the style, so you start from the beginning." ) );
+                break;
+            case 2:
+                add_msg( m_info,
+                         _( "This martial art is not easy to grasp.  You start training the moves from the beginning." ) );
+                break;
+            case 3:
+                add_msg( m_info,
+                         _( "You decide to read the manual and train even more.  In martial arts, patience leads to mastery." ) );
+                break;
+            case 4: // intentionally empty
+            case 5:
+                add_msg( m_info, _( "You try again.  This training will finally pay off." ) );
+                break;
         }
     } else {
         add_msg( m_info, _( "You train for a while." ) );
@@ -1867,8 +1867,8 @@ bool read_activity_actor::npc_read( npc &learner )
     book->mark_chapter_as_read( learner );
 
     if( skill &&
-            learner.get_knowledge_level( skill ) < islotbook->level &&
-            learner.get_skill_level_object( skill ).can_train() ) {
+        learner.get_knowledge_level( skill ) < islotbook->level &&
+        learner.get_skill_level_object( skill ).can_train() ) {
 
         SkillLevel &skill_level = learner.get_skill_level_object( skill );
         std::string skill_name = skill.obj().name();
@@ -1894,9 +1894,9 @@ bool read_activity_actor::npc_read( npc &learner )
         }
 
         if( display_messages &&
-                ( ( skill_level == islotbook->level || !skill_level.can_train() ) ||
-                  ( learner.has_trait( trait_SCHIZOPHRENIC ) && !learner.has_effect( effect_took_thorazine ) &&
-                    one_in( 25 ) ) ) ) {
+            ( ( skill_level == islotbook->level || !skill_level.can_train() ) ||
+              ( learner.has_trait( trait_SCHIZOPHRENIC ) && !learner.has_effect( effect_took_thorazine ) &&
+                one_in( 25 ) ) ) ) {
             add_msg( m_info, _( "%s can no longer learn from %s." ), learner.disp_name(),
                      book->type_name() );
         }
@@ -2012,9 +2012,9 @@ std::string read_activity_actor::get_progress_message( const player_activity & )
     const skill_id &skill = islotbook->skill;
 
     if( skill &&
-            you.get_knowledge_level( skill ) < islotbook->level &&
-            you.get_skill_level_object( skill ).can_train() &&
-            you.has_identified( book->typeId() ) ) {
+        you.get_knowledge_level( skill ) < islotbook->level &&
+        you.get_skill_level_object( skill ).can_train() &&
+        you.has_identified( book->typeId() ) ) {
         const SkillLevel &skill_level = you.get_skill_level_object( skill );
         //~ skill_name current_skill_level -> next_skill_level (% to next level)
         return string_format( pgettext( "reading progress", "%1$s %2$d -> %3$d (%4$d%%)" ),
@@ -3056,17 +3056,17 @@ void try_sleep_activity_actor::query_keep_trying( player_activity &act, Characte
                           _( "Continue trying to fall asleep and don't ask again." ) );
     sleep_query.query();
     switch( sleep_query.ret ) {
-    case UILIST_CANCEL:
-    case 1:
-        act.set_to_null();
-        who.set_movement_mode( move_mode_walk );
-        break;
-    case 3:
-        disable_query = true;
-        break;
-    case 2:
-    default:
-        break;
+        case UILIST_CANCEL:
+        case 1:
+            act.set_to_null();
+            who.set_movement_mode( move_mode_walk );
+            break;
+        case 3:
+            disable_query = true;
+            break;
+        case 2:
+        default:
+            break;
     }
 }
 
@@ -3217,10 +3217,10 @@ void unload_activity_actor::unload( Character &who, item_location &target )
         bool changed = false;
 
         for( item_pocket::pocket_type ptype : {
-                    item_pocket::pocket_type::CONTAINER,
-                    item_pocket::pocket_type::MAGAZINE_WELL,
-                    item_pocket::pocket_type::MAGAZINE
-                } ) {
+                 item_pocket::pocket_type::CONTAINER,
+                 item_pocket::pocket_type::MAGAZINE_WELL,
+                 item_pocket::pocket_type::MAGAZINE
+             } ) {
 
             for( item *contained : it.all_items_top( ptype, true ) ) {
                 int old_charges = contained->charges;
@@ -3476,7 +3476,7 @@ void craft_activity_actor::do_turn( player_activity &act, Character &crafter )
         }
     } else {
         if( level_up && craft.get_making().is_practice() &&
-                query_yn( _( "Your proficiency has increased.  Stop practicing?" ) ) ) {
+            query_yn( _( "Your proficiency has increased.  Stop practicing?" ) ) ) {
             crafter.cancel_activity();
         } else if( craft.item_counter >= craft.get_next_failure_point() ) {
             bool destroy = craft.handle_craft_failure( crafter );
@@ -3590,10 +3590,10 @@ void workout_activity_actor::start( player_activity &act, Character &who )
         return;
     }
     if( !hand_equipment && !leg_equipment &&
-            ( who.is_limb_broken( body_part_arm_l ) ||
-              who.is_limb_broken( body_part_arm_r ) ||
-              who.is_limb_broken( body_part_leg_l ) ||
-              who.is_limb_broken( body_part_leg_r ) ) ) {
+        ( who.is_limb_broken( body_part_arm_l ) ||
+          who.is_limb_broken( body_part_arm_r ) ||
+          who.is_limb_broken( body_part_leg_l ) ||
+          who.is_limb_broken( body_part_leg_r ) ) ) {
         who.add_msg_if_player( _( "You cannot train freely with a broken limb." ) );
         act_id = activity_id::NULL_ID();
         act.set_to_null();
@@ -3614,27 +3614,27 @@ void workout_activity_actor::start( player_activity &act, Character &who )
                                  _( "High intensity exercise with maximum effort and full power.  Exhausting in the long run." ) );
     workout_query.query();
     switch( workout_query.ret ) {
-    case UILIST_CANCEL:
-        act.set_to_null();
-        act_id = activity_id::NULL_ID();
-        return;
-    case 4:
-        act_id = ACT_WORKOUT_HARD;
-        intensity_modifier = 4;
-        break;
-    case 3:
-        act_id = ACT_WORKOUT_ACTIVE;
-        intensity_modifier = 3;
-        break;
-    case 2:
-        act_id = ACT_WORKOUT_MODERATE;
-        intensity_modifier = 2;
-        break;
-    case 1:
-    default:
-        act_id = ACT_WORKOUT_LIGHT;
-        intensity_modifier = 1;
-        break;
+        case UILIST_CANCEL:
+            act.set_to_null();
+            act_id = activity_id::NULL_ID();
+            return;
+        case 4:
+            act_id = ACT_WORKOUT_HARD;
+            intensity_modifier = 4;
+            break;
+        case 3:
+            act_id = ACT_WORKOUT_ACTIVE;
+            intensity_modifier = 3;
+            break;
+        case 2:
+            act_id = ACT_WORKOUT_MODERATE;
+            intensity_modifier = 2;
+            break;
+        case 1:
+        default:
+            act_id = ACT_WORKOUT_LIGHT;
+            intensity_modifier = 1;
+            break;
     }
     int length;
     query_int( length, _( "Train for how long (minutes): " ) );
@@ -3681,7 +3681,7 @@ void workout_activity_actor::do_turn( player_activity &act, Character &who )
         }
         // morale bonus kicks in gradually after 5 minutes of exercise
         if( calendar::once_every( 2_minutes ) &&
-                ( ( elapsed + act.moves_total - act.moves_left ) / 100 * 1_turns ) > 5_minutes ) {
+            ( ( elapsed + act.moves_total - act.moves_left ) / 100 * 1_turns ) > 5_minutes ) {
             who.add_morale( MORALE_FEELING_GOOD, intensity_modifier, 20, 6_hours, 30_minutes );
         }
         if( calendar::once_every( 2_minutes ) ) {
@@ -3726,28 +3726,28 @@ bool workout_activity_actor::query_keep_training( player_activity &act, Characte
     workout_query.addentry( 3, true, 'C', _( "Continue training and don't ask again." ) );
     workout_query.query();
     switch( workout_query.ret ) {
-    case UILIST_CANCEL:
-    case 1:
-        act_id = activity_id::NULL_ID();
-        act.set_to_null();
-        return false;
-    case 3:
-        disable_query = true;
-        elapsed += act.moves_total - act.moves_left;
-        act.moves_total = to_moves<int>( 60_minutes );
-        act.moves_left = act.moves_total;
-        return true;
-    case 2:
-    default:
-        query_int( length, _( "Train for how long (minutes): " ) );
-        elapsed += act.moves_total - act.moves_left;
-        duration = 0_minutes;
-        if( length > 0 ) {
-            duration = length * 1_minutes;
-        }
-        act.moves_total = to_moves<int>( duration );
-        act.moves_left = act.moves_total;
-        return true;
+        case UILIST_CANCEL:
+        case 1:
+            act_id = activity_id::NULL_ID();
+            act.set_to_null();
+            return false;
+        case 3:
+            disable_query = true;
+            elapsed += act.moves_total - act.moves_left;
+            act.moves_total = to_moves<int>( 60_minutes );
+            act.moves_left = act.moves_total;
+            return true;
+        case 2:
+        default:
+            query_int( length, _( "Train for how long (minutes): " ) );
+            elapsed += act.moves_total - act.moves_left;
+            duration = 0_minutes;
+            if( length > 0 ) {
+                duration = length * 1_minutes;
+            }
+            act.moves_total = to_moves<int>( duration );
+            act.moves_left = act.moves_total;
+            return true;
     }
 }
 
@@ -3807,7 +3807,7 @@ static void debug_drop_list( const std::vector<drop_or_stash_item_info> &items )
 static bool is_bulk_unload( const item_location &lhs, const item_location &rhs )
 {
     if( lhs.where() == item_location::type::container &&
-            rhs.where() == item_location::type::container && lhs.parent_item() == rhs.parent_item() ) {
+        rhs.where() == item_location::type::container && lhs.parent_item() == rhs.parent_item() ) {
         return true;
     }
     return false;
@@ -3864,7 +3864,7 @@ static std::list<item> obtain_activity_items( std::vector<drop_or_stash_item_inf
 
         // Take off the item or remove it from where it's been
         if( loc.where_recursive() == item_location::type::map ||
-                loc.where_recursive() == item_location::type::vehicle ) {
+            loc.where_recursive() == item_location::type::vehicle ) {
             item copy( *loc );
             if( loc->count_by_charges() && loc->count() > it->count() ) {
                 copy.charges -= it->count();
@@ -4173,7 +4173,7 @@ void disable_activity_actor::finish( player_activity &act, Character &/*who*/ )
 bool disable_activity_actor::can_disable_or_reprogram( const monster &monster )
 {
     if( get_avatar().get_knowledge_level( skill_electronics ) + get_avatar().get_knowledge_level(
-                skill_mechanics ) <= 0 ) {
+            skill_mechanics ) <= 0 ) {
         return false;
     }
 
@@ -4272,15 +4272,15 @@ static bool is_bulk_load( const item_location &lhs, const item_location &rhs )
 {
     if( lhs.where() == rhs.where() && lhs->stacks_with( *rhs ) ) {
         switch( lhs.where() ) {
-        case item_location::type::container:
-            return lhs.parent_item() == rhs.parent_item();
-            break;
-        case item_location::type::map:
-        case item_location::type::vehicle:
-            return lhs.position() == rhs.position();
-            break;
-        default:
-            break;
+            case item_location::type::container:
+                return lhs.parent_item() == rhs.parent_item();
+                break;
+            case item_location::type::map:
+            case item_location::type::vehicle:
+                return lhs.position() == rhs.position();
+                break;
+            default:
+                break;
         }
     }
     return false;
@@ -4575,21 +4575,21 @@ void reload_activity_actor::finish( player_activity &act, Character &who )
     reload_query.query();
 
     switch( reload_query.ret ) {
-    case 1:
-        // This case is only reachable if wield_check is true
-        who.wield( reloadable );
-        add_msg( m_neutral, _( "The %s no longer fits in your inventory so you wield it instead." ),
-                 reloadable_name );
-        break;
-    case 2:
-    default:
-        // In player inventory and player is wielding something.
-        loc.carrier()->add_msg_if_player( m_neutral,
-                                          _( "The %s no longer fits in your inventory so you drop it instead." ),
-                                          reloadable_name );
-        get_map().add_item_or_charges( loc.position(), reloadable );
-        loc.remove_item();
-        break;
+        case 1:
+            // This case is only reachable if wield_check is true
+            who.wield( reloadable );
+            add_msg( m_neutral, _( "The %s no longer fits in your inventory so you wield it instead." ),
+                     reloadable_name );
+            break;
+        case 2:
+        default:
+            // In player inventory and player is wielding something.
+            loc.carrier()->add_msg_if_player( m_neutral,
+                                              _( "The %s no longer fits in your inventory so you drop it instead." ),
+                                              reloadable_name );
+            get_map().add_item_or_charges( loc.position(), reloadable );
+            loc.remove_item();
+            break;
     }
 }
 
@@ -6110,7 +6110,7 @@ void chop_tree_activity_actor::finish( player_activity &act, Character &who )
 
     tripoint direction;
     if( !who.is_npc() &&
-            ( who.backlog.empty() || who.backlog.front().id() != ACT_MULTIPLE_CHOP_TREES ) ) {
+        ( who.backlog.empty() || who.backlog.front().id() != ACT_MULTIPLE_CHOP_TREES ) ) {
         while( true ) {
             if( const std::optional<tripoint> dir = choose_direction(
                     _( "Select a direction for the tree to fall in." ) ) ) {
@@ -6318,7 +6318,7 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
         it.remove_item();
     } else if( used_tool->is_medication() ) {
         if( !it->count_by_charges() ||
-                it->use_charges( it->typeId(), charges_consumed, used, it.position() ) ) {
+            it->use_charges( it->typeId(), charges_consumed, used, it.position() ) ) {
             it.remove_item();
         }
     } else if( used_tool->is_tool() ) {
@@ -6334,7 +6334,7 @@ void firstaid_activity_actor::finish( player_activity &act, Character &who )
     // Return to first eat or consume meds menu activity in the backlog.
     for( player_activity &backlog_act : who.backlog ) {
         if( backlog_act.id() == ACT_EAT_MENU ||
-                backlog_act.id() == ACT_CONSUME_MEDS_MENU ) {
+            backlog_act.id() == ACT_CONSUME_MEDS_MENU ) {
             backlog_act.auto_resume = true;
             break;
         }
@@ -6404,24 +6404,24 @@ void forage_activity_actor::finish( player_activity &act, Character &who )
     ter_str_id next_ter;
 
     switch( season_of_year( calendar::turn ) ) {
-    case SPRING:
-        group_id = Item_spawn_data_forage_spring;
-        next_ter = ter_t_underbrush_harvested_spring;
-        break;
-    case SUMMER:
-        group_id = Item_spawn_data_forage_summer;
-        next_ter = ter_t_underbrush_harvested_summer;
-        break;
-    case AUTUMN:
-        group_id = Item_spawn_data_forage_autumn;
-        next_ter = ter_t_underbrush_harvested_autumn;
-        break;
-    case WINTER:
-        group_id = Item_spawn_data_forage_winter;
-        next_ter = ter_t_underbrush_harvested_winter;
-        break;
-    default:
-        debugmsg( "Invalid season" );
+        case SPRING:
+            group_id = Item_spawn_data_forage_spring;
+            next_ter = ter_t_underbrush_harvested_spring;
+            break;
+        case SUMMER:
+            group_id = Item_spawn_data_forage_summer;
+            next_ter = ter_t_underbrush_harvested_summer;
+            break;
+        case AUTUMN:
+            group_id = Item_spawn_data_forage_autumn;
+            next_ter = ter_t_underbrush_harvested_autumn;
+            break;
+        case WINTER:
+            group_id = Item_spawn_data_forage_winter;
+            next_ter = ter_t_underbrush_harvested_winter;
+            break;
+        default:
+            debugmsg( "Invalid season" );
     }
 
     const tripoint bush_pos = here.getlocal( act.placement );
@@ -6791,14 +6791,14 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
         // TODO: fix point types
         coord_set.clear();
         for( const tripoint_abs_ms &p :
-                mgr.get_near( zone_type_UNLOAD_ALL, abspos, ACTIVITY_SEARCH_DISTANCE, nullptr,
-                              fac_id ) ) {
+             mgr.get_near( zone_type_UNLOAD_ALL, abspos, ACTIVITY_SEARCH_DISTANCE, nullptr,
+                           fac_id ) ) {
             coord_set.insert( p.raw() );
         }
 
         for( const tripoint_abs_ms &p :
-                mgr.get_near( zone_type_STRIP_CORPSES, abspos, ACTIVITY_SEARCH_DISTANCE, nullptr,
-                              fac_id ) ) {
+             mgr.get_near( zone_type_STRIP_CORPSES, abspos, ACTIVITY_SEARCH_DISTANCE, nullptr,
+                           fac_id ) ) {
             coord_set.insert( p.raw() );
         }
         stage = THINK;
@@ -6849,8 +6849,8 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
             // (to prevent taking out wood off the lit brazier)
             // and inaccessible furniture, like filled charcoal kiln
             if( mgr.has( zone_type_LOOT_IGNORE, src, fac_id ) ||
-                    here.get_field( src_loc, fd_fire ) != nullptr ||
-                    !here.can_put_items_ter_furn( src_loc ) ) {
+                here.get_field( src_loc, fd_fire ) != nullptr ||
+                !here.can_put_items_ter_furn( src_loc ) ) {
                 continue;
             }
 
@@ -6981,9 +6981,9 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
             // check if it is in a unload zone or a strip corpse zone
             // then we should unload it and see what is inside
             if( mgr.has_near( zone_type_UNLOAD_ALL, abspos, 1, fac_id ) ||
-                    ( mgr.has_near( zone_type_STRIP_CORPSES, abspos, 1, fac_id ) && it->first->is_corpse() ) ) {
+                ( mgr.has_near( zone_type_STRIP_CORPSES, abspos, 1, fac_id ) && it->first->is_corpse() ) ) {
                 if( you.rate_action_unload( *it->first ) == hint_rating::good &&
-                        !it->first->any_pockets_sealed() ) {
+                    !it->first->any_pockets_sealed() ) {
                     std::unordered_map<itype_id, int> item_counts;
                     if( unload_sparse_only ) {
                         for( item *contained : it->first->all_items_top( item_pocket::pocket_type::CONTAINER ) ) {
@@ -6996,7 +6996,7 @@ void unload_loot_activity_actor::do_turn( player_activity &act, Character &you )
                         // no liquids don't want to spill stuff
                         if( !contained->made_of( phase_id::LIQUID ) && !contained->made_of( phase_id::GAS ) ) {
                             if( unload_sparse_only &&
-                                    item_counts[contained->typeId()] > unload_sparse_threshold ) {
+                                item_counts[contained->typeId()] > unload_sparse_threshold ) {
                                 continue;
                             }
                             move_item( you, *contained, contained->count(), src_loc, src_loc, this_veh, this_part );
@@ -7345,7 +7345,7 @@ void wash_activity_actor::finish( player_activity &act, Character &p )
     };
     const inventory &crafting_inv = p.crafting_inventory();
     if( !crafting_inv.has_charges( itype_water, requirements.water, is_liquid_crafting_component ) &&
-            !crafting_inv.has_charges( itype_water_clean, requirements.water, is_liquid_crafting_component ) ) {
+        !crafting_inv.has_charges( itype_water_clean, requirements.water, is_liquid_crafting_component ) ) {
         p.add_msg_if_player( _( "You need %1$i charges of water or clean water to wash these items." ),
                              requirements.water );
         act.set_to_null();

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1458,9 +1458,6 @@ bool game::cancel_activity_or_ignore_query( const distraction_type type, const s
 
     if( action == "YES" ) {
         u.cancel_activity();
-        for( player_activity activity : u.backlog ) {
-            activity.canceled( u );
-        }
         return true;
     }
     if( action == "IGNORE" ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1458,7 +1458,7 @@ bool game::cancel_activity_or_ignore_query( const distraction_type type, const s
 
     if( action == "YES" ) {
         u.cancel_activity();
-        for ( player_activity activity : u.backlog ) {
+        for( player_activity activity : u.backlog ) {
             activity.canceled( u );
         }
         return true;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -1458,6 +1458,9 @@ bool game::cancel_activity_or_ignore_query( const distraction_type type, const s
 
     if( action == "YES" ) {
         u.cancel_activity();
+        for ( player_activity activity : u.backlog ) {
+            activity.canceled( u );
+        }
         return true;
     }
     if( action == "IGNORE" ) {

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -346,6 +346,7 @@ void player_activity::do_turn( Character &you )
                     ignoreQuery = true;
                     break;
                 default:
+                    canceled( you );
                     break;
             }
         }

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -340,7 +340,7 @@ void player_activity::do_turn( Character &you )
                 case UILIST_CANCEL:
                 case 2:
                     auto_resume = false;
-                    set_to_null();
+                    you.cancel_activity();
                     break;
                 case 3:
                     ignoreQuery = true;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix camera not being reset after struggling with aiming"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
If the player was aiming with a bow (or any stamina using ranged weapon) and had the camera snapped to a target, and then was prompted with "You struggle to continue.  Keep trying?" there were two unexpected behaviours:

- When selecting "Maybe later." the camera was not reset to the player position.
- When selecting "Continue after a break.", and being either interrupted manually or by a distraction (and with the player choosing to stop to catch your breath) the camera would not be reset to the players position.

Both of those bugs were particularly jarring when snapping to a target in a different level since the ":" center camera command would not reset the camera to the players level.

Fixes #69766
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The problem was that the player's activities were not being properly canceled when interrupted for not having enough stamina. 

Now when selecting "Continue after a break" the current activity will be cancelled but can still be continued after the break, and when selecting "Maybe later" it will simply be cancelled.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Make sure to have have experimental 3D field of vision turned on.
Load the save setup:
[Debug-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/13479532/Debug-trimmed.tar.gz)

1. Get on rooftop with wielding bow and arrows and have a target in your field of view on a lower level
2. Set your stamina to 1
3. start aiming your bow and snap (*) to the target 
4. shoot or aim your bow until you get prompted with "You struggle to continue.  Keep trying?"
5. choose either:
   -  "Continue after a break" and manually interrupt with "5" (or get interrupted by a distraction and choose "Yes" to stop)
   -  "Maybe later"
6. Confirm if camera is reset to players position

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
