### PR TITLE
Fix the issue of NPC using bionic weapon

### DIFF
--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -612,10 +612,10 @@ void npc::discharge_cbm_weapon( bool fired, bool stow_real_weapon)
         return;
     }
 
-    item* pseudo_gun = get_wielded_item().get_item();
-    if ( pseudo_gun != nullptr ) {
-        if (fired) {
-            mod_power_level(-pseudo_gun->get_gun_bionic_drain());
+    item *pseudo_gun = get_wielded_item().get_item();
+    if( pseudo_gun != nullptr ) {
+        if( fired ) {
+            mod_power_level( -pseudo_gun->get_gun_bionic_drain() );
         }
     } else {
         debugmsg("NPC tried to use a non-existent bionic gun with UID %d", weapon_bionic_uid);

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -619,8 +619,8 @@ void npc::discharge_cbm_weapon( bool fired )
     }
     bionic &bio = **bio_opt;
 
-    if (fired) {
-        mod_power_level(-get_wielded_item().get_item()->get_gun_bionic_drain());
+    if( fired ) {
+        mod_power_level( -get_wielded_item().get_item()->get_gun_bionic_drain() );
     }
 
     set_wielded_item( real_weapon );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -617,7 +617,6 @@ void npc::discharge_cbm_weapon( bool fired )
         debugmsg( "NPC tried to use a non-existent gun bionic with UID %d", weapon_bionic_uid );
         return;
     }
-    bionic &bio = **bio_opt;
 
     if( fired ) {
         mod_power_level( -get_wielded_item().get_item()->get_gun_bionic_drain() );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -606,7 +606,7 @@ static void force_comedown( effect &eff )
     eff.set_duration( std::min( eff.get_duration(), eff.get_int_dur_factor() ) );
 }
 
-void npc::discharge_cbm_weapon()
+void npc::discharge_cbm_weapon(bool fired)
 {
     if( !is_using_bionic_weapon() ) {
         return;
@@ -619,7 +619,9 @@ void npc::discharge_cbm_weapon()
     }
     bionic &bio = **bio_opt;
 
-    mod_power_level( -bio.info().power_activate );
+    if (fired) {
+        mod_power_level(-get_wielded_item().get_item()->get_gun_bionic_drain());
+    }
 
     set_wielded_item( real_weapon );
     weapon_bionic_uid = 0;

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -606,7 +606,7 @@ static void force_comedown( effect &eff )
     eff.set_duration( std::min( eff.get_duration(), eff.get_int_dur_factor() ) );
 }
 
-void npc::discharge_cbm_weapon(bool fired)
+void npc::discharge_cbm_weapon( bool fired )
 {
     if( !is_using_bionic_weapon() ) {
         return;

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -618,7 +618,7 @@ void npc::discharge_cbm_weapon( bool fired, bool stow_real_weapon)
             mod_power_level( -pseudo_gun->get_gun_bionic_drain() );
         }
     } else {
-        debugmsg("NPC tried to use a non-existent bionic gun with UID %d", weapon_bionic_uid);
+        debugmsg( "NPC tried to use a non-existent bionic gun with UID %d", weapon_bionic_uid );
     }
 
     set_wielded_item( real_weapon);

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -606,7 +606,7 @@ static void force_comedown( effect &eff )
     eff.set_duration( std::min( eff.get_duration(), eff.get_int_dur_factor() ) );
 }
 
-void npc::discharge_cbm_weapon( bool fired )
+void npc::discharge_cbm_weapon( bool fired, bool stow_real_weapon)
 {
     if( !is_using_bionic_weapon() ) {
         return;
@@ -621,8 +621,37 @@ void npc::discharge_cbm_weapon( bool fired )
         debugmsg("NPC tried to use a non-existent bionic gun with UID %d", weapon_bionic_uid);
     }
 
-    set_wielded_item( real_weapon );
+    set_wielded_item( real_weapon);
+    real_weapon = item();
     weapon_bionic_uid = 0;
+
+    item* real_weapon_ptr = get_wielded_item().get_item();
+    if (stow_real_weapon && real_weapon_ptr != nullptr) {
+       stow_item(*real_weapon_ptr);
+    }
+}
+
+void npc::deactivate_or_discharge_bionic_weapon(bool stow_real_weapon)
+{
+    if (!is_using_bionic_weapon()) {
+        return;
+    }
+
+    std::optional<bionic*> bio_opt = find_bionic_by_uid(get_weapon_bionic_uid());
+    if (!bio_opt) {
+        debugmsg("NPC tried to use a non-existent gun bionic with UID %d", weapon_bionic_uid);
+        return;
+    }
+
+    bionic& bio = **bio_opt;
+    
+    if (bio.powered) {
+        deactivate_bionic(bio);
+    } else {
+        if (bio.info().has_flag(json_flag_BIONIC_GUN)) {
+            discharge_cbm_weapon(false, stow_real_weapon);
+        }
+    }
 }
 
 void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
@@ -653,6 +682,18 @@ void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
 
     item_location weapon = get_wielded_item();
     item weap = weapon ? *weapon : item();
+
+    int ammo_count = weap.ammo_remaining(this);
+    const units::energy ups_drain = weap.get_gun_ups_drain();
+    if (ups_drain > 0_kJ) {
+        ammo_count = units::from_kilojoule(ammo_count) / ups_drain;
+    }
+
+    // the weapon value from `weapon_value` may be different from `npc_attack_rating`
+    // to avoid NPC infinite switch weapon,
+    // only use bionic weapon when the ammo of wielded gun has been used up
+    bool ammo_used_up = !weap.is_gun() || (ammo_count <= 0 && !can_reload_current());
+
     if( bio.info().has_flag( json_flag_BIONIC_GUN ) ) {
         if( !bio.has_weapon() ) {
             debugmsg( "NPC tried to activate gun bionic \"%s\" without fake_weapon",
@@ -667,14 +708,9 @@ void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
             return;
         }
 
-        int ammo_count = weap.ammo_remaining( this );
-        const units::energy ups_drain =  weap.get_gun_ups_drain();
-        if( ups_drain > 0_kJ ) {
-            ammo_count = units::from_kilojoule( ammo_count ) / ups_drain;
-        }
         const int cbm_ammo = free_power / cbm_weapon.get_gun_energy_drain();
 
-        if( weapon_value( weap, ammo_count ) < weapon_value( cbm_weapon, cbm_ammo ) ) {
+        if( ammo_used_up && weapon_value( weap, 0 ) < weapon_value( cbm_weapon, cbm_ammo ) ) {
             if( real_weapon.is_null() ) {
                 // Prevent replacing real weapon when migrating saves
                 real_weapon = weap;
@@ -682,6 +718,7 @@ void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
             set_wielded_item( cbm_weapon );
             weapon_bionic_uid = bio.get_uid();
         }
+
     } else if( bio.info().has_flag( json_flag_BIONIC_WEAPON ) && !weap.has_flag( flag_NO_UNWIELD ) &&
                free_power > bio.info().power_activate ) {
 
@@ -691,16 +728,20 @@ void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
             return;
         }
 
-        if( is_armed() ) {
-            stow_item( *weapon );
-        }
-        add_msg_if_player_sees( pos(), m_info, _( "%s activates their %s." ),
-                                disp_name(), bio.info().name );
+        const item cbm_weapon = bio.get_weapon();
 
-        set_wielded_item( bio.get_weapon() );
-        mod_power_level( -bio.info().power_activate );
-        bio.powered = true;
-        weapon_bionic_uid = bio.get_uid();
+        if ( ammo_used_up && weapon_value(weap, 0) < weapon_value(cbm_weapon, 0) ) {
+            if (is_armed()) {
+                stow_item(*weapon);
+            }
+            add_msg_if_player_sees(pos(), m_info, _("%s activates their %s."),
+                disp_name(), bio.info().name);
+
+            set_wielded_item(bio.get_weapon());
+            mod_power_level(-bio.info().power_activate);
+            bio.powered = true;
+            weapon_bionic_uid = bio.get_uid();
+        }
     }
 }
 

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -690,7 +690,7 @@ void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
     }
 
     // the weapon value from `weapon_value` may be different from `npc_attack_rating`
-    // to avoid NPC infinite switch weapon,
+    // to avoid NPC infinitely switch weapon,
     // only use bionic weapon when the ammo of wielded gun has been used up
     bool ammo_used_up = !weap.is_gun() || ( ammo_count <= 0 && !can_reload_current() );
 

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -612,14 +612,13 @@ void npc::discharge_cbm_weapon( bool fired )
         return;
     }
 
-    std::optional<bionic *> bio_opt = find_bionic_by_uid( get_weapon_bionic_uid() );
-    if( !bio_opt ) {
-        debugmsg( "NPC tried to use a non-existent gun bionic with UID %d", weapon_bionic_uid );
-        return;
-    }
-
-    if( fired ) {
-        mod_power_level( -get_wielded_item().get_item()->get_gun_bionic_drain() );
+    item* pseudo_gun = get_wielded_item().get_item();
+    if ( pseudo_gun != nullptr ) {
+        if (fired) {
+            mod_power_level(-pseudo_gun->get_gun_bionic_drain());
+        }
+    } else {
+        debugmsg("NPC tried to use a non-existent bionic gun with UID %d", weapon_bionic_uid);
     }
 
     set_wielded_item( real_weapon );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -606,50 +606,50 @@ static void force_comedown( effect &eff )
     eff.set_duration( std::min( eff.get_duration(), eff.get_int_dur_factor() ) );
 }
 
-void npc::discharge_cbm_weapon( bool fired, bool stow_real_weapon)
+void npc::discharge_cbm_weapon( bool fired, bool stow_real_weapon )
 {
     if( !is_using_bionic_weapon() ) {
         return;
     }
 
-    item* pseudo_gun = get_wielded_item().get_item();
-    if ( pseudo_gun != nullptr ) {
-        if (fired) {
-            mod_power_level(-pseudo_gun->get_gun_bionic_drain());
+    item *pseudo_gun = get_wielded_item().get_item();
+    if( pseudo_gun != nullptr ) {
+        if( fired ) {
+            mod_power_level( -pseudo_gun->get_gun_bionic_drain() );
         }
     } else {
-        debugmsg("NPC tried to use a non-existent bionic gun with UID %d", weapon_bionic_uid);
+        debugmsg( "NPC tried to use a non-existent bionic gun with UID %d", weapon_bionic_uid );
     }
 
-    set_wielded_item( real_weapon);
+    set_wielded_item( real_weapon );
     real_weapon = item();
     weapon_bionic_uid = 0;
 
-    item* real_weapon_ptr = get_wielded_item().get_item();
-    if (stow_real_weapon && real_weapon_ptr != nullptr) {
-       stow_item(*real_weapon_ptr);
+    item *real_weapon_ptr = get_wielded_item().get_item();
+    if( stow_real_weapon && real_weapon_ptr != nullptr ) {
+        stow_item( *real_weapon_ptr );
     }
 }
 
-void npc::deactivate_or_discharge_bionic_weapon(bool stow_real_weapon)
+void npc::deactivate_or_discharge_bionic_weapon( bool stow_real_weapon )
 {
-    if (!is_using_bionic_weapon()) {
+    if( !is_using_bionic_weapon() ) {
         return;
     }
 
-    std::optional<bionic*> bio_opt = find_bionic_by_uid(get_weapon_bionic_uid());
-    if (!bio_opt) {
-        debugmsg("NPC tried to use a non-existent gun bionic with UID %d", weapon_bionic_uid);
+    std::optional<bionic *> bio_opt = find_bionic_by_uid( get_weapon_bionic_uid() );
+    if( !bio_opt ) {
+        debugmsg( "NPC tried to use a non-existent gun bionic with UID %d", weapon_bionic_uid );
         return;
     }
 
-    bionic& bio = **bio_opt;
-    
-    if (bio.powered) {
-        deactivate_bionic(bio);
+    bionic &bio = **bio_opt;
+
+    if( bio.powered ) {
+        deactivate_bionic( bio );
     } else {
-        if (bio.info().has_flag(json_flag_BIONIC_GUN)) {
-            discharge_cbm_weapon(false, stow_real_weapon);
+        if( bio.info().has_flag( json_flag_BIONIC_GUN ) ) {
+            discharge_cbm_weapon( false, stow_real_weapon );
         }
     }
 }
@@ -683,16 +683,16 @@ void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
     item_location weapon = get_wielded_item();
     item weap = weapon ? *weapon : item();
 
-    int ammo_count = weap.ammo_remaining(this);
+    int ammo_count = weap.ammo_remaining( this );
     const units::energy ups_drain = weap.get_gun_ups_drain();
-    if (ups_drain > 0_kJ) {
-        ammo_count = units::from_kilojoule(ammo_count) / ups_drain;
+    if( ups_drain > 0_kJ ) {
+        ammo_count = units::from_kilojoule( ammo_count ) / ups_drain;
     }
 
     // the weapon value from `weapon_value` may be different from `npc_attack_rating`
     // to avoid NPC infinite switch weapon,
     // only use bionic weapon when the ammo of wielded gun has been used up
-    bool ammo_used_up = !weap.is_gun() || (ammo_count <= 0 && !can_reload_current());
+    bool ammo_used_up = !weap.is_gun() || ( ammo_count <= 0 && !can_reload_current() );
 
     if( bio.info().has_flag( json_flag_BIONIC_GUN ) ) {
         if( !bio.has_weapon() ) {
@@ -730,15 +730,15 @@ void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
 
         const item cbm_weapon = bio.get_weapon();
 
-        if ( ammo_used_up && weapon_value(weap, 0) < weapon_value(cbm_weapon, 0) ) {
-            if (is_armed()) {
-                stow_item(*weapon);
+        if( ammo_used_up && weapon_value( weap, 0 ) < weapon_value( cbm_weapon, 0 ) ) {
+            if( is_armed() ) {
+                stow_item( *weapon );
             }
-            add_msg_if_player_sees(pos(), m_info, _("%s activates their %s."),
-                disp_name(), bio.info().name);
+            add_msg_if_player_sees( pos(), m_info, _( "%s activates their %s." ),
+                                    disp_name(), bio.info().name );
 
-            set_wielded_item(bio.get_weapon());
-            mod_power_level(-bio.info().power_activate);
+            set_wielded_item( bio.get_weapon() );
+            mod_power_level( -bio.info().power_activate );
             bio.powered = true;
             weapon_bionic_uid = bio.get_uid();
         }

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1532,8 +1532,15 @@ bool npc::wear_if_wanted( const item &it, std::string &reason )
     return worn.empty() && wear_item( it, false );
 }
 
-void npc::stow_item( item &it )
+void npc::stow_item(item& it)
 {
+    bool stow_bionic_weapon = is_using_bionic_weapon() 
+        && get_wielded_item().get_item() == &it;
+    if (stow_bionic_weapon){
+        deactivate_or_discharge_bionic_weapon(true);
+        return;
+    }
+
     bool avatar_sees = get_player_view().sees( pos() );
     if( wear_item( it, false ) ) {
         // Wearing the item was successful, remove weapon and post message.

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -1532,12 +1532,12 @@ bool npc::wear_if_wanted( const item &it, std::string &reason )
     return worn.empty() && wear_item( it, false );
 }
 
-void npc::stow_item(item& it)
+void npc::stow_item( item &it )
 {
-    bool stow_bionic_weapon = is_using_bionic_weapon() 
-        && get_wielded_item().get_item() == &it;
-    if (stow_bionic_weapon){
-        deactivate_or_discharge_bionic_weapon(true);
+    bool stow_bionic_weapon = is_using_bionic_weapon()
+                              && get_wielded_item().get_item() == &it;
+    if( stow_bionic_weapon ) {
+        deactivate_or_discharge_bionic_weapon( true );
         return;
     }
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -1046,7 +1046,7 @@ class npc : public Character
         bool deactivate_bionic_by_id( const bionic_id &cbm_id, bool eff_only = false );
         // in bionics.cpp
         // can't use bionics::activate because it calls plfire directly
-        void discharge_cbm_weapon();
+        void discharge_cbm_weapon(bool fired = true);
         // check if an NPC has a bionic weapon and activate it if possible
         void check_or_use_weapon_cbm( const bionic_id &cbm_id );
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -1046,9 +1046,9 @@ class npc : public Character
         bool deactivate_bionic_by_id( const bionic_id &cbm_id, bool eff_only = false );
         // in bionics.cpp
         // can't use bionics::activate because it calls plfire directly
-        void discharge_cbm_weapon( bool fired = true, bool stow_real_weapon = false);
+        void discharge_cbm_weapon( bool fired = true, bool stow_real_weapon = false );
         // deactivate or discharge the fake bionic weapon that NPC wielded
-        void deactivate_or_discharge_bionic_weapon(bool stow_real_weapon = false);
+        void deactivate_or_discharge_bionic_weapon( bool stow_real_weapon = false );
         // check if an NPC has a bionic weapon and activate it if possible
         void check_or_use_weapon_cbm( const bionic_id &cbm_id );
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -1046,7 +1046,7 @@ class npc : public Character
         bool deactivate_bionic_by_id( const bionic_id &cbm_id, bool eff_only = false );
         // in bionics.cpp
         // can't use bionics::activate because it calls plfire directly
-        void discharge_cbm_weapon(bool fired = true);
+        void discharge_cbm_weapon( bool fired = true );
         // check if an NPC has a bionic weapon and activate it if possible
         void check_or_use_weapon_cbm( const bionic_id &cbm_id );
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -1046,7 +1046,9 @@ class npc : public Character
         bool deactivate_bionic_by_id( const bionic_id &cbm_id, bool eff_only = false );
         // in bionics.cpp
         // can't use bionics::activate because it calls plfire directly
-        void discharge_cbm_weapon( bool fired = true );
+        void discharge_cbm_weapon( bool fired = true, bool stow_real_weapon = false);
+        // deactivate or discharge the fake bionic weapon that NPC wielded
+        void deactivate_or_discharge_bionic_weapon(bool stow_real_weapon = false);
         // check if an NPC has a bionic weapon and activate it if possible
         void check_or_use_weapon_cbm( const bionic_id &cbm_id );
 

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -461,7 +461,7 @@ void npc_attack_gun::use( npc &source, const tripoint &location ) const
 bool npc_attack_gun::can_use( const npc &source ) const
 {
     // can't attack with something you can't wield
-    return source.is_wielding(*gunmode) || source.can_wield( *gunmode ).success();
+    return source.is_wielding( *gunmode ) || source.can_wield( *gunmode ).success();
 }
 
 int npc_attack_gun::base_time_penalty( const npc &source ) const

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -460,8 +460,11 @@ void npc_attack_gun::use( npc &source, const tripoint &location ) const
 
 bool npc_attack_gun::can_use( const npc &source ) const
 {
+    // for the case that npc use a wielded bionic gun
+    bool use_wielded_gun = source.get_wielded_item().get_item() == &gun;
+
     // can't attack with something you can't wield
-    return source.can_wield( *gunmode ).success();
+    return use_wielded_gun || source.can_wield( *gunmode ).success();
 }
 
 int npc_attack_gun::base_time_penalty( const npc &source ) const

--- a/src/npc_attack.cpp
+++ b/src/npc_attack.cpp
@@ -460,11 +460,8 @@ void npc_attack_gun::use( npc &source, const tripoint &location ) const
 
 bool npc_attack_gun::can_use( const npc &source ) const
 {
-    // for the case that npc use a wielded bionic gun
-    bool use_wielded_gun = source.get_wielded_item().get_item() == &gun;
-
     // can't attack with something you can't wield
-    return use_wielded_gun || source.can_wield( *gunmode ).success();
+    return source.is_wielding(*gunmode) || source.can_wield( *gunmode ).success();
 }
 
 int npc_attack_gun::base_time_penalty( const npc &source ) const

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -140,7 +140,7 @@ static const itype_id itype_oxygen_tank( "oxygen_tank" );
 static const itype_id itype_smoxygen_tank( "smoxygen_tank" );
 static const itype_id itype_thorazine( "thorazine" );
 
-static const json_character_flag json_flag_BIONIC_GUN("BIONIC_GUN");
+static const json_character_flag json_flag_BIONIC_GUN( "BIONIC_GUN" );
 
 static const mon_flag_str_id mon_flag_RIDEABLE_MECH( "RIDEABLE_MECH" );
 

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -3890,7 +3890,7 @@ bool npc::wield_better_weapon()
     double best_value = -100.0;
 
     const auto compare_weapon =
-    [this, &best, &best_value, can_use_gun, use_silent]( const item & it ) {
+    [this, &weap, &best, &best_value, can_use_gun, use_silent]( const item & it ) {
         bool allowed = can_use_gun && it.is_gun() && ( !use_silent || it.is_silent() );
         double val;
         if( !allowed ) {
@@ -3900,7 +3900,11 @@ bool npc::wield_better_weapon()
             val = weapon_value( it, ammo_count );
         }
 
-        if( val > best_value ) {
+        bool using_same_type_bionic_weapon = is_using_bionic_weapon()
+                                             && &it != &weap
+                                             && it.type->get_id() == weap.type->get_id();
+
+        if( val > best_value && !using_same_type_bionic_weapon ) {
             best = const_cast<item *>( &it );
             best_value = val;
         }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -2216,8 +2216,8 @@ bool npc::deactivate_bionic_by_id( const bionic_id &cbm_id, bool eff_only )
             if( i.powered ) {
                 return deactivate_bionic( i, eff_only );
             } else {
-                if (i.info().has_flag(json_flag_BIONIC_GUN)) {
-                    discharge_cbm_weapon(false);
+                if( i.info().has_flag( json_flag_BIONIC_GUN ) ) {
+                    discharge_cbm_weapon( false );
                 }
                 return false;
             }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -140,6 +140,8 @@ static const itype_id itype_oxygen_tank( "oxygen_tank" );
 static const itype_id itype_smoxygen_tank( "smoxygen_tank" );
 static const itype_id itype_thorazine( "thorazine" );
 
+static const json_character_flag json_flag_BIONIC_GUN("BIONIC_GUN");
+
 static const mon_flag_str_id mon_flag_RIDEABLE_MECH( "RIDEABLE_MECH" );
 
 static const npc_class_id NC_EVAC_SHOPKEEP( "NC_EVAC_SHOPKEEP" );
@@ -2214,6 +2216,9 @@ bool npc::deactivate_bionic_by_id( const bionic_id &cbm_id, bool eff_only )
             if( i.powered ) {
                 return deactivate_bionic( i, eff_only );
             } else {
+                if (i.info().has_flag(json_flag_BIONIC_GUN)) {
+                    discharge_cbm_weapon(false);
+                }
                 return false;
             }
         }

--- a/src/npcmove.cpp
+++ b/src/npcmove.cpp
@@ -140,8 +140,6 @@ static const itype_id itype_oxygen_tank( "oxygen_tank" );
 static const itype_id itype_smoxygen_tank( "smoxygen_tank" );
 static const itype_id itype_thorazine( "thorazine" );
 
-static const json_character_flag json_flag_BIONIC_GUN( "BIONIC_GUN" );
-
 static const mon_flag_str_id mon_flag_RIDEABLE_MECH( "RIDEABLE_MECH" );
 
 static const npc_class_id NC_EVAC_SHOPKEEP( "NC_EVAC_SHOPKEEP" );
@@ -2178,6 +2176,7 @@ void npc::deactivate_combat_cbms()
     for( const bionic_id &cbm_id : weapon_cbms ) {
         deactivate_bionic_by_id( cbm_id );
     }
+    deactivate_or_discharge_bionic_weapon();
     weapon_bionic_uid = 0;
 }
 
@@ -2216,9 +2215,6 @@ bool npc::deactivate_bionic_by_id( const bionic_id &cbm_id, bool eff_only )
             if( i.powered ) {
                 return deactivate_bionic( i, eff_only );
             } else {
-                if( i.info().has_flag( json_flag_BIONIC_GUN ) ) {
-                    discharge_cbm_weapon( false );
-                }
                 return false;
             }
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix the issue of NPC using ranged bionic weapon"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

- (1) NPCs are unable to use ranged bionic weapons correctly, such as "laser finger", as they only activate the weapon and become dazed.
- (2) Even after the battle, NPCs are unable to properly discard the fake weapon.
- (3) NPCs are unable to properly stow fake bionic weapons, they should deactivate bionic instead of do the actually stow

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

- After continuous debugging, I found that the bug of issue (1) occurred in`npc_attack_gun::can_use` , this function simply checks whether the gun can be wielded, but our bionic weapon has already been wielded, so an additional check has been added to solve the issue.
- The bug in issue (2) lies in `npc::deactivate_combat_cbms` did not discard the fake bionic gun after battle.
-  Add code for deactivate the bionic weapon in the function `npc::stow_item`  could solve issue (3)
- Additional fix: `npc::discharge_cbm_weapon`  did not correctly use the energy consumed by ranged bionic weapons ( `power_activate` -> `get_gun_bionic_drain` )
- In `npc::check_or_use_weapon_cbm`, due to the fact that `weapon_value` and `npc_attack_rating` may have different results when calculating the same weapons, NPC may switch weapon infinitely.  To avoid this case, only activate the bionic weapon when the ammo of wielded gun has been used up.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

None.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

After local building and testing, NPCs can now use ranged bionic weapons correctly !
Bionic energy can also be properly drained.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

Test NPC using laser finger shooting zombie

![Screenshot](https://github.com/CleverRaven/Cataclysm-DDA/assets/51994883/83fac52a-4f82-4d6d-b71b-186a1dcfb356)

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
