### PR TITLE
Fix armor sorting bugging active items in inventory

### DIFF
--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -1032,10 +1032,7 @@ void outfit::sort_armor( Character &guy )
             }
         } else if( action == "SORT_ARMOR" ) {
             mid_pane.offset = 0;
-            // Copy to a vector because stable_sort requires random-access
-            // iterators
-            std::vector<item> worn_copy( worn.begin(), worn.end() );
-            std::stable_sort( worn_copy.begin(), worn_copy.end(),
+            worn.sort(
             []( const item & l, const item & r ) {
                 if( l.has_flag( flag_INTEGRATED ) == r.has_flag( flag_INTEGRATED ) ) {
                     return l.get_layer() < r.get_layer();
@@ -1043,8 +1040,7 @@ void outfit::sort_armor( Character &guy )
                     return l.has_flag( flag_INTEGRATED );
                 }
             }
-                            );
-            std::copy( worn_copy.begin(), worn_copy.end(), worn.begin() );
+            );
             guy.calc_encumbrance();
         } else if( action == "EQUIP_ARMOR" ) {
             mid_pane.offset = 0;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix armor sorting bugging active items in inventory"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
If the player went to the sort armor screen (+) and (S)orted their armor, active items would turn off but still be labeled as active in the player's inventory. With this change the items do in fact remain active after sorting.

Fixes #69672
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Instead of copying the list of worn items to a vector to use std::stable_sort and copy the sorted vector over worn items list, use instead the std::list:sort method. It is stable so it should give the same results as the previous method without overwriting the original items.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
[Debug-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/13506272/Debug-trimmed.tar.gz)

Get in game and turn on the headlamp, get in the armor sorting screen (+), (S)ort armor and check if headlamp remains active both in inventory and de facto.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
