### PR TITLE
3D draw point generation

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1725,7 +1725,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         // Multi z-level draw mode
         // Start drawing from the lowest visible z-level (some off-screen tiles
         // are considered visible here to simplify the logic.)
-        int cur_zlevel = center.z + 1;
+        int cur_zlevel = draw_min_z;
         while( cur_zlevel <= center.z ) {
             const half_open_rectangle<point> &cur_any_tile_range = is_isometric()
                     ? z_any_tile_range[center.z - cur_zlevel] : top_any_tile_range;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1304,13 +1304,13 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     const int max_col = top_any_tile_range.p_max.x;
     const int min_row = bottom_any_tile_range.p_min.y;
     const int max_row = top_any_tile_range.p_max.y;
-    const int draw_min_z = std::max( center.z - fov_3d_z_range, -OVERMAP_DEPTH );
 
     avatar &you = get_avatar();
     //limit the render area to maximum view range (121x121 square centered on player)
     const point min_visible( you.posx() % SEEX, you.posy() % SEEY );
     const point max_visible( ( you.posx() % SEEX ) + ( MAPSIZE - 1 ) * SEEX,
                              ( you.posy() % SEEY ) + ( MAPSIZE - 1 ) * SEEY );
+    const int draw_min_z = std::max( you.posz() - fov_3d_z_range, -OVERMAP_DEPTH );
 
     const level_cache &ch = here.access_cache( center.z );
 
@@ -1421,7 +1421,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         creature_tracker &creatures = get_creature_tracker();
         for( int row = min_row; row < max_row; row ++ ) {
             // Reserve columns on each row
-            for( int zlevel = center.z; zlevel > draw_min_z; zlevel -- ) {
+            for( int zlevel = center.z; zlevel >= draw_min_z; zlevel -- ) {
                 here.draw_points_cache[zlevel][row].reserve( std::max( 0, max_col - min_col ) );
             }
             for( int col = min_col; col < max_col; col ++ ) {
@@ -1429,7 +1429,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                 if( !temp.has_value() ) {
                     continue;
                 }
-                for( int zlevel = center.z; zlevel > draw_min_z; zlevel -- ) {
+                for( int zlevel = center.z; zlevel >= draw_min_z; zlevel -- ) {
                     const tripoint pos( temp.value(), zlevel );
                     const tripoint_abs_ms pos_global = here.getglobal( pos );
                     const int &x = pos.x;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1637,6 +1637,10 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
 
             here.draw_points[zlevel][row].emplace_back( tile_render_info::common{ pos, 0 },
                                            tile_render_info::sprite{ ll, invisible } );
+            // Stop building draw points below when floor reached
+            if( here.dont_draw_lower_floor( pos ) ) {
+            	break;
+            }
         }
         }
     }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1456,6 +1456,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                     ll = ch2.visibility_cache[x][y];
                 }
 
+                if( is_center_z ) {
                 // Add scent value to the overlay_strings list for every visible tile when
                 // displaying scent
                 if( g->display_overlay_state( ACTION_DISPLAY_SCENT ) && !invisible[0] ) {
@@ -1612,6 +1613,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                     // cache
                     bool reachable = here.has_potential_los( you.pos(), tile_pos );
                     draw_debug_tile( reachable ? 0 : 6, std::to_string( value ) );
+                }
                 }
 
                 if( !invisible[0] ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1902,7 +1902,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                   "SDL_RenderSetClipRect failed" );
 }
 
-void cata_tiles::clear_draw_caches()
+void cata_tiles::set_draw_cache_dirty()
 {
     get_map().draw_points_cache_dirty = true;
 }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1884,65 +1884,6 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                   "SDL_RenderSetClipRect failed" );
 }
 
-std::pair<lit_level, std::array<bool, 5>> cata_tiles::calc_ll_invis( const tripoint &draw_loc )
-{
-    avatar &you = get_avatar();
-    map &here = get_map();
-    creature_tracker &creatures = get_creature_tracker();
-    const visibility_variables &cache = here.get_visibility_variables_cache();
-    const point min_visible( you.posx() % SEEX, you.posy() % SEEY );
-    const point max_visible( ( you.posx() % SEEX ) + ( MAPSIZE - 1 ) * SEEX,
-                             ( you.posy() % SEEY ) + ( MAPSIZE - 1 ) * SEEY );
-    const level_cache &ch = here.access_cache( draw_loc.z );
-    const auto apply_visible = [&]( const tripoint & np, const level_cache & ch, map & here ) {
-        return np.y < min_visible.y || np.y > max_visible.y ||
-               np.x < min_visible.x || np.x > max_visible.x ||
-               would_apply_vision_effects( here.get_visibility( ch.visibility_cache[np.x][np.y],
-                                           cache ) );
-    };
-
-    lit_level ll  = lit_level::DARK;
-    // invisible to normal eyes
-    std::array<bool, 5> invisible;
-    invisible[0] = false;
-    tripoint pos = draw_loc;
-    tripoint_abs_ms pos_global = here.getglobal( pos );
-
-    if( draw_loc.y < min_visible.y || draw_loc.y > max_visible.y || draw_loc.x < min_visible.x ||
-        draw_loc.x > max_visible.x ) {
-        if( has_memory_at( pos_global ) ) {
-            ll = lit_level::MEMORIZED;
-            invisible[0] = true;
-        } else if( has_draw_override( pos ) ) {
-            ll = lit_level::DARK;
-            invisible[0] = true;
-        }
-    } else {
-        ll = here.access_cache( draw_loc.z ).visibility_cache[draw_loc.x][draw_loc.y];
-    }
-
-    if( !invisible[0] ) {
-        const visibility_type vis_type = here.get_visibility( ll, cache );
-        if( would_apply_vision_effects( vis_type ) ) {
-            const Creature *critter = creatures.creature_at( pos, true );
-            if( has_draw_override( pos ) || has_memory_at( pos_global ) ||
-                ( critter &&
-                  ( critter->has_flag( mon_flag_ALWAYS_VISIBLE )
-                    || you.sees_with_infrared( *critter )
-                    || you.sees_with_specials( *critter ) ) ) ) {
-                invisible[0] = true;
-            }
-        }
-    }
-    for( int i = 0; i < 4; i++ ) {
-        const tripoint np = pos + neighborhood[i];
-        invisible[1 + i] = apply_visible( np, ch, here );
-    }
-
-    std::pair<lit_level, std::array<bool, 5>> ret( ll, invisible );
-    return ret;
-}
-
 void cata_tiles::clear_draw_caches()
 {
     get_map().draw_points.clear();

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1449,7 +1449,10 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     creature_tracker &creatures = get_creature_tracker();
     std::map<int, std::map<int, std::vector<tile_render_info>>> draw_points;
     for( int row = min_row; row < max_row; row ++ ) {
-        draw_points[center.z][row].reserve( std::max( 0, max_col - min_col ) );
+    	// Reserve columns on each row
+    	for( int zlevel = center.z; zlevel > draw_min_z; zlevel -- ) {
+            draw_points[zlevel][row].reserve( std::max( 0, max_col - min_col ) );
+        }
         for( int col = min_col; col < max_col; col ++ ) {
             const std::optional<point> temp = tile_to_player( { col, row } );
             for( int zlevel = center.z; zlevel > draw_min_z; zlevel -- ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -2947,7 +2947,7 @@ bool cata_tiles::draw_sprite_at(
 
     printErrorIf( ret != 0, "SDL_RenderCopyEx() failed" );
     // this reference passes all the way back up the call chain back to
-    // cata_tiles::draw() here.draw_points_cache[row][col].com.height_3d
+    // cata_tiles::draw() here.draw_points_cache[z][row][col].com.height_3d
     // where we are accumulating the height of every sprite stacked up in a tile
     height_3d += tile.height_3d;
     return true;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1739,12 +1739,10 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                 for( auto f : drawing_layers ) {
                     // For each tile
                     for( tile_render_info &p : draw_points[cur_zlevel][row] ) {
-                        tripoint draw_loc = p.com.pos;
-                        draw_loc.z = cur_zlevel;
                         if( const tile_render_info::vision_effect * const
                             var = std::get_if<tile_render_info::vision_effect>( &p.var ) ) {
                             if( f == &cata_tiles::draw_terrain ) {
-                                apply_vision_effects( draw_loc, var->vis, p.com.height_3d );
+                                apply_vision_effects( p.com.pos, var->vis, p.com.height_3d );
                             }
                         } else if( const tile_render_info::sprite * const
                                    var = std::get_if<tile_render_info::sprite>( &p.var ) ) {
@@ -1758,19 +1756,19 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                                 // Reset height_3d to base when drawing vehicles
                                 p.com.height_3d = ( cur_zlevel - center.z ) * zlevel_height;
                                 // Draw
-                                if( !( this->*f )( draw_loc, ll, p.com.height_3d, invisible, false ) ) {
+                                if( !( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false ) ) {
                                     // If no vpart drawn, revert height_3d changes
                                     p.com.height_3d = temp_height_3d;
                                 }
                             } else if( f == &cata_tiles::draw_critter_at ) {
                                 // Draw
-                                if( !( this->*f )( draw_loc, ll, p.com.height_3d, invisible, false ) && do_draw_shadow ) { //replace bottom detection
+                                if( !( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false ) && do_draw_shadow ) { //replace bottom detection
                                     // Draw shadow of flying critters on bottom-most tile if no other critter drawn
-                                    draw_critter_above( draw_loc, ll, p.com.height_3d, invisible );
+                                    draw_critter_above( p.com.pos, ll, p.com.height_3d, invisible );
                                 }
                             } else {
                                 // Draw
-                                ( this->*f )( draw_loc, ll, p.com.height_3d, invisible, false );
+                                ( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false );
                             }
                         }
                     }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1381,20 +1381,6 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     }
     const point half_tile( tile_width / 2, 0 );
     const point quarter_tile( tile_width / 4, tile_height / 4 );
-    if( g->display_overlay_state( ACTION_DISPLAY_VEHICLE_AI ) ) {
-        for( const wrapped_vehicle &elem : here.get_vehicles() ) {
-            const vehicle &veh = *elem.v;
-            const point veh_pos = veh.global_pos3().xy();
-            for( const auto &overlay_data : veh.get_debug_overlay_data() ) {
-                const point pt = veh_pos + std::get<0>( overlay_data );
-                const int color = std::get<1>( overlay_data );
-                const std::string &text = std::get<2>( overlay_data );
-                overlay_strings.emplace( player_to_screen( pt ),
-                                         formatted_text( text, color,
-                                                 text_alignment::left ) );
-            }
-        }
-    }
     const auto apply_visible = [&]( const tripoint & np, const level_cache & ch, map & here ) {
         return np.y < min_visible.y || np.y > max_visible.y ||
                np.x < min_visible.x || np.x > max_visible.x ||
@@ -1416,6 +1402,21 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         here.draw_points_cache.clear();
         here.overlay_strings_cache.clear();
         here.color_blocks_cache = {};
+
+        if( g->display_overlay_state( ACTION_DISPLAY_VEHICLE_AI ) ) {
+            for( const wrapped_vehicle &elem : here.get_vehicles() ) {
+                const vehicle &veh = *elem.v;
+                const point veh_pos = veh.global_pos3().xy();
+                for( const auto &overlay_data : veh.get_debug_overlay_data() ) {
+                    const point pt = veh_pos + std::get<0>( overlay_data );
+                    const int color = std::get<1>( overlay_data );
+                    const std::string &text = std::get<2>( overlay_data );
+                    overlay_strings.emplace( player_to_screen( pt ),
+                                             formatted_text( text, color,
+                                                     text_alignment::left ) );
+                }
+            }
+        }
 
         // Generate new draw points
         creature_tracker &creatures = get_creature_tracker();
@@ -1451,11 +1452,11 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                             ll = lit_level::DARK;
                             invisible[0] = true;
                         } else {
-                            if( is_center_z && would_apply_vision_effects( offscreen_type ) ) {
+                            if( would_apply_vision_effects( offscreen_type ) ) {
                                 here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0 },
                                         tile_render_info::vision_effect{ offscreen_type } );
                             }
-                            continue;
+                            break;
                         }
                     } else {
                         ll = ch2.visibility_cache[x][y];
@@ -1632,11 +1633,9 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                                     || you.sees_with_specials( *critter ) ) ) ) {
                                 invisible[0] = true;
                             } else {
-                                if( is_center_z ) {
-                                    here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0 },
-                                            tile_render_info::vision_effect{ vis_type } );
-                                }
-                                continue;
+                                here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0 },
+                                        tile_render_info::vision_effect{ vis_type } );
+                                break;
                             }
                         }
                     }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1765,27 +1765,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                                    var = std::get_if<tile_render_info::sprite>( &p.var ) ) {
 
                             // Get visibility variables
-                            lit_level ll;
-                            std::array<bool, 5> invisible;
-                            if( cur_zlevel == center.z ) {
-                                // For the same z-level, use tile_render_info vars
-                                ll = var->ll;
-                                invisible = var->invisible;
-                            } else {
-                                // Otherwise, recalculate ll and invisible
-                                if( here.ll_invis_cache.count( draw_loc ) == 0 ) {
-                                    const std::pair<lit_level, std::array<bool, 5>> ll_invis = calc_ll_invis( draw_loc );
-                                    ll = ll_invis.first;
-                                    invisible = ll_invis.second;
-                                    // Only cache ll_invis if not in test mode
-                                    if( !test_mode ) {
-                                        here.ll_invis_cache[ draw_loc ] = ll_invis;
-                                    }
-                                } else {
-                                    ll = here.ll_invis_cache[ draw_loc ].first;
-                                    invisible = here.ll_invis_cache[ draw_loc ].second;
-                                }
-                            }
+                            lit_level ll = var->ll;
+                            std::array<bool, 5> invisible = var->invisible;
 
                             if( f == &cata_tiles::draw_vpart_no_roof || f == &cata_tiles::draw_vpart_roof ) {
                                 int temp_height_3d = p.com.height_3d;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1434,7 +1434,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                     const tripoint_abs_ms pos_global = here.getglobal( pos );
                     const int &x = pos.x;
                     const int &y = pos.y;
-                    const bool is_center_z = ( zlevel == center.z );
+                    const bool is_center_z = zlevel == center.z;
                     const level_cache &ch2 = here.access_cache( zlevel );
 
                     // light level is used for choosing between grayscale filter and normal lit tiles.

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1463,6 +1463,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
             const tripoint_abs_ms pos_global = here.getglobal( pos );
             const int &x = pos.x;
             const int &y = pos.y;
+            const bool is_center_z = ( zlevel == center.z );
 
             // light level is used for choosing between grayscale filter and normal lit tiles.
             lit_level ll;
@@ -1478,7 +1479,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                     ll = lit_level::DARK;
                     invisible[0] = true;
                 } else {
-                    if( would_apply_vision_effects( offscreen_type ) ) {
+                    if( is_center_z && would_apply_vision_effects( offscreen_type ) ) {
                         draw_points[zlevel][row].emplace_back( tile_render_info::common{ pos, 0 },
                                                        tile_render_info::vision_effect{ offscreen_type } );
                     }
@@ -1657,8 +1658,10 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                             || you.sees_with_specials( *critter ) ) ) ) {
                         invisible[0] = true;
                     } else {
+                    	if( is_center_z ) {
                         draw_points[zlevel][row].emplace_back( tile_render_info::common{ pos, 0 },
                                                        tile_render_info::vision_effect{ vis_type } );
+                        }
                         continue;
                     }
                 }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -12,7 +12,6 @@
 #include <stdexcept>
 #include <tuple>
 #include <unordered_set>
-#include <variant>
 
 #include "action.h"
 #include "avatar.h"

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1310,7 +1310,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     const point min_visible( you.posx() % SEEX, you.posy() % SEEY );
     const point max_visible( ( you.posx() % SEEX ) + ( MAPSIZE - 1 ) * SEEX,
                              ( you.posy() % SEEY ) + ( MAPSIZE - 1 ) * SEEY );
-    const int draw_min_z = std::max( you.posz() - fov_3d_z_range, -OVERMAP_DEPTH );
+    const int draw_min_z = std::max( you.posz() - max_draw_depth, -OVERMAP_DEPTH );
 
     const level_cache &ch = here.access_cache( center.z );
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1427,6 +1427,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                 const int &x = pos.x;
                 const int &y = pos.y;
                 const bool is_center_z = ( zlevel == center.z );
+                const level_cache &ch2 = here.access_cache( zlevel );
 
                 // light level is used for choosing between grayscale filter and normal lit tiles.
                 lit_level ll;
@@ -1449,7 +1450,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                         continue;
                     }
                 } else {
-                    ll = ch.visibility_cache[x][y];
+                    ll = ch2.visibility_cache[x][y];
                 }
 
                 // Add scent value to the overlay_strings list for every visible tile when
@@ -1631,7 +1632,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                 }
                 for( int i = 0; i < 4; i++ ) {
                     const tripoint np = pos + neighborhood[i];
-                    invisible[1 + i] = apply_visible( np, ch, here );
+                    invisible[1 + i] = apply_visible( np, ch2, here );
                 }
 
                 here.draw_points[zlevel][row].emplace_back( tile_render_info::common{ pos, 0 },

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1411,249 +1411,249 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     }
 
     if( here.draw_points_cache_dirty ) {
-    here.draw_points_cache_dirty = false;
-    // overlay_strings and color_blocks are generated with draw_points and thus are cleared together
-    here.draw_points_cache.clear();
-    here.overlay_strings_cache.clear();
-    here.color_blocks_cache = {};
-    	
-    // Generate new draw points
-    creature_tracker &creatures = get_creature_tracker();
-    for( int row = min_row; row < max_row; row ++ ) {
-        // Reserve columns on each row
-        for( int zlevel = center.z; zlevel > draw_min_z; zlevel -- ) {
-            here.draw_points_cache[zlevel][row].reserve( std::max( 0, max_col - min_col ) );
-        }
-        for( int col = min_col; col < max_col; col ++ ) {
-            const std::optional<point> temp = tile_to_player( { col, row } );
-            if( !temp.has_value() ) {
-                continue;
-            }
+        here.draw_points_cache_dirty = false;
+        // overlay_strings and color_blocks are generated with draw_points and thus are cleared together
+        here.draw_points_cache.clear();
+        here.overlay_strings_cache.clear();
+        here.color_blocks_cache = {};
+
+        // Generate new draw points
+        creature_tracker &creatures = get_creature_tracker();
+        for( int row = min_row; row < max_row; row ++ ) {
+            // Reserve columns on each row
             for( int zlevel = center.z; zlevel > draw_min_z; zlevel -- ) {
-                const tripoint pos( temp.value(), zlevel );
-                const tripoint_abs_ms pos_global = here.getglobal( pos );
-                const int &x = pos.x;
-                const int &y = pos.y;
-                const bool is_center_z = ( zlevel == center.z );
-                const level_cache &ch2 = here.access_cache( zlevel );
-
-                // light level is used for choosing between grayscale filter and normal lit tiles.
-                lit_level ll;
-                // invisible to normal eyes
-                std::array<bool, 5> invisible;
-                invisible[0] = false;
-
-                if( y < min_visible.y || y > max_visible.y || x < min_visible.x || x > max_visible.x ) {
-                    if( has_memory_at( pos_global ) ) {
-                        ll = lit_level::MEMORIZED;
-                        invisible[0] = true;
-                    } else if( has_draw_override( pos ) ) {
-                        ll = lit_level::DARK;
-                        invisible[0] = true;
-                    } else {
-                        if( is_center_z && would_apply_vision_effects( offscreen_type ) ) {
-                            here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0 },
-                                    tile_render_info::vision_effect{ offscreen_type } );
-                        }
-                        continue;
-                    }
-                } else {
-                    ll = ch2.visibility_cache[x][y];
+                here.draw_points_cache[zlevel][row].reserve( std::max( 0, max_col - min_col ) );
+            }
+            for( int col = min_col; col < max_col; col ++ ) {
+                const std::optional<point> temp = tile_to_player( { col, row } );
+                if( !temp.has_value() ) {
+                    continue;
                 }
+                for( int zlevel = center.z; zlevel > draw_min_z; zlevel -- ) {
+                    const tripoint pos( temp.value(), zlevel );
+                    const tripoint_abs_ms pos_global = here.getglobal( pos );
+                    const int &x = pos.x;
+                    const int &y = pos.y;
+                    const bool is_center_z = ( zlevel == center.z );
+                    const level_cache &ch2 = here.access_cache( zlevel );
 
-                if( is_center_z ) {
-                // Add scent value to the overlay_strings list for every visible tile when
-                // displaying scent
-                if( g->display_overlay_state( ACTION_DISPLAY_SCENT ) && !invisible[0] ) {
-                    const int scent_value = get_scent().get( pos );
-                    if( scent_value > 0 ) {
-                        here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ) + half_tile,
-                                                 formatted_text( std::to_string( scent_value ),
-                                                         8 + catacurses::yellow, direction::NORTH ) );
-                    }
-                }
+                    // light level is used for choosing between grayscale filter and normal lit tiles.
+                    lit_level ll;
+                    // invisible to normal eyes
+                    std::array<bool, 5> invisible;
+                    invisible[0] = false;
 
-                // Add scent type to the overlay_strings list for every visible tile when
-                // displaying scent
-                if( g->display_overlay_state( ACTION_DISPLAY_SCENT_TYPE ) && !invisible[0] ) {
-                    const scenttype_id scent_type = get_scent().get_type( pos );
-                    if( !scent_type.is_empty() ) {
-                        here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ) + half_tile,
-                                                 formatted_text( scent_type.c_str(),
-                                                         8 + catacurses::yellow, direction::NORTH ) );
-                    }
-                }
-
-                if( g->display_overlay_state( ACTION_DISPLAY_RADIATION ) ) {
-                    const auto rad_override = radiation_override.find( pos );
-                    const bool rad_overridden = rad_override != radiation_override.end();
-                    if( rad_overridden || !invisible[0] ) {
-                        const int rad_value = rad_overridden ? rad_override->second :
-                                              here.get_radiation( pos );
-                        catacurses::base_color col;
-                        if( rad_value > 0 ) {
-                            col = catacurses::green;
-                        } else {
-                            col = catacurses::cyan;
-                        }
-                        here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ) + half_tile,
-                                                 formatted_text( std::to_string( rad_value ),
-                                                         8 + col, direction::NORTH ) );
-                    }
-                }
-
-                if( g->display_overlay_state( ACTION_DISPLAY_NPC_ATTACK_POTENTIAL ) ) {
-                    if( npc_attack_rating_map.count( pos ) ) {
-                        const int val = npc_attack_rating_map.at( pos );
-                        short color;
-                        if( val <= 0 ) {
-                            color = catacurses::red;
-                        } else if( val == max_npc_effectiveness ) {
-                            color = catacurses::cyan;
-                        } else {
-                            color = catacurses::white;
-                        }
-                        here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ) + half_tile,
-                                                 formatted_text( std::to_string( val ), color,
-                                                         direction::NORTH ) );
-                    }
-                }
-
-                // Add temperature value to the overlay_strings list for every visible tile when
-                // displaying temperature
-                if( g->display_overlay_state( ACTION_DISPLAY_TEMPERATURE ) && !invisible[0] ) {
-                    const units::temperature temp_value = get_weather().get_temperature( pos );
-                    const float celsius_temp_value = units::to_celsius( temp_value );
-                    short color;
-                    const short bold = 8;
-                    if( celsius_temp_value > 40 ) {
-                        color = catacurses::red;
-                    } else if( celsius_temp_value > 25 ) {
-                        color = catacurses::yellow + bold;
-                    } else if( celsius_temp_value > 10 ) {
-                        color = catacurses::green + bold;
-                    } else if( celsius_temp_value > 0 ) {
-                        color = catacurses::white + bold;
-                    } else if( celsius_temp_value > -10 ) {
-                        color = catacurses::cyan + bold;
-                    } else {
-                        color = catacurses::blue + bold;
-                    }
-
-                    std::string temp_str;
-                    if( get_option<std::string>( "USE_CELSIUS" ) == "celsius" ) {
-                        temp_str = string_format( "%.0f", celsius_temp_value );
-                    } else if( get_option<std::string>( "USE_CELSIUS" ) == "kelvin" ) {
-                        temp_str = string_format( "%.0f", units::to_kelvin( temp_value ) );
-                    } else {
-                        temp_str = string_format( "%.0f", units::to_fahrenheit( temp_value ) );
-                    }
-                    here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ),
-                                             formatted_text( temp_str, color,
-                                                     text_alignment::left ) );
-                }
-
-                if( g->display_overlay_state( ACTION_DISPLAY_VISIBILITY ) &&
-                    g->displaying_visibility_creature && !invisible[0] ) {
-                    const bool visibility = g->displaying_visibility_creature->sees( pos );
-
-                    // color overlay.
-                    SDL_Color block_color = visibility ? windowsPalette[catacurses::green] :
-                                            SDL_Color{ 192, 192, 192, 255 };
-                    block_color.a = 100;
-                    here.color_blocks_cache.first = SDL_BLENDMODE_BLEND;
-                    here.color_blocks_cache.second.emplace( player_to_screen( point( x, y ) ), block_color );
-
-                    // overlay string
-                    std::string visibility_str = visibility ? "+" : "-";
-                    here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ) + quarter_tile,
-                                             formatted_text( visibility_str, catacurses::black,
-                                                     direction::NORTH ) );
-                }
-
-                static std::vector<SDL_Color> lighting_colors;
-                // color hue in the range of [0..10], 0 being white,  10 being blue
-                auto draw_debug_tile = [&]( const int color_hue, const std::string & text ) {
-                    if( lighting_colors.empty() ) {
-                        SDL_Color white = { 255, 255, 255, 255 };
-                        SDL_Color blue = { 0, 0, 255, 255 };
-                        lighting_colors = color_linear_interpolate( white, blue, 9 );
-                    }
-                    point tile_pos = player_to_screen( point( x, y ) );
-
-                    // color overlay
-                    SDL_Color color = lighting_colors[std::min( std::max( 0, color_hue ), 10 )];
-                    color.a = 100;
-                    here.color_blocks_cache.first = SDL_BLENDMODE_BLEND;
-                    here.color_blocks_cache.second.emplace( tile_pos, color );
-
-                    // string overlay
-                    here.overlay_strings_cache.emplace(
-                        tile_pos + quarter_tile,
-                        formatted_text( text, catacurses::black, direction::NORTH ) );
-                };
-
-                if( g->display_overlay_state( ACTION_DISPLAY_LIGHTING ) ) {
-                    if( g->displaying_lighting_condition == 0 ) {
-                        const float light = here.ambient_light_at( {x, y, center.z} );
-                        // note: lighting will be constrained in the [1.0, 11.0] range.
-                        int intensity =
-                            static_cast<int>( std::max( 1.0, LIGHT_AMBIENT_LIT - light + 1.0 ) ) - 1;
-                        draw_debug_tile( intensity, string_format( "%.1f", light ) );
-                    }
-                }
-
-                if( g->display_overlay_state( ACTION_DISPLAY_TRANSPARENCY ) ) {
-                    const float tr = here.light_transparency( {x, y, center.z} );
-                    int intensity =  tr <= LIGHT_TRANSPARENCY_SOLID ? 10 :  static_cast<int>
-                                     ( ( tr - LIGHT_TRANSPARENCY_OPEN_AIR ) * 8 );
-                    draw_debug_tile( intensity, string_format( "%.2f", tr ) );
-                }
-
-                if( g->display_overlay_state( ACTION_DISPLAY_REACHABILITY_ZONES ) ) {
-                    tripoint tile_pos( x, y, center.z );
-                    int value = here.reachability_cache_value( tile_pos,
-                                g->debug_rz_display.r_cache_vertical, g->debug_rz_display.quadrant );
-                    // use color to denote reachability from you to the target tile according to the
-                    // cache
-                    bool reachable = here.has_potential_los( you.pos(), tile_pos );
-                    draw_debug_tile( reachable ? 0 : 6, std::to_string( value ) );
-                }
-                }
-
-                if( !invisible[0] ) {
-                    const visibility_type vis_type = here.get_visibility( ll, cache );
-                    if( would_apply_vision_effects( vis_type ) ) {
-                        const Creature *critter = creatures.creature_at( pos, true );
-                        if( has_draw_override( pos ) || has_memory_at( pos_global ) ||
-                            ( critter &&
-                              ( critter->has_flag( mon_flag_ALWAYS_VISIBLE )
-                                || you.sees_with_infrared( *critter )
-                                || you.sees_with_specials( *critter ) ) ) ) {
+                    if( y < min_visible.y || y > max_visible.y || x < min_visible.x || x > max_visible.x ) {
+                        if( has_memory_at( pos_global ) ) {
+                            ll = lit_level::MEMORIZED;
+                            invisible[0] = true;
+                        } else if( has_draw_override( pos ) ) {
+                            ll = lit_level::DARK;
                             invisible[0] = true;
                         } else {
-                            if( is_center_z ) {
+                            if( is_center_z && would_apply_vision_effects( offscreen_type ) ) {
                                 here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0 },
-                                        tile_render_info::vision_effect{ vis_type } );
+                                        tile_render_info::vision_effect{ offscreen_type } );
                             }
                             continue;
                         }
+                    } else {
+                        ll = ch2.visibility_cache[x][y];
                     }
-                }
-                for( int i = 0; i < 4; i++ ) {
-                    const tripoint np = pos + neighborhood[i];
-                    invisible[1 + i] = apply_visible( np, ch2, here );
-                }
 
-                here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0 },
-                        tile_render_info::sprite{ ll, invisible } );
-                // Stop building draw points below when floor reached
-                if( here.dont_draw_lower_floor( pos ) ) {
-                    break;
+                    if( is_center_z ) {
+                        // Add scent value to the overlay_strings list for every visible tile when
+                        // displaying scent
+                        if( g->display_overlay_state( ACTION_DISPLAY_SCENT ) && !invisible[0] ) {
+                            const int scent_value = get_scent().get( pos );
+                            if( scent_value > 0 ) {
+                                here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ) + half_tile,
+                                                                    formatted_text( std::to_string( scent_value ),
+                                                                            8 + catacurses::yellow, direction::NORTH ) );
+                            }
+                        }
+
+                        // Add scent type to the overlay_strings list for every visible tile when
+                        // displaying scent
+                        if( g->display_overlay_state( ACTION_DISPLAY_SCENT_TYPE ) && !invisible[0] ) {
+                            const scenttype_id scent_type = get_scent().get_type( pos );
+                            if( !scent_type.is_empty() ) {
+                                here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ) + half_tile,
+                                                                    formatted_text( scent_type.c_str(),
+                                                                            8 + catacurses::yellow, direction::NORTH ) );
+                            }
+                        }
+
+                        if( g->display_overlay_state( ACTION_DISPLAY_RADIATION ) ) {
+                            const auto rad_override = radiation_override.find( pos );
+                            const bool rad_overridden = rad_override != radiation_override.end();
+                            if( rad_overridden || !invisible[0] ) {
+                                const int rad_value = rad_overridden ? rad_override->second :
+                                                      here.get_radiation( pos );
+                                catacurses::base_color col;
+                                if( rad_value > 0 ) {
+                                    col = catacurses::green;
+                                } else {
+                                    col = catacurses::cyan;
+                                }
+                                here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ) + half_tile,
+                                                                    formatted_text( std::to_string( rad_value ),
+                                                                            8 + col, direction::NORTH ) );
+                            }
+                        }
+
+                        if( g->display_overlay_state( ACTION_DISPLAY_NPC_ATTACK_POTENTIAL ) ) {
+                            if( npc_attack_rating_map.count( pos ) ) {
+                                const int val = npc_attack_rating_map.at( pos );
+                                short color;
+                                if( val <= 0 ) {
+                                    color = catacurses::red;
+                                } else if( val == max_npc_effectiveness ) {
+                                    color = catacurses::cyan;
+                                } else {
+                                    color = catacurses::white;
+                                }
+                                here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ) + half_tile,
+                                                                    formatted_text( std::to_string( val ), color,
+                                                                            direction::NORTH ) );
+                            }
+                        }
+
+                        // Add temperature value to the overlay_strings list for every visible tile when
+                        // displaying temperature
+                        if( g->display_overlay_state( ACTION_DISPLAY_TEMPERATURE ) && !invisible[0] ) {
+                            const units::temperature temp_value = get_weather().get_temperature( pos );
+                            const float celsius_temp_value = units::to_celsius( temp_value );
+                            short color;
+                            const short bold = 8;
+                            if( celsius_temp_value > 40 ) {
+                                color = catacurses::red;
+                            } else if( celsius_temp_value > 25 ) {
+                                color = catacurses::yellow + bold;
+                            } else if( celsius_temp_value > 10 ) {
+                                color = catacurses::green + bold;
+                            } else if( celsius_temp_value > 0 ) {
+                                color = catacurses::white + bold;
+                            } else if( celsius_temp_value > -10 ) {
+                                color = catacurses::cyan + bold;
+                            } else {
+                                color = catacurses::blue + bold;
+                            }
+
+                            std::string temp_str;
+                            if( get_option<std::string>( "USE_CELSIUS" ) == "celsius" ) {
+                                temp_str = string_format( "%.0f", celsius_temp_value );
+                            } else if( get_option<std::string>( "USE_CELSIUS" ) == "kelvin" ) {
+                                temp_str = string_format( "%.0f", units::to_kelvin( temp_value ) );
+                            } else {
+                                temp_str = string_format( "%.0f", units::to_fahrenheit( temp_value ) );
+                            }
+                            here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ),
+                                                                formatted_text( temp_str, color,
+                                                                        text_alignment::left ) );
+                        }
+
+                        if( g->display_overlay_state( ACTION_DISPLAY_VISIBILITY ) &&
+                            g->displaying_visibility_creature && !invisible[0] ) {
+                            const bool visibility = g->displaying_visibility_creature->sees( pos );
+
+                            // color overlay.
+                            SDL_Color block_color = visibility ? windowsPalette[catacurses::green] :
+                                                    SDL_Color{ 192, 192, 192, 255 };
+                            block_color.a = 100;
+                            here.color_blocks_cache.first = SDL_BLENDMODE_BLEND;
+                            here.color_blocks_cache.second.emplace( player_to_screen( point( x, y ) ), block_color );
+
+                            // overlay string
+                            std::string visibility_str = visibility ? "+" : "-";
+                            here.overlay_strings_cache.emplace( player_to_screen( point( x, y ) ) + quarter_tile,
+                                                                formatted_text( visibility_str, catacurses::black,
+                                                                        direction::NORTH ) );
+                        }
+
+                        static std::vector<SDL_Color> lighting_colors;
+                        // color hue in the range of [0..10], 0 being white,  10 being blue
+                        auto draw_debug_tile = [&]( const int color_hue, const std::string & text ) {
+                            if( lighting_colors.empty() ) {
+                                SDL_Color white = { 255, 255, 255, 255 };
+                                SDL_Color blue = { 0, 0, 255, 255 };
+                                lighting_colors = color_linear_interpolate( white, blue, 9 );
+                            }
+                            point tile_pos = player_to_screen( point( x, y ) );
+
+                            // color overlay
+                            SDL_Color color = lighting_colors[std::min( std::max( 0, color_hue ), 10 )];
+                            color.a = 100;
+                            here.color_blocks_cache.first = SDL_BLENDMODE_BLEND;
+                            here.color_blocks_cache.second.emplace( tile_pos, color );
+
+                            // string overlay
+                            here.overlay_strings_cache.emplace(
+                                tile_pos + quarter_tile,
+                                formatted_text( text, catacurses::black, direction::NORTH ) );
+                        };
+
+                        if( g->display_overlay_state( ACTION_DISPLAY_LIGHTING ) ) {
+                            if( g->displaying_lighting_condition == 0 ) {
+                                const float light = here.ambient_light_at( {x, y, center.z} );
+                                // note: lighting will be constrained in the [1.0, 11.0] range.
+                                int intensity =
+                                    static_cast<int>( std::max( 1.0, LIGHT_AMBIENT_LIT - light + 1.0 ) ) - 1;
+                                draw_debug_tile( intensity, string_format( "%.1f", light ) );
+                            }
+                        }
+
+                        if( g->display_overlay_state( ACTION_DISPLAY_TRANSPARENCY ) ) {
+                            const float tr = here.light_transparency( {x, y, center.z} );
+                            int intensity =  tr <= LIGHT_TRANSPARENCY_SOLID ? 10 :  static_cast<int>
+                                             ( ( tr - LIGHT_TRANSPARENCY_OPEN_AIR ) * 8 );
+                            draw_debug_tile( intensity, string_format( "%.2f", tr ) );
+                        }
+
+                        if( g->display_overlay_state( ACTION_DISPLAY_REACHABILITY_ZONES ) ) {
+                            tripoint tile_pos( x, y, center.z );
+                            int value = here.reachability_cache_value( tile_pos,
+                                        g->debug_rz_display.r_cache_vertical, g->debug_rz_display.quadrant );
+                            // use color to denote reachability from you to the target tile according to the
+                            // cache
+                            bool reachable = here.has_potential_los( you.pos(), tile_pos );
+                            draw_debug_tile( reachable ? 0 : 6, std::to_string( value ) );
+                        }
+                    }
+
+                    if( !invisible[0] ) {
+                        const visibility_type vis_type = here.get_visibility( ll, cache );
+                        if( would_apply_vision_effects( vis_type ) ) {
+                            const Creature *critter = creatures.creature_at( pos, true );
+                            if( has_draw_override( pos ) || has_memory_at( pos_global ) ||
+                                ( critter &&
+                                  ( critter->has_flag( mon_flag_ALWAYS_VISIBLE )
+                                    || you.sees_with_infrared( *critter )
+                                    || you.sees_with_specials( *critter ) ) ) ) {
+                                invisible[0] = true;
+                            } else {
+                                if( is_center_z ) {
+                                    here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0 },
+                                            tile_render_info::vision_effect{ vis_type } );
+                                }
+                                continue;
+                            }
+                        }
+                    }
+                    for( int i = 0; i < 4; i++ ) {
+                        const tripoint np = pos + neighborhood[i];
+                        invisible[1 + i] = apply_visible( np, ch2, here );
+                    }
+
+                    here.draw_points_cache[zlevel][row].emplace_back( tile_render_info::common{ pos, 0 },
+                            tile_render_info::sprite{ ll, invisible } );
+                    // Stop building draw points below when floor reached
+                    if( here.dont_draw_lower_floor( pos ) ) {
+                        break;
+                    }
                 }
             }
         }
-    }
     }
     overlay_strings = here.overlay_strings_cache;
     color_blocks = here.color_blocks_cache;

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1730,7 +1730,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                                 }
                             } else if( f == &cata_tiles::draw_critter_at ) {
                                 // Draw
-                                if( !( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false ) && do_draw_shadow ) { //replace bottom detection
+                                if( !( this->*f )( p.com.pos, ll, p.com.height_3d, invisible, false ) && do_draw_shadow && here.dont_draw_lower_floor( p.com.pos ) ) {
                                     // Draw shadow of flying critters on bottom-most tile if no other critter drawn
                                     draw_critter_above( p.com.pos, ll, p.com.height_3d, invisible );
                                 }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1455,10 +1455,10 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         }
         for( int col = min_col; col < max_col; col ++ ) {
             const std::optional<point> temp = tile_to_player( { col, row } );
-            for( int zlevel = center.z; zlevel > draw_min_z; zlevel -- ) {
             if( !temp.has_value() ) {
                 continue;
             }
+            for( int zlevel = center.z; zlevel > draw_min_z; zlevel -- ) {
             const tripoint pos( temp.value(), zlevel );
             const tripoint_abs_ms pos_global = here.getglobal( pos );
             const int &x = pos.x;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -411,9 +411,6 @@ class cata_tiles
         void draw( const point &dest, const tripoint &center, int width, int height,
                    std::multimap<point, formatted_text> &overlay_strings,
                    color_block_overlay_container &color_blocks );
-        // Standalone version of the ll and invisible calculations normally done when accumulating draw_points
-        // Used to determine visibility of lower z-levels in 3D vision without generating extra draw_points and overlay_strings
-        std::pair<lit_level, std::array<bool, 5>> calc_ll_invis( const tripoint &draw_loc );
         void draw_om( const point &dest, const tripoint_abs_omt &center_abs_omt, bool blink );
 
         /** Minimap functionality */

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -809,9 +809,6 @@ class cata_tiles
 
     public:
         // Draw caches persist data between draws to avoid unnecessary recalculations
-        // Any event that would invalidate cached data should also clear it
-        // Currently only includes ll_invis_cache
-        // Performance gain from caching draw_points, overlay_strings and color_blocks is negligible
         void clear_draw_caches();
 
         std::string memory_map_mode = "color_pixel_sepia";

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -805,8 +805,8 @@ class cata_tiles
         pimpl<pixel_minimap> minimap;
 
     public:
-        // Draw caches persist data between draws to avoid unnecessary recalculations
-        void clear_draw_caches();
+        // Draw caches persist data between draws and are only recalculated when dirty
+        void set_draw_cache_dirty();
 
         std::string memory_map_mode = "color_pixel_sepia";
 };

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -263,6 +263,10 @@ input_context game::get_player_input( std::string &action )
     const visibility_variables &cache = m.get_visibility_variables_cache();
     const level_cache &map_cache = m.get_cache_ref( u.posz() );
     const auto &visibility_cache = map_cache.visibility_cache;
+#if defined(TILES)
+    // Mark cata_tiles draw caches as dirty
+    tilecontext->clear_draw_caches();
+#endif
 
     user_turn current_turn;
 

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -265,7 +265,7 @@ input_context game::get_player_input( std::string &action )
     const auto &visibility_cache = map_cache.visibility_cache;
 #if defined(TILES)
     // Mark cata_tiles draw caches as dirty
-    tilecontext->clear_draw_caches();
+    tilecontext->set_draw_cache_dirty();
 #endif
 
     user_turn current_turn;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6696,7 +6696,7 @@ void map::update_visibility_cache( const int zlev )
 
 #if defined(TILES)
     // Mark cata_tiles draw caches as dirty
-    tilecontext->clear_draw_caches();
+    tilecontext->set_draw_cache_dirty();
 #endif
 
     visibility_variables_cache.last_pos = player_character.pos();
@@ -9395,7 +9395,7 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         camera_cache_dirty = true;
 #if defined(TILES)
         // Mark cata_tiles draw caches as dirty
-        tilecontext->clear_draw_caches();
+        tilecontext->set_draw_cache_dirty();
 #endif
     }
     if( camera_cache_dirty ) {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -6695,7 +6695,7 @@ void map::update_visibility_cache( const int zlev )
     }
 
 #if defined(TILES)
-    // clear previously cached visibility variables from cata_tiles
+    // Mark cata_tiles draw caches as dirty
     tilecontext->clear_draw_caches();
 #endif
 
@@ -9393,6 +9393,10 @@ void map::build_map_cache( const int zlev, bool skip_lightmap )
         player_prev_pos = p;
         player_prev_range = sr;
         camera_cache_dirty = true;
+#if defined(TILES)
+        // Mark cata_tiles draw caches as dirty
+        tilecontext->clear_draw_caches();
+#endif
     }
     if( camera_cache_dirty ) {
         u.moncam_cache = mcache;

--- a/src/map.h
+++ b/src/map.h
@@ -17,6 +17,7 @@
 #include <set>
 #include <tuple>
 #include <utility>
+#include <variant>
 #include <vector>
 
 #include "calendar.h"
@@ -276,6 +277,41 @@ struct drawsq_params {
         //@}
 };
 
+struct tile_render_info {
+    struct common {
+        const tripoint pos;
+        // accumulator for 3d tallness of sprites rendered here so far;
+        int height_3d = 0;
+
+        common( const tripoint &pos, const int height_3d )
+            : pos( pos ), height_3d( height_3d ) {}
+    };
+
+    struct vision_effect {
+        visibility_type vis;
+
+        explicit vision_effect( const visibility_type vis )
+            : vis( vis ) {}
+    };
+
+    struct sprite {
+        lit_level ll;
+        std::array<bool, 5> invisible;
+
+        sprite( const lit_level ll, const std::array<bool, 5> &inv )
+            : ll( ll ), invisible( inv ) {}
+    };
+
+    common com;
+    std::variant<vision_effect, sprite> var;
+
+    tile_render_info( const common &com, const vision_effect &var )
+        : com( com ), var( var ) {}
+
+    tile_render_info( const common &com, const sprite &var )
+        : com( com ), var( var ) {}
+};
+        
 /**
  * Manage and cache data about a part of the map.
  *
@@ -2309,7 +2345,9 @@ class map
         bool has_haulable_items( const tripoint &pos );
         std::vector<item_location> get_haulable_items( const tripoint &pos );
 
-        std::map<tripoint, std::pair<lit_level, std::array<bool, 5>>> ll_invis_cache;
+        
+        
+        std::map<int, std::map<int, std::vector<tile_render_info>>> draw_points;
 };
 
 map &get_map();

--- a/src/map.h
+++ b/src/map.h
@@ -46,6 +46,10 @@
 #include "units.h"
 #include "value_ptr.h"
 
+#if defined(TILES)
+#include "cata_tiles.h"
+#endif
+
 struct scent_block;
 
 namespace catacurses
@@ -2345,8 +2349,12 @@ class map
         bool has_haulable_items( const tripoint &pos );
         std::vector<item_location> get_haulable_items( const tripoint &pos );
 
+#if defined(TILES)
         bool draw_points_cache_dirty = true;
         std::map<int, std::map<int, std::vector<tile_render_info>>> draw_points_cache;
+        std::multimap<point, formatted_text> overlay_strings_cache;
+        color_block_overlay_container color_blocks_cache;
+#endif
 };
 
 map &get_map();

--- a/src/map.h
+++ b/src/map.h
@@ -2345,7 +2345,8 @@ class map
         bool has_haulable_items( const tripoint &pos );
         std::vector<item_location> get_haulable_items( const tripoint &pos );
 
-        std::map<int, std::map<int, std::vector<tile_render_info>>> draw_points;
+        bool draw_points_cache_dirty = true;
+        std::map<int, std::map<int, std::vector<tile_render_info>>> draw_points_cache;
 };
 
 map &get_map();

--- a/src/map.h
+++ b/src/map.h
@@ -311,7 +311,7 @@ struct tile_render_info {
     tile_render_info( const common &com, const sprite &var )
         : com( com ), var( var ) {}
 };
-        
+
 /**
  * Manage and cache data about a part of the map.
  *
@@ -2345,8 +2345,6 @@ class map
         bool has_haulable_items( const tripoint &pos );
         std::vector<item_location> get_haulable_items( const tripoint &pos );
 
-        
-        
         std::map<int, std::map<int, std::vector<tile_render_info>>> draw_points;
 };
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "3D draw point generation"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Tiles draw sprites on screen by generating a draw_point for each grid.  To handle visibility differences on different z-levels in 3D vision, draw_points recalculate their visibility variables on each z-level.  However, there are situations where a grid that should not have a draw_point could inherit a draw_point from the grid above it which would cause the grid to show up as visible when it should not.
Fix #69973

draw_points generation now also includes caching and "occlusion culling" features, replacing my previous code.  Doing these during draw_points generation is not only more efficient, but also substantially reduces code clutter.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- draw_points are now generated separately for each z-level.
- draw_points no longer track the lowest level it should draw.  If a grid should not be drawn, it would not have a draw_point in the first place.
- draw_points, overlay_strings and color_blocks are now cached, which will reduce cpu load per draw.  Visibility variables are contained in draw_points and are no longer cached separately.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
draw_points are stored in a map within a map (std::map<int, std::map<int, std::vector<tile_render_info>>>).  Not sure if there is a more efficient way of storing the data.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiles ok.
Confirmed that #69973 is fixed.
Debug overlays work normally.
Up to 13% faster draw time when displaying multiple z-levels.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
