### PR TITLE
Reduce capacity of test battery to prevent UB

### DIFF
--- a/data/mods/TEST_DATA/appliance.json
+++ b/data/mods/TEST_DATA/appliance.json
@@ -156,10 +156,10 @@
     "symbol": ":",
     "color": "light_cyan",
     "ammo_type": [ "battery" ],
-    "capacity": 1000000000,
-    "count": 1000000000,
+    "capacity": 10000000,
+    "count": 10000000,
     "flags": [ "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "RECHARGE", "NO_REPAIR" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 1000000000 } } ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "battery": 10000000 } } ],
     "melee_damage": { "bash": 20 }
   },
   {


### PR DESCRIPTION

#### Summary
SUMMARY: None

#### Purpose of change
The value being this large resulted in an integer overflow in pocket_data::max_contains_volume().

#### Describe the solution
Reduce it until there's no more integer overflow.

#### Testing
Compiled with `-fsanitize=address,undefined`, ran tests. No more
```
src/item_pocket.cpp:2473:62: runtime error: signed integer overflow: 100 * 1000000000 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior src/item_pocket.cpp:2473:62 in
```