### PR TITLE
[ Xedra Evolved ] Sylph's don't breathe

### DIFF
--- a/data/mods/Xedra_Evolved/items/armor/integrated.json
+++ b/data/mods/Xedra_Evolved/items/armor/integrated.json
@@ -524,6 +524,43 @@
         "cover_vitals": 100
       }
     ]
+  },{
+    "id": "integrated_sylph_breath",
+    "type": "ARMOR",
+    "category": "armor",
+    "name": { "str_sp": "sylph breathe without air" },
+    "description": "You can now exist as your own source of oxygen.  Anywhere that you would be impacted by a lack of oxygen should no longer trouble you.",
+    "weight": "180 g",
+    "volume": "250 ml",
+    "price": 0,
+    "price_postapoc": 0,
+    "to_hit": -2,
+    "material": [ "fae_flesh" ],
+    "symbol": "[",
+    "color": "dark_gray",
+    "warmth": 0,
+    "material_thickness": 1.5,
+    "environmental_protection": 10,
+    "flags": [
+      "INTEGRATED",
+      "UNBREAKABLE",
+      "SKINTIGHT",
+      "SOFT",
+      "WATER_FRIENDLY",
+      "REBREATHER",
+      "NO_REPAIR",
+      "NO_SALVAGE"
+    ],
+    "armor": [
+      {
+        "material": [ { "type": "fae_flesh", "covered_by_mat": 100, "thickness": 0.1 } ],
+        "covers": [ "mouth" ],
+        "coverage": 100,
+        "encumbrance": 0,
+        "rigid_layer_only": true,
+        "cover_vitals": 100
+      }
+    ]
   },
   {
     "id": "integrated_porcelain_skin",

--- a/data/mods/Xedra_Evolved/items/armor/integrated.json
+++ b/data/mods/Xedra_Evolved/items/armor/integrated.json
@@ -524,7 +524,8 @@
         "cover_vitals": 100
       }
     ]
-  },{
+  },
+  {
     "id": "integrated_sylph_breath",
     "type": "ARMOR",
     "category": "armor",
@@ -541,16 +542,7 @@
     "warmth": 0,
     "material_thickness": 1.5,
     "environmental_protection": 10,
-    "flags": [
-      "INTEGRATED",
-      "UNBREAKABLE",
-      "SKINTIGHT",
-      "SOFT",
-      "WATER_FRIENDLY",
-      "REBREATHER",
-      "NO_REPAIR",
-      "NO_SALVAGE"
-    ],
+    "flags": [ "INTEGRATED", "UNBREAKABLE", "SKINTIGHT", "SOFT", "WATER_FRIENDLY", "REBREATHER", "NO_REPAIR", "NO_SALVAGE" ],
     "armor": [
       {
         "material": [ { "type": "fae_flesh", "covered_by_mat": 100, "thickness": 0.1 } ],

--- a/data/mods/Xedra_Evolved/mutations/paraclesians/sylph_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/sylph_mutations.json
@@ -138,10 +138,9 @@
     "points": 1,
     "visibility": 0,
     "ugliness": 0,
-    "description": "Upon gaining this ability the Sylph gains the ability to temporarily breathe without oxygen.  This will prevent damage from a lack of oxygen for a short window.",
+    "description": "Upon gaining this ability the Sylph gains the ability to breathe without oxygen.  This will prevent damage from a lack of oxygen.",
     "category": [ "SYLPH" ],
-    "spells_learned": [ [ "breathe_wo_air", 1 ] ],
-    "//": "Needs an activated ability that affects the hidden oxygen stat."
+    "integrated_armor": [ "integrated_sylph_breath" ]
   },
   {
     "type": "mutation",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Sylph's had a mutation that lacked the ability for breathe without air to work.  This makes it work and improves it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds an integrated item with the rebreather effect.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
