### PR TITLE
Aftershock combat drugs

### DIFF
--- a/data/mods/Aftershock/EOC/drug_eoc.json
+++ b/data/mods/Aftershock/EOC/drug_eoc.json
@@ -1,0 +1,38 @@
+[
+  {
+    "//": "This ensures the effect dissapears if the player gets hit in combat or the antiseptic wears off",
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_MEDIGEL_REMOVE",
+    "eoc_type": "EVENT",
+    "required_event": "character_loses_effect",
+    "condition": {
+      "and": [
+        { "compare_string": [ "disinfected", { "context_val": "effect" } ] },
+        { "u_has_effect": "afs_medigel_eff", "bodypart": { "context_val": "bodypart" } }
+      ]
+    },
+    "effect": [ { "u_lose_effect": "afs_medigel_eff" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_AFS_MEDIGEL_ADD",
+    "eoc_type": "EVENT",
+    "required_event": "character_gains_effect",
+    "condition": {
+      "and": [ { "u_has_effect": "afs_medigel_eff_trigger" }, { "compare_string": [ "disinfected", { "context_val": "effect" } ] } ]
+    },
+    "effect": [
+      { "set_string_var": { "context_val": "bodypart" }, "target_var": { "u_val": "heal_part" } },
+      { "u_add_effect": "afs_medigel_eff", "duration": "3 days", "target_part": { "u_val": "heal_part" } }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "//": "The instant use effects of stimpacks",
+    "id": "EOC_AFS_STIMPACK",
+    "eoc_type": "EVENT",
+    "required_event": "character_consumes_item",
+    "condition": { "compare_string": [ "afs_stimpack", { "context_val": "itype" } ] },
+    "effect": [ { "math": [ "u_pain()", "-=", "80" ] }, { "math": [ "u_val('stamina')", "+=", "2500" ] } ]
+  }
+]

--- a/data/mods/Aftershock/effects.json
+++ b/data/mods/Aftershock/effects.json
@@ -200,6 +200,31 @@
   },
   {
     "type": "effect_type",
+    "id": "afs_medigel_eff_trigger"
+  },
+  {
+    "type": "effect_type",
+    "id": "afs_combat_stims",
+    "name": [ "Combat Stimulants" ],
+    "desc": [ "You are under the effects of powerful military combat stimulants" ],
+    "rating": "good",
+    "blocks_effects": [ "stim_overdose", "shakes" ],
+    "show_in_info": true
+  },
+  {
+    "type": "effect_type",
+    "id": "afs_medigel_eff",
+    "rating": "good",
+    "name": [ "Medigel" ],
+    "desc": [ "The medical gel applied to your wounds is slowly healing them." ],
+    "main_parts_only": true,
+    "part_descs": true,
+    "max_duration": "4 d",
+    "base_mods": { "healing_rate": [ 4 ], "healing_head": [ 50 ], "healing_torso": [ 150 ] },
+    "scaling_mods": { "healing_rate": [ 2 ] }
+  },
+  {
+    "type": "effect_type",
     "id": "decreased_performance",
     "name": [ "Decreased Performance" ],
     "desc": [ "The performance enhancing drugs slowly wear off and leave you in a state of existential grade hangover." ],

--- a/data/mods/Aftershock/itemgroups/medical_groups.json
+++ b/data/mods/Aftershock/itemgroups/medical_groups.json
@@ -1,0 +1,21 @@
+[
+  {
+    "id": "afs_ifak",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ifak_pouch",
+    "items": [
+      { "item": "medical_tape", "charges": 20 },
+      { "item": "tourniquet_upper" },
+      { "group": "quikclot_bag_plastic_5" },
+      { "item": "bandages", "count": 9 },
+      { "item": "medical_gauze", "count": 3 },
+      { "item": "afs_medigel" },
+      { "item": "afs_painkiller" },
+      { "item": "afs_stimpack" },
+      { "item": "syringe" },
+      { "item": "gloves_medical" },
+      { "item": "scissors_medical" }
+    ]
+  }
+]

--- a/data/mods/Aftershock/itemgroups/vending_machine_group.json
+++ b/data/mods/Aftershock/itemgroups/vending_machine_group.json
@@ -18,6 +18,7 @@
       { "group": "drugs_soldier", "prob": 40, "count-min": 5, "count-max": 25 },
       { "group": "drugs_soldier", "prob": 40, "count-min": 5, "count-max": 25 },
       { "item": "afs_synth_blood", "prob": 40, "count-min": 1, "count-max": 5 },
+      { "group": "afs_ifak", "prob": 40, "count-min": 1, "count-max": 2 },
       { "group": "harddrugs", "prob": 10, "count-min": 5, "count-max": 25 }
     ]
   },

--- a/data/mods/Aftershock/items/comestibles/medicine.json
+++ b/data/mods/Aftershock/items/comestibles/medicine.json
@@ -27,5 +27,74 @@
       "effects": [ { "id": "synth_blood_perf", "duration": 28800 } ],
       "vitamins": [ [ "blood", 2500, 2500 ], [ "redcells", 2500, 2500 ] ]
     }
+  },
+  {
+    "id": "afs_painkiller",
+    "type": "COMESTIBLE",
+    "comestible_type": "MED",
+    "name": { "str": "serendipnol" },
+    "description": "A very strong, synthetic narcotic built from alien biochemistry and used to treat intense pain while in the field.  You'll need to inject it, and it's very addictive, so be careful.",
+    "weight": "1 g",
+    "volume": "1 ml",
+    "price": "122 cent",
+    "price_postapoc": "1 USD",
+    "symbol": "!",
+    "color": "yellow",
+    "container": "test_tube",
+    "fun": 6,
+    "flags": [ "NO_INGEST", "EDIBLE_FROZEN" ],
+    "addiction_potential": 10,
+    "addiction_type": "opiate",
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You shoot up.",
+      "tools_needed": { "syringe": -1 },
+      "effects": [ { "id": "pkill3", "duration": "40 minutes" }, { "id": "pkill2", "duration": "2 hours" } ]
+    }
+  },
+  {
+    "id": "afs_medigel",
+    "type": "COMESTIBLE",
+    "comestible_type": "MED",
+    "copy-from": "disinfectant",
+    "name": { "str": "MediGel" },
+    "description": "Mercurial brand medical gel; a thick, translucent substance that can be applied to wounds to seal them and promote rapid healing.  Perhaps the most useful medical invention ever devised, it's a staple of any first aid kit.",
+    "price": "200 USD",
+    "price_postapoc": "200 USD",
+    "volume": "10ml",
+    "container": "test_tube",
+    "flags": [ "NO_INGEST", "EDIBLE_FROZEN", "WATER_DISSOLVE" ],
+    "use_action": {
+      "type": "heal",
+      "disinfectant_power": 4,
+      "bite": 0.95,
+      "move_cost": 3000,
+      "infect": 0.1,
+      "effects": [ { "id": "afs_medigel_eff_trigger", "duration": "2 seconds" } ]
+    }
+  },
+  {
+    "id": "afs_stimpack",
+    "type": "COMESTIBLE",
+    "comestible_type": "MED",
+    "name": { "str": "combat stim" },
+    "description": "A small, disposable injector filled with a cocktail of stimulants and painkillers.  Will kick you from death's door into awareness, but it's not a long-term solution.",
+    "weight": "10 g",
+    "volume": "50 ml",
+    "price": "122 cent",
+    "price_postapoc": "1 USD",
+    "symbol": "!",
+    "color": "yellow",
+    "fun": 6,
+    "flags": [ "NO_INGEST", "EDIBLE_FROZEN" ],
+    "addiction_potential": 25,
+    "addiction_type": "amphetamine",
+    "stim": 40,
+    "use_action": {
+      "type": "consume_drug",
+      "activation_message": "You shove the stimpack against your chest.",
+      "moves": 15,
+      "effects": [ { "id": "pkill3", "duration": "40 minutes" }, { "id": "afs_combat_stims", "duration": "40 minutes" } ]
+    }
   }
 ]

--- a/data/mods/Aftershock/items/tools.json
+++ b/data/mods/Aftershock/items/tools.json
@@ -583,6 +583,23 @@
     "melee_damage": { "bash": 9 }
   },
   {
+    "id": "syringe",
+    "type": "TOOL",
+    "name": { "str": "jet injector" },
+    "description": "A compact jet injector from a first aid kit.  A light based assistive injection system allows use without any medical training.",
+    "weight": "4240 mg",
+    "volume": "10ml",
+    "longest_side": "10 cm",
+    "to_hit": { "grip": "none", "length": "hand", "surface": "point", "balance": "neutral" },
+    "price": "2 USD",
+    "price_postapoc": "2 USD",
+    "material": [ "plastic" ],
+    "symbol": ",",
+    "color": "white",
+    "flags": [ "FRAGILE_MELEE" ],
+    "melee_damage": { "stab": 1 }
+  },
+  {
     "id": "diamond_press",
     "type": "GENERIC",
     "category": "tools",

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1128,13 +1128,13 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | character_eats_item |  | { "character", `character_id` },<br/> { "itype", `itype_id` }, | character / NONE |
 | character_finished_activity | Triggered when character finished or canceled activity | { "character", `character_id` },<br/> { "activity", `activity_id` },<br/> { "canceled", `bool` } | character / NONE |
 | character_forgets_spell |  | { "character", `character_id` },<br/> { "spell", `spell_id` } | character / NONE |
-| character_gains_effect |  | { "character", `character_id` },<br/> { "effect", `efftype_id` }, | character / NONE |
+| character_gains_effect |  | { "character", `character_id` },<br/> { "effect", `efftype_id` },<br/> { "bodypart", `bodypart_id` } | character / NONE |
 | character_gets_headshot |  | { "character", `character_id` } | character / NONE |
 | character_heals_damage |  | { "character", `character_id` },<br/> { "damage", `int` }, | character / NONE |
 | character_kills_character |  | { "killer", `character_id` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character / NONE |
 | character_kills_monster |  | { "killer", `character_id` },<br/> { "victim_type", `mtype_id` },<br/> { "exp", `int` }, | character / monster |
 | character_learns_spell |  | { "character", `character_id` },<br/> { "spell", `spell_id` } | character / NONE |
-| character_loses_effect |  | { "character", `character_id` },<br/> { "effect", `efftype_id` }, | character / NONE |
+| character_loses_effect |  | { "character", `character_id` },<br/> { "effect", `efftype_id` },<br/> { "bodypart", `bodypart_id` } | character / NONE |
 | character_melee_attacks_character |  | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "hits", `bool` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character (attacker) / character (victim) |
 | character_melee_attacks_monster | | { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "hits", `bool` },<br/> { "victim_type", `mtype_id` },| character / monster |
 | character_ranged_attacks_character | |  { "attacker", `character_id` },<br/> { "weapon", `itype_id` },<br/> { "victim", `character_id` },<br/> { "victim_name", `string` }, | character (attacker) / character (victim) |

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1741,7 +1741,7 @@ bool Creature::remove_effect( const efftype_id &eff_id, const bodypart_id &bp )
                          type.get_remove_message() );
             }
         }
-        get_event_bus().send<event_type::character_loses_effect>( ch->getID(), eff_id );
+        get_event_bus().send<event_type::character_loses_effect>( ch->getID(), bp.id(), eff_id );
     }
 
     // bp_null means remove all of a given effect id

--- a/src/event.h
+++ b/src/event.h
@@ -371,8 +371,9 @@ struct event_spec<event_type::character_learns_spell> {
 
 template<>
 struct event_spec<event_type::character_loses_effect> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = {{
             { "character", cata_variant_type::character_id },
+            { "bodypart", cata_variant_type::body_part},
             { "effect", cata_variant_type::efftype_id },
         }
     };

--- a/tests/memorial_test.cpp
+++ b/tests/memorial_test.cpp
@@ -134,7 +134,7 @@ TEST_CASE( "memorials", "[memorial]" )
         m, b, "Killed a Kevlar hulk.", ch, mon, 0 );
 
     check_memorial<event_type::character_loses_effect>(
-        m, b, "Put out the fire.", ch, eff );
+        m, b, "Put out the fire.", ch, bodypart_id( "arm_r" ), eff );
 
     check_memorial<event_type::character_triggers_trap>(
         m, b, "Fell in a pit.", ch, tr_pit );


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Add three new combat drugs"

#### Purpose of change

Stuff for sale in the doctor office in #69364. Based on staple sci-fi combat medicine.

#### Describe the solution
This pr adds three items:

- Serendipnol: Just a copy of morphine
- MediGel: Works militarily to disinfectant, but it also grants an additional bonus to the rate at which health regenerates.
- Combat Stimms: Drug that grants you a tenuous second chance if you get badly injured during combat. 

Currently sold within the medicine vending machines of the mod.

#### Testing

Used the drugs