### PR TITLE
Fixes permadeath when prevent_death is active

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1907,17 +1907,31 @@ bool Character::is_dead_state() const
 
 void Character::set_part_hp_cur( const bodypart_id &id, int set )
 {
-    Creature::set_part_hp_cur( id, set );
-    if( get_part_hp_cur( id ) <= 0 ) {
-        cached_dead_state.reset();
+    if( get_part_hp_cur( id ) > 0 ) {
+        Creature::set_part_hp_cur( id, set );
+        if( get_part_hp_cur( id ) <= 0 ) {
+            cached_dead_state.reset();
+        }
+    } else {
+        Creature::set_part_hp_cur( id, set );
+        if( get_part_hp_cur( id ) > 0 ) {
+            cached_dead_state.reset();
+        }
     }
 }
 
 void Character::mod_part_hp_cur( const bodypart_id &id, int set )
 {
-    Creature::mod_part_hp_cur( id, set );
-    if( get_part_hp_cur( id ) <= 0 ) {
-        cached_dead_state.reset();
+    if( get_part_hp_cur( id ) > 0 ) {
+        Creature::mod_part_hp_cur( id, set );
+        if( get_part_hp_cur( id ) <= 0 ) {
+            cached_dead_state.reset();
+        }
+    } else {
+        Creature::mod_part_hp_cur( id, set );
+        if( get_part_hp_cur( id ) > 0 ) {
+            cached_dead_state.reset();
+        }
     }
 }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1907,9 +1907,9 @@ bool Character::is_dead_state() const
 
 void Character::set_part_hp_cur( const bodypart_id &id, int set )
 {
-    bool is_broken_before = ( get_part_hp_cur( id ) <= 0 );
+    bool is_broken_before = get_part_hp_cur( id ) <= 0;
     Creature::set_part_hp_cur( id, set );
-    bool is_broken_after = ( get_part_hp_cur( id ) <= 0 );
+    bool is_broken_after = get_part_hp_cur( id ) <= 0;
     // detect unbroken->broken (possible death) as well as broken->unbroken (possible revival)
     if( is_broken_before != is_broken_after ) {
         cached_dead_state.reset();
@@ -1918,9 +1918,9 @@ void Character::set_part_hp_cur( const bodypart_id &id, int set )
 
 void Character::mod_part_hp_cur( const bodypart_id &id, int set )
 {
-    bool is_broken_before = ( get_part_hp_cur( id ) <= 0 );
+    bool is_broken_before = get_part_hp_cur( id ) <= 0;
     Creature::mod_part_hp_cur( id, set );
-    bool is_broken_after = ( get_part_hp_cur( id ) <= 0 );
+    bool is_broken_after = get_part_hp_cur( id ) <= 0;
     // detect unbroken->broken (possible death) as well as broken->unbroken (possible revival)
     if( is_broken_before != is_broken_after ) {
         cached_dead_state.reset();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -1907,31 +1907,23 @@ bool Character::is_dead_state() const
 
 void Character::set_part_hp_cur( const bodypart_id &id, int set )
 {
-    if( get_part_hp_cur( id ) > 0 ) {
-        Creature::set_part_hp_cur( id, set );
-        if( get_part_hp_cur( id ) <= 0 ) {
-            cached_dead_state.reset();
-        }
-    } else {
-        Creature::set_part_hp_cur( id, set );
-        if( get_part_hp_cur( id ) > 0 ) {
-            cached_dead_state.reset();
-        }
+    bool is_broken_before = ( get_part_hp_cur( id ) <= 0 );
+    Creature::set_part_hp_cur( id, set );
+    bool is_broken_after = ( get_part_hp_cur( id ) <= 0 );
+    // detect unbroken->broken (possible death) as well as broken->unbroken (possible revival)
+    if( is_broken_before != is_broken_after ) {
+        cached_dead_state.reset();
     }
 }
 
 void Character::mod_part_hp_cur( const bodypart_id &id, int set )
 {
-    if( get_part_hp_cur( id ) > 0 ) {
-        Creature::mod_part_hp_cur( id, set );
-        if( get_part_hp_cur( id ) <= 0 ) {
-            cached_dead_state.reset();
-        }
-    } else {
-        Creature::mod_part_hp_cur( id, set );
-        if( get_part_hp_cur( id ) > 0 ) {
-            cached_dead_state.reset();
-        }
+    bool is_broken_before = ( get_part_hp_cur( id ) <= 0 );
+    Creature::mod_part_hp_cur( id, set );
+    bool is_broken_after = ( get_part_hp_cur( id ) <= 0 );
+    // detect unbroken->broken (possible death) as well as broken->unbroken (possible revival)
+    if( is_broken_before != is_broken_after ) {
+        cached_dead_state.reset();
     }
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "prevent_death EOC can sometimes fail and lead to permadeath"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Resolves #70036, resolves #69814, resolves #68246. If vital body part was brought back to postive hp by a PREVENT_DEATH EOC after death, cached_dead_state will still be "true" since the cache is not invalidated upon healing of a broken limb by set_part_hp_cur or get_part_hp_cur. If no other effects reset cached_dead_state, is_dead will still return "true" even though all vital parts have positive hp.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Detect if hp rises from <=0 to >0 and reset cached_dead_state.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Permadeath no longer occurs in Sky Island. Players using Xedra Evolved or Magiclysm might want to test if this also works for them.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Explains the strange behaviour noted by #68246. set_stored_kcal calls set_stored_calories, which happens to call recalc_hp. recalc_hp then resets cached_dead_state, allowing prevent_death EOCs that set calories to still work.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
