### PR TITLE
Prevent cleanup of MOLLE pockets on contents update

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1278,12 +1278,20 @@ void item::update_modified_pockets()
     std::optional<const pocket_data *> mag_or_mag_well;
     std::vector<const pocket_data *> container_pockets;
 
+    // Prevent cleanup of pockets belonging to the item base type
     for( const pocket_data &pocket : type->pockets ) {
         if( pocket.type == pocket_type::CONTAINER ) {
             container_pockets.push_back( &pocket );
         } else if( pocket.type == pocket_type::MAGAZINE ||
                    pocket.type == pocket_type::MAGAZINE_WELL ) {
             mag_or_mag_well = &pocket;
+        }
+    }
+
+    // Prevent cleanup of added modular pockets
+    for( const item * it : contents.get_added_pockets() ) {
+        for( const pocket_data &pocket : it->type->pockets ) {
+            container_pockets.push_back( &pocket );
         }
     }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1289,7 +1289,7 @@ void item::update_modified_pockets()
     }
 
     // Prevent cleanup of added modular pockets
-    for( const item * it : contents.get_added_pockets() ) {
+    for( const item *it : contents.get_added_pockets() ) {
         for( const pocket_data &pocket : it->type->pockets ) {
             container_pockets.push_back( &pocket );
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent cleanup of MOLLE pockets on contents update"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #70160
Fixes #70126
Fixes #70121
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
See #70160 for more details.

When items are removed from a pocket the item pocket contents are updated and any unexpected pockets are removed from the item. Only pockets defined in the item base type are kept. At some point additional pocket support was added through modular containers that can be integrated in a parent item but the cleanup code wasn't updated to not remove those new pockets during cleanups.

This PR makes it so the cleanup function doesn't remove "additional pockets" coming from integrated containers.

The `update_modified_pockets()` function is called only from one place at the moment. This is only a mitigation though and more problems related to the way additional pockets are handled are to be expected. See alternatives for details.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
A rework of the additional pockets system since it seems to be a very hacky and unmaintainable solution. Currently the integrated items are added to a list of additional storage items while also adding extra pockets to the pocket list itself. The only way to tie the new pockets to the integrated items is through calculating indices based on the amount of pockets added by each item in the list.

This is prone to cause issues if the integrated items are modified down the road (i.e. the number of pockets added is changed) since the indices won't match any longer and their removal will cause issues. The added pockets should be tied uniquely to the item that added them (though a reference to the stored item in `additional_pockets`?) but it's a bigger refactor that I don't want to tackle right now.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Can't reproduce the problem after the changes.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
