### PR TITLE
Glock 40 (full auto)

### DIFF
--- a/data/json/items/gunmod/mechanism.json
+++ b/data/json/items/gunmod/mechanism.json
@@ -114,7 +114,7 @@
     "symbol": ":",
     "color": "red",
     "location": "mechanism",
-    "mod_targets": [ "glock_19", "glock_17", "glock_22", "glock_31", "glock_21", "glock_20", "glock_29" ],
+    "mod_targets": [ "glock_19", "glock_17", "glock_22", "glock_31", "glock_21", "glock_20", "glock_29", "glock_40" ],
     "//": "Install time should be short as it is simply a replacement back plate, installed by slightly more than field stripping the gun.",
     "install_time": "5 m",
     "//durability_modifier": -1,


### PR DESCRIPTION

#### Summary
Bugfixes "Lets the Glock 40 install a glock sear plate"

#### Purpose of change

SOMEONE forgot to let the Glock FSSG thing be installed on the glock 40.

#### Describe the solution
Adds the Glock 40 to the item list for the glocksear.
#### Describe alternatives you've considered
None
#### Testing
Loaded game. Committed felony.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/7764202/c75dab94-a4a9-4173-a736-4a7ef20aaca1)

Plastic fantastic
#### Additional context
None
