### PR TITLE
[MOM] Allow Nether Attunement To Induce Hallucinations

### DIFF
--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -164,6 +164,7 @@
                 [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", { "const": 3 } ],
                 [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", { "const": 3 } ],
                 [ "EOC_NETHER_EFFECT_CHECK_BREATHING", { "const": 3 } ],
+                [ "EOC_NETHER_EFFECT_CHECK_HALLUCINATIONS", { "const": 3 } ],
                 [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", { "const": 3 } ]
               ]
             }
@@ -183,6 +184,7 @@
                 [ "EOC_DRAIN_EFFECT_CHECK_TELEPORT_LOCK", { "const": 3 } ],
                 [ "EOC_DRAIN_EFFECT_CHECK_WEAKNESS", { "const": 3 } ],
                 [ "EOC_NETHER_EFFECT_CHECK_BREATHING", { "const": 3 } ],
+                [ "EOC_NETHER_EFFECT_CHECK_HALLUCINATIONS", { "const": 3 } ],
                 [ "EOC_NETHER_EFFECT_CHECK_FORCE_WAVE", { "const": 3 } ],
                 [ "EOC_NETHER_EFFECT_CHECK_NO_PSIONICS", { "const": 2 } ]
               ]
@@ -517,6 +519,36 @@
         "duration": {
           "math": [
             "u_val('time: 30 s') * rng( ( u_val('vitamin', 'name:vitamin_psionic_drain') / 2 ), ( u_val('vitamin', 'name:vitamin_psionic_drain') * 2 ) )"
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DRAIN_EFFECT_CHECK_HALLUCINATIONS",
+    "condition": {
+      "and": [
+        { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "125" ] },
+        {
+          "x_in_y_chance": {
+            "x": {
+              "math": [
+                "clamp( (u_vitamin('vitamin_psionic_drain') - 280), 0, 50) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 10"
+              ]
+            },
+            "y": 1000
+          }
+        }
+      ]
+    },
+    "effect": [
+      { "u_message": "As you unleash your powers, you begin to feel a sudden sense of dread and paranoia!", "type": "bad" },
+      {
+        "u_add_effect": "hallu",
+        "duration": {
+          "math": [
+            "u_val('time: 45 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )"
           ]
         }
       }

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -528,7 +528,6 @@
     "type": "effect_on_condition",
     "id": "EOC_NETHER_EFFECT_CHECK_HALLUCINATIONS",
     "//": "Base is 1% chance from 125 attunement to 160 attunement, then scaling up 0.1% per attunement up to 6% chance at 210 attunement, then scaling up 0.35% chance per attunement up to 20% chance at max, plus the Difficulty squared.",
- 
     "condition": {
       "and": [
         { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "125" ] },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -534,7 +534,7 @@
           "x_in_y_chance": {
             "x": {
               "math": [
-                "clamp( (u_vitamin('vitamin_psionic_drain') - 100), 0, 50) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 10"
+               "( clamp( ( u_vitamin('vitamin_psionic_drain')  - 160), 0, 100) + clamp( ( (u_vitamin('vitamin_psionic_drain') - 210) * 3.5 ), 0, 150) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 10)"          
               ]
             },
             "y": 1000

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -535,7 +535,7 @@
           "x_in_y_chance": {
             "x": {
               "math": [
-               "( clamp( ( u_vitamin('vitamin_psionic_drain')  - 160), 0, 100) + clamp( ( (u_vitamin('vitamin_psionic_drain') - 210) * 3.5 ), 0, 150) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 10)"          
+                "( clamp( ( u_vitamin('vitamin_psionic_drain')  - 160), 0, 100) + clamp( ( (u_vitamin('vitamin_psionic_drain') - 210) * 3.5 ), 0, 150) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 10)"
               ]
             },
             "y": 1000

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -548,7 +548,7 @@
         "u_add_effect": "hallu",
         "duration": {
           "math": [
-            "u_val('time: 45 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )"
+            "u_val('time: 90 s') * rng( ( u_vitamin('vitamin_psionic_drain') / 2 ), ( u_vitamin('vitamin_psionic_drain') * 2 ) )"
           ]
         }
       }

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -534,7 +534,7 @@
           "x_in_y_chance": {
             "x": {
               "math": [
-                "clamp( (u_vitamin('vitamin_psionic_drain') - 280), 0, 50) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 10"
+                "clamp( (u_vitamin('vitamin_psionic_drain') - 100), 0, 50) + (nether_attune_difficulty_scaler(u_latest_channeled_power_difficulty)) + 10"
               ]
             },
             "y": 1000

--- a/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_nether_attunement_events.json
@@ -526,7 +526,9 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "EOC_DRAIN_EFFECT_CHECK_HALLUCINATIONS",
+    "id": "EOC_NETHER_EFFECT_CHECK_HALLUCINATIONS",
+    "//": "Base is 1% chance from 125 attunement to 160 attunement, then scaling up 0.1% per attunement up to 6% chance at 210 attunement, then scaling up 0.35% chance per attunement up to 20% chance at max, plus the Difficulty squared.",
+ 
     "condition": {
       "and": [
         { "math": [ "u_vitamin('vitamin_psionic_drain')", ">=", "125" ] },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MOM] Allow high nether attunement to induce hallucinations."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Standing Storm thought this was a good [idea](https://github.com/CleverRaven/Cataclysm-DDA/pull/70189#issuecomment-1859007625).
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add an effect that allows significant Nether Attunement (125) to induce hallucinations for a scaling amount of time.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Went into the game and drove my attunement through the roof. I managed to start hallucinating.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None at this time.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
