### PR TITLE
adds a monster I saw in a dream to portal storms

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -308,6 +308,7 @@
         [ "EOC_PORTAL_LIGHT", { "const": 2 } ],
         [ "EOC_PORTAL_ABSENCE", { "const": 4 } ],
         [ "EOC_PORTAL_IMPOSSIBLE_SHAPE", { "const": 5 } ],
+        [ "EOC_PORTAL_FLATLANDER", { "const": 5 } ],
         [ "EOC_PORTAL_MEMORIES", { "const": 1 } ],
         [ "EOC_PORTAL_GIANT_APPENDAGE", { "const": 1 } ],
         [ "EOC_PORTAL_NPC", { "const": 1 } ]

--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -535,6 +535,21 @@
   },
   {
     "type": "effect_on_condition",
+    "id": "EOC_PORTAL_FLATLANDER",
+    "effect": {
+      "u_spawn_monster": "mon_flatlander",
+      "real_count": 1,
+      "hallucination_count": 1,
+      "outdoor_only": true,
+      "min_radius": 3,
+      "max_radius": 20,
+      "lifespan": [ "1 minutes", "3 minutes" ],
+      "spawn messages": "something glides into your field of vision out of thin air, slipping between the space between atoms.",
+      "spawn_message_plural": "several things glide into your field of vision out of thin air, slipping between the spaces between atoms."
+    }
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_PORTAL_GIANT_APPENDAGE",
     "effect": {
       "u_spawn_monster": "mon_giant_appendage",

--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -544,7 +544,7 @@
       "min_radius": 3,
       "max_radius": 20,
       "lifespan": [ "1 minutes", "3 minutes" ],
-      "spawn message": "something glides into your field of vision out of thin air, slipping between the space between atoms.",
+      "spawn_message": "something glides into your field of vision out of thin air, slipping between the space between atoms.",
       "spawn_message_plural": "several things glide into your field of vision out of thin air, slipping between the spaces between atoms."
     }
   },

--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -544,7 +544,7 @@
       "min_radius": 3,
       "max_radius": 20,
       "lifespan": [ "1 minutes", "3 minutes" ],
-      "spawn messages": "something glides into your field of vision out of thin air, slipping between the space between atoms.",
+      "spawn message": "something glides into your field of vision out of thin air, slipping between the space between atoms.",
       "spawn_message_plural": "several things glide into your field of vision out of thin air, slipping between the spaces between atoms."
     }
   },

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -988,7 +988,7 @@
     "message": "",
     "min_duration": 100,
     "max_duration": 400,
-    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "RANDOM_DURATION"  ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "RANDOM_DURATION" ],
     "extra_effects": [ { "id": "flatlander_attack_nausea", "hit_self": true } ]
   },
   {
@@ -1002,7 +1002,7 @@
     "message": "",
     "min_duration": 300,
     "max_duration": 1000,
-    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "RANDOM_DURATION"  ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "RANDOM_DURATION" ],
     "effect_str": "nausea"
   },
   {

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -1004,7 +1004,7 @@
     "max_duration": 1000,
     "flags": [ "SILENT", "NO_EXPLOSION_SFX", "RANDOM_DURATION"  ],
     "effect_str": "nausea"
-  }
+  },
   {
     "type": "SPELL",
     "id": "sloth_attack",

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -979,13 +979,32 @@
     "type": "SPELL",
     "id": "flatlander_attack",
     "name": { "str": "flatlander attack" },
-    "description": "dazes the player and makes them nauseous",
+    "description": "Dazes the player",
     "valid_targets": [ "hostile" ],
     "effect": "attack",
     "effect_str": "stunned",
     "max_range": 4,
-    "extra_effects": [ { "id": "nausea" } ]
+    "shape": "blast",
+    "message": "",
+    "min_duration": 100,
+    "max_duration": 400,
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "RANDOM_DURATION"  ],
+    "extra_effects": [ { "id": "flatlander_attack_nausea", "hit_self": true } ]
   },
+  {
+    "type": "SPELL",
+    "id": "flatlander_attack_nausea",
+    "name": { "str": "flatlander attack nausea" },
+    "description": "Makes enemy nauseous",
+    "valid_targets": [ "hostile" ],
+    "effect": "attack",
+    "shape": "blast",
+    "message": "",
+    "min_duration": 300,
+    "max_duration": 1000,
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "RANDOM_DURATION"  ],
+    "effect_str": "nausea"
+  }
   {
     "type": "SPELL",
     "id": "sloth_attack",

--- a/data/json/monster_special_attacks/spells.json
+++ b/data/json/monster_special_attacks/spells.json
@@ -977,6 +977,17 @@
   },
   {
     "type": "SPELL",
+    "id": "flatlander_attack",
+    "name": { "str": "flatlander attack" },
+    "description": "dazes the player and makes them nauseous",
+    "valid_targets": [ "hostile" ],
+    "effect": "attack",
+    "effect_str": "stunned",
+    "max_range": 4,
+    "extra_effects": [ { "id": "nausea" } ]
+  },
+  {
+    "type": "SPELL",
     "id": "sloth_attack",
     "name": { "str": "Sloth Attack" },
     "description": "Slows you.",

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1248,7 +1248,7 @@
         "type": "spell",
         "spell_data": { "id": "flatlander_attack", "min_level": 1 },
         "cooldown": 10,
-        "monster_message": "Standing close to the %s, your body is violently dragged down to the second dimension. You're there for only an instant but the experience is enough to send you reeling."
+        "monster_message": "Standing close to the %s, your body is violently dragged down to the second dimension.  You're there for only an instant but the experience is enough to send you reeling."
       }
     ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "Your memory can't decide whether the %s was even there in the first place." },

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1232,7 +1232,7 @@
     "type": "MONSTER",
     "name": { "str": "flatlander" },
     "description": "An oblong figure floating parallel with the ground, some feet in the air like a piece of paper - Its far thinner than one as well, to the point it would be invisible if looked at with the right angle.",
-    "default faction": "nether_player_hate",
+    "default_faction": "nether_player_hate",
     "species": [ "NETHER_EMANATION" ],
     "volume": "62500 ml",
     "weight": "0 g",

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1248,7 +1248,7 @@
         "type": "spell",
         "spell_data": { "id": "flatlander_attack", "min_lavel": 1 },
         "cooldown": 10,
-        "monster_message": "For a fraction of a second your body is pulled down to the %s's dimension, leaving you disoriented and reeling from the experience."
+        "monster_message": "For a fraction of an instant, your body is flattened as you are violently pulled into the second dimension.  The fleeting experience is enough to send you reeling."
       }
     ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "Your memory can't decide whether the %s was even there in the first place." },

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1246,7 +1246,7 @@
     "special_attacks": [
       {
         "type": "spell",
-        "spell_data": { "id": "flatlander_attack", "min_lavel": 1 },
+        "spell_data": { "id": "flatlander_attack", "min_level": 1 },
         "cooldown": 10,
         "monster_message": "For a fraction of an instant, your body is flattened as you are violently pulled into the second dimension.  The fleeting experience is enough to send you reeling."
       }

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1228,6 +1228,33 @@
     "flags": [ "FLIES", "NO_BREATHE", "BIOLOGICALPROOF", "STUMBLES" ]
   },
   {
+    "id": "mon_flatlander",
+    "type": "MONSTER",
+    "name": { "str": "flatlander" },
+    "description": "An oblong figure floating parallel with the ground, some feet in the air like a piece of paper - Its far thinner than one as well, to the point it would be invisible if looked at with the right angle.",
+    "default faction": "nether_player_hate",
+    "species": [ "NETHER_EMANATION" ],
+    "volume": "62500 ml",
+    "weight": "0 g",
+    "hp": 30,
+    "speed": 100,
+    "symbol": "|",
+    "color": "white",
+    "aggression": 100,
+    "morale": 100,
+    "dodge": 8,
+    "special_attacks": [
+      {
+        "type": "spell",
+        "spell_data": { "id": "flatlander_attack", "min_lavel": 1 },
+        "cooldown": 10,
+        "monster_message": "For a fraction of a second your body is pulled down to the %s's dimension, leaving you disoriented and reeling from the experience."
+      }
+    ],
+    "death_function": { "corpse_type": "NO_CORPSE", "message": "Your memory can't decide whether the %s was even there in the first place." },
+    "flags": [ "FLIES", "NO_BREATHE", "BIOLOGICALPROOF", "SEES", "HEARS", "RANGED_ATTACKER" ]
+  },
+  {
     "id": "mon_memory",
     "type": "MONSTER",
     "name": { "str": "memory", "str_pl": "memories" },

--- a/data/json/monsters/nether.json
+++ b/data/json/monsters/nether.json
@@ -1248,7 +1248,7 @@
         "type": "spell",
         "spell_data": { "id": "flatlander_attack", "min_level": 1 },
         "cooldown": 10,
-        "monster_message": "For a fraction of an instant, your body is flattened as you are violently pulled into the second dimension.  The fleeting experience is enough to send you reeling."
+        "monster_message": "Standing close to the %s, your body is violently dragged down to the second dimension. You're there for only an instant but the experience is enough to send you reeling."
       }
     ],
     "death_function": { "corpse_type": "NO_CORPSE", "message": "Your memory can't decide whether the %s was even there in the first place." },


### PR DESCRIPTION
#### Summary
Content "New portal storm monster based off a dream I had"

#### Purpose of change

Like a month ago I had a dream that I was playing CDDA and I got attacked by something that looked like a flat shape that flew above my character like a stingray. I thought of making an actual monster based on it. Took a couple creative liberties with it but I think it fits what I saw in my dream really well.

#### Describe the solution

I interpreted the weird thing I saw into the "Flatlander," A being from a universe with only two spatial dimensions. Standing too close to the flatlander will cause it to momentarily snap your character into two dimensions, stunning them and inducing nausea.

~~I'm going to be honest - I've no clue if I did the monster's spell correctly, which is why I made this a draft PR. I'll try and fix it tomorrow as it's getting late.~~ Guardian fixed the spell for me, big thanks to him.

#### Describe alternatives you've considered

I am open to any changes or suggestions.

#### Additional context

It didn't have a name in my dream so the name, description and the attack were thought up after. I don't recall it ever attacking me in the dream because I stayed away from the entire section of a town it was in.