### PR TITLE
select empty containers first when base crafting

### DIFF
--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -919,11 +919,24 @@ void basecamp_action_components::consume_components()
     for( const comp_selection<item_comp> &sel : item_selections_ ) {
         std::list<item> empty_consumed = player_character.consume_items( target_map, sel, batch_size_,
                                          is_empty_component, src );
-        if( empty_consumed.size() < static_cast<size_t>( sel.comp.count ) * batch_size_ ) {
+        int left_to_consume = 0;
+
+        if( empty_consumed.size() >= 1 && empty_consumed.front().count_by_charges() ) {
+            int consumed = 0;
+            for( item itm : empty_consumed ) {
+                consumed += itm.charges;
+            }
+            left_to_consume = sel.comp.count * batch_size_ - consumed;
+        } else if( empty_consumed.size() < static_cast<size_t>( sel.comp.count ) * batch_size_ ) {
+            left_to_consume = static_cast<size_t>( sel.comp.count ) * batch_size_ - empty_consumed.size();
+        }
+
+        if( left_to_consume > 0 ) {
             comp_selection<item_comp> remainder = sel;
             remainder.comp.count = 1;
             player_character.consume_items( target_map, remainder,
-                                            batch_size_ * sel.comp.count - empty_consumed.size(), is_crafting_component, src );
+                                            batch_size_ * static_cast<size_t>( sel.comp.count ) - empty_consumed.size(), is_crafting_component,
+                                            src );
         }
     }
     // this may consume pseudo-resources from fake items

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -921,9 +921,9 @@ void basecamp_action_components::consume_components()
                                          is_empty_component, src );
         int left_to_consume = 0;
 
-        if( empty_consumed.size() >= 1 && empty_consumed.front().count_by_charges() ) {
+        if( !empty_consumed.empty() && empty_consumed.front().count_by_charges() ) {
             int consumed = 0;
-            for( item itm : empty_consumed ) {
+            for( item &itm : empty_consumed ) {
                 consumed += itm.charges;
             }
             left_to_consume = sel.comp.count * batch_size_ - consumed;

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -354,9 +354,9 @@ static std::list<item> sane_consume_items( const comp_selection<item_comp> &it, 
         std::list<item> empty_consumed = crafter->consume_items( it, batch, empty_container_filter );
         int left_to_consume = 0;
 
-        if( empty_consumed.size() >= 1 && empty_consumed.front().count_by_charges() ) {
+        if( !empty_consumed.empty() && empty_consumed.front().count_by_charges() ) {
             int consumed = 0;
-            for( item itm : empty_consumed ) {
+            for( item &itm : empty_consumed ) {
                 consumed += itm.charges;
             }
             left_to_consume = it.comp.count * batch - consumed;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Ensure base camp crafting consumes empty containers first, before starting to consume ones in use.
- Fix #69504 , i.e do the same thing for PC/companion crafting.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Modify the component consumption code to first filter out containers in use before resorting to consuming ones in use (if needed).

Do the same thing for PC/companion crafting.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Before modifying the code:
- Add the broadhead arrow recipe to the bare bones camp personal recipe set.
- Remove all zones in the base camp.
- Add a two tile storage zone just in front of the bulletin board.
- Add storage zones as needed for "machinery" (anvil, forge) for the arrow recipe.
- Collect all component and tools required for a batch of 20 of the recipe, except for plastic bags, and drop them on one of the storage tiles.
- Collect 20 plastic bags with pepper and 20 empty plastic bags. Fight the blasted bag-in-bag syndrome and place 10 empty bags and 10 bags with pepper on each of the two storage tiles.
- Boost a companion to get the skills to produce the arrows.
- Save.
- Order the companion to make a batch of 20 arrows.
- See that all the bags on one tile are gone, while the mixed set of bags remain on the other. No idea where the pepper went, but I would suspect it was just removed, as I couldn't find it when searching a little.
- Kill the game.
- Modify and compile the code.
- Load the save and order the same companion to again make a batch of 20 arrows.
- See that the 10 empty bags from each tile were gone, while the pepper bags remained.
- Kill the game.
- Remove one empty bag from the first tile and drop it outside the zone range (to make sure the PC inventory doesn't come into play).
- Again order the construction of a batch of 20.
- See that all 19 empty bags were gone as well as one of the pepper bags.

- Gather the components needed for 20 makeshift arrows (spot too far away from anvil and forge for the other arrow recipe) in the same spot as the previous test.
- Clear out the area of bags that might be picked up (within range, as zones aren't relevant here),
- Order a companion to craft 20 makeshift arrows.
- Verify the 10 + 10 empty bags are used up, rather than all 20 bags from one of the tiles.
- Restart and regather stuff. Remove 5 empty bags from each of the two tiles.
- Order a companion to craft 20 makeshift arrows.
- Verify that all 15 bags are gone from one tile and the 5 empty ones from the second one, with 1000 pepper under the companion.
- Restart and repeat the second test.
- Verify the same result, bar the disappearance of the contents. Consider the contents part to be out of scope, as the task is to select the correct components.

Edit 5:
- Spawned items for balaclava production.
- Verified the correct number of threads were consumed by companion crafting both directly and via the bulletin board (after adding balclava (that's how the id is spelled...) to the personal crafting set).
- Verified that arrow crafting still works in both cases.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I don't know of a recipe that consumes more than one container per construction, so the code to deals with that remains untested for numbers higher than 1 (the arrow recipe is one I happen to use, so I knew about its bag consumption).

Off the top of my head I can't think of other simple situations where you'd want to preferentially use some components over other components, but I suspect the logic could easily be modified if such conditions are brought to light.
Note that I can think of non trivial situations, such as either using the oldest food items available for near term consumption, and the newest ones for long term storage, but then it's not a simple two pass logic.

It can be noted that there is a bug report for the corresponding issue with direct PC/companion crafting, but that code is elsewhere.

It can also be noted that there is a stale-bot killed bug report for the case where components aren't removed when crafting. It's suspicious that the preview info for crafting is taken from an inv_ variable, whereas the removal of items used loads a map and goes through zones to find components to remove. It doesn't exactly look like a guarantee that the two selection processes would process the same set of items. If inv_ is good enough for the UI step it ought to be good enough for the consumption step, and if it isn't, it shouldn't be good enough for UI presentation step.

PC/companion crafting appears to contain logic in the UI selection step to indicate of there aren't enough empty containers for craft. This logic is missing from the base camp crafting, but on the other hand, the base camp crafting selects the batch size after the UI step, whereas PC/companion crafting presents the info after the batch size has been selected. However, this info would be useful for the component selection step (if there is a choice to be made: if the recipe calls for 3L glass jars only you still wouldn't be notified).

Edit: I tried to add logic to spill container content, but that didn't work, presumably because the consume_items operation doesn't actually return a list of (copies of) the items removed, but rather a list of copies of the item used to match against, which obviously doesn't provide you with the contents of the actual items removed (or even copies of those contents).

Edit 2: The previous edit is wrong. The contents is eliminated by calls to remove_ammo within crafting.cpp operation Character::consume_items.

Edit 3: It turns out I can't understand #69893 and completely fail to understand how to replicate it. However, this OUGHT to address the same issue, although if it's intended to deal with zone construction I don't know if that's part of any of the two call chains addressed.

Edit 4: A test failure is actually relevant! Repeated what appears to be the test actions, and the thread consumption is indeed incorrect (19 thread for a balaclava rather than 10). Requires fault finding, so PR changed to draft.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
