### PR TITLE
[HOTFIX] Fix wrong amount of num_event_types

### DIFF
--- a/src/event.cpp
+++ b/src/event.cpp
@@ -136,7 +136,7 @@ DEFINE_EVENT_HELPER_FIELDS( event_spec_empty )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character )
 DEFINE_EVENT_HELPER_FIELDS( event_spec_character_item )
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 98,
+static_assert( static_cast<int>( event_type::num_event_types ) == 99,
                "This static_assert is a reminder to add a definition below when you add a new "
                "event_type.  If your event_spec specialization inherits from another struct for "
                "its fields definition then you probably don't need a definition here." );

--- a/src/event.h
+++ b/src/event.h
@@ -184,7 +184,7 @@ struct event_spec_character_item {
     };
 };
 
-static_assert( static_cast<int>( event_type::num_event_types ) == 98,
+static_assert( static_cast<int>( event_type::num_event_types ) == 99,
                "This static_assert is to remind you to add a specialization for your new "
                "event_type below" );
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
both #70194 and #70088 added 1 new event type, both advanced it to 1, and both was merged nearly at the same time, so github didn't spot a merge conflict, and that amount of num_event_types should be 99, not 98
#### Describe the solution
Fix amount of events in num_event_types
#### Testing
If game compiles, then it works