### PR TITLE
[Defense Mode] Fix `copy-from` issues pertaining to scenario extensions

### DIFF
--- a/data/json/obsoletion/blacklist_scenarios.json
+++ b/data/json/obsoletion/blacklist_scenarios.json
@@ -1,0 +1,17 @@
+[
+  {
+    "//": "Exists here to prevent errors with Defense Mode stuff.",
+    "type": "scenario",
+    "id": "defense_mode_fortified",
+    "name": "Fortified",
+    "points": 0,
+    "description": "",
+    "allowed_locs": [ "sloc_bar" ],
+    "start_name": ""
+  },
+  {
+    "type": "SCENARIO_BLACKLIST",
+    "subtype": "blacklist",
+    "scenarios": [ "defense_mode_fortified" ]
+  }
+]

--- a/data/mods/Defense_Mode/scenarios.json
+++ b/data/mods/Defense_Mode/scenarios.json
@@ -5,27 +5,30 @@
     "scenarios": [ "defense_mode_fortified" ]
   },
   {
+    "copy-from": "defense_mode_fortified",
     "type": "scenario",
     "id": "defense_mode_fortified",
     "name": "Fortified",
     "points": 0,
     "description": "You do not know who you are, nor do you know why you're here.  All you know is that you must fight and defend yourself from the horde.",
-    "allowed_locs": [
-      "sloc_bar",
-      "sloc_hospital",
-      "public_works",
-      "megastore",
-      "mansion",
-      "sloc_shelter_a",
-      "sloc_gun_store",
-      "survivor_camp",
-      "sloc_cabin",
-      "cave",
-      "sugar_house",
-      "sloc_bank",
-      "sloc_pawn_shop",
-      "sloc_restaurant"
-    ],
+    "extend": {
+      "allowed_locs": [
+        "sloc_bar",
+        "sloc_hospital",
+        "public_works",
+        "megastore",
+        "mansion",
+        "sloc_shelter_a",
+        "sloc_gun_store",
+        "survivor_camp",
+        "sloc_cabin",
+        "cave",
+        "sugar_house",
+        "sloc_bank",
+        "sloc_pawn_shop",
+        "sloc_restaurant"
+      ]
+    },
     "eoc": [ "scenario_defense_mode" ],
     "forced_traits": [ "HAS_NEMESIS" ],
     "missions": [ "MISSION_DEFENSE_MODE_SURVIVE" ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Defense Mode] Fix `copy-from` issues pertaining to scenario extensions."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #68205.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
In the blacklists section of the main game folder, add a fake special which is blacklisted by default and provides a valid ID for mod interactions to copy from when Defense Mode is not loaded. Only when Defense Mode is enabled will this scenario become available for users to see, enabling this sort of cross-mod content to load without errors.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this, or not allowing start location extensions for Defense Mode.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded mods in various load orders and repeatedly executed save-load cycles for all mods which have been made compatible with Defense Mode by way of scenario extensions. No errors appeared.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This also allows extended start locations to appear in any order you load the mods, e.g. Magiclysm can load before Defense Mode, and you still have the option to start in a wizard tower.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
