### PR TITLE
makes satellite maps reveal ocean and shore tiles

### DIFF
--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -254,7 +254,8 @@
         { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
         "lake",
-        { "om_terrain": "river", "om_terrain_match_type": "PREFIX" }
+        { "om_terrain": "river", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "ocean", "om_terrain_match_type": "PREFIX" }
       ],
       "message": "You add terrain and roads to your map."
     }


### PR DESCRIPTION
#### Summary
Bugfixes "makes satellite maps reveal ocean and shore tiles"

#### Describe the solution
Satellite maps are supposed to reveal everything except buildings, so it doesn’t make sense for the ocean to be left blank.
