### PR TITLE
More garlic, onions and potatoes in houses

### DIFF
--- a/data/json/itemgroups/Food/food.json
+++ b/data/json/itemgroups/Food/food.json
@@ -37,6 +37,8 @@
     "entries": [
       { "prob": 40, "group": "flour_bag_paper_powder_1_70" },
       { "prob": 10, "group": "flour_bag_plastic_1_175" },
+      { "prob": 10, "group": "potato_bag_plastic_1" },
+      { "prob": 10, "group": "onion_bag_plastic_1" },
       { "prob": 50, "group": "yeast_bag_plastic_25" },
       { "prob": 8, "group": "yogurt_starter_culture_bag_plastic_4" },
       { "prob": 40, "group": "cornmeal_box_small_10" },

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -482,6 +482,8 @@
       { "group": "dry_goods", "prob": 80, "count": [ 1, 3 ] },
       { "group": "preserved_food", "prob": 20, "count": [ 1, 2 ] },
       { "item": "garlic", "prob": 66, "count": [ 1, 3 ] },
+      { "item": "onion", "prob": 66, "count": [ 1, 3 ] },
+      { "item": "potato", "prob": 30, "count": [ 2, 12 ] },
       { "group": "pet_food", "prob": 50 }
     ]
   },

--- a/data/json/itemgroups/SUS/domestic.json
+++ b/data/json/itemgroups/SUS/domestic.json
@@ -481,6 +481,7 @@
       { "group": "big_canned_food", "prob": 20, "count": [ 1, 2 ] },
       { "group": "dry_goods", "prob": 80, "count": [ 1, 3 ] },
       { "group": "preserved_food", "prob": 20, "count": [ 1, 2 ] },
+      { "item": "garlic", "prob": 66, "count": [ 1, 3 ] },
       { "group": "pet_food", "prob": 50 }
     ]
   },

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -658,6 +658,7 @@
       { "item": "waist_apron_short", "prob": 4 },
       { "item": "apron_leather", "prob": 2 },
       { "item": "hat_chef", "prob": 2 },
+      { "item": "garlic", "prob": 3 },
       { "item": "jacket_chef", "prob": 2 },
       { "item": "gloves_cut_resistant", "prob": 1 },
       { "item": "pot", "prob": 25 },

--- a/data/json/itemgroups/food_service.json
+++ b/data/json/itemgroups/food_service.json
@@ -1720,6 +1720,20 @@
   },
   {
     "type": "item_group",
+    "id": "potato_bag_plastic_1",
+    "subtype": "collection",
+    "container-item": "bag_plastic",
+    "entries": [ { "item": "potato", "container-item": "null", "count": [ 1, 25 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "onion_bag_plastic_1",
+    "subtype": "collection",
+    "container-item": "bag_plastic",
+    "entries": [ { "item": "onion", "container-item": "null", "count": [ 1, 25 ] } ]
+  },
+  {
+    "type": "item_group",
     "id": "chips2_bag_plastic_3",
     "subtype": "collection",
     "//": "This group was created automatically and may contain errors.",

--- a/data/json/itemgroups/food_service.json
+++ b/data/json/itemgroups/food_service.json
@@ -1722,14 +1722,14 @@
     "type": "item_group",
     "id": "potato_bag_plastic_1",
     "subtype": "collection",
-    "container-item": "bag_plastic",
+    "container-item": "bag_canvas",
     "entries": [ { "item": "potato", "container-item": "null", "count": [ 1, 25 ] } ]
   },
   {
     "type": "item_group",
     "id": "onion_bag_plastic_1",
     "subtype": "collection",
-    "container-item": "bag_plastic",
+    "container-item": "bag_canvas",
     "entries": [ { "item": "onion", "container-item": "null", "count": [ 1, 25 ] } ]
   },
   {

--- a/data/mods/Xedra_Evolved/recipes/vampire.json
+++ b/data/mods/Xedra_Evolved/recipes/vampire.json
@@ -10,7 +10,7 @@
       { "id": "SAW_M", "level": 1 }
     ],
     "tools": [ [ [ "surface_heat", 30, "LIST" ] ] ],
-    "components": [ [ [ "mercury", 1 ] ], [ [ "garlic", 4 ] ], [ [ "blood", 3 ] ], [ [ "silver_small", 1 ] ] ],
+    "components": [ [ [ "mercury", 1 ] ], [ [ "garlic_clove", 4 ] ], [ [ "blood", 3 ] ], [ [ "silver_small", 1 ] ] ],
     "time": "30 m",
     "charges": 4,
     "skill_used": "cooking",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Increases odds of finding garlic in houses to a more realistic amount.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds garlic to two item groups it would make sense in.  Also adjusts a recipe in Xedra Evolved to use garlic cloves instead of whole garlic.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
