### PR TITLE
Stay with me buddy

### DIFF
--- a/src/npc.h
+++ b/src/npc.h
@@ -267,6 +267,7 @@ struct npc_combat_memory {
     int assessment_before_repos = 0; // assessment of enemy threat level at the start of repositioning.
     float my_health = 1.0f; // saved when we evaluate_self.  Health 1.0 means 100% unhurt.
     bool repositioning = false; // is NPC running away or just moving around / kiting.
+    int nearby_ranged_buddy = -1; // dist to nearest friend with a gun, or to player
 };
 
 enum class combat_engagement : int {
@@ -1101,7 +1102,7 @@ class npc : public Character
 
         /** rates how dangerous a target is */
         float evaluate_monster( const monster &target, int dist ) const;
-        float evaluate_character( const Character &candidate, bool my_gun, bool enemy ) const;
+        float evaluate_character( const Character &candidate, bool my_gun, bool enemy );
         float evaluate_self( bool my_gun );
 
         void assess_danger();

--- a/src/npc.h
+++ b/src/npc.h
@@ -267,7 +267,8 @@ struct npc_combat_memory {
     int assessment_before_repos = 0; // assessment of enemy threat level at the start of repositioning.
     float my_health = 1.0f; // saved when we evaluate_self.  Health 1.0 means 100% unhurt.
     bool repositioning = false; // is NPC running away or just moving around / kiting.
-    int nearby_ranged_buddy = -1; // dist to nearest friend with a gun, or to player
+    int formation_distance = -1; // dist to nearest ally with a gun, or to player
+    int engagement_distance = 6; // applies to melee NPCs in formation with ranged ones or the player.
 };
 
 enum class combat_engagement : int {

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -241,8 +241,8 @@ void npc_attack_melee::use( npc &source, const tripoint &location ) const
         debugmsg( "ERROR: npc tried to attack null critter" );
         return;
     }
+    int target_distance = rl_dist( source.pos(), location );
     if( !source.is_adjacent( critter, true ) ) {
-        int target_distance = rl_dist( source.pos(), location );
         if( target_distance <= weapon.reach_range( source ) ) {
             add_msg_debug( debugmode::debug_filter::DF_NPC, "%s is attempting a reach attack",
                            source.disp_name() );
@@ -270,15 +270,15 @@ void npc_attack_melee::use( npc &source, const tripoint &location ) const
             source.update_path( location );
             if( source.path.size() > 1 ) {
                 bool clear_path = can_move_melee( source );
-                if( clear_path && source.mem_combat.nearby_ranged_buddy == -1 ) {
+                if( clear_path && source.mem_combat.formation_distance == -1 ) {
                     source.move_to_next();
                     add_msg_debug( debugmode::DF_NPC_MOVEAI,
                                    "<color_light_gray>%s has no nearby ranged allies.  Going for the attack.</color>", source.name );
-                } else if( clear_path && source.mem_combat.nearby_ranged_buddy > target_distance ) {
+                } else if( clear_path && source.mem_combat.formation_distance > target_distance ) {
                     source.move_to_next();
                     add_msg_debug( debugmode::DF_NPC_MOVEAI,
                                    "<color_light_gray>%s is at least %i away from ranged allies, enemy within %i.  Going for attack.</color>",
-                                   source.name, source.mem_combat.nearby_ranged_buddy, target_distance );
+                                   source.name, source.mem_combat.formation_distance, target_distance );
 
                 } else {
                     add_msg_debug( debugmode::DF_NPC_MOVEAI,
@@ -299,7 +299,14 @@ void npc_attack_melee::use( npc &source, const tripoint &location ) const
                 source.look_for_player( get_player_character() );
             }
         }
+    } else if( source.mem_combat.formation_distance != -1 &&
+               source.mem_combat.formation_distance <= target_distance &&
+               rng( -10, 10 ) > source.personality.aggression ) {
+        add_msg_debug( debugmode::DF_NPC_MOVEAI,
+                       "<color_light_gray>%s decided to fall back to formation with allies.</color>", source.name );
+        source.look_for_player( get_player_character() );
     } else {
+        // may wish to add a break here to see if target is out of formation with allies, and consider running back.
         add_msg_debug( debugmode::debug_filter::DF_NPC, "%s is attempting a melee attack",
                        source.disp_name() );
         source.melee_attack( *critter, true );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -526,7 +526,7 @@ float npc::evaluate_character( const Character &candidate, bool my_gun, bool ene
             // later we should evaluate if the NPC trusts the player enough to stick to them so reliably
             int dist = rl_dist( pos(), candidate.pos() );
             if( dist > mem_combat.nearby_ranged_buddy ) {
-                mem_combat.nearby_ranged_buddy = std::min( dist, 3 );
+                mem_combat.nearby_ranged_buddy = std::max( dist, 3 );
             }
         }
     }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -525,8 +525,8 @@ float npc::evaluate_character( const Character &candidate, bool my_gun, bool ene
         if( candidate_gun || ( is_player_ally() && candidate.is_avatar() ) ) {
             // later we should evaluate if the NPC trusts the player enough to stick to them so reliably
             int dist = rl_dist( pos(), candidate.pos() );
-            if( dist > mem_combat.nearby_ranged_buddy ) {
-                mem_combat.nearby_ranged_buddy = std::max( dist, 3 );
+            if( dist > mem_combat.formation_distance ) {
+                mem_combat.formation_distance = std::max( dist, mem_combat.engagement_distance );
             }
         }
     }
@@ -754,6 +754,7 @@ void npc::assess_danger()
             def_radius = 1;
         }
     }
+    mem_combat.engagement_distance = def_radius;
 
     const auto ok_by_rules = [max_range, def_radius, this, &player_character]( const Creature & c,
     int dist, int scaled_dist ) {
@@ -1267,7 +1268,7 @@ void npc::regen_ai_cache()
     item &weapon = get_wielded_item() ? *get_wielded_item() : null_item_reference();
     ai_cache.my_weapon_value = weapon_value( weapon );
     ai_cache.dangerous_explosives = find_dangerous_explosives();
-    mem_combat.nearby_ranged_buddy = -1;
+    mem_combat.formation_distance = -1;
 
     assess_danger();
     if( old_assessment > NPC_DANGER_VERY_LOW && ai_cache.danger_assessment <= 0 ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Melee NPCs shouldn't dive out of formation to get surrounded anymore"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Melee NPCs with ranged allies, or melee NPCs who are helping the player, tend to have a suicidal urge to run into the middle of combat. They have settings like "Stay close to me", but these are largely ignored once they see an enemy and begin engaging. If the player flees, they continue engaging until their own AI decides it's time to run, which may not always be correct (or even close to correct, sorry. Still working on it.)

#### Describe the solution
NPCs with melee weapons now track how close the nearest ranged ally, or the player, is. If the enemy is further away than that, they won't consider engaging just yet. The tolerated distance is also limited by whatever clamp you've put in place, if you've told them to remain close to you and they're an ally.

If you've told them to stay close and you start wandering off, they'll make a check based on their personality.aggression and consider breaking away and following. This only applies to melee NPCs for now.

#### Describe alternatives you've considered
I considered having this apply when investigating sounds as well, but more logic is needed there on the NPCs part and I wanted to keep this simple.

I note that the default break behaviour for melee characters is to seek the player if they can't make an attack. That's pretty silly, but for now I don't have a good other option. I'd like to have them identify a "party leader" and follow them instead.

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/98bfcae9-8da4-412c-8e7e-19e7cba82fe8)
With the default "engage freely" option, my fairly brave buddy here decided to get suicidally surrounded by bad guys.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/41ce5230-c257-4ff1-89a3-be379b61787c)
But once he is told to stay close, he begins pulling away to the set distance of 6 squares.

Not shown but as I make the set distance shorter, he comes in to join me. What a good NPC.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Just a quick thing but I think it should be very, very game changing.
