### PR TITLE
un-variant eye color mutation

### DIFF
--- a/data/json/mutations/mutation_appearance.json
+++ b/data/json/mutations/mutation_appearance.json
@@ -480,23 +480,75 @@
     "types": [ "hair_style" ]
   },
   {
-    "id": "eye_color",
+    "id": "eye_blue",
     "type": "mutation",
-    "name": { "str": "Eye color" },
-    "description": "You have eyes.",
+    "name": { "str": "Eye color: blue" },
+    "description": "You have blue eyes.",
     "points": 0,
     "starting_trait": true,
     "valid": false,
     "player_display": true,
     "vanity": true,
-    "variants": [
-      { "id": "blue", "name": { "str": "Eye color: blue" }, "description": "You have blue eyes.", "weight": 1 },
-      { "id": "brown", "name": { "str": "Eye color: brown" }, "description": "You have brown eyes.", "weight": 1 },
-      { "id": "hazel", "name": { "str": "Eye color: hazel" }, "description": "You have hazel eyes.", "weight": 1 },
-      { "id": "amber", "name": { "str": "Eye color: amber" }, "description": "You have amber eyes.", "weight": 1 },
-      { "id": "gray", "name": { "str": "Eye color: gray" }, "description": "You have gray eyes.", "weight": 1 },
-      { "id": "green", "name": { "str": "Eye color: green" }, "description": "You have green eyes.", "weight": 1 }
-    ],
+    "types": [ "eye_color" ]
+  },
+  {
+    "id": "eye_brown",
+    "type": "mutation",
+    "name": { "str": "Eye color: brown" },
+    "description": "You have brown eyes.",
+    "points": 0,
+    "starting_trait": true,
+    "valid": false,
+    "player_display": true,
+    "vanity": true,
+    "types": [ "eye_color" ]
+  },
+  {
+    "id": "eye_hazel",
+    "type": "mutation",
+    "name": { "str": "Eye color: hazel" },
+    "description": "You have hazel eyes.",
+    "points": 0,
+    "starting_trait": true,
+    "valid": false,
+    "player_display": true,
+    "vanity": true,
+    "types": [ "eye_color" ]
+  },
+  {
+    "id": "eye_amber",
+    "type": "mutation",
+    "name": { "str": "Eye color: amber" },
+    "description": "You have amber eyes.",
+    "points": 0,
+    "starting_trait": true,
+    "valid": false,
+    "player_display": true,
+    "vanity": true,
+    "types": [ "eye_color" ]
+  },
+  {
+    "id": "eye_gray",
+    "type": "mutation",
+    "name": { "str": "Eye color: gray" },
+    "description": "You have gray eyes.",
+    "points": 0,
+    "starting_trait": true,
+    "valid": false,
+    "player_display": true,
+    "vanity": true,
+    "types": [ "eye_color" ]
+  },
+  {
+    "id": "eye_green",
+    "type": "mutation",
+    "name": { "str": "Eye color: green" },
+    "description": "You have green eyes.",
+    "points": 0,
+    "starting_trait": true,
+    "valid": false,
+    "player_display": true,
+    "vanity": true,
     "types": [ "eye_color" ]
   },
   {

--- a/data/json/npcs/appearance_trait_groups.json
+++ b/data/json/npcs/appearance_trait_groups.json
@@ -174,9 +174,9 @@
     "id": "Eye_light",
     "subtype": "distribution",
     "traits": [
-      { "trait": "eye_color", "variant": "blue", "prob": 55 },
-      { "trait": "eye_color", "variant": "gray", "prob": 25 },
-      { "trait": "eye_color", "variant": "green", "prob": 15 }
+      { "trait": "eye_blue", "prob": 55 },
+      { "trait": "eye_gray", "prob": 25 },
+      { "trait": "eye_green", "prob": 15 }
     ]
   },
   {
@@ -184,9 +184,9 @@
     "id": "Eye_dark",
     "subtype": "distribution",
     "traits": [
-      { "trait": "eye_color", "variant": "brown", "prob": 60 },
-      { "trait": "eye_color", "variant": "hazel", "prob": 20 },
-      { "trait": "eye_color", "variant": "amber", "prob": 20 }
+      { "trait": "eye_brown", "prob": 60 },
+      { "trait": "eye_hazel", "prob": 20 },
+      { "trait": "eye_amber", "prob": 20 }
     ]
   },
   {
@@ -194,12 +194,12 @@
     "id": "Eye_any",
     "subtype": "distribution",
     "traits": [
-      { "trait": "eye_color", "variant": "brown", "prob": 70 },
-      { "trait": "eye_color", "variant": "hazel", "prob": 9 },
-      { "trait": "eye_color", "variant": "amber", "prob": 8 },
-      { "trait": "eye_color", "variant": "blue", "prob": 8 },
-      { "trait": "eye_color", "variant": "gray", "prob": 3 },
-      { "trait": "eye_color", "variant": "green", "prob": 2 }
+      { "trait": "eye_brown", "prob": 70 },
+      { "trait": "eye_hazel", "prob": 9 },
+      { "trait": "eye_amber", "prob": 8 },
+      { "trait": "eye_blue", "prob": 8 },
+      { "trait": "eye_gray", "prob": 3 },
+      { "trait": "eye_green", "prob": 2 }
     ]
   },
   {

--- a/data/json/npcs/random_encounters/john_bailey.json
+++ b/data/json/npcs/random_encounters/john_bailey.json
@@ -27,7 +27,7 @@
     "weapon_override": "John_Bailey_wield",
     "traits": [
       { "trait": "SKIN_LIGHT" },
-      { "trait": "eye_color", "variant": "brown" },
+      { "trait": "eye_brown" },
       { "trait": "hair_brown_short" },
       { "trait": "DEFT" },
       { "trait": "OUTDOORSMAN" },

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
@@ -30,7 +30,7 @@
     "traits": [
       { "group": "BG_survival_story_CRIMINAL" },
       { "trait": "long_over_eye", "variant": "brown" },
-      { "trait": "eye_color", "variant": "blue" },
+      { "trait": "eye_blue" },
       { "trait": "SKIN_LIGHT" },
       { "trait": "QUICK" },
       { "trait": "FASTHEALER" },

--- a/data/json/npcs/robofac/NPC_Cranberry_Foster.json
+++ b/data/json/npcs/robofac/NPC_Cranberry_Foster.json
@@ -30,7 +30,7 @@
       { "trait": "PACIFIST" },
       { "trait": "TRUTHTELLER" },
       { "trait": "hair_blond_medium" },
-      { "trait": "eye_color", "variant": "blue" },
+      { "trait": "eye_blue" },
       { "trait": "SKIN_PINK" }
     ],
     "bonus_str": 2,


### PR DESCRIPTION
#### Summary
Bugfixes "fixes eye color mutation"

#### Purpose of change
Closes #69944. Eye color mutation for some reason was a single entry with multiple variants, which prevented people from changing to a specific eye color via mirrors or debug.

#### Describe the solution
Change eye colors to be 6 different mutations with different variants instead of one mutation with 6 variants, adjust npcs accordingly.

#### Describe alternatives you've considered
don't do this

#### Testing
the game gave a warning about eye_color being an invalid trait, but otherwise nothing else for now.

#### Additional context
![Ekran görüntüsü 2023-12-06 012628](https://github.com/CleverRaven/Cataclysm-DDA/assets/30256012/e4ede031-015f-4127-b015-7268a3be35b3)

