### PR TITLE
mapbuffer: fix saving of reverted submaps

### DIFF
--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -342,6 +342,7 @@ void submap::mirror( bool horizontally )
 
 void submap::revert_submap( submap &sr )
 {
+    reverted = true;
     if( sr.is_uniform() ) {
         m.reset();
         set_all_ter( sr.get_ter( point_zero ), true );

--- a/src/submap.h
+++ b/src/submap.h
@@ -295,6 +295,7 @@ class submap
 
         int field_count = 0;
         time_point last_touched = calendar::turn_zero;
+        bool reverted = false; // NOLINT(cata-serialize)
         std::vector<spawn_point> spawns;
         /**
          * Vehicles on this submap (their (0,0) point is on this submap).


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Reverting a submap to a uniform state in a uniform quad makes the mapbuffer ignore it for saving, potentially leaving behind an older copy.

* Fixes: #67781
* Fixes: #64382 (duplicate)

#### Describe the solution
1. Force serialize the reverted-to-uniform quad
2. Delete the quad file

Some platforms (Windows) can fail to delete the file in odd cases so step 1 is there as a backup.

#### Describe alternatives you've considered
Instead of adding a new bool to `submap`, I tried repurposing `last_touched` but that needed a lot more `if`s

#### Testing
From this save [Fort Davis.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/13609022/Fort.Davis.tar.gz):
1. Enter the teleporter
2. Use clairvoyance to verify that the dungeon above you has disappeared
4. Save and reload
5. Repeat step 2

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Thanks a lot to KHeket for figuring out the reproduction steps.


