### PR TITLE
Add u_has_proficiency to EoC conditions

### DIFF
--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -675,6 +675,22 @@ checks are you hot or cold
 { "u_has_any_effect": [ "hot", "cold" ], "bodypart": "torso" }
 ```
 
+### `u_has_proficiency`, `npc_has_proficiency`
+- type: string or [variable object](##variable-object)
+- return true if alpha or beta talker has mastered a proficiency (to 100%).
+
+#### Valid talkers:
+
+| Avatar | Character | NPC | Monster |  Furniture | Item |
+| ------ | --------- | --------- | ---- | ------- | --- | 
+| ✔️ | ✔️ | ✔️ | ❌ | ❌ | ❌ |
+
+#### Examples
+check do you have `Principles of Chemistry`
+```json
+{ "u_has_proficiency": "prof_intro_chemistry" }
+```
+
 ### `u_can_stow_weapon`, `npc_can_stow_weapon`
 - type: simple string
 - return true if alpha or beta talker wield an item, and have enough space to put it away

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -568,7 +568,8 @@ void conditional_t::set_has_activity( bool is_npc )
     };
 }
 
-void conditional_t::set_has_proficiency( const JsonObject &jo, std::string_view member, bool is_npc )
+void conditional_t::set_has_proficiency( const JsonObject &jo, std::string_view member,
+        bool is_npc )
 {
     str_or_var proficiency_to_check = get_str_or_var( jo.get_member( member ), member, true );
     condition = [proficiency_to_check, is_npc]( dialogue const & d ) {

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -568,6 +568,14 @@ void conditional_t::set_has_activity( bool is_npc )
     };
 }
 
+void conditional_t::set_has_proficiency( const JsonObject &jo, std::string_view member, bool is_npc )
+{
+    str_or_var proficiency_to_check = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [proficiency_to_check, is_npc]( dialogue const & d ) {
+        return d.actor( is_npc )->knows_proficiency( proficiency_id( proficiency_to_check.evaluate( d ) ) );
+    };
+}
+
 void conditional_t::set_is_riding( bool is_npc )
 {
     condition = [is_npc]( dialogue const & d ) {
@@ -3443,6 +3451,7 @@ parsers = {
     {"u_has_visible_trait", "npc_has_visible_trait", jarg::member, &conditional_t::set_has_visible_trait },
     {"u_has_martial_art", "npc_has_martial_art", jarg::member, &conditional_t::set_has_martial_art },
     {"u_using_martial_art", "npc_using_martial_art", jarg::member, &conditional_t::set_using_martial_art },
+    {"u_has_proficiency", "npc_has_proficiency", jarg::member, &conditional_t::set_has_proficiency },
     {"u_has_flag", "npc_has_flag", jarg::member, &conditional_t::set_has_flag },
     {"u_has_species", "npc_has_species", jarg::member, &conditional_t::set_has_species },
     {"u_bodytype", "npc_bodytype", jarg::member, &conditional_t::set_bodytype },

--- a/src/condition.h
+++ b/src/condition.h
@@ -84,6 +84,7 @@ struct conditional_t {
         void set_has_martial_art( const JsonObject &jo, std::string_view member, bool is_npc = false );
         void set_has_flag( const JsonObject &jo, std::string_view member, bool is_npc = false );
         void set_has_species( const JsonObject &jo, std::string_view member, bool is_npc = false );
+        void set_has_proficiency( const JsonObject &jo, std::string_view member, bool is_npc = false );
         void set_bodytype( const JsonObject &jo, std::string_view member, bool is_npc = false );
         void set_has_var( const JsonObject &jo, std::string_view member, bool is_npc = false );
         void set_expects_vars( const JsonObject &jo, std::string_view member );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Add u_has_proficiency to EoC conditions"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I need u_has_proficiency for something I want to do, so I figured I'd try to add it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add a "u_has_proficiency" condition as stated.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Make the following test EoC
```
  {
    "type": "effect_on_condition",
    "id": "EOC_PROFICIENCY_U_TEST",
    "condition": { "u_has_proficiency": "prof_intro_biology" },
    "effect": [ { "u_message": "You have the proficiency" } ],
    "false_effect": [ { "u_message": "You don't have the proficiency" } ]
  }
```

Starting character with no proficiency: "You don't have the proficiency"
Debug in proficiency: "You have the proficiency"
Remove proficiency, spawn in zombie and dissect it so I'm 4% toward proficiency: "You don't have the proficiency" (as intended)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

This should definitely go into dialogue too but I'm not sure how to do that.

Messed around with the math parser a bit but didn't have any luck setting it up as a math condition right now.  I'll let this merge and try again (unless anyone has any insight why a similar solution to #69464 isn't working)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
