### PR TITLE
Remove choke from HWP breacher configuration

### DIFF
--- a/data/json/items/gun/robofac_gun.json
+++ b/data/json/items/gun/robofac_gun.json
@@ -297,6 +297,7 @@
     "integral_longest_side": "12 cm",
     "longest_side": "42 cm",
     "barrel_length": "197 mm",
+    "flags": [  ],
     "//": "based on M26-MASS; shot_spread_multiplier_modifier is increased due the short barrel",
     "name": { "str_sp": "HWP breacher configuration" },
     "description": "A Hub 01 Hybrid Weapons Platform quick swap conversion kit.  This version looks like the close quarters configuration, but has a shortened barrel with \"00 BREACH\" stamped into the metal."


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
It was the whole idea of breacher config to not have a choke, but i forgot to supress flag inheritance, so it accidentally copied CHOKE flag from cqc config 
#### Describe the solution
supress flag inhetitance