### PR TITLE
Add ak bayonets (as a variant)

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/mall_item_groups.json
+++ b/data/json/itemgroups/Locations_MapExtras/mall_item_groups.json
@@ -159,6 +159,7 @@
       [ "knife_combat_army", 2 ],
       [ "knife_combat_marine", 1 ],
       [ "knife_KABAR", 35 ],
+      { "item": "knife_combat_army", "variant": "akbayonet", "prob": 10, "entry-wrapper": "sheath" },
       { "group": "infantry_knives", "prob": 5 },
       { "item": "throwing_knife", "count-min": 1, "count-max": 6, "entry-wrapper": "leg_sheath6", "prob": 5 },
       [ "throwing_knife", 10 ],

--- a/data/json/itemgroups/Monsters_Animals_Lairs/monster_drops_lairs.json
+++ b/data/json/itemgroups/Monsters_Animals_Lairs/monster_drops_lairs.json
@@ -134,7 +134,7 @@
       { "item": "boots_combat", "prob": 20 },
       { "item": "bandages", "prob": 10, "count": [ 1, 3 ] },
       { "prob": 30, "group": "cig_box_cigarette_1_20" },
-      { "item": "knife_combat_army", "prob": 10 },
+      { "item": "knife_combat_army", "variant": "m9bayonet", "prob": 10 },
       { "item": "vest", "prob": 15 },
       { "item": "glasses_safety", "prob": 15 },
       { "item": "9mm", "prob": 15, "charges": [ 1, 50 ] },

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -478,7 +478,7 @@
     "subtype": "distribution",
     "entries": [
       { "item": "knife_combat", "prob": 30 },
-      { "item": "knife_combat_army", "prob": 50 },
+      { "item": "knife_combat_army", "variant": "m9bayonet", "prob": 50 },
       { "item": "knife_combat_marine", "prob": 20 }
     ]
   },
@@ -788,7 +788,7 @@
       { "group": "adhesive_bandages_box_used", "prob": 10 },
       { "prob": 60, "group": "cig_box_cigarette_1_20" },
       { "item": "knife_combat_marine", "prob": 10 },
-      { "item": "knife_combat_army", "prob": 30 },
+      { "item": "knife_combat_army", "variant": "m9bayonet", "prob": 30 },
       { "item": "pockknife", "prob": 30 },
       { "item": "knife_folding", "prob": 20 },
       { "item": "glasses_safety", "prob": 45 },

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -348,7 +348,7 @@
         "description": "The current issue Army bayonet, before the Cataclysm anyways.  It is thick, heavy, and surprisingly sharp.  This bayonet also functions as a wire cutter, and a mediocre saw for cutting through aircraft fuselage.  That the handle and tang can be completely disassembled from the blade is surely a fact of great comfort to the soldier, survivalist, and you."
       },
       {
-        "id": "6h4bayonet",
+        "id": "akbayonet",
         "name": { "str_sp": "AK bayonet" },
         "description": "A 6H4 bayonet for Kalashnikov pattern rifles imported from eastern bloc countries, usually military surplus.  The blade is made of stainless steel and the handle of a lightweight and durable plastic.  It features a middling metal saw on the spine of the blade, and can function as a wire cutter as well.  Though it is quite sturdy, it can't hold an edge very well."
       }

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -339,8 +339,20 @@
     "id": "knife_combat_army",
     "type": "TOOL",
     "category": "weapons",
-    "name": { "str": "Army bayonet" },
+    "name": { "str": "Bayonet" },
     "description": "The current issue Army bayonet, before the Cataclysm anyways.  It is thick, heavy, and surprisingly sharp.  This bayonet also functions as a wire cutter, and a mediocre saw for cutting through aircraft fuselage.  That the handle and tang can be completely disassembled from the blade is surely a fact of great comfort to the soldier, survivalist, and you.",
+    "variants": [
+      {
+        "id": "m9bayonet",
+        "name": { "str_sp": "Army bayonet" },
+        "description": "The current issue Army bayonet, before the Cataclysm anyways.  It is thick, heavy, and surprisingly sharp.  This bayonet also functions as a wire cutter, and a mediocre saw for cutting through aircraft fuselage.  That the handle and tang can be completely disassembled from the blade is surely a fact of great comfort to the soldier, survivalist, and you."
+      },
+      {
+        "id": "6h4bayonet",
+        "name": { "str_sp": "AK bayonet" },
+        "description": "A 6H4 bayonet for Kalashnikov pattern rifles imported from eastern bloc countries, usually military surplus.  The blade is made of stainless steel and the handle of a lightweight and durable plastic.  It features a middling metal saw on the spine of the blade, and can function as a wire cutter as well.  Though it is quite sturdy, it can't hold an edge very well."
+      }
+    ],
     "//": "An M9 Bayonet.",
     "weight": "450 g",
     "volume": "209 ml",

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -350,7 +350,7 @@
       {
         "id": "akbayonet",
         "name": { "str_sp": "AK bayonet" },
-        "description": "A 6H4 bayonet for Kalashnikov pattern rifles imported from eastern bloc countries, usually military surplus.  The blade is made of stainless steel and the handle of a lightweight and durable plastic.  It features a middling metal saw on the spine of the blade, and can function as a wire cutter as well.  Though it is quite sturdy, it can't hold an edge very well."
+        "description": "A 6H4 bayonet for Kalashnikov pattern rifles, usually imported military surplus from eastern bloc countries.  The blade is made of stainless steel and the handle of a lightweight and durable plastic.  It features a middling metal saw on the spine of the blade, and can function as a wire cutter as well.  Though it is quite sturdy, it can't hold an edge very well."
       }
     ],
     "//": "An M9 Bayonet.",

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -1529,7 +1529,7 @@
           { "group": "us_ballistic_vest_pristine" },
           { "item": "water_clean", "container-item": "canteen" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat_army", "container-item": "sheath" },
+          { "item": "knife_combat_army", "variant": "m9bayonet", "container-item": "sheath" },
           { "item": "shot_00", "count": 2 },
           {
             "item": "mossberg_930",
@@ -1592,7 +1592,7 @@
           { "item": "water_clean", "container-item": "canteen" },
           { "item": "legpouch_large", "contents-group": "army_mags_m4" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat_army", "container-item": "sheath" },
+          { "item": "knife_combat_army", "variant": "m9bayonet", "container-item": "sheath" },
           {
             "item": "modular_m4_carbine",
             "variant": "modular_m4a1",
@@ -4460,7 +4460,7 @@
         "entries": [
           { "item": "water_clean", "container-item": "canteen" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat_army", "container-item": "sheath" },
+          { "item": "knife_combat_army", "variant": "m9bayonet", "container-item": "sheath" },
           {
             "item": "modular_m4_carbine",
             "variant": "modular_m4a1",
@@ -5578,7 +5578,7 @@
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "grenadebandolier", "contents-item": [ "flashbang", "flashbang" ] },
           { "item": "bandolier_shotgun", "contents-group": "bandolier_swat_cqc1" },
-          { "item": "knife_combat_army", "container-item": "sheath" },
+          { "item": "knife_combat_army", "variant": "m9bayonet", "container-item": "sheath" },
           { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
         ]
       },
@@ -5640,7 +5640,7 @@
             "contents-item": [ "shoulder_strap", "rifle_scope" ]
           },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat_army", "container-item": "sheath" },
+          { "item": "knife_combat_army", "variant": "m9bayonet", "container-item": "sheath" },
           { "item": "m17", "ammo-item": "9mmfmj", "container-item": "holster", "charges": 17 },
           { "item": "legpouch_large", "contents-group": "army_mags_m17" }
         ]
@@ -5947,7 +5947,7 @@
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "mask_dust", "variant": "camo_mask_dust", "custom-flags": [ "no_auto_equip" ] },
           { "item": "stethoscope", "custom-flags": [ "no_auto_equip" ] },
-          { "item": "knife_combat_army", "container-item": "sheath" },
+          { "item": "knife_combat_army", "variant": "m9bayonet", "container-item": "sheath" },
           {
             "item": "modular_m4_carbine",
             "variant": "modular_m4a1",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Adds AK bayonets"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
An imported bayonet would be cool.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds the widely imported 6H4 bayonet and m9 bayonets as variants of the army bayonet. The 6H3 was also an option, but I wanted to go with the most common one in the states. 
Specified the m9 bayonet variant for most of the military spawns of the army bayonet.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The 6h3 as previously mentioned. The 6H5 is very rare in the states, so not considered.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded game, spawned bayonets,  tested item groups to make sure the new variant was spawning.<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Thanks to Drew4484 for consult on steel appropriateness. He'd suggested switching the steel to LC_steel if desired, as well.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
