### PR TITLE
[BombasticPerks] "Unstoppable Force" perk description clarification

### DIFF
--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -401,7 +401,7 @@
   {
     "type": "mutation",
     "id": "perk_jugg",
-    "name": { "str": "Unstoppable force" },
+    "name": { "str": "Iron arm" },
     "points": 0,
     "description": "You've always been a bit of a bull in a china shop; people used to call you heavy handed but now they aren't saying much at all.  You deal extra damage based on how protective your right arm is.",
     "category": [ "perk" ],

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -403,7 +403,7 @@
     "id": "perk_jugg",
     "name": { "str": "Unstoppable force" },
     "points": 0,
-    "description": "You've always been a bit of a bull in a china shop; people used to call you heavy handed but now they aren't saying much at all.  You deal extra damage based on how protective your armor is.",
+    "description": "You've always been a bit of a bull in a china shop; people used to call you heavy handed but now they aren't saying much at all.  You deal extra damage based on how protective your right arm is.",
     "category": [ "perk" ],
     "enchantments": [
       {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

At the behest of @bombasticSlacks , i changed the description to reflect the fact that it only takes account of the right arm armor.

#### Describe the solution

See commit.

#### Describe alternatives you've considered

Rewrite the whole description. ~~Renaming the perk to "Iron Arm"~~
#### Testing

It's a string change.
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
