### PR TITLE
Parameterize new overmap changes and adjust forests in the process

### DIFF
--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -267,6 +267,41 @@
   },
   {
     "type": "EXTERNAL_OPTION",
+    "name": "OVERMAP_FOREST_INCREASE_NORTH",
+    "info": "Rate at which forest coverage of the map increases to the North, based on regional map settings thresholds.  0=no increase.",
+    "stype": "float",
+    "value": 0.04
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "OVERMAP_FOREST_INCREASE_EAST",
+    "info": "Rate at which forest coverage of the map increases to the East.  0=no increase.",
+    "stype": "float",
+    "value": 0
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "OVERMAP_FOREST_INCREASE_WEST",
+    "info": "Rate at which forest coverage of the map increases to the West.  0=no increase.",
+    "stype": "float",
+    "value": 0.02
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "OVERMAP_FOREST_INCREASE_SOUTH",
+    "info": "Rate at which forest coverage of the map increases to the South.  0=no increase.",
+    "stype": "float",
+    "value": 0
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "OVERMAP_FOREST_LIMIT",
+    "info": "Caps how high the forest threshold can rise.  No cities form at values over 0.4",
+    "stype": "float",
+    "value": 0.395
+  },
+  {
+    "type": "EXTERNAL_OPTION",
     "name": "OVERMAP_PLACE_SWAMPS",
     "info": "Allows to place procgen swamps during overmap generation.",
     "stype": "bool",
@@ -327,6 +362,41 @@
     "info": "Allows to place procgen forest trailheads during overmap generation.",
     "stype": "bool",
     "value": true
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "OVERMAP_URBAN_INCREASE_NORTH",
+    "info": "Rate at which urbanity of the map increases to the North.  0=no increase.  Negative numbers are technically allowed but may cause weird effects.",
+    "stype": "int",
+    "value": 0
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "OVERMAP_URBAN_INCREASE_EAST",
+    "info": "Rate at which urbanity of the map increases to the East.  0=no increase.",
+    "stype": "int",
+    "value": 10
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "OVERMAP_URBAN_INCREASE_WEST",
+    "info": "Rate at which urbanity of the map increases to the South.  0=no increase.",
+    "stype": "int",
+    "value": 0
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "OVERMAP_URBAN_INCREASE_SOUTH",
+    "info": "Rate at which urbanity of the map increases to the West.  0=no increase.",
+    "stype": "int",
+    "value": 5
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "OVERMAP_MAXIMUM_URBANITY",
+    "info": "How urban do we allow our megacities to go?  Mostly functions as a multiple of map settings city size.",
+    "stype": "int",
+    "value": 5
   },
   {
     "type": "EXTERNAL_OPTION",

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -5124,7 +5124,7 @@ void overmap::calculate_forestosity()
         forest_size_adjust += this_om.y() * southern_forest_increase;
     }
     forestosity = forest_size_adjust * 25.0f;
-    debugmsg( "forestosity = %1.2f at OM %i, %i", forestosity, this_om.x(), this_om.y() );
+    //debugmsg( "forestosity = %1.2f at OM %i, %i", forestosity, this_om.x(), this_om.y() );
     // make sure forest size never totally overwhelms the map
     forest_size_adjust = std::min( forest_size_adjust,
                                    get_option<float>( "OVERMAP_FOREST_LIMIT" ) - static_cast<float>
@@ -5187,7 +5187,7 @@ void overmap::calculate_urbanity()
         }
     }
     urbanity = static_cast<int>( urbanity_adj );
-    debugmsg( "urbanity = %i at OM %i, %i", urbanity, this_om.x(), this_om.y() );
+    //debugmsg( "urbanity = %i at OM %i, %i", urbanity, this_om.x(), this_om.y() );
 }
 
 /*: the root is overmap::place_cities()

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -200,7 +200,7 @@ class overmap
         const point_abs_om &pos() const {
             return loc;
         }
-        int get_urbanity() {
+        int get_urbanity() const {
             return urbanity;
         }
 

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -449,10 +449,13 @@ class overmap
         overmap_special_id pick_random_building_to_place( int town_dist ) const;
 
         // urbanity and forestosity are biome stats that can be used to trigger changes in biome.
+        // NOLINTNEXTLINE(cata-serialize)
         int urbanity = 0;
         // forest_size_adjust is basically the same as forestosity, but forestosity is
         // scaled to be comparable to urbanity and other biome stats.
+        // NOLINTNEXTLINE(cata-serialize)
         float forest_size_adjust = 0.0f;
+        // NOLINTNEXTLINE(cata-serialize)
         float forestosity = 0.0f;
         void calculate_urbanity();
         void calculate_forestosity();

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -200,7 +200,7 @@ class overmap
         const point_abs_om &pos() const {
             return loc;
         }
-        int get_urbanity(){
+        int get_urbanity() {
             return urbanity;
         }
 
@@ -447,13 +447,13 @@ class overmap
 
         // City Building
         overmap_special_id pick_random_building_to_place( int town_dist ) const;
-        
+
         // urbanity and forestosity are biome stats that can be used to trigger changes in biome.
         int urbanity = 0;
-        // forest_size_adjust is basically the same as forestosity, but forestosity is cast
-        // to an int and scaled to be comparable to urbanity and other biome stats.
+        // forest_size_adjust is basically the same as forestosity, but forestosity is
+        // scaled to be comparable to urbanity and other biome stats.
         float forest_size_adjust = 0.0f;
-        int forestosity = 0;
+        float forestosity = 0.0f;
         void calculate_urbanity();
         void calculate_forestosity();
 

--- a/src/overmap.h
+++ b/src/overmap.h
@@ -200,6 +200,9 @@ class overmap
         const point_abs_om &pos() const {
             return loc;
         }
+        int get_urbanity(){
+            return urbanity;
+        }
 
         void save() const;
 
@@ -444,6 +447,15 @@ class overmap
 
         // City Building
         overmap_special_id pick_random_building_to_place( int town_dist ) const;
+        
+        // urbanity and forestosity are biome stats that can be used to trigger changes in biome.
+        int urbanity = 0;
+        // forest_size_adjust is basically the same as forestosity, but forestosity is cast
+        // to an int and scaled to be comparable to urbanity and other biome stats.
+        float forest_size_adjust = 0.0f;
+        int forestosity = 0;
+        void calculate_urbanity();
+        void calculate_forestosity();
 
         void place_cities();
         void place_building( const tripoint_om_omt &p, om_direction::type dir, const city &town );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Parameterize new geography changes to overmaps"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

In #69912 I made a quick, dirty, and effective change to make cities increase in the East and South, while forests increase in the North and West. This should be something we can adjust and control with JSON settings

#### Describe the solution
Allow this to be adjusted and controlled with JSON settings.
- you can set a direction - N,E,S,W - in which forests or cities should increase. For cities, the increase will falloff in the adjacent cardinal direction, so if you set cities to only increase to the S, then if you travel SE or SW the megacity will fall away.
- You can set max values for these changes as well.
- Implicit to the increasing forest comes a decrease in city size and increase in spacing, so that we don't see a bunch of cities crammed into the tiny remaining open space in the forests.

This creates two new variables in overmap - urbanity and forestosity. These will be used for other things soon.



#### Testing

So much. Argh.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/58e0a75d-e450-4652-a004-1781d45d1bde)
Here's a nice example of what we can see in the new forests. A tiny podunk little town surrounded by farms, orchards, and a mine.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45136638/08076663-ec09-4367-9d7e-820097fc2c91)
here's a larger zoom out on four overmaps near that previous shot. I can just see the people of that small town, Lebanon, telling you you're gonna have to head up to Brandon, just past Newfields, if you want to get supplies.

The cities haven't changed substantially.

#### Additional context
Gosh, we need more roads now hey?

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
