### PR TITLE
Fix cabled-only pseudo-tools, part 2

### DIFF
--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2369,8 +2369,8 @@ struct weldrig_hack {
             return null_item_reference();
         }
         pseudo.ammo_set( itype_battery, part->vehicle().drain( itype_battery,
-                         return_true< vehicle_part &>,
-                         pseudo.ammo_capacity( ammo_battery ), false ) ); // no cable loss since all of this is virtual
+                         pseudo.ammo_capacity( ammo_battery ),
+                         return_true< vehicle_part &>, false ) ); // no cable loss since all of this is virtual
         return pseudo;
     }
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2369,7 +2369,7 @@ struct weldrig_hack {
             return null_item_reference();
         }
         pseudo.ammo_set( itype_battery, part->vehicle().drain( itype_battery,
-                         pseudo.ammo_capacity( ammo_battery ) , false ) ); // no cable loss since all of this is virtual
+                         pseudo.ammo_capacity( ammo_battery ), false ) ); // no cable loss since all of this is virtual
         return pseudo;
     }
 

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2378,7 +2378,8 @@ struct weldrig_hack {
             return;
         }
 
-        part->vehicle().charge_battery( pseudo.ammo_remaining(), false ); // return unused charges without cable loss
+        part->vehicle().charge_battery( pseudo.ammo_remaining(),
+                                        false ); // return unused charges without cable loss
     }
 
     ~weldrig_hack() {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2369,6 +2369,7 @@ struct weldrig_hack {
             return null_item_reference();
         }
         pseudo.ammo_set( itype_battery, part->vehicle().drain( itype_battery,
+                         return_true< vehicle_part &>,
                          pseudo.ammo_capacity( ammo_battery ), false ) ); // no cable loss since all of this is virtual
         return pseudo;
     }

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2369,7 +2369,7 @@ struct weldrig_hack {
             return null_item_reference();
         }
         pseudo.ammo_set( itype_battery, part->vehicle().drain( itype_battery,
-                         pseudo.ammo_capacity( ammo_battery ) ) );
+                         pseudo.ammo_capacity( ammo_battery ) , false ) ); // no cable loss since all of this is virtual
         return pseudo;
     }
 
@@ -2378,7 +2378,7 @@ struct weldrig_hack {
             return;
         }
 
-        part->vehicle().charge_battery( pseudo.ammo_remaining() ); // return unused charges
+        part->vehicle().charge_battery( pseudo.ammo_remaining(), false ); // return unused charges without cable loss
     }
 
     ~weldrig_hack() {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -6978,7 +6978,7 @@ std::string item::display_name( unsigned int quantity ) const
         } else {
             max_amount = ammo_capacity( item_controller->find_template( ammo_default() )->ammo->type );
         }
-        show_amt = ( !has_flag( flag_RELOAD_AND_SHOOT ) && !has_flag( flag_PSEUDO ) );
+        show_amt = !has_flag( flag_RELOAD_AND_SHOOT );
     } else if( count_by_charges() && !has_infinite_charges() ) {
         // A chargeable item
         amount = charges;
@@ -7013,7 +7013,7 @@ std::string item::display_name( unsigned int quantity ) const
         }
     }
 
-    if( amount || show_amt ) {
+    if( ( amount || show_amt ) && !has_flag( flag_PSEUDO ) ) {
         if( is_money() ) {
             amt = " " + format_money( amount );
         } else {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3539,7 +3539,7 @@ int vehicle::drain( const int index, int amount, bool apply_loss )
         //to not break existing code, but C++ requires you also invoke all optional
         //arguments to the left of any invoked. make sure to change this if the default for
         //filters in the function above ever changes
-        return drain( fuel_type_battery, amount, return_true< vehicle_part &>, apply_loss ); 
+        return drain( fuel_type_battery, amount, return_true< vehicle_part &>, apply_loss );
     }
     if( !pt.is_tank() || !pt.ammo_remaining() ) {
         debugmsg( "Tried to drain something without any liquid: %s amount: %d ammo: %d",

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -3493,13 +3493,14 @@ int vehicle::fuel_capacity( const itype_id &ftype ) const
 }
 
 int vehicle::drain( const itype_id &ftype, int amount,
-                    const std::function<bool( vehicle_part & )> &filter )
+                    const std::function<bool( vehicle_part & )> &filter,
+                    bool apply_loss )
 {
     if( ftype == fuel_type_battery ) {
         // Batteries get special handling to take advantage of jumper
         // cables -- discharge_battery knows how to recurse properly
         // (including taking cable power loss into account).
-        int remnant = discharge_battery( amount );
+        int remnant = discharge_battery( amount, apply_loss );
 
         // discharge_battery returns amount of charges that were not
         // found anywhere in the power network, whereas this function
@@ -3526,7 +3527,7 @@ int vehicle::drain( const itype_id &ftype, int amount,
     return drained;
 }
 
-int vehicle::drain( const int index, int amount )
+int vehicle::drain( const int index, int amount, bool apply_loss )
 {
     if( index < 0 || index >= static_cast<int>( parts.size() ) ) {
         debugmsg( "Tried to drain an invalid part index: %d", index );
@@ -3534,7 +3535,11 @@ int vehicle::drain( const int index, int amount )
     }
     vehicle_part &pt = parts[index];
     if( pt.ammo_current() == fuel_type_battery ) {
-        return drain( fuel_type_battery, amount );
+        //return_true< vehicle_part &> is needed because apply_loss needs to be last arg
+        //to not break existing code, but C++ requires you also invoke all optional
+        //arguments to the left of any invoked. make sure to change this if the default for
+        //filters in the function above ever changes
+        return drain( fuel_type_battery, amount, return_true< vehicle_part &>, apply_loss ); 
     }
     if( !pt.is_tank() || !pt.ammo_remaining() ) {
         debugmsg( "Tried to drain something without any liquid: %s amount: %d ammo: %d",

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1414,8 +1414,9 @@ class vehicle
         // drains a fuel type (e.g. for the kitchen unit)
         // returns amount actually drained, does not engage reactor
         int drain( const itype_id &ftype, int amount,
-                   const std::function<bool( vehicle_part & )> &filter = return_true< vehicle_part &> );
-        int drain( int index, int amount );
+                   const std::function<bool( vehicle_part & )> &filter = return_true< vehicle_part &>,
+                   bool apply_loss = true );
+        int drain( int index, int amount, bool apply_loss = true );
         /**
          * Consumes enough fuel by energy content. Does not support cable draining.
          * @param ftype Type of fuel


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix cabled-only pseudo-tools, part 2"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #70394. 
Turns out the code for charging and discharging vehicle batteries has a toggle for cable loss that defaults to on. Since the pseudo-tool is first filled (discharging the grid, up to the total charge stored in the grid or the max capacity of the tool, whichever is smaller), used, and then has its remaining charges drained back into the grid (charging it), cable losses are incurred at both steps along the way. Seems like the original contributor of the current pseudo-tools implementation also missed this, but because back then most default magazines had relatively small sizes (on the order of thousands as opposed to millions of charges) this issue likely manifested as slightly increased power usage and did not become apparent until my recent usage of the large pseudo_magazine. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Turn off cable loss for the virtual operations shuffling charges to and from pseudo-tools.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Rework weldrig_hack somehow.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Compiles successfully
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Also noticed the charges on the pseudo_magazine are still being displayed in #70394, so fixing that as well.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
