### PR TITLE
[MoM] Add ability for pyrokinetics to cauterize their wounds

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_learn_recipes.json
@@ -135,6 +135,7 @@
     "effect": [
       { "u_learn_recipe": "practice_pyrokinetic_flash" },
       { "u_learn_recipe": "practice_pyrokinetic_eruption" },
+      { "u_learn_recipe": "practice_pyrokinetic_cauterize" },
       { "u_learn_recipe": "practice_pyrokinetic_call_flames" },
       { "u_learn_recipe": "practice_pyrokinetic_quell_flames" },
       { "u_learn_recipe": "practice_pyrokinetic_cloak" },

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -1244,6 +1244,16 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_psi_post_cauterize",
+    "name": [ "Cauterized" ],
+    "desc": [ "You used your powers to cauterize a wound here.  Whether it worked or not, it still sting terribly." ],
+    "rating": "bad",
+    "max_intensity": 5,
+    "base_mods": { "pain_max_val": [ 30 ], "pain_min": [ 1 ], "pain_chance": [ 6 ], "pain_tick": [ 120 ] },
+    "scaling_mods": { "pain_chance": [ -1 ], "pain_tick": [ -10 ] }
+  },
+  {
+    "type": "effect_type",
     "id": "effect_pyrokinetic_fire_tool",
     "//": "Hidden effect, used as a tracker",
     "name": [ "" ],

--- a/data/mods/MindOverMatter/effects/effects_psionic.json
+++ b/data/mods/MindOverMatter/effects/effects_psionic.json
@@ -1246,7 +1246,7 @@
     "type": "effect_type",
     "id": "effect_psi_post_cauterize",
     "name": [ "Cauterized" ],
-    "desc": [ "You used your powers to cauterize a wound here.  Whether it worked or not, it still sting terribly." ],
+    "desc": [ "You used your powers to cauterize a wound here.  Whether it worked or not, it still stings terribly." ],
     "rating": "bad",
     "max_intensity": 5,
     "base_mods": { "pain_max_val": [ 30 ], "pain_min": [ 1 ], "pain_chance": [ 6 ], "pain_tick": [ 120 ] },

--- a/data/mods/MindOverMatter/powers/pyrokinesis.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis.json
@@ -45,8 +45,8 @@
     "ignored_monster_species": [ "PSI_NULL" ],
     "learn_spells": {
       "pyrokinetic_call_flames": 5,
-      "pyrokinetic_flamethrower": 7,
-      "pyrokinetic_flash": 9,
+      "pyrokinetic_cauterize": 7,
+      "pyrokinetic_flamethrower": 9,
       "pyrokinetic_thermogenesis": 12,
       "pyrokinetic_blast": 15,
       "pyrokinetic_cloak": 17
@@ -97,6 +97,32 @@
     "casting_time_increment": -8,
     "ignored_monster_species": [ "PSI_NULL" ],
     "learn_spells": { "pyrokinetic_cloak": 7, "pyrokinetic_thermogenesis": 10, "pyrokinetic_blast": 15 }
+  },
+  {
+    "id": "pyrokinetic_cauterize",
+    "type": "SPELL",
+    "name": "[Ψ]Cauterize",
+    "description": "Using an extremely focused application of pyrokinesis, sear a wound shut to stop the bleeding.  This is liable to be painful and is almost certainly likely to just cause more damage if you don't have any medical knowledge.",
+    "message": "",
+    "teachable": false,
+    "valid_targets": [ "self" ],
+    "spell_class": "PYROKINETIC",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "CONCENTRATE", "NO_PROJECTILE", "NO_HANDS", "NO_LEGS" ],
+    "difficulty": 2,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_PYROKIN_CAUTERIZE_SELECTOR",
+    "extra_effects": [ { "id": "psionic_drained_difficulty_two", "hit_self": true } ],
+    "shape": "blast",
+    "energy_source": "STAMINA",
+    "base_energy_cost": 2200,
+    "final_energy_cost": 750,
+    "energy_increment": -95,
+    "base_casting_time": 120,
+    "final_casting_time": 55,
+    "casting_time_increment": -5,
+    "learn_spells": { "pyrokinetic_lance": 7 }
   },
   {
     "id": "pyrokinetic_call_flames",

--- a/data/mods/MindOverMatter/powers/pyrokinesis.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis.json
@@ -102,7 +102,7 @@
     "id": "pyrokinetic_cauterize",
     "type": "SPELL",
     "name": "[Ψ]Cauterize",
-    "description": "Using an extremely focused application of pyrokinesis, sear a wound shut to stop the bleeding.  This is liable to be painful and is almost certainly likely to just cause more damage if you don't have any medical knowledge.  If the bleeding is too strong, cauterization will be ineffective",
+    "description": "Using an extremely focused application of pyrokinesis, sear a wound shut to stop the bleeding.  This is liable to be painful and is almost certainly likely to just cause more damage if you don't have any medical knowledge.  If the bleeding is too strong, cauterization will be ineffective, and there is a <color_red>chance of infection</color> whether you are successful or not.",
     "message": "",
     "teachable": false,
     "valid_targets": [ "self" ],

--- a/data/mods/MindOverMatter/powers/pyrokinesis.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis.json
@@ -102,7 +102,7 @@
     "id": "pyrokinetic_cauterize",
     "type": "SPELL",
     "name": "[Ψ]Cauterize",
-    "description": "Using an extremely focused application of pyrokinesis, sear a wound shut to stop the bleeding.  This is liable to be painful and is almost certainly likely to just cause more damage if you don't have any medical knowledge.",
+    "description": "Using an extremely focused application of pyrokinesis, sear a wound shut to stop the bleeding.  This is liable to be painful and is almost certainly likely to just cause more damage if you don't have any medical knowledge.  If the bleeding is too strong, cauterization will be ineffective",
     "message": "",
     "teachable": false,
     "valid_targets": [ "self" ],

--- a/data/mods/MindOverMatter/powers/pyrokinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis_eoc.json
@@ -30,7 +30,8 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM",
-    "//": "Nesting needed here because otherwise if the condition is not met, the option is not even selectable",
+    "//": "Bleed level here goes up to a little beyond what is possible to stop with your hands.",
+    "condition": { "math": [ "u_effect_intensity('bleed', 'bodypart': 'arm_l')", "<=", "29" ] },
     "effect": [
       {
         "run_eocs": {
@@ -73,12 +74,13 @@
           ]
         }
       }
-    ]
+    ],
+    "false_effect": { "u_message": "The bleeding is too much for you to stop with your powers.", "type": "bad" }
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_ARM",
-    "//": "Nesting needed here because otherwise if the condition is not met, the option is not even selectable",
+    "condition": { "math": [ "u_effect_intensity('bleed', 'bodypart': 'arm_r')", "<=", "29" ] },
     "effect": [
       {
         "run_eocs": {
@@ -121,12 +123,13 @@
           ]
         }
       }
-    ]
+    ],
+    "false_effect": { "u_message": "The bleeding is too much for you to stop with your powers.", "type": "bad" }
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_PYROKIN_CAUTERIZE_HEAD",
-    "//": "Nesting needed here because otherwise if the condition is not met, the option is not even selectable",
+    "condition": { "math": [ "u_effect_intensity('bleed', 'bodypart': 'head')", "<=", "29" ] },
     "effect": [
       {
         "run_eocs": {
@@ -169,12 +172,13 @@
           ]
         }
       }
-    ]
+    ],
+    "false_effect": { "u_message": "The bleeding is too much for you to stop with your powers.", "type": "bad" }
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_PYROKIN_CAUTERIZE_LEFT_LEG",
-    "//": "Nesting needed here because otherwise if the condition is not met, the option is not even selectable",
+    "condition": { "math": [ "u_effect_intensity('bleed', 'bodypart': 'leg_r')", "<=", "29" ] },
     "effect": [
       {
         "run_eocs": {
@@ -217,12 +221,13 @@
           ]
         }
       }
-    ]
+    ],
+    "false_effect": { "u_message": "The bleeding is too much for you to stop with your powers.", "type": "bad" }
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG",
-    "//": "Nesting needed here because otherwise if the condition is not met, the option is not even selectable",
+    "condition": { "math": [ "u_effect_intensity('bleed', 'bodypart': 'leg_r')", "<=", "29" ] },
     "effect": [
       {
         "run_eocs": {
@@ -265,12 +270,13 @@
           ]
         }
       }
-    ]
+    ],
+    "false_effect": { "u_message": "The bleeding is too much for you to stop with your powers.", "type": "bad" }
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_PYROKIN_CAUTERIZE_BODY",
-    "//": "Nesting needed here because otherwise if the condition is not met, the option is not even selectable",
+    "condition": { "math": [ "u_effect_intensity('bleed', 'bodypart': 'torso')", "<=", "29" ] },
     "effect": [
       {
         "run_eocs": {
@@ -293,7 +299,6 @@
               "target_part": "torso",
               "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'torso') + 1" ] }
             },
-            { "u_lose_effect": "bleed", "target_part": "torso" },
             { "u_set_hp": { "math": [ "u_hp('torso') - 1" ] }, "target_part": "torso" },
             { "math": [ "u_pain()", "+=", "rng(1,3)" ] }
           ],
@@ -313,7 +318,8 @@
           ]
         }
       }
-    ]
+    ],
+    "false_effect": { "u_message": "The bleeding is too much for you to stop with your powers.", "type": "bad" }
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/powers/pyrokinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis_eoc.json
@@ -383,7 +383,7 @@
     "false_effect": { "u_message": "The bleeding is too much for you to stop with your powers.", "type": "bad" }
   },
   {
-    "type": "",
+    "type": "effect_on_condition",
     "id": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_INFECTION_CHECK",
     "condition": { "x_in_y_chance": { "x": 1, "y": 15 } },
     "effect": [
@@ -419,7 +419,7 @@
     ]
   },
   {
-    "type": "",
+    "type": "effect_on_condition",
     "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_ARM_INFECTION_CHECK",
     "condition": { "x_in_y_chance": { "x": 1, "y": 15 } },
     "effect": [
@@ -455,7 +455,7 @@
     ]
   },
   {
-    "type": "",
+    "type": "effect_on_condition",
     "id": "EOC_PYROKIN_CAUTERIZE_HEAD_INFECTION_CHECK",
     "condition": { "x_in_y_chance": { "x": 1, "y": 15 } },
     "effect": [
@@ -491,7 +491,7 @@
     ]
   },
   {
-    "type": "",
+    "type": "effect_on_condition",
     "id": "EOC_PYROKIN_CAUTERIZE_LEFT_LEG_INFECTION_CHECK",
     "condition": { "x_in_y_chance": { "x": 1, "y": 15 } },
     "effect": [
@@ -527,7 +527,7 @@
     ]
   },
   {
-    "type": "",
+    "type": "effect_on_condition",
     "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG_INFECTION_CHECK",
     "condition": { "x_in_y_chance": { "x": 1, "y": 15 } },
     "effect": [
@@ -561,7 +561,7 @@
     ]
   },
   {
-    "type": "",
+    "type": "effect_on_condition",
     "id": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_INFECTION_CHECK",
     "condition": { "x_in_y_chance": { "x": 1, "y": 15 } },
     "effect": [
@@ -597,7 +597,7 @@
     ]
   },
   {
-    "type": "",
+    "type": "effect_on_condition",
     "id": "EOC_PYROKIN_CAUTERIZE_TORSO_INFECTION_CHECK",
     "condition": { "x_in_y_chance": { "x": 1, "y": 15 } },
     "effect": [

--- a/data/mods/MindOverMatter/powers/pyrokinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis_eoc.json
@@ -55,11 +55,11 @@
                 "target_part": "arm_l",
                 "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'arm_l') + 1" ] }
               },
-              { "u_remove_effect": "bleed", "target_part": "arm_l" },
+              { "u_lose_effect": "bleed", "target_part": "arm_l" },
               { "u_set_hp": { "math": [ "u_hp('arm_l') - 1" ] }, "target_part": "arm_l" },
               { "math": [ "u_pain()", "+=", "rng(1,2)" ] },
               {
-                "run_eocs": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_INFECTION_CHECK",
+                "queue_eocs": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_INFECTION_CHECK",
                 "time_in_future": [ "6 hours", "24 hours" ]
               }
             ],
@@ -77,7 +77,7 @@
               { "u_set_hp": { "math": [ "u_hp('arm_l') - 3" ] }, "target_part": "arm_l" },
               { "math": [ "u_pain()", "+=", "rng(1,3)" ] },
               {
-                "run_eocs": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_INFECTION_CHECK",
+                "queue_eocs": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_INFECTION_CHECK",
                 "time_in_future": [ "6 hours", "24 hours" ]
               }
             ]
@@ -114,11 +114,11 @@
                 "target_part": "arm_r",
                 "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'arm_r') + 1" ] }
               },
-              { "u_remove_effect": "bleed", "target_part": "arm_r" },
+              { "u_lose_effect": "bleed", "target_part": "arm_r" },
               { "u_set_hp": { "math": [ "u_hp('arm_r') - 1" ] }, "target_part": "arm_r" },
               { "math": [ "u_pain()", "+=", "rng(1,2)" ] },
               {
-                "run_eocs": "EOC_PYROKIN_CAUTERIZE_RIGHT_ARM_INFECTION_CHECK",
+                "queue_eocs": "EOC_PYROKIN_CAUTERIZE_RIGHT_ARM_INFECTION_CHECK",
                 "time_in_future": [ "6 hours", "24 hours" ]
               }
             ],
@@ -136,7 +136,7 @@
               { "u_set_hp": { "math": [ "u_hp('arm_r') - 3" ] }, "target_part": "arm_r" },
               { "math": [ "u_pain()", "+=", "rng(1,3)" ] },
               {
-                "run_eocs": "EOC_PYROKIN_CAUTERIZE_RIGHT_ARM_INFECTION_CHECK",
+                "queue_eocs": "EOC_PYROKIN_CAUTERIZE_RIGHT_ARM_INFECTION_CHECK",
                 "time_in_future": [ "6 hours", "24 hours" ]
               }
             ]
@@ -173,11 +173,11 @@
                 "target_part": "head",
                 "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'head') + 1" ] }
               },
-              { "u_remove_effect": "bleed", "target_part": "head" },
+              { "u_lose_effect": "bleed", "target_part": "head" },
               { "u_set_hp": { "math": [ "u_hp('head') - 1" ] }, "target_part": "head" },
               { "math": [ "u_pain()", "+=", "rng(1,4)" ] },
               {
-                "run_eocs": "EOC_PYROKIN_CAUTERIZE_HEAD_INFECTION_CHECK",
+                "queue_eocs": "EOC_PYROKIN_CAUTERIZE_HEAD_INFECTION_CHECK",
                 "time_in_future": [ "6 hours", "24 hours" ]
               }
             ],
@@ -195,7 +195,7 @@
               { "u_set_hp": { "math": [ "u_hp('head') - 3" ] }, "target_part": "head" },
               { "math": [ "u_pain()", "+=", "rng(2,6)" ] },
               {
-                "run_eocs": "EOC_PYROKIN_CAUTERIZE_HEAD_INFECTION_CHECK",
+                "queue_eocs": "EOC_PYROKIN_CAUTERIZE_HEAD_INFECTION_CHECK",
                 "time_in_future": [ "6 hours", "24 hours" ]
               }
             ]
@@ -232,11 +232,11 @@
                 "target_part": "leg_l",
                 "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'leg_r') + 1" ] }
               },
-              { "u_remove_effect": "bleed", "target_part": "leg_l" },
+              { "u_lose_effect": "bleed", "target_part": "leg_l" },
               { "u_set_hp": { "math": [ "u_hp('leg_l') - 1" ] }, "target_part": "leg_l" },
               { "math": [ "u_pain()", "+=", "rng(1,2)" ] },
               {
-                "run_eocs": "EOC_PYROKIN_CAUTERIZE_LEFT_LEG_INFECTION_CHECK",
+                "queue_eocs": "EOC_PYROKIN_CAUTERIZE_LEFT_LEG_INFECTION_CHECK",
                 "time_in_future": [ "6 hours", "24 hours" ]
               }
             ],
@@ -254,7 +254,7 @@
               { "u_set_hp": { "math": [ "u_hp('leg_l') - 3" ] }, "target_part": "leg_l" },
               { "math": [ "u_pain()", "+=", "rng(1,3)" ] },
               {
-                "run_eocs": "EOC_PYROKIN_CAUTERIZE_LEFT_LEG_INFECTION_CHECK",
+                "queue_eocs": "EOC_PYROKIN_CAUTERIZE_LEFT_LEG_INFECTION_CHECK",
                 "time_in_future": [ "6 hours", "24 hours" ]
               }
             ]
@@ -291,11 +291,11 @@
                 "target_part": "leg_r",
                 "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'leg_r') + 1" ] }
               },
-              { "u_remove_effect": "bleed", "target_part": "leg_r" },
+              { "u_lose_effect": "bleed", "target_part": "leg_r" },
               { "u_set_hp": { "math": [ "u_hp('leg_r') - 1" ] }, "target_part": "leg_r" },
               { "math": [ "u_pain()", "+=", "rng(1,2)" ] },
               {
-                "run_eocs": "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG_INFECTION_CHECK",
+                "queue_eocs": "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG_INFECTION_CHECK",
                 "time_in_future": [ "6 hours", "24 hours" ]
               }
             ],
@@ -313,7 +313,7 @@
               { "u_set_hp": { "math": [ "u_hp('leg_r') - 3" ] }, "target_part": "leg_r" },
               { "math": [ "u_pain()", "+=", "rng(1,3)" ] },
               {
-                "run_eocs": "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG_INFECTION_CHECK",
+                "queue_eocs": "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG_INFECTION_CHECK",
                 "time_in_future": [ "6 hours", "24 hours" ]
               }
             ]
@@ -350,11 +350,11 @@
                 "target_part": "torso",
                 "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'torso') + 1" ] }
               },
-              { "u_remove_effect": "bleed", "target_part": "torso" },
+              { "u_lose_effect": "bleed", "target_part": "torso" },
               { "u_set_hp": { "math": [ "u_hp('torso') - 1" ] }, "target_part": "torso" },
               { "math": [ "u_pain()", "+=", "rng(1,3)" ] },
               {
-                "run_eocs": "EOC_PYROKIN_CAUTERIZE_TORSO_INFECTION_CHECK",
+                "queue_eocs": "EOC_PYROKIN_CAUTERIZE_TORSO_INFECTION_CHECK",
                 "time_in_future": [ "6 hours", "24 hours" ]
               }
             ],
@@ -372,7 +372,7 @@
               { "u_set_hp": { "math": [ "u_hp('torso') - 3" ] }, "target_part": "torso" },
               { "math": [ "u_pain()", "+=", "rng(1,3)" ] },
               {
-                "run_eocs": "EOC_PYROKIN_CAUTERIZE_TORSO_INFECTION_CHECK",
+                "queue_eocs": "EOC_PYROKIN_CAUTERIZE_TORSO_INFECTION_CHECK",
                 "time_in_future": [ "6 hours", "24 hours" ]
               }
             ]
@@ -395,19 +395,14 @@
             "effect": [
               {
                 "u_add_effect": "infected",
-                "duration": "24 hours",
+                "duration": "PERMANENT",
                 "target_part": "arm_l",
                 "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_l') + 1" ] }
               },
               { "u_message": "The infection on your left arm is getting worse.", "type": "bad" }
             ],
             "false_effect": [
-              {
-                "u_add_effect": "infected",
-                "duration": "24 hours",
-                "target_part": "arm_l",
-                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_l') + 1" ] }
-              },
+              { "u_add_effect": "infected", "duration": "PERMANENT", "target_part": "arm_l", "intensity": 1 },
               {
                 "u_message": "The wound on your left arm you tried to cauterize is starting to itch and swell.  It's probably infected.",
                 "type": "bad"
@@ -431,19 +426,14 @@
             "effect": [
               {
                 "u_add_effect": "infected",
-                "duration": "24 hours",
+                "duration": "PERMANENT",
                 "target_part": "arm_r",
                 "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_r') + 1" ] }
               },
               { "u_message": "The infection on your right arm is getting worse.", "type": "bad" }
             ],
             "false_effect": [
-              {
-                "u_add_effect": "infected",
-                "duration": "24 hours",
-                "target_part": "arm_r",
-                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_r') + 1" ] }
-              },
+              { "u_add_effect": "infected", "duration": "PERMANENT", "target_part": "arm_r", "intensity": 1 },
               {
                 "u_message": "The wound on your right arm you tried to cauterize is starting to itch and swell.  It's probably infected.",
                 "type": "bad"
@@ -467,19 +457,14 @@
             "effect": [
               {
                 "u_add_effect": "infected",
-                "duration": "24 hours",
+                "duration": "PERMANENT",
                 "target_part": "head",
                 "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'head') + 1" ] }
               },
               { "u_message": "The infection on your head is getting worse.", "type": "bad" }
             ],
             "false_effect": [
-              {
-                "u_add_effect": "infected",
-                "duration": "24 hours",
-                "target_part": "head",
-                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'head') + 1" ] }
-              },
+              { "u_add_effect": "infected", "duration": "PERMANENT", "target_part": "head", "intensity": 1 },
               {
                 "u_message": "The wound on your head you tried to cauterize is starting to itch and swell.  It's probably infected.",
                 "type": "bad"
@@ -503,19 +488,14 @@
             "effect": [
               {
                 "u_add_effect": "infected",
-                "duration": "24 hours",
+                "duration": "PERMANENT",
                 "target_part": "leg_l",
                 "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'leg_l') + 1" ] }
               },
               { "u_message": "The infection on your left leg is getting worse.", "type": "bad" }
             ],
             "false_effect": [
-              {
-                "u_add_effect": "infected",
-                "duration": "24 hours",
-                "target_part": "leg_l",
-                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'leg_l') + 1" ] }
-              },
+              { "u_add_effect": "infected", "duration": "PERMANENT", "target_part": "leg_l", "intensity": 1 },
               {
                 "u_message": "The wound on your left leg you tried to cauterize is starting to itch and swell.  It's probably infected.",
                 "type": "bad"
@@ -538,61 +518,20 @@
           "effect": [
             {
               "u_add_effect": "infected",
-              "duration": "24 hours",
+              "duration": "PERMANENT",
               "target_part": "leg_r",
               "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'leg_r') + 1" ] }
             },
             { "u_message": "The infection on your right leg is getting worse.", "type": "bad" }
           ],
           "false_effect": [
-            {
-              "u_add_effect": "infected",
-              "duration": "24 hours",
-              "target_part": "leg_r",
-              "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'leg_r') + 1" ] }
-            },
+            { "u_add_effect": "infected", "duration": "PERMANENT", "target_part": "leg_r", "intensity": 1 },
             {
               "u_message": "The wound on your right leg you tried to cauterize is starting to itch and swell.  It's probably infected.",
               "type": "bad"
             }
           ]
         }
-      }
-    ]
-  },
-  {
-    "type": "effect_on_condition",
-    "id": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_INFECTION_CHECK",
-    "condition": { "x_in_y_chance": { "x": 1, "y": 15 } },
-    "effect": [
-      {
-        "run_eocs": [
-          {
-            "id": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_INFECTION_CHECK_2",
-            "condition": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_l')", ">=", "1" ] },
-            "effect": [
-              {
-                "u_add_effect": "infected",
-                "duration": "24 hours",
-                "target_part": "arm_l",
-                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_l') + 1" ] }
-              },
-              { "u_message": "The infection on your left arm is getting worse.", "type": "bad" }
-            ],
-            "false_effect": [
-              {
-                "u_add_effect": "infected",
-                "duration": "24 hours",
-                "target_part": "arm_l",
-                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_l') + 1" ] }
-              },
-              {
-                "u_message": "The wound on your left arm you tried to cauterize is starting to itch and swell.  It's probably infected.",
-                "type": "bad"
-              }
-            ]
-          }
-        ]
       }
     ]
   },
@@ -609,19 +548,14 @@
             "effect": [
               {
                 "u_add_effect": "infected",
-                "duration": "24 hours",
+                "duration": "PERMANENT",
                 "target_part": "torso",
                 "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'torso') + 1" ] }
               },
               { "u_message": "The infection on your torso is getting worse.", "type": "bad" }
             ],
             "false_effect": [
-              {
-                "u_add_effect": "infected",
-                "duration": "24 hours",
-                "target_part": "torso",
-                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'torso') + 1" ] }
-              },
+              { "u_add_effect": "infected", "duration": "PERMANENT", "target_part": "torso", "intensity": 1 },
               {
                 "u_message": "The wound on your torso you tried to cauterize is starting to itch and swell.  It's probably infected.",
                 "type": "bad"

--- a/data/mods/MindOverMatter/powers/pyrokinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis_eoc.json
@@ -1,6 +1,322 @@
 [
   {
     "type": "effect_on_condition",
+    "id": "EOC_PYROKIN_CAUTERIZE_SELECTOR",
+    "effect": [
+      {
+        "run_eoc_selector": [
+          "EOC_PYROKIN_CAUTERIZE_LEFT_ARM",
+          "EOC_PYROKIN_CAUTERIZE_RIGHT_ARM",
+          "EOC_PYROKIN_CAUTERIZE_HEAD",
+          "EOC_PYROKIN_CAUTERIZE_LEFT_LEG",
+          "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG",
+          "EOC_PYROKIN_CAUTERIZE_BODY",
+          "EOC_PORTAL_NULL_AWAKENING"
+        ],
+        "names": [ "Left Arm", "Right Arm", "Head", "Left Leg", "Right Leg", "Torso", "Nevermind." ],
+        "keys": [ "1", "2", "3", "4", "5", "6", "7" ],
+        "descriptions": [
+          "Cauterize wounds on the left arm.",
+          "Cauterize wounds on the right arm.",
+          "Cauterize wounds on the head.",
+          "Cauterize wounds on the left leg.",
+          "Cauterize wounds on the right leg.",
+          "Cauterize wounds on the torso.",
+          "Do nothing for now."
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM",
+    "//": "Nesting needed here because otherwise if the condition is not met, the option is not even selectable",
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_2",
+          "condition": {
+            "or": [
+              { "u_has_trait": "PROF_MED" },
+              { "u_has_proficiency": "prof_burn_care" },
+              { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+            ]
+          },
+          "effect": [
+            {
+              "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
+              "type": "good"
+            },
+            {
+              "u_add_effect": "effect_psi_post_cauterize",
+              "duration": { "math": [ "rand(10800) + 3600" ] },
+              "target_part": "arm_l",
+              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'arm_l') + 1" ] }
+            },
+            { "u_add_effect": "effect_psi_cauterize_no_bleed", "duration": 1, "target_part": "arm_l" },
+            { "u_set_hp": { "math": [ "u_hp('arm_l') - 1" ] }, "target_part": "arm_l" },
+            { "math": [ "u_pain()", "+=", "rng(1,2)" ] }
+          ],
+          "false_effect": [
+            {
+              "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
+              "type": "bad"
+            },
+            {
+              "u_add_effect": "effect_psi_post_cauterize",
+              "duration": { "math": [ "rand(10800) + 3600" ] },
+              "target_part": "arm_l",
+              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'arm_l') + 1" ] }
+            },
+            { "u_set_hp": { "math": [ "u_hp('arm_l') - 3" ] }, "target_part": "arm_l" },
+            { "math": [ "u_pain()", "+=", "rng(1,3)" ] }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_ARM",
+    "//": "Nesting needed here because otherwise if the condition is not met, the option is not even selectable",
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_ARM_2",
+          "condition": {
+            "or": [
+              { "u_has_trait": "PROF_MED" },
+              { "u_has_proficiency": "prof_burn_care" },
+              { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+            ]
+          },
+          "effect": [
+            {
+              "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
+              "type": "good"
+            },
+            {
+              "u_add_effect": "effect_psi_post_cauterize",
+              "duration": { "math": [ "rand(10800) + 3600" ] },
+              "target_part": "arm_r",
+              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'arm_r') + 1" ] }
+            },
+            { "u_add_effect": "effect_psi_cauterize_no_bleed", "duration": 1, "target_part": "arm_r" },
+            { "u_set_hp": { "math": [ "u_hp('arm_l') - 1" ] }, "target_part": "arm_r" },
+            { "math": [ "u_pain()", "+=", "rng(1,2)" ] }
+          ],
+          "false_effect": [
+            {
+              "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
+              "type": "bad"
+            },
+            {
+              "u_add_effect": "effect_psi_post_cauterize",
+              "duration": { "math": [ "rand(10800) + 3600" ] },
+              "target_part": "arm_r",
+              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'arm_r') + 1" ] }
+            },
+            { "u_set_hp": { "math": [ "u_hp('arm_l') - 3" ] }, "target_part": "arm_r" },
+            { "math": [ "u_pain()", "+=", "rng(1,3)" ] }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PYROKIN_CAUTERIZE_HEAD",
+    "//": "Nesting needed here because otherwise if the condition is not met, the option is not even selectable",
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_PYROKIN_CAUTERIZE_HEAD_2",
+          "condition": {
+            "or": [
+              { "u_has_trait": "PROF_MED" },
+              { "u_has_proficiency": "prof_burn_care" },
+              { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+            ]
+          },
+          "effect": [
+            {
+              "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
+              "type": "good"
+            },
+            {
+              "u_add_effect": "effect_psi_post_cauterize",
+              "duration": { "math": [ "rand(10800) + 3600" ] },
+              "target_part": "head",
+              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'head') + 1" ] }
+            },
+            { "u_add_effect": "effect_psi_cauterize_no_bleed", "duration": 1, "target_part": "head" },
+            { "u_set_hp": { "math": [ "u_hp('head') - 1" ] }, "target_part": "head" },
+            { "math": [ "u_pain()", "+=", "rng(1,4)" ] }
+          ],
+          "false_effect": [
+            {
+              "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
+              "type": "bad"
+            },
+            {
+              "u_add_effect": "effect_psi_post_cauterize",
+              "duration": { "math": [ "rand(10800) + 3600" ] },
+              "target_part": "head",
+              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'head') + 1" ] }
+            },
+            { "u_set_hp": { "math": [ "u_hp('head') - 3" ] }, "target_part": "head" },
+            { "math": [ "u_pain()", "+=", "rng(2,6)" ] }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PYROKIN_CAUTERIZE_LEFT_LEG",
+    "//": "Nesting needed here because otherwise if the condition is not met, the option is not even selectable",
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_PYROKIN_CAUTERIZE_LEFT_LEG_2",
+          "condition": {
+            "or": [
+              { "u_has_trait": "PROF_MED" },
+              { "u_has_proficiency": "prof_burn_care" },
+              { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+            ]
+          },
+          "effect": [
+            {
+              "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
+              "type": "good"
+            },
+            {
+              "u_add_effect": "effect_psi_post_cauterize",
+              "duration": { "math": [ "rand(10800) + 3600" ] },
+              "target_part": "leg_l",
+              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'leg_r') + 1" ] }
+            },
+            { "u_add_effect": "effect_psi_cauterize_no_bleed", "duration": 1, "target_part": "leg_l" },
+            { "u_set_hp": { "math": [ "u_hp('leg_l') - 1" ] }, "target_part": "leg_l" },
+            { "math": [ "u_pain()", "+=", "rng(1,2)" ] }
+          ],
+          "false_effect": [
+            {
+              "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
+              "type": "bad"
+            },
+            {
+              "u_add_effect": "effect_psi_post_cauterize",
+              "duration": { "math": [ "rand(10800) + 3600" ] },
+              "target_part": "leg_l",
+              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'leg_l') + 1" ] }
+            },
+            { "u_set_hp": { "math": [ "u_hp('leg_l') - 3" ] }, "target_part": "leg_l" },
+            { "math": [ "u_pain()", "+=", "rng(1,3)" ] }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG",
+    "//": "Nesting needed here because otherwise if the condition is not met, the option is not even selectable",
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG_2",
+          "condition": {
+            "or": [
+              { "u_has_trait": "PROF_MED" },
+              { "u_has_proficiency": "prof_burn_care" },
+              { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+            ]
+          },
+          "effect": [
+            {
+              "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
+              "type": "good"
+            },
+            {
+              "u_add_effect": "effect_psi_post_cauterize",
+              "duration": { "math": [ "rand(10800) + 3600" ] },
+              "target_part": "leg_r",
+              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'leg_r') + 1" ] }
+            },
+            { "u_add_effect": "effect_psi_cauterize_no_bleed", "duration": 1, "target_part": "leg_r" },
+            { "u_set_hp": { "math": [ "u_hp('leg_r') - 1" ] }, "target_part": "leg_r" },
+            { "math": [ "u_pain()", "+=", "rng(1,2)" ] }
+          ],
+          "false_effect": [
+            {
+              "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
+              "type": "bad"
+            },
+            {
+              "u_add_effect": "effect_psi_post_cauterize",
+              "duration": { "math": [ "rand(10800) + 3600" ] },
+              "target_part": "leg_r",
+              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'leg_r') + 1" ] }
+            },
+            { "u_set_hp": { "math": [ "u_hp('leg_r') - 3" ] }, "target_part": "leg_r" },
+            { "math": [ "u_pain()", "+=", "rng(1,3)" ] }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_PYROKIN_CAUTERIZE_BODY",
+    "//": "Nesting needed here because otherwise if the condition is not met, the option is not even selectable",
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_PYROKIN_CAUTERIZE_BODY_2",
+          "condition": {
+            "or": [
+              { "u_has_trait": "PROF_MED" },
+              { "u_has_proficiency": "prof_burn_care" },
+              { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+            ]
+          },
+          "effect": [
+            {
+              "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
+              "type": "good"
+            },
+            {
+              "u_add_effect": "effect_psi_post_cauterize",
+              "duration": { "math": [ "rand(10800) + 3600" ] },
+              "target_part": "torso",
+              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'torso') + 1" ] }
+            },
+            { "u_lose_effect": "bleed", "target_part": "torso" },
+            { "u_set_hp": { "math": [ "u_hp('torso') - 1" ] }, "target_part": "torso" },
+            { "math": [ "u_pain()", "+=", "rng(1,3)" ] }
+          ],
+          "false_effect": [
+            {
+              "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
+              "type": "bad"
+            },
+            {
+              "u_add_effect": "effect_psi_post_cauterize",
+              "duration": { "math": [ "rand(10800) + 3600" ] },
+              "target_part": "torso",
+              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'torso') + 1" ] }
+            },
+            { "u_set_hp": { "math": [ "u_hp('torso') - 3" ] }, "target_part": "torso" },
+            { "math": [ "u_pain()", "+=", "rng(1,3)" ] }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
     "id": "EOC_SPELL_PYROKIN_THERMOGENESIS_SELECTOR",
     "effect": [
       {

--- a/data/mods/MindOverMatter/powers/pyrokinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/pyrokinesis_eoc.json
@@ -34,45 +34,55 @@
     "condition": { "math": [ "u_effect_intensity('bleed', 'bodypart': 'arm_l')", "<=", "29" ] },
     "effect": [
       {
-        "run_eocs": {
-          "id": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_2",
-          "condition": {
-            "or": [
-              { "u_has_trait": "PROF_MED" },
-              { "u_has_proficiency": "prof_burn_care" },
-              { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+        "run_eocs": [
+          {
+            "id": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_2",
+            "condition": {
+              "or": [
+                { "u_has_trait": "PROF_MED" },
+                { "u_has_proficiency": "prof_burn_care" },
+                { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+              ]
+            },
+            "effect": [
+              {
+                "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
+                "type": "good"
+              },
+              {
+                "u_add_effect": "effect_psi_post_cauterize",
+                "duration": { "math": [ "rand(10800) + 3600" ] },
+                "target_part": "arm_l",
+                "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'arm_l') + 1" ] }
+              },
+              { "u_remove_effect": "bleed", "target_part": "arm_l" },
+              { "u_set_hp": { "math": [ "u_hp('arm_l') - 1" ] }, "target_part": "arm_l" },
+              { "math": [ "u_pain()", "+=", "rng(1,2)" ] },
+              {
+                "run_eocs": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_INFECTION_CHECK",
+                "time_in_future": [ "6 hours", "24 hours" ]
+              }
+            ],
+            "false_effect": [
+              {
+                "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
+                "type": "bad"
+              },
+              {
+                "u_add_effect": "effect_psi_post_cauterize",
+                "duration": { "math": [ "rand(10800) + 3600" ] },
+                "target_part": "arm_l",
+                "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'arm_l') + 1" ] }
+              },
+              { "u_set_hp": { "math": [ "u_hp('arm_l') - 3" ] }, "target_part": "arm_l" },
+              { "math": [ "u_pain()", "+=", "rng(1,3)" ] },
+              {
+                "run_eocs": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_INFECTION_CHECK",
+                "time_in_future": [ "6 hours", "24 hours" ]
+              }
             ]
-          },
-          "effect": [
-            {
-              "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
-              "type": "good"
-            },
-            {
-              "u_add_effect": "effect_psi_post_cauterize",
-              "duration": { "math": [ "rand(10800) + 3600" ] },
-              "target_part": "arm_l",
-              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'arm_l') + 1" ] }
-            },
-            { "u_add_effect": "effect_psi_cauterize_no_bleed", "duration": 1, "target_part": "arm_l" },
-            { "u_set_hp": { "math": [ "u_hp('arm_l') - 1" ] }, "target_part": "arm_l" },
-            { "math": [ "u_pain()", "+=", "rng(1,2)" ] }
-          ],
-          "false_effect": [
-            {
-              "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
-              "type": "bad"
-            },
-            {
-              "u_add_effect": "effect_psi_post_cauterize",
-              "duration": { "math": [ "rand(10800) + 3600" ] },
-              "target_part": "arm_l",
-              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'arm_l') + 1" ] }
-            },
-            { "u_set_hp": { "math": [ "u_hp('arm_l') - 3" ] }, "target_part": "arm_l" },
-            { "math": [ "u_pain()", "+=", "rng(1,3)" ] }
-          ]
-        }
+          }
+        ]
       }
     ],
     "false_effect": { "u_message": "The bleeding is too much for you to stop with your powers.", "type": "bad" }
@@ -83,45 +93,55 @@
     "condition": { "math": [ "u_effect_intensity('bleed', 'bodypart': 'arm_r')", "<=", "29" ] },
     "effect": [
       {
-        "run_eocs": {
-          "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_ARM_2",
-          "condition": {
-            "or": [
-              { "u_has_trait": "PROF_MED" },
-              { "u_has_proficiency": "prof_burn_care" },
-              { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+        "run_eocs": [
+          {
+            "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_ARM_2",
+            "condition": {
+              "or": [
+                { "u_has_trait": "PROF_MED" },
+                { "u_has_proficiency": "prof_burn_care" },
+                { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+              ]
+            },
+            "effect": [
+              {
+                "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
+                "type": "good"
+              },
+              {
+                "u_add_effect": "effect_psi_post_cauterize",
+                "duration": { "math": [ "rand(10800) + 3600" ] },
+                "target_part": "arm_r",
+                "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'arm_r') + 1" ] }
+              },
+              { "u_remove_effect": "bleed", "target_part": "arm_r" },
+              { "u_set_hp": { "math": [ "u_hp('arm_r') - 1" ] }, "target_part": "arm_r" },
+              { "math": [ "u_pain()", "+=", "rng(1,2)" ] },
+              {
+                "run_eocs": "EOC_PYROKIN_CAUTERIZE_RIGHT_ARM_INFECTION_CHECK",
+                "time_in_future": [ "6 hours", "24 hours" ]
+              }
+            ],
+            "false_effect": [
+              {
+                "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
+                "type": "bad"
+              },
+              {
+                "u_add_effect": "effect_psi_post_cauterize",
+                "duration": { "math": [ "rand(10800) + 3600" ] },
+                "target_part": "arm_r",
+                "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'arm_r') + 1" ] }
+              },
+              { "u_set_hp": { "math": [ "u_hp('arm_r') - 3" ] }, "target_part": "arm_r" },
+              { "math": [ "u_pain()", "+=", "rng(1,3)" ] },
+              {
+                "run_eocs": "EOC_PYROKIN_CAUTERIZE_RIGHT_ARM_INFECTION_CHECK",
+                "time_in_future": [ "6 hours", "24 hours" ]
+              }
             ]
-          },
-          "effect": [
-            {
-              "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
-              "type": "good"
-            },
-            {
-              "u_add_effect": "effect_psi_post_cauterize",
-              "duration": { "math": [ "rand(10800) + 3600" ] },
-              "target_part": "arm_r",
-              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'arm_r') + 1" ] }
-            },
-            { "u_add_effect": "effect_psi_cauterize_no_bleed", "duration": 1, "target_part": "arm_r" },
-            { "u_set_hp": { "math": [ "u_hp('arm_l') - 1" ] }, "target_part": "arm_r" },
-            { "math": [ "u_pain()", "+=", "rng(1,2)" ] }
-          ],
-          "false_effect": [
-            {
-              "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
-              "type": "bad"
-            },
-            {
-              "u_add_effect": "effect_psi_post_cauterize",
-              "duration": { "math": [ "rand(10800) + 3600" ] },
-              "target_part": "arm_r",
-              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'arm_r') + 1" ] }
-            },
-            { "u_set_hp": { "math": [ "u_hp('arm_l') - 3" ] }, "target_part": "arm_r" },
-            { "math": [ "u_pain()", "+=", "rng(1,3)" ] }
-          ]
-        }
+          }
+        ]
       }
     ],
     "false_effect": { "u_message": "The bleeding is too much for you to stop with your powers.", "type": "bad" }
@@ -132,45 +152,55 @@
     "condition": { "math": [ "u_effect_intensity('bleed', 'bodypart': 'head')", "<=", "29" ] },
     "effect": [
       {
-        "run_eocs": {
-          "id": "EOC_PYROKIN_CAUTERIZE_HEAD_2",
-          "condition": {
-            "or": [
-              { "u_has_trait": "PROF_MED" },
-              { "u_has_proficiency": "prof_burn_care" },
-              { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+        "run_eocs": [
+          {
+            "id": "EOC_PYROKIN_CAUTERIZE_HEAD_2",
+            "condition": {
+              "or": [
+                { "u_has_trait": "PROF_MED" },
+                { "u_has_proficiency": "prof_burn_care" },
+                { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+              ]
+            },
+            "effect": [
+              {
+                "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
+                "type": "good"
+              },
+              {
+                "u_add_effect": "effect_psi_post_cauterize",
+                "duration": { "math": [ "rand(10800) + 3600" ] },
+                "target_part": "head",
+                "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'head') + 1" ] }
+              },
+              { "u_remove_effect": "bleed", "target_part": "head" },
+              { "u_set_hp": { "math": [ "u_hp('head') - 1" ] }, "target_part": "head" },
+              { "math": [ "u_pain()", "+=", "rng(1,4)" ] },
+              {
+                "run_eocs": "EOC_PYROKIN_CAUTERIZE_HEAD_INFECTION_CHECK",
+                "time_in_future": [ "6 hours", "24 hours" ]
+              }
+            ],
+            "false_effect": [
+              {
+                "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
+                "type": "bad"
+              },
+              {
+                "u_add_effect": "effect_psi_post_cauterize",
+                "duration": { "math": [ "rand(10800) + 3600" ] },
+                "target_part": "head",
+                "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'head') + 1" ] }
+              },
+              { "u_set_hp": { "math": [ "u_hp('head') - 3" ] }, "target_part": "head" },
+              { "math": [ "u_pain()", "+=", "rng(2,6)" ] },
+              {
+                "run_eocs": "EOC_PYROKIN_CAUTERIZE_HEAD_INFECTION_CHECK",
+                "time_in_future": [ "6 hours", "24 hours" ]
+              }
             ]
-          },
-          "effect": [
-            {
-              "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
-              "type": "good"
-            },
-            {
-              "u_add_effect": "effect_psi_post_cauterize",
-              "duration": { "math": [ "rand(10800) + 3600" ] },
-              "target_part": "head",
-              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'head') + 1" ] }
-            },
-            { "u_add_effect": "effect_psi_cauterize_no_bleed", "duration": 1, "target_part": "head" },
-            { "u_set_hp": { "math": [ "u_hp('head') - 1" ] }, "target_part": "head" },
-            { "math": [ "u_pain()", "+=", "rng(1,4)" ] }
-          ],
-          "false_effect": [
-            {
-              "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
-              "type": "bad"
-            },
-            {
-              "u_add_effect": "effect_psi_post_cauterize",
-              "duration": { "math": [ "rand(10800) + 3600" ] },
-              "target_part": "head",
-              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'head') + 1" ] }
-            },
-            { "u_set_hp": { "math": [ "u_hp('head') - 3" ] }, "target_part": "head" },
-            { "math": [ "u_pain()", "+=", "rng(2,6)" ] }
-          ]
-        }
+          }
+        ]
       }
     ],
     "false_effect": { "u_message": "The bleeding is too much for you to stop with your powers.", "type": "bad" }
@@ -181,45 +211,55 @@
     "condition": { "math": [ "u_effect_intensity('bleed', 'bodypart': 'leg_r')", "<=", "29" ] },
     "effect": [
       {
-        "run_eocs": {
-          "id": "EOC_PYROKIN_CAUTERIZE_LEFT_LEG_2",
-          "condition": {
-            "or": [
-              { "u_has_trait": "PROF_MED" },
-              { "u_has_proficiency": "prof_burn_care" },
-              { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+        "run_eocs": [
+          {
+            "id": "EOC_PYROKIN_CAUTERIZE_LEFT_LEG_2",
+            "condition": {
+              "or": [
+                { "u_has_trait": "PROF_MED" },
+                { "u_has_proficiency": "prof_burn_care" },
+                { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+              ]
+            },
+            "effect": [
+              {
+                "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
+                "type": "good"
+              },
+              {
+                "u_add_effect": "effect_psi_post_cauterize",
+                "duration": { "math": [ "rand(10800) + 3600" ] },
+                "target_part": "leg_l",
+                "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'leg_r') + 1" ] }
+              },
+              { "u_remove_effect": "bleed", "target_part": "leg_l" },
+              { "u_set_hp": { "math": [ "u_hp('leg_l') - 1" ] }, "target_part": "leg_l" },
+              { "math": [ "u_pain()", "+=", "rng(1,2)" ] },
+              {
+                "run_eocs": "EOC_PYROKIN_CAUTERIZE_LEFT_LEG_INFECTION_CHECK",
+                "time_in_future": [ "6 hours", "24 hours" ]
+              }
+            ],
+            "false_effect": [
+              {
+                "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
+                "type": "bad"
+              },
+              {
+                "u_add_effect": "effect_psi_post_cauterize",
+                "duration": { "math": [ "rand(10800) + 3600" ] },
+                "target_part": "leg_l",
+                "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'leg_l') + 1" ] }
+              },
+              { "u_set_hp": { "math": [ "u_hp('leg_l') - 3" ] }, "target_part": "leg_l" },
+              { "math": [ "u_pain()", "+=", "rng(1,3)" ] },
+              {
+                "run_eocs": "EOC_PYROKIN_CAUTERIZE_LEFT_LEG_INFECTION_CHECK",
+                "time_in_future": [ "6 hours", "24 hours" ]
+              }
             ]
-          },
-          "effect": [
-            {
-              "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
-              "type": "good"
-            },
-            {
-              "u_add_effect": "effect_psi_post_cauterize",
-              "duration": { "math": [ "rand(10800) + 3600" ] },
-              "target_part": "leg_l",
-              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'leg_r') + 1" ] }
-            },
-            { "u_add_effect": "effect_psi_cauterize_no_bleed", "duration": 1, "target_part": "leg_l" },
-            { "u_set_hp": { "math": [ "u_hp('leg_l') - 1" ] }, "target_part": "leg_l" },
-            { "math": [ "u_pain()", "+=", "rng(1,2)" ] }
-          ],
-          "false_effect": [
-            {
-              "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
-              "type": "bad"
-            },
-            {
-              "u_add_effect": "effect_psi_post_cauterize",
-              "duration": { "math": [ "rand(10800) + 3600" ] },
-              "target_part": "leg_l",
-              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'leg_l') + 1" ] }
-            },
-            { "u_set_hp": { "math": [ "u_hp('leg_l') - 3" ] }, "target_part": "leg_l" },
-            { "math": [ "u_pain()", "+=", "rng(1,3)" ] }
-          ]
-        }
+          }
+        ]
       }
     ],
     "false_effect": { "u_message": "The bleeding is too much for you to stop with your powers.", "type": "bad" }
@@ -230,45 +270,55 @@
     "condition": { "math": [ "u_effect_intensity('bleed', 'bodypart': 'leg_r')", "<=", "29" ] },
     "effect": [
       {
-        "run_eocs": {
-          "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG_2",
-          "condition": {
-            "or": [
-              { "u_has_trait": "PROF_MED" },
-              { "u_has_proficiency": "prof_burn_care" },
-              { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+        "run_eocs": [
+          {
+            "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG_2",
+            "condition": {
+              "or": [
+                { "u_has_trait": "PROF_MED" },
+                { "u_has_proficiency": "prof_burn_care" },
+                { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+              ]
+            },
+            "effect": [
+              {
+                "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
+                "type": "good"
+              },
+              {
+                "u_add_effect": "effect_psi_post_cauterize",
+                "duration": { "math": [ "rand(10800) + 3600" ] },
+                "target_part": "leg_r",
+                "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'leg_r') + 1" ] }
+              },
+              { "u_remove_effect": "bleed", "target_part": "leg_r" },
+              { "u_set_hp": { "math": [ "u_hp('leg_r') - 1" ] }, "target_part": "leg_r" },
+              { "math": [ "u_pain()", "+=", "rng(1,2)" ] },
+              {
+                "run_eocs": "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG_INFECTION_CHECK",
+                "time_in_future": [ "6 hours", "24 hours" ]
+              }
+            ],
+            "false_effect": [
+              {
+                "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
+                "type": "bad"
+              },
+              {
+                "u_add_effect": "effect_psi_post_cauterize",
+                "duration": { "math": [ "rand(10800) + 3600" ] },
+                "target_part": "leg_r",
+                "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'leg_r') + 1" ] }
+              },
+              { "u_set_hp": { "math": [ "u_hp('leg_r') - 3" ] }, "target_part": "leg_r" },
+              { "math": [ "u_pain()", "+=", "rng(1,3)" ] },
+              {
+                "run_eocs": "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG_INFECTION_CHECK",
+                "time_in_future": [ "6 hours", "24 hours" ]
+              }
             ]
-          },
-          "effect": [
-            {
-              "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
-              "type": "good"
-            },
-            {
-              "u_add_effect": "effect_psi_post_cauterize",
-              "duration": { "math": [ "rand(10800) + 3600" ] },
-              "target_part": "leg_r",
-              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'leg_r') + 1" ] }
-            },
-            { "u_add_effect": "effect_psi_cauterize_no_bleed", "duration": 1, "target_part": "leg_r" },
-            { "u_set_hp": { "math": [ "u_hp('leg_r') - 1" ] }, "target_part": "leg_r" },
-            { "math": [ "u_pain()", "+=", "rng(1,2)" ] }
-          ],
-          "false_effect": [
-            {
-              "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
-              "type": "bad"
-            },
-            {
-              "u_add_effect": "effect_psi_post_cauterize",
-              "duration": { "math": [ "rand(10800) + 3600" ] },
-              "target_part": "leg_r",
-              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'leg_r') + 1" ] }
-            },
-            { "u_set_hp": { "math": [ "u_hp('leg_r') - 3" ] }, "target_part": "leg_r" },
-            { "math": [ "u_pain()", "+=", "rng(1,3)" ] }
-          ]
-        }
+          }
+        ]
       }
     ],
     "false_effect": { "u_message": "The bleeding is too much for you to stop with your powers.", "type": "bad" }
@@ -279,47 +329,308 @@
     "condition": { "math": [ "u_effect_intensity('bleed', 'bodypart': 'torso')", "<=", "29" ] },
     "effect": [
       {
-        "run_eocs": {
-          "id": "EOC_PYROKIN_CAUTERIZE_BODY_2",
-          "condition": {
-            "or": [
-              { "u_has_trait": "PROF_MED" },
-              { "u_has_proficiency": "prof_burn_care" },
-              { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+        "run_eocs": [
+          {
+            "id": "EOC_PYROKIN_CAUTERIZE_BODY_2",
+            "condition": {
+              "or": [
+                { "u_has_trait": "PROF_MED" },
+                { "u_has_proficiency": "prof_burn_care" },
+                { "roll_contested": { "math": [ "u_skill('firstaid')" ] }, "difficulty": 7 }
+              ]
+            },
+            "effect": [
+              {
+                "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
+                "type": "good"
+              },
+              {
+                "u_add_effect": "effect_psi_post_cauterize",
+                "duration": { "math": [ "rand(10800) + 3600" ] },
+                "target_part": "torso",
+                "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'torso') + 1" ] }
+              },
+              { "u_remove_effect": "bleed", "target_part": "torso" },
+              { "u_set_hp": { "math": [ "u_hp('torso') - 1" ] }, "target_part": "torso" },
+              { "math": [ "u_pain()", "+=", "rng(1,3)" ] },
+              {
+                "run_eocs": "EOC_PYROKIN_CAUTERIZE_TORSO_INFECTION_CHECK",
+                "time_in_future": [ "6 hours", "24 hours" ]
+              }
+            ],
+            "false_effect": [
+              {
+                "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
+                "type": "bad"
+              },
+              {
+                "u_add_effect": "effect_psi_post_cauterize",
+                "duration": { "math": [ "rand(10800) + 3600" ] },
+                "target_part": "torso",
+                "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'torso') + 1" ] }
+              },
+              { "u_set_hp": { "math": [ "u_hp('torso') - 3" ] }, "target_part": "torso" },
+              { "math": [ "u_pain()", "+=", "rng(1,3)" ] },
+              {
+                "run_eocs": "EOC_PYROKIN_CAUTERIZE_TORSO_INFECTION_CHECK",
+                "time_in_future": [ "6 hours", "24 hours" ]
+              }
             ]
-          },
-          "effect": [
-            {
-              "u_message": "There is a moment of searing pain, and when you look at the wound, The bleeding has stopped.",
-              "type": "good"
-            },
-            {
-              "u_add_effect": "effect_psi_post_cauterize",
-              "duration": { "math": [ "rand(10800) + 3600" ] },
-              "target_part": "torso",
-              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'torso') + 1" ] }
-            },
-            { "u_set_hp": { "math": [ "u_hp('torso') - 1" ] }, "target_part": "torso" },
-            { "math": [ "u_pain()", "+=", "rng(1,3)" ] }
-          ],
-          "false_effect": [
-            {
-              "u_message": "There is a moment of searing pain, but when you look at the wound, you're still bleeding.  You'll have to try again.",
-              "type": "bad"
-            },
-            {
-              "u_add_effect": "effect_psi_post_cauterize",
-              "duration": { "math": [ "rand(10800) + 3600" ] },
-              "target_part": "torso",
-              "intensity": { "math": [ "u_effect_intensity('effect_psi_post_cauterize', 'bodypart': 'torso') + 1" ] }
-            },
-            { "u_set_hp": { "math": [ "u_hp('torso') - 3" ] }, "target_part": "torso" },
-            { "math": [ "u_pain()", "+=", "rng(1,3)" ] }
-          ]
-        }
+          }
+        ]
       }
     ],
     "false_effect": { "u_message": "The bleeding is too much for you to stop with your powers.", "type": "bad" }
+  },
+  {
+    "type": "",
+    "id": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_INFECTION_CHECK",
+    "condition": { "x_in_y_chance": { "x": 1, "y": 15 } },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_INFECTION_CHECK_2",
+            "condition": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_l')", ">=", "1" ] },
+            "effect": [
+              {
+                "u_add_effect": "infected",
+                "duration": "24 hours",
+                "target_part": "arm_l",
+                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_l') + 1" ] }
+              },
+              { "u_message": "The infection on your left arm is getting worse.", "type": "bad" }
+            ],
+            "false_effect": [
+              {
+                "u_add_effect": "infected",
+                "duration": "24 hours",
+                "target_part": "arm_l",
+                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_l') + 1" ] }
+              },
+              {
+                "u_message": "The wound on your left arm you tried to cauterize is starting to itch and swell.  It's probably infected.",
+                "type": "bad"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "",
+    "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_ARM_INFECTION_CHECK",
+    "condition": { "x_in_y_chance": { "x": 1, "y": 15 } },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_ARM_INFECTION_CHECK_2",
+            "condition": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_r')", ">=", "1" ] },
+            "effect": [
+              {
+                "u_add_effect": "infected",
+                "duration": "24 hours",
+                "target_part": "arm_r",
+                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_r') + 1" ] }
+              },
+              { "u_message": "The infection on your right arm is getting worse.", "type": "bad" }
+            ],
+            "false_effect": [
+              {
+                "u_add_effect": "infected",
+                "duration": "24 hours",
+                "target_part": "arm_r",
+                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_r') + 1" ] }
+              },
+              {
+                "u_message": "The wound on your right arm you tried to cauterize is starting to itch and swell.  It's probably infected.",
+                "type": "bad"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "",
+    "id": "EOC_PYROKIN_CAUTERIZE_HEAD_INFECTION_CHECK",
+    "condition": { "x_in_y_chance": { "x": 1, "y": 15 } },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PYROKIN_CAUTERIZE_HEAD_INFECTION_CHECK_CHECK_2",
+            "condition": { "math": [ "u_effect_intensity('infected', 'bodypart': 'head')", ">=", "1" ] },
+            "effect": [
+              {
+                "u_add_effect": "infected",
+                "duration": "24 hours",
+                "target_part": "head",
+                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'head') + 1" ] }
+              },
+              { "u_message": "The infection on your head is getting worse.", "type": "bad" }
+            ],
+            "false_effect": [
+              {
+                "u_add_effect": "infected",
+                "duration": "24 hours",
+                "target_part": "head",
+                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'head') + 1" ] }
+              },
+              {
+                "u_message": "The wound on your head you tried to cauterize is starting to itch and swell.  It's probably infected.",
+                "type": "bad"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "",
+    "id": "EOC_PYROKIN_CAUTERIZE_LEFT_LEG_INFECTION_CHECK",
+    "condition": { "x_in_y_chance": { "x": 1, "y": 15 } },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PYROKIN_CAUTERIZE_LEFT_LEG_INFECTION_CHECK_2",
+            "condition": { "math": [ "u_effect_intensity('infected', 'bodypart': 'leg_l')", ">=", "1" ] },
+            "effect": [
+              {
+                "u_add_effect": "infected",
+                "duration": "24 hours",
+                "target_part": "leg_l",
+                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'leg_l') + 1" ] }
+              },
+              { "u_message": "The infection on your left leg is getting worse.", "type": "bad" }
+            ],
+            "false_effect": [
+              {
+                "u_add_effect": "infected",
+                "duration": "24 hours",
+                "target_part": "leg_l",
+                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'leg_l') + 1" ] }
+              },
+              {
+                "u_message": "The wound on your left leg you tried to cauterize is starting to itch and swell.  It's probably infected.",
+                "type": "bad"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "",
+    "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG_INFECTION_CHECK",
+    "condition": { "x_in_y_chance": { "x": 1, "y": 15 } },
+    "effect": [
+      {
+        "run_eocs": {
+          "id": "EOC_PYROKIN_CAUTERIZE_RIGHT_LEG_INFECTION_CHECK_2",
+          "condition": { "math": [ "u_effect_intensity('infected', 'bodypart': 'leg_r')", ">=", "1" ] },
+          "effect": [
+            {
+              "u_add_effect": "infected",
+              "duration": "24 hours",
+              "target_part": "leg_r",
+              "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'leg_r') + 1" ] }
+            },
+            { "u_message": "The infection on your right leg is getting worse.", "type": "bad" }
+          ],
+          "false_effect": [
+            {
+              "u_add_effect": "infected",
+              "duration": "24 hours",
+              "target_part": "leg_r",
+              "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'leg_r') + 1" ] }
+            },
+            {
+              "u_message": "The wound on your right leg you tried to cauterize is starting to itch and swell.  It's probably infected.",
+              "type": "bad"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "",
+    "id": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_INFECTION_CHECK",
+    "condition": { "x_in_y_chance": { "x": 1, "y": 15 } },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PYROKIN_CAUTERIZE_LEFT_ARM_INFECTION_CHECK_2",
+            "condition": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_l')", ">=", "1" ] },
+            "effect": [
+              {
+                "u_add_effect": "infected",
+                "duration": "24 hours",
+                "target_part": "arm_l",
+                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_l') + 1" ] }
+              },
+              { "u_message": "The infection on your left arm is getting worse.", "type": "bad" }
+            ],
+            "false_effect": [
+              {
+                "u_add_effect": "infected",
+                "duration": "24 hours",
+                "target_part": "arm_l",
+                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'arm_l') + 1" ] }
+              },
+              {
+                "u_message": "The wound on your left arm you tried to cauterize is starting to itch and swell.  It's probably infected.",
+                "type": "bad"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "",
+    "id": "EOC_PYROKIN_CAUTERIZE_TORSO_INFECTION_CHECK",
+    "condition": { "x_in_y_chance": { "x": 1, "y": 15 } },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_PYROKIN_CAUTERIZE_TORSO_INFECTION_CHECK_2",
+            "condition": { "math": [ "u_effect_intensity('infected', 'bodypart': 'torso')", ">=", "1" ] },
+            "effect": [
+              {
+                "u_add_effect": "infected",
+                "duration": "24 hours",
+                "target_part": "torso",
+                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'torso') + 1" ] }
+              },
+              { "u_message": "The infection on your torso is getting worse.", "type": "bad" }
+            ],
+            "false_effect": [
+              {
+                "u_add_effect": "infected",
+                "duration": "24 hours",
+                "target_part": "torso",
+                "intensity": { "math": [ "u_effect_intensity('infected', 'bodypart': 'torso') + 1" ] }
+              },
+              {
+                "u_message": "The wound on your torso you tried to cauterize is starting to itch and swell.  It's probably infected.",
+                "type": "bad"
+              }
+            ]
+          }
+        ]
+      }
+    ]
   },
   {
     "type": "effect_on_condition",

--- a/data/mods/MindOverMatter/recipes/practice/pyrokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/pyrokinesis_practice.json
@@ -12,6 +12,7 @@
     "nested_category_data": [
       "practice_pyrokinetic_flash",
       "practice_pyrokinetic_eruption",
+      "practice_pyrokinetic_cauterize",
       "practice_pyrokinetic_call_flames",
       "practice_pyrokinetic_quell_flames",
       "practice_pyrokinetic_thermogenesis",
@@ -114,6 +115,57 @@
             {
               "id": "EOC_PRACTICE_PYROKIN_FLAMES_FALSE",
               "condition": { "math": [ "u_val('spell_level', 'spell: pyrokinetic_eruption')", ">=", "1" ] },
+              "effect": [
+                { "u_message": "Your knowledge of your powers is so deep that mere contemplation is of no further use to you." },
+                { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+              ],
+              "false_effect": [
+                { "u_message": "Without even a basic understanding of the power, your meditation is nothing but idle musings." },
+                { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: cauterize",
+    "id": "practice_pyrokinetic_cauterize",
+    "description": "Contemplate your powers and improve your ability to close your wounds with precisely-directed fire.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 1,
+    "time": "30 m",
+    "autolearn": false,
+    "tools": [ [ [ "matrix_crystal_drained", -1 ] ] ],
+    "flags": [ "SECRET", "BLIND_HARD" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_PYROKIN_FLAMES",
+        "condition": {
+          "and": [
+            { "math": [ "u_val('spell_level', 'spell: pyrokinetic_cauterize')", ">=", "1" ] },
+            {
+              "math": [ "u_val('spell_exp', 'spell: pyrokinetic_cauterize')", "<=", "(difficulty_two_contemplation(1))" ]
+            }
+          ]
+        },
+        "effect": [
+          { "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge." },
+          { "math": [ "u_val('spell_exp', 'spell: pyrokinetic_cauterize')", "+=", "(contemplation_factor(1))" ] },
+          { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 0,2 )" ] },
+          { "math": [ "u_val('stored_kcal')", "-=", "psionics_contemplation_kcal_cost(2)" ] },
+          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+        ],
+        "false_effect": {
+          "run_eocs": [
+            {
+              "id": "EOC_PRACTICE_PYROKIN_FLAMES_FALSE",
+              "condition": { "math": [ "u_val('spell_level', 'spell: pyrokinetic_cauterize')", ">=", "1" ] },
               "effect": [
                 { "u_message": "Your knowledge of your powers is so deep that mere contemplation is of no further use to you." },
                 { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }

--- a/data/mods/MindOverMatter/recipes/practice/pyrokinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/pyrokinesis_practice.json
@@ -145,7 +145,7 @@
     "flags": [ "SECRET", "BLIND_HARD" ],
     "result_eocs": [
       {
-        "id": "EOC_PRACTICE_PYROKIN_FLAMES",
+        "id": "EOC_PRACTICE_PYROKIN_CAUTERIZE",
         "condition": {
           "and": [
             { "math": [ "u_val('spell_level', 'spell: pyrokinetic_cauterize')", ">=", "1" ] },
@@ -164,7 +164,7 @@
         "false_effect": {
           "run_eocs": [
             {
-              "id": "EOC_PRACTICE_PYROKIN_FLAMES_FALSE",
+              "id": "EOC_PRACTICE_PYROKIN_CAUTERIZE_FALSE",
               "condition": { "math": [ "u_val('spell_level', 'spell: pyrokinetic_cauterize')", ">=", "1" ] },
               "effect": [
                 { "u_message": "Your knowledge of your powers is so deep that mere contemplation is of no further use to you." },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Add ability for pyrokinetics to cauterize their wounds"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Stick-a-knife-in-a-fire cauterizing was removed from the game for good reason--it seems like it should work because we have thousands of years of tradition of people thinking it worked, but it actually just makes things worse.  It might stop bleeding but the additional tissue damage encourages infection. 

Cauterizing is still used in modern medicine, but in a much more small-scale and targeted fashion--electrocautery during surgery, for example. With pyrokinesis, it should be possible for a psion to apply their powers to a small enough area to mimic that effect...if they have some medical knowledge. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add the Cauterize power.  On use, it pops up a menu to select a body part, and when a part is chosen it makes a check. If the psion is a physician or has the Burn Care proficiency this check automatically passes, otherwise it's a check against the health care skill. Success causes a small amount of damage and pain, applies an effect that causes pain over time, but stops the bleeding. Failure causes more damage and more pain, applies that same pain over time effect, and does not stop anything. The pain and damage all stack with repeated failures, and each attempt also has a 7% chance to cause an infection within 24 hours (this is checked independently per attempt)--I never meant to imply doing this was a _good_ idea, but if you're a pyrokinetic trapped in a lab and all your bandages are gone, you should be able to try.

This is more difficult because a pyrokinetic does not have any of the same psionic awareness of their body that a vitakinetic would have, so they're forced to rely on their mundane medical knowledge.

Cauterize cannot stop arterial bleeding at all, and at lower levels you're better off using your hands to stop the bleeding (though you can still use this power if you want). 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works. Bleeding is removed from the appropriate body part, bleeding that is too strong cannot be removed, and if you're unlucky you'll get an infection later.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

You know, I could probably add an escalating chance of infection (matching real life) if you repeatedly fail your cauterization too (I did).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
