### PR TITLE
Knife for the knife feral

### DIFF
--- a/data/json/monsterdrops/feral_humans.json
+++ b/data/json/monsterdrops/feral_humans.json
@@ -685,7 +685,7 @@
       { "item": "e_tool", "prob": 15, "damage": [ 1, 4 ] },
       { "item": "mask_gas", "prob": 5, "charges": [ 0, 100 ], "damage": [ 1, 4 ] },
       { "item": "two_way_radio", "prob": 15, "charges": [ 0, 100 ], "damage": [ 1, 4 ] },
-      { "group": "infantry_knives", "prob": 50, "damage": [ 2, 4 ] },
+      { "group": "infantry_knives", "prob": 100, "damage": [ 2, 4 ] },
       { "item": "stanag30", "prob": 50, "ammo-item": "556", "charges": [ 0, 10 ] },
       { "item": "stanag30ranger", "prob": 1, "ammo-item": "556", "charges": [ 0, 30 ] },
       { "item": "stanag30", "prob": 50, "ammo-item": "556", "charges": [ 0, 30 ] }


### PR DESCRIPTION
#### Summary
Bugfixes "Feral soldiers now always drop their knife again"

#### Purpose of change
I noticed while playing that the feral soldier, which has a special knife attack, doesn't has a guaranteed chance of dropping said knife... Even though I remember they always dropping one.

It seems that when #69201 was done the chance was dropped, weapon wielding enemies should always drop the weapon that they use to attack you.

#### Describe the solution
Increased the probability of the ferals dropping their weapon to 100 again.

#### Describe alternatives you've considered

#### Testing

#### Additional context
