### PR TITLE
Many small logic adjustments and bugfixes for NPC targeting / threat assessment

### DIFF
--- a/data/json/damage_types.json
+++ b/data/json/damage_types.json
@@ -58,6 +58,7 @@
     "magic_color": "light_red",
     "name": "pierce",
     "skill": "stabbing",
+    "mon_difficulty": true,
     "//2": "derived from cut only for monster defs",
     "derived_from": [ "cut", 0.8 ],
     "immune_flags": { "character": [ "STAB_IMMUNE" ] }
@@ -79,6 +80,7 @@
     "type": "damage_type",
     "physical": true,
     "magic_color": "light_red",
+    "mon_difficulty": true,
     "name": "ballistic",
     "material_required": true,
     "immune_flags": { "character": [ "BULLET_IMMUNE" ] }

--- a/data/json/npcs/TALK_TEST.json
+++ b/data/json/npcs/TALK_TEST.json
@@ -214,7 +214,11 @@
         "topic": "TALK_DONE",
         "condition": { "npc_aim_rule": "AIM_SPRAY" }
       },
-      { "text": "This is a npc rule test response.", "topic": "TALK_DONE", "condition": { "npc_rule": "avoid_doors" } }
+      {
+        "text": "This is a npc rule test response.",
+        "topic": "TALK_DONE",
+        "condition": { "npc_rule": "avoid_doors" }
+      }
     ]
   },
   {

--- a/data/json/npcs/TALK_TEST.json
+++ b/data/json/npcs/TALK_TEST.json
@@ -214,7 +214,7 @@
         "topic": "TALK_DONE",
         "condition": { "npc_aim_rule": "AIM_SPRAY" }
       },
-      { "text": "This is a npc rule test response.", "topic": "TALK_DONE", "condition": { "npc_rule": "use_silent" } }
+      { "text": "This is a npc rule test response.", "topic": "TALK_DONE", "condition": { "npc_rule": "avoid_doors" } }
     ]
   },
   {

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -405,7 +405,7 @@ void MonsterGenerator::finalize_mtypes()
                                      matk->max_mul ) / 2;
                 bonus_increment += total_damage;
                 bonus_increment += matk->throw_strength;
-                bonus_increment *= std::min( matk->range - 1, 1.0f );
+                bonus_increment *= static_cast<float>( std::min( matk->range - 1, 1 ) );
                 bonus_increment /= ( matk->move_cost / 10.0f );
                 if( !matk->blockable || !matk->dodgeable ) {
                     bonus_increment *= 1.5f;

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -399,7 +399,7 @@ void MonsterGenerator::finalize_mtypes()
                 continue;
             }
             const melee_actor *matk = dynamic_cast<const melee_actor *>( &*special.second );
-            if( matk != nullptr() && matk->damage_max_instance.total_damage() > 0 ) {
+            if( matk != nullptr && matk->damage_max_instance.total_damage() > 0 ) {
                 float bonus_increment = 0.0f;
                 float total_damage = matk->damage_max_instance.total_damage() * ( matk->min_mul +
                                      matk->max_mul ) / 2;
@@ -410,17 +410,17 @@ void MonsterGenerator::finalize_mtypes()
                 if( !matk->blockable || !matk->dodgeable ) {
                     bonus_increment *= 1.5f;
                 }
-                special_attack_bonus += bonus_increment;
+                special_attack_bonus += std::min( bonus_increment, 1.0f );
             }
             const gun_actor *ratk = dynamic_cast<const gun_actor *>( &*special.second );
-            if( ratk != nullptr() && ratk->get_max_range() > 1 ) {
+            if( ratk != nullptr && ratk->get_max_range() > 1 ) {
                 // this doesn't really look at the quality of the gun, but it will give
                 // a large difficulty boost to any monsters with guns of any kind.
                 // That's a good start but this could be refined significantly.
                 float bonus_increment = 0.0f;
                 bonus_increment += static_cast<float>( ratk->get_max_range() * ratk->max_ammo );
                 bonus_increment /= ( ( ratk->move_cost + ratk->targeting_cost ) / 20.0f );
-                special_attack_bonus += bonus_increment;
+                special_attack_bonus += std::min( bonus_increment, 1.0f );
             }
             other_special_attacks -= 1;
         }

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -357,7 +357,6 @@ void MonsterGenerator::finalize_mtypes()
         }
 
         finalize_damage_map( mon.armor.resist_vals, true );
-        //check for changes in copy-from
         if( mon.armor_proportional.has_value() ) {
             finalize_damage_map( mon.armor_proportional->resist_vals, false, 1.f );
             for( std::pair<const damage_type_id, float> &dt : mon.armor.resist_vals ) {
@@ -380,53 +379,13 @@ void MonsterGenerator::finalize_mtypes()
         float melee_dmg_total = mon.melee_damage.total_damage();
         float armor_diff = 3.0f;
         for( const auto &dt : mon.armor.resist_vals ) {
-            // mon_difficulty is defined in JSON by damage type.
-            // Only damage types explicitly set to true will be counted.
             if( dt.first->mon_difficulty ) {
                 armor_diff += dt.second;
             }
         }
-        // We can't track the extra difficulty of *all* special attacks, but
-        // certain ones can be specifically tracked.
-        float special_attack_bonus = 0.0f;
-        // "other" special attacks counts up any specials we haven't run details for and
-        // makes them count a bit.
-        int other_special_attacks = mon.special_attacks.size();
-        for( const std::pair<const std::string, mtype_special_attack> &special : mon.special_attacks ) {
-            if( special.first == "grab" ) {
-                special_attack_bonus += 2.0f;
-                other_special_attacks -= 1;
-                continue;
-            }
-            const melee_actor *matk = dynamic_cast<const melee_actor *>( &*special.second );
-            if( matk != nullptr && matk->damage_max_instance.total_damage() > 0 ) {
-                float bonus_increment = 0.0f;
-                float total_damage = matk->damage_max_instance.total_damage() * ( matk->min_mul +
-                                     matk->max_mul ) / 2;
-                bonus_increment += total_damage;
-                bonus_increment += matk->throw_strength;
-                bonus_increment *= static_cast<float>( std::min( matk->range - 1, 1 ) );
-                bonus_increment /= ( matk->move_cost / 10.0f );
-                if( !matk->blockable || !matk->dodgeable ) {
-                    bonus_increment *= 1.5f;
-                }
-                special_attack_bonus += std::min( bonus_increment, 1.0f );
-            }
-            const gun_actor *ratk = dynamic_cast<const gun_actor *>( &*special.second );
-            if( ratk != nullptr && ratk->get_max_range() > 1 ) {
-                // this doesn't really look at the quality of the gun, but it will give
-                // a large difficulty boost to any monsters with guns of any kind.
-                // That's a good start but this could be refined significantly.
-                float bonus_increment = 0.0f;
-                bonus_increment += static_cast<float>( ratk->get_max_range() * ratk->max_ammo );
-                bonus_increment /= ( ( ratk->move_cost + ratk->targeting_cost ) / 20.0f );
-                special_attack_bonus += std::min( bonus_increment, 1.0f );
-            }
-            other_special_attacks -= 1;
-        }
         mon.difficulty = ( mon.melee_skill + 1 ) * mon.melee_dice * ( melee_dmg_total + mon.melee_sides ) *
-                         0.04 + ( mon.sk_dodge + 1 ) * armor_diff * 0.04 + special_attack_bonus +
-                         ( mon.difficulty_base + other_special_attacks + 8 * mon.emit_fields.size() );
+                         0.04 + ( mon.sk_dodge + 1 ) * armor_diff * 0.04 +
+                         ( mon.difficulty_base + mon.special_attacks.size() + 8 * mon.emit_fields.size() );
         mon.difficulty *= ( mon.hp + mon.speed - mon.attack_cost + ( mon.morale + mon.agro ) * 0.1 ) * 0.01
                           + ( mon.vision_day + 2 * mon.vision_night ) * 0.01;
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2629,11 +2629,11 @@ Creature::Attitude npc::attitude_to( const Creature &other ) const
         case MATT_FPASSIVE:
         case MATT_IGNORE:
         case MATT_FLEE:
-		    if( m.has_flag( mon_flag_HIT_AND_RUN ) ) {
+            if( m.has_flag( mon_flag_HIT_AND_RUN ) ) {
                 return Attitude::HOSTILE;
             } else {
                 return Attitude::NEUTRAL;
-			}
+            }
         case MATT_FRIEND:
             return Attitude::FRIENDLY;
         case MATT_ATTACK:

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -119,6 +119,7 @@ static const mfaction_str_id monfaction_human( "human" );
 static const mfaction_str_id monfaction_player( "player" );
 
 static const mon_flag_str_id mon_flag_RIDEABLE_MECH( "RIDEABLE_MECH" );
+static const mon_flag_str_id mon_flag_HIT_AND_RUN( "HIT_AND_RUN" );
 
 static const overmap_location_str_id overmap_location_source_of_ammo( "source_of_ammo" );
 static const overmap_location_str_id overmap_location_source_of_anything( "source_of_anything" );
@@ -3785,8 +3786,8 @@ npc_follower_rules::npc_follower_rules()
     override_enable = ally_rule::DEFAULT;
 
     set_flag( ally_rule::use_guns );
-    set_flag( ally_rule::use_grenades );
-    clear_flag( ally_rule::use_silent );
+    clear_flag( ally_rule::use_grenades );
+    set_flag( ally_rule::use_silent );
     set_flag( ally_rule::avoid_friendly_fire );
 
     clear_flag( ally_rule::allow_pick_up );
@@ -3794,13 +3795,13 @@ npc_follower_rules::npc_follower_rules()
     clear_flag( ally_rule::allow_sleep );
     set_flag( ally_rule::allow_complain );
     set_flag( ally_rule::allow_pulp );
-    clear_flag( ally_rule::close_doors );
-    clear_flag( ally_rule::follow_close );
+    set_flag( ally_rule::close_doors );
+    set_flag( ally_rule::follow_close );
     clear_flag( ally_rule::avoid_doors );
     clear_flag( ally_rule::hold_the_line );
-    clear_flag( ally_rule::ignore_noise );
+    set_flag( ally_rule::ignore_noise );
     clear_flag( ally_rule::forbid_engage );
-    set_flag( ally_rule::follow_distance_2 );
+    clear_flag( ally_rule::follow_distance_2 );
 }
 
 bool npc_follower_rules::has_flag( ally_rule test, bool check_override ) const

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -118,8 +118,8 @@ static const mfaction_str_id monfaction_bee( "bee" );
 static const mfaction_str_id monfaction_human( "human" );
 static const mfaction_str_id monfaction_player( "player" );
 
-static const mon_flag_str_id mon_flag_RIDEABLE_MECH( "RIDEABLE_MECH" );
 static const mon_flag_str_id mon_flag_HIT_AND_RUN( "HIT_AND_RUN" );
+static const mon_flag_str_id mon_flag_RIDEABLE_MECH( "RIDEABLE_MECH" );
 
 static const overmap_location_str_id overmap_location_source_of_ammo( "source_of_ammo" );
 static const overmap_location_str_id overmap_location_source_of_anything( "source_of_anything" );

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -2629,7 +2629,11 @@ Creature::Attitude npc::attitude_to( const Creature &other ) const
         case MATT_FPASSIVE:
         case MATT_IGNORE:
         case MATT_FLEE:
-            return Attitude::NEUTRAL;
+		    if( m.has_flag( mon_flag_HIT_AND_RUN ) ) {
+                return Attitude::HOSTILE;
+            } else {
+                return Attitude::NEUTRAL;
+			}
         case MATT_FRIEND:
             return Attitude::FRIENDLY;
         case MATT_ATTACK:

--- a/src/npc.h
+++ b/src/npc.h
@@ -572,7 +572,7 @@ struct npc_short_term_cache {
 
     npc_attack_rating current_attack_evaluation;
     std::shared_ptr<npc_attack> current_attack;
-	
+
 
     // Use weak_ptr to avoid circular references between Creatures
     // attitude of creatures the npc can see
@@ -1378,7 +1378,7 @@ class npc : public Character
         npc_personality personality;
         npc_opinion op_of_u;
         npc_combat_memory_cache mem_combat;
-		
+
         dialogue_chatbin chatbin;
         int patience = 0; // Used when we expect the player to leave the area
         npc_follower_rules rules;

--- a/src/npc.h
+++ b/src/npc.h
@@ -256,21 +256,7 @@ struct npc_opinion {
     void deserialize( const JsonObject &data );
 };
 
-// npc_combat_memory should store short-term trackers that don't really need to be saved if
-// the player exits the game. Minor logic behaviour changes might occur, but nothing serious.
-struct npc_combat_memory {
-    float assess_ally = 0.0f;
-    float assess_enemy = 0.0f;
-    int panic = 0;
-    int swarm_count = 0; //so you can tell if you're getting away over multiple turns
-    int failing_to_reposition = 0; // Inc. when tries to flee/move and doesn't change assess
-    int reposition_countdown = 0; // set when repos fails so that we don't keep trying.
-    int assessment_before_repos = 0; // assessment of enemy threat level at the start of repos
-    float my_health = 1.0f; // saved when we evaluate_self.  Health 1.0 means 100% unhurt.
-    bool repositioning = false; // is NPC running away or just moving around / kiting.
-    int formation_distance = -1; // dist to nearest ally with a gun, or to player
-    int engagement_distance = 6; // applies to melee NPCs in formation with ranged ones or the player.
-};
+
 
 enum class combat_engagement : int {
     NONE = 0,
@@ -586,6 +572,7 @@ struct npc_short_term_cache {
 
     npc_attack_rating current_attack_evaluation;
     std::shared_ptr<npc_attack> current_attack;
+	
 
     // Use weak_ptr to avoid circular references between Creatures
     // attitude of creatures the npc can see
@@ -600,6 +587,22 @@ struct npc_short_term_cache {
     // friendly creature.
     // returns nullopt if not applicable
     std::optional<int> closest_enemy_to_friendly_distance() const;
+};
+
+// npc_combat_memory should store short-term trackers that don't really need to be saved if
+// the player exits the game. Minor logic behaviour changes might occur, but nothing serious.
+struct npc_combat_memory_cache {
+    float assess_ally = 0.0f;
+    float assess_enemy = 0.0f;
+    int panic = 0;
+    int swarm_count = 0; //so you can tell if you're getting away over multiple turns
+    int failing_to_reposition = 0; // Inc. when tries to flee/move and doesn't change assess
+    int reposition_countdown = 0; // set when repos fails so that we don't keep trying.
+    int assessment_before_repos = 0; // assessment of enemy threat level at the start of repos
+    float my_health = 1.0f; // saved when we evaluate_self.  Health 1.0 means 100% unhurt.
+    bool repositioning = false; // is NPC running away or just moving around / kiting.
+    int formation_distance = -1; // dist to nearest ally with a gun, or to player
+    int engagement_distance = 6; // applies to melee NPCs in formation with ranged ones or the player.
 };
 
 struct npc_need_goal_cache {
@@ -1374,7 +1377,8 @@ class npc : public Character
         npc_mission previous_mission = NPC_MISSION_NULL;
         npc_personality personality;
         npc_opinion op_of_u;
-        npc_combat_memory mem_combat;
+        npc_combat_memory_cache mem_combat;
+		
         dialogue_chatbin chatbin;
         int patience = 0; // Used when we expect the player to leave the area
         npc_follower_rules rules;

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -283,7 +283,7 @@ void npc_attack_melee::use( npc &source, const tripoint &location ) const
                     source.move_to_next();
                     add_msg_debug( debugmode::DF_NPC_MOVEAI,
                                    "<color_light_gray>%s is at least %i away from allies, enemy within %i of them.  Going for attack.</color>",
-                                   source.name, source.mem_combat.formation_distance, closest_enemy_to_friendly_distance() );
+                                   source.name, source.mem_combat.formation_distance, source.closest_enemy_to_friendly_distance() );
 			    } else {
                     add_msg_debug( debugmode::DF_NPC_MOVEAI,
                                    "<color_light_gray>%s can't path to melee target, or is staying close to ranged allies.</color>",

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -279,8 +279,12 @@ void npc_attack_melee::use( npc &source, const tripoint &location ) const
                     add_msg_debug( debugmode::DF_NPC_MOVEAI,
                                    "<color_light_gray>%s is at least %i away from ranged allies, enemy within %i.  Going for attack.</color>",
                                    source.name, source.mem_combat.formation_distance, target_distance );
-
-                } else {
+                } else if( clear_path && source.mem_combat.formation_distance > source.closest_enemy_to_friendly_distance() ){
+                    source.move_to_next();
+                    add_msg_debug( debugmode::DF_NPC_MOVEAI,
+                                   "<color_light_gray>%s is at least %i away from allies, enemy within %i of them.  Going for attack.</color>",
+                                   source.name, source.mem_combat.formation_distance, closest_enemy_to_friendly_distance() );
+			    } else {
                     add_msg_debug( debugmode::DF_NPC_MOVEAI,
                                    "<color_light_gray>%s can't path to melee target, or is staying close to ranged allies.</color>",
                                    source.name );

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -273,18 +273,19 @@ void npc_attack_melee::use( npc &source, const tripoint &location ) const
                 if( clear_path && source.mem_combat.formation_distance == -1 ) {
                     source.move_to_next();
                     add_msg_debug( debugmode::DF_NPC_MOVEAI,
-                                   "<color_light_gray>%s has no nearby ranged allies.  Going for the attack.</color>", source.name );
+                                   "<color_light_gray>%s has no nearby ranged allies.  Going for attack.</color>", source.name );
                 } else if( clear_path && source.mem_combat.formation_distance > target_distance ) {
                     source.move_to_next();
                     add_msg_debug( debugmode::DF_NPC_MOVEAI,
                                    "<color_light_gray>%s is at least %i away from ranged allies, enemy within %i.  Going for attack.</color>",
                                    source.name, source.mem_combat.formation_distance, target_distance );
-                } else if( clear_path && source.mem_combat.formation_distance > source.closest_enemy_to_friendly_distance() ){
+                } else if( clear_path &&
+                           source.mem_combat.formation_distance > source.closest_enemy_to_friendly_distance() ) {
                     source.move_to_next();
-                    add_msg_debug( debugmode::DF_NPC_MOVEAI,
-                                   "<color_light_gray>%s is at least %i away from allies, enemy within %i of them.  Going for attack.</color>",
-                                   source.name, source.mem_combat.formation_distance, source.closest_enemy_to_friendly_distance() );
-			    } else {
+                    //add_msg_debug( debugmode::DF_NPC_MOVEAI,
+                    //               "<color_light_gray>%s is at least %i away from allies, enemy within %i of ally.  Going for attack.</color>",
+                    //               source.name, source.mem_combat.formation_distance, source.closest_enemy_to_friendly_distance() );
+                } else {
                     add_msg_debug( debugmode::DF_NPC_MOVEAI,
                                    "<color_light_gray>%s can't path to melee target, or is staying close to ranged allies.</color>",
                                    source.name );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -1157,7 +1157,6 @@ void npc::act_on_danger_assessment()
             } else {
                 add_msg_debug( debugmode::DF_NPC_COMBATAI, "%s still wants to reposition, but they just tried.",
                                name );
-                mem_combat.reposition_countdown --;
             }
             mem_combat.panic *= ( mem_combat.assess_enemy / ( mem_combat.assess_ally + 0.5f ) );
             mem_combat.panic += std::min(
@@ -1273,6 +1272,19 @@ void npc::regen_ai_cache()
     mem_combat.assess_enemy = 0.0f;
     mem_combat.assess_ally = 0.0f;
     mem_combat.swarm_count = 0;
+    if( mem_combat.reposition_countdown > 0 ) {
+        mem_combat.reposition_countdown --;
+    }
+
+    if( mem_combat.repositioning && !has_effect( effect_npc_run_away ) &&
+        !has_effect( effect_npc_fire_bad ) ) {
+        // if NPC no longer has the run away effect and isn't fleeing in panic,
+        // they can stop moving away.
+        mem_combat.repositioning = false;
+        mem_combat.reposition_countdown = 1;
+        path.clear();
+    }
+
     assess_danger();
     if( old_assessment > NPC_DANGER_VERY_LOW && ai_cache.danger_assessment <= 0 ) {
         warn_about( "relax", 30_minutes );

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3725,7 +3725,7 @@ bool npc::find_corpse_to_pulp()
 {
     Character &player_character = get_player_character();
     if( ( is_player_ally() ) ) {
-    if( !rules.has_flag( ally_rule::allow_pulp ) ||
+        if( !rules.has_flag( ally_rule::allow_pulp ) ||
             player_character.in_vehicle || is_hallucination() ) {
             return false;
         }
@@ -3736,8 +3736,8 @@ bool npc::find_corpse_to_pulp()
     }
 
     map &here = get_map();
-                // Pathing with overdraw can get expensive, limit it
-                int path_counter = 4;
+    // Pathing with overdraw can get expensive, limit it
+    int path_counter = 4;
     const auto check_tile = [this, &path_counter, &here]( const tripoint & p ) -> const item * {
         if( !here.sees_some_items( p, *this ) || !sees( p ) )
         {
@@ -3774,17 +3774,17 @@ bool npc::find_corpse_to_pulp()
 
     const int range = 6;
 
-                      const item *corpse = nullptr;
+    const item *corpse = nullptr;
     if( pulp_location && square_dist( get_location(), *pulp_location ) <= range ) {
-    corpse = check_tile( here.getlocal( *pulp_location ) );
+        corpse = check_tile( here.getlocal( *pulp_location ) );
     }
 
     // Find the old target to avoid spamming
     const item *old_target = corpse;
 
     if( corpse == nullptr ) {
-    // If we're following the player, don't wander off to pulp corpses
-    const tripoint around = is_walking_with() ? player_character.pos() : pos();
+        // If we're following the player, don't wander off to pulp corpses
+        const tripoint around = is_walking_with() ? player_character.pos() : pos();
         for( const item_location &location : here.get_active_items_in_radius( around, range,
                 special_item_type::corpse ) ) {
             corpse = check_tile( location.position() );
@@ -3801,8 +3801,8 @@ bool npc::find_corpse_to_pulp()
     }
 
     if( corpse != nullptr && corpse != old_target && is_walking_with() ) {
-    std::string talktag = chatbin.snip_pulp_zombie;
-    parse_tags( talktag, get_player_character(), *this );
+        std::string talktag = chatbin.snip_pulp_zombie;
+        parse_tags( talktag, get_player_character(), *this );
         say( string_format( _( talktag ), corpse->tname() ) );
     }
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3716,7 +3716,7 @@ std::list<item> npc::pick_up_item_vehicle( vehicle &veh, int part_index )
 bool npc::find_corpse_to_pulp()
 {
     Character &player_character = get_player_character();
-    if( ( is_player_ally() ) ) {
+    if( is_player_ally() ) {
         if( !rules.has_flag( ally_rule::allow_pulp ) ||
             player_character.in_vehicle || is_hallucination() ) {
             return false;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3764,7 +3764,7 @@ bool npc::find_corpse_to_pulp()
         return nullptr;
     };
 
-    const int range = 6;
+    const int range = mem_combat.engagement_distance;
 
     const item *corpse = nullptr;
     if( pulp_location && square_dist( get_location(), *pulp_location ) <= range ) {

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -475,23 +475,16 @@ std::vector<sphere> npc::find_dangerous_explosives() const
 float npc::evaluate_monster( const monster &target, int dist ) const
 {
     float speed = target.speed_rating();
-    float scaled_distance = std::max( 1.0f, dist * dist / ( speed + 10.0f ) );
+    float scaled_distance = std::max( 1.0f, dist * dist / ( speed * 250.0f ) );
     float hp_percent = static_cast<float>( target.get_hp() ) / target.get_hp_max();
-    float diff = std::min( static_cast<float>( target.type->difficulty ), NPC_DANGER_VERY_LOW );
+    float diff = std::max( static_cast<float>( target.type->difficulty ), NPC_DANGER_VERY_LOW );
     add_msg_debug( debugmode::DF_NPC_COMBATAI,
-                   "<color_yellow>evaluate_monster </color><color_light_gray>%s thinks %s threat level is %1.2f before considering situation.</color>",
-                   name,
-                   target.type->nname(), diff );
+                   "<color_yellow>evaluate_monster </color><color_dark_gray>%s thinks %s threat level is <color_light_gray>%1.2f</color><color_dark_gray> before considering situation.  Speed rating: %1.2f; dist: %i; scaled_distance: %1.0f; HP: %1.0f%%</color>",
+                   name, target.type->nname(), diff, speed, dist, scaled_distance, hp_percent * 100 );
     // Note that the danger can pass below "very low" if the monster is weak and far away.
     diff *= ( hp_percent * 0.5f + 0.5f ) / scaled_distance;
-    /*add_msg_debug( debugmode::DF_NPC_COMBATAI,
-                   "<color_light_gray>%s distance from %s: %i.  Speed rating: %1.2f.  Scaled distance: %1.2f.</color>",
-                   name, target.type->nname(), dist, speed, scaled_distance );
     add_msg_debug( debugmode::DF_NPC_COMBATAI,
-                   "<color_light_gray>%s sees %s hp percent remaining is %1.0f%%.</color>",
-                   name, target.type->nname(), hp_percent * 100 );*/
-    add_msg_debug( debugmode::DF_NPC_COMBATAI,
-                   "%s puts final %s threat level at %1.2f<color_light_gray> after counting speed, distance, hp</color>",
+                   "<color_light_gray>%s puts final %s threat level at </color>%1.2f<color_light_gray> after counting speed, distance, hp</color>",
                    name, target.type->nname(), diff );
     return std::min( diff, NPC_MONSTER_DANGER_MAX );
 }
@@ -859,14 +852,14 @@ void npc::assess_danger()
         if( !clear_shot_reach( pos(), critter.pos(), false ) ) {
             if( is_enemy() || !critter.friendly ) {
                 // still warn about enemies behind impassable glass walls, but not as often.
-                add_msg_debug( debugmode::DF_NPC,
+                add_msg_debug( debugmode::DF_NPC_COMBATAI,
                                "%s ignored %s because there's an obstacle in between.  Might warn about it.",
                                name, critter.type->nname() );
                 if( critter_threat > 2 * ( 8.0f + personality.bravery + rng( 0, 5 ) ) ) {
                     warn_about( "monster", 10_minutes, critter.type->nname(), dist, critter.pos() );
                 }
             } else {
-                add_msg_debug( debugmode::DF_NPC,
+                add_msg_debug( debugmode::DF_NPC_COMBATAI,
                                "%s ignored %s because there's an obstacle in between, and it's not worth warning about.",
                                name, critter.type->nname() );
             }
@@ -895,8 +888,7 @@ void npc::assess_danger()
             continue;
         }
 
-
-        add_msg_debug( debugmode::DF_NPC_COMBATAI,
+        add_msg_debug( debugmode::DF_NPC,
                        "%s assessed threat of critter %s as %1.2f.",
                        name, critter.type->nname(), critter_threat );
         ai_cache.total_danger += critter_threat;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -681,7 +681,7 @@ float npc::estimate_armour( const Character &candidate ) const
             armour_step *= 4;
             number_of_parts += 3;
         }
-		// obtain an average value of the 4 armour types we checked.
+        // obtain an average value of the 4 armour types we checked.
         armour += static_cast<float>( armour_step ) / 4.0f;
     }
     armour /= number_of_parts;
@@ -732,13 +732,13 @@ void npc::assess_danger()
     }
     // Radius we can attack without moving
     int max_range = *confident_range_cache;
-	// Radius in which enemy threats are multiplied to avoid surrounding
-	int preferred_medium_range = std::max( max_range, 8 );
-	preferred_medium_range = std::min( preferred_medium_range, 15 );
-	// Radius in which enemy threats are hugely multiplied to encourage repositioning
-	int preferred_close_range = std::max( max_range, 1 );
-	preferred_close_range = std::min( preferred_close_range, preferred_medium_range / 2 );
-	
+    // Radius in which enemy threats are multiplied to avoid surrounding
+    int preferred_medium_range = std::max( max_range, 8 );
+    preferred_medium_range = std::min( preferred_medium_range, 15 );
+    // Radius in which enemy threats are hugely multiplied to encourage repositioning
+    int preferred_close_range = std::max( max_range, 1 );
+    preferred_close_range = std::min( preferred_close_range, preferred_medium_range / 2 );
+
     Character &player_character = get_player_character();
     bool sees_player = sees( player_character.pos() );
     const bool self_defense_only = rules.engagement == combat_engagement::NO_MOVE ||
@@ -758,7 +758,7 @@ void npc::assess_danger()
         }
     }
     mem_combat.engagement_distance = def_radius;
-	
+
     const auto ok_by_rules = [max_range, def_radius, this, &player_character]( const Creature & c,
     int dist, int scaled_dist ) {
         // If we're forbidden to attack, no need to check engagement rules
@@ -1180,7 +1180,8 @@ void npc::act_on_danger_assessment()
                     }
                 }
             }
-        } else if( failed_reposition || ( mem_combat.assess_ally < mem_combat.assess_enemy * mem_combat.swarm_count ) ) {
+        } else if( failed_reposition ||
+                   ( mem_combat.assess_ally < mem_combat.assess_enemy * mem_combat.swarm_count ) ) {
             add_msg_debug( debugmode::DF_NPC_COMBATAI,
                            "<color_light_gray>%s considers </color>repositioning<color_light_gray> from swarming enemies.</color>",
                            name );

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -423,13 +423,13 @@ TEST_CASE( "npc_talk_rules", "[npc_talk]" )
     CHECK( d.responses[0].text == "This is a basic test response." );
     talker_npc.rules.engagement = combat_engagement::ALL;
     talker_npc.rules.aim = aim_rule::SPRAY;
-    talker_npc.rules.set_flag( ally_rule::use_silent );
+    talker_npc.rules.set_flag( ally_rule::forbid_engage );
     gen_response_lines( d, 4 );
     CHECK( d.responses[0].text == "This is a basic test response." );
     CHECK( d.responses[1].text == "This is a npc engagement rule test response." );
     CHECK( d.responses[2].text == "This is a npc aim rule test response." );
     CHECK( d.responses[3].text == "This is a npc rule test response." );
-    talker_npc.rules.clear_flag( ally_rule::use_silent );
+    talker_npc.rules.clear_flag( ally_rule::forbid_engage );
 }
 
 TEST_CASE( "npc_talk_needs", "[npc_talk]" )

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -423,13 +423,13 @@ TEST_CASE( "npc_talk_rules", "[npc_talk]" )
     CHECK( d.responses[0].text == "This is a basic test response." );
     talker_npc.rules.engagement = combat_engagement::ALL;
     talker_npc.rules.aim = aim_rule::SPRAY;
-    //talker_npc.rules.set_flag( ally_rule::avoid_doors );
+    talker_npc.rules.set_flag( ally_rule::avoid_doors );
     gen_response_lines( d, 3 );
     CHECK( d.responses[0].text == "This is a basic test response." );
     CHECK( d.responses[1].text == "This is a npc engagement rule test response." );
     CHECK( d.responses[2].text == "This is a npc aim rule test response." );
-    //CHECK( d.responses[3].text == "This is a npc rule test response." );
-    //talker_npc.rules.clear_flag( ally_rule::avoid_doors );
+    CHECK( d.responses[3].text == "This is a npc rule test response." );
+    talker_npc.rules.clear_flag( ally_rule::avoid_doors );
 }
 
 TEST_CASE( "npc_talk_needs", "[npc_talk]" )

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -423,13 +423,13 @@ TEST_CASE( "npc_talk_rules", "[npc_talk]" )
     CHECK( d.responses[0].text == "This is a basic test response." );
     talker_npc.rules.engagement = combat_engagement::ALL;
     talker_npc.rules.aim = aim_rule::SPRAY;
-    talker_npc.rules.set_flag( ally_rule::avoid_doors );
-    gen_response_lines( d, 4 );
+    //talker_npc.rules.set_flag( ally_rule::avoid_doors );
+    gen_response_lines( d, 3 );
     CHECK( d.responses[0].text == "This is a basic test response." );
     CHECK( d.responses[1].text == "This is a npc engagement rule test response." );
     CHECK( d.responses[2].text == "This is a npc aim rule test response." );
-    CHECK( d.responses[3].text == "This is a npc rule test response." );
-    talker_npc.rules.clear_flag( ally_rule::avoid_doors );
+    //CHECK( d.responses[3].text == "This is a npc rule test response." );
+    //talker_npc.rules.clear_flag( ally_rule::avoid_doors );
 }
 
 TEST_CASE( "npc_talk_needs", "[npc_talk]" )

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -424,7 +424,7 @@ TEST_CASE( "npc_talk_rules", "[npc_talk]" )
     talker_npc.rules.engagement = combat_engagement::ALL;
     talker_npc.rules.aim = aim_rule::SPRAY;
     talker_npc.rules.set_flag( ally_rule::avoid_doors );
-    gen_response_lines( d, 3 );
+    gen_response_lines( d, 4 );
     CHECK( d.responses[0].text == "This is a basic test response." );
     CHECK( d.responses[1].text == "This is a npc engagement rule test response." );
     CHECK( d.responses[2].text == "This is a npc aim rule test response." );

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -836,11 +836,11 @@ TEST_CASE( "npc_talk_combat_commands", "[npc_talk]" )
     gen_response_lines( d, 10 );
     CHECK( d.responses[0].text == "Change your engagement rules…" );
     CHECK( d.responses[1].text == "Change your aiming rules…" );
-    CHECK( d.responses[2].text == "Stick close to me, no matter what." );
-    CHECK( d.responses[3].text == "<ally_rule_follow_distance_request_4_text>" );
+    CHECK( d.responses[2].text == "Move freely as you need to." );
+    CHECK( d.responses[3].text == "<ally_rule_follow_distance_request_2_text>" );
     CHECK( d.responses[4].text == "Don't use ranged weapons anymore." );
-    CHECK( d.responses[5].text == "Use only silent weapons." );
-    CHECK( d.responses[6].text == "Don't use grenades anymore." );
+    CHECK( d.responses[5].text == "Don't worry about noise." );
+    CHECK( d.responses[6].text == "You can use grenades." );
     CHECK( d.responses[7].text == "Don't worry about shooting an ally." );
     CHECK( d.responses[8].text == "Hold the line: don't move onto obstacles adjacent to me." );
     CHECK( d.responses[9].text == "Never mind." );

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -423,13 +423,13 @@ TEST_CASE( "npc_talk_rules", "[npc_talk]" )
     CHECK( d.responses[0].text == "This is a basic test response." );
     talker_npc.rules.engagement = combat_engagement::ALL;
     talker_npc.rules.aim = aim_rule::SPRAY;
-    talker_npc.rules.set_flag( ally_rule::forbid_engage );
+    talker_npc.rules.set_flag( ally_rule::avoid_doors );
     gen_response_lines( d, 4 );
     CHECK( d.responses[0].text == "This is a basic test response." );
     CHECK( d.responses[1].text == "This is a npc engagement rule test response." );
     CHECK( d.responses[2].text == "This is a npc aim rule test response." );
     CHECK( d.responses[3].text == "This is a npc rule test response." );
-    talker_npc.rules.clear_flag( ally_rule::forbid_engage );
+    talker_npc.rules.clear_flag( ally_rule::avoid_doors );
 }
 
 TEST_CASE( "npc_talk_needs", "[npc_talk]" )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Several more small adjustments to NPC logic and bugfixes from reports"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This is mostly another small cleanup of my code, which also takes the time to fix a few omissions or errors I've made along the way.

Edit: swap that, now it's a lot of small changes and a little bit of code cleanup. All of these are individually small, bases on error reports and player feedback.

#### Describe the solution

- NPCs have been less afraid of crowds than I'd like, and overrating their own gear if they have any armour. I realized they were not averaging their resistances across damage types out, so since their armour evaluation was a sum of the four major combat damage types, not an average. I've divided the result by 4 to get an average so they shouldn't overrate their gear as much.
- I took a closer look at how monster difficulty was being calculated, and realized that their stab and bullet armour was being ignored. This is part of why soldiers and cops were being underrated in difficulty. ~~I also added a method to try to calculate the effect of their special attacks a bit; this will need some testing as the numbers are kind of arbitrary, but it should help with underrating ferals and other monsters that have a lot of special attacks.~~ This all turned out to be unnecessary because the real issue was that I had made a math mistake when calculating difficulty, and the code was making bugs so I took it out for now.
- I also removed some checks and balances from crowd calculations that were there from before my rewrites and shouldn't be necessary anymore.
- In the process I changed some arbitrary numbers I'd set up for what an NPC considers "close" and "super close" for the purposes of evaluating threat from crowds of enemies. These numbers are now defined based on the NPC's weapon's effective range, rather than simply "is it a gun or not"... NPCs with polearms will now try to kite targets to keep them in melee range but too close. This one's gonna need some playtesting for sure. THis should also make melee characters try to break out of crowds a little sooner, to avoid getting surrounded.
- My new additions to keep melee NPCs from running in would probably keep them from ever attacking if a ranged ally was between them and the enemy. I've added a check to avoid that problem. First the melee character checks if the enemy is further from them than it is from their ranged ally; then, they check if there are enemies getting in closer to their other allies, and allow engagement if that's the case. In this situation, that should mean their friends are already engaged so they should go in as well. This could be made smarter.
- I renamed my combat_memory feature to make it look like the other caches that work similarly.
- try to reduce NPC 'yo yo' behaviour when repositioning where they go too far and keep boinging all the way back to the player instead of just taking one or two steps and continuing.
- NPCs were ignoring monsters like mi-go that come in, hit, and then back away. This is because the enemies were declaring themselves as "fleeing", and the code tells NPCs to ignore fleeing enemies. Now, if they have the hit-and-run flag, they'll remain hostile while fleeing. This should also be good for NPC threat assessments since a mi-go shouldn't stop being assessed as a threat while it's backing up for another attack.
- if an NPC follower is farther than their safe distance (or 6 tiles if they've been told to roam free) they won't look for a corpse to pulp, and they'll only seek corpses within a radius equal to the distance you've told them to stay close.

I also flipped several NPC follower default behaviour switches that I think should be flipped by default:
- by default followers will use silent weapons and avoid grenades
- by default followers will stay within 4 paces, not roam freely
- they'll also close doors behind them and avoid investigating noises.

#### Describe alternatives you've considered
I'm not sure if I like the way I've solved the melee problem. I may instead check if the enemy is closer to the ranged ally, but I'm not totally sure how that would work.

#### Testing
As far as I can tell these seem to be working as advertised. I'm sure there are some things I messed up, it's going to be a few dozen hours of playtesting to capture all the corner cases. On playtests, I was really impressed at how much easier and more natural it feels to sneak through a city with a follower, and I didn't ahve to give them orders to keep them from running into a fight.

#### Additional context
One tiny math error on my own part led to me doing a largish overhaul of monster difficulty calculations before I found the mistake. At least the work seems to be ok.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
