### PR TITLE
Brewing fixes

### DIFF
--- a/data/json/recipes/food/brewing.json
+++ b/data/json/recipes/food/brewing.json
@@ -68,7 +68,9 @@
     "tools": [ [ [ "surface_heat", 58, "LIST" ] ] ],
     "//": "assuming grains are roasted, that's 52u flour by weight, plus 6u to heat water and activate yeast",
     "components": [ [ [ "water_clean", 3 ] ], [ [ "malted_grain", 2 ] ], [ [ "sugar", 50 ] ], [ [ "yeast", 1 ] ] ],
-    "charges": 3
+    "//1": "Using 3x250ml of water, this should give us ~750ml of product. For brew_whiskey it is 7 charges",
+    "//2": "per 250ml. Hence 3x7=21 charges",
+    "charges": 21
   },
   {
     "type": "recipe",
@@ -90,7 +92,9 @@
       [ [ "corn", 3 ], [ "cornmeal", 5 ], [ "barley", 1 ], [ "buckwheat", 1 ], [ "oats", 3 ] ],
       [ [ "juniper", 10 ] ]
     ],
-    "charges": 3
+    "//1": "Using 2x250ml of water, this should give us ~500ml of product. For brew_gin it is 7 charges",
+    "//2": "per 250ml. Hence 2x7=14 charges",
+    "charges": 14
   },
   {
     "type": "recipe",
@@ -121,7 +125,9 @@
     "book_learn": [ [ "brewing_cookbook", 6 ] ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
     "components": [ [ [ "sake_koji_rice", 1 ] ], [ [ "rice_cooked", 1 ] ], [ [ "water_clean", 3 ] ], [ [ "yeast", 1 ] ] ],
-    "charges": 3
+    "//1": "Using 3x250ml of water, this should give us ~750ml of product. For brew_sake it is 7 charges",
+    "//2": "per 250ml. Hence 3x7=21 charges",
+    "charges": 21
   },
   {
     "type": "recipe",
@@ -153,7 +159,9 @@
     "book_learn": [ [ "cookbook_sushi", 6 ] ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
     "components": [ [ [ "soy_wheat_dough_done", 1 ] ], [ [ "water_clean", 3 ] ], [ [ "salt", 30 ] ] ],
-    "charges": 3
+    "//1": "Using 3x250ml of water, this should give us ~750ml of product. For brew_soy_sauce it is 10 charges",
+    "//2": "per 250ml. Hence 3x10=30 charges",
+    "charges": 30
   },
   {
     "type": "recipe",
@@ -184,7 +192,10 @@
       ],
       [ [ "yeast", 1 ] ]
     ],
-    "charges": 3
+    "//1": "Using 3x250ml of water, this should give us ~750ml of product. For brew_vodka it is 7 charges per 250ml.",
+    "//2": "Plus evaporation process. I don't have exact numbers on evaporation loss, so let's make it 33%.",
+    "//3": "Hence 2x7=14 charges",
+    "charges": 14
   },
   {
     "type": "recipe",
@@ -201,7 +212,10 @@
     "qualities": [ { "id": "BOIL", "level": 2 } ],
     "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
     "components": [ [ [ "water_clean", 3 ] ], [ [ "molasses", 2 ], [ "sugar_beet", 5 ] ], [ [ "yeast", 1 ] ] ],
-    "charges": 3
+    "//1": "Using 3x250ml of water, this should give us ~750ml of product. For brew_rum it is 7 charges per 250ml.",
+    "//2": "Plus evaporation process. I don't have exact numbers on evaporation loss, so let's make it 33%.",
+    "//3": "Hence 2x7=14 charges",
+    "charges": 14
   },
   {
     "type": "recipe",
@@ -219,7 +233,11 @@
     "tools": [ [ [ "surface_heat", 60, "LIST" ] ] ],
     "//": "30u for corn and 30u to heat water & activate the yeast",
     "components": [ [ [ "water_clean", 15 ] ], [ [ "cornmeal", 12 ], [ "corn", 2 ] ], [ [ "sugar", 100 ] ], [ [ "yeast", 2 ] ] ],
-    "charges": 15
+    "components": [ [ [ "water_clean", 3 ] ], [ [ "molasses", 2 ], [ "sugar_beet", 5 ] ], [ [ "yeast", 1 ] ] ],
+    "//1": "Using (15+3)x250ml of water, this should give us ~4500ml of product. For brew_moonshine it is 7 charges per 250ml.",
+    "//2": "Plus evaporation process. I don't have exact numbers on evaporation loss, so let's make it 33%.",
+    "//3": "Hence 3000ml/250ml*7=14 charges",
+    "charges": 84
   },
   {
     "type": "recipe",
@@ -242,7 +260,10 @@
       [ [ "yeast", 1 ] ],
       [ [ "juice", 2 ], [ "apple_cider", 4 ], [ "sweet_fruit", 1, "LIST" ] ]
     ],
-    "charges": 10
+    "//1": "Using 10x250ml of water, this should give us ~2500ml of product. For brew_hb_seltzer it is 1 charge per 250ml.",
+    "//2": "Plus evaporation process. I don't have exact numbers on evaporation loss, so let's make it 33%.",
+    "//3": "Hence (2500/3*2)/250*1=6.(6) charges. Let's make it 7.",
+    "charges": 7
   },
   {
     "type": "recipe",
@@ -261,7 +282,10 @@
     "tools": [ [ [ "surface_heat", 54, "LIST" ] ] ],
     "//": "24u for pumpkin and 30u to heat water & activate the yeast",
     "components": [ [ [ "water_clean", 15 ] ], [ [ "pumpkin_cut", 12 ] ], [ [ "sugar", 50 ] ], [ [ "yeast", 2 ] ] ],
-    "charges": 15
+    "//1": "Using 15x250ml of water, this should give us ~3750ml of product. For brew_moonshine it is 7 charges per 250ml.",
+    "//2": "Plus evaporation process. I don't have exact numbers on evaporation loss, so let's make it 33%.",
+    "//3": "Hence (3750/3*2)ml/250ml*7=70 charges",
+    "charges": 70
   },
   {
     "type": "recipe",
@@ -277,7 +301,9 @@
     "proficiencies": [ { "proficiency": "prof_food_prep" }, { "proficiency": "prof_fermenting" }, { "proficiency": "prof_winemaking" } ],
     "qualities": [ { "id": "CONTAIN", "level": 1 } ],
     "components": [ [ [ "juice", 2 ] ], [ [ "yeast", 1 ] ], [ [ "water_clean", 2 ] ] ],
-    "charges": 3
+    "//1": "Using 2x250ml of water plus 2x125ml of juice, this should give us ~750ml of product. For brew_fruit_wine it is 7 charges",
+    "//2": "per 250ml. Hence (750ml/250ml)x7=21 charges",
+    "charges": 21
   },
   {
     "type": "recipe",
@@ -295,7 +321,10 @@
     "tools": [ [ [ "surface_heat", 74, "LIST" ] ] ],
     "//": "assuming grains are roasted, that's 52u flour by weight, 2u for hops, plus 20u to heat water and activate yeast",
     "components": [ [ [ "water_clean", 10 ] ], [ [ "malted_grain", 2 ] ], [ [ "hops", 1 ] ], [ [ "yeast", 1 ] ] ],
-    "charges": 10
+    "//1": "Using 10x250ml of water, this should give us ~2500ml of product. For brew_hb_beer it is 1 charge per 250ml.",
+    "//2": "Plus evaporation process. I don't have exact numbers on evaporation loss, so let's make it 33%.",
+    "//3": "Hence (2500/3*2)ml/250ml*1=6.(6) charges. Let's make it 7.",
+    "charges": 7
   },
   {
     "type": "recipe",
@@ -315,7 +344,9 @@
       [ [ "honey_bottled", 12 ], [ "honeycomb", 2 ], [ "honey_glassed", 4 ] ],
       [ [ "yeast", 1 ] ]
     ],
-    "charges": 3
+    "//1": "Using 3x250ml of water, this should give us ~750ml of product. For brew_mead it is 7 charges per 250ml.",
+    "//2": "Hence (750ml/250ml)x7=21 charges",
+    "charges": 21
   },
   {
     "type": "recipe",
@@ -338,7 +369,9 @@
       [ [ "hops", 1 ] ],
       [ [ "yeast", 1 ] ]
     ],
-    "charges": 3
+    "//1": "Using 3x250ml of water, this should give us ~750ml of product. For brew_hopped_mead it is 7 charges per 250ml",
+    "//2": "(copy from brew_mead). Hence (750ml/250ml)x7=21 charges",
+    "charges": 21
   },
   {
     "type": "recipe",
@@ -368,7 +401,9 @@
       ],
       [ [ "yeast", 1 ] ]
     ],
-    "charges": 3
+    "//1": "Using 3x250ml of water, this should give us ~750ml of product. For brew_spiced_mead it is 7 charges per 250ml",
+    "//2": "(copy from brew_mead). Hence (750ml/250ml)x7=21 charges",
+    "charges": 21
   },
   {
     "type": "recipe",
@@ -397,7 +432,9 @@
       [ [ "sugar_standard", 2, "LIST" ], [ "honeycomb", 1 ] ],
       [ [ "yeast", 1 ] ]
     ],
-    "charges": 3
+    "//1": "Using 3x250ml of water, this should give us ~750ml of product. For brew_dandelion_wine it is 7 charges per 250ml.",
+    "//2": "Hence (750ml/250ml)x7=21 charges",
+    "charges": 21
   },
   {
     "type": "recipe",
@@ -431,7 +468,9 @@
       [ [ "sugar_standard", 2, "LIST" ], [ "honeycomb", 1 ] ],
       [ [ "yeast", 1 ] ]
     ],
-    "charges": 3
+    "//1": "Using 3x250ml of water, this should give us ~750ml of product. For brew_burdock_wine it is 7 charges per 250ml.",
+    "//2": "No distilling/evaporation (just roasting), so no volume loss. Hence (750ml/250ml)x7=21 charges",
+    "charges": 21
   },
   {
     "type": "recipe",
@@ -454,7 +493,9 @@
       [ [ "sugar_standard", 2, "LIST" ], [ "honeycomb", 1 ] ],
       [ [ "yeast", 1 ] ]
     ],
-    "charges": 3
+    "//1": "Using 3x250ml of water, this should give us ~750ml of product. For brew_burdock_wine it is 7 charges per 250ml.",
+    "//2": "No distilling/evaporation (not even roasting, see comment above), so no volume loss. Hence (750ml/250ml)x7=21 charges",
+    "charges": 21
   },
   {
     "type": "recipe",
@@ -518,7 +559,9 @@
         [ "wild_herbs", 40 ]
       ]
     ],
-    "charges": 1
+    "//1": "Using 2x250ml of water, this should give us ~500ml of product. For brew_vinegar it is 16 charges per 250ml.",
+    "//2": "Hence (500ml/250ml)x16=32 charges",
+    "charges": 32
   },
   {
     "type": "recipe",
@@ -567,6 +610,8 @@
       [ [ "yeast", 1 ] ],
       [ [ "sassafras_root", 1 ] ]
     ],
-    "charges": 1
+    "//1": "Using 1x250ml of water, this should give us ~250ml of product. For brew_rootbeer it is 7 charges per 250ml.",
+    "//2": "Hence (250ml/250ml)x7=7 charges",
+    "charges": 7
   }
 ]

--- a/data/json/recipes/food/brewing.json
+++ b/data/json/recipes/food/brewing.json
@@ -193,9 +193,8 @@
       [ [ "yeast", 1 ] ]
     ],
     "//1": "Using 3x250ml of water, this should give us ~750ml of product. For brew_vodka it is 7 charges per 250ml.",
-    "//2": "Plus evaporation process. I don't have exact numbers on evaporation loss, so let's make it 33%.",
-    "//3": "Hence 2x7=14 charges",
-    "charges": 14
+    "//2": "Hence 3x7=21 charges",
+    "charges": 21
   },
   {
     "type": "recipe",
@@ -213,9 +212,8 @@
     "tools": [ [ [ "surface_heat", 2, "LIST" ] ] ],
     "components": [ [ [ "water_clean", 3 ] ], [ [ "molasses", 2 ], [ "sugar_beet", 5 ] ], [ [ "yeast", 1 ] ] ],
     "//1": "Using 3x250ml of water, this should give us ~750ml of product. For brew_rum it is 7 charges per 250ml.",
-    "//2": "Plus evaporation process. I don't have exact numbers on evaporation loss, so let's make it 33%.",
-    "//3": "Hence 2x7=14 charges",
-    "charges": 14
+    "//2": "Hence 3x7=21 charges",
+    "charges": 21
   },
   {
     "type": "recipe",
@@ -233,11 +231,9 @@
     "tools": [ [ [ "surface_heat", 60, "LIST" ] ] ],
     "//": "30u for corn and 30u to heat water & activate the yeast",
     "components": [ [ [ "water_clean", 15 ] ], [ [ "cornmeal", 12 ], [ "corn", 2 ] ], [ [ "sugar", 100 ] ], [ [ "yeast", 2 ] ] ],
-    "components": [ [ [ "water_clean", 3 ] ], [ [ "molasses", 2 ], [ "sugar_beet", 5 ] ], [ [ "yeast", 1 ] ] ],
-    "//1": "Using (15+3)x250ml of water, this should give us ~4500ml of product. For brew_moonshine it is 7 charges per 250ml.",
-    "//2": "Plus evaporation process. I don't have exact numbers on evaporation loss, so let's make it 33%.",
-    "//3": "Hence 3000ml/250ml*7=14 charges",
-    "charges": 84
+    "//1": "Using 15x250ml of water, this should give us ~3750ml of product. For brew_moonshine it is 7 charges per 250ml.",
+    "//2": "Hence 3750/250ml*7=105 charges",
+    "charges": 105
   },
   {
     "type": "recipe",
@@ -261,9 +257,8 @@
       [ [ "juice", 2 ], [ "apple_cider", 4 ], [ "sweet_fruit", 1, "LIST" ] ]
     ],
     "//1": "Using 10x250ml of water, this should give us ~2500ml of product. For brew_hb_seltzer it is 1 charge per 250ml.",
-    "//2": "Plus evaporation process. I don't have exact numbers on evaporation loss, so let's make it 33%.",
-    "//3": "Hence (2500/3*2)/250*1=6.(6) charges. Let's make it 7.",
-    "charges": 7
+    "//2": "Hence 2500/250*1=10 charges.",
+    "charges": 10
   },
   {
     "type": "recipe",
@@ -283,9 +278,8 @@
     "//": "24u for pumpkin and 30u to heat water & activate the yeast",
     "components": [ [ [ "water_clean", 15 ] ], [ [ "pumpkin_cut", 12 ] ], [ [ "sugar", 50 ] ], [ [ "yeast", 2 ] ] ],
     "//1": "Using 15x250ml of water, this should give us ~3750ml of product. For brew_moonshine it is 7 charges per 250ml.",
-    "//2": "Plus evaporation process. I don't have exact numbers on evaporation loss, so let's make it 33%.",
-    "//3": "Hence (3750/3*2)ml/250ml*7=70 charges",
-    "charges": 70
+    "//2": "Hence 3750ml/250ml*7=105 charges",
+    "charges": 105
   },
   {
     "type": "recipe",
@@ -322,9 +316,8 @@
     "//": "assuming grains are roasted, that's 52u flour by weight, 2u for hops, plus 20u to heat water and activate yeast",
     "components": [ [ [ "water_clean", 10 ] ], [ [ "malted_grain", 2 ] ], [ [ "hops", 1 ] ], [ [ "yeast", 1 ] ] ],
     "//1": "Using 10x250ml of water, this should give us ~2500ml of product. For brew_hb_beer it is 1 charge per 250ml.",
-    "//2": "Plus evaporation process. I don't have exact numbers on evaporation loss, so let's make it 33%.",
-    "//3": "Hence (2500/3*2)ml/250ml*1=6.(6) charges. Let's make it 7.",
-    "charges": 7
+    "//2": "Hence 2500ml/250ml*1=10 charges.",
+    "charges": 10
   },
   {
     "type": "recipe",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Brewing Recipes Output Correction"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Most brewing-related recipes have provided inadequate output material, as they didn't took into account that the output liquids have charges, so instead of producing (almost) equal volume of output liquids, they gave just one charge of said liquid (e.g. a recipe for "unfermented vinegar" made just 1/32th of input volume, or 62.5ml from 500ml of input water and juice/berries).

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

I've recalculated the output to closely match input volume of base liquid (clean water).

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

We could dispose of "charges" in liquids (considering, "charges" are being slowly obsoleted) and just produce base items in appropriate quantities, but I believe this is a task for other PR.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

I've tested recipes in-game. They seem to produce correct amounts of product now.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
Not applicable.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
