### PR TITLE
Fixes scout mutation

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1424,7 +1424,7 @@
     "cancels": [ "UNOBSERVANT" ],
     "valid": false,
     "triggers": [ [ { "condition": "is_day", "msg_on": { "text": "", "rating": "good" } } ] ],
-    "transform": { "target": "EAGLEEYED_NIGHT", "msg_transform": "", "active": false, "moves": 0 }
+    "transform": { "target": "EAGLEEYED", "msg_transform": "", "active": false, "moves": 0 }
   },
   {
     "type": "mutation",


### PR DESCRIPTION
#### Summary
Bugfixes "Scout mutation works again"

#### Purpose of change
I was looking at some PRs and I noticed a very obvious looking copy-paste bug. This bug might also cause some performance issues because EAGLEEYED_NIGHT will constantly try to transform back to EAGLEEYED_NIGHT every time it is checked.

#### Describe the solution
Fixes the bug

#### Describe alternatives you've considered

#### Testing

#### Additional context
