### PR TITLE
Make run_eocs/queue_eocs support variable objects

### DIFF
--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1448,7 +1448,7 @@ Runs another EoC. It can be a separate EoC, or an inline EoC inside `run_eocs` e
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
-| "run_eocs" | **mandatory** | string or array of eocs | EoC or EoCS that would be run |
+| "run_eocs" | **mandatory** | string (eoc id or inline eoc) or [variable object](#variable-object)) or array of eocs | EoC or EoCS that would be run |
 
 ##### Valid talkers:
 
@@ -1502,13 +1502,52 @@ if it's bigger, `are_you_super_strong` effect is run, that checks is your str is
 }
 ```
 
+Use Context Variable as a eoc (A trick for loop)
+```
+[
+    {
+        "type": "effect_on_condition",
+        "id": "debug_eoc_for_loop",
+        "effect": [{
+                    "run_eoc_with": "eoc_for_loop",
+                    "variables": {
+                      "i": "0",
+                      "length": "10",
+                      "eoc":"eoc_msg_hello_world"
+                      }}]
+    },
+    {
+        "type":"effect_on_condition",
+        "id":"eoc_msg_hello_world",
+        "effect":[{"u_message": "hello world"}]
+    },
+    {
+        "type": "effect_on_condition",
+        "id": "eoc_for_loop",
+        "condition": {"and": [
+                {"expects_vars": ["i","length","eoc"]},
+                {"math": ["_i","<","_length"]}
+            ]
+        },
+        "effect": [
+            {"run_eocs": [{"context_val":"eoc"}]},
+            {"math":["_i", "++"]},
+            {
+                "run_eocs": "eoc_for_loop"
+            }
+        ],
+        "//": "As the generated dialogue for next EOC is a complete copy of the dialogue for this EOC, the context value will be passed on to the next EOC"
+    }
+]
+```
+
 
 #### `run_eoc_with`
 Same as `run_eocs`, but runs the specific EoC with provided variables as context variables
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
-| "run_eoc_with" | **mandatory** | string | EoC or EoCS that would be run |
+| "run_eoc_with" | **mandatory** | string (eoc id or inline eoc) | EoC or EoCS that would be run |
 | "beta_loc" | optional | [variable object](#variable-object) | `u_location_variable`, where the EoC should be run | 
 | "variables" | optional | pair of `"variable_name": "varialbe"` | variables, that would be passed to the EoC; `expects_vars` condition can be used to ensure every variable exist before the EoC is run | 
 
@@ -1578,7 +1617,7 @@ Second EoC `EOC_I_NEED_AN_AK47` aslo run `EOC_GIVE_A_GUN` with the same variable
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
-| "queue_eocs" | **mandatory** | string, [variable object](#variable-object) or array | EoCs, that would be added into queue; Could be an inline EoC |
+| "queue_eocs" | **mandatory** | string (eoc id or inline eoc) or [variable object](#variable-object)) or array of eocs | EoCs, that would be added into queue; Could be an inline EoC |
 | "time_in_future" | optional | int, duration, [variable object](#variable-object) or value between two | When in the future EoC would be run; default 0 | 
 
 ##### Valid talkers:
@@ -1604,7 +1643,7 @@ Combination of `run_eoc_with` and `queue_eocs` - Put EoC into queue and run into
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
-| "queue_eoc_with" | **mandatory** | string or [variable object](#variable-object) | EoC, that would be added into queue; Could be an inline EoC |
+| "queue_eoc_with" | **mandatory** | string (eoc id or inline eoc) | EoC, that would be added into queue; Could be an inline EoC |
 | "time_in_future" | optional | int, duration, [variable object](#variable-object) or value between two | When in the future EoC would be run; default 0 |
 | "variables" | optional | pair of `"variable_name": "varialbe"` | variables, that would be passed to the EoC; `expects_vars` condition can be used to ensure every variable exist before the EoC is run | 
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Brief description"
Make run_eocs/queue_eocs support variable objects

#### Purpose of change

With this feature, we can use run_eoc_with to call a eoc with receives an another eoc as a context variable
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://github.com/CleverRaven/Cataclysm-DDA/issues/69846#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged. 

#### Describe the solution

modify npctalk.cpp use load_eoc_vector_id_and_var instead of load_eoc_vector in 'set_run_eocs' and 'set_queue_eocs'

When process the json object, load_eoc_vector only return a vector of eoc id, while load_eoc_vector_id_and_var can recognize the variable objects and return a pair includes 2 vectors: eoc id and eoc variables(str_or_var)

Then in the `function`, process eoc id and eoc variables(str_or_var) seperately.

#### Describe alternatives you've considered


#### Testing
```json
[
    {
        "type": "effect_on_condition",
        "id": "debug_eoc_for_loop",
        "effect": [{
                    "run_eoc_with": "eoc_for_loop",
                    "variables": {"i": "0","length": "10",
                    "eoc":"eoc_msg_hello_world"}
                  }]
    },
    {
        "type":"effect_on_condition",
        "id":"eoc_msg_hello_world",
        "effect":[{"u_message": "hello world"}]
    },
    {
        "type": "effect_on_condition",
        "id": "eoc_for_loop",
        "condition": {"and": [
                {"expects_vars": ["i","length","eoc"]},
                {"math": ["_i","<","_length"]}
            ]
        },
        "effect": [
            {"run_eocs": [{"context_val":"eoc"}]},
            {"math":["_i", "++"]},
            {
                "run_eocs": "eoc_for_loop"
            }
        ],
        "//": "As the generated dialogue for next EOC is a complete copy of the dialogue for this EOC, the context value will be passed on to the next EOC"
    }
]
```
just replace `{"run_eocs": [{"context_val":"eoc"}]}` with `{"queue_eocs": [{"context_val":"eoc"}]}` and you can test queue eocs

#### Additional context

None. 


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
