### PR TITLE
Simplify/jsonify NPC generation from npc classes

### DIFF
--- a/data/json/npcs/classes.json
+++ b/data/json/npcs/classes.json
@@ -87,6 +87,8 @@
     "bonus_dex": { "rng": [ -2, 0 ] },
     "bonus_int": { "rng": [ 1, 5 ] },
     "bonus_per": { "rng": [ -2, 0 ] },
+    "bonus_aggression": { "rng": [ -3, -1 ] },
+    "bonus_bravery": { "rng": [ -2, 0 ] },
     "skills": [
       { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "rng": [ -1, -2 ] } ] } ] } },
       { "skill": "electronics", "bonus": { "rng": [ 1, 4 ] } },
@@ -102,6 +104,7 @@
     "bonus_str": { "rng": [ -2, 0 ] },
     "bonus_int": { "rng": [ 0, 2 ] },
     "bonus_per": { "rng": [ 0, 2 ] },
+    "bonus_aggression": { "rng": [ -4, 0 ] },
     "shopkeeper_item_group": "NC_DOCTOR_misc",
     "proficiencies": [
       "prof_intro_chemistry",
@@ -127,7 +130,8 @@
     "job_description": "I'm collecting gear and selling it.",
     "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
     "bonus_int": { "one_in": 4 },
-    "bonus_per": { "one_in": 4 }
+    "bonus_per": { "one_in": 4 },
+    "bonus_collector": { "rng": [ 1, 5 ] }
   },
   {
     "type": "npc_class",
@@ -138,6 +142,8 @@
     "bonus_str": { "rng": [ -1, 0 ] },
     "bonus_dex": { "rng": [ 0, 2 ] },
     "bonus_per": { "rng": [ 0, 2 ] },
+    "bonus_bravery": { "rng": [ 0, 3 ] },
+    "bonus_collector": { "rng": [ -6, -1 ] },
     "skills": [
       { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "rng": [ -1, -2 ] } ] } ] } },
       { "skill": "dodge", "bonus": { "rng": [ 2, 4 ] } },
@@ -155,6 +161,8 @@
     "bonus_str": { "rng": [ 0, 1 ] },
     "bonus_int": { "rng": [ -2, 0 ] },
     "bonus_per": { "rng": [ 0, 2 ] },
+    "bonus_aggression": { "rng": [ 0, 2 ] },
+    "bonus_bravery": { "rng": [ 1, 5 ] },
     "skills": [
       { "skill": "ALL", "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "rng": [ 0, -4 ] } ] } ] } },
       { "skill": "gun", "bonus": { "rng": [ 1, 3 ] } },
@@ -213,6 +221,9 @@
     "bonus_str": { "rng": [ -1, -3 ] },
     "bonus_dex": { "rng": [ -1, 0 ] },
     "bonus_int": { "rng": [ 2, 5 ] },
+    "bonus_aggression": { "rng": [ -5, -1 ] },
+    "bonus_bravery": { "rng": [ -8, -2 ] },
+    "bonus_collector": { "rng": [ 0, 2 ] },
     "proficiencies": [
       "prof_intro_chemistry",
       "prof_intro_biology",
@@ -235,6 +246,8 @@
     "name": { "str": "Bounty Hunter" },
     "job_description": "I'm a killer for hire.",
     "traits": [ { "group": "BG_survival_story_POLICE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "bonus_aggression": { "rng": [ 1, 6 ] },
+    "bonus_bravery": { "rng": [ 0, 5 ] },
     "skills": [
       { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -3 } ] } },
       { "skill": "gun", "bonus": { "rng": [ 2, 4 ] } },
@@ -275,6 +288,8 @@
     ],
     "bonus_str": { "rng": [ 2, 4 ] },
     "bonus_dex": { "rng": [ 0, 2 ] },
+    "bonus_aggression": { "rng": [ 1, 6 ] },
+    "bonus_bravery": { "rng": [ 0, 5 ] },
     "skills": [
       { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -4 } ] } },
       { "skill": "dodge", "bonus": { "rng": [ 1, 3 ] } },
@@ -291,6 +306,8 @@
     "name": { "str": "Scavenger" },
     "job_description": "I'm just trying to survive.",
     "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "bonus_aggression": { "rng": [ 1, 3 ] },
+    "bonus_bravery": { "rng": [ 1, 4 ] },
     "skills": [
       { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -3 } ] } },
       { "skill": "gun", "bonus": { "rng": [ 2, 4 ] } },
@@ -415,6 +432,8 @@
     "bonus_str": { "rng": [ 0, 2 ] },
     "bonus_dex": { "one_in": 2 },
     "bonus_int": { "rng": [ 0, -2 ] },
+    "bonus_aggression": { "rng": [ 1, 3 ] },
+    "bonus_bravery": { "rng": [ 0, 3 ] },
     "skills": [
       { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -3 } ] } },
       { "skill": "dodge", "bonus": { "rng": [ 1, 2 ] } },
@@ -432,6 +451,7 @@
     "traits": [ { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
     "common": false,
     "bonus_per": { "one_in": 4 },
+    "bonus_collector": { "rng": [ 1, 5 ] },
     "shopkeeper_item_group": "NC_BARTENDER_misc",
     "skills": [
       {
@@ -450,6 +470,7 @@
     "//": "This is a unique NPC who doesn't get randomly selected background traits",
     "common": false,
     "bonus_per": { "one_in": 4 },
+    "bonus_collector": { "rng": [ 1, 5 ] },
     "shopkeeper_item_group": "NC_JUNK_SHOPKEEP_misc",
     "skills": [
       {

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/NPC_Smokes.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/NPC_Smokes.json
@@ -60,6 +60,7 @@
     "common": false,
     "bonus_int": { "one_in": 4 },
     "bonus_per": { "one_in": 4 },
+    "bonus_collector": { "rng": [ 1, 5 ] },
     "shopkeeper_item_group": "NC_EVAC_SHOPKEEP_misc",
     "carry_override": "NC_EVAC_SHOPKEEP_misc",
     "skills": [

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
@@ -41,6 +41,8 @@
     "bonus_dex": { "rng": [ 2, 2 ] },
     "bonus_int": { "rng": [ 1, 1 ] },
     "bonus_per": { "rng": [ 2, 2 ] },
+    "bonus_aggression": { "rng": [ 0, 1 ] },
+    "bonus_collector": { "rng": [ 0, 2 ] },
     "shopkeeper_item_group": "NC_ARSONIST_STOCK",
     "carry_override": "NC_ARSONIST_STOCK",
     "worn_override": "NC_ARSONIST_worn",

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -40,6 +40,10 @@ Format:
   "bonus_dex": 100,                                                        // Optional. This example always adds exactly 100 to the stat.
   "bonus_int": { "one_in": 3 },                                            // Optional. This example adds 1 to the stat, but only about ~33.33% of the time (1 in 3).
   "bonus_per": { "sum": [ { "constant": 100 }, { "dice": [ 10, 10 ] } ] }, // Optional. This example adds 100 + 10d10 (10 dice each with 10 sides) to the stat.
+  "bonus_aggression": { "rng": [ -4, 0 ] },                                // Optional. Modifies NPC's personality score like the above examples.
+  "bonus_bravery": 100,                                                    // Optional.
+  "bonus_collector": { "one_in": 3 },                                      // Optional.
+  "bonus_altruism": -10,                                                   // Optional.
   "skills": [
     {
       "skill": "ALL",                                                      // Optional. Applies bonuses/penalties to skills like the examples above. `ALL` is a special string which

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -31,24 +31,27 @@ Format:
 ```json
 {
   "type": "npc_class",
-  "id": "NC_EXAMPLE",
-  "name": { "str": "Example NPC" },
-  "job_description": "I'm helping you learn the game.",
-  "common": false,
-  "sells_belongings": false,
-  "bonus_str": { "rng": [ -4, 0 ] },
-  "bonus_dex": { "rng": [ -2, 0 ] },
-  "bonus_int": { "rng": [ 1, 5 ] },
+  "id": "NC_EXAMPLE",                                                      // Mandatory, unique id that refers to this class.
+  "name": { "str": "Example NPC" },                                        // Mandatory, display name for this class.
+  "job_description": "I'm helping you learn the game.",                    // Mandatory
+  "common": false,                                                         // Optional. Whether or not this class can appear via random generation.
+  "sells_belongings": false,                                               // Optional. See [Shopkeeper NPC configuration](#shopkeeper-npc-configuration)
+  "bonus_str": { "rng": [ -4, 0 ] },                                       // Optional. Modifies stat by the given value. This example shows a random distribution between -4 and 0.
+  "bonus_dex": 100,                                                        // Optional. This example always adds exactly 100 to the stat.
+  "bonus_int": { "one_in": 3 },                                            // Optional. This example adds 1 to the stat, but only about ~33.33% of the time (1 in 3).
+  "bonus_per": { "sum": [ { "constant": 100 }, { "dice": [ 10, 10 ] } ] }, // Optional. This example adds 100 + 10d10 (10 dice each with 10 sides) to the stat.
   "skills": [
     {
-      "skill": "ALL",
+      "skill": "ALL",                                                      // Optional. Applies bonuses/penalties to skills like the examples above. `ALL` is a special string which
+                                                                           // applies to all skills not otherwise modified. See data/json/skills.json for a list of skill IDs.
       "level": { "mul": [ { "one_in": 3 }, { "sum": [ { "dice": [ 2, 2 ] }, { "constant": -2 }, { "one_in": 4 } ] } ] }
     }
   ],
-  "worn_override": "NC_EXAMPLE_worn",
-  "carry_override": "NC_EXAMPLE_carried",
-  "weapon_override": "NC_EXAMPLE_weapon",
-  "shopkeeper_item_group": [
+  "worn_override": "NC_EXAMPLE_worn",                                      // Optional. Defines an [item group](ITEM_SPAWN.md) that replaces all of their worn items.
+  "carry_override": "NC_EXAMPLE_carried",                                  // Optional. Defines an item group that replaces their carried items (in pockets, etc). Items which cannot
+                                                                           // be carried will overflow(fall to the ground) when the NPC is loaded.
+  "weapon_override": "NC_EXAMPLE_weapon",                                  // Optional. Defines an item group that replaces their wielded weapon.
+  "shopkeeper_item_group": [                                               // Optional. See [Shopkeeper NPC configuration](#shopkeeper-npc-configuration) below.
     { "group": "example_shopkeeper_itemgroup1" },
     { "group": "example_shopkeeper_itemgroup2", "trust": 10 },
     { "group": "example_shopkeeper_itemgroup3", "trust": 20, "rigid": true }
@@ -64,12 +67,9 @@ Format:
   ],
   "shopkeeper_blacklist": "test_blacklist",
   "restock_interval": "6 days",
-  "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ]
+  "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ]     // Optional
 }
 ```
-There are some items in the above template that may not be self explanatory:
-* `"common": false` means that this NPC class will not spawn randomly. It defaults to `true` if not specified.
-* See also [Shopkeeper NPC configuration](#shopkeeper-npc-configuration) below.
 
 ### Shopkeeper NPC configuration
 `npc_class` supports several properties for configuring the behavior of NPCs that behave as shopkeepers:

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -40,7 +40,8 @@ Format:
   "bonus_dex": 100,                                                        // Optional. This example always adds exactly 100 to the stat.
   "bonus_int": { "one_in": 3 },                                            // Optional. This example adds 1 to the stat, but only about ~33.33% of the time (1 in 3).
   "bonus_per": { "sum": [ { "constant": 100 }, { "dice": [ 10, 10 ] } ] }, // Optional. This example adds 100 + 10d10 (10 dice each with 10 sides) to the stat.
-  "bonus_aggression": { "rng": [ -4, 0 ] },                                // Optional. Modifies NPC's personality score like the above examples.
+  "bonus_aggression": { "rng": [ -4, 0 ] },                                // Optional. Modifies NPC's personality score like the above examples. Resulting value will be
+                                                                           // clamped to within a range of -10, 10. (e.g. if aggression would be -12 it's instead set to -10)
   "bonus_bravery": 100,                                                    // Optional.
   "bonus_collector": { "one_in": 3 },                                      // Optional.
   "bonus_altruism": -10,                                                   // Optional.

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1904,7 +1904,7 @@ static void character_edit_menu()
     if( np != nullptr ) {
         std::stringstream data;
         data << np->get_name() << " - " << ( np->male ? _( "Male" ) : _( "Female" ) ) << " " <<
-             np->myclass->get_name() << std::endl;
+             np->myclass->get_name() << " " << _( "class ID:" ) << np->myclass.obj().id << std::endl;
         if( !np->get_unique_id().empty() ) {
             data << string_format( _( "Unique Id: %s" ), np->get_unique_id() ) << std::endl;
         }
@@ -2203,7 +2203,8 @@ static void character_edit_menu()
             size_t i = 0;
             for( const npc_class &cl : npc_class::get_all() ) {
                 ids.push_back( cl.id );
-                classes.addentry( i, true, -1, cl.get_name() );
+                classes.addentry( i, true, -1, string_format( _( "%1$s (ID: %2$s)" ), cl.get_name(),
+                                  cl.id.c_str() ) );
                 i++;
             }
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -821,6 +821,11 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
     int_max += the_class.roll_intelligence();
     per_max += the_class.roll_perception();
 
+    personality.aggression += the_class.roll_aggression();
+    personality.bravery += the_class.roll_bravery();
+    personality.collector += the_class.roll_collector();
+    personality.altruism += the_class.roll_altruism();
+
     for( Skill &skill : Skill::skills ) {
         int level = myclass->roll_skill( skill.ident() );
 

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -837,53 +837,6 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
         set_skill_level( skill.ident(), level );
     }
 
-    if( type.is_null() ) { // Untyped; no particular specialization
-    } else if( type == NC_EVAC_SHOPKEEP || type == NC_BARTENDER || type == NC_JUNK_SHOPKEEP ) {
-        personality.collector += rng( 1, 5 );
-
-    } else if( type == NC_ARSONIST ) {
-        personality.aggression += rng( 0, 1 );
-        personality.collector += rng( 0, 2 );
-
-    } else if( type == NC_SOLDIER ) {
-        personality.aggression += rng( 1, 3 );
-        personality.bravery += rng( 0, 5 );
-
-    } else if( type == NC_HACKER ) {
-        personality.bravery -= rng( 1, 3 );
-        personality.aggression -= rng( 0, 2 );
-
-    } else if( type == NC_DOCTOR ) {
-        personality.aggression -= rng( 0, 4 );
-        cash += 10000 * rng( 0, 3 ) * rng( 0, 3 );
-
-    } else if( type == NC_TRADER ) {
-        personality.collector += rng( 1, 5 );
-        cash += 25000 * rng( 1, 10 );
-
-    } else if( type == NC_NINJA ) {
-        personality.bravery += rng( 0, 3 );
-        personality.collector -= rng( 1, 6 );
-        // TODO: give ninja his styles back
-
-    } else if( type == NC_COWBOY ) {
-        personality.aggression += rng( 0, 2 );
-        personality.bravery += rng( 1, 5 );
-
-    } else if( type == NC_SCIENTIST ) {
-        personality.aggression -= rng( 1, 5 );
-        personality.bravery -= rng( 2, 8 );
-        personality.collector += rng( 0, 2 );
-
-    } else if( type == NC_BOUNTY_HUNTER || type == NC_THUG ) {
-        personality.aggression += rng( 1, 6 );
-        personality.bravery += rng( 0, 5 );
-
-    } else if( type == NC_SCAVENGER ) {
-        personality.aggression += rng( 1, 3 );
-        personality.bravery += rng( 1, 4 );
-
-    }
     //A universal barter boost to keep NPCs competitive with players
     //The int boost from trade wasn't active... now that it is, most
     //players will vastly outclass npcs in trade without a little help.

--- a/src/npc.cpp
+++ b/src/npc.cpp
@@ -826,6 +826,11 @@ void npc::randomize( const npc_class_id &type, const npc_template_id &tem_id )
     personality.collector += the_class.roll_collector();
     personality.altruism += the_class.roll_altruism();
 
+    std::clamp( personality.aggression, NPC_PERSONALITY_MIN, NPC_PERSONALITY_MAX );
+    std::clamp( personality.bravery, NPC_PERSONALITY_MIN, NPC_PERSONALITY_MAX );
+    std::clamp( personality.collector, NPC_PERSONALITY_MIN, NPC_PERSONALITY_MAX );
+    std::clamp( personality.altruism, NPC_PERSONALITY_MIN, NPC_PERSONALITY_MAX );
+
     for( Skill &skill : Skill::skills ) {
         int level = myclass->roll_skill( skill.ident() );
 

--- a/src/npc.h
+++ b/src/npc.h
@@ -56,6 +56,9 @@ class npc_class;
 class talker;
 class vehicle;
 
+constexpr int8_t NPC_PERSONALITY_MIN = -10;
+constexpr int8_t NPC_PERSONALITY_MAX = 10;
+
 namespace catacurses
 {
 class window;

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -278,6 +278,11 @@ void npc_class::load( const JsonObject &jo, const std::string_view )
     bonus_int = load_distribution( jo, "bonus_int" );
     bonus_per = load_distribution( jo, "bonus_per" );
 
+    bonus_aggression = load_distribution( jo, "bonus_aggression" );
+    bonus_bravery = load_distribution( jo, "bonus_bravery" );
+    bonus_collector = load_distribution( jo, "bonus_collector" );
+    bonus_altruism = load_distribution( jo, "bonus_altruism" );
+
     if( jo.has_member( "shopkeeper_item_group" ) ) {
         if( jo.has_array( "shopkeeper_item_group" ) &&
             jo.get_array( "shopkeeper_item_group" ).test_object() ) {
@@ -466,6 +471,26 @@ int npc_class::roll_intelligence() const
 int npc_class::roll_perception() const
 {
     return bonus_per.roll();
+}
+
+int npc_class::roll_aggression() const
+{
+    return bonus_aggression.roll();
+}
+
+int npc_class::roll_bravery() const
+{
+    return bonus_bravery.roll();
+}
+
+int npc_class::roll_collector() const
+{
+    return bonus_collector.roll();
+}
+
+int npc_class::roll_altruism() const
+{
+    return bonus_altruism.roll();
 }
 
 int npc_class::roll_skill( const skill_id &sid ) const

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -81,6 +81,11 @@ class npc_class
         distribution bonus_int;
         distribution bonus_per;
 
+        distribution bonus_aggression;
+        distribution bonus_bravery;
+        distribution bonus_collector;
+        distribution bonus_altruism;
+
         std::map<skill_id, distribution> skills;
         // Just for finalization
         std::map<skill_id, distribution> bonus_skills;
@@ -119,6 +124,11 @@ class npc_class
         int roll_dexterity() const;
         int roll_intelligence() const;
         int roll_perception() const;
+
+        int roll_aggression() const;
+        int roll_bravery() const;
+        int roll_collector() const;
+        int roll_altruism() const;
 
         int roll_skill( const skill_id & ) const;
 


### PR DESCRIPTION
#### Summary
Infrastructure "Simplify/jsonify NPC generation from npc classes"

#### Purpose of change
I look at npc::randomize and I see hardcoded modifiers defined per-class. I weep.

#### Describe the solution
c44cd1aecb181041af33695e906d3bcb23a9194b Prep work, just explained our existing docs and replaced some of the unhelpful existing examples with the full range of what is possible. (We support several ways to define these values but only had one documented...)

08a56d232cbec63606e295a02e8d71fe53d2d8de Add support to read personality modifiers from the classes' json and modify appropriately. Update docs to explain this, document how it works, etc.

cf7795895bf68a7de9d0cc1e2cfc2a46e5e80dbd Clamp personality scores to the previously-set-but-not-enforced range of -10, 10.

771bbcee8157177a1fa5643fe1402ae04df20b6c Migrate the hardcoded modifiers to json

6b9e75278c62b4ffe24d78c3e4ed816bfa0b23ac Update the debug menu to display class IDs in addition to class names wherever possible.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/ce636809-ce6d-47bf-924f-34d0c6a80a14)



#### Describe alternatives you've considered


#### Testing
Compiles, scores generate as expected. Confirmed that the modifiers apply by putting in some silly values (+200 aggression) before the clamping commit. Debug spawned NPCs until I got one of that class and confirmed their aggression was >200.


#### Additional context
This PR should probably not be squashed if merged.

Two hardcoded modifiers for increasing the characters' `cash` value were not maintained. As far as can be told, these were dead code so there is no loss of functionality. 

A comment for `TODO: give ninja his styles back` was also deleted but that appears to be referring to character-specific techniques detached from modern implementations of MAs. And well it's been sitting there for a decade, so... not too worried about anyone missing it.
