### PR TITLE
Make run_eocs/queue_eocs support variable objects

### DIFF
--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1448,7 +1448,7 @@ Runs another EoC. It can be a separate EoC, or an inline EoC inside `run_eocs` e
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
-| "run_eocs" | **mandatory** | string or array of eocs | EoC or EoCS that would be run |
+| "run_eocs" | **mandatory** | string (eoc id or inline eoc) or [variable object](#variable-object)) or array of eocs | EoC or EoCS that would be run |
 
 ##### Valid talkers:
 
@@ -1502,13 +1502,52 @@ if it's bigger, `are_you_super_strong` effect is run, that checks is your str is
 }
 ```
 
+Use Context Variable as a eoc (A trick for loop)
+```
+[
+    {
+        "type": "effect_on_condition",
+        "id": "debug_eoc_for_loop",
+        "effect": [{
+                    "run_eoc_with": "eoc_for_loop",
+                    "variables": {
+                      "i": "0",
+                      "length": "10",
+                      "eoc":"eoc_msg_hello_world"
+                      }}]
+    },
+    {
+        "type":"effect_on_condition",
+        "id":"eoc_msg_hello_world",
+        "effect":[{"u_message": "hello world"}]
+    },
+    {
+        "type": "effect_on_condition",
+        "id": "eoc_for_loop",
+        "condition": {"and": [
+                {"expects_vars": ["i","length","eoc"]},
+                {"math": ["_i","<","_length"]}
+            ]
+        },
+        "effect": [
+            {"run_eocs": [{"context_val":"eoc"}]},
+            {"math":["_i", "++"]},
+            {
+                "run_eocs": "eoc_for_loop"
+            }
+        ],
+        "//": "As the generated dialogue for next EOC is a complete copy of the dialogue for this EOC, the context value will be passed on to the next EOC"
+    }
+]
+```
+
 
 #### `run_eoc_with`
 Same as `run_eocs`, but runs the specific EoC with provided variables as context variables
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
-| "run_eoc_with" | **mandatory** | string | EoC or EoCS that would be run |
+| "run_eoc_with" | **mandatory** | string (eoc id or inline eoc) | EoC or EoCS that would be run |
 | "beta_loc" | optional | [variable object](#variable-object) | `u_location_variable`, where the EoC should be run | 
 | "variables" | optional | pair of `"variable_name": "varialbe"` | variables, that would be passed to the EoC; `expects_vars` condition can be used to ensure every variable exist before the EoC is run | 
 
@@ -1578,7 +1617,7 @@ Second EoC `EOC_I_NEED_AN_AK47` aslo run `EOC_GIVE_A_GUN` with the same variable
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
-| "queue_eocs" | **mandatory** | string, [variable object](#variable-object) or array | EoCs, that would be added into queue; Could be an inline EoC |
+| "queue_eocs" | **mandatory** | string (eoc id or inline eoc) or [variable object](#variable-object) or array of eocs | EoCs, that would be added into queue; Could be an inline EoC |
 | "time_in_future" | optional | int, duration, [variable object](#variable-object) or value between two | When in the future EoC would be run; default 0 | 
 
 ##### Valid talkers:
@@ -1604,7 +1643,7 @@ Combination of `run_eoc_with` and `queue_eocs` - Put EoC into queue and run into
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
-| "queue_eoc_with" | **mandatory** | string or [variable object](#variable-object) | EoC, that would be added into queue; Could be an inline EoC |
+| "queue_eoc_with" | **mandatory** | string (eoc id or inline eoc) | EoC, that would be added into queue; Could be an inline EoC |
 | "time_in_future" | optional | int, duration, [variable object](#variable-object) or value between two | When in the future EoC would be run; default 0 |
 | "variables" | optional | pair of `"variable_name": "varialbe"` | variables, that would be passed to the EoC; `expects_vars` condition can be used to ensure every variable exist before the EoC is run | 
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -4556,7 +4556,7 @@ void talk_effect_fun_t::set_run_eocs( const JsonObject &jo, std::string_view mem
     std::vector<str_or_var> eocs_var;
     std::tie( eocs_id, eocs_var ) = load_eoc_vector_id_and_var( jo, member );
 
-    if( eocs_id.empty() and eocs_var.empty() ) {
+    if( eocs_id.empty() && eocs_var.empty() ) {
         jo.throw_error( "Invalid input for run_eocs" );
     }
     function = [eocs_id, eocs_var]( dialogue const & d ) {
@@ -5072,7 +5072,7 @@ void talk_effect_fun_t::set_queue_eocs( const JsonObject &jo, std::string_view m
     std::vector<effect_on_condition_id> eocs_id;
     std::vector<str_or_var> eocs_var;
     std::tie( eocs_id, eocs_var ) = load_eoc_vector_id_and_var( jo, member );
-    if( eocs_id.empty() and eocs_var.empty() ) {
+    if( eocs_id.empty() && eocs_var.empty() ) {
         jo.throw_error( "Invalid input for queue_eocs" );
     }
 

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -248,6 +248,35 @@ static std::vector<effect_on_condition_id> load_eoc_vector( const JsonObject &jo
     return eocs;
 }
 
+// Split the eoc array to two part, first part includes eoc id/eoc objects, second part includes variables object
+static std::pair<std::vector<effect_on_condition_id>, std::vector<str_or_var>>
+        load_eoc_vector_id_and_var(
+            const JsonObject &jo, const std::string_view member )
+{
+    std::vector<effect_on_condition_id> eocs_id;
+    std::vector<str_or_var> eocs_var;
+
+    auto process_jv = [member, &eocs_id, &eocs_var]( const JsonValue & jv ) {
+        try {
+            eocs_id.push_back( effect_on_conditions::load_inline_eoc( jv, "" ) );
+        } catch( const JsonError &e ) {
+            std::optional<str_or_var> jv_var = get_str_or_var( jv, member );
+            if( jv_var.has_value() ) {
+                eocs_var.push_back( jv_var.value() );
+            }
+        }
+    };
+    if( jo.has_array( member ) ) {
+        for( JsonValue jv : jo.get_array( member ) ) {
+            process_jv( jv );
+        }
+    } else if( jo.has_member( member ) ) {
+        process_jv( jo.get_member( member ) );
+    }
+    return { eocs_id, eocs_var };
+}
+
+
 /** Time (in turns) and cost (in cent) for training: */
 time_duration calc_skill_training_time_char( const Character &teacher, const Character &student,
         const skill_id &skill )
@@ -4519,17 +4548,27 @@ void talk_effect_fun_t::set_make_sound( const JsonObject &jo, std::string_view m
     };
 }
 
+
+
 void talk_effect_fun_t::set_run_eocs( const JsonObject &jo, std::string_view member )
 {
-    std::vector<effect_on_condition_id> eocs = load_eoc_vector( jo, member );
-    if( eocs.empty() ) {
+    std::vector<effect_on_condition_id> eocs_id;
+    std::vector<str_or_var> eocs_var;
+    std::tie( eocs_id, eocs_var ) = load_eoc_vector_id_and_var( jo, member );
+
+    if( eocs_id.empty() and eocs_var.empty() ) {
         jo.throw_error( "Invalid input for run_eocs" );
     }
-    function = [eocs]( dialogue const & d ) {
-        for( const effect_on_condition_id &eoc : eocs ) {
+    function = [eocs_id, eocs_var]( dialogue const & d ) {
+        for( const effect_on_condition_id &eoc : eocs_id ) {
             dialogue newDialog( d );
             eoc->activate( newDialog );
-        }
+        };
+        for( const str_or_var &eoc_var : eocs_var ) {
+            effect_on_condition_id eoc( eoc_var.evaluate( d ) );
+            dialogue newDialog( d );
+            eoc->activate( newDialog );
+        };
     };
 }
 
@@ -5030,30 +5069,41 @@ void talk_effect_fun_t::set_map_run_item_eocs( const JsonObject &jo, std::string
 
 void talk_effect_fun_t::set_queue_eocs( const JsonObject &jo, std::string_view member )
 {
-    std::vector<effect_on_condition_id> eocs = load_eoc_vector( jo, member );
-    if( eocs.empty() ) {
+    std::vector<effect_on_condition_id> eocs_id;
+    std::vector<str_or_var> eocs_var;
+    std::tie( eocs_id, eocs_var ) = load_eoc_vector_id_and_var( jo, member );
+    if( eocs_id.empty() and eocs_var.empty() ) {
         jo.throw_error( "Invalid input for queue_eocs" );
     }
 
     duration_or_var dov_time_in_future = get_duration_or_var( jo, "time_in_future", false,
                                          0_seconds );
-    function = [dov_time_in_future, eocs]( dialogue & d ) {
-        time_duration time_in_future = dov_time_in_future.evaluate( d );
-        for( const effect_on_condition_id &eoc : eocs ) {
-            if( eoc->type == eoc_type::ACTIVATION ) {
-                Character *alpha = d.has_alpha ? d.actor( false )->get_character() : nullptr;
-                if( alpha ) {
-                    effect_on_conditions::queue_effect_on_condition( time_in_future, eoc, *alpha, d.get_context() );
-                } else if( eoc->global ) {
-                    effect_on_conditions::queue_effect_on_condition( time_in_future, eoc, get_player_character(),
-                            d.get_context() );
-                }
-                // If the target is a monster or item and the eoc is non global it won't be queued and will silently "fail"
-                // this is so monster attacks against other monsters won't give error messages.
-            } else {
-                debugmsg( "Cannot queue a non activation effect_on_condition.  %s", d.get_callstack() );
+    auto process_eoc = []( const effect_on_condition_id & eoc, dialogue & d,
+    time_duration time_in_future ) {
+        if( eoc->type == eoc_type::ACTIVATION ) {
+            Character *alpha = d.has_alpha ? d.actor( false )->get_character() : nullptr;
+            if( alpha ) {
+                effect_on_conditions::queue_effect_on_condition( time_in_future, eoc, *alpha, d.get_context() );
+            } else if( eoc->global ) {
+                effect_on_conditions::queue_effect_on_condition( time_in_future, eoc, get_player_character(),
+                        d.get_context() );
             }
+            // If the target is a monster or item and the eoc is non global it won't be queued and will silently "fail"
+            // this is so monster attacks against other monsters won't give error messages.
+        } else {
+            debugmsg( "Cannot queue a non activation effect_on_condition.  %s", d.get_callstack() );
         }
+    };
+
+    function = [dov_time_in_future, eocs_id, eocs_var, process_eoc]( dialogue & d ) {
+        time_duration time_in_future = dov_time_in_future.evaluate( d );
+        for( const effect_on_condition_id &eoc : eocs_id ) {
+            process_eoc( eoc, d, time_in_future );
+        }
+        for( const str_or_var &eoc_var : eocs_var ) {
+            effect_on_condition_id eoc( eoc_var.evaluate( d ) );
+            process_eoc( eoc, d, time_in_future );
+        };
     };
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Make run_eocs/queue_eocs support variable objects"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
With this feature, you can use run_eoc_with to call a eoc with receives an another eoc as a context variable
Closes #69846 



<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
modify npctalk.cpp use load_eoc_vector_id_and_var instead of load_eoc_vector in 'set_run_eocs' and 'set_queue_eocs'

When process the json object, load_eoc_vector only return a vector of eoc id, while load_eoc_vector_id_and_var can return the eocs_entries ( vector<eoc_entry> )

```cpp
struct eoc_entry {
    std::optional<effect_on_condition_id> id;
    std::optional<str_or_var> var;
};
```

Then in the `function`, process each eoc entry. 

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
```json
[
    {
        "type": "effect_on_condition",
        "id": "EOC_MSG_HELLO_WORLD",
        "effect": [
            {
                "u_message": "Hello World !"
            }
        ]
    },
    {
        "type": "effect_on_condition",
        "id": "EOC_VARIABLE_OBJECT_FOR_RUN_AND_QUEUE_EOCS_TEST",
        "effect": [
            {
                "set_string_var": "EOC_MSG_HELLO_WORLD",
                "target_var": {
                    "global_val": "eoc_msg_1"
                }
            },
            {
                "set_string_var": "EOC_MSG_HELLO_WORLD",
                "target_var": {
                    "context_val": "eoc_msg_2"
                }
            },
            {
                "set_string_var": "eoc_msg_1",
                "target_var": {
                    "context_val": "eoc_msg_3"
                }
            },
            {
                "set_string_var": "EOC_MSG_HELLO_WORLD",
                "target_var": {
                    "u_val": "eoc_msg_4"
                }
            },
            {
                "run_eocs": [
                    {
                        "id": "EOC_VARIABLE_OBJECT_FOR_RUN_EOCS_PASS_MSG_0",
                        "effect":[{"u_message": "run_eocs test starts. There should be a 'hello world' message between each pass message. This will test global_val, context_val, var_val, u_val"}]
                    },
                    {
                        "global_val": "eoc_msg_1"
                    },
                    {
                        "id": "EOC_VARIABLE_OBJECT_FOR_RUN_EOCS_PASS_MSG_1",
                        "effect":[{"u_message": "global_var pass"}]
                    },
                    {
                        "context_val": "eoc_msg_2"
                    },
                    {
                        "id": "EOC_VARIABLE_OBJECT_FOR_RUN_EOCS_PASS_MSG_2",
                        "effect":[{"u_message": "context_var pass"}]
                    },
                    {
                        "var_val": "eoc_msg_3"
                    },
                    {
                        "id": "EOC_VARIABLE_OBJECT_FOR_RUN_EOCS_PASS_MSG_3",
                        "effect":[{"u_message": "val_var pass"}]
                    },
                    {
                        "u_val": "eoc_msg_4"
                    },
                    {
                        "id": "EOC_VARIABLE_OBJECT_FOR_RUN_EOCS_PASS_MSG_4",
                        "effect":[{"u_message": "u_var pass"}]
                    },
                    {
                        "id": "EOC_VARIABLE_OBJECT_FOR_QUEUE_EOCS_PASS_MSG_0",
                        "effect":[{"u_message": "queue_eocs test starts after 1 second."}]
                    }
                ]
            },
            {
                "queue_eocs": [
                    {
                        "id": "EOC_VARIABLE_OBJECT_FOR_QUEUE_EOCS_PASS_MSG_1",
                        "effect":[{"run_eocs":{"global_val": "eoc_msg_1"}},{"u_message": "global_var pass"}]
                    },
                    {
                        "id": "EOC_VARIABLE_OBJECT_FOR_QUEUE_EOCS_PASS_MSG_2",
                        "effect":[{"run_eocs":{"context_val": "eoc_msg_2"}},{"u_message": "context_var pass"}]
                    },
                    {
                        "id": "EOC_VARIABLE_OBJECT_FOR_QUEUE_EOCS_PASS_MSG_3",
                        "effect":[{"run_eocs":{"var_val": "eoc_msg_3"}},{"u_message": "val_var pass"}]
                    },
                    {
                        "id": "EOC_VARIABLE_OBJECT_FOR_QUEUE_EOCS_PASS_MSG_4",
                        "effect":[{"run_eocs":{"u_val": "eoc_msg_4"}},{"u_message": "u_var pass"}]
                    }
                ],
                "time_in_future": "1 seconds"
            }
        ]
    }
]
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
