### PR TITLE
[Sky Island] Allow selection of room teleport behavior

### DIFF
--- a/data/mods/Sky_Island/EOCs.json
+++ b/data/mods/Sky_Island/EOCs.json
@@ -129,12 +129,56 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_statue_return",
-    "//": "This EOC is activated by return portals.  It's just here to confirm that you want to return home, then triggers the actual teleport home.",
+    "//": "This EOC is activated by return portals.  It's just here to confirm that you want to return home, then triggers the actual teleport home.  Behavior based on difficulty selector",
+    "effect": {
+      "switch": { "math": [ "roomteleportselector" ] },
+      "cases": [
+        { "case": 0, "effect": [ { "run_eocs": "EOC_statue_return_whole_room" } ] },
+        { "case": 1, "effect": [ { "run_eocs": "EOC_statue_return_whole_room_cost" } ] },
+        { "case": 2, "effect": [ { "run_eocs": "EOC_statue_return_self_only" } ] }
+      ]
+    }
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_statue_return_whole_room",
+    "//": "This is the version that returns the whole room home.",
     "condition": {
       "u_query": "This will teleport you back to your sky island.  Any items inside the room will be teleported home alongside you.  Are you ready to leave?",
       "default": false
     },
     "effect": [ { "math": [ "raidswon", "++" ] }, { "run_eocs": [ "EOC_return_OM_teleport_item" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_statue_return_whole_room_cost",
+    "condition": { "u_has_items": { "item": "warp_vortex_token", "count": 1 } },
+    "effect": [ { "run_eocs": [ "EOC_statue_return_whole_room_cost_2" ] } ],
+    "false_effect": [ { "run_eocs": [ "EOC_statue_return_self_only" ] } ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_statue_return_whole_room_cost_2",
+    "//": "This is the version that returns the whole room home if you pay a vortex token.",
+    "condition": {
+      "u_query": "This will teleport you back to your sky island.  You will spend your vortex token to return any items in the room home alongside you.  Are you ready to leave?",
+      "default": false
+    },
+    "effect": [
+      { "math": [ "raidswon", "++" ] },
+      { "u_consume_item": "warp_vortex_token", "count": 1 },
+      { "run_eocs": [ "EOC_return_OM_teleport_item" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_statue_return_self_only",
+    "//": "This version returns only you home.",
+    "condition": {
+      "u_query": "This will teleport you back to your sky island.  Any items not on your person WILL BE LOST.  Are you ready to leave?",
+      "default": false
+    },
+    "effect": [ { "math": [ "raidswon", "++" ] }, { "run_eocs": [ "EOC_return_OM_teleport" ] } ]
   },
   {
     "type": "effect_on_condition",
@@ -340,7 +384,7 @@
         "u_message": "Difficulty set to Casual.  You can use the Difficulty Adjuster if you wish to change your setting at any time."
       },
       { "arithmetic": [ { "global_val": "var", "var_name": "sicknessintervals" }, "=", { "time": "90 m" } ] },
-      { "math": [ "has_set_difficulty", "=", "1" ] }
+      { "run_eocs": "EOC_difficultycheck_2" }
     ]
   },
   {
@@ -351,7 +395,7 @@
         "u_message": "Difficulty set to Normal.  You can use the Difficulty Adjuster if you wish to change your setting at any time."
       },
       { "arithmetic": [ { "global_val": "var", "var_name": "sicknessintervals" }, "=", { "time": "45 m" } ] },
-      { "math": [ "has_set_difficulty", "=", "1" ] }
+      { "run_eocs": "EOC_difficultycheck_2" }
     ]
   },
   {
@@ -362,7 +406,7 @@
         "u_message": "Difficulty set to Hard.  You can use the Difficulty Adjuster if you wish to change your setting at any time."
       },
       { "arithmetic": [ { "global_val": "var", "var_name": "sicknessintervals" }, "=", { "time": "30 m" } ] },
-      { "math": [ "has_set_difficulty", "=", "1" ] }
+      { "run_eocs": "EOC_difficultycheck_2" }
     ]
   },
   {
@@ -373,6 +417,55 @@
         "u_message": "Difficulty set to Impossible.  You can use the Difficulty Adjuster if you wish to change your setting at any time."
       },
       { "arithmetic": [ { "global_val": "var", "var_name": "sicknessintervals" }, "=", { "time": "15 m" } ] },
+      { "run_eocs": "EOC_difficultycheck_2" }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_difficultycheck_2",
+    "effect": [
+      {
+        "run_eoc_selector": [ "EOC_warphome_adjuster_1", "EOC_warphome_adjuster_2", "EOC_warphome_adjuster_3" ],
+        "names": [ "Whole Room", "Whole Room for a Cost", "Self Only" ],
+        "keys": [ "1", "2", "3" ],
+        "descriptions": [
+          "Set the behavior of the return obelisk.\nWith this option, everything in the room with you will return to your sky island.  Getting resources will generally not be a problem as long as you make it to the extraction point.",
+          "Set the behavior of the return obelisk.\nWith this option, if you have a warp vortex token with you, everything in the room with you will return to your sky island.  Otherwise, only what you are carrying on your person will return with you.  You may have to make difficult choices about what to bring back.",
+          "Set the behavior of the return obelisk.\nWith this option, only what you are carrying on your person will return with you.  You will always have to make difficult choices about what to bring back."
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_warphome_adjuster_1",
+    "effect": [
+      {
+        "u_message": "Warp home behavior set to whole room.  You can use the Difficulty Adjuster if you wish to change your setting at any time."
+      },
+      { "math": [ "roomteleportselector", "=", "0" ] },
+      { "math": [ "has_set_difficulty", "=", "1" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_warphome_adjuster_2",
+    "effect": [
+      {
+        "u_message": "Warp home behavior set to whole room at a cost.  You can use the Difficulty Adjuster if you wish to change your setting at any time."
+      },
+      { "math": [ "roomteleportselector", "=", "1" ] },
+      { "math": [ "has_set_difficulty", "=", "1" ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_warphome_adjuster_3",
+    "effect": [
+      {
+        "u_message": "Warp home behavior set to self only.  You can use the Difficulty Adjuster if you wish to change your setting at any time."
+      },
+      { "math": [ "roomteleportselector", "=", "2" ] },
       { "math": [ "has_set_difficulty", "=", "1" ] }
     ]
   },

--- a/data/mods/Sky_Island/recipes.json
+++ b/data/mods/Sky_Island/recipes.json
@@ -31,6 +31,21 @@
     "flags": [ "BLIND_EASY" ]
   },
   {
+    "result": "warp_vortex_token",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_WARP",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "1 m",
+    "autolearn": true,
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [ [ [ "warptoken", 15 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
     "result": "warphome",
     "type": "recipe",
     "activity_level": "NO_EXERCISE",

--- a/data/mods/Sky_Island/warpitems.json
+++ b/data/mods/Sky_Island/warpitems.json
@@ -340,7 +340,7 @@
     "type": "AMMO",
     "category": "other",
     "name": { "str_sp": "warp vortex token" },
-    "description": "This irregular purplish lumb seems to slowly pull in air even while you hold it in your hand.  If you have one with you when you activate the return obelisk and the obelisk is correctly configured, it will drag the entire contents of the room with you back up to your island.",
+    "description": "This irregular purplish lump seems to slowly pull in air even while you hold it in your hand.  If you have one with you when you activate the return obelisk and the obelisk is correctly configured, it will drag the entire contents of the room with you back up to your island.",
     "weight": "5 g",
     "volume": "5 ml",
     "count": 1,

--- a/data/mods/Sky_Island/warpitems.json
+++ b/data/mods/Sky_Island/warpitems.json
@@ -336,6 +336,23 @@
     "ammo_type": "components"
   },
   {
+    "id": "warp_vortex_token",
+    "type": "AMMO",
+    "category": "other",
+    "name": { "str_sp": "warp vortex token" },
+    "description": "This irregular purplish lumb seems to slowly pull in air even while you hold it in your hand.  If you have one with you when you activate the return obelisk, it will drag the entire contents of the room with you back up to your island.",
+    "weight": "5 g",
+    "volume": "5 ml",
+    "count": 1,
+    "stack_size": 100,
+    "looks_like": "spiral_stone",
+    "flags": [ "UNBREAKABLE" ],
+    "material": [ "alien_resin" ],
+    "symbol": ".",
+    "color": "magenta",
+    "ammo_type": "components"
+  },
+  {
     "id": "warptoken",
     "type": "AMMO",
     "category": "other",

--- a/data/mods/Sky_Island/warpitems.json
+++ b/data/mods/Sky_Island/warpitems.json
@@ -340,7 +340,7 @@
     "type": "AMMO",
     "category": "other",
     "name": { "str_sp": "warp vortex token" },
-    "description": "This irregular purplish lumb seems to slowly pull in air even while you hold it in your hand.  If you have one with you when you activate the return obelisk, it will drag the entire contents of the room with you back up to your island.",
+    "description": "This irregular purplish lumb seems to slowly pull in air even while you hold it in your hand.  If you have one with you when you activate the return obelisk and the obelisk is correctly configured, it will drag the entire contents of the room with you back up to your island.",
     "weight": "5 g",
     "volume": "5 ml",
     "count": 1,


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Sky Island] Allow selection of room teleport behavior"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I saw two points of view--one that room teleporting for Sky Island was a huge change to the balance, and one that it didn't matter because everyone just stuffed a refrigerator full, picked up the refrigerator, and staggered to the extraction point holding it.  Well, let's give everyone what they want.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds extraction room behavior to the difficulty selector.  You can either have everything in the room teleport home (default behavior, so no save-game disruption occurs), require a "warp vortex token" to teleport everything in the room (craftable using 15 warp shards) otherwise you go home with only what you can carry, or make it so you only go home with what you can carry. You can change this at any time with the selector, just like the warp pulse timer.

The warp vortex token is not technically single-use, but if you have one, your only option is to spend it to take the whole room with you, and if you put it down, the room doesn't come with you and so neither does the token, so in that way it's the equivalent of the homeward mote.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested all three difficulties and warp vortex token crafting, everything worked.  Existing games retain whole room behavior until the difficulty is changed. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Just started a Sky Island game so expect more Sky Island PRs from me. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
