### PR TITLE
[MoM] Scale nether attunement gain with level of nether attunement

### DIFF
--- a/data/mods/MindOverMatter/powers/nether_attunement_spells.json
+++ b/data/mods/MindOverMatter/powers/nether_attunement_spells.json
@@ -37,7 +37,9 @@
     "condition": { "u_has_effect": "effect_noetic_resilience" },
     "effect": [
       { "u_message": "You feel a strange tingling sensation as your powers are unleashed.", "type": "mixed" },
-      { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 0,3 ) * u_nether_attunement_power_scaling" ] }
+      {
+        "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 0,3 ) * u_nether_attunement_power_scaling" ]
+      }
     ],
     "false_effect": [
       { "u_message": "You feel a strange tingling sensation as your powers are unleashed.", "type": "mixed" },

--- a/data/mods/MindOverMatter/powers/nether_attunement_spells.json
+++ b/data/mods/MindOverMatter/powers/nether_attunement_spells.json
@@ -37,11 +37,11 @@
     "condition": { "u_has_effect": "effect_noetic_resilience" },
     "effect": [
       { "u_message": "You feel a strange tingling sensation as your powers are unleashed.", "type": "mixed" },
-      { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 0,3 )" ] }
+      { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 0,3 ) * u_nether_attunement_power_scaling" ] }
     ],
     "false_effect": [
       { "u_message": "You feel a strange tingling sensation as your powers are unleashed.", "type": "mixed" },
-      { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 2,6 )" ] }
+      { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 2,6 ) * u_nether_attunement_power_scaling" ] }
     ]
   },
   {
@@ -276,8 +276,41 @@
     "flags": [ "SILENT", "NO_EXPLOSION_SFX", "NO_FAIL" ],
     "message": "",
     "effect": "effect_on_condition",
-    "effect_str": "EOC_RAISE_NETHER_ATTUNEMENT",
+    "effect_str": "EOC_RAISE_NETHER_ATTUNEMENT_MAINTENANCE",
     "shape": "blast"
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_RAISE_NETHER_ATTUNEMENT_MAINTENANCE",
+    "condition": { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "<", "15" ] },
+    "effect": [ { "run_eocs": "EOC_RAISE_NETHER_ATTUNEMENT_MAINTENANCE_BELOW_THRESHOLD" } ],
+    "false_effect": [ { "run_eocs": "EOC_RAISE_NETHER_ATTUNEMENT_MAINTENANCE_ABOVE_THRESHOLD" } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_RAISE_NETHER_ATTUNEMENT_MAINTENANCE_BELOW_THRESHOLD",
+    "condition": { "u_has_effect": "effect_noetic_resilience" },
+    "effect": [
+      { "u_message": "You feel a strange tingling sensation as you concentrate.", "type": "mixed" },
+      { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 0,1 )" ] }
+    ],
+    "false_effect": [
+      { "u_message": "You feel a strange tingling sensation as you concentrate.", "type": "mixed" },
+      { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 0,3 )" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_RAISE_NETHER_ATTUNEMENT_MAINTENANCE_ABOVE_THRESHOLD",
+    "condition": { "u_has_effect": "effect_noetic_resilience" },
+    "effect": [
+      { "u_message": "You feel a strange tingling sensation as you concentrate.", "type": "mixed" },
+      { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 0,3 ) * u_nether_attunement_power_scaling" ] }
+    ],
+    "false_effect": [
+      { "u_message": "You feel a strange tingling sensation as you concentrate.", "type": "mixed" },
+      { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 2,6 ) * u_nether_attunement_power_scaling" ] }
+    ]
   },
   {
     "id": "psionic_maintenance_drained_difficulty_one",

--- a/data/mods/MindOverMatter/powers/nether_attunement_spells.json
+++ b/data/mods/MindOverMatter/powers/nether_attunement_spells.json
@@ -315,7 +315,9 @@
     ],
     "false_effect": [
       { "u_message": "You feel a strange tingling sensation as you concentrate.", "type": "mixed" },
-      { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 2,6 ) * u_nether_attunement_power_scaling" ] }
+      {
+        "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 2,6 ) * u_nether_attunement_power_scaling" ]
+      }
     ]
   },
   {

--- a/data/mods/MindOverMatter/powers/nether_attunement_spells.json
+++ b/data/mods/MindOverMatter/powers/nether_attunement_spells.json
@@ -43,7 +43,9 @@
     ],
     "false_effect": [
       { "u_message": "You feel a strange tingling sensation as your powers are unleashed.", "type": "mixed" },
-      { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 2,6 ) * u_nether_attunement_power_scaling" ] }
+      {
+        "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 2,6 ) * u_nether_attunement_power_scaling" ]
+      }
     ]
   },
   {

--- a/data/mods/MindOverMatter/powers/nether_attunement_spells.json
+++ b/data/mods/MindOverMatter/powers/nether_attunement_spells.json
@@ -309,7 +309,9 @@
     "condition": { "u_has_effect": "effect_noetic_resilience" },
     "effect": [
       { "u_message": "You feel a strange tingling sensation as you concentrate.", "type": "mixed" },
-      { "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 0,3 ) * u_nether_attunement_power_scaling" ] }
+      {
+        "math": [ "u_val('vitamin', 'name:vitamin_psionic_drain')", "+=", "rng( 0,3 ) * u_nether_attunement_power_scaling" ]
+      }
     ],
     "false_effect": [
       { "u_message": "You feel a strange tingling sensation as you concentrate.", "type": "mixed" },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Scale nether attunement gain with level of nether attunement"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I can feel the Warp overtaking me.  It is a good pain. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Multiplies any nether attunement gain by the same bonus you get to your powers. This starts with no effect (unless vitamin levels are secretly doubles instead of ints, in which case it starts very slowly instead) but will rapidly ramp up starting around Nether Attunement (6) and should make it easier to get to higher levels for the huge power boosts without risking a ton of side effects along the way.  You'll have plenty of side effects when you get there. 

It also edits the nether attunement messages so that maintaining your powers does not confusingly have a message about "unleashing" your powers. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Gave myself 200 Nether Attunement vitamin, gained Nether Attunement, got +9 on a modified rng(2,6) roll
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
