### PR TITLE
map: fix tripoint use in pl_sees

### DIFF
--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -789,17 +789,12 @@ bool tinymap::pl_sees( const tripoint &, int ) const
 
 bool map::pl_sees( const tripoint &t, const int max_range ) const
 {
-    Character &player_character = get_player_character();
-
-    if( square_dist( t, player_character.pos() ) > MAX_VIEW_DISTANCE ) {
-        return false;
-    }
-
     if( !inbounds( t ) ) {
         return false;
     }
 
     const level_cache &map_cache = get_cache_ref( t.z );
+    Character &player_character = get_player_character();
     if( max_range >= 0 && square_dist( t, player_character.pos() ) > max_range &&
         map_cache.camera_cache[t.x][t.y] == 0 ) {
         return false;    // Out of range!

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -790,13 +790,14 @@ bool map::pl_sees( const tripoint &t, const int max_range ) const
 
     const level_cache &map_cache = get_cache_ref( t.z );
     Character &player_character = get_player_character();
-    if( max_range >= 0 && square_dist( t, player_character.pos() ) > max_range &&
+    if( max_range >= 0 && square_dist( getglobal( t ), player_character.get_location() ) > max_range &&
         map_cache.camera_cache[t.x][t.y] == 0 ) {
         return false;    // Out of range!
     }
 
     const apparent_light_info a = apparent_light_helper( map_cache, t );
-    const float light_at_player = map_cache.lm[player_character.posx()][player_character.posy()].max();
+    // avatar might not be on *this* map
+    const float light_at_player = get_map().ambient_light_at( player_character.pos() );
     return !a.obstructed &&
            ( a.apparent_light >= player_character.get_vision_threshold( light_at_player ) ||
              map_cache.sm[t.x][t.y] > 0.0 );

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -782,11 +782,6 @@ lit_level map::apparent_light_at( const tripoint &p, const visibility_variables 
     }
 }
 
-bool tinymap::pl_sees( const tripoint &, int ) const
-{
-    return false;
-}
-
 bool map::pl_sees( const tripoint &t, const int max_range ) const
 {
     if( !inbounds( t ) ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1786,7 +1786,7 @@ bool map::furn_set( const tripoint &p, const furn_id &new_furniture, const bool 
     invalidate_max_populated_zlev( p.z );
 
     memory_cache_dec_set_dirty( p, true );
-    if( pl_sees( p, player_character.sight_max ) ) {
+    if( player_character.sees( p ) ) {
         player_character.memorize_clear_decoration( getglobal( p ), "f_" );
     }
 
@@ -2233,7 +2233,7 @@ bool map::ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_crea
 
     memory_cache_dec_set_dirty( p, true );
     avatar &player_character = get_avatar();
-    if( pl_sees( p, player_character.sight_max ) ) {
+    if( player_character.sees( p ) ) {
         player_character.memorize_clear_decoration( getglobal( p ), "t_" );
     }
 
@@ -6089,7 +6089,7 @@ void map::partial_con_remove( const tripoint_bub_ms &p )
     current_submap->partial_constructions.erase( tripoint_sm_ms( l, p.z() ) );
     memory_cache_dec_set_dirty( p.raw(), true );
     avatar &player_character = get_avatar();
-    if( pl_sees( p.raw(), player_character.sight_max ) ) {
+    if( player_character.sees( p ) ) {
         player_character.memorize_clear_decoration( getglobal( p ), "tr_" );
     }
 }
@@ -6132,7 +6132,7 @@ void map::trap_set( const tripoint &p, const trap_id &type )
 
     memory_cache_dec_set_dirty( p, true );
     avatar &player_character = get_avatar();
-    if( pl_sees( p, player_character.sight_max ) ) {
+    if( player_character.sees( p ) ) {
         player_character.memorize_clear_decoration( getglobal( p ), "tr_" );
     }
     // If there was already a trap here, remove it.
@@ -6169,7 +6169,7 @@ void map::remove_trap( const tripoint &p )
         if( g != nullptr && this == &get_map() ) {
             memory_cache_dec_set_dirty( p, true );
             avatar &player_character = get_avatar();
-            if( pl_sees( p, player_character.sight_max ) ) {
+            if( player_character.sees( p ) ) {
                 player_character.memorize_clear_decoration( getglobal( p ), "tr_" );
             }
             player_character.add_known_trap( p, tr_null.obj() );

--- a/src/map.h
+++ b/src/map.h
@@ -1774,7 +1774,7 @@ class map
          * @param max_range All squares that are further away than this are invisible.
          * Ignored if smaller than 0.
          */
-        virtual bool pl_sees( const tripoint &t, int max_range ) const;
+        bool pl_sees( const tripoint &t, int max_range ) const;
         /**
          * Uses the map cache to tell if the player could see the given square.
          * pl_sees implies pl_line_of_sight
@@ -2323,8 +2323,6 @@ class tinymap : public map
     public:
         tinymap() : map( 2, false ) {}
         bool inbounds( const tripoint &p ) const override;
-        // @returns false
-        bool pl_sees( const tripoint &t, int max_range ) const override;
 };
 
 class fake_map : public tinymap

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -20,6 +20,7 @@
 #include "mapdata.h"
 #include "mtype.h"
 #include "options_helpers.h"
+#include "player_helpers.h"
 #include "point.h"
 #include "type_id.h"
 #include "units.h"
@@ -1139,4 +1140,15 @@ TEST_CASE( "vision_inside_meth_lab", "[shadowcasting][vision][moncam]" )
 
     t.test_all();
     clear_vehicles();
+}
+
+TEST_CASE( "pl_sees-oob-nocrash", "[vision]" )
+{
+    // oob crash from game::place_player_overmap() or game::start_game(), simplified
+    clear_avatar();
+    get_map().load( project_to<coords::sm>( get_avatar().get_location() ) + point_south_east, false,
+                    false );
+    get_avatar().sees( tripoint_zero ); // CRASH?
+
+    clear_avatar();
 }


### PR DESCRIPTION

#### Summary
None

#### Purpose of change

`map::pl_sees` mixes tripoint types/origins and gets wrong results in the best case, or leads to out-of-bounds crashes in the worst case.

#### Describe the solution

Check distance with `tripoint_abs_ms`
Get light at player from the main map, which includes a proper bounds check
Revert previous fix attempts

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Micro test that replicates the crash path and should always trigger with ASan.
For manual testing, build with ASan and/or with _GLIBCXX_ASSERTIONS and long-teleport inside cities or start a few games with the `Missed` scenario.

#### Additional context
Needs #69947 to be strictly correct for `Character::sees()` but it shouldn't crash either way.

Six months ago I said I'd do this `next week`. If we're measuring weeks by days on Venus, I can still say I've kept my promise.