### PR TITLE
No sword bayonets on pistols

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -1657,7 +1657,7 @@
     "color": "light_gray",
     "gunmod_data": {
       "location": "bayonet lug",
-      "mod_targets": [ "pistol", "smg", "rifle", "shotgun", "launcher", "crossbow" ],
+      "mod_targets": [ "smg", "rifle", "shotgun", "launcher", "crossbow" ],
       "blacklist_mod": [
         "crafted_suppressor",
         "filter_suppressor",


### PR DESCRIPTION
#### Summary
Bugfixes "No sword bayonets on pistols"

#### Purpose of change

Sword bayonets can be attached to pistols w/ rail bayonet lugs while being over twice as long as them. This is ridiculous.

#### Describe the solution

Remove gun mod compatibility for pistols with sword bayonets.

#### Describe alternatives you've considered

~~Allowing really long barrel pistols to do this for the meme factor~~
Removing ability for the rail bayonet lug to be used on pistols, along with the knife bayonets being attachable to them.
#### Testing

Attempted to attach a sword bayonet to a pocket pistol.

#### Additional context

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/99621099/14bde28e-f7e6-4c65-987d-ed3df1679edf)


