### PR TITLE
Fix cabled-only pseudo-tools

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2348,6 +2348,7 @@ struct weldrig_hack {
             // null item should be handled just fine
             return null_item_reference();
         }
+        pseudo.set_flag( STATIC( flag_id( "PSEUDO" ) ) )
         item mag_mod( "pseudo_magazine_mod" );
         mag_mod.set_flag( STATIC( flag_id( "IRREMOVABLE" ) ) );
         if( !pseudo.put_in( mag_mod, pocket_type::MOD ).success() ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -197,6 +197,7 @@ static const itype_id itype_animal( "animal" );
 static const itype_id itype_battery( "battery" );
 static const itype_id itype_burnt_out_bionic( "burnt_out_bionic" );
 static const itype_id itype_muscle( "muscle" );
+static const itype_id itype_pseudo_magazine( "pseudo_magazine" );
 
 static const json_character_flag json_flag_CANNIBAL( "CANNIBAL" );
 static const json_character_flag json_flag_PAIN_IMMUNE( "PAIN_IMMUNE" );
@@ -2346,9 +2347,25 @@ struct weldrig_hack {
             // null item should be handled just fine
             return null_item_reference();
         }
-
-        item pseudo_magazine( pseudo.magazine_default() );
-        pseudo.put_in( pseudo_magazine, pocket_type::MAGAZINE_WELL );
+        item mag_mod( "pseudo_magazine_mod" );
+        mag_mod.set_flag( STATIC( flag_id( "IRREMOVABLE" ) ) );
+        if( !pseudo.put_in( mag_mod, pocket_type::MOD ).success() ) {
+            debugmsg( "tool %s has no space for a %s, this is likely a bug",
+                      pseudo.typeId().str(), mag_mod.type->nname( 1 ) );
+        }
+        itype_id mag_type;
+        if( pseudo.can_link_up() ) {
+            mag_type = itype_pseudo_magazine;
+        } else {
+            mag_type = pseudo.magazine_default();
+        }
+        item mag( mag_type );
+        mag.clear_items(); // no initial ammo
+        if( !pseudo.put_in( mag, pocket_type::MAGAZINE_WELL ).success() ) {
+            debugmsg( "inserting %s into %s's MAGAZINE_WELL pocket failed",
+                      mag.typeId().str(), pseudo.typeId().str() );
+            return 0;
+        }
         pseudo.ammo_set( itype_battery, part->vehicle().drain( itype_battery,
                          pseudo.ammo_capacity( ammo_battery ) ) );
         return pseudo;

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -59,6 +59,7 @@
 #include "iuse_actor.h"
 #include "line.h"
 #include "magic.h"
+#include "make_static.h"
 #include "map.h"
 #include "map_iterator.h"
 #include "map_selector.h"
@@ -2364,7 +2365,7 @@ struct weldrig_hack {
         if( !pseudo.put_in( mag, pocket_type::MAGAZINE_WELL ).success() ) {
             debugmsg( "inserting %s into %s's MAGAZINE_WELL pocket failed",
                       mag.typeId().str(), pseudo.typeId().str() );
-            return 0;
+            return null_item_reference();
         }
         pseudo.ammo_set( itype_battery, part->vehicle().drain( itype_battery,
                          pseudo.ammo_capacity( ammo_battery ) ) );

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2348,7 +2348,7 @@ struct weldrig_hack {
             // null item should be handled just fine
             return null_item_reference();
         }
-        pseudo.set_flag( STATIC( flag_id( "PSEUDO" ) ) )
+        pseudo.set_flag( STATIC( flag_id( "PSEUDO" ) ) );
         item mag_mod( "pseudo_magazine_mod" );
         mag_mod.set_flag( STATIC( flag_id( "IRREMOVABLE" ) ) );
         if( !pseudo.put_in( mag_mod, pocket_type::MOD ).success() ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6978,7 +6978,7 @@ std::string item::display_name( unsigned int quantity ) const
         } else {
             max_amount = ammo_capacity( item_controller->find_template( ammo_default() )->ammo->type );
         }
-        show_amt = !has_flag( flag_RELOAD_AND_SHOOT );
+        show_amt = ( !has_flag( flag_RELOAD_AND_SHOOT ) && !has_flag( flag_PSEUDO ) );
     } else if( count_by_charges() && !has_infinite_charges() ) {
         // A chargeable item
         amount = charges;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -304,7 +304,7 @@ void vehicle::build_electronics_menu( veh_menu &menu )
                 add_msg( _( "Camera system disabled" ) );
             } else
             {
-                add_msg( _( "Camera system enabled" ) );
+                add_msg( _( "Camera system enabled" ) );find_pocket_for
             }
             camera_on = !camera_on;
         } );
@@ -1783,10 +1783,11 @@ int vehicle::prepare_tool( item &tool ) const
         debugmsg( "tool %s has no space for a %s, this is likely a bug",
                   tool.typeId().str(), mag_mod.type->nname( 1 ) );
     }
+    item* mag;
     if( tool.can_link_up() ) {
-        item mag( "pseudo_magazine" );
+        mag = item( "pseudo_magazine" );
     } else {
-        item mag( tool.magazine_default() );
+        mag = item( tool.magazine_default() );
     }
     mag.clear_items(); // no initial ammo
     if( !tool.put_in( mag, pocket_type::MAGAZINE_WELL ).success() ) {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1783,9 +1783,9 @@ int vehicle::prepare_tool( item &tool ) const
         debugmsg( "tool %s has no space for a %s, this is likely a bug",
                   tool.typeId().str(), mag_mod.type->nname( 1 ) );
     }
-    std::string mag_type;
+    itype_id mag_type;
     if( tool.can_link_up() ) {
-        mag_type = "pseudo_magazine";
+        mag_type = itype_id( "pseudo_magazine" );
     } else {
         mag_type = tool.magazine_default();
     }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -304,7 +304,7 @@ void vehicle::build_electronics_menu( veh_menu &menu )
                 add_msg( _( "Camera system disabled" ) );
             } else
             {
-                add_msg( _( "Camera system enabled" ) );find_pocket_for
+                add_msg( _( "Camera system enabled" ) );
             }
             camera_on = !camera_on;
         } );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1783,7 +1783,7 @@ int vehicle::prepare_tool( item &tool ) const
         debugmsg( "tool %s has no space for a %s, this is likely a bug",
                   tool.typeId().str(), mag_mod.type->nname( 1 ) );
     }
-    str mag_type;
+    std::string mag_type;
     if( tool.can_link_up() ) {
         mag_type = "pseudo_magazine";
     } else {

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1785,7 +1785,7 @@ int vehicle::prepare_tool( item &tool ) const
     }
     itype_id mag_type;
     if( tool.can_link_up() ) {
-        mag_type = itype_id( "pseudo_magazine" );
+        mag_type = itype_pseudo_magazine;
     } else {
         mag_type = tool.magazine_default();
     }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -87,6 +87,7 @@ static const itype_id itype_fungal_seeds( "fungal_seeds" );
 static const itype_id itype_large_repairkit( "large_repairkit" );
 static const itype_id itype_marloss_seed( "marloss_seed" );
 static const itype_id itype_null( "null" );
+static const itype_id itype_pseudo_magazine( "pseudo_magazine" );
 static const itype_id itype_small_repairkit( "small_repairkit" );
 static const itype_id itype_soldering_iron( "soldering_iron" );
 static const itype_id itype_water( "water" );
@@ -96,7 +97,6 @@ static const itype_id itype_water_purifier( "water_purifier" );
 static const itype_id itype_welder( "welder" );
 static const itype_id itype_welder_crude( "welder_crude" );
 static const itype_id itype_welding_kit( "welding_kit" );
-static const itype_id itype_pseudo_magazine( "pseudo_magazine" );
 
 static const mon_flag_str_id mon_flag_PET_HARNESSABLE( "PET_HARNESSABLE" );
 static const mon_flag_str_id mon_flag_PET_MOUNTABLE( "PET_MOUNTABLE" );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -96,6 +96,7 @@ static const itype_id itype_water_purifier( "water_purifier" );
 static const itype_id itype_welder( "welder" );
 static const itype_id itype_welder_crude( "welder_crude" );
 static const itype_id itype_welding_kit( "welding_kit" );
+static const itype_id itype_pseudo_magazine( "pseudo_magazine" );
 
 static const mon_flag_str_id mon_flag_PET_HARNESSABLE( "PET_HARNESSABLE" );
 static const mon_flag_str_id mon_flag_PET_MOUNTABLE( "PET_MOUNTABLE" );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1783,12 +1783,13 @@ int vehicle::prepare_tool( item &tool ) const
         debugmsg( "tool %s has no space for a %s, this is likely a bug",
                   tool.typeId().str(), mag_mod.type->nname( 1 ) );
     }
-    item* mag;
+    str mag_type;
     if( tool.can_link_up() ) {
-        mag = item( "pseudo_magazine" );
+        mag_type = "pseudo_magazine";
     } else {
-        mag = item( tool.magazine_default() );
+        mag_type = tool.magazine_default();
     }
+    item mag( mag_type );
     mag.clear_items(); // no initial ammo
     if( !tool.put_in( mag, pocket_type::MAGAZINE_WELL ).success() ) {
         debugmsg( "inserting %s into %s's MAGAZINE_WELL pocket failed",

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1783,7 +1783,11 @@ int vehicle::prepare_tool( item &tool ) const
         debugmsg( "tool %s has no space for a %s, this is likely a bug",
                   tool.typeId().str(), mag_mod.type->nname( 1 ) );
     }
-    item mag( tool.magazine_default() );
+    if( tool.can_link_up() ) {
+        item mag( "pseudo_magazine" );
+    } else {
+        item mag( tool.magazine_default() );
+    }
     mag.clear_items(); // no initial ammo
     if( !tool.put_in( mag, pocket_type::MAGAZINE_WELL ).success() ) {
         debugmsg( "inserting %s into %s's MAGAZINE_WELL pocket failed",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Non-portable electric tools cause errors when used as pseudo-tools"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #70014, fix #70109, fix #68901. Following the addition of cables in certain tools by #64334 and the subsequent removal of battery slots from the non-portable (cabled-only) subset of those tools by #69965, some electrically-powered tools no longer have a default magazine. This causes an issue with their use as mounted tools (for instance in the workshop station) because the code for pseudo-tools that provides this function assumes all such tools have a magazine_default(), and then attempts to put this default magazine into a pseudo_magazine_mod pocket, leading to the game trying to insert a null into a pocket.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Insert a pseudo_magazine (introduced by #64682) rather than the (non-existent) default magazine into the pseudo_magazine_mod when a cabled tool is detected. Capacity of the pseudo_magazine (1000000 charges) has been concealed from the player by having display_name detect flag_PSEUDO and not show charges available.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Figure out how to link and unlink the transient pseudo-tool to and from the vehicle.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Repair screen appears as expected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
