### PR TITLE
Fix lake shore mapgen corner case

### DIFF
--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -2000,12 +2000,23 @@ void mapgen_ocean_shore( mapgendata &dat )
         if( n_ocean && w_ocean ) {
             nw.x += sector_length / 2;
             nw.y += sector_length / 2;
-        } else if( n_shore && w_shore ) {
+        } else if( ( n_shore || n_river_bank ) && ( w_shore || w_river_bank ) ) {
             point n = nw_corner;
             point w = nw_corner;
 
-            n.x += sector_length;
-            w.y += sector_length;
+            n.x += sector_length * ( n_river_bank ? 2 : 1 );
+            w.y += sector_length * ( w_river_bank ? 2 : 1 );
+
+            n.y += n_river_bank ? sector_length / 2 : 0;
+            w.x += w_river_bank ? sector_length / 2 : 0;
+
+            if( w_river_bank ) {
+                line_segments.push_back( { sw, w } );
+            }
+
+            if( n_river_bank ) {
+                line_segments.push_back( { n, ne } );
+            }
 
             line_segments.push_back( { n, w } );
         }
@@ -2015,12 +2026,23 @@ void mapgen_ocean_shore( mapgendata &dat )
         if( n_ocean && e_ocean ) {
             ne.x -= sector_length / 2;
             ne.y += sector_length / 2;
-        } else if( n_shore && e_shore ) {
+        } else if( ( n_shore || n_river_bank ) && ( e_shore || e_river_bank ) ) {
             point n = ne_corner;
             point e = ne_corner;
 
-            n.x -= sector_length;
-            e.y += sector_length;
+            n.x -= sector_length * ( n_river_bank ? 2 : 1 );
+            e.y += sector_length * ( e_river_bank ? 2 : 1 );
+
+            n.y += n_river_bank ? sector_length / 2 : 0;
+            e.x -= e_river_bank ? sector_length / 2 : 0;
+
+            if( e_river_bank ) {
+                line_segments.push_back( { se, e } );
+            }
+
+            if( n_river_bank ) {
+                line_segments.push_back( { n, nw } );
+            }
 
             line_segments.push_back( { n, e } );
         }
@@ -2030,12 +2052,23 @@ void mapgen_ocean_shore( mapgendata &dat )
         if( s_ocean && w_ocean ) {
             sw.x += sector_length / 2;
             sw.y -= sector_length / 2;
-        } else if( s_shore && w_shore ) {
+        } else if( ( s_shore || s_river_bank ) && ( w_shore || w_river_bank ) ) {
             point s = sw_corner;
             point w = sw_corner;
 
-            s.x += sector_length;
-            w.y -= sector_length;
+            s.x += sector_length * ( s_river_bank ? 2 : 1 );
+            w.y -= sector_length * ( w_river_bank ? 2 : 1 );
+
+            s.y -= s_river_bank ? sector_length / 2 : 0;
+            w.x += w_river_bank ? sector_length / 2 : 0;
+
+            if( w_river_bank ) {
+                line_segments.push_back( { nw, w } );
+            }
+
+            if( s_river_bank ) {
+                line_segments.push_back( { s, se } );
+            }
 
             line_segments.push_back( { s, w } );
         }
@@ -2045,12 +2078,23 @@ void mapgen_ocean_shore( mapgendata &dat )
         if( s_ocean && e_ocean ) {
             se.x -= sector_length / 2;
             se.y -= sector_length / 2;
-        } else if( s_shore && e_shore ) {
+        } else if( ( s_shore || s_river_bank ) && ( e_shore || e_river_bank ) ) {
             point s = se_corner;
             point e = se_corner;
 
-            s.x -= sector_length;
-            e.y -= sector_length;
+            s.x -= sector_length * ( s_river_bank ? 2 : 1 );
+            e.y -= sector_length * ( e_river_bank ? 2 : 1 );
+
+            s.y -= s_river_bank ? sector_length / 2 : 0;
+            e.x -= e_river_bank ? sector_length / 2 : 0;
+
+            if( e_river_bank ) {
+                line_segments.push_back( { ne, e } );
+            }
+
+            if( s_river_bank ) {
+                line_segments.push_back( { s, sw } );
+            }
 
             line_segments.push_back( { s, e } );
         }

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -1605,12 +1605,23 @@ void mapgen_lake_shore( mapgendata &dat )
         if( n_lake && w_lake ) {
             nw.x += sector_length / 2;
             nw.y += sector_length / 2;
-        } else if( n_shore && w_shore ) {
+        } else if( ( n_shore || n_river_bank ) && ( w_shore || w_river_bank ) ) {
             point n = nw_corner;
             point w = nw_corner;
 
-            n.x += sector_length;
-            w.y += sector_length;
+            n.x += sector_length * ( n_river_bank ? 2 : 1 );
+            w.y += sector_length * ( w_river_bank ? 2 : 1 );
+
+            n.y += n_river_bank ? sector_length / 2 : 0;
+            w.x += w_river_bank ? sector_length / 2 : 0;
+
+            if( w_river_bank ) {
+                line_segments.push_back( { sw, w } );
+            }
+
+            if( n_river_bank ) {
+                line_segments.push_back( { n, ne } );
+            }
 
             line_segments.push_back( { n, w } );
         }
@@ -1620,12 +1631,23 @@ void mapgen_lake_shore( mapgendata &dat )
         if( n_lake && e_lake ) {
             ne.x -= sector_length / 2;
             ne.y += sector_length / 2;
-        } else if( n_shore && e_shore ) {
+        } else if( ( n_shore || n_river_bank ) && ( e_shore || e_river_bank ) ) {
             point n = ne_corner;
             point e = ne_corner;
 
-            n.x -= sector_length;
-            e.y += sector_length;
+            n.x -= sector_length * ( n_river_bank ? 2 : 1 );
+            e.y += sector_length * ( e_river_bank ? 2 : 1 );
+
+            n.y += n_river_bank ? sector_length / 2 : 0;
+            e.x -= e_river_bank ? sector_length / 2 : 0;
+
+            if( e_river_bank ) {
+                line_segments.push_back( { se, e } );
+            }
+
+            if( n_river_bank ) {
+                line_segments.push_back( { n, nw } );
+            }
 
             line_segments.push_back( { n, e } );
         }
@@ -1635,12 +1657,23 @@ void mapgen_lake_shore( mapgendata &dat )
         if( s_lake && w_lake ) {
             sw.x += sector_length / 2;
             sw.y -= sector_length / 2;
-        } else if( s_shore && w_shore ) {
+        } else if( ( s_shore || s_river_bank ) && ( w_shore || w_river_bank ) ) {
             point s = sw_corner;
             point w = sw_corner;
 
-            s.x += sector_length;
-            w.y -= sector_length;
+            s.x += sector_length * ( s_river_bank ? 2 : 1 );
+            w.y -= sector_length * ( w_river_bank ? 2 : 1 );
+
+            s.y -= s_river_bank ? sector_length / 2 : 0;
+            w.x += w_river_bank ? sector_length / 2 : 0;
+
+            if( w_river_bank ) {
+                line_segments.push_back( { nw, w } );
+            }
+
+            if( s_river_bank ) {
+                line_segments.push_back( { s, se } );
+            }
 
             line_segments.push_back( { s, w } );
         }
@@ -1650,12 +1683,23 @@ void mapgen_lake_shore( mapgendata &dat )
         if( s_lake && e_lake ) {
             se.x -= sector_length / 2;
             se.y -= sector_length / 2;
-        } else if( s_shore && e_shore ) {
+        } else if( ( s_shore || s_river_bank ) && ( e_shore || e_river_bank ) ) {
             point s = se_corner;
             point e = se_corner;
 
-            s.x -= sector_length;
-            e.y -= sector_length;
+            s.x -= sector_length * ( s_river_bank ? 2 : 1 );
+            e.y -= sector_length * ( e_river_bank ? 2 : 1 );
+
+            s.y -= s_river_bank ? sector_length / 2 : 0;
+            e.x -= e_river_bank ? sector_length / 2 : 0;
+
+            if( e_river_bank ) {
+                line_segments.push_back( { ne, e } );
+            }
+
+            if( s_river_bank ) {
+                line_segments.push_back( { s, sw } );
+            }
 
             line_segments.push_back( { s, e } );
         }


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Fixes #38036

#### Describe the solution

In my original implementation, I overlooked the scenario where a lake shore was bounded on the cardinal directions by river banks and had a lake on the diagonal that bounded the river banks. As a result, the mapgen would not draw any shoreline and just fill the whole location with water.

I also ported this change into the ocean shore code that is derived from this.

#### Describe alternatives you've considered

None. Ultimately we'll want to revisit the overmap level generation and its handling of the confluence of rivers, lakes, and oceans to not just play whack-a-mole (as much) with weird generation, but this issue is just a legit oversight in my original implementation.

#### Testing

Set up a test scenario that went through the cases and checked it out:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/11464/74b2da19-78ad-410f-80d1-109aee40866a)

Also teleported around and looked for this particular case occurring naturally. There are still lots of weird interactions at the confluence of lakes and rivers but this fixes the most egregious one.

#### Additional context

**Before**
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/11464/ccf2617d-17a9-47d0-bbbc-f3f00de95304)

**After**

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/11464/66fe1d02-0fa5-4e64-988e-0ab318cbd078)