### PR TITLE
Revert "turn FOV_3D on by default"

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2845,8 +2845,8 @@ void options_manager::add_options_debug()
                                       to_translation( "Options regarding 3D field of vision." ) ),
     [&]( const std::string & page_id ) {
         add( "FOV_3D", page_id, to_translation( "Experimental 3D field of vision" ),
-             to_translation( "If true, the vision will extend beyond current Z-level.  If false, vision is limited to current Z-level.  It affects only visibility, activity on different z-levels is still calculated regardless." ),
-             true
+             to_translation( "If true and the world is in Z-level mode, the vision will extend beyond current Z-level.  If false, vision is limited to current Z-level." ),
+             false
            );
 
         add( "FOV_3D_Z_RANGE", page_id, to_translation( "Vertical range of 3D field of vision" ),


### PR DESCRIPTION
Reverts CleverRaven/Cataclysm-DDA#69935

in case LTO is failing from the change. 
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Revert 69935 Turn FOV3d on for LTO test failures"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

```
Error: (~[slow] ~[.],starting_items)=>   false
(~[slow] ~[.],starting_items)=> with message:
(~[slow] ~[.],starting_items)=>   activity.id() := string_id( "ACT_TENT_DECONSTRUCT" )
(~[slow] ~[.],starting_items)=> 
(~[slow] ~[.],starting_items)=> -------------------------------------------------------------------------------
(~[slow] ~[.],starting_items)=> activity_interruption_by_distractions
(~[slow] ~[.],starting_items)=>   ACT_TRY_SLEEP enemy nearby, but no line of sight
(~[slow] ~[.],starting_items)=> -------------------------------------------------------------------------------
(~[slow] ~[.],starting_items)=> ../tests/player_activities_test.cpp:1826
(~[slow] ~[.],starting_items)=> ...............................................................................
(~[slow] ~[.],starting_items)=> 
(~[slow] ~[.],starting_items)=> ../tests/player_activities_test.cpp:1833: FAILED:
(~[slow] ~[.],starting_items)=>   REQUIRE( !dummy.sees( zombie ) )
(~[slow] ~[.],starting_items)=> with expansion:
Error: (~[slow] ~[.],starting_items)=>   false
(~[slow] ~[.],starting_items)=> with message:
(~[slow] ~[.],starting_items)=>   activity.id() := string_id( "ACT_TRY_SLEEP" )
```
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Revert
#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing



<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
