### PR TITLE
Adds some geography. This one is a kind of big deal.

### DIFF
--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -4410,7 +4410,7 @@ void overmap::place_forest_trails()
             // Figure out how many random points we'll add to our trail system, based on the forest
             // size and our configuration.
             int max_random_points = forest_trail.random_point_min + forest_points.size() /
-                                    forest_trail.random_point_size_adjust;
+                                    forest_trail.random_point_size_scalar;
             max_random_points = std::min( max_random_points, forest_trail.random_point_max );
 
             // Start with the center...

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -5129,7 +5129,7 @@ void overmap::place_cities()
     // used to increase city size as we move East and South.
     int city_size_adjust = 0;
     // used to space cities out as we go more into the West and the Appalachians.
-    int city_space_adjust = 0; 
+    int city_space_adjust = 0;
     const point_abs_om this_om = pos();
     city_space_adjust += this_om.x() / 2;
     if( this_om.x() > 0 ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "The map changes as you travel east-west and north-south, revealing either rural areas or oceans and megacities"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Our current mapgen creates a sort of weird suburban zone. It's fine but it's bland. There's very little reason to explore outside one overmap. There are no real cities. No ocean. No mountains. No vast forests.

#### Describe the solution
Adds these things.

1. As you travel West, the cities don't get smaller but they start to space out more.
2. As you travel East, the cities get bigger and more crowded until you're basically in a constant megacity.
3. As you travel West and North, the forests get denser and thicker until you're soon in a rural forest interspersed by roads and campgrounds
4. In the eastern megacity as you travel north, the cities remain big but get less dense again.

#### Describe alternatives you've considered
The massachussets mod would be another way to do this but I've wanted to boost the mapgen abilities for a while, and it turned out to be easier than I thought.

I wanted to add oceans in this PR (see screenshot below) but they were causing things to hang on generation and I don't want to introduce too many points of failure in one go.

#### Testing
here's a large image showing just the change to cities:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/38f93c18-9593-4c72-b04e-c2087bfc29ba)

This shows forest density increasing as you head West from the starting map
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/d39aa15f-9e46-4c9f-8195-1608d942c0ad)


This is a city at overmap 10,10, which is getting into the outskirts of boston.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/fcaf53a1-4ee5-4ded-bfa6-467a439bcfb6)

When you get into the really rural areas approaching what would be vermont, you get... rural areas.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/06072178-dabf-4bae-9a3f-6113b9f32664)

But zooming in, those areas still have roads and points of interest:
![image-1](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/3dcf4620-57a0-430f-aa2c-393df8902037)

This is just a cool shot around the 5,-2 area:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/ea664ae6-c340-4c5c-8e6c-b4c41f53e969)
I can't get over how much cooler this is because here's a shot from in the same worldgen, a bit more to the west and north:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/5f03b4a5-a816-4593-86e7-3922e75ab3bd)

#### Additional context
this one shows the later ocean change. It's super cool but I have moved it to a later PR so I can push the stuff that's working right... the ocean stuff causes worldgen to hang and crash, and the fix is not super simple.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/4ee6257d-0ae8-406d-96e8-e9b88b29ed1f)

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
