### PR TITLE
Field Cap Addition

### DIFF
--- a/data/json/itemgroups/Clothing_Gear/clothing.json
+++ b/data/json/itemgroups/Clothing_Gear/clothing.json
@@ -459,10 +459,11 @@
     "id": "clothing_military_headwear",
     "type": "item_group",
     "subtype": "distribution",
-    "//": "add in field caps when they are added to the game.",
+    "//": "Standard set of hats worn by a uniformed soldier.",
     "items": [
-      { "item": "beret", "prob": 60 },
-      { "item": "hat_boonie", "prob": 38 },
+      { "item": "beret", "prob": 40 },
+      { "item": "hat_field", "prob": 35 },
+      { "item": "hat_boonie", "prob": 23 },
       { "item": "turban", "prob": 1 },
       { "item": "headscarf", "prob": 1 }
     ]

--- a/data/json/items/armor/hats.json
+++ b/data/json/items/armor/hats.json
@@ -273,7 +273,7 @@
     "id": "hat_field",
     "type": "ARMOR",
     "name": { "str": "patrol cap" },
-    "description": "A simple round cap in woodland camouflage. Often used by the military when helmets arent needed. Its brim helps keep the sun out of your eyes.",
+    "description": "A simple round cap in a camouflage pattern.  Often used by the military when helmets aren't needed.  Its brim helps keep the sun out of your eyes.",
     "weight": "92 g",
     "volume": "500 ml",
     "price": 1500,

--- a/data/json/items/armor/hats.json
+++ b/data/json/items/armor/hats.json
@@ -270,6 +270,32 @@
     ]
   },
   {
+    "id": "hat_field",
+    "type": "ARMOR",
+    "name": { "str": "patrol cap" },
+    "description": "A simple round cap in woodland camouflage. Often used by the military when helmets arent needed. Its brim helps keep the sun out of your eyes.",
+    "weight": "92 g",
+    "volume": "500 ml",
+    "price": 1500,
+    "price_postapoc": 80,
+    "material": [ "cotton" ],
+    "symbol": "[",
+    "looks_like": "cowboy_hat",
+    "color": "dark_gray",
+    "warmth": 5,
+    "material_thickness": 0.3,
+    "environmental_protection": 1,
+    "flags": [ "VARSIZE", "SUN_GLASSES" ],
+    "armor": [
+      {
+        "encumbrance_modifiers": [ "NONE" ],
+        "coverage": 100,
+        "covers": [ "head" ],
+        "specifically_covers": [ "head_crown", "head_forehead" ]
+      }
+    ]
+  },
+  {
     "id": "hat_boonie",
     "type": "ARMOR",
     "name": { "str": "boonie hat" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Adds a military field cap"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
With how there is a eight point cap in game, which is used in the Marines and Navy, it just makes sense to add a field cap for the Army.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds a field cap found on uniformed zombies.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Testing
![ijw](https://github.com/CleverRaven/Cataclysm-DDA/assets/152467517/567852ba-1b3a-4b67-b314-3268b16dc08c)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->



<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
