### PR TITLE
Fix portal dungeon giving reward without entering the vortex, scale said reward

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -1131,7 +1131,7 @@
     "id": "EOC_PORTAL_DUNGEON_REWARD_WEAKENED_INERTIA",
     "effect": {
       "u_add_effect": "weakened_inertia",
-      "duration": { "math": [ "(ps_effect_length + rng(0, 2)) * u_val('time: 1 d')" ] }
+      "duration": { "math": [ "(portal_dungeon_level + rng(-1, 1)) * u_val('time: 1 d')" ] }
     }
   },
   {
@@ -1139,7 +1139,7 @@
     "id": "EOC_PORTAL_DUNGEON_REWARD_WARPED_VIEWPOINT",
     "effect": {
       "u_add_effect": "warped_viewpoint",
-      "duration": { "math": [ "(ps_effect_length + rng(0, 2)) * u_val('time: 1 d')" ] }
+      "duration": { "math": [ "(portal_dungeon_level + rng(-1, 1)) * u_val('time: 1 d')" ] }
     }
   },
   {
@@ -1147,7 +1147,7 @@
     "id": "EOC_PORTAL_DUNGEON_REWARD_WEAKENED_GRAVITY",
     "effect": {
       "u_add_effect": "weakened_gravity",
-      "duration": { "math": [ "(ps_effect_length + rng(0, 2)) * u_val('time: 1 d')" ] }
+      "duration": { "math": [ "(portal_dungeon_level + rng(-1, 1)) * u_val('time: 1 d')" ] }
     }
   },
   {

--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -1077,7 +1077,7 @@
       "switch": { "global_val": "var", "var_name": "portal_dungeon_level" },
       "cases": [
         {
-          "case": 0,
+          "case": 2,
           "effect": [
             {
               "weighted_list_eocs": [
@@ -1098,7 +1098,7 @@
           ]
         },
         {
-          "case": 5,
+          "case": 7,
           "effect": {
             "run_eocs": [
               { "id": "EOC_PORTAL_DUNGEON_REWARD_ITEM" },
@@ -1129,17 +1129,26 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_DUNGEON_REWARD_WEAKENED_INERTIA",
-    "effect": { "u_add_effect": "weakened_inertia", "duration": { "global_val": "ps_effect_length", "default": "5 days" } }
+    "effect": {
+      "u_add_effect": "weakened_inertia",
+      "duration": { "math": [ "(ps_effect_length + rng(0, 2)) * u_val('time: 1 d')" ] }
+    }
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_DUNGEON_REWARD_WARPED_VIEWPOINT",
-    "effect": { "u_add_effect": "warped_viewpoint", "duration": { "global_val": "ps_effect_length", "default": "5 days" } }
+    "effect": {
+      "u_add_effect": "warped_viewpoint",
+      "duration": { "math": [ "(ps_effect_length + rng(0, 2)) * u_val('time: 1 d')" ] }
+    }
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_PORTAL_DUNGEON_REWARD_WEAKENED_GRAVITY",
-    "effect": { "u_add_effect": "weakened_gravity", "duration": { "global_val": "ps_effect_length", "default": "5 days" } }
+    "effect": {
+      "u_add_effect": "weakened_gravity",
+      "duration": { "math": [ "(ps_effect_length + rng(0, 2)) * u_val('time: 1 d')" ] }
+    }
   },
   {
     "type": "effect_on_condition",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Someone pointed out that you can enter portal dungeon, instantly leave it, and still get 5 days of the reward
upon further examination found the game always picks "default" value no matter what actual value of portal_dungeon_level is
#### Describe the solution
Make `EOC_PORTAL_DUNGEON_REWARD` give revard if you have at least `portal_dungeon_level` = 2 (1 when portal dungeon is created, +1 every time one enter the vortex)
Make effect scale from `portal_dungeon_level`, and give 1 day of bonus per jump plus `rng(-1, 1)` day to make it randomized a bit - the biggest reward in this case is 7 days, and the smallest is 1 day, which i think is fair
#### Additional context
@Ramza13 your opinion?