### PR TITLE
[Sky Island] Teleporting items back home

### DIFF
--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -148,7 +148,7 @@
         "max_radius": 10,
         "true_eocs": [ { "id": "EOC_map_item_run", "effect": [ { "npc_teleport": { "global_val": "OM_HQ_origin" } } ] } ]
       },
-      { "queue_eocs": [ "EOC_return_OM_teleport" ] },
+      { "queue_eocs": [ "EOC_return_OM_teleport" ], "time_in_future": "1 s" },
       { "u_message": "Now teleporting back home.  Please wait…" }
     ]
   },

--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -142,14 +142,14 @@
     "effect": [
       { "u_location_variable": { "context_val": "loc" } },
       {
-        "u_map_run_item_eocs": "manual_mult",
+        "u_map_run_item_eocs": "all",
         "loc": { "context_val": "loc" },
-        "min_radius": 1,
+        "min_radius": 0,
         "max_radius": 10,
-        "title": "Pick the items on the ground you want to bring back home.",
         "true_eocs": [ { "id": "EOC_map_item_run", "effect": [ { "npc_teleport": { "global_val": "OM_HQ_origin" } } ] } ]
       },
-      { "queue_eocs": [ "EOC_return_OM_teleport" ], "time_in_future": "3 seconds" }
+      { "queue_eocs": [ "EOC_return_OM_teleport" ], "time_in_future": "3 seconds" },
+      { "u_message": "Now teleporting back home.  Please wait…" }
     ]
   },
   {

--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -145,11 +145,11 @@
         "u_map_run_item_eocs": "manual_mult",
         "loc": { "context_val": "loc" },
         "min_radius": 1,
-        "max_radius": 7,
+        "max_radius": 10,
         "title": "Pick the items on the ground you want to bring back home.",
         "true_eocs": [ { "id": "EOC_map_item_run", "effect": [ { "npc_teleport": { "global_val": "OM_HQ_origin" } } ] } ]
       },
-      { "queue_eocs": [ "EOC_return_OM_teleport" ], "time_in_future": "1 seconds" }
+      { "queue_eocs": [ "EOC_return_OM_teleport" ], "time_in_future": "3 seconds" }
     ]
   },
   {

--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -131,7 +131,7 @@
     "id": "EOC_statue_return",
     "//": "This EOC is activated by return portals.  It's just here to confirm that you want to return home, then triggers the actual teleport home.",
     "condition": {
-      "u_query": "This will teleport you back home. Anything left behind will be as good as gone.  Are you ready to leave?",
+      "u_query": "This will teleport you back to your sky island.  Any items inside the room will be teleported home alongside you.  Are you ready to leave?",
       "default": false
     },
     "effect": [ { "math": [ "raidswon", "++" ] }, { "run_eocs": [ "EOC_return_OM_teleport_item" ] } ]
@@ -148,7 +148,7 @@
         "max_radius": 10,
         "true_eocs": [ { "id": "EOC_map_item_run", "effect": [ { "npc_teleport": { "global_val": "OM_HQ_origin" } } ] } ]
       },
-      { "queue_eocs": [ "EOC_return_OM_teleport" ], "time_in_future": "3 seconds" },
+      { "queue_eocs": [ "EOC_return_OM_teleport" ] },
       { "u_message": "Now teleporting back home.  Please wait…" }
     ]
   },

--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -131,10 +131,26 @@
     "id": "EOC_statue_return",
     "//": "This EOC is activated by return portals.  It's just here to confirm that you want to return home, then triggers the actual teleport home.",
     "condition": {
-      "u_query": "This will teleport you back home with only the items on your person.  Anything left behind will be as good as gone.  Are you ready to leave?",
+      "u_query": "This will teleport you back home. Anything left behind will be as good as gone.  Are you ready to leave?",
       "default": false
     },
-    "effect": [ { "math": [ "raidswon", "++" ] }, { "run_eocs": [ "EOC_return_OM_teleport" ] } ]
+    "effect": [ { "math": [ "raidswon", "++" ] }, { "run_eocs": [ "EOC_return_OM_teleport_item" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_return_OM_teleport_item",
+    "effect": [
+      { "u_location_variable": { "context_val": "loc" } },
+      {
+        "u_map_run_item_eocs": "manual_mult",
+        "loc": { "context_val": "loc" },
+        "min_radius": 1,
+        "max_radius": 7,
+        "title": "Pick the items on the ground you want to bring back home.",
+        "true_eocs": [ { "id": "EOC_map_item_run", "effect": [ { "npc_teleport": { "global_val": "OM_HQ_origin" } } ] } ]
+      },
+      { "queue_eocs": [ "EOC_return_OM_teleport" ], "time_in_future": "1 seconds" }
+    ]
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION

#### Summary
Mods "[Sky Island] teleporting items back home"

#### Purpose of change

The exit obelisk being in a room kinda implies it can transport item back home, but can't. Now that item teleportation is possible, i'm adding it.

#### Describe the solution

See commit.

#### Describe alternatives you've considered

Not doing so.

#### Testing

I teleported good amount of items and it got teleported back home.

#### Additional context

It may teleport some stuff that is outside of the room, but i dont think that'll be much issue, i hope.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
