### PR TITLE
Fix rotation issue with using lake and ocean shores as predecessors

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_waterbody.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_waterbody.json
@@ -16,7 +16,7 @@
     "name": "lake shore",
     "color": "light_blue",
     "delete": { "flags": [ "LAKE" ] },
-    "extend": { "flags": [ "LAKE_SHORE" ] },
+    "extend": { "flags": [ "LAKE_SHORE", "IGNORE_ROTATION_FOR_ADJACENCY" ] },
     "extras": "lake_shore",
     "travel_cost_type": "shore",
     "mapgen": [ { "method": "builtin", "name": "lake_shore" } ]
@@ -56,7 +56,7 @@
     "name": "ocean shore",
     "color": "light_blue",
     "delete": { "flags": [ "OCEAN" ] },
-    "extend": { "flags": [ "OCEAN_SHORE" ] },
+    "extend": { "flags": [ "OCEAN_SHORE", "IGNORE_ROTATION_FOR_ADJACENCY" ] },
     "extras": "ocean_shore",
     "travel_cost_type": "shore",
     "mapgen": [ { "method": "builtin", "name": "ocean_shore" } ]

--- a/data/mods/desert_region/overmap/desert_overmap_terrain.json
+++ b/data/mods/desert_region/overmap/desert_overmap_terrain.json
@@ -161,7 +161,7 @@
     "name": "lake bed shore",
     "color": "light_gray",
     "delete": { "flags": [ "LAKE" ] },
-    "extend": { "flags": [ "LAKE_SHORE" ] },
+    "extend": { "flags": [ "LAKE_SHORE", "IGNORE_ROTATION_FOR_ADJACENCY" ] },
     "extras": "lake_shore",
     "mapgen": [ { "method": "builtin", "name": "lake_shore" } ]
   },

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -104,7 +104,26 @@ mapgendata::mapgendata( const tripoint_abs_omt &over, map &mp, const float densi
 
 mapgendata::mapgendata( const mapgendata &other, const oter_id &other_id ) : mapgendata( other )
 {
+    const int old_rotation = terrain_type_->has_flag(
+                                 oter_flags::ignore_rotation_for_adjacency ) ? 0 : terrain_type_->get_rotation();
+    const int new_rotation = other_id->has_flag( oter_flags::ignore_rotation_for_adjacency ) ? 0 :
+                             other_id->get_rotation();
+
     terrain_type_ = other_id;
+
+    const int rotation_delta = new_rotation - old_rotation;
+
+    if( rotation_delta == 0 ) {
+        return;
+    }
+
+    const int shift = ( rotation_delta + 4 ) % 4;
+
+    // The array of neighbors is actually logically more like two independent arrays smashed
+    // together, so we need to first rotate the cardinal directions section, and then the
+    // ordinal directions section. They both rotate the same direction.
+    std::rotate( t_nesw.begin(), t_nesw.begin() + shift, t_nesw.begin() + 4 );
+    std::rotate( t_nesw.begin() + 4, t_nesw.begin() + 4 + shift, t_nesw.end() );
 }
 
 mapgendata::mapgendata( const mapgendata &other,


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

Fix mapgen of overmap terrains using lake shores as a predecessor when rotated.

#### Describe the solution

The changes in #51913 broke the rotation of lake shores when used as predecessors by essentially pre-rotating the entries in the mapgendata neighbors even though the shore itself is not a rotatable terrain.

As a result, the predecessor omt generation would be rotated in the direction of the final mapgen, negating the predecessor application logic that would pre-rotate it in the opposite direction so that the final mapgen rotation would put it in the correct spot.

The end result would be that the lake shores used as predecessor terrain would be incorrect in all orientations except north.

To fix this, I applied the IGNORE_ROTATION_FOR_ADJACENCY flag that was added in #52168 to lake and ocean shores so that their mapgendata is provided as expected.

...however, the implementation in that PR only works for the final overmap terrain and not predecessors because the mapgendata constructor that swapped overmap terrain types didn't reevaluate the flag to see if the neighbors should be rotated. Consequently, if the final one is rotated, all the predecessors got rotated data even if they set this flag.

I updated it so now it checks for a difference in rotation between the original and new overmap terrain type, and adjusts the neighbors.

Also went ahead and applied the flag to ocean shores, since they'll have the same issue.

#### Describe alternatives you've considered

None.

#### Testing

Used the overmap editor plop down a bunch of rotated specials on lake shores and verify they render correctly. Teleported around the world to check the same.

#### Additional context

I figured some infrastructure piece broke this along the way, because I added predecessor mapgen to the game in #30582 *specifically for* lake specials (you can even see them mapgen'd correctly with rotations in that PR), so it was mostly an exercise in sleuthing what exactly happened through the commit history.