### PR TITLE
add merge_group event to test actions

### DIFF
--- a/.github/workflows/CBA.yml
+++ b/.github/workflows/CBA.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+  merge_group:
   workflow_dispatch:
 
 # Mixing in event_name so that a master push and a workflow dispatch can run at the same time.

--- a/.github/workflows/astyle.yml
+++ b/.github/workflows/astyle.yml
@@ -1,6 +1,8 @@
 name: astyle
 
-on: pull_request
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   skip-duplicates:

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -5,6 +5,8 @@ on:
     branches:
     - master
 
+  merge_group:
+
   pull_request:
     branches:
     - master

--- a/.github/workflows/cmake-format.yml
+++ b/.github/workflows/cmake-format.yml
@@ -15,6 +15,7 @@ on:
     - '**/CMakeLists.txt'
     - '**.cmake'
     - '**.cmake.in'
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/json.yml
+++ b/.github/workflows/json.yml
@@ -1,6 +1,8 @@
 name: JSON Validation
 
-on: pull_request
+on:
+  pull_request:
+  merge_group:
 
 jobs:
   skip-duplicates:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,6 +15,7 @@ on:
       - '**.cpp'
       - '**.h'
       - '**.c'
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}-${{ github.event_name }}

--- a/.github/workflows/matrix.yml
+++ b/.github/workflows/matrix.yml
@@ -8,6 +8,7 @@ on:
     branches:
     - master
     types: [opened, reopened, synchronize, ready_for_review]
+  merge_group:
 
 # We only care about the latest revision of a PR, so cancel all previous instances.
 # Allow running master builds to complete to help with ccache refreshes.

--- a/.github/workflows/msvc-full-features.yml
+++ b/.github/workflows/msvc-full-features.yml
@@ -29,6 +29,7 @@ on:
     - 'tools/**'
     - '!tools/format/**'
     - 'utilities/**'
+  merge_group:
 
 # We only care about the latest revision of a PR, so cancel previous instances.
 concurrency:


### PR DESCRIPTION
#### Summary
Build "Enable tests for merge queue"

#### Purpose of change
When merging multiple PRs in a short time period, there is a risk of introducing regressions due to interactions between the different change sets.  A merge queue mitigates this risk by re-running the tests actions for each change one last time immediately before final merge.

#### Describe the solution
I've already set up the merge queue feature for a test branch, the test actions need to be adjusted, hopefully in a minor way to enable the merge queue logic, and then we can discuss merging these changes to the master branch and enabling the merge queue there.

#### Testing
If the tests run to completion we should be good to go.

#### Additional context
See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue
