### PR TITLE
.380 auto ballistics by the inch

### DIFF
--- a/data/json/items/ammo/380.json
+++ b/data/json/items/ammo/380.json
@@ -19,7 +19,29 @@
     "ammo_type": "380",
     "casing": "380_casing",
     "range": 13,
-    "damage": { "damage_type": "bullet", "amount": 16, "armor_penetration": 2 },
+    "//": " .355in, 95gr, Sierra FMJ FN TM 8105, 4.0gr Alliant UNIQUE",
+    "damage": {
+      "damage_type": "bullet",
+      "amount": 16,
+      "armor_penetration": 2,
+      "barrels": [
+        { "barrel_length": "28 mm", "amount": 11 },
+        { "barrel_length": "36 mm", "amount": 12 },
+        { "barrel_length": "45 mm", "amount": 13 },
+        { "barrel_length": "57 mm", "amount": 14 },
+        { "barrel_length": "68 mm", "amount": 15 },
+        { "barrel_length": "87 mm", "amount": 16 },
+        { "barrel_length": "113 mm", "amount": 17 },
+        { "barrel_length": "149 mm", "amount": 18 },
+        { "barrel_length": "198 mm", "amount": 19 },
+        { "barrel_length": "269 mm", "amount": 20 },
+        { "barrel_length": "373 mm", "amount": 21 },
+        { "barrel_length": "531 mm", "amount": 22 },
+        { "barrel_length": "707 mm", "amount": 23 },
+        { "barrel_length": "1073 mm", "amount": 24 },
+        { "barrel_length": "1256 mm", "amount": 25 }
+      ]
+    },
     "dispersion": 60,
     "recoil": 300,
     "effects": [ "COOKOFF" ]

--- a/data/json/items/gun/380.json
+++ b/data/json/items/gun/380.json
@@ -207,7 +207,6 @@
     "durability": 8,
     "blackpowder_tolerance": 30,
     "min_cycle_recoil": 270,
-    "ranged_damage": { "damage_type": "bullet", "amount": 2 },
     "valid_mod_locations": [
       [ "barrel", 1 ],
       [ "bore", 1 ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
.380  Auto was missing ballistics data.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds .380 auto ballistics data.

Removes .380 auto ranged damage entries from .380 guns so the data gets used correctly.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded game. Beheld glorious gun of zinc and pot metal, hipoint 3895.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
