### PR TITLE
fix weapon steadiness bar not working

### DIFF
--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1707,7 +1707,7 @@ static std::vector<aim_type_prediction> calculate_ranged_chances(
     const recoil_prediction aim_to_selected = predict_recoil( you, weapon, target,
             ui.get_sight_dispersion(), ui.get_selected_aim_type(), you.recoil );
 
-    const int selected_steadiness = calc_steadiness( you, weapon, pos, aim_to_selected.recoil );
+    const double selected_steadiness = calc_steadiness( you, weapon, pos, aim_to_selected.recoil );
 
     const int throw_moves = throw_cost( you, weapon );
 


### PR DESCRIPTION
fix weapon steadiness bar not working


#### Summary
Bugfixes "fix weapon steadiness bar not working"

#### Purpose of change

Due to a bug the bar only shows up when steadiness is full. Fixes #69954.

#### Describe the solution

Problem was that the calculated steadiness to display was wrongly stored in an int while the calculated value was a double resulting in either empty (0) or full bar (1). 

#### Describe alternatives you've considered

I actually thought that the problem would be way harder to solve

#### Testing

I created a default world spawned myself a gun and now steadiness fills up correctly

#### Additional context


