### PR TITLE
Hide AIM during directional prompts

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1098,6 +1098,8 @@ std::optional<tripoint> choose_direction( const std::string &message, const bool
     //~ %s: "Close where?" "Pry where?" etc.
     popup.message( _( "%s (Direction button)" ), message ).on_top( true );
 
+    temp_hide_advanced_inv();
+    
     std::string action;
     do {
         ui_manager::redraw();

--- a/src/action.cpp
+++ b/src/action.cpp
@@ -1099,7 +1099,6 @@ std::optional<tripoint> choose_direction( const std::string &message, const bool
     popup.message( _( "%s (Direction button)" ), message ).on_top( true );
 
     temp_hide_advanced_inv();
-    
     std::string action;
     do {
         ui_manager::redraw();

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -130,7 +130,7 @@ void kill_advanced_inv()
 
 void temp_hide_advanced_inv()
 {
-    if ( advinv ) {
+    if( advinv ) {
         advinv->temp_hide();
     }
 }

--- a/src/advanced_inv.cpp
+++ b/src/advanced_inv.cpp
@@ -128,6 +128,13 @@ void kill_advanced_inv()
     cancel_aim_processing();
 }
 
+void temp_hide_advanced_inv()
+{
+    if ( advinv ) {
+        advinv->temp_hide();
+    }
+}
+
 // *INDENT-OFF*
 advanced_inventory::advanced_inventory()
     : recalc( true )
@@ -1539,7 +1546,7 @@ void advanced_inventory::action_examine( advanced_inv_listitem *sitem,
         ret = g->inventory_item_menu( loc, info_startx, info_width,
                                       src == advanced_inventory::side::left ? game::LEFT_OF_INFO : game::RIGHT_OF_INFO );
         always_recalc = false;
-        if( !player_character.has_activity( ACT_ADV_INVENTORY ) ) {
+        if( !player_character.has_activity( ACT_ADV_INVENTORY ) || !ui ) {
             exit = true;
         } else {
             player_character.cancel_activity();
@@ -2145,6 +2152,13 @@ void advanced_inventory::do_return_entry()
     player_character.assign_activity( ACT_ADV_INVENTORY );
     player_character.activity.auto_resume = true;
     save_state->exit_code = aim_exit::re_entry;
+}
+
+void advanced_inventory::temp_hide()
+{
+    ui.reset();
+    do_return_entry();
+    cancel_aim_processing();
 }
 
 bool advanced_inventory::is_processing() const

--- a/src/advanced_inv.h
+++ b/src/advanced_inv.h
@@ -32,6 +32,7 @@ class advanced_inventory
         ~advanced_inventory();
 
         void display();
+        void temp_hide();
 
         /**
          * Converts from screen relative location to game-space relative location

--- a/src/ui.h
+++ b/src/ui.h
@@ -587,6 +587,7 @@ class pointmenu_cb : public uilist_callback
 };
 
 void kill_advanced_inv();
+void temp_hide_advanced_inv();
 
 /**
  * Helper for typical UI list navigation with wrap-around


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Hide AIM during directional prompts"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
When initiating a directional prompt from within the AIM (ex. select a brazier > Examine > Activate) the AIM window stays in front of the world, obscuring the world you're interacting with.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds a `temp_hide()` function to the AIM that removes its window and adds an open AIM event to the backlog so it re-opens after the action is complete. Call this function inside of `choose_direction()`.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Use various directional commands from inside the AIM, like emptying buckets, placing braziers, connecting cords. See that the AIM hides itself and reopens after finishing.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This PR alone is enough to work for most cases, but I found that firestarting actions, specifically, would fail to reopen the AIM if targeting an nonflammable spot. I fixed this, but it's a huge scope increase so I made it a separate PR: #70336
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
