### PR TITLE
Make "wail" sfx only play 1% of the time

### DIFF
--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -627,8 +627,10 @@ bool mattack::shriek_alert( monster *z )
     }
     add_msg_if_player_sees( *z, _( "The %s begins shrieking!" ), z->name() );
     z->moves -= 150;
-    sounds::sound( z->pos(), 120, sounds::sound_t::alert, _( "a piercing wail!" ), false, "shout",
-                   "wail" );
+    if( one_in( 100 ) ) {
+        sounds::sound( z->pos(), 120, sounds::sound_t::alert, _( "a piercing wail!" ), false, "shout",
+                       "wail" );
+    }
     z->add_effect( effect_shrieking, 1_minutes );
 
     return true;
@@ -4579,8 +4581,10 @@ static void parrot_common( monster *parrot )
 bool mattack::parrot( monster *z )
 {
     if( z->has_effect( effect_shrieking ) ) {
-        sounds::sound( z->pos(), 120, sounds::sound_t::alert, _( "a piercing wail!" ), false, "shout",
-                       "wail" );
+        if( one_in( 100 ) ) {
+            sounds::sound( z->pos(), 120, sounds::sound_t::alert, _( "a piercing wail!" ), false, "shout",
+                           "wail" );
+        }
         z->moves -= 40;
         return false;
     } else if( one_in( 20 ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

#### Purpose of change

Scream sfx linked to an attack are awfull because if multiple monster with this attack are around and/or the attack is on a short cool down the game spams the sfx every fraction of a second

#### Describe the solution
use `one_in` to make the soudn sfx only play 1% of the time

#### Describe alternatives you've considered

Literally delete the sfx, there's no way it provides a good experience for anyone

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Seriously should we go through the code and just delete similar sfx?

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
