### PR TITLE
Handgun is one word

### DIFF
--- a/data/json/proficiencies/melee_weapons.json
+++ b/data/json/proficiencies/melee_weapons.json
@@ -49,7 +49,7 @@
     "type": "proficiency",
     "id": "prof_auto_pistols_pro",
     "category": "prof_combat",
-    "name": { "str": "Hand Gun CQC Proficiency" },
+    "name": { "str": "Handgun CQC Proficiency" },
     "description": "You're proficient in striking with your handgun and can do so precisely.",
     "can_learn": true,
     "default_time_multiplier": 1.5,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fixes #70416.

#### Describe the solution

Handgun has no space

#### Describe alternatives you've considered

#### Testing

This was a typo, how do you check a typo 🤔

#### Additional context


