### PR TITLE
[Xedra Evolved] Fix deathray expanding in size as charge fills

### DIFF
--- a/data/mods/Xedra_Evolved/items/ammo.json
+++ b/data/mods/Xedra_Evolved/items/ammo.json
@@ -88,8 +88,6 @@
     "type": "AMMO",
     "name": { "str_sp": "aetheric charge" },
     "description": "Charged ether pulled out of the void between all things.",
-    "weight": "1 g",
-    "volume": "12 ml",
     "price": "10 USD",
     "price_postapoc": "10 USD",
     "material": [ "forged_dreamstuff" ],
@@ -100,6 +98,7 @@
     "range": 12,
     "count": 1,
     "recoil": 900,
-    "effects": [ "INCENDIARY" ]
+    "effects": [ "INCENDIARY" ],
+    "flags": [ "ZERO_WEIGHT" ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Fix deathray volume expanding as charge increases"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
As the deathray charged up, the volume of the gun would expand to improbable sizes, only stopping at 62 liters. This change prevents the gun's size changing based on its energy ammo storage.
![charge_bad](https://github.com/CleverRaven/Cataclysm-DDA/assets/70666939/30f2402d-7189-4478-80c3-dd73a725ec9e)

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Remove volume and weight of aetheric charge ammunition and adds ZERO_WEIGHT flag to prevent load errors.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Let death ray remain a balloon.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![charge_good](https://github.com/CleverRaven/Cataclysm-DDA/assets/70666939/f1b944e3-0c84-4e46-8e4e-3a4914b6769b)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
