### PR TITLE
Add side lengths for solar panels

### DIFF
--- a/data/json/items/vehicle/solar.json
+++ b/data/json/items/vehicle/solar.json
@@ -11,6 +11,7 @@
       "Numbers from https://modernize.com/homeowner-resources/solar/average-solar-panel-dimensions-and-sizes"
     ],
     "weight": "2630 g",
+    "longest_side": "50 cm",
     "to_hit": -4,
     "color": "yellow",
     "symbol": "]",
@@ -29,7 +30,7 @@
     "name": { "str": "solar panel array" },
     "description": "A collection of four solar panels, ready to get to work converting solar radiation into electric power.  Install them to use them in a static power grid.",
     "copy-from": "solar_panel",
-    "proportional": { "weight": 4, "volume": 4, "price": 4, "price_postapoc": 4 }
+    "proportional": { "weight": 4, "volume": 4, "price": 4, "price_postapoc": 4, "longest_side": 2 }
   },
   {
     "type": "GENERIC",
@@ -127,7 +128,7 @@
     "name": { "str": "advanced solar panel array" },
     "description": "A collection of four smaller solar panels, read to convert solar radiation into electric power.  These panels are high-performance, made with monocrystalline silicon cells.",
     "copy-from": "solar_panel_v2",
-    "proportional": { "price": 4, "price_postapoc": 4, "weight": 4, "volume": 4 }
+    "proportional": { "price": 4, "price_postapoc": 4, "weight": 4, "volume": 4, "longest_side": 2 }
   },
   {
     "type": "GENERIC",


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Solar panels did not have explicitly specified side lengths.

#### Describe the solution
Add side lengths.

#### Testing
Spawn in some solar panels. See the side lengths are 50cm/1m.