### PR TITLE
[BombasticPerks] Update the math in the "Unstoppable Force" perk

### DIFF
--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -408,7 +408,16 @@
     "enchantments": [
       {
         "condition": "ALWAYS",
-        "values": [ { "value": "ITEM_DAMAGE_BASH", "add": { "math": [ "u_armor('bash', 'arm_r') * u_attack_speed() / 200" ] } } ]
+        "values": [
+          {
+            "value": "ITEM_DAMAGE_BASH",
+            "add": {
+              "math": [
+                "u_armor('bash', 'torso') + u_armor('bash', 'head') + u_armor('bash', 'arm_l') + u_armor('bash', 'arm_r') + u_armor('bash', 'hand_l') + u_armor('bash', 'hand_r') + u_armor('bash', 'leg_l') + u_armor('bash', 'leg_r') * u_attack_speed() / 200"
+              ]
+            }
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Update the math in the Unstoppable Force perk so it takes account the other main bodyparts"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I noticed that the Unstoppable Force perk only takes account of the armour on the right arm bodypart, despite the perk saying that it's supposed to increase my damage based of how armoured the character is. Unless im missing something here, im changing it.

#### Describe the solution

See commit.
#### Describe alternatives you've considered

Changing the perk name and description to reflect the fact.

#### Testing

Applied the change onto my build, tested it by only wearing a ballistic vest on an all-8 stat and level 3 in melee and unarmed character.
![Screenshot_2023-12-19_22-04-39_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/78019001/c5e39684-06ff-4c1e-a2c6-9c06ffbbfb73)


#### Additional context

Despite this, i feel like im missing the reasoning on why is it just only the right arm armour. If that's intended, then it's fair enough and i'll close this pr.


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
