### PR TITLE
Show language selection window in options menu

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -776,7 +776,8 @@ int main( int argc, const char *argv[] )
 
 #if defined(LOCALIZE)
     if( get_option<std::string>( "USE_LANG" ).empty() && !SystemLocale::Language().has_value() ) {
-        select_language();
+        const std::string lang = select_language();
+        get_options().get_option( "USE_LANG" ).setValue( lang );
         set_language_from_options();
     }
 #endif

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3649,6 +3649,11 @@ std::string options_manager::show( bool ingame, const bool world_options_only, b
         const auto on_select_option = [&]() {
             cOpt &current_opt = cOPTIONS[curr_item.data];
 
+            if( current_opt.getName() == "USE_LANG" ) {
+                current_opt.setValue( select_language() );
+                return;
+            }
+
             bool hasPrerequisite = current_opt.hasPrerequisite();
             bool hasPrerequisiteFulfilled = current_opt.checkPrerequisite();
 

--- a/src/translations.cpp
+++ b/src/translations.cpp
@@ -31,7 +31,7 @@ int detail::get_current_language_version()
 #include "system_locale.h"
 #include "ui.h"
 
-void select_language()
+std::string select_language()
 {
     auto languages = get_options().get_option( "USE_LANG" ).getItems();
 
@@ -48,8 +48,7 @@ void select_language()
     }
     sm.query();
 
-    get_options().get_option( "USE_LANG" ).setValue( languages[sm.ret].first );
-    get_options().save();
+    return languages[sm.ret].first;
 }
 #endif // LOCALIZE
 

--- a/src/translations.h
+++ b/src/translations.h
@@ -35,7 +35,7 @@
 #  define ATTRIBUTE_FORMAT_ARG(a)
 #endif
 
-void select_language();
+std::string select_language();
 
 // For code analysis purposes in our clang-tidy plugin we need to be able to
 // detect when something is the argument to a translation function.  The _


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Show language selection window in options menu"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There is no enough space to show the list of available languages and their level of completion in options menu:

<img width="1072" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/21075502/ae1d7852-1633-410f-be1c-e84bd1f80ff8">

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
When the user presses ENTER or clicks at the language option, pop up a language selection window:

<img width="1072" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/21075502/f8a7de99-5edb-46e0-a316-d8d16f318c80">
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
