### PR TITLE
Fix using variables for spawning items

### DIFF
--- a/src/mission.cpp
+++ b/src/mission.cpp
@@ -767,7 +767,7 @@ character_id mission::get_npc_id() const
     return npc_id;
 }
 
-const std::vector<std::pair<int, itype_id>> &mission::get_likely_rewards() const
+const talk_effect_fun_t::likely_rewards_t &mission::get_likely_rewards() const
 {
     return type->likely_rewards;
 }

--- a/src/mission.h
+++ b/src/mission.h
@@ -201,7 +201,7 @@ struct mission_type {
         bool has_generic_rewards = true;
 
         // A limited subset of the talk_effects on the mission
-        std::vector<std::pair<int, itype_id>> likely_rewards;
+        talk_effect_fun_t::likely_rewards_t likely_rewards;
 
         // Points of origin
         std::vector<mission_origin> origins;
@@ -349,7 +349,7 @@ class mission
         int get_id() const;
         const itype_id &get_item_id() const;
         character_id get_npc_id() const;
-        const std::vector<std::pair<int, itype_id>> &get_likely_rewards() const;
+        const talk_effect_fun_t::likely_rewards_t &get_likely_rewards() const;
         bool has_generic_rewards() const;
         void register_kill_needed() {
             monster_kill_goal++;

--- a/src/mission_ui.cpp
+++ b/src/mission_ui.cpp
@@ -97,13 +97,25 @@ void game::list_missions()
         draw_scrollbar( w_missions, selection, entries_per_page, umissions.size(), point( 0, 3 ) );
 
         mission_row_coords.clear();
+        dialogue d( get_talker_for( get_avatar() ), nullptr, {} );
+        auto format_tokenized_description = [&d]( const std::string & description,
+        const talk_effect_fun_t::likely_rewards_t &rewards ) {
+            std::string formatted_description = description;
+            for( const auto &reward : rewards ) {
+                std::string token = "<reward_count:" + itype_id( reward.second.evaluate( d ) ).str() + ">";
+                formatted_description = string_replace( formatted_description, token, string_format( "%g",
+                                                        reward.first.evaluate( d ) ) );
+            }
+            parse_tags( formatted_description, get_avatar(), get_avatar() );
+            return formatted_description;
+        };
         for( int i = top_of_page; i <= bottom_of_page; i++ ) {
             mission *miss = umissions[i];
             const nc_color col = u.get_active_mission() == miss ? c_light_green : c_white;
             const int y = i - top_of_page + 3;
             trim_and_print( w_missions, point( 1, y ), MAX_CHARS_PER_MISSION_ROW_NAME,
                             static_cast<int>( selection ) == i ? hilite( col ) : col,
-                            miss->name() );
+                            format_tokenized_description( miss->name(), miss->get_likely_rewards() ) );
             inclusive_rectangle<point> rec( point( 1, y ), point( 1 + MAX_CHARS_PER_MISSION_ROW_NAME - 1, y ) );
             mission_row_coords.emplace( i, rec );
         }
@@ -121,16 +133,6 @@ void game::list_missions()
 
             int y = 3;
 
-            auto format_tokenized_description = []( const std::string & description,
-            const std::vector<std::pair<int, itype_id>> &rewards ) {
-                std::string formatted_description = description;
-                for( const auto &reward : rewards ) {
-                    std::string token = "<reward_count:" + reward.second.str() + ">";
-                    formatted_description = string_replace( formatted_description, token, string_format( "%d",
-                                                            reward.first ) );
-                }
-                return formatted_description;
-            };
             y += fold_and_print( w_missions, point( 41, y ), getmaxx( w_missions ) - 43, col,
                                  format_tokenized_description( miss->name(), miss->get_likely_rewards() ) + for_npc );
             y++;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3072,9 +3072,7 @@ void talk_effect_fun_t::set_spawn_item( const JsonObject &jo, std::string_view m
                       suppress_message, flags_str, add_talker, target_location, force_equip );
     };
     dialogue d( get_talker_for( get_avatar() ), nullptr, {} );
-    likely_rewards.emplace_back( static_cast<int>( count.min.dbl_val.value_or(
-                                     count.min.default_val.value_or( 1 ) ) ),
-                                 itype_id( item_name.default_val.value_or( item_name.str_val.value_or( "" ) ) ) );
+    likely_rewards.emplace_back( count, item_name );
 }
 
 void talk_effect_fun_t::set_u_buy_item( const JsonObject &jo, std::string_view member )
@@ -3897,7 +3895,7 @@ void talk_effect_fun_t::set_add_mission( const JsonObject &jo, std::string_view 
     };
 }
 
-const std::vector<std::pair<int, itype_id>> &talk_effect_fun_t::get_likely_rewards() const
+const talk_effect_fun_t::likely_rewards_t &talk_effect_fun_t::get_likely_rewards() const
 {
     return likely_rewards;
 }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3072,8 +3072,9 @@ void talk_effect_fun_t::set_spawn_item( const JsonObject &jo, std::string_view m
                       suppress_message, flags_str, add_talker, target_location, force_equip );
     };
     dialogue d( get_talker_for( get_avatar() ), nullptr, {} );
-    likely_rewards.emplace_back( static_cast<int>( count.evaluate( d ) ),
-                                 itype_id( item_name.evaluate( d ) ) );
+    likely_rewards.emplace_back( static_cast<int>( count.min.dbl_val.value_or(
+                                     count.min.default_val.value_or( 1 ) ) ),
+                                 itype_id( item_name.default_val.value_or( item_name.str_val.value_or( "" ) ) ) );
 }
 
 void talk_effect_fun_t::set_u_buy_item( const JsonObject &jo, std::string_view member )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #68747
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
