### PR TITLE
Bugfix: Allow resuming backlog activity_actor

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -352,12 +352,25 @@ std::string enum_to_string<butcher_type>( butcher_type data )
 
 } // namespace io
 
+static void assign_multi_activity( Character &you, const player_activity &act )
+{
+    const bool requires_actor = activity_actors::deserialize_functions.find( act.id() ) !=
+                                activity_actors::deserialize_functions.end();
+    if( requires_actor ) {
+        // the activity uses `activity_actor` and requires `player_activity::actor` to be set
+        you.assign_activity( player_activity( act ) );
+    } else {
+        // the activity uses the older type of player_activity where `player_activity::actor` is not used
+        you.assign_activity( act.id() );
+    }
+}
+
 bool activity_handlers::resume_for_multi_activities( Character &you )
 {
     if( !you.backlog.empty() ) {
         player_activity &back_act = you.backlog.front();
         if( back_act.is_multi_type() ) {
-            you.assign_activity( you.backlog.front().id() );
+            assign_multi_activity( you, back_act );
             you.backlog.clear();
             return true;
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Allow resuming backlog activity_actor"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Allows resuming activities from backlog, when the activity is an `activity_actor`
* Fixes #69863 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The savegame in #69863 contains the following backlog activity:
```json
"type": "ACT_UNLOAD_LOOT",
"actor": {
  "actor_type": "ACT_UNLOAD_LOOT",
  "actor_data": {
	"moves": 0,
	"num_processed": 5,
	"stage": 2,
	...
  }
}
``` 
* This backlog activity is deserialized into `player_activity`, which sets the `actor` field.
* `player_activity` will check if `actor` is set, and if so use that to do each turn: https://github.com/CleverRaven/Cataclysm-DDA/blob/400add923a65d53dd16ffd8110d65eb8d56925d4/src/player_activity.cpp#L303-L308
* But when this backlog activity was resumed after doing a dismember activity, the value of `player_activity::actor` was not set.
* This had the effect that a `player_activity` would execute, but it had no function to call for `do_turn` , so it would never finish. This is the cause of the softlock as reported in #69863 .
* The reason `player_activity::actor` was not set was because of how the activity is copied in `activity_handlers::resume_for_multi_activities` , which is changed in this commit. When using the overloaded call to `assign_activity` that only takes an id, the `actor` field is not copied.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* Might also consider adding something like this in the `player_activity` constructor that only takes an id (and not `actor`):
```c++
const bool requires_actor = activity_actors::deserialize_functions.find( type ) !=
                            activity_actors::deserialize_functions.end();
if( requires_actor ) {
    debugmsg( "Created player_activity for type=%s but without activity_actor. Activities of this type should have an actor, since do_turn might softlock if they do not.",
              type.c_str() );
}
```

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Tested the steps from #69863 . With this change, the game does not lock after dismembering the zombie.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
