### PR TITLE
Minor hauling fixes

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2070,7 +2070,9 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
         quantities.pop_back();
 
         if( !target ) {
-            debugmsg( "Lost target item of ACT_MOVE_ITEMS" );
+            if( !hauling_mode ) {
+                debugmsg( "Lost target item of ACT_MOVE_ITEMS" );
+            }
             continue;
         }
 
@@ -2109,7 +2111,7 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
             } else {
                 std::vector<item_location> dropped_items = drop_on_map( who, item_drop_reason::deliberate, { newit },
                         dest );
-                if( who.is_hauling() ) {
+                if( hauling_mode ) {
                     who.haul_list.insert( who.haul_list.end(), dropped_items.begin(), dropped_items.end() );
                 }
             }
@@ -2123,7 +2125,7 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
     if( target_items.empty() ) {
         // Nuke the current activity, leaving the backlog alone.
         act.set_to_null();
-        if( who.is_hauling() ) {
+        if( hauling_mode ) {
             std::vector<item_location> haulable_items = get_map().get_haulable_items( who.pos() );
             bool overflow = who.trim_haul_list( haulable_items );
             if( who.is_hauling() && haulable_items.empty() ) {
@@ -2146,6 +2148,7 @@ void move_items_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "quantities", quantities );
     jsout.member( "to_vehicle", to_vehicle );
     jsout.member( "relative_destination", relative_destination );
+    jsout.member( "hauling_mode", hauling_mode );
 
     jsout.end_object();
 }
@@ -2160,6 +2163,7 @@ std::unique_ptr<activity_actor> move_items_activity_actor::deserialize( JsonValu
     data.read( "quantities", actor.quantities );
     data.read( "to_vehicle", actor.to_vehicle );
     data.read( "relative_destination", actor.relative_destination );
+    data.read( "hauling_mode", actor.hauling_mode );
 
     return actor.clone();
 }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -2070,9 +2070,7 @@ void move_items_activity_actor::do_turn( player_activity &act, Character &who )
         quantities.pop_back();
 
         if( !target ) {
-            if( !hauling_mode ) {
-                debugmsg( "Lost target item of ACT_MOVE_ITEMS" );
-            }
+            debugmsg( "Lost target item of ACT_MOVE_ITEMS" );
             continue;
         }
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -462,13 +462,15 @@ class move_items_activity_actor : public activity_actor
         std::vector<int> quantities;
         bool to_vehicle;
         tripoint relative_destination;
+        bool hauling_mode;
 
     public:
         move_items_activity_actor( std::vector<item_location> target_items, std::vector<int> quantities,
-                                   bool to_vehicle, tripoint relative_destination ) :
+                                   bool to_vehicle, tripoint relative_destination, bool hauling_mode = false ) :
             target_items( std::move( target_items ) ), quantities( std::move( quantities ) ),
             to_vehicle( to_vehicle ),
-            relative_destination( relative_destination ) {}
+            relative_destination( relative_destination ),
+            hauling_mode( hauling_mode ) {}
 
         activity_id get_type() const override {
             return activity_id( "ACT_MOVE_ITEMS" );

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12110,6 +12110,7 @@ void game::start_hauling( const tripoint &pos )
 {
     std::vector<item_location> candidate_items = m.get_haulable_items( pos );
     // Find target items and quantities thereof for the new activity
+    u.trim_haul_list( candidate_items );
     std::vector<item_location> target_items = u.haul_list;
 
     if( u.is_autohauling() && !u.suppress_autohaul ) {

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -12147,7 +12147,8 @@ void game::start_hauling( const tripoint &pos )
     // Destination relative to the player
     const tripoint relative_destination{};
 
-    const move_items_activity_actor actor( target_items, quantities, to_vehicle, relative_destination );
+    const move_items_activity_actor actor( target_items, quantities, to_vehicle, relative_destination,
+                                           true );
     u.assign_activity( actor );
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Messing with hauled items while hauling is on can produce some spurious debugmsgs and log messages

Fixes #52426 (incidentally)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Instead of move_items activity checking whether character is hauling, explicitly store that it's meant to be hauling. This fixes other move_items activities done while hauling (e.g. with AIM) producing nonsense messages
Trim the list of hauled items at the start of hauling to account for items being removed in between steps (e.g. by being picked up, consumed by crafting, butchered, whatever)
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I have some bigger improvements to hauling in mind, which among other things would resolve this in a more elegant way, but it's turning out to be difficult, so I'm just doing this for now.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
* Start hauling some items, pick up one of them, continue hauling
  * Before: debugmsg
  * After: nothing
* Start hauling some items, move some of them away from the tile with AIM
  * Before: nonsense message in log about tile being too full to hold items
  * After: nothing
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
