### PR TITLE
Fix 'den_palette' test errors

### DIFF
--- a/data/json/mapgen/trail.json
+++ b/data/json/mapgen/trail.json
@@ -364,7 +364,7 @@
       "parameters": {
         "den_palette": {
           "type": "palette_id",
-          "scope": "omt",
+          "scope": "nest",
           "default": {
             "distribution": [
               [ "trail_small_den_empty_palette", 20 ],


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
The parameters for the den_palette had the wrong scope, and so were never found.

#### Describe the solution
Change the scope parameter scope to `nest`, because this is a nested mapgen.

#### Testing
I could reproduce this with `tests/cata_test --rng-seed=1702733333`. The error triggered before any tests ran.
