### PR TITLE
[MoM] Clarify and standardize nether attunement messages

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -128,8 +128,14 @@
           {
             "id": "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE_2",
             "condition": { "math": [ "rand(1)", ">=", "1" ] },
-            "effect": [ { "u_add_effect": "effect_nether_attunement_health_bonus", "duration": "30 seconds" }, { "u_message": "As you unleash your powers, you bloom with vitality.", "type": "good" } ],
-            "false_effect": [ { "u_add_effect": "effect_nether_attunement_health_penalty", "duration": "30 seconds" }, { "u_message": "As you unleash your powers, you are struck with malaise.", "type": "bad" } ]
+            "effect": [
+              { "u_add_effect": "effect_nether_attunement_health_bonus", "duration": "30 seconds" },
+              { "u_message": "As you unleash your powers, you bloom with vitality.", "type": "good" }
+            ],
+            "false_effect": [
+              { "u_add_effect": "effect_nether_attunement_health_penalty", "duration": "30 seconds" },
+              { "u_message": "As you unleash your powers, you are struck with malaise.", "type": "bad" }
+            ]
           }
         ]
       }

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -184,7 +184,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, you expend more energy than anticipated.", "type": "bad" },
+      { "u_message": "As you unleash your powers, they take more out of you than you expected.", "type": "bad" },
       { "math": [ "u_val('stamina')", "-=", "rng(3000,9000)" ] }
     ]
   },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -70,7 +70,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, your head suddenly begins to throb!", "type": "bad" },
+      { "u_message": "As you unleash your powers, your head begins to throb.", "type": "bad" },
       {
         "u_add_effect": "psionic_overload",
         "duration": {
@@ -100,7 +100,7 @@
       ]
     },
     "effect": [
-      { "u_message": "You feel a strange tingling sensation as your powers are unleashed.", "type": "mixed" },
+      { "u_message": "As you unleash your powers, you feel a strange tingling sensation.", "type": "mixed" },
       { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 2,6 )" ] }
     ]
   },
@@ -123,14 +123,13 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, an electric feeling passes through your whole body!", "type": "mixed" },
       {
         "run_eocs": [
           {
             "id": "EOC_DRAIN_EFFECT_CHECK_HEALTH_CHANGE_2",
             "condition": { "math": [ "rand(1)", ">=", "1" ] },
-            "effect": [ { "u_add_effect": "effect_nether_attunement_health_bonus", "duration": "30 seconds" } ],
-            "false_effect": [ { "u_add_effect": "effect_nether_attunement_health_penalty", "duration": "30 seconds" } ]
+            "effect": [ { "u_add_effect": "effect_nether_attunement_health_bonus", "duration": "30 seconds" }, { "u_message": "As you unleash your powers, you bloom with vitality.", "type": "good" } ],
+            "false_effect": [ { "u_add_effect": "effect_nether_attunement_health_penalty", "duration": "30 seconds" }, { "u_message": "As you unleash your powers, you are struck with malaise.", "type": "bad" } ]
           }
         ]
       }
@@ -155,7 +154,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, blood drips from your nose!", "type": "bad" },
+      { "u_message": "As you unleash your powers, blood drips from your nose.", "type": "bad" },
       { "u_add_effect": "bleed", "intensity": 1, "target_part": "head", "duration": "5 minutes" },
       { "u_set_hp": { "math": [ "u_hp('head') - 1" ] }, "target_part": "head" }
     ]
@@ -179,7 +178,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, your vigor leaves you in a rush!", "type": "bad" },
+      { "u_message": "As you unleash your powers, you expend more energy than anticipated.", "type": "bad" },
       { "math": [ "u_val('stamina')", "-=", "rng(3000,9000)" ] }
     ]
   },
@@ -202,7 +201,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, you feel weary!", "type": "bad" },
+      { "u_message": "As you unleash your powers, you feel tired.", "type": "bad" },
       { "math": [ "u_val('fatigue')", "+=", "rng(30,90)" ] }
     ]
   },
@@ -225,7 +224,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, you feel a surge of energy!", "type": "good" },
+      { "u_message": "As you unleash your powers, you feel a surge of strength!", "type": "good" },
       {
         "u_add_effect": "effect_nether_attunement_power_surge",
         "duration": { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain') * rng(1,10)" ] }
@@ -251,7 +250,7 @@
       ]
     },
     "effect": [
-      { "u_message": "As you unleash your powers, your muscles begin trembling!", "type": "bad" },
+      { "u_message": "As you unleash your powers, your muscles tremble and weaken.", "type": "bad" },
       {
         "u_add_effect": "effect_biokin_overload",
         "duration": {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "[MoM] Clarify and standardize nether attunement messages"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Many of the messages you get when triggering Nether Attunement effects are misleading. It would be fine if they were just cryptic, but in many cases they seem to suggest their effects are something entirely different from what they actually do. The most obvious example is that the effect that increases fatigue (tiredness) states that you "feel weary", which of course sounds like it's talking about weariness, an entirely different mechanic.

There were also some inconsistencies in how the messages were formatted, so I changed them to be more consistent. Also made one or two edits I just thought sounded better.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Replaced the offending vocabulary with phrases I thought were more clear, without just outright stating the effect.

Replaced the exclamation marks with periods. This feels more ominous and appropriate, as the effects are generally subtly wearing away at you rather than making a big splash. "You feel tired!" comes across as too cheery and excited for me. I left it on the power surge, though, because that one actually is supposed to be exciting and explosive, plus it's a short-term buff so it's useful if it calls more attention to itself.

Changed the phrasing on the extra attunement to match the other messages. Did not clarify this one, as Nether Attunement is supposed to be vague and mysterious, and being the _only_ vague and mysterious message makes it a bit clearer anyway.

Restructured the health gain/loss so there are separate messages for gaining and losing health. I just couldn't think of a singular message that adequately covered both.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Ran the game to make sure there weren't any errors. Activated EOCs to make sure the messages were displaying.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This was harder than anticipated. We have a lot of gameplay elements that represent related concepts and are differentiated by closely related words, e.g. weariness, fatigue and stamina referring to three separate mechanics. This makes it really difficult to find a word that accurately describes the relevant mechanic that couldn't also be referring to some other mechanic, at least without outright writing "You lose some Health." As a result, many of these are rather less elegant than I would like.

I'm particularly displeased with the stamina loss, as the new phrasing is very clinical and boring compared to the old. But "vigor" could refer to health, fatigue, weariness or pretty much any kind of debuff, so I felt compelled to change it, and I couldn't find a good one-word replacement.

I'm also not stoked about the power surge. "Strength" can obviously be misinterpreted as referring to the Strength stat, but I think it's better than "energy" because that could refer to a stamina boost, a speed increase, a damage increase or pretty much any other kind of buff. "Strength" at least conveys the central idea that you become more powerful, and you can hopefully just glance at your stats to see that your Strength hasn't increased and conclude it must be something else.

(My initial instinct was of course to change it to be a "surge of power", but I immediately realized why that isn't already the case when I read the full sentence. "As you unleash your powers, you feel a surge of power!" is not an elegant phrase, to put it mildly.)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
