### PR TITLE
goodbye, redundant lab subway sounds

### DIFF
--- a/data/json/effects_on_condition/misc_effect_on_condition.json
+++ b/data/json/effects_on_condition/misc_effect_on_condition.json
@@ -19,14 +19,6 @@
   },
   {
     "type": "effect_on_condition",
-    "id": "ambient_lab_subway",
-    "recurrence": [ "1 hours", "2 hours" ],
-    "global": true,
-    "condition": { "or": [ { "u_at_om_location": "lab_subway_ns" }, { "u_at_om_location": "lab_subway_ew" } ] },
-    "effect": [ { "u_message": "AMBIENT_LAB_SUBWAY", "snippet": true, "sound": true } ]
-  },
-  {
-    "type": "effect_on_condition",
     "id": "robofac_surveillance",
     "recurrence": [ "1 days", "7 days" ],
     "global": true,

--- a/data/json/snippets/effect_on_conditions.json
+++ b/data/json/snippets/effect_on_conditions.json
@@ -537,25 +537,6 @@
   },
   {
     "type": "snippet",
-    "category": "AMBIENT_LAB_SUBWAY",
-    "text": [
-      "<AMBIENT_SUBWAY>",
-      "These tunnels look even more utilitarian than those of the normal line, with barely any emergency lights - not that they'd help you without power, of course.",
-      "Do you still know where you're going?  Did you ever?",
-      "You could swear you already saw this spot already.  Did you get turned around, or did the tunnels shift with you?",
-      "Bullet marks pock the walls, interspersed with finger-deep scratches and dried blood.",
-      "A bobbing light in the distance, a flurry of movement, and a drawn-out scream.  You're alone with the darkness, again.",
-      "Behind you.",
-      "It is peaceful down here, away from the harsh sun and the noises of the new world.  You could lose yourself in the dark, still embrace of the tunnels.  Maybe you want to.",
-      "The tunnel's wall is covered in a thin membrane of shuddering flesh, growing (flowing?  crawling?) from a broken pipe.  You keep your distance.",
-      "You notice a single line of three-fingered footprints, starting on the floor but continuing without pause on the walls before disappearing in a hole on the ceiling that's dripping sticky, bluish ichor.",
-      "There is a shimmering spot above the rails.  Looking through, you can see the night sky and hear something howl with hatred and hunger.  You're certain it could not pass through an opening so small.  You're also certain the gateway will grow.",
-      "The wall is carpeted by green-gray mushrooms, their caps turning towards you with anticipation.",
-      "The wall's concrete is warped into a spiral relief, drawing your eye inexorably to its center.  You force yourself to look away, and feel something shift behind the wall."
-    ]
-  },
-  {
-    "type": "snippet",
     "category": "play_piano",
     "text": [
       "You play a short, light-hearted ditty.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

Lab subways (`lab_subway_ns`/`lab_subway_ew`) have been removed since quite a while. I do not know since when exactly but these unused snippets and its eoc are leftovers.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Remove them.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

Reuse them? Due to the nature of any VCS they will never be lost though.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

None, the tests will suffice since this is just removing an eoc that will never trigger and its list of messages.
I have grepped the *entire* repo and except for the tilesets there are no references to this overmap terrain at all anymore.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
