### PR TITLE
Update item_search.cpp with flag flitering

### DIFF
--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -67,6 +67,19 @@ std::function<bool( const item & )> basic_item_filter( std::string filter )
                 const std::string note = i.get_var( "item_note" );
                 return !note.empty() && lcmatch( note, filter );
             };
+        // item flags, must type in whole flag string name(case insensitive) so as to avoid revealing hidden flags. 
+        case 'f': 
+            return [filter](const item& i) {
+                std::string flag_filter = filter;
+                transform(flag_filter.begin(), flag_filter.end(), flag_filter.begin(), ::toupper);
+                const flag_id fsearch(flag_filter);
+                if (fsearch.is_valid()) {
+                    return i.has_flag(fsearch);
+                }
+                else {
+                    return false;
+                }
+             };
         // by book skill
         case 's':
             return [filter]( const item & i ) {

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -67,9 +67,9 @@ std::function<bool( const item & )> basic_item_filter( std::string filter )
                 const std::string note = i.get_var( "item_note" );
                 return !note.empty() && lcmatch( note, filter );
             };
-        // item flags, must type in whole flag string name(case insensitive) so as to avoid revealing hidden flags. 
-        case 'f': 
-            return [filter](const item& i) {
+        // item flags, must type in whole flag string name(case insensitive) so as to avoid revealing hidden flags.
+        case 'f':
+            return [filter]( const item & i ) {
                 std::string flag_filter = filter;
                 transform( flag_filter.begin(), flag_filter.end(), flag_filter.begin(), ::toupper );
                 const flag_id fsearch( flag_filter );

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -78,7 +78,7 @@ std::function<bool( const item & )> basic_item_filter( std::string filter )
                 } else {
                     return false;
                 }
-             };
+            };
         // by book skill
         case 's':
             return [filter]( const item & i ) {

--- a/src/item_search.cpp
+++ b/src/item_search.cpp
@@ -71,12 +71,11 @@ std::function<bool( const item & )> basic_item_filter( std::string filter )
         case 'f': 
             return [filter](const item& i) {
                 std::string flag_filter = filter;
-                transform(flag_filter.begin(), flag_filter.end(), flag_filter.begin(), ::toupper);
-                const flag_id fsearch(flag_filter);
-                if (fsearch.is_valid()) {
-                    return i.has_flag(fsearch);
-                }
-                else {
+                transform( flag_filter.begin(), flag_filter.end(), flag_filter.begin(), ::toupper );
+                const flag_id fsearch( flag_filter );
+                if( fsearch.is_valid() ) {
+                    return i.has_flag( fsearch );
+                } else {
                     return false;
                 }
              };


### PR DESCRIPTION
#### Summary
Features "Adds flags as a filtering option for items. Also have an update for the filter explanation window for Output.cpp"

#### Purpose of change

Filtering options were sometimes too limiting, and it is desireable to be able to filter things like whether certain food will become mushy in the freezer, or whether a tool also works well as a weapon. Flags are a ay to perform this filtering and easily accessible. 

#### Describe the solution

This code allows 'f' to be used as a filter for flags. It determines whether the user has input a valid flag, and then filters for that flag using the same filtering function as for notes and quality of items.

#### Describe alternatives you've considered

Not adding the feature, or converting some flags to materials or qualities, which i felt was inelegant. 

#### Testing

Compiled the game, tested lowercase and uppercase versions of flags, and tried invalid flags. using invalid(nonexistent) flags results in no items found by the filter. using case-insensitive flags allows the filter to find items with that flag. 

#### Additional context

I also tested code to update the filtering screen making it known that 'f' was available. I'm not sure how to add it to this PR. I'll just add it as another PR if this gets approved. 


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
