### PR TITLE
Added new "pre_note" annotations on several constructions.

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -1626,6 +1626,7 @@
       [ [ "straw_pile", 60 ], [ "withered", 60 ] ],
       [ [ "cordage", 8, "LIST" ] ]
     ],
+    "pre_note": "Must be supported on at least two sides.",
     "pre_special": "check_support",
     "post_terrain": "t_dirtfloor_thatchroof"
   },
@@ -6615,6 +6616,7 @@
     "time": "15 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "SCREW", "level": 1 } ] ],
     "components": [ [ [ "grip_hook", 1 ] ], [ [ "chain", 1 ] ] ],
+    "pre_note": "Must be supported on at least two sides.",
     "pre_special": "check_support",
     "post_terrain": "f_hanging_meathook"
   },
@@ -7902,6 +7904,7 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 1 ] ],
     "time": "60 m",
+    "pre_note": "Must be built indoors.",
     "qualities": [ [ { "id": "DRILL", "level": 1 } ], [ { "id": "WRENCH_FINE", "level": 1 } ] ],
     "components": [
       [ [ "heavy_punching_bag_sack", 1 ] ],
@@ -7998,6 +8001,7 @@
     "category": "TOOL",
     "time": "30 s",
     "required_skills": [ [ "fabrication", 0 ] ],
+    "pre_note": "Built in a tree.",
     "components": [ [ [ "rope_30", 1 ] ] ],
     "pre_flags": [ "SUPPORTS_ROOF", "TREE" ],
     "post_terrain": "f_hoist_rope"
@@ -8009,6 +8013,7 @@
     "category": "TOOL",
     "time": "5 m",
     "required_skills": [ [ "fabrication", 1 ] ],
+    "pre_note": "Must be built indoors.",
     "qualities": [ [ { "id": "HAMMER", "level": 1 } ] ],
     "components": [ [ [ "rope_30", 1 ] ], [ [ "nail", 6 ] ], [ [ "2x4", 2 ] ] ],
     "pre_flags": [ "SUPPORTS_ROOF", "INDOORS" ],
@@ -8021,6 +8026,7 @@
     "category": "TOOL",
     "time": "10 m",
     "required_skills": [ [ "fabrication", 0 ] ],
+    "pre_note": "Built in a tree.",
     "qualities": [ [ { "id": "HAMMER", "level": 1 } ] ],
     "components": [ [ [ "rope_30", 1 ] ], [ [ "block_and_tackle", 1 ] ], [ [ "spike", 1 ] ] ],
     "pre_flags": [ "SUPPORTS_ROOF", "TREE" ],
@@ -8035,6 +8041,7 @@
     "required_skills": [ [ "fabrication", 1 ] ],
     "qualities": [ [ { "id": "HAMMER", "level": 1 } ] ],
     "components": [ [ [ "rope_30", 1 ] ], [ [ "block_and_tackle", 1 ] ], [ [ "spike", 1 ] ], [ [ "nail", 6 ] ], [ [ "2x4", 2 ] ] ],
+    "pre_note": "Must be supported on at least two sides.",
     "pre_special": "check_support",
     "post_terrain": "f_hoist_pulley"
   },
@@ -8045,6 +8052,7 @@
     "category": "TOOL",
     "time": "10 m",
     "required_skills": [ [ "fabrication", 0 ] ],
+    "pre_note": "Must be built indoors.",
     "qualities": [ [ { "id": "HAMMER", "level": 1 } ] ],
     "components": [ [ [ "rope_30", 1 ] ], [ [ "block_and_tackle", 1 ] ], [ [ "spike", 1 ] ] ],
     "pre_flags": [ "SUPPORTS_ROOF", "INDOORS" ],


### PR DESCRIPTION
Added missing pre_note flags on entries with pre_special "check_support", any pre_flags annotations for "TREE" and "SUPPORTS_ROOF" Tested it in game too and it does what's expected :3

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Adds annotations to construction menu entries done indoors, in trees, and that require supporting walls."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Some of the construction entries would show that you met all the requirements to place it but still wouldn't allow you to build it due to none of the terrain having the needed flags. This behavior was pretty weird and not very intuitive from the result descriptions.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Created new annotations with "pre_note" in construction.json giving the player more context on where the construction should be placed. Any construction using "pre_flags" for TREE or INDOORS has been given a helpful annotation, and added annotation for constructions with "pre_special" check_support that were missing it.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I was contemplating digging into the construction menu code and attempting to write strings in the requirements section based on flags. I have little experience with the game's codebase currently, so adding annotations seemed much easier to start with.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Checked the construction menu for each updated entry and saw they had their new notes. I went ahead and built a few of them just to make sure they all worked. The annotations make it much more clear which variant needs to be placed where, especially with the various hoists.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
