### PR TITLE
[Xedra Evolved] Fix Arvore mutation regressions

### DIFF
--- a/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
+++ b/data/mods/Xedra_Evolved/mutations/paraclesians/arvore_mutations.json
@@ -195,7 +195,14 @@
     "points": 3,
     "visibility": 0,
     "ugliness": 0,
-    "prereqs": [ "ARVORE_SUN_NUTRIENTS_AND_MANA", "ARVORE_SUN_NUTRIENTS_AND_MANA_ON" ],
+    "prereqs": [
+      "ARVORE_SUN_NUTRIENTS_AND_MANA",
+      "ARVORE_SUN_NUTRIENTS_AND_MANA_ON",
+      "ARVORE_SUN_MANA_BONUS",
+      "ARVORE_SUN_MANA_BONUS_ON",
+      "ARVORE_SUN_POWER_MANA_STATS",
+      "ARVORE_SUN_POWER_MANA_STATS_ON"
+    ],
     "description": "Upon gaining this ability the Arvore gains the ability to bind their soul to the heart of the forest, rebirthing themselves when on the verge of death.",
     "category": [ "ARVORE" ],
     "threshreq": [ "THRESH_ARVORE" ],
@@ -208,6 +215,7 @@
     "points": 3,
     "visibility": 0,
     "ugliness": 0,
+    "valid": false,
     "description": "You have bound your soul to the forest, and death will merely be a momentary inconvenience.",
     "category": [ "ARVORE" ],
     "threshreq": [ "THRESH_ARVORE" ]
@@ -224,7 +232,11 @@
       "ARVORE_SUN_NUTRIENTS",
       "ARVORE_SUN_NUTRIENTS_ON",
       "ARVORE_SUN_NUTRIENTS_AND_MANA",
-      "ARVORE_SUN_NUTRIENTS_AND_MANA_ON"
+      "ARVORE_SUN_NUTRIENTS_AND_MANA_ON",
+      "ARVORE_SUN_MANA_BONUS",
+      "ARVORE_SUN_MANA_BONUS_ON",
+      "ARVORE_SUN_POWER_MANA_STATS",
+      "ARVORE_SUN_POWER_MANA_STATS_ON"
     ],
     "description": "Upon gaining this ability the Arvore gains the ability to infuse their companions with the vitality of the forest.",
     "category": [ "ARVORE" ],
@@ -489,7 +501,7 @@
     "visibility": 1,
     "types": [ "PAIN" ],
     "description": "Filled with the energy of life, pain does not affect you as strongly.",
-    "prereqs": [ "ARVORE_SKIN_1" ],
+    "prereqs": [ "ARVORE_SKIN_1", "ARVORE_SKIN_2", "ARVORE_SKIN_3" ],
     "prereqs2": [ "ARVORE_NURTURING_THE_GREEN" ],
     "category": [ "ARVORE" ],
     "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "PAIN", "multiply": -0.25 } ] } ]
@@ -502,7 +514,7 @@
     "active": true,
     "description": "At will, you can transform your hands into jagged wooden claws.  They are potent weapons but make anything other than combat more difficult.",
     "types": [ "CLAWS" ],
-    "prereqs": [ "ARVORE_SKIN_2" ],
+    "prereqs": [ "ARVORE_SKIN_2", "ARVORE_SKIN_3" ],
     "category": [ "ARVORE" ],
     "transform": {
       "target": "ARVORE_WOOD_CLAWS_active",
@@ -521,7 +533,7 @@
     "ugliness": 2,
     "description": "Your hands are transformed into jagged wooden claws.  You can use them to attack, but performing mundane tasks will be harder.",
     "types": [ "CLAWS" ],
-    "prereqs": [ "ARVORE_SKIN_2" ],
+    "prereqs": [ "ARVORE_SKIN_2", "ARVORE_SKIN_3" ],
     "category": [ "ARVORE" ],
     "transform": {
       "target": "ARVORE_WOOD_CLAWS",
@@ -594,7 +606,7 @@
     "visibility": 0,
     "ugliness": 0,
     "prereqs": [ "ARVORE_STR_BONUS_1" ],
-    "prereqs2": [ "ARVORE_SKIN_1" ],
+    "prereqs2": [ "ARVORE_SKIN_1", "ARVORE_SKIN_2", "ARVORE_SKIN_3" ],
     "changes_to": [ "ARVORE_STR_BONUS_3" ],
     "description": "Like the young tree reaching for the sun, your limbs are filled with power.  +3 Strength.",
     "category": [ "ARVORE" ],
@@ -608,7 +620,7 @@
     "visibility": 0,
     "ugliness": 0,
     "prereqs": [ "ARVORE_STR_BONUS_2" ],
-    "prereqs2": [ "ARVORE_SKIN_2" ],
+    "prereqs2": [ "ARVORE_SKIN_2", "ARVORE_SKIN_3" ],
     "description": "Like forest giants that have stood for a hundred years, you are unshakeable.  +5 Strength.",
     "category": [ "ARVORE" ],
     "passive_mods": { "str_mod": 5 }
@@ -963,7 +975,7 @@
     "visibility": 0,
     "ugliness": 0,
     "description": "When in wild areas, you can draw on the revitalizing power of the land to heal yourself.  When in natural areas, your limbs will heal much faster.",
-    "prereqs": [ "ARVORE_SKIN_2" ],
+    "prereqs": [ "ARVORE_SKIN_2", "ARVORE_SKIN_3" ],
     "prereqs2": [ "ARVORE_VERDANT_INFUSION" ],
     "category": [ "ARVORE" ],
     "threshreq": [ "THRESH_ARVORE" ],
@@ -1096,6 +1108,7 @@
     "restricts_gear": [ "head", "torso", "arm_l", "arm_r", "leg_r", "leg_l" ],
     "remove_rigid": [ "head", "torso", "arm_l", "arm_r", "leg_r", "leg_l" ],
     "allow_soft_gear": true,
+    "valid": false,
     "category": [ "ARVORE" ],
     "threshreq": [ "THRESH_ARVORE" ],
     "metabolism_modifier": -0.5,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "[Xedra Evolved] Fix Arvore mutation regressions"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Someone mentioned that they were suffering Arvore mutation regressions and mutating into mutations that were used as part of other mutations--mutating directly into a tree, for example, instead of the mutation that allows you to turn into a tree.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Fix the prereqs, add valid: false to mutations that should not be able to be mutated.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Took a ton of destiny draughts and mutated all the mutations, no regressions observed. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
