### PR TITLE
Allow pocket_mods to add magazine or magazine well pockets to items without them

### DIFF
--- a/data/mods/TEST_DATA/pocket_mods_test.json
+++ b/data/mods/TEST_DATA/pocket_mods_test.json
@@ -1,0 +1,165 @@
+[
+  {
+    "type": "test_data",
+    "pocket_mod_data": {
+      "change existing magazine well": {
+        "base_item": "debug_gun_with_mag_well",
+        "mod_item": "debug_retool_mag_well",
+        "expected_pockets": { "MAGAZINE_WELL": 1 }
+      },
+      "add magazine well to item without one": {
+        "base_item": "debug_gun_no_mag_well",
+        "mod_item": "debug_retool_mag_well",
+        "expected_pockets": { "MAGAZINE_WELL": 1 }
+      },
+      "add pocket to pocketless tool": {
+        "base_item": "debug_tool_no_pockets",
+        "mod_item": "debug_retool_container_no_mag_well",
+        "expected_pockets": { "CONTAINER": 1 }
+      },
+      "add pocket to tool with pocket": {
+        "base_item": "debug_tool_one_pocket",
+        "mod_item": "debug_retool_container_no_mag_well",
+        "expected_pockets": { "CONTAINER": 2 }
+      }
+    }
+  },
+  {
+    "id": "debug_gun_no_mag_well",
+    "type": "GUN",
+    "name": { "str": "debug gun without mag well" },
+    "copy-from": "rifle_auto",
+    "description": "Just a debug gun.",
+    "weight": "902 g",
+    "volume": "1550 ml",
+    "longest_side": "520 mm",
+    "price": 125000,
+    "price_postapoc": 4000,
+    "to_hit": -1,
+    "material": [ "aluminum", "steel", "plastic" ],
+    "symbol": "(",
+    "color": "black",
+    "ammo": [ "NULL" ],
+    "dispersion": 150,
+    "durability": 7,
+    "min_cycle_recoil": 1350,
+    "weapon_category": [ "AUTOMATIC_RIFLES" ],
+    "valid_mod_locations": [ [ "bore", 1 ], [ "grip", 1 ], [ "mechanism", 4 ], [ "sling", 1 ], [ "stock accessory", 2 ], [ "stock", 1 ] ],
+    "melee_damage": { "bash": 12 },
+    "flags": [ "NO_TURRET" ]
+  },
+  {
+    "id": "debug_gun_with_mag_well",
+    "type": "GUN",
+    "name": "debug gun with mag well",
+    "copy-from": "debug_gun_no_mag_well",
+    "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "ammo_restriction": { "223": 20 } } ]
+  },
+  {
+    "id": "debug_tool_no_pockets",
+    "type": "TOOL",
+    "name": "debug tool with no pockets",
+    "description": "debug",
+    "symbol": "(",
+    "volume": "1L",
+    "weight": "1kg"
+  },
+  {
+    "id": "debug_tool_one_pocket",
+    "type": "TOOL",
+    "name": "debug tool with one pocket",
+    "copy-from": "debug_tool_no_pockets",
+    "pocket_data": [ { "pocket_type": "CONTAINER", "max_contains_volume": "2L" } ]
+  },
+  {
+    "id": "debug_retool_container_no_mag_well",
+    "type": "TOOLMOD",
+    "name": "debug toolmod to add container",
+    "description": "debug",
+    "symbol": "(",
+    "volume": "1L",
+    "weight": "1kg",
+    "pocket_mods": [ { "pocket_type": "CONTAINER", "max_contains_volume": "1L" } ]
+  },
+  {
+    "id": "debug_retool_mag_well",
+    "type": "GUNMOD",
+    "name": { "str": "debug gunmod to add/alter magazine well" },
+    "description": "This is a complete upper receiver assembly containing a barrel, handguard, and bolt carrier group that, given the right knowledge, is installable upon an AR-15-style rifle’s lower frame.  Swappable uppers allow compatible firearms to be retooled for different cartridges and barrel lengths, with this kit furnishing a weapon with a standard 16-inch barrel chambered for .223 Remington ammunition.",
+    "weight": "2268 g",
+    "volume": "1550 ml",
+    "longest_side": "480 mm",
+    "integral_volume": "1550 ml",
+    "integral_weight": "2268 g",
+    "integral_longest_side": "41 cm",
+    "barrel_length": "406 mm",
+    "price": 25999,
+    "price_postapoc": 1000,
+    "material": [ "steel", "aluminum", "plastic" ],
+    "symbol": ":",
+    "color": "green",
+    "location": "bore",
+    "mod_targets": [ "debug_modular_ar15" ],
+    "install_time": "5 m",
+    "ammo_modifier": [ "223" ],
+    "magazine_adaptor": [
+      [
+        "223",
+        [
+          "stanag30",
+          "stanag5",
+          "stanag5ranger",
+          "stanag10",
+          "stanag10ranger",
+          "stanag20",
+          "stanag20ranger",
+          "stanag30ranger",
+          "stanag40",
+          "stanag40ranger",
+          "stanag50",
+          "stanag60",
+          "stanag60drum",
+          "stanag90",
+          "stanag100",
+          "stanag100drum",
+          "stanag150",
+          "stanag20_beowulf",
+          "stanag20ranger_beowulf",
+          "stanag30_beowulf",
+          "stanag30ranger_beowulf",
+          "survivor223mag"
+        ]
+      ]
+    ],
+    "pocket_mods": [
+      {
+        "pocket_type": "MAGAZINE_WELL",
+        "item_restriction": [
+          "stanag30",
+          "stanag5",
+          "stanag5ranger",
+          "stanag10",
+          "stanag10ranger",
+          "stanag20",
+          "stanag20ranger",
+          "stanag30ranger",
+          "stanag40",
+          "stanag40ranger",
+          "stanag50",
+          "stanag60",
+          "stanag60drum",
+          "stanag90",
+          "stanag100",
+          "stanag100drum",
+          "stanag150",
+          "stanag20_beowulf",
+          "stanag20ranger_beowulf",
+          "stanag30_beowulf",
+          "stanag30ranger_beowulf",
+          "survivor223mag"
+        ]
+      }
+    ],
+    "add_mod": [ [ "brass catcher", 1 ], [ "bayonet lug", 1 ], [ "rail", 2 ], [ "sights", 1 ], [ "underbarrel", 1 ], [ "muzzle", 1 ] ]
+  }
+]

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1839,6 +1839,7 @@ void item_contents::update_modified_pockets(
     const std::optional<const pocket_data *> &mag_or_mag_well,
     std::vector<const pocket_data *> container_pockets )
 {
+    bool mag_or_well_found = false;
     for( auto pocket_iter = contents.begin(); pocket_iter != contents.end(); ) {
         item_pocket &pocket = *pocket_iter;
         if( pocket.is_type( pocket_type::CONTAINER ) ) {
@@ -1878,9 +1879,9 @@ void item_contents::update_modified_pockets(
                         // in case the debugmsg wasn't clear, this should never happen
                         debugmsg( "Oops!  deleted some items when updating pockets that were added via toolmods" );
                     }
-                    contents.emplace_back( *mag_or_mag_well );
                     pocket_iter = contents.erase( pocket_iter );
                 } else {
+                    mag_or_well_found = true;
                     ++pocket_iter;
                 }
             } else {
@@ -1895,6 +1896,9 @@ void item_contents::update_modified_pockets(
     // we've deleted all of the superfluous copies already, so time to add the new pockets
     for( const pocket_data *container_pocket : container_pockets ) {
         contents.emplace_back( container_pocket );
+    }
+    if( mag_or_mag_well && !mag_or_well_found ) {
+        contents.emplace_back( *mag_or_mag_well );
     }
 
 }

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -208,6 +208,9 @@ bool pocket_data::operator==( const pocket_data &rhs ) const
            airtight == rhs.airtight &&
            fire_protection == rhs.fire_protection &&
            get_flag_restrictions() == rhs.get_flag_restrictions() &&
+           ammo_restriction == rhs.ammo_restriction &&
+           item_id_restriction == rhs.item_id_restriction &&
+           material_restriction == rhs.material_restriction &&
            type == rhs.type &&
            volume_capacity == rhs.volume_capacity &&
            min_item_volume == rhs.min_item_volume &&

--- a/src/item_pocket.h
+++ b/src/item_pocket.h
@@ -32,7 +32,6 @@ struct iteminfo;
 struct itype;
 struct tripoint;
 class map;
-template <typename E> struct enum_traits;
 
 class item_pocket
 {
@@ -559,11 +558,6 @@ class pocket_data
     private:
 
         FlagsSetType flag_restrictions;
-};
-
-template<>
-struct enum_traits<pocket_type> {
-    static constexpr pocket_type last = pocket_type::LAST;
 };
 
 template<>

--- a/src/pocket_type.h
+++ b/src/pocket_type.h
@@ -2,6 +2,8 @@
 #ifndef CATA_SRC_POCKET_TYPE_H
 #define CATA_SRC_POCKET_TYPE_H
 
+template <typename E> struct enum_traits;
+
 enum class pocket_type : int {
     CONTAINER,
     MAGAZINE,
@@ -13,6 +15,11 @@ enum class pocket_type : int {
     CABLE, // pocket for storing power/data cables and handling their connections
     MIGRATION, // this allows items to load contents that are too big, in order to spill them later.
     LAST
+};
+
+template<>
+struct enum_traits<pocket_type> {
+    static constexpr pocket_type last = pocket_type::LAST;
 };
 
 #endif // CATA_SRC_POCKET_TYPE_H

--- a/src/test_data.cpp
+++ b/src/test_data.cpp
@@ -7,6 +7,7 @@ std::map<vproto_id, std::vector<double>> test_data::drag_data;
 std::map<vproto_id, efficiency_data> test_data::eff_data;
 std::map<itype_id, double> test_data::expected_dps;
 std::map<spawn_type, std::vector<container_spawn_test_data>> test_data::container_spawn_data;
+std::map<std::string, pocket_mod_test_data> test_data::pocket_mod_data;
 std::map<std::string, npc_boarding_test_data> test_data::npc_boarding_data;
 
 void efficiency_data::deserialize( const JsonObject &jo )
@@ -38,6 +39,13 @@ void container_spawn_test_data::deserialize( const JsonObject &jo )
     if( jo.has_member( "charges" ) ) {
         jo.read( "charges", charges );
     }
+}
+
+void pocket_mod_test_data::deserialize( const JsonObject &jo )
+{
+    jo.read( "base_item", base_item );
+    jo.read( "mod_item", mod_item );
+    jo.read( "expected_pockets", expected_pockets );
 }
 
 void npc_boarding_test_data::deserialize( const JsonObject &jo )
@@ -109,6 +117,12 @@ void test_data::load( const JsonObject &jo )
             container_spawn_data[spawn_type::map].insert( container_spawn_data[spawn_type::map].end(),
                     test_map.begin(), test_map.end() );
         }
+    }
+
+    if( jo.has_object( "pocket_mod_data" ) ) {
+        std::map<std::string, pocket_mod_test_data> new_pocket_mod_data;
+        jo.read( "pocket_mod_data", new_pocket_mod_data );
+        pocket_mod_data.insert( new_pocket_mod_data.begin(), new_pocket_mod_data.end() );
     }
 
     if( jo.has_object( "npc_boarding_data" ) ) {

--- a/src/test_data.h
+++ b/src/test_data.h
@@ -8,6 +8,7 @@
 
 #include "point.h"
 #include "type_id.h"
+#include "pocket_type.h"
 
 class JsonObject;
 
@@ -40,6 +41,14 @@ struct container_spawn_test_data {
     void deserialize( const JsonObject &jo );
 };
 
+struct pocket_mod_test_data {
+    itype_id base_item;
+    itype_id mod_item;
+    std::map<pocket_type, uint64_t> expected_pockets;
+
+    void deserialize( const JsonObject &jo );
+};
+
 struct npc_boarding_test_data {
     vproto_id veh_prototype;
     tripoint player_pos;
@@ -58,6 +67,7 @@ class test_data
         static std::map<vproto_id, efficiency_data> eff_data;
         static std::map<itype_id, double> expected_dps;
         static std::map<spawn_type, std::vector<container_spawn_test_data>> container_spawn_data;
+        static std::map<std::string, pocket_mod_test_data> pocket_mod_data;
         static std::map<std::string, npc_boarding_test_data> npc_boarding_data;
 
         static void load( const JsonObject &jo );


### PR DESCRIPTION
#### Summary
Bugfixes "Allow pocket_mods to add magazine or magazine well pockets to items without them"

#### Purpose of change

#69725 throws a ton of errors because gunmods could only alter magazine wells, but not add them.

#### Describe the solution

- gunmods and toolmods will now also add magazine or magazine well pockets if they didn't have one before.
- adds a test to check pocket_mods functionality
- fixes a small oversight from #69794
- `pocket_data::operator==` also compares various restrictions

#### Describe alternatives you've considered



#### Testing

The new test passes.

#### Additional context

