### PR TITLE
Add ```gains_proficiency``` event

### DIFF
--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -1173,6 +1173,7 @@ Every event EOC passes context vars with each of their key value pairs that the 
 | fuel_tank_explodes | Triggers when vehicle part (that is watertight container/magazine with magazine pocket/or is a reactor) is sufficiently damaged | { "vehicle_name", `string` }, | avatar / NONE |
 | gains_addiction | |  { "character", `character_id` },<br/> { "add_type", `addiction_id` }, | character / NONE |
 | gains_mutation | |  { "character", `character_id` },<br/> { "trait", `trait_id` }, | character / NONE |
+| gains_proficiency | | { "character", `character_id` },<br/> { "proficiency", `proficiency_id` }, | character / NONE |
 | gains_skill_level | | { "character", `character_id` },<br/> { "skill", `skill_id` },<br/> { "new_level", `int` }, | character / NONE |
 | game_avatar_death | Triggers during bury screen with ASCII grave art is displayed (when avatar dies, obviously) | { "avatar_id", `character_id` },<br/> { "avatar_name", `string` },<br/> { "avatar_is_male", `bool` },<br/> { "is_suicide", `bool` },<br/> { "last_words", `string` }, | avatar / NONE |
 | game_avatar_new | Triggers when new character is controlled and during new game character initialization  | { "is_new_game", `bool` },<br/> { "is_debug", `bool` },<br/> { "avatar_id", `character_id` },<br/> { "avatar_name", `string` },<br/> { "avatar_is_male", `bool` },<br/> { "avatar_profession", `profession_id` },<br/> { "avatar_custom_profession", `string` }, | avatar / NONE |

--- a/src/cata_variant.cpp
+++ b/src/cata_variant.cpp
@@ -69,6 +69,7 @@ std::string enum_to_string<cata_variant_type>( cata_variant_type type )
         case cata_variant_type::palette_id: return "palette_id";
         case cata_variant_type::point: return "point";
         case cata_variant_type::profession_id: return "profession_id";
+        case cata_variant_type::proficiency_id: return "proficiency_id";
         case cata_variant_type::skill_id: return "skill_id";
         case cata_variant_type::species_id: return "species_id";
         case cata_variant_type::spell_id: return "spell_id";

--- a/src/cata_variant.h
+++ b/src/cata_variant.h
@@ -68,6 +68,7 @@ enum class cata_variant_type : int {
     palette_id,
     point,
     profession_id,
+    proficiency_id,
     skill_id,
     species_id,
     spell_id,
@@ -188,7 +189,7 @@ struct convert_enum {
 };
 
 // These are the specializations of convert for each value type.
-static_assert( static_cast<int>( cata_variant_type::num_types ) == 48,
+static_assert( static_cast<int>( cata_variant_type::num_types ) == 49,
                "This assert is a reminder to add conversion support for any new types to the "
                "below specializations" );
 
@@ -360,6 +361,9 @@ struct convert<cata_variant_type::point> {
 
 template<>
 struct convert<cata_variant_type::profession_id> : convert_string_id<profession_id> {};
+
+template<>
+struct convert<cata_variant_type::proficiency_id> : convert_string_id<proficiency_id> {};
 
 template<>
 struct convert<cata_variant_type::skill_id> : convert_string_id<skill_id> {};

--- a/src/character_proficiency.cpp
+++ b/src/character_proficiency.cpp
@@ -1,5 +1,6 @@
 #include "cached_options.h"
 #include "character.h"
+#include "event_bus.h"
 #include "proficiency.h"
 
 bool Character::has_proficiency( const proficiency_id &prof ) const
@@ -72,6 +73,7 @@ bool Character::practice_proficiency( const proficiency_id &prof, const time_dur
     }
 
     if( learned ) {
+        get_event_bus().send<event_type::gains_proficiency>( getID(), prof );
         add_msg_if_player( m_good, _( "You are now proficient in %s!" ), prof->name() );
     }
     return learned;

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -78,6 +78,7 @@ std::string enum_to_string<event_type>( event_type data )
         case event_type::fuel_tank_explodes: return "fuel_tank_explodes";
         case event_type::gains_addiction: return "gains_addiction";
         case event_type::gains_mutation: return "gains_mutation";
+        case event_type::gains_proficiency: return "gains_proficiency";
         case event_type::gains_skill_level: return "gains_skill_level";
         case event_type::game_avatar_death: return "game_avatar_death";
         case event_type::game_avatar_new: return "game_avatar_new";
@@ -134,7 +135,7 @@ DEFINE_EVENT_HELPER_FIELDS( event_spec_empty )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character_item )
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 97,
+static_assert( static_cast<int>( event_type::num_event_types ) == 98,
                "This static_assert is a reminder to add a definition below when you add a new "
                "event_type.  If your event_spec specialization inherits from another struct for "
                "its fields definition then you probably don't need a definition here." );
@@ -178,6 +179,7 @@ DEFINE_EVENT_FIELDS( fails_to_remove_cbm )
 DEFINE_EVENT_FIELDS( fuel_tank_explodes )
 DEFINE_EVENT_FIELDS( gains_addiction )
 DEFINE_EVENT_FIELDS( gains_mutation )
+DEFINE_EVENT_FIELDS( gains_proficiency )
 DEFINE_EVENT_FIELDS( gains_skill_level )
 DEFINE_EVENT_FIELDS( game_avatar_death )
 DEFINE_EVENT_FIELDS( game_avatar_new )

--- a/src/event.h
+++ b/src/event.h
@@ -89,6 +89,7 @@ enum class event_type : int {
     fuel_tank_explodes,
     gains_addiction,
     gains_mutation,
+    gains_proficiency,
     gains_skill_level,
     game_avatar_death,
     game_avatar_new,
@@ -182,7 +183,7 @@ struct event_spec_character_item {
     };
 };
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 97,
+static_assert( static_cast<int>( event_type::num_event_types ) == 98,
                "This static_assert is to remind you to add a specialization for your new "
                "event_type below" );
 
@@ -600,6 +601,15 @@ struct event_spec<event_type::gains_mutation> {
     static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
             { "character", cata_variant_type::character_id },
             { "trait", cata_variant_type::trait_id },
+        }
+    };
+};
+
+template<>
+struct event_spec<event_type::gains_proficiency> {
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = {{
+            { "character", cata_variant_type::character_id },
+            { "proficiency", cata_variant_type::proficiency_id },
         }
     };
 };

--- a/src/memorial_logger.cpp
+++ b/src/memorial_logger.cpp
@@ -866,6 +866,16 @@ void memorial_logger::notify( const cata::event &e )
             }
             break;
         }
+        case event_type::gains_proficiency: {
+            character_id ch = e.get<character_id>( "character" );
+            if( ch == avatar_id ) {
+                proficiency_id proficiency = e.get<proficiency_id>( "proficiency" );
+                add( pgettext( "memorial_male", "Gained the proficiency '%s'." ),
+                     pgettext( "memorial_female", "Gained the proficiency '%s'." ),
+                     proficiency->name() );
+            }
+            break;
+        }
         case event_type::gains_skill_level: {
             character_id ch = e.get<character_id>( "character" );
             if( ch == avatar_id ) {

--- a/tests/memorial_test.cpp
+++ b/tests/memorial_test.cpp
@@ -92,6 +92,7 @@ TEST_CASE( "memorials", "[memorial]" )
     trait_id mut2( "SAPROPHAGE" );
     trait_id mut3( "NONE" );
     bionic_id cbm( "bio_alarm" );
+    proficiency_id prof( "prof_wound_care" );
 
     check_memorial<event_type::activates_artifact>(
         m, b, "Activated the art_name.", ch, "art_name" );
@@ -216,6 +217,9 @@ TEST_CASE( "memorials", "[memorial]" )
 
     check_memorial<event_type::gains_mutation>(
         m, b, "Gained the mutation 'Carnivore'.", ch, mut );
+
+    check_memorial<event_type::gains_proficiency>(
+        m, b, "Gained the proficiency 'Wound Care'.", ch, prof );
 
     check_memorial<event_type::gains_skill_level>(
         m, b, "Reached skill level 8 in vehicles.", ch, skill_driving, 8 );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Add ```gains_proficiency``` event"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Adds a ```gains_proficiency``` event that triggers when a character, well, gains a proficiency. 

Closes #69804
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- [x]  Created a new event called ```gains_proficiency``` that has two fields that can be used in EoCs: the character id and proficiency id.
- [x] Added event to memorial logger
- [x] Updated relevant docs
- [x] Updated relevant unit tests

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not adding the event
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
First, added this json to data\json\effects_on_condition: [furran_tests.json](https://github.com/CleverRaven/Cataclysm-DDA/files/13666506/furran_tests.json) (it prints the character id and proficiency id when the event triggers)

Got in game with a character with no proficiencies. Spawned bandages and started practicing bandaging until I got Wound Care. Checked message log for character id and proficiency id. 

- Also confirmed that the event triggered when gaining 'Wound Care' through bandaging wounds instead of practice. ( [Save file with 99% wound care](https://github.com/CleverRaven/Cataclysm-DDA/files/13666824/Grandview.Plaza-trimmed.tar.gz) )

Finally: Executed the updated memorial_test.cpp unit test.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
