### PR TITLE
Keep displaying selected outfit throughout chargen

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -2454,6 +2454,7 @@ static std::string assemble_hobby_details( const avatar &u, const input_context 
 
     assembled += string_format( g_switch_msg( u ), ctxt.get_desc( "CHANGE_GENDER" ),
                                 sorted_hobbies[cur_id]->gender_appropriate_name( !u.male ) ) + "\n";
+    assembled += string_format( dress_switch_msg(), ctxt.get_desc( "CHANGE_OUTFIT" ) ) + "\n";
 
     assembled += "\n" + colorize( _( "Background story:" ), COL_HEADER ) + "\n";
     assembled += colorize( sorted_hobbies[cur_id]->description( u.male ), c_green ) + "\n";
@@ -2567,6 +2568,7 @@ void set_hobbies( tab_manager &tabs, avatar &u, pool_type pool )
     ctxt.register_navigate_ui_list();
     ctxt.register_action( "CONFIRM" );
     ctxt.register_action( "CHANGE_GENDER" );
+    ctxt.register_action( "CHANGE_OUTFIT" );
     ctxt.register_action( "SORT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "FILTER" );
@@ -2737,6 +2739,9 @@ void set_hobbies( tab_manager &tabs, avatar &u, pool_type pool )
                 u.toggle_trait_deps( trait );
             }
 
+        } else if( action == "CHANGE_OUTFIT" ) {
+            outfit = !outfit;
+            recalc_hobbies = true;
         } else if( action == "CHANGE_GENDER" ) {
             u.male = !u.male;
             profession_sorter.male = u.male;
@@ -3111,6 +3116,8 @@ static std::string assemble_scenario_details( const avatar &u, const input_conte
 
     assembled += string_format( g_switch_msg( u ), ctxt.get_desc( "CHANGE_GENDER" ),
                                 current_scenario->gender_appropriate_name( !u.male ) ) + "\n";
+    assembled += string_format( dress_switch_msg(), ctxt.get_desc( "CHANGE_OUTFIT" ) ) + "\n";
+
     assembled += string_format(
                      _( "Press <color_light_green>%1$s</color> to change cataclysm start date, <color_light_green>%2$s</color> to change game start date, <color_light_green>%3$s</color> to reset calendar." ),
                      ctxt.get_desc( "CHANGE_START_OF_CATACLYSM" ), ctxt.get_desc( "CHANGE_START_OF_GAME" ),
@@ -3237,6 +3244,7 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
     ctxt.register_action( "SORT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "CHANGE_GENDER" );
+    ctxt.register_action( "CHANGE_OUTFIT" );
     ctxt.register_action( "FILTER" );
     ctxt.register_action( "RESET_FILTER" );
     ctxt.register_action( "CHANGE_START_OF_CATACLYSM" );
@@ -3384,6 +3392,9 @@ void set_scenario( tab_manager &tabs, avatar &u, pool_type pool )
             }
             reset_scenario( u, sorted_scens[cur_id] );
             details_recalc = true;
+        } else if( action == "CHANGE_OUTFIT" ) {
+            outfit = !outfit;
+            recalc_scens = true;
         } else if( action == "CHANGE_GENDER" ) {
             u.male = !u.male;
             recalc_scens = true;
@@ -3440,6 +3451,7 @@ namespace char_creation
 enum description_selector {
     NAME,
     GENDER,
+    OUTFIT,
     HEIGHT,
     AGE,
     BLOOD,
@@ -3487,6 +3499,27 @@ static void draw_gender( ui_adaptor &ui, const catacurses::window &w_gender,
     mvwprintz( w_gender, female_pos, ( you.male ? c_light_gray : c_pink ),
                _( "Female" ) );
     wnoutrefresh( w_gender );
+}
+
+static void draw_outfit( ui_adaptor &ui, const catacurses::window &w_outfit,
+                         const avatar &you, const bool highlight )
+{
+    const point male_pos( 1 + utf8_width( _( "Outfit:" ) ), 1 );
+    const point female_pos = male_pos + point( 2 + utf8_width( _( "Male" ) ), 1 );
+
+    werase( w_outfit );
+    mvwprintz( w_outfit, point_zero, highlight ? COL_SELECT : c_light_gray, _( "Outfit:" ) );
+    if( highlight && outfit ) {
+        ui.set_cursor( w_outfit, male_pos );
+    }
+    mvwprintz( w_outfit, male_pos, ( outfit ? c_light_cyan : c_light_gray ),
+               _( "Male" ) );
+    if( highlight && !outfit ) {
+        ui.set_cursor( w_outfit, female_pos );
+    }
+    mvwprintz( w_outfit, female_pos, ( outfit ? c_light_gray : c_pink ),
+               _( "Female" ) );
+    wnoutrefresh( w_outfit );
 }
 
 static void draw_height( ui_adaptor &ui, const catacurses::window &w_height,
@@ -3629,6 +3662,7 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
     catacurses::window w;
     catacurses::window w_name;
     catacurses::window w_gender;
+    catacurses::window w_outfit;
     catacurses::window w_location;
     catacurses::window w_vehicle;
     catacurses::window w_stats;
@@ -3659,7 +3693,8 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
         if( isWide ) {
             w = catacurses::newwin( TERMY, TERMX, point_zero );
             w_name = catacurses::newwin( 2, ncol2 + 2, point( 2, 6 ) );
-            w_gender = catacurses::newwin( 1, ncol2 + 2, point( 2, 8 ) );
+            w_gender = catacurses::newwin( 1, ncol2 + 2, point( 2, 7 ) );
+            w_outfit = catacurses::newwin( 1, ncol2 + 1, point( 2, 8 ) );
             w_location = catacurses::newwin( 1, ncol3, point( beginx3, 6 ) );
             w_vehicle = catacurses::newwin( 1, ncol3, point( beginx3, 7 ) );
             w_addictions = catacurses::newwin( 1, ncol3, point( beginx3, 8 ) );
@@ -3679,8 +3714,9 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
             ui.position_from_window( w );
         } else {
             w = catacurses::newwin( TERMY, TERMX, point_zero );
-            w_name = catacurses::newwin( 1, ncol_small, point( 2, 6 ) );
+            w_name = catacurses::newwin( 1, ncol_small, point( 2, 5 ) );
             w_gender = catacurses::newwin( 1, ncol_small, point( 2, 7 ) );
+            w_outfit = catacurses::newwin( 1, ncol_small, point( 2, 6 ) );
             w_height = catacurses::newwin( 1, ncol_small, point( 2, 8 ) );
             w_age = catacurses::newwin( 1, ncol_small, point( begin_sncol, 6 ) );
             w_blood = catacurses::newwin( 1, ncol_small, point( begin_sncol, 7 ) );
@@ -3714,6 +3750,7 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
         ctxt.register_action( "REROLL_CHARACTER_WITH_SCENARIO" );
     }
     ctxt.register_action( "CHANGE_GENDER" );
+    ctxt.register_action( "CHANGE_OUTFIT" );
     ctxt.register_action( "HELP_KEYBINDINGS" );
     ctxt.register_action( "CHANGE_START_OF_CATACLYSM" );
     ctxt.register_action( "CHANGE_START_OF_GAME" );
@@ -3956,6 +3993,7 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
         char_creation::draw_name( ui, w_name, you, current_selector == char_creation::NAME,
                                   no_name_entered );
         char_creation::draw_gender( ui, w_gender, you, current_selector == char_creation::GENDER );
+        char_creation::draw_outfit( ui, w_outfit, you, current_selector == char_creation::OUTFIT );
         char_creation::draw_age( ui, w_age, you, current_selector == char_creation::AGE );
         char_creation::draw_height( ui, w_height, you, current_selector == char_creation::HEIGHT );
         char_creation::draw_blood( ui, w_blood, you, current_selector == char_creation::BLOOD );
@@ -4117,6 +4155,9 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
                     current_selector = char_creation::GENDER;
                     break;
                 case char_creation::GENDER:
+                    current_selector = char_creation::OUTFIT;
+                    break;
+                case char_creation::OUTFIT:
                     current_selector = char_creation::HEIGHT;
                     break;
                 case char_creation::HEIGHT:
@@ -4147,6 +4188,9 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
                     current_selector = char_creation::HEIGHT;
                     break;
                 case char_creation::HEIGHT:
+                    current_selector = char_creation::OUTFIT;
+                    break;
+                case char_creation::OUTFIT:
                     current_selector = char_creation::GENDER;
                     break;
                 case char_creation::GENDER:
@@ -4182,6 +4226,9 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
                 case char_creation::GENDER:
                     you.male = !you.male;
                     break;
+                case char_creation::OUTFIT:
+                    outfit = !outfit;
+                    break;
                 default:
                     break;
             }
@@ -4214,6 +4261,9 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
                 case char_creation::GENDER:
                     you.male = !you.male;
                     break;
+                case char_creation::OUTFIT:
+                    outfit = !outfit;
+                    break;
                 default:
                     break;
             }
@@ -4244,6 +4294,8 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
             you.randomize_height();
             you.randomize_blood();
             you.randomize_heartrate();
+        } else if( action == "CHANGE_OUTFIT" ) {
+            outfit = !outfit;
         } else if( action == "CHANGE_GENDER" ) {
             you.male = !you.male;
         } else if( action == "CHANGE_START_OF_CATACLYSM" ) {
@@ -4352,6 +4404,18 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
                         break;
                     }
                     you.male = static_cast<bool>( gselect.ret );
+                    break;
+                }
+                case char_creation::OUTFIT: {
+                    uilist gselect;
+                    gselect.text = _( "Select outfit" );
+                    gselect.addentry( 0, true, '1', _( "Female" ) );
+                    gselect.addentry( 1, true, '2', _( "Male" ) );
+                    gselect.query();
+                    if( gselect.ret < 0 ) {
+                        break;
+                    }
+                    outfit = static_cast<bool>( gselect.ret );
                     break;
                 }
                 case char_creation::LOCATION: {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3715,8 +3715,8 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
         } else {
             w = catacurses::newwin( TERMY, TERMX, point_zero );
             w_name = catacurses::newwin( 1, ncol_small, point( 2, 5 ) );
-            w_gender = catacurses::newwin( 1, ncol_small, point( 2, 7 ) );
-            w_outfit = catacurses::newwin( 1, ncol_small, point( 2, 6 ) );
+            w_gender = catacurses::newwin( 1, ncol_small, point( 2, 6 ) );
+            w_outfit = catacurses::newwin( 1, ncol_small, point( 2, 7 ) );
             w_height = catacurses::newwin( 1, ncol_small, point( 2, 8 ) );
             w_age = catacurses::newwin( 1, ncol_small, point( begin_sncol, 6 ) );
             w_blood = catacurses::newwin( 1, ncol_small, point( begin_sncol, 7 ) );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3504,8 +3504,8 @@ static void draw_gender( ui_adaptor &ui, const catacurses::window &w_gender,
 static void draw_outfit( ui_adaptor &ui, const catacurses::window &w_outfit,
                          const avatar &you, const bool highlight )
 {
-    const point male_pos( 1 + utf8_width( _( "Outfit:" ) ), 1 );
-    const point female_pos = male_pos + point( 2 + utf8_width( _( "Male" ) ), 1 );
+    const point male_pos( 1 + utf8_width( _( "Outfit:" ) ), 0 );
+    const point female_pos = male_pos + point( 2 + utf8_width( _( "Male" ) ), 0 );
 
     werase( w_outfit );
     mvwprintz( w_outfit, point_zero, highlight ? COL_SELECT : c_light_gray, _( "Outfit:" ) );

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -3501,8 +3501,7 @@ static void draw_gender( ui_adaptor &ui, const catacurses::window &w_gender,
     wnoutrefresh( w_gender );
 }
 
-static void draw_outfit( ui_adaptor &ui, const catacurses::window &w_outfit,
-                         const avatar &you, const bool highlight )
+static void draw_outfit( ui_adaptor &ui, const catacurses::window &w_outfit, const bool highlight )
 {
     const point male_pos( 1 + utf8_width( _( "Outfit:" ) ), 0 );
     const point female_pos = male_pos + point( 2 + utf8_width( _( "Male" ) ), 0 );
@@ -3993,7 +3992,7 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
         char_creation::draw_name( ui, w_name, you, current_selector == char_creation::NAME,
                                   no_name_entered );
         char_creation::draw_gender( ui, w_gender, you, current_selector == char_creation::GENDER );
-        char_creation::draw_outfit( ui, w_outfit, you, current_selector == char_creation::OUTFIT );
+        char_creation::draw_outfit( ui, w_outfit, current_selector == char_creation::OUTFIT );
         char_creation::draw_age( ui, w_age, you, current_selector == char_creation::AGE );
         char_creation::draw_height( ui, w_height, you, current_selector == char_creation::HEIGHT );
         char_creation::draw_blood( ui, w_blood, you, current_selector == char_creation::BLOOD );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Keep displaying selected outfit throughout chargen"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Follow up on #69358
Communicate better the current selected outfit, avoid accidental crossdressing

#### Describe the solution

Display Outfit everywhere we display Gender
Allow to edit Outfit everywher you can edit Gender

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works

Normal screen
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41293484/e7c3d3ef-f8d6-4845-a599-e3588943c94a)


Small screen
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/41293484/6642aa3d-27a0-4020-b76f-ea26aa95fc9c)


#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
