### PR TITLE
re-add pre-seeded hordes, make them unconditional, and show up even with wandering hordes disabled

### DIFF
--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -120,10 +120,17 @@
   },
   {
     "type": "EXTERNAL_OPTION",
+    "name": "SPAWN_CITY_HORDE_SPREAD",
+    "info": "A scaling factor that determines how far from the center of cities extra zombies spawn, multiplied by city size, when city hordes are indicated.",
+    "stype": "float",
+    "value": 1.5
+  },
+  {
+    "type": "EXTERNAL_OPTION",
     "name": "SPAWN_CITY_HORDE_SCALAR",
     "info": "A scaling factor that determines how many zombies are spawned in cites, multiplied by city size, when city hordes are indicated.",
-    "stype": "int",
-    "value": 80
+    "stype": "float",
+    "value": 80.0
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -107,7 +107,7 @@
   {
     "type": "EXTERNAL_OPTION",
     "name": "SPAWN_CITY_HORDE_THRESHOLD",
-    "info": "Minimum city size to guarantee extra zombies are spawned in cities. 0 means all cities spawn extra zombies. Negative values disable extra city zombies.",
+    "info": "Minimum city size to guarantee extra zombies are spawned in cities.  0 means all cities spawn extra zombies.  Negative values disable extra city zombies.",
     "stype": "int",
     "value": 4
   },

--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -106,6 +106,27 @@
   },
   {
     "type": "EXTERNAL_OPTION",
+    "name": "SPAWN_CITY_HORDE_THRESHOLD",
+    "info": "Minimum city size to guarantee extra zombies are spawned in cities. 0 means all cities spawn extra zombies. Negative values disable extra city zombies.",
+    "stype": "int",
+    "value": 4
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "SPAWN_CITY_HORDE_SMALL_CITY_CHANCE",
+    "info": "Probability of a city smaller than SPAWN_HORDE_THRESHOLD having city zombies spawned, express in 'one in x' fashion .",
+    "stype": "int",
+    "value": 16
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "SPAWN_CITY_HORDE_SCALAR",
+    "info": "A scaling factor that determines how many zombies are spawned in cites, multiplied by city size, when city hordes are indicated.",
+    "stype": "int",
+    "value": 80
+  },
+  {
+    "type": "EXTERNAL_OPTION",
     "name": "SPAWN_ANIMAL_DENSITY",
     "info": "A scaling factor that determines density of wild, formerly domesticated and mutated animal spawns.",
     "stype": "float",

--- a/src/do_turn.cpp
+++ b/src/do_turn.cpp
@@ -456,7 +456,10 @@ bool do_turn()
 
     // Move hordes every 2.5 min
     if( calendar::once_every( time_duration::from_minutes( 2.5 ) ) ) {
-        overmap_buffer.move_hordes();
+
+        if( get_option<bool>( "WANDER_SPAWNS" ) ) {
+            overmap_buffer.move_hordes();
+        }
         if( u.has_trait( trait_HAS_NEMESIS ) ) {
             overmap_buffer.move_nemesis();
         }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6591,6 +6591,19 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
 
 void overmap::place_mongroups()
 {
+    // Cities are full of zombies
+    for( city &elem : cities ) {
+        if( get_option<bool>( "WANDER_SPAWNS" ) ) {
+            if( !one_in( 16 ) || elem.size > 5 ) {
+                mongroup m( GROUP_ZOMBIE, project_to<coords::sm>( project_combine( elem.pos_om,
+                            tripoint_om_omt( elem.pos, 0 ) ) ), elem.size * 80 );
+                m.horde = true;
+                m.wander( *this );
+                add_mon_group( m );
+            }
+        }
+    }
+
     if( get_option<bool>( "DISABLE_ANIMAL_CLASH" ) ) {
         // Figure out where swamps are, and place swamp monsters
         for( int x = 3; x < OMAPX - 3; x += 7 ) {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6631,9 +6631,9 @@ void overmap::place_mongroups()
                             // get all four quadrants for better distribution.
                             std::vector<tripoint_abs_sm> local_sm_list;
                             local_sm_list.push_back( this_sm );
-                            local_sm_list.push_back( this_sm + point( 0, 1 ) );
-                            local_sm_list.push_back( this_sm + point( 1, 0 ) );
-                            local_sm_list.push_back( this_sm + point( 1, 1 ) );
+                            local_sm_list.push_back( this_sm + point_east );
+                            local_sm_list.push_back( this_sm + point_south );
+                            local_sm_list.push_back( this_sm + point_south_east );
 
                             // shuffle, then prune submaps based on distance from city center
                             // this should let us concentrate hordes closer to the center.
@@ -6654,12 +6654,12 @@ void overmap::place_mongroups()
                     // somehow the city has no roads. this shouldn't happen.
                     add_msg_debug( debugmode::DF_OVERMAP,
                                    "tried to add zombie hordes to city %s centered at omt %s, but there were no roads!",
-                                   elem.name, city_center.to_string() );
+                                   elem.name, city_center.to_string_writable() );
                     continue;
                 }
 
                 add_msg_debug( debugmode::DF_OVERMAP, "adding %i zombies in hordes to city %s centered at omt %s.",
-                               desired_zombies, elem.name, city_center.to_string() );
+                               desired_zombies, elem.name, city_center.to_string_writable() );
 
                 // if there aren't enough roads, we'll just reuse them, re-shuffled.
                 while( desired_zombies > 0 ) {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6591,14 +6591,18 @@ void overmap::place_specials( overmap_special_batch &enabled_specials )
 
 void overmap::place_mongroups()
 {
-    // Cities are full of zombies
+    // Cities can be full of zombies
     for( city &elem : cities ) {
-        if( get_option<bool>( "WANDER_SPAWNS" ) ) {
-            if( !one_in( 16 ) || elem.size > 5 ) {
+        if( get_option<int>( "SPAWN_CITY_HORDE_THRESHOLD" ) > -1 ) {
+            if( !one_in( get_option<int>( "SPAWN_CITY_HORDE_SMALL_CITY_CHANCE" ) ) ||
+                elem.size > get_option<int>( "SPAWN_CITY_HORDE_THRESHOLD" ) ) {
+
                 mongroup m( GROUP_ZOMBIE, project_to<coords::sm>( project_combine( elem.pos_om,
-                            tripoint_om_omt( elem.pos, 0 ) ) ), elem.size * 80 );
-                m.horde = true;
-                m.wander( *this );
+                            tripoint_om_omt( elem.pos, 0 ) ) ), elem.size * get_option<int>( "SPAWN_CITY_HORDE_SCALAR" ) );
+                if( get_option<bool>( "WANDER_SPAWNS" ) ) {
+                    m.horde = true;
+                    m.wander( *this );
+                }
                 add_mon_group( m );
             }
         }

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -6657,8 +6657,8 @@ void overmap::place_mongroups()
                         // zombie spawns and behave like ants, triffids, fungals, etc.
                         // they won't try very hard to get placed in the world, so there will
                         // probably be fewer zombies than expected.
+                        m.horde = true;
                         if( get_option<bool>( "WANDER_SPAWNS" ) ) {
-                            m.horde = true;
                             m.wander( *this );
                         }
                         add_mon_group( m );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -94,6 +94,7 @@ static const oter_str_id oter_unexplored( "unexplored" );
 static const oter_type_str_id oter_type_forest_trail( "forest_trail" );
 
 static const trait_id trait_DEBUG_NIGHTVISION( "DEBUG_NIGHTVISION" );
+static const trait_id trait_DEBUG_CLAIRVOYANCE( "DEBUG_CLAIRVOYANCE" );
 
 #if defined(__ANDROID__)
 #include <SDL_keyboard.h>
@@ -783,7 +784,8 @@ static void draw_ascii(
                 ter_sym = "!";
             } else if( blink && showhordes &&
                        overmap_buffer.get_horde_size( omp ) >= HORDE_VISIBILITY_SIZE &&
-                       get_and_assign_los( los, player_character, omp, sight_points ) ) {
+                       ( get_and_assign_los( los, player_character, omp, sight_points ) ||
+                         uistate.overmap_debug_mongroup || trait_DEBUG_CLAIRVOYANCE ) ) {
                 // Display Hordes only when within player line-of-sight
                 ter_color = c_green;
                 ter_sym = overmap_buffer.get_horde_size( omp ) > HORDE_VISIBILITY_SIZE * 2 ? "Z" : "z";

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -93,8 +93,8 @@ static const oter_str_id oter_unexplored( "unexplored" );
 
 static const oter_type_str_id oter_type_forest_trail( "forest_trail" );
 
-static const trait_id trait_DEBUG_NIGHTVISION( "DEBUG_NIGHTVISION" );
 static const trait_id trait_DEBUG_CLAIRVOYANCE( "DEBUG_CLAIRVOYANCE" );
+static const trait_id trait_DEBUG_NIGHTVISION( "DEBUG_NIGHTVISION" );
 
 #if defined(__ANDROID__)
 #include <SDL_keyboard.h>

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -785,7 +785,7 @@ static void draw_ascii(
             } else if( blink && showhordes &&
                        overmap_buffer.get_horde_size( omp ) >= HORDE_VISIBILITY_SIZE &&
                        ( get_and_assign_los( los, player_character, omp, sight_points ) ||
-                         uistate.overmap_debug_mongroup || trait_DEBUG_CLAIRVOYANCE ) ) {
+                         uistate.overmap_debug_mongroup || player_character.has_trait( trait_DEBUG_CLAIRVOYANCE ) ) ) {
                 // Display Hordes only when within player line-of-sight
                 ter_color = c_green;
                 ter_sym = overmap_buffer.get_horde_size( omp ) > HORDE_VISIBILITY_SIZE * 2 ? "Z" : "z";

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -939,7 +939,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                     // a little bit of hardcoded fallbacks for hordes
                     if( find_tile_with_season( id ) ) {
                         // NOLINTNEXTLINE(cata-translate-string-literal)
-                        draw_from_id_string( string_format( "overmap_horde_%d", horde_size ),
+                        draw_from_id_string( string_format( "overmap_horde_%d", horde_size < 10 ? horde_size : 10 ),
                                              omp.raw(), 0, 0, lit_level::LIT, false );
                     } else {
                         switch( horde_size ) {

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -100,6 +100,7 @@
 static const oter_type_str_id oter_type_forest_trail( "forest_trail" );
 
 static const trait_id trait_DEBUG_NIGHTVISION( "DEBUG_NIGHTVISION" );
+static const trait_id trait_DEBUG_CLAIRVOYANCE( "DEBUG_CLAIRVOYANCE" );
 
 //***********************************
 //Globals                           *
@@ -891,7 +892,8 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             const tripoint_abs_omt omp = origin + point( col, row );
 
             const bool see = overmap_buffer.seen( omp );
-            const bool los = see && you.overmap_los( omp, sight_points );
+            const bool los = see && ( you.overmap_los( omp, sight_points ) || uistate.overmap_debug_mongroup ||
+                                      trait_DEBUG_CLAIRVOYANCE );
             // the full string from the ter_id including _north etc.
             std::string id;
             int rotation = 0;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -893,7 +893,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
 
             const bool see = overmap_buffer.seen( omp );
             const bool los = see && ( you.overmap_los( omp, sight_points ) || uistate.overmap_debug_mongroup ||
-                                      trait_DEBUG_CLAIRVOYANCE );
+                                      you.has_trait( trait_DEBUG_CLAIRVOYANCE ) );
             // the full string from the ter_id including _north etc.
             std::string id;
             int rotation = 0;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -99,8 +99,8 @@
 
 static const oter_type_str_id oter_type_forest_trail( "forest_trail" );
 
-static const trait_id trait_DEBUG_NIGHTVISION( "DEBUG_NIGHTVISION" );
 static const trait_id trait_DEBUG_CLAIRVOYANCE( "DEBUG_CLAIRVOYANCE" );
+static const trait_id trait_DEBUG_NIGHTVISION( "DEBUG_NIGHTVISION" );
 
 //***********************************
 //Globals                           *


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "re-add pre-seeded hordes, make them unconditional, and show up even with wandering hordes disabled"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

back in the olden days before #49279, the "wandering hordes" setting (also known as wander_spawns) also pre-seeded cities with zombies, in order to make sure there actually WERE hordes in cities that could wander around and be visible in the distance before the player has actually caused world generation to occur.

while some of the concerns raised in that removal PR had merit (including the implicit balance concerns with that setting causing a large shift in the amount of zombies spawned in the world, with no tunability to speak of), most of the stated methods of getting the zombies back "properly" aren't actually viable without radical overhauls of how world generation and monster spawning actually work.

specifically, without pre-seeded spawns, zombies now only generate hordes after the player has been to a location, caused local map generation to occur, and walked away, and even then only under specific circumstances that allow zombies to form hordes. even with wandering hordes on, without pre-seeded hordes there are none visible in the distance, and they certainly aren't going to be moving around (because they don't exist).

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

1.  first i reverted the feature removal, then repaired it to account for loss of infrastructure in the intervening years (dead code gets cleaned up, that's life)
2.  next was adding a bunch of json elements in the form of external options to govern the behavior; almost all of the constants used in the logic are specified in json (should be straightforward for modders), and the logic as a whole should respect monster spawn scaling.
3.  the extra city zombie spawns are completely insensate to the wandering hordes option, so players will get these new zombies whether they can move around or not... but i also changed things so that they're still visible on the overmap as hordes, even with wandering spawns off. (they don't move, though, and they don't re-hordify if the player leaves after they're deposited)
4. to ease in troubleshooting, i added some debug logic to the tile and non-tile overmap stuff to help see hordes in the distance (currently tied to the `debug_clairvoyance` mutation)
5. all of the new spawns ONLY spawn on road tiles, to hopefully prevent them from landing inside buildings inappropriately
6. added a small tweak to horde rendering in tilesets. **this will require tileset changes for best results** (see notes below additional context )
7. tried to concentrate horde spawns closer to city center. this seems to have succeeded, and helps provide a threat gradient between town outskirts and city centers.

the balance implications of this are substantial; it will be a very sharp uptick in the threat levels of city interiors (and exteriors, for smaller cities). should be managable, but a less obvious consequence is that with every additional zombie, there's more opportunities for someone to hit their evolution threshold sooner than expected. this is going to result in increasingly dangerous mobs in city centers, especially the more the player has to travel to reach them, or the more zombies manage to resurrect before the player can pulp/dismember them.

that said, with the current concentration logic, it should still be possible to drive through some lower zombie concentration areas with a vehicle early on. (especially a smaller vehicle, like a bike, although then you'll have to deal with ferals throwing rocks at you. whoops.)

an idiosyncracy of the current use of the horde mechanics for non-wandering-hordes players is that the zombies WILL show up on the map **until** the player gets close, but once they get deposited as spawns the horde is depleted and gone. this might result in modest confusion. this function can be backed out fairly easily if it's determined undesirable, but i suspect the better long-term call is inching towards better display of mobs on the overmap outside of hordes.

someone more prepared for writing documentation than me might consider updating the in-game help to cover these changes.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

having the hordes show up for players with wandering hordes turned off was a bit of a toss-up for me, it can be removed if it confuses people. 

i also considered having zombies re-absorb back to the overmap when conditions permit, even with wandering hordes turned off ... this COULD help with keeping distant zombies 'visible' on the overmap, even after the player walks away, but without the wandering logic they can't bunch up and that means they might not be big enough to actually be visible on the overmap with the current rules.

i SERIOUSLY considered upping the range at which zombies can be seen on the overmap, but scope creep was fatiguing me, and there's a lot of bikeshed potential there.

the 'concentrate hordes towards the center' functionality was scope creep, and could be dropped, but i think the effect is worth it

for the record: not getting the hordes back was never really in question as far as i'm concerned; we needed the zombies. cities don't have enough. this is a straightforward way to do it, which ALSO repairs the wandering hordes feature.


#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

i spent a GREAT DEAL of time creating worlds with and without wander_spawns enabled, teleporting around, hitting 'debug -> map -> reveal', adding the `debug_clairvoyance` mutation when appropriate... i'm fairly confident at this point hordes are spawning correctly.

what i'm substantially less sure about is if i got all of the infinite loop bugs -- i ran into three distinct ones (one of which was caused by undocumented unintuitive behavior in `city::pos_om`, which i've adjusted to behave more reasonably). i'd ideally like to hear from testers if running around around massive amounts of mapping can cause any hangs in world generation or the overmap view. cascading mapgen sucks.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

screenies!

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/1569754/fdce03e3-41c4-4b97-a5ee-dbbcb470a00c)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/1569754/b4b65b9d-5cd0-4ce2-a4f2-59fd58cb5b13)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/1569754/4a0fb066-ad84-4648-9994-848bfea1fade)

a city center minimap full of zombies
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/1569754/068cfe9f-fd03-4abc-ae95-4e154c64238c)

outskirt streets can be pretty empty
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/1569754/1b7fcb02-cf35-4bd3-9542-b268f7abdfa1)

extreme case: very wide city, very few hordes out into the distance. with the city-center focused placement, it might be worth increasing the default radius spread. i'll leave that bikeshedding to other people.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/1569754/77de98f4-e623-4db8-a7e0-08d2aadb3698)

some nice easterly things at overmap coordinates `5, 0, 0` (playing with @I-am-Erk 's new stuff)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/1569754/eeb813cb-8f2c-43e4-8a39-33d1ef9176ec)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/1569754/25ee25ff-16ec-4a24-86f0-3c8700e2e50d)

overmap coordinates `10, 0, 0`
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/1569754/4905d1fc-bdc8-4084-b397-55f4bc56a75a)

i want to draw specific attention to the lower left:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/1569754/d9f2cf93-c90f-498d-a16f-b0e498bee3cd)

this showcases consequences of a) overlapping cities, b) small cities. it gets weird.
also you can't tell but a lot of those tiles have 3 hordes in them for a total size of 30... and with our spawning rules, that can be potentially 90 zombies. (it almost certainly won't be, though, that would require it to consistently pick 'zombie' then the upper scale of 3 per pack)

#### horde tileset notes

pinging @Fris0uman per request.

not all of the tilesets were consistently rendering hordes, nor were they consistent in the ways they failed to render hordes, and it turns out this is because there's no guaranteed "this will be picked if all else fails" tile option for hordes due to the logic used.

in order to get the larwick overmap tileset to consistently display hordes, i adjusted the overmap tileset rendering to cap effective horde size (for the purposes of zombie horde rendering) to a size of 10 (the size i currently use to deposit pre-seed

because i didn't have it in me to go through composing tilesets, i manually edited `tile_config.json` to add the additional ids to `overmap_horde_6`:

```
"id": [ "overmap_horde_6", "overmap_horde_7", "overmap_horde_8", "overmap_horde_9", "overmap_horde_10"  ]
```

any tilesets that can be used for the overmap are going to want to have `overmap_horde_3` through `overmap_horde_10` represented in their id lists. that said, it isn't actually necessary to have all of them distinct; you can get away with just size 3-5 and size 6-10; the non-tiles horde rendering only has two states (`z` and `Z`) right now, so it would be feature parity.

having sizes 1 and 2 defined won't hurt in case of future changes, but as of right now won't do anything.

on the whole, i don't recommend putting too much effort into all of these tiles, it's very likely horde scaling and the thresholds for changing hordes (not to mention considerations for alternative horde types) will change at some point.

for further errorproofing, it would also be good to ensure the following tiles are defined even for overmap-specific tilesets, just in case (the overmap tileset rendering will sometimes fall back to these, even if the horde tiles exist):

```
mon_zombie
mon_zombie_tough
mon_zombie_brute
mon_zombie_hulk
mon_zombie_necro
mon_zombie_master
```

**everything** above would even apply to ascii tiles as an overmap tileset. worth checking.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
