### PR TITLE
Move vehicle pivot near rear axle

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6512,8 +6512,8 @@ void vehicle::refresh_pivot() const
             weight_p = contact_area * 2.0;
         } else if( part_with_feature( wheel.mount, "STEERABLE", true ) != -1 ) {
             // Unbroken steerable wheels can handle motion on both axes
-            // (but roll a little more easily inline)
-            weight_i = contact_area * 0.1;
+            // and don't move the pivot away from non-steerable wheels/axles
+            weight_i = contact_area * 0.001;
             weight_p = contact_area * 0.2;
         } else {
             // Regular wheels resist perpendicular motion


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Move vehicle pivot closer to rear axle of typical vehicles"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Typical 4-wheel vehicles (cars, trucks, etc) currently pivot around the center of the vehicle, instead of around the center of the rear axle like real vehicles do. This PR begins to explore making this more realistic.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This initial PR makes a single change to the weighting of wheels in calculating the pivot point. Instead of steerable and non-steerable wheels having equal weight in the forward/back placement of the pivot, non-steerable wheels now have 100x the weight of steerable wheels. This moves the pivot from the middle of the wheelbase to 99% of the way from the front axle to the rear axle.
Due to rounding/truncation, for small vehicles the pivot is still one tile ahead of the axle, which is a lot more than 1% of the way to the front axle, but for large vehicles or vehicles with multiple rear axles it's closer to reasonable in placement and behavior.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Moving all the way to the rear axle by this method would require changing the weight of the steerable wheels to zero, which would be problematic for vehicles with only steerable wheels. Additional logic could be added to handle this situation. This would likely be worthwhile.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I'm playing with this patch and watching for vehicle misbehavior.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/src/vehicle_autodrive.cpp#L78-L80 makes this realistic but currently inaccurate statement:
> The pivot point is the part of the vehicle that moves the least while steering and is usually between the wheels of the vehicle, closer to the non-steerable ones.

Although normal and auto driving seems to be working correctly, It seems likely that I have missed some other effect of moving the pivot that will require a more complicated solution.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
