### PR TITLE
Adds fancy log messages for characters high on weed

### DIFF
--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -31,19 +31,21 @@
 
 #include "options.h"
 
+static const efftype_id effect_weed_high( "weed_high" );
+
 namespace
 {
 
 struct game_message {
     std::string       message;
-    time_point timestamp_in_turns  = calendar::turn_zero;
+    time_point timestamp_in_turns = calendar::turn_zero;
     int               timestamp_in_user_actions = 0; // NOLINT(cata-serialize)
     int               count = 1;
     // number of times this message has been seen while it was in cooldown.
     unsigned cooldown_seen = 1; // NOLINT(cata-serialize)
     // hide the message, because at some point it was in cooldown period.
     bool cooldown_hidden = false; // NOLINT(cata-serialize)
-    game_message_type type  = m_neutral;
+    game_message_type type = m_neutral;
 
     game_message() = default;
     game_message( std::string &&msg, game_message_type const t ) :
@@ -94,7 +96,7 @@ struct game_message {
         return c_dark_gray;
     }
 
-    void deserialize( const JsonObject &obj )  {
+    void deserialize( const JsonObject &obj ) {
         obj.read( "turn", timestamp_in_turns );
         message = obj.get_string( "message" );
         count = obj.get_int( "count" );
@@ -176,6 +178,108 @@ class messages_impl
 
             if( type == m_debug && !debug_mode ) {
                 return;
+            }
+
+            // add smileys to messages if the player is high on weed
+            Character *p_char = &get_player_character();
+            if( p_char->has_effect( effect_weed_high ) ) {
+
+                const time_duration weed_dur = p_char->get_effect_dur( effect_weed_high );
+                const float in_minutes = to_minutes<float>( weed_dur );
+                // we will now calculate how often smiley faces should appear in messages.
+                // Slowly rises. 0 at 0, 1 at 22.5, 2 at 45 mins. Asymptote at 3.
+                const float max_per_msg = 3 - 3 / ( 1 + 0.001 * in_minutes * in_minutes );
+                //possible values for smiles_for_this_msg are 0,1,2,3.
+                int smiles_for_this_msg = static_cast<int>( round( rng_normal( 0, max_per_msg ) ) );
+
+                // now insert the smiley face somewhere in the msg string. We want to avoid breaking up words, so we will only replace spaces.
+                // find all suitable locations for smiley. That is, end of message + all spaces (except after certain words)
+                std::vector<size_t> smiley_locations;
+                // we also need to track space locations to extract words properly. Annoying but necessary.
+                std::vector<size_t> space_locations;
+
+                // end of msg
+                smiley_locations.push_back( msg.size() );
+                // now all spaces
+                for( size_t j = 0; j < msg.size(); j++ ) {
+                    if( msg[j] == ' ' ) {
+                        bool wordskip = false;
+                        // fancy logic. It's weird if the smiley comes after "to" or "that" or "a". Let's try and skip words like those.
+                        // We skip all short words (<=3 letters), and all words in the forbidden_words array.
+                        if( !space_locations.empty() ) {
+                            const size_t prev_space = space_locations.back();
+                            // if prev_space is the previous char, skip
+                            if( prev_space == j - 1 ) {
+                                wordskip = true;
+                            }
+                            // check that smiley_locations.back() did not return none
+                            if( prev_space != std::string::npos ) {
+                                const std::string word = msg.substr( prev_space, j - prev_space );
+                                const std::string forbidden_words[] = { " that", " with", " this", " over", " your", " onto" };
+                                for( const std::string &forbidden_word : forbidden_words ) {
+                                    if( word == forbidden_word ) {
+                                        wordskip = true;
+                                        break;
+                                    }
+                                }
+                                if( word.size() > 1 && word.size() <= 4 ) {
+                                    wordskip = true;
+                                }
+                            }
+                        } else {
+                            // skip very first word
+                            wordskip = true;
+                        }
+                        space_locations.push_back( j );
+                        if( !wordskip ) {
+                            smiley_locations.push_back( j );
+                        }
+                    }
+                }
+                // first, check if smiles_for_this_msg == len(smiley_locations)
+                if( smiles_for_this_msg >= static_cast<int>( smiley_locations.size() ) ) {
+                    smiles_for_this_msg = static_cast<int>( smiley_locations.size() ) - 1;
+                }
+                // then pick one at random
+                for( int i = 0; i < smiles_for_this_msg; i++ ) {
+                    const size_t smiley_location = random_entry_removed( smiley_locations );
+                    std::string smiley_string = " :)";
+                    if( type == m_good || type == m_critical ) {
+                        if( one_in( 5 ) ) {
+                            smiley_string = " :D";
+                        }
+                    }
+                    msg.insert( smiley_location, smiley_string );
+                    for( size_t j = 0; j < smiley_locations.size(); j++ ) {
+                        if( smiley_locations[j] > smiley_location ) {
+                            // we increment to account for the insertion of the smiley string
+                            smiley_locations[j] += 3;
+                        }
+                    }
+                }
+
+                // if we are *very* high, there will be a chance to finish a long message with an exclamation
+                if( smiles_for_this_msg > 1 ) {
+                    int woah_chance = static_cast<int>( 10 / smiles_for_this_msg );
+                    if( msg.size() > 16 && one_in( woah_chance ) ) {
+                        std::vector<std::string> exclamations = {
+                            "Woah.", "Dude."
+                        };
+                        std::vector<std::string> good_exclamations = {
+                            "Cool!", "Wicked!", "Awesome!"
+                        };
+                        std::vector<std::string> bad_exclamations = {
+                            "Not cool.", "Oof.", "Bummer."
+                        };
+                        if( type == m_good || type == m_critical || type == m_headshot ) {
+                            msg += " " + random_entry( good_exclamations );
+                        } else if( type == m_bad || type == m_grazing ) {
+                            msg += " " + random_entry( bad_exclamations );
+                        } else {
+                            msg += " " + random_entry( exclamations );
+                        }
+                    }
+                }
             }
 
             game_message m = game_message( std::move( msg ), type );

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -247,104 +247,105 @@ class messages_impl
         void modify_msg_with_exclamations( std::string &msg, game_message_type const type ) {
             // add smileys to messages if the player is high on weed
             Character *p_char = &get_player_character();
-            if( p_char->has_effect( effect_weed_high ) ) {
+            if( !p_char->has_effect( effect_weed_high ) ) {
+                return;
+            }
 
-                const time_duration weed_dur = p_char->get_effect_dur( effect_weed_high );
-                const float in_minutes = to_minutes<float>( weed_dur );
-                // we will now calculate how often smiley faces should appear in messages.
-                // Slowly rises. 0 at 0, 1 at 22.5, 2 at 45 mins. Asymptote at 3.
-                const float max_per_msg = 3 - 3 / ( 1 + 0.001 * in_minutes * in_minutes );
-                //possible values for smiles_for_this_msg are 0,1,2,3.
-                int smiles_for_this_msg = static_cast<int>( round( rng_normal( 0, max_per_msg ) ) );
+            const time_duration weed_dur = p_char->get_effect_dur( effect_weed_high );
+            const float in_minutes = to_minutes<float>( weed_dur );
+            // we will now calculate how often smiley faces should appear in messages.
+            // Slowly rises. 0 at 0, 1 at 22.5, 2 at 45 mins. Asymptote at 3.
+            const float max_per_msg = 3 - 3 / ( 1 + 0.001 * in_minutes * in_minutes );
+            //possible values for smiles_for_this_msg are 0,1,2,3.
+            int smiles_for_this_msg = static_cast<int>( round( rng_normal( 0, max_per_msg ) ) );
 
-                // now insert the smiley face somewhere in the msg string. We want to avoid breaking up words, so we will only replace spaces.
-                // find all suitable locations for smiley. That is, end of message + all spaces (except after certain words)
-                std::vector<size_t> smiley_locations;
-                // we also need to track space locations to extract words properly. Annoying but necessary.
-                std::vector<size_t> space_locations;
+            // now insert the smiley face somewhere in the msg string. We want to avoid breaking up words, so we will only replace spaces.
+            // find all suitable locations for smiley. That is, end of message + all spaces (except after certain words)
+            std::vector<size_t> smiley_locations;
+            // we also need to track space locations to extract words properly. Annoying but necessary.
+            std::vector<size_t> space_locations;
 
-                // end of msg
-                smiley_locations.push_back( msg.size() );
-                // now all spaces
-                for( size_t j = 0; j < msg.size(); j++ ) {
-                    if( msg[j] == ' ' ) {
-                        bool wordskip = false;
-                        // fancy logic. It's weird if the smiley comes after "to" or "that" or "a". Let's try and skip words like those.
-                        // We skip all short words (<=3 letters), and all words in the forbidden_words array.
-                        if( !space_locations.empty() ) {
-                            const size_t prev_space = space_locations.back();
-                            // if prev_space is the previous char, skip
-                            if( prev_space == j - 1 ) {
-                                wordskip = true;
-                            }
-                            // check that smiley_locations.back() did not return none
-                            if( prev_space != std::string::npos ) {
-                                const std::string word = msg.substr( prev_space, j - prev_space );
-                                const std::array<std::string, 6> forbidden_words = { " that", " with", " this", " over", " your", " onto" };
-                                for( const std::string &forbidden_word : forbidden_words ) {
-                                    if( word == forbidden_word ) {
-                                        wordskip = true;
-                                        break;
-                                    }
-                                }
-                                if( word.size() > 1 && word.size() <= 4 ) {
-                                    wordskip = true;
-                                }
-                            }
-                        } else {
-                            // skip very first word
+            // end of msg
+            smiley_locations.push_back( msg.size() );
+            // now all spaces
+            for( size_t j = 0; j < msg.size(); j++ ) {
+                if( msg[j] == ' ' ) {
+                    bool wordskip = false;
+                    // fancy logic. It's weird if the smiley comes after "to" or "that" or "a". Let's try and skip words like those.
+                    // We skip all short words (<=3 letters), and all words in the forbidden_words array.
+                    if( !space_locations.empty() ) {
+                        const size_t prev_space = space_locations.back();
+                        // if prev_space is the previous char, skip
+                        if( prev_space == j - 1 ) {
                             wordskip = true;
                         }
-                        space_locations.push_back( j );
-                        if( !wordskip ) {
-                            smiley_locations.push_back( j );
+                        // check that smiley_locations.back() did not return none
+                        if( prev_space != std::string::npos ) {
+                            const std::string word = msg.substr( prev_space, j - prev_space );
+                            const std::array<std::string, 6> forbidden_words = { " that", " with", " this", " over", " your", " onto" };
+                            for( const std::string &forbidden_word : forbidden_words ) {
+                                if( word == forbidden_word ) {
+                                    wordskip = true;
+                                    break;
+                                }
+                            }
+                            if( word.size() > 1 && word.size() <= 4 ) {
+                                wordskip = true;
+                            }
                         }
+                    } else {
+                        // skip very first word
+                        wordskip = true;
+                    }
+                    space_locations.push_back( j );
+                    if( !wordskip ) {
+                        smiley_locations.push_back( j );
                     }
                 }
-                // first, check if smiles_for_this_msg == len(smiley_locations)
-                if( smiles_for_this_msg >= static_cast<int>( smiley_locations.size() ) ) {
-                    smiles_for_this_msg = static_cast<int>( smiley_locations.size() ) - 1;
-                }
-                // then pick one at random
-                for( int i = 0; i < smiles_for_this_msg; i++ ) {
-                    const size_t smiley_location = random_entry_removed( smiley_locations );
-                    std::string smiley_string = " :)";
-                    if( type == m_good || type == m_critical ) {
-                        if( one_in( 5 ) ) {
-                            smiley_string = " :D";
-                        }
-                    }
-                    msg.insert( smiley_location, smiley_string );
-                    //for( size_t j = 0; j < smiley_locations.size(); j++ ) {
-                    // modernize-loop-convert. Use range-based for loop instead.
-                    for( size_t &smil_loc : smiley_locations ) {
-                        if( smil_loc > smiley_location ) {
-                            // we increment to account for the insertion of the smiley string
-                            smil_loc += 3;
-                        }
+            }
+            // first, check if smiles_for_this_msg == len(smiley_locations)
+            if( smiles_for_this_msg >= static_cast<int>( smiley_locations.size() ) ) {
+                smiles_for_this_msg = static_cast<int>( smiley_locations.size() ) - 1;
+            }
+            // then pick one at random
+            for( int i = 0; i < smiles_for_this_msg; i++ ) {
+                const size_t smiley_location = random_entry_removed( smiley_locations );
+                std::string smiley_string = " :)";
+                if( type == m_good || type == m_critical ) {
+                    if( one_in( 5 ) ) {
+                        smiley_string = " :D";
                     }
                 }
+                msg.insert( smiley_location, smiley_string );
+                //for( size_t j = 0; j < smiley_locations.size(); j++ ) {
+                // modernize-loop-convert. Use range-based for loop instead.
+                for( size_t &smil_loc : smiley_locations ) {
+                    if( smil_loc > smiley_location ) {
+                        // we increment to account for the insertion of the smiley string
+                        smil_loc += 3;
+                    }
+                }
+            }
 
-                // if we are *very* high, there will be a chance to finish a long message with an exclamation
-                if( smiles_for_this_msg > 1 ) {
-                    int woah_chance = static_cast<int>( 10 / smiles_for_this_msg );
-                    if( msg.size() > 16 && one_in( woah_chance ) ) {
-                        std::vector<std::string> exclamations = {
-                            "Woah.", "Dude."
-                        };
-                        std::vector<std::string> good_exclamations = {
-                            "Cool!", "Wicked!", "Awesome!"
-                        };
-                        std::vector<std::string> bad_exclamations = {
-                            "Not cool.", "Oof.", "Bummer."
-                        };
-                        if( type == m_good || type == m_critical || type == m_headshot ) {
-                            msg += " " + random_entry( good_exclamations );
-                        } else if( type == m_bad || type == m_grazing ) {
-                            msg += " " + random_entry( bad_exclamations );
-                        } else {
-                            msg += " " + random_entry( exclamations );
-                        }
+            // if we are *very* high, there will be a chance to finish a long message with an exclamation
+            if( smiles_for_this_msg > 1 ) {
+                int woah_chance = static_cast<int>( 10 / smiles_for_this_msg );
+                if( msg.size() > 16 && one_in( woah_chance ) ) {
+                    std::vector<std::string> exclamations = {
+                        "Woah.", "Dude."
+                    };
+                    std::vector<std::string> good_exclamations = {
+                        "Cool!", "Wicked!", "Awesome!"
+                    };
+                    std::vector<std::string> bad_exclamations = {
+                        "Not cool.", "Oof.", "Bummer."
+                    };
+                    if( type == m_good || type == m_critical || type == m_headshot ) {
+                        msg += " " + random_entry( good_exclamations );
+                    } else if( type == m_bad || type == m_grazing ) {
+                        msg += " " + random_entry( bad_exclamations );
+                    } else {
+                        msg += " " + random_entry( exclamations );
                     }
                 }
             }

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -33,6 +33,7 @@
 
 static const efftype_id effect_weed_high( "weed_high" );
 
+
 namespace
 {
 

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -215,7 +215,7 @@ class messages_impl
                             // check that smiley_locations.back() did not return none
                             if( prev_space != std::string::npos ) {
                                 const std::string word = msg.substr( prev_space, j - prev_space );
-                                const std::string forbidden_words[] = { " that", " with", " this", " over", " your", " onto" };
+                                const std::array<std::string, 6> forbidden_words = { " that", " with", " this", " over", " your", " onto" };
                                 for( const std::string &forbidden_word : forbidden_words ) {
                                     if( word == forbidden_word ) {
                                         wordskip = true;
@@ -250,10 +250,12 @@ class messages_impl
                         }
                     }
                     msg.insert( smiley_location, smiley_string );
-                    for( size_t j = 0; j < smiley_locations.size(); j++ ) {
-                        if( smiley_locations[j] > smiley_location ) {
+                    //for( size_t j = 0; j < smiley_locations.size(); j++ ) {
+                    // modernize-loop-convert. Use range-based for loop instead.
+                    for( size_t &smil_loc : smiley_locations ) {
+                        if( smil_loc > smiley_location ) {
                             // we increment to account for the insertion of the smiley string
-                            smiley_locations[j] += 3;
+                            smil_loc += 3;
                         }
                     }
                 }

--- a/src/messages.cpp
+++ b/src/messages.cpp
@@ -33,7 +33,6 @@
 
 static const efftype_id effect_weed_high( "weed_high" );
 
-
 namespace
 {
 

--- a/src/messages.h
+++ b/src/messages.h
@@ -216,4 +216,7 @@ inline void add_msg_debug_if_player_sees( const Creature &target, debugmode::deb
     }
 }
 
+void add_msg_player_or_npc( const game_message_params &params, std::string msg,
+                               const Creature *const speaker );
+
 #endif // CATA_SRC_MESSAGES_H

--- a/src/messages.h
+++ b/src/messages.h
@@ -216,6 +216,6 @@ inline void add_msg_debug_if_player_sees( const Creature &target, debugmode::deb
     }
 }
 
-void modify_msg_with_exclamations( std::string &msg, game_message_type const type );
+void modify_msg_with_exclamations( std::string &msg, game_message_type type );
 
 #endif // CATA_SRC_MESSAGES_H

--- a/src/messages.h
+++ b/src/messages.h
@@ -216,7 +216,6 @@ inline void add_msg_debug_if_player_sees( const Creature &target, debugmode::deb
     }
 }
 
-void add_msg_player_or_npc( const game_message_params &params, std::string msg,
-                               const Creature *const speaker );
+void modify_msg_with_exclamations( std::string &msg, game_message_type const type );
 
 #endif // CATA_SRC_MESSAGES_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "High characters now see fancy smiley faces and exclamations in their message log."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Based on Erk's suggestion in #53152.
This will make being high more fun, introducing harmless (hopefully not too annoying) smiley faces and exclamations in the log.


<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

At most, you will see 3 smiley faces per message, and that is if you are *very* high. Most messages will have 0 to 1 smiley faces. The logic behind is a bit complex: I am only inserting the smiley faces between words, and they can only go after words that are long enough. The intent is to stop a smiley being added before words like "a" or "the", as they make it harder to read the log. Smiley faces can also go at the end of any chat message.

Furthermore, past a certain weed threshold, long messages may end in an exclamation, such as "Woah.", "Dude." (generic messages), "Wicked!" (good messages/critical hits) or "Bummer." (bad messages).
This is also inspired by Erk's suggestions.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

I would appreciate feedback on whether this happens too often or not. I can certainly tone down the frequency of both smileys and explanations, but this seems reasonable to me and is a cool flavor effect.

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/25616971/e877da42-9f75-44ac-9506-4204d4e35018)
(image is old, I have made the smiley handling smarter so that their placement is more consistent).
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
