### PR TITLE
Plug in tools with cables during crafting tests

### DIFF
--- a/data/mods/TEST_DATA/appliance.json
+++ b/data/mods/TEST_DATA/appliance.json
@@ -157,7 +157,7 @@
     "color": "light_cyan",
     "ammo_type": [ "battery" ],
     "capacity": 1000000000,
-    "count" : 1000000000,
+    "count": 1000000000,
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "RECHARGE", "NO_REPAIR" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 1000000000 } } ],
     "melee_damage": { "bash": 20 }

--- a/data/mods/TEST_DATA/appliance.json
+++ b/data/mods/TEST_DATA/appliance.json
@@ -140,5 +140,51 @@
     "flags": [ "NO_INSTALL_HIDDEN", "UNMOUNT_ON_DAMAGE", "POWER_TRANSFER" ],
     "breaks_into": [ { "item": "cable", "charges": [ 1, 10 ] }, { "item": "plastic_chunk", "count": [ 1, 2 ] } ],
     "variants": [ { "symbols": "{", "symbols_broken": "*" } ]
+  },
+  {
+    "id": "test_storage_battery",
+    "type": "MAGAZINE",
+    "category": "veh_parts",
+    "name": { "str": "large storage battery", "str_pl": "large storage batteries" },
+    "description": "A large storage battery containing many lithium-ion cells.  Could be installed into a storage battery case for easy removal from a vehicle, or just welded straight in.",
+    "weight": "75 kg",
+    "volume": "25 L",
+    "price": 200000,
+    "price_postapoc": 1500,
+    "to_hit": -2,
+    "material": [ "plastic", "steel" ],
+    "symbol": ":",
+    "color": "light_cyan",
+    "ammo_type": [ "battery" ],
+    "capacity": 1000000000,
+    "count" : 1000000000,
+    "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "RECHARGE", "NO_REPAIR" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 1000000000 } } ],
+    "melee_damage": { "bash": 20 }
+  },
+  {
+    "id": "ap_test_storage_battery",
+    "type": "vehicle_part",
+    "name": { "str": "large grid battery" },
+    "categories": [ "energy" ],
+    "item": "test_storage_battery",
+    "location": "fuel_source",
+    "fuel_type": "battery",
+    "color": "light_red",
+    "broken_color": "red",
+    "durability": 300,
+    "description": "A large battery to store electrical power in a static power grid.",
+    "damage_modifier": 80,
+    "breaks_into": [
+      { "item": "steel_lump", "count": [ 5, 10 ] },
+      { "item": "steel_chunk", "count": [ 5, 10 ] },
+      { "item": "scrap", "count": [ 5, 10 ] },
+      { "item": "medium_storage_battery", "count": [ 1, 2 ] }
+    ],
+    "//": "29cm length battery, welded on at least two edges",
+    "requirements": { "removal": { "time": "6 m" } },
+    "damage_reduction": { "bash": 10 },
+    "flags": [ "OBSTACLE", "APPLIANCE" ],
+    "variants": [ { "symbols": "B", "symbols_broken": "#" } ]
   }
 ]

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -365,7 +365,7 @@ TEST_CASE( "crafting_with_a_companion", "[.]" )
     }
 }
 
-static void give_tools( const std::vector<item> &tools )
+static void give_tools( const std::vector<item> &tools, const bool plug_in )
 {
     Character &player_character = get_player_character();
     player_character.clear_worn();
@@ -380,12 +380,13 @@ static void give_tools( const std::vector<item> &tools )
         if( gear.get_quality( qual_BOIL, false ) == 0 ) {
             item_location added_tool = player_character.i_add( gear );
             REQUIRE( added_tool );
-            if( added_tool->can_link_up() ) {
+            if( plug_in && added_tool->can_link_up() ) {
                 added_tool->link = cata::make_value<item::link_data>();
                 added_tool->link->t_state = link_state::vehicle_port;
                 added_tool->link->t_abs_pos = get_map().getglobal( player_character.pos() + tripoint_north );
                 added_tool->link->last_processed = calendar::turn;
-                added_tool->link->t_veh_safe = get_map().veh_at( player_character.pos() + tripoint_north )->vehicle().get_safe_reference();
+                added_tool->link->t_veh_safe = get_map().veh_at( player_character.pos() +
+                                               tripoint_north )->vehicle().get_safe_reference();
                 added_tool->set_link_traits();
                 REQUIRE( added_tool->link->t_veh_safe );
             }
@@ -427,7 +428,7 @@ static void grant_profs_to_character( Character &you, const recipe &r )
 }
 
 static void prep_craft( const recipe_id &rid, const std::vector<item> &tools,
-                        bool expect_craftable, int offset = 0, bool grant_profs = false )
+                        bool expect_craftable, int offset = 0, bool grant_profs = false, bool plug_in_tools = true )
 {
     clear_avatar();
     clear_map();
@@ -448,7 +449,7 @@ static void prep_craft( const recipe_id &rid, const std::vector<item> &tools,
     optional_vpart_position battery_part = get_map().veh_at( battery_pos );
     REQUIRE( battery_part.has_value() );
 
-    give_tools( tools );
+    give_tools( tools, plug_in_tools );
     const inventory &crafting_inv = player_character.crafting_inventory();
 
     bool can_craft_with_crafting_inv = r.deduped_requirements()
@@ -561,7 +562,7 @@ TEST_CASE( "proficiency_gain_short_crafts", "[crafting][proficiency]" )
 
     do {
         turns_taken += test_craft_for_prof( rec, proficiency_prof_carving, 1.0f );
-        give_tools( tools );
+        give_tools( tools, true );
 
         // Escape door to avoid infinite loop if there is no progress
         REQUIRE( turns_taken < max_turns );
@@ -860,7 +861,7 @@ TEST_CASE( "tools_use_charge_to_craft", "[crafting][charge]" )
             tools.push_back( plastic_molding );
 
             THEN( "crafting succeeds, and uses charges from each tool" ) {
-                prep_craft( recipe_carver_off, tools, true );
+                prep_craft( recipe_carver_off, tools, true, 0, false, false );
                 int turns = actually_test_craft( recipe_carver_off, INT_MAX );
                 CAPTURE( turns );
                 CHECK( get_remaining_charges( "hotplate_induction" ) == 0 );
@@ -874,7 +875,7 @@ TEST_CASE( "tools_use_charge_to_craft", "[crafting][charge]" )
             tools.insert( tools.end(), 1, tool_with_ammo( "vac_mold", 4 ) );
 
             THEN( "crafting succeeds, and uses charges from multiple tools" ) {
-                prep_craft( recipe_carver_off, tools, true );
+                prep_craft( recipe_carver_off, tools, true, 0, false, false );
                 actually_test_craft( recipe_carver_off, INT_MAX );
                 CHECK( get_remaining_charges( "hotplate_induction" ) == 0 );
                 CHECK( get_remaining_charges( "soldering_iron" ) == 0 );
@@ -896,7 +897,7 @@ TEST_CASE( "tools_use_charge_to_craft", "[crafting][charge]" )
             tools.push_back( tool_with_ammo( "vac_mold", 4 ) );
 
             THEN( "crafting succeeds, and uses charges from the UPS" ) {
-                prep_craft( recipe_carver_off, tools, true );
+                prep_craft( recipe_carver_off, tools, true, 0, false, false );
                 actually_test_craft( recipe_carver_off, INT_MAX );
                 CHECK( get_remaining_charges( "hotplate" ) == 0 );
                 CHECK( get_remaining_charges( "soldering_iron" ) == 0 );
@@ -919,7 +920,7 @@ TEST_CASE( "tools_use_charge_to_craft", "[crafting][charge]" )
             tools.push_back( ups );
 
             THEN( "crafting fails, and no charges are used" ) {
-                prep_craft( recipe_carver_off, tools, false );
+                prep_craft( recipe_carver_off, tools, false, 0, false, false );
                 CHECK( get_remaining_charges( "UPS_off" ) == 10 );
             }
         }
@@ -1191,7 +1192,7 @@ static void test_skill_progression( const recipe_id &test_recipe, int expected_t
             REQUIRE( previous_knowledge < new_knowledge );
             previous_knowledge = new_knowledge;
         }
-        give_tools( tools );
+        give_tools( tools, true );
     } while( static_cast<int>( you.get_skill_level( skill_used ) ) == starting_skill_level );
     CAPTURE( test_recipe.str() );
     CAPTURE( expected_turns_taken );
@@ -1355,7 +1356,7 @@ TEST_CASE( "book_proficiency_mitigation", "[crafting][proficiency]" )
         WHEN( "player has a book mitigating lack of proficiency" ) {
             std::vector<item> books;
             books.emplace_back( "manual_tailor" );
-            give_tools( books );
+            give_tools( books, true );
             get_player_character().invalidate_crafting_inventory();
             int mitigated_time_taken = test_recipe.batch_time( get_player_character(), 1, 1, 0 );
             THEN( "it takes less time to craft the recipe" ) {

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -446,8 +446,6 @@ static void prep_craft( const recipe_id &rid, const std::vector<item> &tools,
     const tripoint battery_pos = test_origin + tripoint_north;
     std::optional<item> battery_item( "test_storage_battery" );
     place_appliance( battery_pos, vpart_ap_test_storage_battery, battery_item );
-    optional_vpart_position battery_part = get_map().veh_at( battery_pos );
-    REQUIRE( battery_part.has_value() );
 
     give_tools( tools, plug_in_tools );
     const inventory &crafting_inv = player_character.crafting_inventory();

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -17,14 +17,17 @@
 #include "ret_val.h"
 #include "type_id.h"
 #include "units.h"
+#include "veh_appliance.h"
 #include "veh_type.h"
 #include "vehicle.h"
 
 static const skill_id skill_mechanics( "mechanics" );
 
+static const vpart_id vpart_ap_test_storage_battery( "ap_test_storage_battery" );
+
 static const vproto_id vehicle_prototype_car( "car" );
 
-static void test_repair( const std::vector<item> &tools, bool expect_craftable )
+static void test_repair( const std::vector<item> &tools, bool plug_in_tools, bool expect_craftable )
 {
     clear_avatar();
     clear_map();
@@ -34,8 +37,23 @@ static void test_repair( const std::vector<item> &tools, bool expect_craftable )
     player_character.setpos( test_origin );
     const item debug_backpack( "debug_backpack" );
     player_character.wear_item( debug_backpack );
+
+    const tripoint battery_pos = test_origin + tripoint_north_west;
+    std::optional<item> battery_item( "test_storage_battery" );
+    place_appliance( battery_pos, vpart_ap_test_storage_battery, battery_item );
+
     for( const item &gear : tools ) {
-        player_character.i_add( gear );
+        item_location added_tool = player_character.i_add( gear );
+        if( plug_in_tools && added_tool->can_link_up() ) {
+            added_tool->link = cata::make_value<item::link_data>();
+            added_tool->link->t_state = link_state::vehicle_port;
+            added_tool->link->t_abs_pos = get_map().getglobal( player_character.pos() + tripoint_north_west );
+            added_tool->link->last_processed = calendar::turn;
+            added_tool->link->t_veh_safe = get_map().veh_at( player_character.pos() +
+                                           tripoint_north_west )->vehicle().get_safe_reference();
+            added_tool->set_link_traits();
+            REQUIRE( added_tool->link->t_veh_safe );
+        }
     }
     player_character.set_skill_level( skill_mechanics, 10 );
 
@@ -87,7 +105,7 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
         tools.emplace_back( "hammer" );
         tools.insert( tools.end(), 20, item( "steel_chunk" ) );
         tools.insert( tools.end(), 200, item( "welding_wire_steel" ) );
-        test_repair( tools, true );
+        test_repair( tools, true, true );
     }
     SECTION( "UPS_modded_welder" ) {
         std::vector<item> tools;
@@ -105,7 +123,7 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
         tools.emplace_back( "hammer" );
         tools.insert( tools.end(), 5, item( "steel_chunk" ) );
         tools.insert( tools.end(), 50, item( "welding_wire_steel" ) );
-        test_repair( tools, true );
+        test_repair( tools, false, true );
     }
     SECTION( "welder_missing_goggles" ) {
         std::vector<item> tools;
@@ -119,7 +137,7 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
         tools.emplace_back( "hammer" );
         tools.insert( tools.end(), 5, item( "steel_chunk" ) );
         tools.insert( tools.end(), 50, item( "welding_wire_steel" ) );
-        test_repair( tools, false );
+        test_repair( tools, true, false );
     }
     SECTION( "welder_missing_charge" ) {
         std::vector<item> tools;
@@ -134,7 +152,7 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
         tools.emplace_back( "hammer" );
         tools.insert( tools.end(), 5, item( "steel_chunk" ) );
         tools.insert( tools.end(), 50, item( "welding_wire_steel" ) );
-        test_repair( tools, false );
+        test_repair( tools, false, false );
     }
     SECTION( "UPS_modded_welder_missing_charges" ) {
         std::vector<item> tools;
@@ -151,7 +169,7 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
         tools.emplace_back( "goggles_welding" );
         tools.insert( tools.end(), 5, item( "steel_chunk" ) );
         tools.insert( tools.end(), 50, item( "welding_wire_steel" ) );
-        test_repair( tools, false );
+        test_repair( tools, false, false );
     }
     SECTION( "welder_missing_consumables" ) {
         std::vector<item> tools;
@@ -163,6 +181,6 @@ TEST_CASE( "repair_vehicle_part", "[vehicle]" )
         tools.push_back( welder );
 
         tools.emplace_back( "goggles_welding" );
-        test_repair( tools, false );
+        test_repair( tools, true, false );
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Plug in tools with cables during crafting tests"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Crafting tests currently have no way of handling tools that don't run on batteries, which has caused problems for #69965.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
`prep_craft` now places a very large test battery adjacent to the player, and if `give_tools` provides a tool that can plug in it will be attached to the battery, which allows the tool to be used.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
The lines of code establishing a new link should really be made into a dedicated function, since it's being reused in a number of places. Better to do a separate PR for that, though.

It'd be worth adding another test for checking that using plugged in tools uses up charges of the linked battery. I'd want to wait until after #69965 to do that, though.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Ran `repair_vehicle_part` and all `[crafting]` tests, all green.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
