### PR TITLE
Consolidate `suspendable` and `no_resume` activity parameters

### DIFF
--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -4,17 +4,16 @@
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "reloading",
-    "suspendable": false,
-    "based_on": "speed"
+    "based_on": "speed",
+    "can_resume": false
   },
   {
     "id": "ACT_FIND_MOUNT",
     "type": "activity_type",
     "activity_level": "LIGHT_EXERCISE",
     "verb": "finding a mount",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_READ",
@@ -41,8 +40,7 @@
     "activity_level": "NO_EXERCISE",
     "verb": "constructing",
     "based_on": "neither",
-    "suspendable": false,
-    "no_resume": true,
+    "can_resume": false,
     "multi_activity": true,
     "auto_needs": true
   },
@@ -52,8 +50,7 @@
     "activity_level": "EXTRA_EXERCISE",
     "verb": "mining",
     "based_on": "neither",
-    "suspendable": false,
-    "no_resume": true,
+    "can_resume": false,
     "multi_activity": true
   },
   {
@@ -62,8 +59,7 @@
     "activity_level": "NO_EXERCISE",
     "verb": "mopping",
     "based_on": "neither",
-    "suspendable": false,
-    "no_resume": true,
+    "can_resume": false,
     "multi_activity": true
   },
   {
@@ -72,8 +68,7 @@
     "activity_level": "NO_EXERCISE",
     "verb": "reading",
     "based_on": "neither",
-    "suspendable": false,
-    "no_resume": true,
+    "can_resume": false,
     "multi_activity": true,
     "auto_needs": true
   },
@@ -97,8 +92,7 @@
     "activity_level": "BRISK_EXERCISE",
     "verb": "deconstructing a vehicle",
     "based_on": "neither",
-    "suspendable": false,
-    "no_resume": true,
+    "can_resume": false,
     "multi_activity": true
   },
   {
@@ -107,8 +101,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "verb": "folding a vehicle",
     "based_on": "speed",
-    "suspendable": false,
-    "no_resume": true,
+    "can_resume": false,
     "multi_activity": false
   },
   {
@@ -117,8 +110,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "verb": "unfolding a vehicle",
     "based_on": "speed",
-    "suspendable": false,
-    "no_resume": true,
+    "can_resume": false,
     "multi_activity": false
   },
   {
@@ -127,8 +119,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "verb": "repairing a vehicle",
     "based_on": "neither",
-    "suspendable": false,
-    "no_resume": true,
+    "can_resume": false,
     "multi_activity": true
   },
   {
@@ -138,7 +129,7 @@
     "verb": "mounting a vehicle onto rack",
     "rooted": true,
     "based_on": "time",
-    "no_resume": true,
+    "can_resume": false,
     "refuel_fires": false,
     "auto_needs": false
   },
@@ -149,7 +140,7 @@
     "verb": "taking a vehicle from rack",
     "rooted": true,
     "based_on": "time",
-    "no_resume": true,
+    "can_resume": false,
     "refuel_fires": false,
     "auto_needs": false
   },
@@ -159,8 +150,7 @@
     "activity_level": "EXTRA_EXERCISE",
     "verb": "chopping logs",
     "based_on": "neither",
-    "suspendable": false,
-    "no_resume": true,
+    "can_resume": false,
     "multi_activity": true,
     "auto_needs": true
   },
@@ -170,8 +160,7 @@
     "activity_level": "NO_EXERCISE",
     "verb": "crafting",
     "based_on": "neither",
-    "suspendable": false,
-    "no_resume": true,
+    "can_resume": false,
     "multi_activity": true,
     "auto_needs": true
   },
@@ -181,8 +170,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "verb": "disassembling things",
     "based_on": "neither",
-    "suspendable": false,
-    "no_resume": true,
+    "can_resume": false,
     "multi_activity": true,
     "auto_needs": true
   },
@@ -192,8 +180,7 @@
     "activity_level": "MODERATE_EXERCISE",
     "verb": "butchering",
     "based_on": "neither",
-    "suspendable": false,
-    "no_resume": true,
+    "can_resume": false,
     "multi_activity": true,
     "auto_needs": true
   },
@@ -203,8 +190,7 @@
     "activity_level": "EXTRA_EXERCISE",
     "verb": "chopping trees",
     "based_on": "neither",
-    "suspendable": false,
-    "no_resume": true,
+    "can_resume": false,
     "multi_activity": true,
     "auto_needs": true
   },
@@ -246,7 +232,7 @@
     "verb": "waiting",
     "rooted": true,
     "based_on": "time",
-    "no_resume": true,
+    "can_resume": false,
     "refuel_fires": true,
     "auto_needs": true
   },
@@ -264,7 +250,7 @@
     "type": "activity_type",
     "activity_level": "MODERATE_EXERCISE",
     "verb": "disassembling",
-    "suspendable": false,
+    "can_resume": false,
     "rooted": true,
     "based_on": "neither",
     "refuel_fires": true,
@@ -332,7 +318,7 @@
     "activity_level": "BRISK_EXERCISE",
     "verb": "salvaging",
     "based_on": "speed",
-    "no_resume": true,
+    "can_resume": false,
     "refuel_fires": true,
     "auto_needs": true
   },
@@ -372,7 +358,7 @@
     "activity_level": "ACTIVE_EXERCISE",
     "verb": "teaching",
     "based_on": "speed",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_SOCIALIZE",
@@ -389,7 +375,7 @@
     "verb": "waiting",
     "rooted": true,
     "based_on": "time",
-    "no_resume": true,
+    "can_resume": false,
     "auto_needs": true
   },
   {
@@ -398,7 +384,7 @@
     "activity_level": "LIGHT_EXERCISE",
     "verb": "using first aid",
     "based_on": "speed",
-    "suspendable": false
+    "can_resume": false
   },
   {
     "id": "ACT_FISH",
@@ -407,7 +393,7 @@
     "verb": "fishing",
     "rooted": true,
     "based_on": "speed",
-    "suspendable": false
+    "can_resume": false
   },
   {
     "id": "ACT_PICKAXE",
@@ -422,7 +408,7 @@
     "activity_level": "EXTRA_EXERCISE",
     "verb": "smashing",
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_HAND_CRANK",
@@ -451,63 +437,56 @@
     "type": "activity_type",
     "activity_level": "LIGHT_EXERCISE",
     "verb": "dropping",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_STASH",
     "type": "activity_type",
     "activity_level": "LIGHT_EXERCISE",
     "verb": "stashing",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_PICKUP",
     "type": "activity_type",
     "activity_level": "LIGHT_EXERCISE",
     "verb": "picking up",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_MOVE_ITEMS",
     "type": "activity_type",
     "activity_level": "MODERATE_EXERCISE",
     "verb": "moving items",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_INSERT_ITEM",
     "type": "activity_type",
     "activity_level": "LIGHT_EXERCISE",
     "verb": "inserting",
-    "suspendable": false,
     "based_on": "speed",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_AUTODRIVE",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "driving",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_TRAVELLING",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "traveling",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_MOVE_LOOT",
@@ -529,18 +508,16 @@
     "type": "activity_type",
     "activity_level": "MODERATE_EXERCISE",
     "verb": "fetching components",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_MULTIPLE_FARM",
     "type": "activity_type",
     "activity_level": "BRISK_EXERCISE",
     "verb": "farming",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true,
+    "can_resume": false,
     "multi_activity": true,
     "auto_needs": true
   },
@@ -549,9 +526,8 @@
     "type": "activity_type",
     "activity_level": "MODERATE_EXERCISE",
     "verb": "fertilizing plots",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true,
+    "can_resume": false,
     "auto_needs": true
   },
   {
@@ -559,18 +535,16 @@
     "type": "activity_type",
     "activity_level": "MODERATE_EXERCISE",
     "verb": "interacting with inventory",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_ARMOR_LAYERS",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "fiddling with your clothes",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_START_FIRE",
@@ -579,7 +553,7 @@
     "verb": "lighting the fire",
     "rooted": true,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_OPEN_GATE",
@@ -593,30 +567,27 @@
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "filling the container",
-    "suspendable": false,
     "rooted": true,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_MILK",
     "type": "activity_type",
     "activity_level": "LIGHT_EXERCISE",
     "verb": "milking an animal",
-    "suspendable": false,
     "rooted": true,
     "based_on": "time",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_SHEARING",
     "type": "activity_type",
     "activity_level": "MODERATE_EXERCISE",
     "verb": "shearing an animal",
-    "suspendable": false,
     "rooted": true,
     "based_on": "speed",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_HOTWIRE_CAR",
@@ -630,36 +601,33 @@
     "type": "activity_type",
     "activity_level": "LIGHT_EXERCISE",
     "verb": "aiming",
-    "suspendable": false,
     "based_on": "neither",
     "ignored_distractions": [ "hunger", "thirst", "hostile_spotted_near", "hostile_spotted_far" ],
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_PULL_CREATURE",
     "type": "activity_type",
     "activity_level": "MODERATE_EXERCISE",
     "verb": "pulling a creature",
-    "suspendable": false,
     "based_on": "time",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_ATM",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "using the ATM",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_START_ENGINES",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "trying to start the vehicle",
-    "suspendable": false,
-    "based_on": "time"
+    "based_on": "time",
+    "can_resume": false
   },
   {
     "id": "ACT_OXYTORCH",
@@ -682,9 +650,8 @@
     "activity_level": "NO_EXERCISE",
     "verb": "picking lock",
     "rooted": true,
-    "suspendable": false,
-    "no_resume": true,
-    "based_on": "speed"
+    "based_on": "speed",
+    "can_resume": false
   },
   {
     "id": "ACT_REPAIR_ITEM",
@@ -711,24 +678,24 @@
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "modifying gun",
-    "suspendable": false,
-    "based_on": "speed"
+    "based_on": "speed",
+    "can_resume": false
   },
   {
     "id": "ACT_GUNMOD_REMOVE",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "modifying gun",
-    "suspendable": false,
-    "based_on": "speed"
+    "based_on": "speed",
+    "can_resume": false
   },
   {
     "id": "ACT_TOOLMOD_ADD",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "modifying tool",
-    "suspendable": false,
-    "based_on": "speed"
+    "based_on": "speed",
+    "can_resume": false
   },
   {
     "id": "ACT_WAIT_NPC",
@@ -737,7 +704,7 @@
     "verb": "interacting with the NPC",
     "rooted": true,
     "based_on": "time",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_WAIT_STAMINA",
@@ -746,7 +713,7 @@
     "verb": "catching breath",
     "rooted": true,
     "based_on": "time",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_CLEAR_RUBBLE",
@@ -812,7 +779,7 @@
     "activity_level": "ACTIVE_EXERCISE",
     "verb": "cutting planks",
     "based_on": "speed",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_JACKHAMMER",
@@ -865,7 +832,7 @@
     "verb": "trying to fall asleep",
     "rooted": true,
     "based_on": "speed",
-    "suspendable": false
+    "can_resume": false
   },
   {
     "id": "ACT_OPERATION",
@@ -874,7 +841,7 @@
     "verb": "being operated on",
     "based_on": "time",
     "interruptable": false,
-    "suspendable": false
+    "can_resume": false
   },
   {
     "id": "ACT_MEASURE",
@@ -884,55 +851,51 @@
     "verb": "getting measurements taken",
     "based_on": "time",
     "interruptable": false,
-    "suspendable": false,
     "rooted": true,
     "refuel_fires": true,
-    "auto_needs": true
+    "auto_needs": true,
+    "can_resume": false
   },
   {
     "id": "ACT_UNLOAD",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "unloading",
-    "suspendable": false,
-    "based_on": "speed"
+    "based_on": "speed",
+    "can_resume": false
   },
   {
     "id": "ACT_ROBOT_CONTROL",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "programming override",
-    "suspendable": false,
     "based_on": "time",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_WEAR",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "putting on items",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_WIELD",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "wielding item",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_INVOKE_ITEM",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "using item",
-    "suspendable": false,
     "rooted": true,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_TREE_COMMUNION",
@@ -940,9 +903,8 @@
     "activity_level": "NO_EXERCISE",
     "verb": "communing with the trees",
     "rooted": true,
-    "suspendable": false,
     "based_on": "time",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_MUTANT_TREE_COMMUNION",
@@ -950,101 +912,91 @@
     "activity_level": "NO_EXERCISE",
     "verb": "communing with the mutant tree",
     "rooted": true,
-    "suspendable": false,
     "based_on": "time",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_EAT_MENU",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "eating",
-    "suspendable": false,
     "rooted": true,
     "based_on": "neither",
     "ignored_distractions": [ "hunger", "thirst" ],
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_PICKUP_MENU",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "picking up",
-    "suspendable": false,
     "rooted": true,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_CONSUME_FOOD_MENU",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "consuming",
-    "suspendable": false,
     "rooted": true,
     "based_on": "neither",
     "ignored_distractions": [ "hunger", "thirst" ],
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_VIEW_RECIPE",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "viewing recipe",
-    "suspendable": false,
     "rooted": true,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_SPELLCASTING",
     "type": "activity_type",
     "activity_level": "LIGHT_EXERCISE",
     "verb": "casting",
-    "suspendable": false,
     "based_on": "speed",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_STUDY_SPELL",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "studying",
-    "suspendable": false,
     "refuel_fires": true,
     "auto_needs": true,
     "rooted": true,
     "based_on": "time",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_CONSUME_DRINK_MENU",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "drinking",
-    "suspendable": false,
     "based_on": "neither",
     "ignored_distractions": [ "hunger", "thirst" ],
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_CONSUME_MEDS_MENU",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "using drugs",
-    "suspendable": false,
     "based_on": "neither",
     "ignored_distractions": [ "hunger", "thirst" ],
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_HACKING",
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "hacking",
-    "suspendable": false,
     "based_on": "time",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_BINDER_COPY_RECIPE",
@@ -1059,9 +1011,8 @@
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "downloading data",
-    "suspendable": false,
     "auto_needs": true,
-    "no_resume": true,
+    "can_resume": false,
     "based_on": "time"
   },
   {
@@ -1069,9 +1020,8 @@
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "canceling activity serialized with legacy code",
-    "suspendable": false,
     "based_on": "neither",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_CONSUME",
@@ -1114,7 +1064,7 @@
     "type": "activity_type",
     "activity_level": "NO_EXERCISE",
     "verb": "disabling",
-    "suspendable": false,
+    "can_resume": false,
     "based_on": "speed"
   },
   {
@@ -1122,9 +1072,8 @@
     "type": "activity_type",
     "activity_level": "ACTIVE_EXERCISE",
     "verb": "moving",
-    "suspendable": false,
     "based_on": "time",
-    "no_resume": true
+    "can_resume": false
   },
   {
     "id": "ACT_TENT_PLACE",
@@ -1133,7 +1082,7 @@
     "verb": "pitching a tent",
     "rooted": true,
     "based_on": "time",
-    "no_resume": true,
+    "can_resume": false,
     "refuel_fires": false,
     "auto_needs": false
   },
@@ -1144,7 +1093,7 @@
     "verb": "packing up a tent",
     "rooted": true,
     "based_on": "time",
-    "no_resume": true,
+    "can_resume": false,
     "refuel_fires": false,
     "auto_needs": false
   },
@@ -1162,7 +1111,7 @@
     "verb": "preparing",
     "based_on": "time",
     "interruptable": false,
-    "suspendable": false,
+    "can_resume": false,
     "interruptable_with_kb": false
   },
   {
@@ -1172,7 +1121,7 @@
     "verb": "being operated on",
     "based_on": "time",
     "interruptable": false,
-    "suspendable": false,
+    "can_resume": false,
     "interruptable_with_kb": false
   }
 ]

--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -141,7 +141,7 @@
     "activity_level": "NO_EXERCISE",
     "verb": "meditating",
     "based_on": "time",
-    "no_resume": true,
+    "can_resume": false,
     "rooted": true,
     "do_turn_eoc": "EOC_VITAKIN_WAKEFUL_REST_MEDITATE"
   },

--- a/doc/PLAYER_ACTIVITY.md
+++ b/doc/PLAYER_ACTIVITY.md
@@ -42,12 +42,8 @@ to e.g. pain or seeing monsters will be suppressed.
 
 * interruptable_with_kb (true): Can this be interrupted by a key press.
 
-* no_resume (false): Rather than resuming, you must always restart the
-activity from scratch.
-
-* suspendable (true): If true, the activity can be continued without
-starting from scratch again. This is only possible if `can_resume_with()`
-returns true.
+* can_resume (true): If true, the activity can be resumed after an interruption,
+letting you continue from where you left off rather than from scratch.
 
 * based_on: Can be 'time', 'speed', or 'neither'.
 
@@ -100,7 +96,7 @@ There are several ways an activity can be ended:
     Canceling an activity prevents the `activity_actor::finish`
     function from running, and the activity does therefore not yield a
     result. Instead, `activity_actor::canceled` is called. If activity is
-    suspendable, a copy of it is written to `Character::backlog`.
+    resumable, a copy of it is written to `Character::backlog`.
 
 ## Notes
 

--- a/src/activity_type.cpp
+++ b/src/activity_type.cpp
@@ -94,8 +94,7 @@ void activity_type::load( const JsonObject &jo )
     assign( jo, "verb", result.verb_, true );
     assign( jo, "interruptable", result.interruptable_, true );
     assign( jo, "interruptable_with_kb", result.interruptable_with_kb_, true );
-    assign( jo, "suspendable", result.suspendable_, true );
-    assign( jo, "no_resume", result.no_resume_, true );
+    assign( jo, "can_resume", result.can_resume_, true );
     assign( jo, "multi_activity", result.multi_activity_, false );
     assign( jo, "refuel_fires", result.refuel_fires, false );
     assign( jo, "auto_needs", result.auto_needs, false );

--- a/src/activity_type.h
+++ b/src/activity_type.h
@@ -41,9 +41,8 @@ class activity_type
         translation verb_ = to_translation( "THIS IS A BUG" );
         bool interruptable_ = true;
         bool interruptable_with_kb_ = true;
-        bool suspendable_ = true;
         based_on_type based_on_ = based_on_type::SPEED;
-        bool no_resume_ = false;
+        bool can_resume_ = true;
         bool multi_activity_ = false;
         bool refuel_fires = false;
         bool auto_needs = false;
@@ -68,9 +67,6 @@ class activity_type
         bool interruptable_with_kb() const {
             return interruptable_with_kb_;
         }
-        bool suspendable() const {
-            return suspendable_;
-        }
         std::string stop_phrase() const;
         const translation &verb() const {
             return verb_;
@@ -78,8 +74,8 @@ class activity_type
         based_on_type based_on() const {
             return based_on_;
         }
-        bool no_resume() const {
-            return no_resume_;
+        bool can_resume() const {
+            return can_resume_;
         }
         bool multi_activity() const {
             return multi_activity_;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8905,7 +8905,7 @@ void Character::cancel_activity()
         backlog.front().auto_resume ) {
         backlog.front().auto_resume = false;
     }
-    if( activity && activity.is_suspendable() ) {
+    if( activity && activity.can_resume() ) {
         activity.allow_distractions();
         backlog.push_front( activity );
     }

--- a/src/player_activity.cpp
+++ b/src/player_activity.cpp
@@ -119,9 +119,9 @@ int player_activity::get_value( size_t index, int def ) const
     return index < values.size() ? values[index] : def;
 }
 
-bool player_activity::is_suspendable() const
+bool player_activity::can_resume() const
 {
-    return type->suspendable();
+    return type->can_resume();
 }
 
 bool player_activity::is_multi_type() const
@@ -428,7 +428,7 @@ bool player_activity::can_resume_with( const player_activity &other, const Chara
     // Should be used for relative positions
     // And to forbid resuming now-invalid crafting
 
-    if( !*this || !other || type->no_resume() ) {
+    if( !*this || !other || !type->can_resume() ) {
         return false;
     }
 

--- a/src/player_activity.h
+++ b/src/player_activity.h
@@ -136,7 +136,7 @@ class player_activity
          * possible if the player start the very same activity (with the same
          * parameters) again.
          */
-        bool is_suspendable() const;
+        bool can_resume() const;
 
         void serialize( JsonOut &json ) const;
         void deserialize( const JsonObject &data );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Consolidate `suspendable` and `no_resume` activity parameters"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
While working on #70335, I noticed that firestarter items wouldn't reopen the AIM if they targeted an invalid position. I found that this was because the activity only had `"no_resume": true`, and not `"suspendable": false`. These two parameters ostensibly do the exact same thing going by the documentation, but in practice `suspendable` is only used in `cancel_activity()` to determine if a cancelled activity should be added to the backlog if cancelled, and `no_resume` is only used in `can_resume_with()` to determine if a previously interrupted activity can be resumed by a new one. Because firestarter only had no_resume, it was pointlessly adding a copy to the backlog.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Consolidate suspendable and no_resume activity parameters into one: `can_resume`. It doesn't really make sense for there to be two different parameters; almost all activities have both `"no_resume": true` and `"suspendable": false`, and the ones that don't aren't getting anything out of it.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I could've kept the parameter named "suspendable" but "can_resume" makes the purpose a lot clearer to me.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Added changes from #70335, the AIM now reopens after failing a firestarter activity, including when a magnifying glass loses the required light level in the middle of the activity. Did a can_resume action (hacksawing a fence) with a zombie nearby to ensure resuming activities still works.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
