### PR TITLE
Fix get_rating bound clamping

### DIFF
--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -551,11 +551,8 @@ bool effect_type::has_flag( const flag_id &flag ) const
 
 game_message_type effect_type::get_rating( int intensity ) const
 {
-    if( apply_msgs.size() < static_cast<size_t>( intensity ) ) {
-        return apply_msgs[intensity - 1].second;
-    } else {
-        return apply_msgs[0].second;
-    }
+    intensity = std::clamp(intensity, 0, static_cast<int>(apply_msgs.size()) - 1);
+    return apply_msgs[intensity].second;
 }
 
 bool effect_type::use_name_ints() const

--- a/src/effect.cpp
+++ b/src/effect.cpp
@@ -551,7 +551,7 @@ bool effect_type::has_flag( const flag_id &flag ) const
 
 game_message_type effect_type::get_rating( int intensity ) const
 {
-    intensity = std::clamp(intensity, 0, static_cast<int>(apply_msgs.size()) - 1);
+    intensity = std::clamp( intensity, 0, static_cast<int>( apply_msgs.size() ) - 1 );
     return apply_msgs[intensity].second;
 }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

#### Purpose of change

fixes #70330

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
The get_rating method seems to want to clamp the intensity inside the `apply_msgs` vector, but seems like it can overrun.

#### Describe alternatives you've considered

https://github.com/CleverRaven/Cataclysm-DDA/issues/69703#issuecomment-1826008940

#### Testing
See https://github.com/CleverRaven/Cataclysm-DDA/issues/70330#issue-2051199232

#### Additional context

I have almost 0 experience on the project so please double-check that's what it's supposed to do please.