### PR TITLE
Allow use of variants when using add_trait effect

### DIFF
--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2758,7 +2758,7 @@ void talk_effect_fun_t::set_add_trait( const JsonObject &jo, std::string_view me
     }
 
     function = [is_npc, new_trait, new_variant]( dialogue const & d ) {
-        const trait_id trait = trait_id( new_trait.evaluate( d ));
+        const trait_id trait = trait_id( new_trait.evaluate( d ) );
         const mutation_variant *variant = trait->variant( new_variant.evaluate( d ) );
 
         d.actor( is_npc )->set_mutation( trait, variant );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2749,8 +2749,19 @@ void talk_effect_fun_t::set_add_trait( const JsonObject &jo, std::string_view me
                                        bool is_npc )
 {
     str_or_var new_trait = get_str_or_var( jo.get_member( member ), member, true );
-    function = [is_npc, new_trait]( dialogue const & d ) {
-        d.actor( is_npc )->set_mutation( trait_id( new_trait.evaluate( d ) ) );
+    str_or_var new_variant;
+
+    if( jo.has_member( "variant" ) ) {
+        new_variant = get_str_or_var( jo.get_member( "variant" ), "variant", true );
+    } else {
+        new_variant.str_val = "";
+    }
+
+    function = [is_npc, new_trait, new_variant]( dialogue const & d ) {
+        const trait_id trait = trait_id( new_trait.evaluate( d ));
+        const mutation_variant *variant = trait->variant( new_variant.evaluate( d ) );
+
+        d.actor( is_npc )->set_mutation( trait, variant );
     };
 }
 

--- a/src/talker.h
+++ b/src/talker.h
@@ -22,6 +22,7 @@ class Character;
 class recipe;
 struct tripoint;
 class vehicle;
+struct mutation_variant;
 
 using bodytype_id = std::string;
 
@@ -224,7 +225,7 @@ class talker
         virtual void forget_recipe( const recipe_id & ) {}
         virtual void mutate( const int &, const bool & ) {}
         virtual void mutate_category( const mutation_category_id &, const bool & ) {}
-        virtual void set_mutation( const trait_id & ) {}
+        virtual void set_mutation( const trait_id &, const mutation_variant * = nullptr ) {}
         virtual void unset_mutation( const trait_id & ) {}
         virtual void activate_mutation( const trait_id & ) {}
         virtual void deactivate_mutation( const trait_id & ) {}

--- a/src/talker_character.cpp
+++ b/src/talker_character.cpp
@@ -250,9 +250,9 @@ void talker_character::mutate_category( const mutation_category_id &mut_cat,
     me_chr->mutate_category( mut_cat, use_vitamins );
 }
 
-void talker_character::set_mutation( const trait_id &new_trait )
+void talker_character::set_mutation( const trait_id &new_trait, const mutation_variant *variant )
 {
-    me_chr->set_mutation( new_trait );
+    me_chr->set_mutation( new_trait, variant );
 }
 
 void talker_character::unset_mutation( const trait_id &old_trait )

--- a/src/talker_character.h
+++ b/src/talker_character.h
@@ -21,6 +21,8 @@ class time_duration;
 class vehicle;
 struct tripoint;
 
+struct mutation_variant;
+
 /*
  * Talker wrapper class for const Character access.
  * Should never be invoked directly.  Only talker_avatar and talker_npc are really valid.
@@ -236,7 +238,7 @@ class talker_character: public talker_cloner<talker_character, talker_character_
         void set_proficiency_practiced_time( const proficiency_id &prof, int turns ) override;
         void mutate( const int &highest_cat_chance, const bool &use_vitamins ) override;
         void mutate_category( const mutation_category_id &mut_cat, const bool &use_vitamins ) override;
-        void set_mutation( const trait_id &new_trait ) override;
+        void set_mutation( const trait_id &new_trait, const mutation_variant * = nullptr ) override;
         void unset_mutation( const trait_id &old_trait ) override;
         void activate_mutation( const trait_id &trait ) override;
         void deactivate_mutation( const trait_id &trait ) override;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Allow for a "variant" field when using the add_trait effect"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Makes it so you can specify a variant if you are using u_add_trait or npc_add_trait effect.

Closes #70027
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- "variant" is now an optional field for u_add_trait and npc_add_trait
- if variant is invalid/doesn't exist, it is randomized. No errors are thrown
- specifying a variant for a trait that doesn't have them just adds the trait normally

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Used these jsons for testing: [variants_test_eocs.json](https://github.com/CleverRaven/Cataclysm-DDA/files/13620056/variants_test_eocs.json)

1. Added the jsons to data\json\effects_on_condition\mutation_eocs
2. used debug menu to run all the eocs in variants_test_eocs.json

Expected/obtained results for each eoc:

- ```test_add_purple_mohawk```: character gains a purple mohawk
- ```test_add_feline_ears```: character gains feline ears
- ```test_invalid_variant```: character gains short hair, but the color is randomized

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
