### PR TITLE
Corrected excercise correlation to base camp food consumption

### DIFF
--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -85,13 +85,15 @@ std::string base_camps::faction_decode( const std::string_view full_type )
     return std::string{ full_type.substr( prefix_len, size_t( last_bar - prefix_len ) ) };
 }
 
+const time_duration work_day_hours_time = work_day_hours * 1_hours;
+
 time_duration base_camps::to_workdays( const time_duration &work_time )
 {
-    if( work_time < 11_hours ) {
+    if( work_time < ( work_day_hours + 1 ) * 1_hours ) {
         return work_time;
     }
-    int work_days = work_time / 10_hours;
-    time_duration excess_time = work_time - work_days * 10_hours;
+    int work_days = work_time / work_day_hours_time;
+    time_duration excess_time = work_time - work_days * work_day_hours_time;
     return excess_time + 24_hours * work_days;
 }
 

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -85,7 +85,7 @@ std::string base_camps::faction_decode( const std::string_view full_type )
     return std::string{ full_type.substr( prefix_len, size_t( last_bar - prefix_len ) ) };
 }
 
-const time_duration work_day_hours_time = work_day_hours * 1_hours;
+static const time_duration work_day_hours_time = work_day_hours * 1_hours;
 
 time_duration base_camps::to_workdays( const time_duration &work_time )
 {

--- a/src/basecamp.h
+++ b/src/basecamp.h
@@ -35,6 +35,10 @@ class mission_data;
 class recipe;
 class tinymap;
 
+const int work_day_hours = 10;
+const int work_day_rest_hours = 8;
+const int work_day_idle_hours = 6;
+
 struct expansion_data {
     std::string type;
     std::vector<itype_id> available_pseudo_items;
@@ -319,11 +323,11 @@ class basecamp
                                const std::vector<item *> &equipment, float exertion_level,
                                const std::map<skill_id, int> &required_skills = {} );
         comp_list start_multi_mission( const mission_id &miss_id,
-                                       bool must_feed, const std::string &desc, float exertion_level,
+                                       bool must_feed, const std::string &desc,
                                        // const std::vector<item*>& equipment, //  No support for extracting equipment from recipes currently..
                                        const skill_id &skill_tested, int skill_level );
         comp_list start_multi_mission( const mission_id &miss_id,
-                                       bool must_feed, const std::string &desc, float exertion_level,
+                                       bool must_feed, const std::string &desc,
                                        //  const std::vector<item*>& equipment, //  No support for extracting equipment from recipes currently..
                                        const std::map<skill_id, int> &required_skills = {} );
         void start_upgrade( const mission_id &miss_id );
@@ -332,7 +336,7 @@ class basecamp
         void start_menial_labor();
         void worker_assignment_ui();
         void job_assignment_ui();
-        void start_crafting( const std::string &type, const mission_id &miss_id, float exertion_level );
+        void start_crafting( const std::string &type, const mission_id &miss_id );
 
         /// Called when a companion is sent to cut logs
         void start_cut_logs( const mission_id &miss_id, float exertion_level );

--- a/src/character_oracle.cpp
+++ b/src/character_oracle.cpp
@@ -42,7 +42,7 @@ status_t character_oracle_t::needs_water_badly( const std::string_view ) const
 status_t character_oracle_t::needs_food_badly( const std::string_view ) const
 {
     // Check hunger threshold.
-    if( subject->get_hunger() >= 300 && subject->get_starvation() > 2500 ) {
+    if( subject->get_hunger() >= 300 && subject->get_starvation() > base_metabolic_rate ) {
         return status_t::running;
     }
     return status_t::success;

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -307,9 +307,11 @@ static std::string camp_trip_description( const time_duration &total_time,
         const time_duration &travel_time,
         int distance, int trips, int need_food );
 
+/// The number of days the current camp supplies lasts at the given exertion level.
+static int camp_food_supply_days( float exertion_level );
 /// Changes the faction food supply by @ref change, 0 returns total food supply, a negative
 /// total food supply hurts morale
-static int camp_food_supply( int change = 0, bool return_days = false );
+static int camp_food_supply( int change = 0 );
 /// Same as above but takes a time_duration and consumes from faction food supply for that
 /// duration of work
 static int camp_food_supply( time_duration work, float exertion_level = NO_EXERCISE );
@@ -802,8 +804,8 @@ void basecamp::get_available_missions_by_dir( mission_data &mission_key, const p
                 const recipe &making = *recipe_id( miss_id.parameters );
                 const int foodcost = time_to_food( base_camps::to_workdays( time_duration::from_moves(
                                                        making.blueprint_build_reqs().reqs_by_parameters.find( miss_id.mapgen_args )->second.time ) ),
-                                                   BRISK_EXERCISE );
-                const int available_calories = camp_food_supply( 0, false );
+                                                   making.exertion_level() );
+                const int available_calories = camp_food_supply( );
                 bool can_upgrade = upgrade.avail;
                 entry = om_upgrade_description( upgrade.bldg, upgrade.args );
                 if( foodcost > available_calories ) {
@@ -1462,8 +1464,10 @@ void basecamp::get_available_missions( mission_data &mission_key, map &here )
                                       "> Rotten: 0%%\n"
                                       "> Rots in < 2 days: 60%%\n"
                                       "> Rots in < 5 days: 80%%\n\n"
-                                      "Total faction food stock: %d kcal\nor %d day's rations" ),
-                                   camp_food_supply(), camp_food_supply( 0, true ) );
+                                      "Total faction food stock: %d kcal\nor %d / %d / %d day's rations\n"
+                                      "where the days is measured for Extra / Moderate / No exercise levels" ),
+                                   camp_food_supply(), camp_food_supply_days( EXTRA_EXERCISE ),
+                                   camp_food_supply_days( MODERATE_EXERCISE ), camp_food_supply_days( NO_EXERCISE ) );
             mission_key.add( { miss_id, false }, name_display_of( miss_id ),
                              entry );
         }
@@ -1719,8 +1723,8 @@ bool basecamp::handle_mission( const ui_mission_id &miss_id )
                                          msg,
                                          skill_construction.str(), 2 );
             } else {
-                start_crafting( recipe_group::get_building_of_recipe( miss_id.id.parameters ), miss_id.id,
-                                MODERATE_EXERCISE );
+                const std::string bldg = recipe_group::get_building_of_recipe( miss_id.id.parameters );
+                start_crafting( recipe_group::get_building_of_recipe( miss_id.id.parameters ), miss_id.id );
             }
             break;
 
@@ -1933,17 +1937,17 @@ npc_ptr basecamp::start_mission( const mission_id &miss_id, time_duration durati
 }
 
 comp_list basecamp::start_multi_mission( const mission_id &miss_id,
-        bool must_feed, const std::string &desc, float exertion_level,
+        bool must_feed, const std::string &desc,
         // const std::vector<item*>& equipment, //  No support for extracting equipment from recipes currently..
         const skill_id &skill_tested, int skill_level )
 {
     std::map<skill_id, int> required_skills;
     required_skills[skill_tested] = skill_level;
-    return start_multi_mission( miss_id, must_feed, desc, exertion_level, required_skills );
+    return start_multi_mission( miss_id, must_feed, desc, required_skills );
 }
 
 comp_list basecamp::start_multi_mission( const mission_id &miss_id,
-        bool must_feed, const std::string &desc, float exertion_level,
+        bool must_feed, const std::string &desc,
         // const std::vector<item*>& equipment, //  No support for extracting equipment from recipes currently..
         const std::map<skill_id, int> &required_skills )
 {
@@ -1961,7 +1965,7 @@ comp_list basecamp::start_multi_mission( const mission_id &miss_id,
         work_days = base_camps::to_workdays( base_time / ( result.size() + 1 ) );
 
         if( must_feed &&
-            camp_food_supply() < time_to_food( work_days * ( result.size() + 1 ), exertion_level ) ) {
+            camp_food_supply() < time_to_food( work_days * ( result.size() + 1 ), making.exertion_level() ) ) {
             if( result.empty() ) {
                 popup( _( "You don't have enough food stored to feed your companion for this task." ) );
                 return result;
@@ -1993,7 +1997,7 @@ comp_list basecamp::start_multi_mission( const mission_id &miss_id,
             comp->companion_mission_time_ret = calendar::turn + work_days;
         }
         if( must_feed ) {
-            camp_food_supply( work_days * result.size(), exertion_level );
+            camp_food_supply( work_days * result.size(), making.exertion_level() );
         }
         return result;
     }
@@ -2028,15 +2032,14 @@ void basecamp::start_upgrade( const mission_id &miss_id )
         if( bld_reqs.skills.empty() ) {
             if( making.skill_used.is_valid() ) {
                 comp = start_multi_mission( miss_id, must_feed,
-                                            _( "begins to upgrade the camp…" ), BRISK_EXERCISE,
+                                            _( "begins to upgrade the camp…" ),
                                             making.skill_used, making.difficulty );
             } else {
                 comp = start_multi_mission( miss_id, must_feed,
-                                            _( "begins to upgrade the camp…" ), BRISK_EXERCISE );
+                                            _( "begins to upgrade the camp…" ) );
             }
         } else {
             comp = start_multi_mission( miss_id, must_feed, _( "begins to upgrade the camp…" ),
-                                        BRISK_EXERCISE,
                                         bld_reqs.skills );
         }
         if( comp.empty() ) {
@@ -2923,11 +2926,11 @@ bool basecamp::common_salt_water_pipe_construction(
 
     if( segment_number == 0 ) {
         comp = start_multi_mission( miss_id, true,
-                                    _( "Start constructing salt water pipes…" ), BRISK_EXERCISE,
+                                    _( "Start constructing salt water pipes…" ),
                                     making.required_skills );
     } else {
         comp = start_multi_mission( miss_id, true,
-                                    _( "Continue constructing salt water pipes…" ), BRISK_EXERCISE,
+                                    _( "Continue constructing salt water pipes…" ),
                                     making.required_skills );
     }
 
@@ -3191,8 +3194,7 @@ void basecamp::start_combat_mission( const mission_id &miss_id, float exertion_l
 // and then search for the mission id without direction prefix in the recipes
 // if there's a match, the player has selected a crafting mission
 
-void basecamp::start_crafting( const std::string &type, const mission_id &miss_id,
-                               float exertion_level )
+void basecamp::start_crafting( const std::string &type, const mission_id &miss_id )
 {
     const std::map<recipe_id, translation> &recipes = recipe_deck( type );
     const auto it = recipes.find( recipe_id( miss_id.parameters ) );
@@ -3229,7 +3231,7 @@ void basecamp::start_crafting( const std::string &type, const mission_id &miss_i
         time_duration work_days = base_camps::to_workdays( making.batch_duration( get_player_character(),
                                   batch_size ) );
         npc_ptr comp = start_mission( miss_id, work_days, true,
-                                      _( "begins to work…" ), false, {}, exertion_level,
+                                      _( "begins to work…" ), false, {}, making.exertion_level(),
                                       making.required_skills );
         if( comp != nullptr ) {
             components.consume_components();
@@ -4089,7 +4091,7 @@ void basecamp::recruit_return( const mission_id &miss_id, int score )
         description += _( "Asking for:\n" );
         description += string_format( _( "> Food:     %10d days\n\n" ), food_desire );
         description += string_format( _( "Faction Food:%9d days\n\n" ),
-                                      camp_food_supply( 0, true ) );
+                                      camp_food_supply_days( NO_EXERCISE ) );
         description += string_format( _( "Recruit Chance: %10d%%\n\n" ),
                                       std::min( 100 * ( 10 + appeal ) / 20, 100 ) );
         description += _( "Select an option:" );
@@ -4106,7 +4108,7 @@ void basecamp::recruit_return( const mission_id &miss_id, int score )
             return;
         }
 
-        if( rec_m == 0 && food_desire + 1 <= camp_food_supply( 0, true ) ) {
+        if( rec_m == 0 && food_desire + 1 <= camp_food_supply_days( NO_EXERCISE ) ) {
             food_desire++;
             appeal++;
         }
@@ -5253,7 +5255,15 @@ std::string basecamp::farm_description( const tripoint_abs_omt &farm_pos, size_t
 }
 
 // food supply
-int camp_food_supply( int change, bool return_days )
+
+int camp_food_supply_days( float exertion_level )
+{
+    faction *yours = get_player_character().get_faction();
+
+    return yours->food_supply / time_to_food( 24_hours, exertion_level );
+}
+
+int camp_food_supply( int change )
 {
     faction *yours = get_player_character().get_faction();
     yours->food_supply += change;
@@ -5262,9 +5272,6 @@ int camp_food_supply( int change, bool return_days )
         yours->respects_u += yours->food_supply / 625;
         yours->trusts_u += yours->food_supply / 625;
         yours->food_supply = 0;
-    }
-    if( return_days ) {
-        return yours->food_supply / 2500;
     }
 
     return yours->food_supply;
@@ -5277,7 +5284,11 @@ int camp_food_supply( time_duration work, float exertion_level )
 
 int time_to_food( time_duration work, float exertion_level )
 {
-    return ( 2500 * exertion_level ) * to_hours<int>( work ) / 24;
+    const int days = to_hours<int>( work ) / 24;
+    const int work_time = days * work_day_hours + to_hours<int>( work ) - days * 24;
+
+    return base_metabolic_rate * ( work_time * exertion_level + days * work_day_rest_hours * NO_EXERCISE
+                                   + days * work_day_idle_hours * SLEEP_EXERCISE ) / 24;
 }
 
 static const npc &getAverageJoe()

--- a/src/itype.h
+++ b/src/itype.h
@@ -114,6 +114,9 @@ struct islot_tool {
     std::vector<int> rand_charges;
 };
 
+constexpr float base_metabolic_rate =
+    2500.0f;  // kcal / day, standard average for human male, but game does not differentiate genders here.
+
 struct islot_comestible {
     public:
         friend Item_factory;
@@ -179,7 +182,7 @@ struct islot_comestible {
         int monotony_penalty = 2;
 
         /** 1 nutr ~= 8.7kcal (1 nutr/5min = 288 nutr/day at 2500kcal/day) */
-        static constexpr float kcal_per_nutr = 2500.0f / ( 12 * 24 );
+        static constexpr float kcal_per_nutr = base_metabolic_rate / ( 12 * 24 );
 
         bool has_calories() const {
             return default_nutrition.calories > 0;

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -4374,7 +4374,8 @@ bool npc::consume_food_from_camp()
     if( get_hunger() > 0 && current_kcals < kcal_threshold ) {
         // Try to eat a bit more than the bare minimum so that we're not eating every 5 minutes
         // but also don't try to eat a week's worth of food in one sitting
-        int desired_kcals = std::min( 2500, std::max( 0, kcal_threshold + 100 - current_kcals ) );
+        int desired_kcals = std::min( static_cast<int>( base_metabolic_rate ), std::max( 0,
+                                      kcal_threshold + 100 - current_kcals ) );
         int kcals_to_eat = std::min( desired_kcals, yours->food_supply );
 
         if( kcals_to_eat > 0 ) {

--- a/src/stomach.cpp
+++ b/src/stomach.cpp
@@ -6,6 +6,7 @@
 
 #include "cata_utility.h"
 #include "character.h"
+#include "itype.h"
 #include "json.h"
 #include "stomach.h"
 #include "units.h"
@@ -373,7 +374,7 @@ void stomach_contents::mod_calories( int kcal )
 void stomach_contents::mod_nutr( int nutr )
 {
     // nutr is legacy type code, this function simply converts old nutrition to new kcal
-    mod_calories( -1 * std::round( nutr * 2500.0f / ( 12 * 24 ) ) );
+    mod_calories( -1 * std::round( nutr * base_metabolic_rate / ( 12 * 24 ) ) );
 }
 
 void stomach_contents::mod_water( const units::volume &h2o )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #69559

i.e. correct the calculation and application of exercise levels to faction camp crafting.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Define base_metabolic_rate as 2500, rather than using the magic number 2500 all over the place, and replace applicable usages of said magic number with the definition.
- Updated the Distribute Food UI to display the number of days the food will last based on three different exertion levels (Extra, Moderate, and Idle).
- Calculated the daily calorie usage for work days based on the time spent at work, idle, and sleeping.
- Applied the above where applicable.
- Replaced hard coded exercise levels on activities and replaced those with the levels defined in the recipes they work on.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Ordered the construction of a chicken coop (livestock 2), which should take just over 6 days and checked that the calorie cost was approximately that of 6 days of medium exercise.
- Debug forwarded time, retrieved the companion, and verified that approximately the specified number of calories had been deducted from the calorie store (no companions are attached to the base camp, so no other consumption should be present).
- Ordered the construction of a hatchet from a bare bones basecamp (has a nice round 3 day production time), and verified the number of calories to consume approximately matched what the recipe exercise level should yield.
- Debug waited 4 days and verified approximately the specified number of calories were removed from the store.
- Looked at the Distribute Food display and verified that the 3 day numbers presented approximately matched what you would expect based on the calorie stores available.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

The updated Distribute Food display:
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/22739822/18af7317-6bb1-4c8f-884b-921cac95abb4)

There's some weird side effect code in the function used for the dual purpose of modifying the current stores and check what they are that looks like is accumulate some sort penalties whenever the stores are insufficient and the operation is called. That's rather weird, as any penalties shouldn't be applied based on call frequency, but either on a regular basis or when the stored results are actually changed.
Regardless, this PR changes the weird behavior slightly by factoring out the stored days logic from the other calorie store logic, thus reducing the frequency with which the side effects are applied somewhat, as they're note applied when the calorie days are checked.
I don't think the logic of the side effect is correct, but on the other side, I don't really understand what it is intended to do.

Note that there are a bunch of hard coded exercise levels left, but those apply to tasks that aren't tied to recipes, and thus don't have any exercise levels to extract from the non existent recipes.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
