### PR TITLE
Industrial trash can looks like something

### DIFF
--- a/data/json/items/containers/generic.json
+++ b/data/json/items/containers/generic.json
@@ -49,7 +49,7 @@
     "type": "GENERIC",
     "category": "container",
     "name": { "str": "industrial trash can" },
-    "looks_like": "f_trashcan",
+    "looks_like": "f_recycle_bin",
     "description": "A really big trashcan in which you can store, you guessed it, trash, ready for the garbage truck to pick up.  Made out of thick plastic, this can was meant for household or industrial use, something you roll up to the curb once a week.",
     "weight": "15 kg",
     "//1": "Weight taken from https://www.uline.com/Product/Detail/H-7938BL/Trash-Cans-with-Wheels/Uline-Trash-Can-with-Wheels-95-Gallon-Black?pricode=WB3072&utm_source=Bing&utm_medium=pla&utm_term=H-7938BL&utm_campaign=Facilities%2BMaintenance&utm_source=Bing&utm_medium=pla&utm_term=H-7938BL&utm_campaign=Facilities%2BMaintenance&msclkid=d3c8827d02691eb87066e72c65ff5790",

--- a/data/json/vehicleparts/cargo.json
+++ b/data/json/vehicleparts/cargo.json
@@ -195,6 +195,7 @@
     "type": "vehicle_part",
     "name": { "str": "industrial trash can" },
     "categories": [ "cargo" ],
+    "looks_like": "f_recycle_bin",
     "color": "light_gray",
     "broken_color": "light_gray",
     "size": "359614 ml",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There are now trash can vehicles lining the streets, I'd prefer they look like something other than a crate.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Make the industrial trash can look like a recycle bin since it's the closest we have to a proper curbside garbage bin.

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
Learning how to draw and making a proper small person sized sprite with rotations and everything. I thought we already had that for Ultica but it seems to have been a dream.

#### Testing
Check out the vehicle in game.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
After
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/2456481/d10092a1-7fb3-4de2-be26-86165296a33b)

Before
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/2456481/0b271ec7-2428-4fc8-8d10-dda2754632d5)



<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
