### PR TITLE
Removes dead code

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1739,13 +1739,6 @@
   },
   {
     "type": "keybinding",
-    "id": "UNPLUG",
-    "category": "APP_INTERACT",
-    "name": "Unplug power connections",
-    "bindings": [ { "input_method": "keyboard_any", "key": "u" } ]
-  },
-  {
-    "type": "keybinding",
     "id": "MERGE",
     "category": "APP_INTERACT",
     "name": "Merge power grids",

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -147,7 +147,6 @@ veh_app_interact::veh_app_interact( vehicle &veh, const point &p )
     ctxt.register_action( "SIPHON" );
     ctxt.register_action( "RENAME" );
     ctxt.register_action( "REMOVE" );
-    ctxt.register_action( "UNPLUG" );
     ctxt.register_action( "MERGE" );
 }
 

--- a/src/veh_appliance.h
+++ b/src/veh_appliance.h
@@ -99,9 +99,9 @@ class veh_app_interact
         */
         bool can_siphon();
         /**
-         * Checks whether the current appliance has any power connections that
-         * can be disconnected by the player.
-         * @returns True if the appliance can be unplugged.
+         * Checks whether the current appliance is power storage
+         * or powergen or a cable and can thus be merged into a powergrid.
+         * @returns True if the appliance can be merged.
         */
         bool can_merge();
         /**


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

#### Purpose of change

This code is a left over of https://github.com/CleverRaven/Cataclysm-DDA/pull/60681 that never did anything. My bad.

#### Describe the solution
Remove dead code
#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compile > start game > run around installing and taking down appliances > the menu that this dead code does not produce does not bug out when the dead code is removed because it doesn't exist

Can still disconnect power cords
#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
