### PR TITLE
Change ammo type for miniguns on helicopters

### DIFF
--- a/data/json/vehicles/helicopters.json
+++ b/data/json/vehicles/helicopters.json
@@ -619,7 +619,7 @@
       {
         "x": -2,
         "y": -5,
-        "parts": [ { "part": "turret_m134", "ammo": 80, "ammo_types": [ "308" ], "ammo_qty": [ 0, 500 ] } ]
+        "parts": [ { "part": "turret_m134", "ammo": 80, "ammo_types": [ "762_51", "762_51_m993" ], "ammo_qty": [ 0, 500 ] } ]
       },
       { "x": -2, "y": 1, "parts": [ "frame#ne", "board#horizontal", "plating_military" ] },
       { "x": -2, "y": 2, "parts": [ "frame#horizontal", "plating_military", "board#horizontal" ] },
@@ -627,7 +627,7 @@
       {
         "x": -2,
         "y": 3,
-        "parts": [ { "part": "turret_m134", "ammo": 80, "ammo_types": [ "308" ], "ammo_qty": [ 0, 500 ] } ]
+        "parts": [ { "part": "turret_m134", "ammo": 80, "ammo_types": [ "762_51", "762_51_m993" ], "ammo_qty": [ 0, 500 ] } ]
       },
       { "x": -3, "y": -1, "parts": [ "frame#cross", "engine_turbine_medium", "alternator_car" ] },
       { "x": -3, "y": -1, "parts": [ "plating_military", "board#vertical" ] },
@@ -726,7 +726,7 @@
       {
         "x": -2,
         "y": -5,
-        "parts": [ { "part": "turret_m134", "ammo": 80, "ammo_types": [ "308" ], "ammo_qty": [ 0, 500 ] } ]
+        "parts": [ { "part": "turret_m134", "ammo": 80, "ammo_types": [ "762_51", "762_51_m993" ], "ammo_qty": [ 0, 500 ] } ]
       },
       { "x": -2, "y": 1, "parts": [ "frame#ne" ] },
       { "x": -3, "y": 0, "parts": [ "frame#nw", { "part": "tank_55gal_drum", "fuel": "jp8" } ] },
@@ -800,7 +800,7 @@
       {
         "x": -2,
         "y": -3,
-        "parts": [ { "part": "turret_m134", "ammo": 80, "ammo_types": [ "308" ], "ammo_qty": [ 0, 500 ] } ]
+        "parts": [ { "part": "turret_m134", "ammo": 80, "ammo_types": [ "762_51", "762_51_m993" ], "ammo_qty": [ 0, 500 ] } ]
       },
       { "x": -2, "y": 1, "parts": [ "xlframe#horizontal", "board#vertical", "storage_battery" ] },
       { "x": -2, "y": 1, "parts": [ "plating_military" ] },
@@ -811,7 +811,7 @@
       {
         "x": -2,
         "y": 5,
-        "parts": [ { "part": "turret_m134", "ammo": 80, "ammo_types": [ "308" ], "ammo_qty": [ 0, 500 ] } ]
+        "parts": [ { "part": "turret_m134", "ammo": 80, "ammo_types": [ "762_51", "762_51_m993" ], "ammo_qty": [ 0, 500 ] } ]
       },
       { "x": -3, "y": 0, "parts": [ "frame#ne", "board#vertical", "plating_military" ] },
       { "x": -3, "y": -1, "parts": [ "frame#horizontal", "plating_military", "board#horizontal" ] },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #69884
#### Describe the solution
Replace 308 with 762x51 and 762x51 AP
#### Describe alternatives you've considered
replace with only 762x51