### PR TITLE
github: enable BACKTRACE in linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,7 +238,7 @@ jobs:
       - name: Build CDDA (linux)
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none' && matrix.artifact != 'linux-objectcreator-x64'
         run: |
-          make -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=0 PCH=0 bindist
+          make -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 PCH=0 bindist
           mv cataclysmdda-0.F.tar.gz cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.tar.gz
       - name: Login to GitHub Container Registry
         if: matrix.artifact == 'windows-objectcreator-x64' || matrix.artifact == 'linux-objectcreator-x64'

--- a/Makefile
+++ b/Makefile
@@ -435,7 +435,7 @@ ifeq ($(RELEASE), 1)
   OTHERS += $(RELEASE_FLAGS)
   DEBUG =
   ifndef DEBUG_SYMBOLS
-    ifeq ($(LIBBACKTRACE), 1)
+    ifeq ($(BACKTRACE), 1)
       DEBUGSYMS = -g1
     else
       DEBUGSYMS =


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Linux builds don't generate crash logs
* Fixes: #53551

#### Describe the solution
Flip the switch. This uses the slow `addr2line` code. We can't use the `libbacktrace` path because no one ships it, unless we include it in the project or use a prebuilt binary like on mingw.

#### Describe alternatives you've considered
N/A

#### Testing
1. Build with `make TILES=1 SOUND=1 RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 PCH=0 bindist` or download a bindist from [here](https://github.com/andrei8l/Cataclysm-DDA/releases/tag/cdda-experimental-2023-12-08-0609).
2. Send a SIGSEGV or a SIGABRT, or use the debug option to crash, or reproduce one of the crashes from the triage list
3. Verify that there's a `config/crash.log` and it contains symbol names and locations 

#### Additional context
This will stay in draft until the release linked above has at least one linux binary