### PR TITLE
Remove excessive receiver migration

### DIFF
--- a/data/json/obsoletion/migration_items.json
+++ b/data/json/obsoletion/migration_items.json
@@ -7,128 +7,107 @@
   {
     "id": "ar15_223long",
     "type": "MIGRATION",
-    "replace": "modular_ar15",
-    "contents": [ { "id": "retool_ar15_223rem_extended", "count": 1 } ]
+    "replace": "modular_ar15"
   },
   {
     "id": "ar15_223medium",
     "type": "MIGRATION",
-    "replace": "modular_ar15",
-    "contents": [ { "id": "retool_ar15_223rem_medium", "count": 1 } ]
+    "replace": "modular_ar15"
   },
   {
     "id": "ar15_223short",
     "type": "MIGRATION",
-    "replace": "modular_ar15",
-    "contents": [ { "id": "retool_ar15_223rem_short", "count": 1 } ]
+    "replace": "modular_ar15"
   },
   {
     "id": "ar15_300",
     "type": "MIGRATION",
-    "replace": "modular_ar15",
-    "contents": [ { "id": "retool_ar15_300blk", "count": 1 } ]
+    "replace": "modular_ar15"
   },
   {
     "id": "ar15_300medium",
     "type": "MIGRATION",
-    "replace": "modular_ar15",
-    "contents": [ { "id": "retool_ar15_300blk_medium", "count": 1 } ]
+    "replace": "modular_ar15"
   },
   {
     "id": "ar15_300short",
     "type": "MIGRATION",
-    "replace": "modular_ar15",
-    "contents": [ { "id": "retool_ar15_300blk_short", "count": 1 } ]
+    "replace": "modular_ar15"
   },
   {
     "id": "ar15_50",
     "type": "MIGRATION",
-    "replace": "modular_ar15",
-    "contents": [ { "id": "retool_ar15_50beowulf", "count": 1 } ]
+    "replace": "modular_ar15"
   },
   {
     "id": "ar15_50medium",
     "type": "MIGRATION",
-    "replace": "modular_ar15",
-    "contents": [ { "id": "retool_ar15_50beowulf_medium", "count": 1 } ]
+    "replace": "modular_ar15"
   },
   {
     "id": "ar15_50short",
     "type": "MIGRATION",
-    "replace": "modular_ar15",
-    "contents": [ { "id": "retool_ar15_50beowulf_short", "count": 1 } ]
+    "replace": "modular_ar15"
   },
   {
     "id": "ar15_450",
     "type": "MIGRATION",
-    "replace": "modular_ar15",
-    "contents": [ { "id": "retool_ar15_450", "count": 1 } ]
+    "replace": "modular_ar15"
   },
   {
     "id": "ar15_450medium",
     "type": "MIGRATION",
-    "replace": "modular_ar15",
-    "contents": [ { "id": "retool_ar15_450_medium", "count": 1 } ]
+    "replace": "modular_ar15"
   },
   {
     "id": "ar15_450short",
     "type": "MIGRATION",
-    "replace": "modular_ar15",
-    "contents": [ { "id": "retool_ar15_450_short", "count": 1 } ]
+    "replace": "modular_ar15"
   },
   {
     "id": "ar15_762",
     "type": "MIGRATION",
-    "replace": "modular_ar15",
-    "contents": [ { "id": "retool_ar15_762", "count": 1 } ]
+    "replace": "modular_ar15"
   },
   {
     "id": "mdrx_223",
     "type": "MIGRATION",
-    "replace": "mdrx",
-    "contents": [ { "id": "retool_mdrx_223rem", "count": 1 } ]
+    "replace": "mdrx"
   },
   {
     "id": "mdrx_223short",
     "type": "MIGRATION",
-    "replace": "mdrx",
-    "contents": [ { "id": "retool_mdrx_223rem_short", "count": 1 } ]
+    "replace": "mdrx"
   },
   {
     "id": "mdrx_300",
     "type": "MIGRATION",
-    "replace": "mdrx",
-    "contents": [ { "id": "retool_mdrx_300blk", "count": 1 } ]
+    "replace": "mdrx"
   },
   {
     "id": "mdrx_308",
     "type": "MIGRATION",
-    "replace": "mdrx",
-    "contents": [ { "id": "retool_mdrx_308win", "count": 1 } ]
+    "replace": "mdrx"
   },
   {
     "id": "mdrx_308medium",
     "type": "MIGRATION",
-    "replace": "mdrx",
-    "contents": [ { "id": "retool_mdrx_308win_medium", "count": 1 } ]
+    "replace": "mdrx"
   },
   {
     "id": "axmc_300",
     "type": "MIGRATION",
-    "replace": "axmc",
-    "contents": [ { "id": "retool_axmc_300win", "count": 1 } ]
+    "replace": "axmc"
   },
   {
     "id": "axmc_308",
     "type": "MIGRATION",
-    "replace": "axmc",
-    "contents": [ { "id": "retool_axmc_308win", "count": 1 } ]
+    "replace": "axmc"
   },
   {
     "id": "cz600_762",
     "type": "MIGRATION",
-    "replace": "cz600",
-    "contents": [ { "id": "retool_cz600_762", "count": 1 } ]
+    "replace": "cz600"
   },
   {
     "id": "mobile_memory_card_used",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Testing #69725, found the game properly migrates gunmods, which makes the game spawn two receivers on a gun instead of one
#### Describe the solution
Remove second receiver migration by removing `contents` of a migration type
#### Additional context
Apparently ar15_modular has no brandless variant? not sure i can fix it, not a great in making a descriptions