### PR TITLE
Invalidate draw point cache if viewport size or position changes

### DIFF
--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1359,7 +1359,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     }
     here.prev_min_mm_reg = min_mm_reg;
     here.prev_max_mm_reg = max_mm_reg;
-    
+
     you.prepare_map_memory_region(
         here.getglobal( tripoint( min_mm_reg, center.z ) ),
         here.getglobal( tripoint( max_mm_reg, center.z ) )

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1356,8 +1356,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
 
     //invalidate draw_points_cache if viewport dimensions have changed
     //recomputing these points even though they showed up above for cleanliness of code. Just an addition so shouldn't have a performance impact
-    point bottom_left = tile_to_player( { min_col, min_row } );
-    point top_right = tile_to_player( { max_col, max_row } );
+    std::optional<point> bottom_left = tile_to_player( { min_col, min_row } );
+    std::optional<point> top_right = tile_to_player( { max_col, max_row } );
     if( bottom_left != here.prev_bottom_left || top_right != here.prev_top_right ) {
         set_draw_cache_dirty();
     }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1356,8 +1356,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
 
     //invalidate draw_points_cache if viewport dimensions have changed
     //recomputing these points even though they showed up above for cleanliness of code. Just an addition so shouldn't have a performance impact
-    point bottom_left = tile_to_player( { min_col, min_row } )
-    point top_right = tile_to_player( { max_col, max_row } )
+    point bottom_left = tile_to_player( { min_col, min_row } );
+    point top_right = tile_to_player( { max_col, max_row } );
     if( bottom_left != here.prev_bottom_left || top_right != here.prev_top_right ) {
         set_draw_cache_dirty();
     }

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1305,7 +1305,8 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     const int min_row = bottom_any_tile_range.p_min.y;
     const int max_row = top_any_tile_range.p_max.y;
     //invalidate draw_points_cache if viewport dimensions have changed
-    if( min_col != here.prev_min_col || max_col != here.prev_max_col || min_row != here.prev_min_row || max_row != here.prev_max_row ) {
+    if( min_col != here.prev_min_col || max_col != here.prev_max_col || min_row != here.prev_min_row ||
+        max_row != here.prev_max_row ) {
         here.draw_points_cache_dirty = true;
     }
 

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1309,6 +1309,10 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         max_row != here.prev_max_row ) {
         here.draw_points_cache_dirty = true;
     }
+    here.prev_min_col = min_col
+    here.prev_max_col = max_col
+    here.prev_min_row = min_row
+    here.prev_max_row = max_row
 
     avatar &you = get_avatar();
     //limit the render area to maximum view range (121x121 square centered on player)

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1353,12 +1353,16 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                                 std::max( max_mm_reg.y, southeast->y ) );
         }
     }
+
     //invalidate draw_points_cache if viewport dimensions have changed
-    if( min_mm_reg != here.prev_min_mm_reg || max_mm_reg != here.prev_max_mm_reg ) {
+    //recomputing these points even though they showed up above for cleanliness of code. Just an addition so shouldn't have a performance impact
+    point bottom_left = tile_to_player( { min_col, min_row } )
+    point top_right = tile_to_player( { max_col, max_row } )
+    if( bottom_left != here.prev_bottom_left || top_right != here.prev_top_right ) {
         set_draw_cache_dirty();
     }
-    here.prev_min_mm_reg = min_mm_reg;
-    here.prev_max_mm_reg = max_mm_reg;
+    here.prev_bottom_left = bottom_left;
+    here.prev_top_right = top_right;
 
     you.prepare_map_memory_region(
         here.getglobal( tripoint( min_mm_reg, center.z ) ),

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1309,10 +1309,10 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
         max_row != here.prev_max_row ) {
         set_draw_cache_dirty();
     }
-    here.prev_min_col = min_col
-    here.prev_max_col = max_col
-    here.prev_min_row = min_row
-    here.prev_max_row = max_row
+    here.prev_min_col = min_col;
+    here.prev_max_col = max_col;
+    here.prev_min_row = min_row;
+    here.prev_max_row = max_row;
 
     avatar &you = get_avatar();
     //limit the render area to maximum view range (121x121 square centered on player)

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1304,6 +1304,10 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     const int max_col = top_any_tile_range.p_max.x;
     const int min_row = bottom_any_tile_range.p_min.y;
     const int max_row = top_any_tile_range.p_max.y;
+    //invalidate draw_points_cache if viewport dimensions have changed
+    if( min_col != here.prev_min_col || max_col != here.prev_max_col || min_row != here.prev_min_row || max_row != here.prev_max_row ) {
+        here.draw_points_cache_dirty = true;
+    }
 
     avatar &you = get_avatar();
     //limit the render area to maximum view range (121x121 square centered on player)

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1304,15 +1304,6 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     const int max_col = top_any_tile_range.p_max.x;
     const int min_row = bottom_any_tile_range.p_min.y;
     const int max_row = top_any_tile_range.p_max.y;
-    //invalidate draw_points_cache if viewport dimensions have changed
-    if( min_col != here.prev_min_col || max_col != here.prev_max_col || min_row != here.prev_min_row ||
-        max_row != here.prev_max_row ) {
-        set_draw_cache_dirty();
-    }
-    here.prev_min_col = min_col;
-    here.prev_max_col = max_col;
-    here.prev_min_row = min_row;
-    here.prev_max_row = max_row;
 
     avatar &you = get_avatar();
     //limit the render area to maximum view range (121x121 square centered on player)
@@ -1362,6 +1353,13 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
                                 std::max( max_mm_reg.y, southeast->y ) );
         }
     }
+    //invalidate draw_points_cache if viewport dimensions have changed
+    if( min_mm_reg != here.prev_min_mm_reg || max_mm_reg != here.prev_max_mm_reg ) {
+        set_draw_cache_dirty();
+    }
+    here.prev_min_mm_reg = min_mm_reg;
+    here.prev_max_mm_reg = max_mm_reg;
+    
     you.prepare_map_memory_region(
         here.getglobal( tripoint( min_mm_reg, center.z ) ),
         here.getglobal( tripoint( max_mm_reg, center.z ) )

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1356,13 +1356,14 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
 
     //invalidate draw_points_cache if viewport dimensions have changed
     //recomputing these points even though they showed up above for cleanliness of code. Just an addition so shouldn't have a performance impact
-    std::optional<point> bottom_left = tile_to_player( { min_col, min_row } );
-    std::optional<point> top_right = tile_to_player( { max_col, max_row } );
-    if( bottom_left != here.prev_bottom_left || top_right != here.prev_top_right ) {
+    point bottom_left( min_col, min_row );
+    point top_right( max_col, max_row );
+    if( bottom_left != here.prev_bottom_left || top_right != here.prev_top_right || o != here.prev_o ) {
         set_draw_cache_dirty();
     }
     here.prev_bottom_left = bottom_left;
     here.prev_top_right = top_right;
+    here.prev_o = o;
 
     you.prepare_map_memory_region(
         here.getglobal( tripoint( min_mm_reg, center.z ) ),

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1355,7 +1355,6 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     }
 
     //invalidate draw_points_cache if viewport dimensions have changed
-    //recomputing these points even though they showed up above for cleanliness of code. Just an addition so shouldn't have a performance impact
     point bottom_left( min_col, min_row );
     point top_right( max_col, max_row );
     if( bottom_left != here.prev_bottom_left || top_right != here.prev_top_right || o != here.prev_o ) {

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1355,13 +1355,13 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     }
 
     //invalidate draw_points_cache if viewport dimensions have changed
-    point bottom_left( min_col, min_row );
-    point top_right( max_col, max_row );
-    if( bottom_left != here.prev_bottom_left || top_right != here.prev_top_right || o != here.prev_o ) {
+    point bottom_right( min_col, min_row );
+    point top_left( max_col, max_row );
+    if( bottom_right != here.prev_bottom_right || top_left != here.prev_top_left || o != here.prev_o ) {
         set_draw_cache_dirty();
     }
-    here.prev_bottom_left = bottom_left;
-    here.prev_top_right = top_right;
+    here.prev_bottom_right = bottom_right;
+    here.prev_top_left = top_left;
     here.prev_o = o;
 
     you.prepare_map_memory_region(

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1355,13 +1355,13 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     }
 
     //invalidate draw_points_cache if viewport dimensions have changed
-    point bottom_right( min_col, min_row );
-    point top_left( max_col, max_row );
-    if( bottom_right != here.prev_bottom_right || top_left != here.prev_top_left || o != here.prev_o ) {
+    point top_left( min_col, min_row );
+    point bottom_right( max_col, max_row );
+    if( top_left != here.prev_top_left || bottom_right != here.prev_bottom_right || o != here.prev_o ) {
         set_draw_cache_dirty();
     }
-    here.prev_bottom_right = bottom_right;
     here.prev_top_left = top_left;
+    here.prev_bottom_right = bottom_right;
     here.prev_o = o;
 
     you.prepare_map_memory_region(

--- a/src/cata_tiles.cpp
+++ b/src/cata_tiles.cpp
@@ -1307,7 +1307,7 @@ void cata_tiles::draw( const point &dest, const tripoint &center, int width, int
     //invalidate draw_points_cache if viewport dimensions have changed
     if( min_col != here.prev_min_col || max_col != here.prev_max_col || min_row != here.prev_min_row ||
         max_row != here.prev_max_row ) {
-        here.draw_points_cache_dirty = true;
+        set_draw_cache_dirty();
     }
     here.prev_min_col = min_col
     here.prev_max_col = max_col

--- a/src/map.h
+++ b/src/map.h
@@ -2352,8 +2352,8 @@ class map
 #if defined(TILES)
         bool draw_points_cache_dirty = true;
         std::map<int, std::map<int, std::vector<tile_render_info>>> draw_points_cache;
-        point prev_bottom_left;
-        point prev_top_right;
+        point prev_bottom_right;
+        point prev_top_left;
         point prev_o;
         std::multimap<point, formatted_text> overlay_strings_cache;
         color_block_overlay_container color_blocks_cache;

--- a/src/map.h
+++ b/src/map.h
@@ -2352,8 +2352,8 @@ class map
 #if defined(TILES)
         bool draw_points_cache_dirty = true;
         std::map<int, std::map<int, std::vector<tile_render_info>>> draw_points_cache;
-        point prev_bottom_right;
         point prev_top_left;
+        point prev_bottom_right;
         point prev_o;
         std::multimap<point, formatted_text> overlay_strings_cache;
         color_block_overlay_container color_blocks_cache;

--- a/src/map.h
+++ b/src/map.h
@@ -2352,8 +2352,8 @@ class map
 #if defined(TILES)
         bool draw_points_cache_dirty = true;
         std::map<int, std::map<int, std::vector<tile_render_info>>> draw_points_cache;
-        point prev_min_mm_reg;
-        point prev_max_mm_reg;
+        point prev_bottom_left;
+        point prev_top_right;
         std::multimap<point, formatted_text> overlay_strings_cache;
         color_block_overlay_container color_blocks_cache;
 #endif

--- a/src/map.h
+++ b/src/map.h
@@ -2352,10 +2352,8 @@ class map
 #if defined(TILES)
         bool draw_points_cache_dirty = true;
         std::map<int, std::map<int, std::vector<tile_render_info>>> draw_points_cache;
-        int prev_min_col;
-        int prev_max_col;
-        int prev_min_row;
-        int prev_max_row;
+        point prev_min_mm_reg;
+        point prev_max_mm_reg;
         std::multimap<point, formatted_text> overlay_strings_cache;
         color_block_overlay_container color_blocks_cache;
 #endif

--- a/src/map.h
+++ b/src/map.h
@@ -2352,6 +2352,10 @@ class map
 #if defined(TILES)
         bool draw_points_cache_dirty = true;
         std::map<int, std::map<int, std::vector<tile_render_info>>> draw_points_cache;
+        int prev_min_col;
+        int prev_max_col;
+        int prev_min_row;
+        int prev_max_row;
         std::multimap<point, formatted_text> overlay_strings_cache;
         color_block_overlay_container color_blocks_cache;
 #endif

--- a/src/map.h
+++ b/src/map.h
@@ -2354,6 +2354,7 @@ class map
         std::map<int, std::map<int, std::vector<tile_render_info>>> draw_points_cache;
         point prev_bottom_left;
         point prev_top_right;
+        point prev_o;
         std::multimap<point, formatted_text> overlay_strings_cache;
         color_block_overlay_container color_blocks_cache;
 #endif


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Invalidate draw point cache if viewport size or position changes"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Attempt to implement the viewport caching suggested by @Qrox in #70355. 
Fixes #70351, fixes #70408.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Save the previous corners of the viewport and invalidate draw_points_cache if they have changed
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Testing
Game compiled successfully. "List all items around the player" and "Look around" function as expected again.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Credit goes to @Rewryte for figuring out the problem and @Qrox for the (hopefully) more robust solution.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
