### PR TITLE
Added sword tags back onto wooden training swords.

### DIFF
--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -13,6 +13,7 @@
     "to_hit": { "grip": "solid", "length": "long", "surface": "any", "balance": "neutral" },
     "price_postapoc": 50,
     "flags": [ "BELT_CLIP" ],
+    "weapon_category": [ "MEDIUM_SWORDS" ],
     "techniques": [ "WBLOCK_1" ],
     "melee_damage": { "bash": 12, "cut": 1 }
   },
@@ -31,7 +32,7 @@
     "to_hit": { "grip": "solid", "length": "long", "surface": "any", "balance": "uneven" },
     "price_postapoc": 50,
     "flags": [ "BELT_CLIP", "ALWAYS_TWOHAND" ],
-    "weapon_category": [ "GREAT_HAMMERS" ],
+    "weapon_category": [ "GREAT_SWORDS" ],
     "techniques": [ "WBLOCK_1", "SWEEP", "BRUTAL" ],
     "melee_damage": { "bash": 16, "cut": 2 }
   },
@@ -49,6 +50,7 @@
     "to_hit": { "grip": "solid", "length": "long", "surface": "any", "balance": "neutral" },
     "price_postapoc": 100,
     "techniques": [ "WBLOCK_1" ],
+    "weapon_category": [ "MEDIUM_SWORDS" ],
     "flags": [ "FRAGILE_MELEE", "BELT_CLIP" ],
     "melee_damage": { "bash": 12, "cut": 4 }
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Added sword tags back onto wooden training swords."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
PR #68582 pruned a little too aggressively around what qualified for various martial arts. Many of those changes were justified when it involved fencing, but did not make sense when involving HEMA-similar styles. I discussed this in #70110
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This re-adds a few missing tags to the early wooden swords. It also removes the club tag from the wooden greatsword, as the balance would be entirely wrong to work as a club.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
One could delete the swords entirely, since they have no purpose seperate from clubs if they cannot be used by medieval martial arts. But this is unrealistic in the extreme, since the weight and balance of such swords is meant to mimic a real weapon, and thus while they would lack damage, they would perform as a fine substitute.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded the game, spawned the various swords, confirmed that they work with the proper martial art.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I'm not entirely sure a 'nord' should exist, since driving a ton of nails into a wooden sword would probably just make it prone to breaking easily. But I can't find anything about nords in real life, so I felt it was beyond my knowledge to say they ought not to work at all.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
