### PR TITLE
Allow non wielded items to provide techniques

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -653,6 +653,11 @@
     "//": "This item will store the OMT it spawned in in the 'spawn_location_omt' var"
   },
   {
+    "id": "PROVIDES_TECHNIQUES",
+    "type": "json_flag",
+    "//": "This item provides martial arts techniques in addition to the character's weapon"
+  },
+  {
     "id": "SPAWN_ACTIVE",
     "type": "json_flag",
     "//": "This item will spawn active. Not advised for items that drain power when active."

--- a/data/mods/Xedra_Evolved/items/inventor/armor.json
+++ b/data/mods/Xedra_Evolved/items/inventor/armor.json
@@ -454,7 +454,7 @@
     "material": [ "aluminum", "steel" ],
     "volume": "11678 ml",
     "weight": "3970 g",
-    "flags": [ "DURABLE_MELEE", "PADDED", "MUNDANE", "INVENTOR_CRAFTED" ],
+    "flags": [ "DURABLE_MELEE", "PADDED", "MUNDANE", "INVENTOR_CRAFTED", "PROVIDES_TECHNIQUES" ],
     "techniques": [ "WBLOCK_3", "BRUTAL", "SWEEP" ],
     "material_thickness": 1,
     "armor": [

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -815,6 +815,7 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 - ```PERFECT_LOCKPICK``` Item is a perfect lockpick. Takes only 5 seconds to pick a lock and never fails, but using it grants only a small amount of lock picking xp. The item should have `LOCKPICK` quality of at least 1.
 - ```PLANTABLE_SEED``` This item is a seed, and you can plant it
 - ```PRESERVE_SPAWN_OMT``` This item will store the OMT that it spawns in, in the `spawn_location_omt` item var.
+- ```PROVIDES_TECHNIQUES``` This item will provide martial arts techniques when worn/in the character's inventory, in addition to those provided by the weapon and martial art.
 - ```PSEUDO``` Used internally to mark items that are referred to in the crafting inventory but are not actually items. They can be used as tools, but not as components. Implies `TRADER_AVOID`.
 - ```RABBIT``` Food, that only player with `RABBIT` threshold mutation can eat; see `INEDIBLE`
 - ```RADIOACTIVE``` Is radioactive (can be used with `LEAK_*`).

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -40,6 +40,8 @@ static const bionic_id bio_armor_arms( "bio_armor_arms" );
 static const bionic_id bio_armor_legs( "bio_armor_legs" );
 static const bionic_id bio_cqb( "bio_cqb" );
 
+static const flag_id json_flag_PROVIDES_TECHNIQUES( "PROVIDES_TECHNIQUES" );
+
 static const json_character_flag json_flag_ALWAYS_BLOCK( "ALWAYS_BLOCK" );
 static const json_character_flag json_flag_NONSTANDARD_BLOCK( "NONSTANDARD_BLOCK" );
 
@@ -1320,6 +1322,13 @@ std::vector<matec_id> character_martial_arts::get_all_techniques( const item_loc
     if( weap && !style.force_unarmed ) {
         const auto &weapon_techs = weap->get_techniques();
         tecs.insert( tecs.end(), weapon_techs.begin(), weapon_techs.end() );
+    }
+    // If we have any items that also provide techniques
+    const std::vector<const item *> tech_providing_items = u.cache_get_items_with(
+                json_flag_PROVIDES_TECHNIQUES );
+    for( const item *it : tech_providing_items ) {
+        const std::set<matec_id> &item_techs = it->get_techniques();
+        tecs.insert( tecs.end(), item_techs.begin(), item_techs.end() );
     }
     // and martial art techniques
     tecs.insert( tecs.end(), style.techniques.begin(), style.techniques.end() );


### PR DESCRIPTION
#### Summary
Infrastructure "Allow items to provide martial art techniques when not wielded"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/69736

#### Describe the solution
Add a `PROVIDES_TECHNIQUES` flag that items that are worn/in inventory to provide martial arts techniques. Hook this up to the martial arts techniques code.
Add it to the Xedra Evolved item that prompted this feature.

#### Describe alternatives you've considered
I should break this out into wielded/in inventory as separate flags, but I'm out of time for now.

#### Testing
Follow the steps in the linked issue. See that worn output is the same as wielded.