### PR TITLE
fix seminar printing the id of a skill instead of it's name, add debug function to run seminar

### DIFF
--- a/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
@@ -54,6 +54,11 @@
       { "text": "There's something I want you to do.", "topic": "TALK_ALLY_ORDERS" },
       { "text": "I just wanted to talk for a bit.", "topic": "TALK_ALLY_SOCIAL" },
       { "text": "Can you help me understand something?  (HELP/TUTORIAL)", "topic": "TALK_ALLY_TUTORIAL" },
+      {
+        "text": "[HAS DEBUG MIND CONTROL] Now listen closely… (DEBUG FUNCTIONS)",
+        "condition": { "u_has_trait": "DEBUG_MIND_CONTROL" },
+        "topic": "TALK_ALLY_DEBUG"
+      },
       { "text": "I'm going to go my own way for a while.", "topic": "TALK_LEAVE" },
       { "text": "Let's go.", "topic": "TALK_DONE" }
     ]
@@ -1080,6 +1085,86 @@
     "responses": [
       { "text": "Yes, I'm sure.", "topic": "TALK_DONE", "effect": "abandon_camp" },
       { "text": "Actually, never mind.", "topic": "TALK_NONE" }
+    ]
+  },
+  {
+    "id": [ "TALK_ALLY_DEBUG" ],
+    "type": "talk_topic",
+    "dynamic_line": { "is_by_radio": " *tshk* Not sure it works when i am that far.", "no": "Yes?" },
+    "responses": [
+      {
+        "text": "Trust me (+10 trust).",
+        "trial": { "type": "NONE" },
+        "success": { "topic": "TALK_ALLY_DEBUG", "opinion": { "trust": 10 } }
+      },
+      {
+        "text": "Do not trust me (-10 trust).",
+        "trial": { "type": "NONE" },
+        "success": { "topic": "TALK_ALLY_DEBUG", "opinion": { "trust": -10 } }
+      },
+      {
+        "text": "Fear me (+10 fear).",
+        "trial": { "type": "NONE" },
+        "success": { "topic": "TALK_ALLY_DEBUG", "opinion": { "fear": 10 } }
+      },
+      {
+        "text": "Do not fear me (-10 fear).",
+        "trial": { "type": "NONE" },
+        "success": { "topic": "TALK_ALLY_DEBUG", "opinion": { "fear": -10 } }
+      },
+      {
+        "text": "Fear me (+10 fear).",
+        "trial": { "type": "NONE" },
+        "success": { "topic": "TALK_ALLY_DEBUG", "opinion": { "fear": 10 } }
+      },
+      {
+        "text": "Do not fear me (-10 fear).",
+        "trial": { "type": "NONE" },
+        "success": { "topic": "TALK_ALLY_DEBUG", "opinion": { "fear": -10 } }
+      },
+      {
+        "text": "Value me (+10 value).",
+        "trial": { "type": "NONE" },
+        "success": { "topic": "TALK_ALLY_DEBUG", "opinion": { "value": 10 } }
+      },
+      {
+        "text": "Do not value me (-10 value).",
+        "trial": { "type": "NONE" },
+        "success": { "topic": "TALK_ALLY_DEBUG", "opinion": { "value": -10 } }
+      },
+      {
+        "text": "Be angry (+10 anger).",
+        "trial": { "type": "NONE" },
+        "success": { "topic": "TALK_ALLY_DEBUG", "opinion": { "anger": 10 } }
+      },
+      {
+        "text": "Do not be angry (-10 anger).",
+        "trial": { "type": "NONE" },
+        "success": { "topic": "TALK_ALLY_DEBUG", "opinion": { "anger": -10 } }
+      },
+      {
+        "text": "Owe me (+10 owed).",
+        "trial": { "type": "NONE" },
+        "success": { "topic": "TALK_ALLY_DEBUG", "opinion": { "owed": 10 } }
+      },
+      {
+        "text": "Do not owe me (-10 owed).",
+        "trial": { "type": "NONE" },
+        "success": { "topic": "TALK_ALLY_DEBUG", "opinion": { "owed": -10 } }
+      },
+      {
+        "text": "Favor me (+10 favors).",
+        "trial": { "type": "NONE" },
+        "success": { "topic": "TALK_ALLY_DEBUG", "opinion": { "favors": 10 } }
+      },
+      {
+        "text": "Do not favor me (-10 favors).",
+        "trial": { "type": "NONE" },
+        "success": { "topic": "TALK_ALLY_DEBUG", "opinion": { "favors": -10 } }
+      },
+      { "text": "Train me.", "topic": "TALK_TRAIN" },
+      { "text": "Do a seminar.", "topic": "TALK_TRAIN_SEMINAR" },
+      { "text": "Nevermind.", "topic": "TALK_NONE" }
     ]
   }
 ]

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -516,7 +516,7 @@ static std::string training_select_menu( const Character &c, const std::string &
     std::vector<std::string> trainlist;
     for( const std::pair<const skill_id, SkillLevel> &s : *c._skills ) {
         bool enabled = s.first->is_teachable() && s.second.level() > 0;
-        std::string entry = string_format( "%s: %s (%d)", _( "Skill" ), s.first.str(), s.second.level() );
+        std::string entry = string_format( "%s: %s (%d)", _( "Skill" ), s.first->name(), s.second.level() );
         nmenu.addentry( i, enabled, MENU_AUTOASSIGN, entry );
         trainlist.emplace_back( s.first.c_str() );
         i++;


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
fix #69869
#### Describe the solution
use [suggested change](https://github.com/CleverRaven/Cataclysm-DDA/issues/69869#issuecomment-1834025131), compile the game, find there is no easy way to run a seminar without extensive work with npc, add debug function for ally npcs so i can run seminar
#### Testing
I spend more time testing than actually making the thing
#### Additional context
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/8be6cb3c-cc09-46b2-96e5-62fc34fa6fbb)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/1d937d4f-baf0-48a7-b8b6-15f79162d3e5)
