### PR TITLE
[MoM] fix Voltaic Strikes

### DIFF
--- a/data/mods/MindOverMatter/enchantments/enchantments_player.json
+++ b/data/mods/MindOverMatter/enchantments/enchantments_player.json
@@ -61,7 +61,7 @@
     "id": "enchant_electrokin_electric_strikes",
     "condition": "ALWAYS",
     "has": "HELD",
-    "hit_me_effect": [ { "id": "electrokin_zap_attack", "hit_self": false, "once_in": 3 } ],
+    "hit_you_effect": [ { "id": "electrokin_zap_attack", "hit_self": false, "once_in": 3 } ],
     "values": [ { "value": "ARMOR_ELEC", "add": { "math": [ "u_val('spell_level', 'spell: electrokinetic_melee_attacks') * -1" ] } } ]
   },
   {
@@ -76,12 +76,12 @@
     "damage_type": "electric",
     "min_damage": {
       "math": [
-        "( (u_val('spell_level', 'spell: electrokinesis_melee_thorns') / 3 ) + 3) * (scaling_factor(u_val('intelligence') ) )"
+        "( (u_val('spell_level', 'spell: electrokinetic_melee_attacks') / 3 ) + 3) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "max_damage": {
       "math": [
-        "( (u_val('spell_level', 'spell: electrokinesis_melee_thorns') / 1.5 ) + 10) * (scaling_factor(u_val('intelligence') ) )"
+        "( (u_val('spell_level', 'spell: electrokinetic_melee_attacks') / 1.5 ) + 10) * (scaling_factor(u_val('intelligence') ) )"
       ]
     },
     "min_range": 1,

--- a/data/mods/MindOverMatter/enchantments/enchantments_player.json
+++ b/data/mods/MindOverMatter/enchantments/enchantments_player.json
@@ -61,7 +61,7 @@
     "id": "enchant_electrokin_electric_strikes",
     "condition": "ALWAYS",
     "has": "HELD",
-    "hit_you_effect": [ { "id": "electrokin_zap_attack", "hit_self": false, "once_in": 3 } ],
+    "hit_you_effect": [ { "id": "electrokin_zap_attack", "hit_self": false, "once_in": 2 } ],
     "values": [ { "value": "ARMOR_ELEC", "add": { "math": [ "u_val('spell_level', 'spell: electrokinetic_melee_attacks') * -1" ] } } ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "[MoM] fix Voltaic Strikes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The Voltaic Strikes power wasn't working correctly, due to a combination of being implemented as a hit_me_effect instead of a hit_you_effect, and the damage of the hit_you_effect spell being pegged to the nonexistant electrokinesis_melee_thorns instead of electrokinetic_melee_attacks

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changed those references to the correct ones.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded up the game with the changes and confirmed that you occasionally get bonus damage now.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I think this power could use a buff because it both adds a fairly small amount of damage ( around 10 or so at level 12) _and_ only activts on 1/3 attacks, but I figured I'd start by just fixing it.

It's also really unclear when you're actually getting the bonus damage. It mostly just says "You hit the X in the Y for Z damage" with no indication that it's the bonus electrical damage. I've noticed mutations doing this as well, seems to be becasue of weakpoints.

e: Implemented a buff by making it trigger on 1/2 attacks instead of 1/3
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
