### PR TITLE
make more stuff outta fiberglass

### DIFF
--- a/data/json/items/ranged/archery.json
+++ b/data/json/items/ranged/archery.json
@@ -609,7 +609,7 @@
     "description": "A modern fiberglass bow that can be used effectively by those of somewhat above-average strength.",
     "price": 38000,
     "//": "60in Fiberglass recurved bow at 26in draw, 80lb draw, 54J, 0.403 slugs with 30g arrow.",
-    "material": [ "steel", "plastic" ],
+    "material": [ "steel", "fiberglass" ],
     "flags": [
       "FIRE_TWOHAND",
       "RELOAD_AND_SHOOT",
@@ -665,7 +665,7 @@
     "description": "A modern fiberglass bow that can be taken down for storage.  For use by those of somewhat above-average strength.  Use it to disassemble it for storage.",
     "price": 38000,
     "//": "Most stats copied from the recurve bow, can be adjusted later to reflect a different model.",
-    "material": [ "steel", "plastic" ],
+    "material": [ "steel", "fiberglass" ],
     "flags": [
       "FIRE_TWOHAND",
       "RELOAD_AND_SHOOT",
@@ -732,7 +732,7 @@
     "description": "A modern fiberglass bow that has been taken down for storage.  For use by those of somewhat above-average strength.  Use it to assemble it into shape.",
     "price": 38000,
     "//": "Most stats copied from the recurve bow, can be adjusted later to reflect a different model.",
-    "material": [ "steel", "plastic" ],
+    "material": [ "steel", "fiberglass" ],
     "weight": "540 g",
     "volume": "2500 ml",
     "longest_side": "60 cm",

--- a/data/json/items/ranged/crossbows.json
+++ b/data/json/items/ranged/crossbows.json
@@ -250,7 +250,7 @@
     "//": "27in Fiberglass pistol crossbow at 11in draw, 48J, 80 lbs draw, 0.3 Slugs with 30g bolt.",
     "price": 55000,
     "price_postapoc": 2500,
-    "material": [ "steel", "plastic" ],
+    "material": [ "steel", "wood" ],
     "flags": [ "PRIMITIVE_RANGED_WEAPON" ],
     "skill": "pistol",
     "ammo": [ "bolt" ],

--- a/data/json/items/tool/firefighting.json
+++ b/data/json/items/tool/firefighting.json
@@ -182,7 +182,7 @@
     "name": { "str": "pike pole" },
     "description": "A durable tool consisting of a sturdy fiberglass shaft tipped with a small steel hook.",
     "price": 10000,
-    "material": [ "plastic", "fiberglass" ],
+    "material": [ "fiberglass", "steel" ],
     "techniques": [ "WBLOCK_1", "SWEEP" ],
     "flags": [ "DURABLE_MELEE", "REACH_ATTACK", "NONCONDUCTIVE", "SHEATH_SPEAR", "ALWAYS_TWOHAND" ],
     "weight": "3100 g",

--- a/data/json/items/tool/firefighting.json
+++ b/data/json/items/tool/firefighting.json
@@ -182,7 +182,7 @@
     "name": { "str": "pike pole" },
     "description": "A durable tool consisting of a sturdy fiberglass shaft tipped with a small steel hook.",
     "price": 10000,
-    "material": [ "plastic", "steel" ],
+    "material": [ "plastic", "fiberglass" ],
     "techniques": [ "WBLOCK_1", "SWEEP" ],
     "flags": [ "DURABLE_MELEE", "REACH_ATTACK", "NONCONDUCTIVE", "SHEATH_SPEAR", "ALWAYS_TWOHAND" ],
     "weight": "3100 g",

--- a/data/json/items/tool/fishing.json
+++ b/data/json/items/tool/fishing.json
@@ -94,12 +94,11 @@
     "price_postapoc": 1500,
     "to_hit": { "grip": "solid", "length": "long", "surface": "any", "balance": "neutral" },
     "//": "7 lead subst. for 8 bismuth, which doesn't have its own material",
-    "//2": "plastic is stand-in for fiberglass / carbon fiber; kevlar_rigid is also an option but has no suitable item for uncraft output",
     "material": [
       { "type": "lead", "portion": 7 },
       { "type": "steel", "portion": 4 },
       { "type": "cotton", "portion": 4 },
-      { "type": "plastic", "portion": 3 }
+      { "type": "fiberglass", "portion": 3 }
     ],
     "symbol": "/",
     "color": "brown",
@@ -119,12 +118,11 @@
     "price_postapoc": 1600,
     "to_hit": { "grip": "solid", "length": "short", "surface": "any", "balance": "neutral" },
     "//": "7 lead subst. for 8 bismuth, which doesn't have its own material",
-    "//2": "plastic is stand-in for fiberglass / carbon fiber; kevlar_rigid is also an option but has no suitable item for uncraft output",
     "material": [
       { "type": "lead", "portion": 7 },
       { "type": "steel", "portion": 4 },
       { "type": "cotton", "portion": 4 },
-      { "type": "plastic", "portion": 4 }
+      { "type": "fiberglass", "portion": 4 }
     ],
     "symbol": "/",
     "color": "blue",
@@ -170,12 +168,11 @@
     "price_postapoc": 1750,
     "to_hit": { "grip": "solid", "length": "short", "surface": "any", "balance": "neutral" },
     "//": "7 lead subst. for 8 bismuth, which doesn't have its own material",
-    "//2": "plastic is stand-in for fiberglass / carbon fiber; kevlar_rigid is also an option but has no suitable item for uncraft output",
     "material": [
       { "type": "lead", "portion": 7 },
       { "type": "steel", "portion": 5 },
       { "type": "cotton", "portion": 4 },
-      { "type": "plastic", "portion": 4 }
+      { "type": "fiberglass", "portion": 4 }
     ],
     "symbol": "/",
     "color": "dark_gray",

--- a/data/json/uncraft/tools.json
+++ b/data/json/uncraft/tools.json
@@ -215,7 +215,6 @@
     "time": "5 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
-      [ [ "plastic_chunk", 3 ] ],
       [ [ "string_36", 6 ] ],
       [ [ "fishing_hook_basic", 1 ] ],
       [ [ "wire", 1 ] ],
@@ -232,7 +231,6 @@
     "time": "5 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
-      [ [ "plastic_chunk", 4 ] ],
       [ [ "string_36", 6 ] ],
       [ [ "fishing_hook_basic", 1 ] ],
       [ [ "wire", 1 ] ],
@@ -250,7 +248,6 @@
     "time": "5 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
-      [ [ "plastic_chunk", 4 ] ],
       [ [ "string_36", 6 ] ],
       [ [ "fishing_hook_basic", 1 ] ],
       [ [ "wire", 1 ] ],
@@ -267,7 +264,6 @@
     "time": "5 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
-      [ [ "plastic_chunk", 4 ] ],
       [ [ "string_36", 6 ] ],
       [ [ "fishing_hook_basic", 1 ] ],
       [ [ "wire", 1 ] ],
@@ -285,7 +281,6 @@
     "time": "5 m",
     "qualities": [ { "id": "CUT", "level": 1 } ],
     "components": [
-      [ [ "plastic_chunk", 4 ] ],
       [ [ "string_36", 6 ] ],
       [ [ "fishing_hook_basic", 1 ] ],
       [ [ "wire", 1 ] ],


### PR DESCRIPTION
#### Summary
Content "Changes some items' material to fiberglass"
#### Purpose of change

Fiberglass was  recently added. We had several items that were waiting for such a material.

#### Describe the solution

Makes most of these items into fiberglass laminate, where appropriate.

Hand crossbow: since this is craftable from wood, I changed it to wood. *Ideally* a new variant of the hand crossbow would be added, that'd be craftable with wood, and the old hand crossbow would be made of fiberglass.

Makes fishing rods out of fiberglass. Removes the shafts from the deconstruction recipe.

#### Describe alternatives you've considered
Since I've added FIberglass *laminate* and not raw fiberglass, making the insulation batt out of fiberglass wouldn't be appropriate. I considered adding a new material for the batt.

Also, the Handcrossbow thing mentioned above.
#### Testing

Loaded game. Observed new decon products of the fishing rods.

#### Additional context
None. Fiberglass is cool.