### PR TITLE
[MoM] Fix zombie null aura not disappearing on death

### DIFF
--- a/data/mods/MindOverMatter/monsters/death_effects.json
+++ b/data/mods/MindOverMatter/monsters/death_effects.json
@@ -185,5 +185,19 @@
     "min_aoe": 2,
     "max_aoe": 6,
     "min_duration": 9999999999999999999
+  },
+  {
+    "id": "delete_nullifying_fields_monster",
+    "type": "SPELL",
+    "name": "[Ψ]Delete Nullifying Fields Monster",
+    "description": "This cleans up the nullifying fields after a zombie null dies.  It's a bug if you have it.",
+    "valid_targets": [ "ground" ],
+    "flags": [ "SILENT", "NO_EXPLOSION_SFX", "IGNORE_WALLS" ],
+    "effect": "ter_transform",
+    "effect_str": "ter_null_zombie_delete_fields",
+    "shape": "blast",
+    "max_level": 1,
+    "min_aoe": 12,
+    "max_aoe": 12
   }
 ]

--- a/data/mods/MindOverMatter/monsters/monsters_spells.json
+++ b/data/mods/MindOverMatter/monsters/monsters_spells.json
@@ -32,20 +32,6 @@
     "max_range": 10
   },
   {
-    "id": "delete_nullifying_fields_monster",
-    "type": "SPELL",
-    "name": "[Ψ]Delete Nullifying Fields Monster",
-    "description": "This cleans up the nullifying fields after a zombie null dies.  It's a bug if you have it.",
-    "valid_targets": [ "ground" ],
-    "flags": [ "SILENT", "NO_EXPLOSION_SFX" ],
-    "effect": "ter_transform",
-    "effect_str": "ter_null_zombie_delete_fields",
-    "shape": "blast",
-    "max_level": 1,
-    "min_aoe": 12,
-    "max_aoe": 12
-  },
-  {
     "id": "biokinetic_speed_boost_monster_01",
     "type": "SPELL",
     "name": "[Ψ]Biokinetic Speed Boost Monster Lesser",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "[MoM] Fix zombie null aura not disappearing on death"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Had a couple reports of the droning hum not disappearing when the zombie null died and couldn't replicate it, but had a bug report that showed me what was wrong.

Fixes #70107
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add IGNORE_WALLS to the death spell so that fields that go through a door or behind furniture get deleted as well. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded the save in the bug report, spawned a zombie null in the spot the original died, debug-killed it, the fields out in the hallway were deleted after its death. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
