### PR TITLE
[MoM] Vitakinesis automatically brings up the bleeding/infection menu

### DIFF
--- a/data/mods/MindOverMatter/powers/vitakinesis.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis.json
@@ -322,7 +322,7 @@
     "type": "SPELL",
     "name": "[Ψ]Allay Infection",
     "description": "Before you could stop your bleeding with but a thought.  Now, you can treat infected wounds with your powers as well.",
-    "message": "You concentrate on the injuries, and the itching eases [(a)ctivate to disinfect].",
+    "message": "You concentrate on the injuries, and the itching eases.",
     "teachable": false,
     "valid_targets": [ "self" ],
     "spell_class": "VITAKINETIC",

--- a/data/mods/MindOverMatter/powers/vitakinesis.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis.json
@@ -3,8 +3,8 @@
     "id": "vita_stop_bleeding",
     "type": "SPELL",
     "name": "[Ψ]Staunch Wound",
-    "description": "You concentrate on your injuries, and they close and the blood flow stops [(a)ctivate to bandage].",
-    "message": "You summon up the energy to close your wounds!  [(a)ctivate to bandage]",
+    "description": "You concentrate on your injuries, and they close and the blood flow stops.",
+    "message": "You summon up the energy to close your wounds!",
     "teachable": false,
     "valid_targets": [ "self" ],
     "spell_class": "VITAKINETIC",
@@ -49,8 +49,8 @@
     "shape": "blast",
     "min_damage": 1,
     "max_damage": 1,
-    "min_duration": 1200,
-    "max_duration": 1200
+    "min_duration": 200,
+    "max_duration": 200
   },
   {
     "id": "vita_stop_bleeding_02",
@@ -66,8 +66,8 @@
     "shape": "blast",
     "min_damage": 1,
     "max_damage": 1,
-    "min_duration": 1200,
-    "max_duration": 1200
+    "min_duration": 200,
+    "max_duration": 200
   },
   {
     "id": "vita_stop_bleeding_03",
@@ -83,8 +83,8 @@
     "shape": "blast",
     "min_damage": 1,
     "max_damage": 1,
-    "min_duration": 1200,
-    "max_duration": 1200
+    "min_duration": 200,
+    "max_duration": 200
   },
   {
     "id": "vita_health_power",
@@ -357,8 +357,8 @@
     "shape": "blast",
     "min_damage": 1,
     "max_damage": 1,
-    "min_duration": 1200,
-    "max_duration": 1200
+    "min_duration": 200,
+    "max_duration": 200
   },
   {
     "id": "vita_stop_infection_02",
@@ -374,8 +374,8 @@
     "shape": "blast",
     "min_damage": 1,
     "max_damage": 1,
-    "min_duration": 1200,
-    "max_duration": 1200
+    "min_duration": 200,
+    "max_duration": 200
   },
   {
     "id": "vita_stop_infection_03",
@@ -391,8 +391,8 @@
     "shape": "blast",
     "min_damage": 1,
     "max_damage": 1,
-    "min_duration": 1200,
-    "max_duration": 1200
+    "min_duration": 200,
+    "max_duration": 200
   },
   {
     "id": "vita_healing_trance",

--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -253,9 +253,18 @@
     "effect": {
       "switch": { "math": [ "u_val('spell_level', 'spell: vita_stop_infection')" ] },
       "cases": [
-        { "case": 0, "effect": [ { "u_cast_spell": { "id": "vita_stop_infection_01" } } ] },
-        { "case": 6, "effect": [ { "u_cast_spell": { "id": "vita_stop_infection_02" } } ] },
-        { "case": 12, "effect": [ { "u_cast_spell": { "id": "vita_stop_infection_03" } } ] }
+        {
+          "case": 0,
+          "effect": [ { "u_cast_spell": { "id": "vita_stop_infection_01" } }, { "run_eocs": "EOC_VITAKIN_STOP_INFECTION_ITEM_01" } ]
+        },
+        {
+          "case": 6,
+          "effect": [ { "u_cast_spell": { "id": "vita_stop_infection_02" } }, { "run_eocs": "EOC_VITAKIN_STOP_INFECTION_ITEM_02" } ]
+        },
+        {
+          "case": 12,
+          "effect": [ { "u_cast_spell": { "id": "vita_stop_infection_03" } }, { "run_eocs": "EOC_VITAKIN_STOP_INFECTION_ITEM_03" } ]
+        }
       ]
     }
   },

--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -72,11 +72,53 @@
     "effect": {
       "switch": { "math": [ "u_val('spell_level', 'spell: vita_stop_bleeding')" ] },
       "cases": [
-        { "case": 0, "effect": [ { "u_cast_spell": { "id": "vita_stop_bleeding_01" } } ] },
-        { "case": 6, "effect": [ { "u_cast_spell": { "id": "vita_stop_bleeding_02" } } ] },
-        { "case": 12, "effect": [ { "u_cast_spell": { "id": "vita_stop_bleeding_03" } } ] }
+        {
+          "case": 0,
+          "effect": [ { "u_cast_spell": { "id": "vita_stop_bleeding_01" } }, { "run_eocs": "EOC_VITAKIN_STOP_BLEEDING_ITEM_01" } ]
+        },
+        {
+          "case": 6,
+          "effect": [ { "u_cast_spell": { "id": "vita_stop_bleeding_02" } }, { "run_eocs": "EOC_VITAKIN_STOP_BLEEDING_ITEM_02" } ]
+        },
+        {
+          "case": 12,
+          "effect": [ { "u_cast_spell": { "id": "vita_stop_bleeding_03" } }, { "run_eocs": "EOC_VITAKIN_STOP_BLEEDING_ITEM_03" } ]
+        }
       ]
     }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VITAKIN_STOP_BLEEDING_ITEM_01",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "vita_bandage_01" } ],
+        "true_eocs": [ { "id": "EOC_VITAKIN_STOP_BLEEDING_ITEM_01_ACTIVATE", "effect": { "u_activate": "heal" } } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VITAKIN_STOP_BLEEDING_ITEM_02",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "vita_bandages_02" } ],
+        "true_eocs": [ { "id": "EOC_VITAKIN_STOP_BLEEDING_ITEM_02_ACTIVATE", "effect": { "u_activate": "heal" } } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VITAKIN_STOP_BLEEDING_ITEM_03",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "vita_bandages_03" } ],
+        "true_eocs": [ { "id": "EOC_VITAKIN_STOP_BLEEDING_ITEM_03_ACTIVATE", "effect": { "u_activate": "heal" } } ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",
@@ -216,6 +258,39 @@
         { "case": 12, "effect": [ { "u_cast_spell": { "id": "vita_stop_infection_03" } } ] }
       ]
     }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VITAKIN_STOP_INFECTION_ITEM_01",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "vita_disinfectant_01" } ],
+        "true_eocs": [ { "id": "EOC_VITAKIN_STOP_INFECTION_ITEM_01_ACTIVATE", "effect": { "u_activate": "heal" } } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VITAKIN_STOP_INFECTION_ITEM_02",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "vita_disinfectant_02" } ],
+        "true_eocs": [ { "id": "EOC_VITAKIN_STOP_INFECTION_ITEM_02_ACTIVATE", "effect": { "u_activate": "heal" } } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_VITAKIN_STOP_INFECTION_ITEM_03",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "vita_disinfectant_03" } ],
+        "true_eocs": [ { "id": "EOC_VITAKIN_STOP_INFECTION_ITEM_03_ACTIVATE", "effect": { "u_activate": "heal" } } ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Vitakinesis automatically brings up the bleeding/infection menu"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

It's always been a little immersion-breaking that Staunch Wound and Allay Infection summoned an item that you then had to go into your inventory to use, but there was nothing to be done. But thanks to the power of u_run_inv_eocs, that's not true anymore.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Using u_run_inv_eocs, automatically activate the summoned item immediately after the vitakinetic uses their powers, so from the player's perspective, they channel Staunch Wound and then the stop bleeding menu immediately pops up, and similarly for Allay Infection. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Went in game, tried it with different levels of each power, everything worked. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I'm not doing this for the druid spell I wrote that does the same thing because that spell is supposed to create a magical bandage that you then have to apply. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
