### PR TITLE
WIP: add map revealing all airports and tall obstacles

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,4 @@
+;;; Directory Local Variables            -*- no-byte-compile: t -*-
+;;; For more information see (info "(emacs) Directory Variables")
+
+((c++-mode . ((c-basic-offset . 4))))

--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2371,5 +2371,10 @@
     "id": "TRANSPARENT",
     "type": "json_flag",
     "info": "This is transparent and <info>won't block light</info> from hitting the wearer."
+  },
+  {
+    "id": "WORLD_MAP",
+    "type": "json_flag",
+    "info": "This map contains information about a significant chunk of the world, rather than a small corner of it."
   }
 ]

--- a/data/json/itemgroups/corpses.json
+++ b/data/json/itemgroups/corpses.json
@@ -22,7 +22,10 @@
       { "item": "two_way_radio", "prob": 50, "charges": [ 0, 100 ], "damage-min": 1, "damage-max": 4 },
       { "prob": 40, "group": "adderall_bottle_plastic_pill_prescription_10" },
       { "group": "wallets_military", "prob": 5 },
-      { "item": "militarymap", "prob": 5 },
+      {
+        "distribution": [ { "item": "militarymap", "prob": 1 }, { "item": "aeronautical_section_chart", "prob": 4 } ],
+        "prob": 5
+      },
       { "group": "mil_food", "prob": 15 },
       { "item": "bone_human", "count": [ 5, 8 ], "prob": 100 },
       { "item": "human_flesh", "count": [ 5, 8 ], "prob": 100 },

--- a/data/json/itemgroups/military.json
+++ b/data/json/itemgroups/military.json
@@ -729,7 +729,7 @@
       { "item": "knife_trench", "prob": 14 },
       { "item": "flaregun", "prob": 20 },
       { "item": "signal_flare", "prob": 25 },
-      { "item": "militarymap", "prob": 4 },
+      { "group": "maps_milspec", "prob": 4 },
       { "item": "halligan", "prob": 10 },
       { "item": "fire_ax", "prob": 5 },
       { "prob": 2, "group": "antiparasitic_bottle_plastic_pill_prescription_5" },
@@ -996,7 +996,7 @@
   {
     "id": "maps_milspec",
     "type": "item_group",
-    "items": [ [ "militarymap", 100 ], [ "satellitemap", 100 ] ]
+    "items": [ [ "militarymap", 45 ], [ "satellitemap", 45 ], [ "aeronautical_section_chart", 10 ] ]
   },
   {
     "id": "supplies_mechanics_milspec",

--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -560,5 +560,34 @@
       ],
       "message": "You add roads and local electronic and hardware stores as well as arcades and internet cafes to your map."
     }
+  },
+  {
+    "id": "aeronautical_section_chart",
+    "copy-from": "abstractmap",
+    "type": "GENERIC",
+    "name": { "str": "aeronautical section chart" },
+    "description": "A large map densely covered in information related to airports, regional flight routes, radio navigation beacons, and other arcana mostly of interest only to an airline pilot. Probably nobody cares about the airspace classifications or flight restriction zones any more.",
+    "flags": [ "PAPER_SHAPED", "WORLD_MAP" ],
+    "color": "light_green",
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 2160,
+      "terrain": [
+        "ocean",
+        { "om_terrain": "runway", "om_terrain_match_type": "CONTAINS" },
+        { "om_terrain": "control_tower", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "stadium", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "ws_fire_lookout_tower", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "radio_tower", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "wind_turbine", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "helipad", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "mil_base", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "s_air", "om_terrain_match_type": "PREFIX" }
+      ],
+      "//": "This map is intended to reveal anything taller than 200 feet (60 meters). The real maps do not necessarily reveal what type of structure is there, only that it is a tall obstacle. They also group multiple tall objects together into a single symbol. Stadiums are shown not as an obstacle but because they are a source of bright light.",
+      "//2": "It should also reveal at least the major highways and rail routes, major urban areas, as well as large–scale water features, but we don’t quite have any way to do that yet.",
+      "//3": "See https://aeronav.faa.gov/visual/11-30-2023/PDFs/New_York.pdf or https://aeronav.faa.gov/visual/11-30-2023/PDFs/Boston_TAC.pdf for examples",
+      "message": "You add a number of regional airports and other landmarks to your map."
+    }
   }
 ]

--- a/data/json/items/book/maps.json
+++ b/data/json/items/book/maps.json
@@ -566,7 +566,7 @@
     "copy-from": "abstractmap",
     "type": "GENERIC",
     "name": { "str": "aeronautical section chart" },
-    "description": "A large map densely covered in information related to airports, regional flight routes, radio navigation beacons, and other arcana mostly of interest only to an airline pilot. Probably nobody cares about the airspace classifications or flight restriction zones any more.",
+    "description": "A large map densely covered in information related to airports, regional flight routes, radio navigation beacons, and other arcana mostly of interest only to an airline pilot.  Probably nobody cares about the airspace classifications or flight restriction zones any more.",
     "flags": [ "PAPER_SHAPED", "WORLD_MAP" ],
     "color": "light_green",
     "use_action": {

--- a/data/json/mapgen/airliner.json
+++ b/data/json/mapgen/airliner.json
@@ -449,7 +449,8 @@
       },
       { "group": "full_1st_aid", "prob": 40 },
       { "item": "handflare", "count-min": 1, "count-max": 3, "prob": 30, "charges": 300 },
-      { "item": "sm_extinguisher", "prob": 75 }
+      { "item": "sm_extinguisher", "prob": 75 },
+      { "item": "aeronautical_section_chart", "prob": 5 }
     ]
   },
   {

--- a/data/json/mapgen/military/mil_base/mil_base_z-1.json
+++ b/data/json/mapgen/military/mil_base/mil_base_z-1.json
@@ -237,7 +237,7 @@
       },
       "monster": { "i": { "monster": "mon_zombie_soldier_blackops_1", "chance": 75 } },
       "place_loot": [
-        { "item": "militarymap", "x": 14, "y": 5 },
+        { "group": "maps_milspec", "x": 14, "y": 5 },
         { "group": "SUS_coffee_cupboard", "x": 1, "y": 2, "chance": 50, "repeat": [ 1, 2 ] },
         { "group": "dinnerware", "x": 1, "y": 1, "chance": 2, "repeat": [ 5, 10 ] },
         { "group": "liquor_and_spirits", "x": 1, "y": 3, "chance": 50, "repeat": [ 3, 4 ] }

--- a/data/json/mapgen/missile_silo.json
+++ b/data/json/mapgen/missile_silo.json
@@ -167,9 +167,10 @@
         "f": { "item": "SUS_fridge_breakroom", "chance": 70 },
         "C": { "item": "office_supplies", "chance": 60 },
         "t": { "item": "dining", "chance": 45 },
-        "b": { "item": "bunker_basement_books", "chance": 70, "repeat": 2 }
+        "b": { "item": "bunker_basement_books", "chance": 70, "repeat": 2 },
+        "T": { "item": "maps_milspec", "chance": 30 }
       },
-      "item": { "e": { "item": "microwave", "chance": 70 }, "T": { "item": "militarymap", "chance": 30 } },
+      "item": { "e": { "item": "microwave", "chance": 70 } },
       "toilets": { "&": {  } },
       "monster": { ".": { "monster": "mon_zombie_soldier", "chance": 10 } },
       "liquids": { "W": { "liquid": "water_clean", "amount": [ 0, 80 ] } }

--- a/data/json/mapgen/regional_airport.json
+++ b/data/json/mapgen/regional_airport.json
@@ -214,6 +214,8 @@
       ],
       "palettes": [ "airport_palette" ],
       "terrain": { " ": "t_open_air", "s": "t_grate" },
+      "//": "I count 21 desks in there. That gives a (1 − 0.05)²¹ = ~34% chance that any given airport fails to have a chart of the region.",
+      "item": { "d": [ { "item": "aeronautical_section_chart", "chance": 5 } ] },
       "place_monster": [
         { "group": "GROUP_CIVILIAN", "x": [ 4, 19 ], "y": [ 4, 19 ], "chance": 65, "repeat": [ 4, 8 ] },
         { "group": "GROUP_CIVILIAN", "x": [ 4, 19 ], "y": [ 52, 67 ], "chance": 50, "repeat": [ 1, 3 ] }

--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -2113,7 +2113,7 @@
     "proficiencies": [ "prof_helicopter_pilot" ],
     "items": {
       "both": {
-        "items": [ "pants_cargo", "socks", "polo_shirt", "boots", "wristwatch", "fancy_sunglasses" ],
+        "items": [ "pants_cargo", "socks", "polo_shirt", "boots", "wristwatch", "fancy_sunglasses", "aeronautical_section_chart" ],
         "entries": [ { "group": "charged_smart_phone" }, { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] } ]
       },
       "male": [ "boxer_shorts" ],
@@ -5792,7 +5792,8 @@
           "mil_flight_suit",
           "chestrig",
           "webbing_belt",
-          "legpouch_large"
+          "legpouch_large",
+          "aeronautical_section_chart"
         ],
         "entries": [
           { "group": "charged_matches" },

--- a/data/json/recipes/recipe_deconstruction.json
+++ b/data/json/recipes/recipe_deconstruction.json
@@ -7636,5 +7636,13 @@
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
     "components": [ [ [ "stick", 1 ], [ "splinter", 1 ] ] ],
     "flags": [ "BLIND_EASY" ]
+  },
+  {
+    "result": "aeronautical_section_chart",
+    "type": "uncraft",
+    "activity_level": "NO_EXERCISE",
+    "time": "30 s",
+    "components": [ [ [ "paper", 50 ] ] ],
+    "flags": [ "BLIND_EASY" ]
   }
 ]

--- a/data/json/vehicles/helicopters.json
+++ b/data/json/vehicles/helicopters.json
@@ -43,7 +43,8 @@
       { "x": 0, "y": 0, "chance": 100, "items": [ "caff_gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "nic_gum" ] },
-      { "x": 0, "y": 1, "chance": 100, "items": [ "roadmap" ] }
+      { "x": 0, "y": 1, "chance": 100, "items": [ "roadmap" ] },
+      { "x": 0, "y": 1, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -90,7 +91,8 @@
       { "x": 0, "y": 0, "chance": 100, "items": [ "caff_gum" ] },
       { "x": 0, "y": 0, "chance": 100, "item_groups": [ "full_ifak" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "binoculars" ] },
-      { "x": 0, "y": 1, "chance": 100, "items": [ "roadmap" ] }
+      { "x": 0, "y": 1, "chance": 100, "items": [ "roadmap" ] },
+      { "x": 0, "y": 1, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -124,7 +126,8 @@
       { "x": 0, "y": 0, "chance": 100, "items": [ "caff_gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "nic_gum" ] },
-      { "x": 0, "y": 0, "chance": 100, "items": [ "roadmap" ] }
+      { "x": 0, "y": 0, "chance": 100, "items": [ "roadmap" ] },
+      { "x": 0, "y": 0, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -160,7 +163,8 @@
       { "x": 0, "y": 0, "chance": 100, "items": [ "caff_gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "nic_gum" ] },
-      { "x": 0, "y": 0, "chance": 100, "items": [ "roadmap" ] }
+      { "x": 0, "y": 0, "chance": 100, "items": [ "roadmap" ] },
+      { "x": 0, "y": 0, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -198,7 +202,8 @@
       { "x": -1, "y": 0, "chance": 100, "items": [ "caff_gum" ] },
       { "x": -1, "y": 0, "chance": 100, "items": [ "gum" ] },
       { "x": -1, "y": 0, "chance": 100, "items": [ "nic_gum" ] },
-      { "x": -1, "y": 0, "chance": 100, "items": [ "ampoule" ] }
+      { "x": -1, "y": 0, "chance": 100, "items": [ "ampoule" ] },
+      { "x": 0, "y": 0, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -263,7 +268,8 @@
       { "x": 0, "y": 0, "chance": 100, "items": [ "caff_gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "nic_gum" ] },
-      { "x": 0, "y": 2, "chance": 100, "items": [ "roadmap" ] }
+      { "x": 0, "y": 2, "chance": 100, "items": [ "roadmap" ] },
+      { "x": 0, "y": 2, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -328,7 +334,8 @@
       { "x": 0, "y": 0, "chance": 100, "items": [ "caff_gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "nic_gum" ] },
-      { "x": 0, "y": 2, "chance": 100, "items": [ "roadmap" ] }
+      { "x": 0, "y": 2, "chance": 100, "items": [ "roadmap" ] },
+      { "x": 0, "y": 2, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -366,7 +373,8 @@
     "items": [
       { "x": 0, "y": 0, "chance": 100, "items": [ "caff_gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "gum" ] },
-      { "x": 0, "y": 0, "chance": 100, "items": [ "nic_gum" ] }
+      { "x": 0, "y": 0, "chance": 100, "items": [ "nic_gum" ] },
+      { "x": 0, "y": 0, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -392,7 +400,8 @@
       { "x": 0, "y": 0, "chance": 100, "items": [ "caff_gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "nic_gum" ] },
-      { "x": 0, "y": 0, "chance": 100, "items": [ "roadmap" ] }
+      { "x": 0, "y": 0, "chance": 100, "items": [ "roadmap" ] },
+      { "x": 0, "y": 0, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -422,7 +431,8 @@
       { "x": 0, "y": 0, "chance": 100, "items": [ "caff_gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "nic_gum" ] },
-      { "x": 0, "y": 0, "chance": 100, "items": [ "roadmap" ] }
+      { "x": 0, "y": 0, "chance": 100, "items": [ "roadmap" ] },
+      { "x": 0, "y": 0, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -458,7 +468,8 @@
       { "x": 1, "y": 0, "chance": 100, "items": [ "caff_gum" ] },
       { "x": 1, "y": 0, "chance": 100, "items": [ "gum" ] },
       { "x": 1, "y": 0, "chance": 100, "items": [ "nic_gum" ] },
-      { "x": 1, "y": 0, "chance": 100, "items": [ "ampoule" ] }
+      { "x": 1, "y": 0, "chance": 100, "items": [ "ampoule" ] },
+      { "x": 1, "y": 0, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -512,7 +523,8 @@
       { "x": 0, "y": 0, "chance": 100, "items": [ "caff_gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "nic_gum" ] },
-      { "x": 0, "y": 2, "chance": 100, "items": [ "roadmap" ] }
+      { "x": 0, "y": 2, "chance": 100, "items": [ "roadmap" ] },
+      { "x": 0, "y": 2, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -577,7 +589,8 @@
       { "x": 0, "y": 0, "chance": 100, "items": [ "caff_gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "gum" ] },
       { "x": 0, "y": 0, "chance": 100, "items": [ "nic_gum" ] },
-      { "x": 0, "y": 2, "chance": 100, "items": [ "roadmap" ] }
+      { "x": 0, "y": 2, "chance": 100, "items": [ "roadmap" ] },
+      { "x": 0, "y": 2, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -684,7 +697,8 @@
       { "x": 0, "y": -1, "chance": 5, "items": [ "screwdriver_set" ] },
       { "x": 0, "y": -1, "chance": 10, "items": [ "knife_combat" ] },
       { "x": 0, "y": -1, "chance": 5, "ammo": 90, "items": [ "ecig" ] },
-      { "x": 2, "y": -1, "chance": 5, "ammo": 90, "items": [ "mp3" ] }
+      { "x": 2, "y": -1, "chance": 5, "ammo": 90, "items": [ "mp3" ] },
+      { "x": -1, "y": -1, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -774,7 +788,8 @@
       { "x": 0, "y": -1, "chance": 20, "item_groups": [ "remains_pilot" ] },
       { "x": 0, "y": -1, "chance": 50, "items": [ "militarymap" ] },
       { "x": 2, "y": -1, "chance": 20, "item_groups": [ "remains_pilot" ] },
-      { "x": 2, "y": -1, "chance": 5, "ammo": 90, "items": [ "mp3" ] }
+      { "x": 2, "y": -1, "chance": 5, "ammo": 90, "items": [ "mp3" ] },
+      { "x": 0, "y": -1, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -855,7 +870,8 @@
       { "x": -1, "y": 1, "chance": 7, "items": [ "mag_fieldrepair" ] },
       { "x": -1, "y": 1, "chance": 15, "items": [ "e_scrap" ] },
       { "x": -1, "y": 1, "chance": 7, "items": [ "screwdriver" ] },
-      { "x": -1, "y": 1, "chance": 7, "items": [ "wrench" ] }
+      { "x": -1, "y": 1, "chance": 7, "items": [ "wrench" ] },
+      { "x": -1, "y": 1, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -1086,7 +1102,8 @@
       { "x": -2, "y": 1, "chance": 7, "items": [ "screwdriver" ] },
       { "x": -2, "y": 1, "chance": 10, "items": [ "mag_fieldrepair" ] },
       { "x": -2, "y": 1, "chance": 7, "items": [ "wrench" ] },
-      { "x": -2, "y": 1, "chance": 5, "items": [ "two_way_radio" ] }
+      { "x": -2, "y": 1, "chance": 5, "items": [ "two_way_radio" ] },
+      { "x": -7, "y": -2, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -1296,7 +1313,8 @@
       { "x": -2, "y": 1, "chance": 5, "items": [ "two_way_radio" ] },
       { "x": 0, "y": -1, "chance": 5, "items": [ "advanced_ecig" ] },
       { "x": 0, "y": -1, "chance": 10, "items": [ "helmet_army" ] },
-      { "x": 0, "y": 1, "chance": 20, "item_groups": [ "remains_pilot" ] }
+      { "x": 0, "y": 1, "chance": 20, "item_groups": [ "remains_pilot" ] },
+      { "x": 0, "y": 1, "chance": 25, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -1468,7 +1486,8 @@
       { "x": -2, "y": 1, "chance": 10, "items": [ "mag_fieldrepair" ] },
       { "x": -2, "y": 1, "chance": 7, "items": [ "wrench" ] },
       { "x": -2, "y": 1, "chance": 5, "items": [ "two_way_radio" ] },
-      { "x": 0, "y": 1, "chance": 20, "item_groups": [ "remains_pilot" ] }
+      { "x": 0, "y": 1, "chance": 20, "item_groups": [ "remains_pilot" ] },
+      { "x": 0, "y": 1, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -1588,7 +1607,8 @@
       { "x": -1, "y": 2, "chance": 5, "items": [ "two_way_radio" ] },
       { "x": 0, "y": 2, "chance": 7, "items": [ "roadmap" ] },
       { "x": 0, "y": 2, "chance": 7, "items": [ "pockknife" ] },
-      { "x": 0, "y": 2, "chance": 5, "items": [ "box_cigarette" ] }
+      { "x": 0, "y": 2, "chance": 5, "items": [ "box_cigarette" ] },
+      { "x": 0, "y": 2, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -1706,7 +1726,8 @@
       { "x": -1, "y": 2, "chance": 5, "items": [ "two_way_radio" ] },
       { "x": 0, "y": 2, "chance": 7, "items": [ "roadmap" ] },
       { "x": 0, "y": 2, "chance": 7, "items": [ "pockknife" ] },
-      { "x": 0, "y": 2, "chance": 5, "items": [ "box_cigarette" ] }
+      { "x": 0, "y": 2, "chance": 5, "items": [ "box_cigarette" ] },
+      { "x": 0, "y": 2, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   },
   {
@@ -1813,7 +1834,8 @@
       { "x": -1, "y": 2, "chance": 5, "items": [ "two_way_radio" ] },
       { "x": 0, "y": 2, "chance": 7, "items": [ "roadmap" ] },
       { "x": 0, "y": 2, "chance": 7, "items": [ "pockknife" ] },
-      { "x": 0, "y": 2, "chance": 5, "items": [ "box_cigarette" ] }
+      { "x": 0, "y": 2, "chance": 5, "items": [ "box_cigarette" ] },
+      { "x": 0, "y": 2, "chance": 5, "items": [ "aeronautical_section_chart" ] }
     ]
   }
 ]

--- a/data/mods/MindOverMatter/itemgroups/books.json
+++ b/data/mods/MindOverMatter/itemgroups/books.json
@@ -93,6 +93,13 @@
     "type": "item_group",
     "subtype": "distribution",
     "id": "dist_maps",
-    "items": [ [ "satellitemap", 3 ], [ "roadmap", 2 ], [ "subwaystationmap", 1 ], [ "militarymap", 2 ], [ "sewermap", 1 ] ]
+    "items": [
+      [ "satellitemap", 3 ],
+      [ "roadmap", 2 ],
+      [ "subwaystationmap", 1 ],
+      [ "militarymap", 2 ],
+      [ "sewermap", 1 ],
+      [ "aeronautical_section_chart", 1 ]
+    ]
   }
 ]

--- a/doc/JSON_FLAGS.md
+++ b/doc/JSON_FLAGS.md
@@ -936,6 +936,14 @@ These flags can be applied via JSON item definition to most items.  Not to be co
 
 See [Mapgen flags](MAPGEN.md#mapgen-flags).
 
+## Maps
+
+- ```WORLD_MAP``` Map is centered on overmap 0,0 rather than the
+  player’s location, and the name of the map item is built from the
+  name of the world rather than the name of the nearest city. This
+  type of map is intended to reveal sparse but global information
+  rather than detailed but local information. The player can only use
+  this type of item once, rather than using each instance once.
 
 ## Map Specials
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -13187,3 +13187,21 @@ bool character_martial_arts::pick_style( const Character &you ) // Style selecti
 
     return true;
 }
+
+bool Character::has_used_item_type( const item *it ) const
+{
+    const auto needle = string_format( ";%s;", it->type->get_id().str() );
+    auto previously_used = get_value( "ITEM_TYPES_USED" );
+    return previously_used.find( needle ) != std::string::npos;
+}
+
+void Character::mark_item_type_as_used( const item *it )
+{
+    std::string &previously_used = values[ "ITEM_TYPES_USED" ];
+    if( previously_used.empty() ) {
+        // *always* start with a ';'
+        previously_used = ";";
+    }
+    // and always end with a ';'
+    previously_used += string_format( "%s;", it->type->get_id().str() );
+}

--- a/src/character.h
+++ b/src/character.h
@@ -4022,6 +4022,17 @@ class Character : public Creature, public visitable
         // a cache of all active enchantment values.
         // is recalculated every turn in Character::recalculate_enchantment_cache
         pimpl<enchant_cache> enchantment_cache;
+
+        /**
+         * True if this character has already used this type of item. The
+         * item is identified by its id.
+         */
+        bool has_used_item_type( const item *it ) const;
+        /**
+         * Make this character remember that they have used this type of
+         * item. The item is identified by its id.
+         */
+        void mark_item_type_as_used( const item *it );
 };
 
 Character &get_player_character();

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -363,6 +363,7 @@ const flag_id flag_WET( "WET" );
 const flag_id flag_WHIP( "WHIP" );
 const flag_id flag_WIND_EXTINGUISH( "WIND_EXTINGUISH" );
 const flag_id flag_WONT_TRAIN_MARKSMANSHIP( "WONT_TRAIN_MARKSMANSHIP" );
+const flag_id flag_WORLD_MAP( "WORLD_MAP" );
 const flag_id flag_WRITE_MESSAGE( "WRITE_MESSAGE" );
 const flag_id flag_ZERO_WEIGHT( "ZERO_WEIGHT" );
 const flag_id flag_ZOOM( "ZOOM" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -373,6 +373,7 @@ extern const flag_id flag_ZERO_WEIGHT;
 extern const flag_id flag_ZOOM;
 extern const flag_id flag_wooled;
 extern const flag_id flag_WONT_TRAIN_MARKSMANSHIP;
+extern const flag_id flag_WORLD_MAP;
 extern const flag_id flag_MUTE;
 extern const flag_id flag_NO_CLEAN;
 extern const flag_id flag_SOFT;

--- a/src/item.h
+++ b/src/item.h
@@ -1404,7 +1404,7 @@ class item : public visitable
          * Marks the item as being used by this specific player, it remains unmarked
          * for other players. The player is identified by its id.
          */
-        void mark_as_used_by_player( const Character &p );
+        void mark_as_used_by_player( Character &p );
         /** Marks the item as filthy, so characters with squeamish trait can't wear it.
         */
         bool is_filthy() const;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -5239,7 +5239,11 @@ item &map::add_item( const tripoint &p, item new_item, int copies )
     }
 
     if( new_item.is_map() && !new_item.has_var( "reveal_map_center_omt" ) ) {
-        new_item.set_var( "reveal_map_center_omt", ms_to_omt_copy( getabs( p ) ) );
+        if( new_item.has_flag( flag_WORLD_MAP ) ) {
+            new_item.set_var( "reveal_map_center_omt", tripoint( 0, 0, 0 ) );
+        } else {
+            new_item.set_var( "reveal_map_center_omt", ms_to_omt_copy( getabs( p ) ) );
+        }
     }
 
     if( new_item.has_flag( json_flag_PRESERVE_SPAWN_OMT ) &&


### PR DESCRIPTION
#### Summary
Features "Add a new type of map that reveals all airports and tall obstacles in the world"

#### Purpose of change

Real–world pilots use Aeronautical Section Charts to plot cross–country routes. They include many relevant details about every airport in the country, including all the thousands of smaller general avaition airports. Tall obstacles such as wind turbines and tall buildings are marked, as are sources of bright light such as stadiums. Urban areas, interstate highways, and major rail routes are also marked for improved situational awareness. All navigational beacons are plotted, and all control towers have their radio frequencies indicated. Airspace limitations and restrictions are prominant.

#### Describe the solution

This commit adds a new type of map to the game, tagged with WORLD_MAP. This new type of map works a little differently from the existing maps. The area revealed is centered around the midlands, rather than around the character who reads them. Instead of being labeled with a city name, they are labled with the name of the game world. Instead of finding multiple maps and reading each one once, the player is only allowed to read each type of world map once; multiple world maps convey no additional information.

The air chart currently implemented reveals terrain in a square 24 overmaps on a side, centered on the midlands. It takes my computer several minutes to generate all of that terrain, and several gigabytes of memory. During that time there is no feedback to the player that a long–running task is taking place. It’s a pretty bad experience, actually. Use with caution.

#### Describe alternatives you've considered

What we really should do is rearrange the terrain generation so that the locations of certain items within an overmap can be determined without needing to completely generate everything in the overmap.

Do we spawn items and monsters in these overmaps, even if they are far from the player? If so, perhaps the simplest change would be to defer that work and only generate the overmap terrain without actually doing the rest of the work. I don’t know enough about how it works, however, to make concrete recommendations.

#### Testing

Just manual testing.

#### Additional context

I picked the radius so that it would reveal the coastline, which is definitely included on the real maps.

Fixes #70327