### PR TITLE
Change char cooldown ("succession") ---> 3 days

### DIFF
--- a/data/json/npcs/missiondef.json
+++ b/data/json/npcs/missiondef.json
@@ -1003,7 +1003,7 @@
     "id": "EOC_FACTION_SUCCESSION_COOLDOWN",
     "eoc_type": "EVENT",
     "required_event": "game_begin",
-    "effect": [ { "math": [ "time_between_succession", "=", "u_val('time: 90 d')" ] } ]
+    "effect": [ { "math": [ "time_between_succession", "=", "u_val('time: 3 d')" ] } ]
   },
   {
     "type": "effect_on_condition",

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -1580,8 +1580,8 @@ void basecamp::choose_new_leader()
     time_point next_succession_chance = last_succession_time + succession_cooldown;
     int current_time_int = to_seconds<int>( calendar::turn - calendar::turn_zero );
     if( next_succession_chance >= calendar::turn ) {
-        popup( _( "It's too early for that.  A new leader can be chosen in %s days." ),
-               to_days<int>( next_succession_chance - calendar::turn ) );
+        popup( _( "It's too early for that.  A new leader can be chosen in %s." ),
+               to_string( next_succession_chance - calendar::turn ) );
         return;
     }
     std::vector<std::string> choices;


### PR DESCRIPTION
#### Summary
Balance "Cooldown to change character at a camp lowered"

#### Purpose of change
#69927 (does not close issue)

#### Describe the solution
I made the number smaller 😎 

(also I made the message nicer and more accurate rather than rounding it to the number of days)

#### Describe alternatives you've considered
90 days

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/862148ed-e370-4138-9aad-a5d60efce8f8)


#### Additional context
At some point there will be consequences for choosing (/not choosing) a new leader at times, because people either don't want you in charge, or they want democracy, or whatever sort of things people can get upset about. (Anything and everything).

At that time, the cooldown will go back up, and **ideally**, the action of changing character to a different one in the same faction will be decoupled, with the change character cooldown remaining short, and the leadership one being a long cooldown.

But all that will be a lot of work and there is no guarantee that I or anyone will do any of it (let alone anytime soon). So here is your warning that this change should be considered temporary™ until we have better systems to represent such social dynamics.