### PR TITLE
Silence -Wmissing-declarations GCC warning in sdl_wrappers.h

### DIFF
--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -9,6 +9,7 @@
 #   include <SDL2/SDL_ttf.h>
 #else
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #   include <SDL.h>
 #pragma GCC diagnostic pop


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
#70301 broke MinGW cross-compile build: https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/7302931503/job/19903613365#step:14:720

```
In file included from /opt/mxe/usr/x86_64-w64-mingw32.static.gcc12/include/SDL2/SDL.h:32,
                 from ../src/sdl_wrappers.h:13,
                 from ../src/cata_tiles.h:26,
                 from ../src/map.h:50,
                 from ../tests/test_main.cpp:41:
Error: /opt/mxe/usr/x86_64-w64-mingw32.static.gcc12/include/SDL2/SDL_main.h:143:17: error: no previous declaration for 'int SDL_main(int, const char**)' [-Werror=missing-declarations]
  143 | #define main    SDL_main
      |                 ^~~~~~~~
/opt/mxe/usr/x86_64-w64-mingw32.static.gcc12/include/SDL2/SDL_main.h:143:17: note: in definition of macro 'main'
  143 | #define main    SDL_main
      |                 ^~~~~~~~
cc1plus: note: unrecognized command-line option '-Wno-dangling-reference' may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics
cc1plus: all warnings being treated as errors
make[1]: *** [Makefile:87: objwin/tiles/test_main.o] Error 1
```
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
In SDL headers it declares `SDL_main` after the macro definition and that causes the warning:
```c
#if defined(SDL_MAIN_NEEDED) || defined(SDL_MAIN_AVAILABLE)
#define main    SDL_main
#endif

#include <SDL2/begin_code.h>
#ifdef __cplusplus
extern "C" {
#endif

/**
 *  The prototype for the application's main() function
 */
typedef int (*SDL_main_func)(int argc, char *argv[]);
extern SDLMAIN_DECLSPEC int SDL_main(int argc, char *argv[]);
```

So try to suppress this warning in our `sdl_wrappers.h`.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Expecting MinGW cross-compile build passing in this pull request.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
