### PR TITLE
Fix spells pick incorrect values if min bigger than max

### DIFF
--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -714,10 +714,17 @@ int spell::damage( const Creature &caster ) const
                     std::max( leveled_damage,
                               static_cast<int>( type->max_damage.evaluate( d ) ) ) );
     } else {
-        if( type->min_damage.evaluate( d ) >= 0 ||
-            type->max_damage.evaluate( d ) >= type->min_damage.evaluate( d ) ) {
-            return std::min( leveled_damage, static_cast<int>( type->max_damage.evaluate( d ) ) );
-        } else { // if it's negative, min and max work differently
+        if( type->min_damage.evaluate( d ) >= 0 ) {
+            if( type->max_damage.evaluate( d ) > type->min_damage.evaluate( d ) ) {
+                return std::clamp( leveled_damage, static_cast<int>( type->min_damage.evaluate( d ) ),
+                                   static_cast<int>( type->max_damage.evaluate( d ) ) );
+            } else {
+                return std::min( leveled_damage, static_cast<int>( type->max_damage.evaluate( d ) ) );
+            }
+        } else if( type->max_damage.evaluate( d ) < type->min_damage.evaluate( d ) ) {
+            return std::clamp( leveled_damage, static_cast<int>( type->min_damage.evaluate( d ) ),
+                               static_cast<int>( type->max_damage.evaluate( d ) ) );
+        } else {
             return std::max( leveled_damage, static_cast<int>( type->max_damage.evaluate( d ) ) );
         }
     }
@@ -734,10 +741,18 @@ int spell::accuracy( Creature &caster ) const
 {
     dialogue d( get_talker_for( caster ), nullptr );
     const int leveled_accuracy = min_leveled_accuracy( caster );
-    if( type->min_accuracy.evaluate( d ) >= 0 ||
-        type->max_accuracy.evaluate( d ) >= type->min_accuracy.evaluate( d ) ) {
-        return std::min( leveled_accuracy, static_cast<int>( type->max_accuracy.evaluate( d ) ) );
-    } else { // if it's negative, min and max work differently
+
+    if( type->min_accuracy.evaluate( d ) > 0 ) {
+        if( type->max_accuracy.evaluate( d ) > type->min_accuracy.evaluate( d ) ) {
+            return std::clamp( leveled_accuracy, static_cast<int>( type->min_accuracy.evaluate( d ) ),
+                               static_cast<int>( type->max_accuracy.evaluate( d ) ) );
+        } else {
+            return std::min( leveled_accuracy, static_cast<int>( type->max_accuracy.evaluate( d ) ) );
+        }
+    } else if( type->max_accuracy.evaluate( d ) < type->min_accuracy.evaluate( d ) ) {
+        return std::clamp( leveled_accuracy, static_cast<int>( type->min_accuracy.evaluate( d ) ),
+                           static_cast<int>( type->max_accuracy.evaluate( d ) ) );
+    } else {
         return std::max( leveled_accuracy, static_cast<int>( type->max_accuracy.evaluate( d ) ) );
     }
 }
@@ -753,10 +768,17 @@ int spell::damage_dot( const Creature &caster ) const
 {
     dialogue d( get_talker_for( caster ), nullptr );
     const int leveled_dot = min_leveled_dot( caster );
-    if( type->min_dot.evaluate( d ) >= 0 ||
-        type->max_dot.evaluate( d ) >= type->min_dot.evaluate( d ) ) {
-        return std::min( leveled_dot, static_cast<int>( type->max_dot.evaluate( d ) ) );
-    } else { // if it's negative, min and max work differently
+    if( type->min_dot.evaluate( d ) >= 0 ) {
+        if( type->max_dot.evaluate( d ) > type->min_dot.evaluate( d ) ) {
+            return std::clamp( leveled_dot, static_cast<int>( type->min_dot.evaluate( d ) ),
+                               static_cast<int>( type->max_dot.evaluate( d ) ) );
+        } else {
+            return std::min( leveled_dot, static_cast<int>( type->max_dot.evaluate( d ) ) );
+        }
+    } else if( type->max_dot.evaluate( d ) < type->min_dot.evaluate( d ) ) {
+        return std::clamp( leveled_dot, static_cast<int>( type->min_dot.evaluate( d ) ),
+                           static_cast<int>( type->max_dot.evaluate( d ) ) );
+    } else {
         return std::max( leveled_dot, static_cast<int>( type->max_dot.evaluate( d ) ) );
     }
 }
@@ -863,10 +885,11 @@ int spell::aoe( const Creature &caster ) const
         return_value = rng( std::min( leveled_aoe, static_cast<int>( type->max_aoe.evaluate( d ) ) ),
                             std::max( leveled_aoe, static_cast<int>( type->max_aoe.evaluate( d ) ) ) );
     } else {
-        if( type->max_aoe.evaluate( d ) >= type->min_aoe.evaluate( d ) ) {
-            return_value = std::min( leveled_aoe, static_cast<int>( type->max_aoe.evaluate( d ) ) );
+        if( type->max_aoe.evaluate( d ) > type->min_aoe.evaluate( d ) ) {
+            return_value = std::clamp( leveled_aoe, static_cast<int>( type->min_aoe.evaluate( d ) ),
+                                       static_cast<int>( type->max_aoe.evaluate( d ) ) );
         } else {
-            return_value = std::max( leveled_aoe, static_cast<int>( type->max_aoe.evaluate( d ) ) );
+            return_value = std::min( leveled_aoe, static_cast<int>( type->max_aoe.evaluate( d ) ) );
         }
     }
     return return_value * temp_aoe_multiplyer;
@@ -910,8 +933,9 @@ int spell::range( const Creature &caster ) const
     const int leveled_range = type->min_range.evaluate( d ) + std::round( get_effective_level() *
                               type->range_increment.evaluate( d ) );
     float range;
-    if( type->max_range.evaluate( d ) >= type->min_range.evaluate( d ) ) {
-        range = std::min( leveled_range, static_cast<int>( type->max_range.evaluate( d ) ) );
+    if( type->max_range.evaluate( d ) > type->min_range.evaluate( d ) ) {
+        range = std::clamp( leveled_range, static_cast<int>( type->min_range.evaluate( d ) ),
+                            static_cast<int>( type->max_range.evaluate( d ) ) );
     } else {
         range = std::max( leveled_range, static_cast<int>( type->max_range.evaluate( d ) ) );
     }
@@ -975,10 +999,11 @@ int spell::duration( const Creature &caster ) const
                     std::max( leveled_duration,
                               static_cast<int>( type->max_duration.evaluate( d ) ) ) );
     } else {
-        if( type->max_duration.evaluate( d ) >= type->min_duration.evaluate( d ) ) {
-            return std::min( leveled_duration, static_cast<int>( type->max_duration.evaluate( d ) ) );
+        if( type->max_duration.evaluate( d ) > type->min_duration.evaluate( d ) ) {
+            return std::clamp( leveled_duration, static_cast<int>( type->min_duration.evaluate( d ) ),
+                               static_cast<int>( type->max_duration.evaluate( d ) ) );
         } else {
-            return std::max( leveled_duration, static_cast<int>( type->max_duration.evaluate( d ) ) );
+            return std::min( leveled_duration, static_cast<int>( type->max_duration.evaluate( d ) ) );
         }
     }
     return std::max( duration * temp_duration_multiplyer, 0.0f );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -708,7 +708,6 @@ int spell::damage( const Creature &caster ) const
 {
     dialogue d( get_talker_for( caster ), nullptr );
     const int leveled_damage = min_leveled_damage( caster );
-    
     double const min = type->min_damage.evaluate( d );
     double const max = std::max( min, type->max_damage.evaluate( d ) );
 


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Attempt to fix #67589
#### Describe the solution
Use solution proposed by Andrei, apply to all fields that may suffer from this issue

- [x] aoe
- [x] range
- [x] damage
- [x] duration
- [x] dot
- [x] accuracy

currently have some issue with damage, aoe and accuracy, since it has slightly different calculations for positive and negative values, but i believe i can wrap my head around it

not sure should i change the behavior for casting_time/energy_cost?
#### Testing 
confirmed to work properly with `pyrokinetic_flamethrower`, edited in the old way, without math `min` limiting the value

<details>
  <summary>Spell</summary>

```
{
    "id": "debug_pyrokinetic_flamethrower",
    "type": "SPELL",
    "name": "DEBUG [Ψ]Flamethrower",
    "description": "Spray fire in a cone in front of you.",
    "message": "You hurl a spray of flames.",
    "teachable": false,
    "valid_targets": [ "hostile", "ground", "ally" ],
    "spell_class": "PYROKINETIC",
    "skill": "metaphysics",
    "flags": [ "PSIONIC", "CONCENTRATE", "LOUD", "NO_PROJECTILE", "IGNITE_FLAMMABLE", "RANDOM_DAMAGE", "NO_HANDS", "NO_LEGS" ],
    "difficulty": 5,
    "max_level": { "math": [ "int_to_level(1)" ] },
    "effect": "attack",
    "extra_effects": [ { "id": "psionic_drained_difficulty_five", "hit_self": true } ],
    "shape": "cone",
    "damage_type": "heat",
    "min_damage": {
      "math": [
        "( (u_spell_level('pyrokinetic_flamethrower') * 1.5) + 15) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
      ]
    },
    "max_damage": {
      "math": [
        "( (u_spell_level('pyrokinetic_flamethrower') * 2.5) + 40) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
      ]
    },
    "min_range": {
      "math": [
        "(( (u_val('spell_level', 'spell: pyrokinetic_flamethrower') * 0.2) + 3) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling)"
      ]
    },
    "max_range": 20,
    "min_aoe": {
      "math": [
        "(( (u_val('spell_level', 'spell: pyrokinetic_flamethrower') * 3) + 27) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling)"
      ]
    },
    "max_aoe": 145,
    "field_id": "fd_fire",
    "min_field_intensity": 1,
    "max_field_intensity": 2,
    "field_chance": 5,
    "energy_source": "STAMINA",
    "base_energy_cost": 3500,
    "final_energy_cost": 1200,
    "energy_increment": -150,
    "base_casting_time": 100,
    "final_casting_time": 35,
    "casting_time_increment": -6,
    "sound_type": "combat",
    "sound_id": "fire_spell",
    "sound_description": "a crackle!",
    "ignored_monster_species": [ "PSI_NULL" ],
    "learn_spells": { "pyrokinetic_lance": 6, "pyrokinetic_blast": 9, "pyrokinetic_aura": 12, "pyrokinetic_aoe_blast": 16 }
  },
```

</details>

#### Additional context
I can't properly install astyle to use in the project, and it sucks