### PR TITLE
Removing gun- or toolmods with `pocket_mods` updates the pockets

### DIFF
--- a/data/mods/TEST_DATA/pocket_mods_test.json
+++ b/data/mods/TEST_DATA/pocket_mods_test.json
@@ -5,22 +5,23 @@
       "change existing magazine well": {
         "base_item": "debug_gun_with_mag_well",
         "mod_item": "debug_retool_mag_well",
-        "expected_pockets": { "MAGAZINE_WELL": 1 }
+        "//": "array values are before/after mod insertion",
+        "expected_pockets": { "MAGAZINE_WELL": [ 1, 1 ] }
       },
       "add magazine well to item without one": {
         "base_item": "debug_gun_no_mag_well",
         "mod_item": "debug_retool_mag_well",
-        "expected_pockets": { "MAGAZINE_WELL": 1 }
+        "expected_pockets": { "MAGAZINE_WELL": [ 0, 1 ] }
       },
       "add pocket to pocketless tool": {
         "base_item": "debug_tool_no_pockets",
         "mod_item": "debug_retool_container_no_mag_well",
-        "expected_pockets": { "CONTAINER": 1 }
+        "expected_pockets": { "CONTAINER": [ 0, 1 ] }
       },
       "add pocket to tool with pocket": {
         "base_item": "debug_tool_one_pocket",
         "mod_item": "debug_retool_container_no_mag_well",
-        "expected_pockets": { "CONTAINER": 2 }
+        "expected_pockets": { "CONTAINER": [ 1, 2 ] }
       }
     }
   },

--- a/src/test_data.h
+++ b/src/test_data.h
@@ -46,7 +46,7 @@ struct container_spawn_test_data {
 struct pocket_mod_test_data {
     itype_id base_item;
     itype_id mod_item;
-    std::map<pocket_type, uint64_t> expected_pockets;
+    std::map<pocket_type, std::vector<uint64_t>> expected_pockets;
 
     void deserialize( const JsonObject &jo );
 };

--- a/src/visitable.cpp
+++ b/src/visitable.cpp
@@ -566,6 +566,11 @@ std::list<item> item::remove_items_with( const std::function<bool( const item &e
     }
 
     contents.remove_internal( filter, count, res );
+
+    // updating pockets is only necessary when removing mods,
+    // but no way to determine where something got removed here
+    update_modified_pockets();
+
     return res;
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Removing a mod with `pocket_mods` didn't update the pockets, that only happened when inserting mods or loading a save.

#### Describe the solution

For a lack of determining what kind of pocket an item was removed from, update pockets when removing any item from any pocket.

#### Describe alternatives you've considered



#### Testing

Extended the test to also cover removing the mod again and it passes locally.

#### Additional context

