### PR TITLE
[MoM] Psion NPCs

### DIFF
--- a/data/json/npcs/starting_traits.json
+++ b/data/json/npcs/starting_traits.json
@@ -2,6 +2,7 @@
   {
     "//": "Mainlined from a mod originally written by Spencer Michaels",
     "//2": "This group picks out several negative and positive traits",
+    "//3": "This implicitly extends if attempting to add to it for mod purposes",
     "type": "trait_group",
     "id": "NPC_starting_traits",
     "subtype": "collection",

--- a/data/mods/MindOverMatter/npcs/starting_traits.json
+++ b/data/mods/MindOverMatter/npcs/starting_traits.json
@@ -1,0 +1,85 @@
+[
+  {
+    "type": "trait_group",
+    "id": "NPC_starting_traits",
+    "subtype": "collection",
+    "traits": [ { "group": "trait_group_PSION", "prob": 1 } ]
+  },
+  {
+    "//": "This group picks out one of the traits, leading to a 1% chance for an NPC to be a psion.",
+    "type": "trait_group",
+    "id": "trait_group_PSION",
+    "subtype": "distribution",
+    "traits": [
+      { "group": "trait_group_BIOKINETIC", "prob": 1 },
+      { "group": "trait_group_CLAIRSENTIENT", "prob": 1 },
+      { "group": "trait_group_ELECTROKINETIC", "prob": 1 },
+      { "group": "trait_group_PHOTOKINETIC", "prob": 1 },
+      { "group": "trait_group_PYROKINETIC", "prob": 1 },
+      { "group": "trait_group_TELEKINETIC", "prob": 1 },
+      { "group": "trait_group_TELEPATH", "prob": 1 },
+      { "group": "trait_group_TELEPORTER", "prob": 1 },
+      { "group": "trait_group_VITAKINETIC", "prob": 1 }
+    ]
+  },
+  {
+    "type": "trait_group",
+    "id": "trait_group_NULL",
+    "subtype": "collection",
+    "traits": [  ]
+  },
+  {
+    "type": "trait_group",
+    "id": "trait_group_BIOKINETIC",
+    "subtype": "collection",
+    "traits": [ { "trait": "BIOKINETIC", "prob": 100 }, { "trait": "BIOKIN_NEEDS", "prob": 100 } ]
+  },
+  {
+    "type": "trait_group",
+    "id": "trait_group_CLAIRSENTIENT",
+    "subtype": "collection",
+    "traits": [ { "trait": "CLAIRSENTIENT", "prob": 100 }, { "trait": "CLAIR_SENSES", "prob": 100 } ]
+  },
+  {
+    "type": "trait_group",
+    "id": "trait_group_ELECTROKINETIC",
+    "subtype": "collection",
+    "traits": [ { "trait": "ELECTROKINETIC", "prob": 100 }, { "trait": "ELECTRO_SHIELD", "prob": 100 } ]
+  },
+  {
+    "type": "trait_group",
+    "id": "trait_group_PHOTOKINETIC",
+    "subtype": "collection",
+    "traits": [ { "trait": "PHOTOKINETIC", "prob": 100 }, { "trait": "PHOTO_EYES", "prob": 100 } ]
+  },
+  {
+    "type": "trait_group",
+    "id": "trait_group_PYROKINETIC",
+    "subtype": "collection",
+    "traits": [ { "trait": "PYROKINETIC", "prob": 100 }, { "trait": "PYROKIN_ADAPTATION", "prob": 100 } ]
+  },
+  {
+    "type": "trait_group",
+    "id": "trait_group_TELEKINETIC",
+    "subtype": "collection",
+    "traits": [ { "trait": "TELEKINETIC", "prob": 100 }, { "trait": "TELEKINETIC_LIFTER_1", "prob": 100 } ]
+  },
+  {
+    "type": "trait_group",
+    "id": "trait_group_TELEPATH",
+    "subtype": "collection",
+    "traits": [ { "trait": "TELEPATH", "prob": 100 }, { "trait": "TELEPATHIC_SUGGESTION", "prob": 100 } ]
+  },
+  {
+    "type": "trait_group",
+    "id": "trait_group_TELEPORTER",
+    "subtype": "collection",
+    "traits": [ { "trait": "TELEPORTER", "prob": 100 }, { "trait": "TELEPORTER_PROTECT", "prob": 100 } ]
+  },
+  {
+    "type": "trait_group",
+    "id": "trait_group_VITAKINETIC",
+    "subtype": "collection",
+    "traits": [ { "trait": "VITAKINETIC", "prob": 100 }, { "trait": "VITAKINETIC_HEALTH", "prob": 100 } ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Psion NPCs"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Just like the player can take a hobby to have been awakened by the portal storms that occurred during the Cataclysm, NPCs should spawn with that having happened to them too. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds a 1% chance for an NPC to be a psion. This is the equivalent of the "newly-awakened" hobby, so they have the starting traits and nothing else. In the future I'll add dedicated NPC classes for NPCs who have actually developed their powers more, along with stories where they talk about them. 

This means that anyone who draws from NPC_starting_traits has a small chance to be psionic--Boris at the Refugee Center, Cranberry, that bandit at the dairy farm trying to rob you, the third Free Merchant guard on the left, anyone. The portal storms had no rhyme or reason in who awoke during them.

Note that this explicitly does not provide any AI improvements to NPCs using their powers.  During testing an NPC pyrokinetic alternated between setting a zombie on fire and running away screaming about how dangerous the fire was.  Hopefully eventually they'll be able to handle combat powers and buffs, but for the moment, treat any NPC follower with offensive powers carefully. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned in a bunch of NPCs, some of them were psions. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
