### PR TITLE
Optimize allocation patterns in item and elsewhere

### DIFF
--- a/src/catacharset.h
+++ b/src/catacharset.h
@@ -59,6 +59,7 @@ std::u32string utf8_to_utf32( std::string_view str );
 // Split the given string into displayed characters.  Each element of the returned vector
 // contains one 'regular' codepoint and all subsequent combining characters.
 std::vector<std::string> utf8_display_split( const std::string & );
+void utf8_display_split_into( const std::string &, std::vector<std::string_view> & );
 
 /**
  * UTF8-Wrapper over std::string.

--- a/src/field.cpp
+++ b/src/field.cpp
@@ -124,8 +124,8 @@ field_entry *field::find_field( const field_type_id &field_type_to_find, const b
     if( !_displayed_field_type ) {
         return nullptr;
     }
-    const auto it = _field_type_list.find( field_type_to_find );
-    if( it != _field_type_list.end() && ( !alive_only || it->second.is_field_alive() ) ) {
+    const auto it = _field_type_list->find( field_type_to_find );
+    if( it != _field_type_list->end() && ( !alive_only || it->second.is_field_alive() ) ) {
         return &it->second;
     }
     return nullptr;
@@ -137,8 +137,8 @@ const field_entry *field::find_field( const field_type_id &field_type_to_find,
     if( !_displayed_field_type ) {
         return nullptr;
     }
-    const auto it = _field_type_list.find( field_type_to_find );
-    if( it != _field_type_list.end() && ( !alive_only || it->second.is_field_alive() ) ) {
+    const auto it = _field_type_list->find( field_type_to_find );
+    if( it != _field_type_list->end() && ( !alive_only || it->second.is_field_alive() ) ) {
         return &it->second;
     }
     return nullptr;
@@ -159,8 +159,8 @@ bool field::add_field( const field_type_id &field_type_to_add, const int new_int
     if( !field_type_to_add ) {
         return false;
     }
-    auto it = _field_type_list.find( field_type_to_add );
-    if( it != _field_type_list.end() ) {
+    auto it = _field_type_list->find( field_type_to_add );
+    if( it != _field_type_list->end() ) {
         //Already exists, but lets update it. This is tentative.
         int prev_intensity = it->second.get_field_intensity();
         if( !it->second.is_field_alive() ) {
@@ -180,8 +180,8 @@ bool field::add_field( const field_type_id &field_type_to_add, const int new_int
 
 bool field::remove_field( const field_type_id &field_to_remove )
 {
-    const auto it = _field_type_list.find( field_to_remove );
-    if( it == _field_type_list.end() ) {
+    const auto it = _field_type_list->find( field_to_remove );
+    if( it == _field_type_list->end() ) {
         return false;
     }
     remove_field( it );
@@ -190,9 +190,9 @@ bool field::remove_field( const field_type_id &field_to_remove )
 
 void field::remove_field( std::map<field_type_id, field_entry>::iterator const it )
 {
-    _field_type_list.erase( it );
+    _field_type_list->erase( it );
     _displayed_field_type = fd_null;
-    for( auto &fld : _field_type_list ) {
+    for( auto &fld : *_field_type_list ) {
         if( !_displayed_field_type || fld.first.obj().priority >= _displayed_field_type.obj().priority ) {
             _displayed_field_type = fld.first;
         }
@@ -201,7 +201,7 @@ void field::remove_field( std::map<field_type_id, field_entry>::iterator const i
 
 void field::clear()
 {
-    _field_type_list.clear();
+    _field_type_list->clear();
     _displayed_field_type = fd_null;
 }
 
@@ -211,27 +211,27 @@ Returns the number of fields existing on the current tile.
 */
 unsigned int field::field_count() const
 {
-    return _field_type_list.size();
+    return _field_type_list->size();
 }
 
 std::map<field_type_id, field_entry>::iterator field::begin()
 {
-    return _field_type_list.begin();
+    return _field_type_list->begin();
 }
 
 std::map<field_type_id, field_entry>::const_iterator field::begin() const
 {
-    return _field_type_list.begin();
+    return _field_type_list->begin();
 }
 
 std::map<field_type_id, field_entry>::iterator field::end()
 {
-    return _field_type_list.end();
+    return _field_type_list->end();
 }
 
 std::map<field_type_id, field_entry>::const_iterator field::end() const
 {
-    return _field_type_list.end();
+    return _field_type_list->end();
 }
 
 /*
@@ -250,14 +250,14 @@ description_affix field::displayed_description_affix() const
 
 int field::displayed_intensity() const
 {
-    auto it = _field_type_list.find( _displayed_field_type );
+    auto it = _field_type_list->find( _displayed_field_type );
     return it->second.get_field_intensity();
 }
 
 int field::total_move_cost() const
 {
     int current_cost = 0;
-    for( const auto &fld : _field_type_list ) {
+    for( const auto &fld : *_field_type_list ) {
         current_cost += fld.second.get_intensity_level().move_cost;
     }
     return current_cost;

--- a/src/field.h
+++ b/src/field.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "calendar.h"
+#include "cata_lazy.h"
 #include "color.h"
 #include "enums.h"
 #include "field_type.h"
@@ -180,7 +181,7 @@ class field
 
     private:
         // A pointer lookup table of all field effects on the current tile.
-        std::map<field_type_id, field_entry> _field_type_list;
+        lazy<std::map<field_type_id, field_entry>> _field_type_list;
         //_displayed_field_type currently is equal to the last field added to the square. You can modify this behavior in the class functions if you wish.
         field_type_id _displayed_field_type;
 };

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -587,10 +587,10 @@ item::item( const recipe *rec, int qty, item &component )
 }
 
 item::item( const item & ) = default;
-item::item( item && ) noexcept( map_is_noexcept ) = default;
+item::item( item && ) noexcept = default;
 item::~item() = default;
 item &item::operator=( const item & ) = default;
-item &item::operator=( item && ) noexcept( list_is_noexcept ) = default;
+item &item::operator=( item && ) noexcept = default;
 
 item item::make_corpse( const mtype_id &mt, time_point turn, const std::string &name,
                         const int upgrade_time )

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1489,7 +1489,8 @@ bool item::stacks_with( const item &rhs, bool check_components, bool combine_liq
     // Guns that differ only by dirt/shot_counter can still stack,
     // but other item_vars such as label/note will prevent stacking
     const std::vector<std::string> ignore_keys = { "dirt", "shot_counter", "spawn_location_omt" };
-    if( map_without_keys( item_vars, ignore_keys ) != map_without_keys( rhs.item_vars, ignore_keys ) ) {
+    if( map_without_keys( *item_vars, ignore_keys ) != map_without_keys( *rhs.item_vars,
+            ignore_keys ) ) {
         return false;
     }
     const std::string omt_loc_var = "spawn_location_omt";

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -415,7 +415,7 @@ item::item( const itype_id &id, time_point turn, solitary_tag tag )
 
 safe_reference<item> item::get_safe_reference()
 {
-    return anchor.reference_to( this );
+    return anchor->reference_to( this );
 }
 
 static const item *get_most_rotten_component( const item &craft )

--- a/src/item.h
+++ b/src/item.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include "calendar.h"
+#include "cata_lazy.h"
 #include "cata_utility.h"
 #include "compatibility.h"
 #include "enums.h"
@@ -3005,7 +3006,7 @@ class item : public visitable
         bool requires_tags_processing = true;
         cata::heap<FlagsSetType> item_tags; // generic item specific flags
         cata::heap<FlagsSetType> inherited_tags_cache;
-        safe_reference_anchor anchor;
+        lazy<safe_reference_anchor> anchor;
         cata::heap<std::map<std::string, std::string>> item_vars;
         const mtype *corpse = nullptr;
         std::string corpse_name;       // Name of the late lamented

--- a/src/item.h
+++ b/src/item.h
@@ -3006,7 +3006,7 @@ class item : public visitable
         FlagsSetType item_tags; // generic item specific flags
         FlagsSetType inherited_tags_cache;
         safe_reference_anchor anchor;
-        std::map<std::string, std::string> item_vars;
+        cata::heap<std::map<std::string, std::string>> item_vars;
         const mtype *corpse = nullptr;
         std::string corpse_name;       // Name of the late lamented
         std::set<matec_id> techniques; // item specific techniques

--- a/src/item.h
+++ b/src/item.h
@@ -193,9 +193,9 @@ class item : public visitable
 
         item();
 
-        item( item && ) noexcept( map_is_noexcept );
+        item( item && ) noexcept;
         item( const item & );
-        item &operator=( item && ) noexcept( list_is_noexcept );
+        item &operator=( item && ) noexcept;
         item &operator=( const item & );
 
         explicit item( const itype_id &id, time_point turn = calendar::turn, int qty = -1 );

--- a/src/item.h
+++ b/src/item.h
@@ -3003,13 +3003,13 @@ class item : public visitable
          * This flag is reset to `true` if item tags are changed.
          */
         bool requires_tags_processing = true;
-        FlagsSetType item_tags; // generic item specific flags
-        FlagsSetType inherited_tags_cache;
+        cata::heap<FlagsSetType> item_tags; // generic item specific flags
+        cata::heap<FlagsSetType> inherited_tags_cache;
         safe_reference_anchor anchor;
         cata::heap<std::map<std::string, std::string>> item_vars;
         const mtype *corpse = nullptr;
         std::string corpse_name;       // Name of the late lamented
-        std::set<matec_id> techniques; // item specific techniques
+        cata::heap<std::set<matec_id>> techniques; // item specific techniques
 
         // Select a random variant from the possibilities
         // Intended to be called when no explicit variant is set

--- a/src/item.h
+++ b/src/item.h
@@ -2995,7 +2995,7 @@ class item : public visitable
         const itype *type;
         item_components components;
         /** What faults (if any) currently apply to this item */
-        std::set<fault_id> faults;
+        cata::heap<std::set<fault_id>> faults;
 
     private:
         item_contents contents;

--- a/src/item_components.h
+++ b/src/item_components.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "type_id.h"
+#include "value_ptr.h"
 
 class item;
 class JsonOut;
@@ -18,7 +19,7 @@ class ret_val;
 class item_components
 {
     private:
-        std::map<itype_id, std::vector<item>> comps;
+        cata::heap<std::map<itype_id, std::vector<item>>> comps;
         using comp_iterator = std::map<itype_id, std::vector<item>>::iterator;
         using const_comp_iterator = std::map<itype_id, std::vector<item>>::const_iterator;
 

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -156,9 +156,11 @@ static void put_into_container(
         ctr.seal();
     }
 
-    excess.emplace_back( std::move( ctr ) );
     items.erase( items.end() - num_items, items.end() );
-    items.insert( items.end(), excess.begin(), excess.end() );
+    items.reserve( items.size() + excess.size() + 1 );
+    items.insert( items.end(), std::make_move_iterator( excess.begin() ),
+                  std::make_move_iterator( excess.end() ) );
+    items.emplace_back( std::move( ctr ) );
 }
 
 Single_item_creator::Single_item_creator( const std::string &_id, Type _type, int _probability,

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -4491,10 +4491,10 @@ bool mapgen_function_json_base::setup_common( const JsonObject &jo )
         }
         for( int c = m_offset.y; c < expected_dim.y; c++ ) {
             const std::string row = parray.get_string( c );
-            std::vector<map_key> row_keys;
-            for( const std::string &key : utf8_display_split( row ) ) {
-                row_keys.emplace_back( key );
-            }
+            static std::vector<std::string_view> row_keys;
+            row_keys.clear();
+            row_keys.reserve( total_size.x );
+            utf8_display_split_into( row, row_keys );
             if( row_keys.size() < static_cast<size_t>( expected_dim.x ) ) {
                 parray.throw_error(
                     string_format( "  format: row %d must have at least %d columns, not %d",
@@ -4507,7 +4507,7 @@ bool mapgen_function_json_base::setup_common( const JsonObject &jo )
             }
             for( int i = m_offset.x; i < expected_dim.x; i++ ) {
                 const point p = point( i, c ) - m_offset;
-                const map_key key = row_keys[i];
+                const map_key key{ std::string( row_keys[i] ) };
                 const auto iter_ter = keys_with_terrain.find( key );
                 const auto fpi = format_placings.find( key );
 

--- a/src/value_ptr.h
+++ b/src/value_ptr.h
@@ -151,6 +151,18 @@ struct heap {
     public:
 
         // Various conditionally defined proxy functions for common types like containers.
+#pragma push_macro("PROXY")
+#define PROXY(func) \
+    template<typename ...Us> \
+    auto func( Us&& ...us ) -> decltype( val().func( std::forward<Us>( us )... ) ) { \
+        return val().func( std::forward<Us>( us )... ); \
+    }
+#pragma push_macro("PROXY_CONST")
+#define PROXY_CONST(func) \
+    template<typename ...Us> \
+    auto func( Us&& ...us ) const -> decltype( val().func( std::forward<Us>( us )... ) ) { \
+        return val().func( std::forward<Us>( us )... ); \
+    }
 
         // Comparison operators.
         auto operator==( heap const &rhs ) const -> decltype( val() == val() ) {
@@ -169,39 +181,16 @@ struct heap {
 
 
         // Tests & sets
-        auto empty() const -> decltype( val().empty() ) {
-            return val().empty();
-        }
-
-        template<typename U>
-        auto count( U &&u ) const -> decltype( val().count( std::forward<U>( u ) ) ) {
-            return val().count( std::forward<U>( u ) );
-        }
-
-        auto size() const -> decltype( val().size() ) {
-            return val().size();
-        }
-
-        auto clear() -> decltype( val().clear() ) {
-            return val().clear();
-        }
+        PROXY_CONST( empty )
+        PROXY_CONST( count )
+        PROXY_CONST( size )
+        PROXY( clear )
 
         // Iterators
-        auto begin() -> decltype( val().begin() ) {
-            return val().begin();
-        }
-
-        auto begin() const -> decltype( val().begin() ) {
-            return val().begin();
-        }
-
-        auto end() -> decltype( val().end() ) {
-            return val().end();
-        }
-
-        auto end() const -> decltype( val().end() ) {
-            return val().end();
-        }
+        PROXY( begin )
+        PROXY_CONST( begin )
+        PROXY( end )
+        PROXY_CONST( end )
 
         // Accessors
         template<typename U>
@@ -209,30 +198,12 @@ struct heap {
             return val()[std::forward<U>( u )];
         }
 
-        template<typename U>
-        auto find( U &&u ) -> decltype( val().find( std::forward<U>( u ) ) ) {
-            return val().find( std::forward<U>( u ) );
-        }
+        PROXY( find )
+        PROXY_CONST( find )
 
-        template<typename U>
-        auto find( U &&u ) const -> decltype( val().find( std::forward<U>( u ) ) ) {
-            return val().find( std::forward<U>( u ) );
-        }
-
-        template<typename U>
-        auto erase( U &&u ) -> decltype( val().erase( std::forward<U>( u ) ) ) {
-            return val().erase( std::forward<U>( u ) );
-        }
-
-        template<typename U>
-        auto insert( U &&u ) -> decltype( val().insert( std::forward<U>( u ) ) ) {
-            return val().insert( std::forward<U>( u ) );
-        }
-
-        template<typename U>
-        auto emplace( U &&u ) -> decltype( val().emplace( std::forward<U>( u ) ) ) {
-            return val().emplace( std::forward<U>( u ) );
-        }
+        PROXY( erase )
+        PROXY( insert )
+        PROXY( emplace )
 
         // Json* support.
         template<typename Stream = JsonOut>
@@ -244,6 +215,8 @@ struct heap {
         void deserialize( const Value &jsin ) {
             jsin.read( val() );
         }
+#pragma pop_macro("PROXY")
+#pragma pop_macro("PROXY_CONST")
 };
 
 } // namespace cata

--- a/src/value_ptr.h
+++ b/src/value_ptr.h
@@ -61,6 +61,80 @@ bool value_ptr_equals( const value_ptr<T> &lhs, const value_ptr<T> &rhs )
     return ( !lhs && !rhs ) || ( lhs && rhs && *lhs == *rhs );
 }
 
+/**
+ * This class is essentially a copyable unique pointer, like value_ptr, except
+ * it hides the fact it is a unique_ptr. It is intended for helping make types
+ * noexcept movable by moving non-noexcept-movable types to the heap.
+ *
+ * Contractually speaking, should never be empty. However for performance reasons
+ * in eg. item, moved-from heap<> objects do not automatically reset with a new
+ * copy of the wrapped data.
+ */
+template <class T>
+struct heap {
+    private:
+        std::unique_ptr<T> heaped_;
+
+    public:
+        template<typename ...Args>
+        // NOLINTNEXTLINE(google-explicit-constructor)
+        heap( Args &&...args ) : heaped_{ new T{ std::forward<Args>( args )... } } {}
+
+        // Unlike value_ptr, moves actually move and leave the moved-from heap empty.
+        // Using it again will cause a segfault without resetting it first.
+        heap( heap && ) noexcept = default;
+        heap &operator=( heap &&other ) noexcept = default;
+
+        // Like value_ptr, copies copy the rhs and leave it intact.
+        heap( heap const &rhs ) {
+            *this = rhs;
+        }
+        heap &operator=( heap const &rhs ) {
+            // This should always be true, however, sanity says do the right thing.
+            if( rhs.heaped_ ) {
+                heaped_.reset( new T{ *rhs.heaped_ } );
+            } else {
+                heaped_.reset( new T{} );
+            }
+            return *this;
+        }
+
+        heap &operator=( T const &t ) {
+            heaped_.reset( new T{ t } );
+            return *this;
+        }
+
+        heap &operator=( T &&t ) {
+            heaped_.reset( new T{ std::move( t ) } );
+            return *this;
+        }
+
+        auto operator==( heap const &rhs ) const -> decltype( *rhs == *rhs ) {
+            const T *lhsp = heaped_.get();
+            const T *rhsp = rhs.heaped_.get();
+
+            return rhsp && lhsp && *rhsp == *lhsp;
+        }
+
+        auto operator!=( heap const &rhs ) const -> decltype( *rhs != *rhs ) {
+            const T *lhsp = heaped_.get();
+            const T *rhsp = rhs.heaped_.get();
+
+            return rhsp && lhsp && *rhsp != *lhsp;
+        }
+
+        // Json* support.
+        template<typename Stream = JsonOut>
+        void serialize( Stream &jsout ) const {
+            jsout.write( val() );
+        }
+
+        template<typename Value = JsonValue, std::enable_if_t<std::is_same_v<std::decay_t<Value>, JsonValue>>* = nullptr>
+        void deserialize( const Value &jsin ) {
+            jsin.read( val() );
+        }
+};
+
 } // namespace cata
 
 #endif // CATA_SRC_VALUE_PTR_H

--- a/src/value_ptr.h
+++ b/src/value_ptr.h
@@ -124,6 +124,22 @@ struct heap {
             return std::move( *heaped_ );
         }
 
+        // The one weird one: since this is ultimately backed on the heap,
+        // allow operator* to get a reference to the thing.
+        // We don't allow exposing it as a pointer directly, but some places need
+        // to peel back the heap<> wrapper because otherwise template type deduction
+        // might break.
+        T &operator*() & { // *NOPAD*
+            return *heaped_;
+        }
+        T const &operator*() const & { // *NOPAD*
+            return *heaped_;
+        }
+        // Intentionally move construct a value T to avoid binding a ref to a temporary.
+        T operator*() && { // *NOPAD*
+            return std::move( *heaped_ );
+        }
+
     private:
         // Helper for proxy functions.
         T &val() {

--- a/src/value_ptr.h
+++ b/src/value_ptr.h
@@ -157,6 +157,11 @@ struct heap {
             return val().empty();
         }
 
+        template<typename U>
+        auto count( U &&u ) const -> decltype( val().count( std::forward<U>( u ) ) ) {
+            return val().count( std::forward<U>( u ) );
+        }
+
         auto size() const -> decltype( val().size() ) {
             return val().size();
         }
@@ -201,6 +206,16 @@ struct heap {
         template<typename U>
         auto erase( U &&u ) -> decltype( val().erase( std::forward<U>( u ) ) ) {
             return val().erase( std::forward<U>( u ) );
+        }
+
+        template<typename U>
+        auto insert( U &&u ) -> decltype( val().insert( std::forward<U>( u ) ) ) {
+            return val().insert( std::forward<U>( u ) );
+        }
+
+        template<typename U>
+        auto emplace( U &&u ) -> decltype( val().emplace( std::forward<U>( u ) ) ) {
+            return val().emplace( std::forward<U>( u ) );
         }
 
         // Json* support.

--- a/src/value_ptr.h
+++ b/src/value_ptr.h
@@ -109,18 +109,98 @@ struct heap {
             return *this;
         }
 
-        auto operator==( heap const &rhs ) const -> decltype( *rhs == *rhs ) {
+        // Implicit conversion functions
+        // NOLINTNEXTLINE(google-explicit-constructor)
+        operator T &() & { // *NOPAD*
+            return *heaped_;
+        }
+        // NOLINTNEXTLINE(google-explicit-constructor)
+        operator T const &() const & { // *NOPAD*
+            return *heaped_;
+        }
+        // Intentionally move construct a value T to avoid binding a ref to a temporary.
+        // NOLINTNEXTLINE(google-explicit-constructor)
+        operator T() && { // *NOPAD*
+            return std::move( *heaped_ );
+        }
+
+    private:
+        // Helper for proxy functions.
+        T &val() {
+            return *heaped_;
+        }
+        T const &val() const {
+            return *heaped_;
+        }
+    public:
+
+        // Various conditionally defined proxy functions for common types like containers.
+
+        // Comparison operators.
+        auto operator==( heap const &rhs ) const -> decltype( val() == val() ) {
             const T *lhsp = heaped_.get();
             const T *rhsp = rhs.heaped_.get();
 
             return rhsp && lhsp && *rhsp == *lhsp;
         }
 
-        auto operator!=( heap const &rhs ) const -> decltype( *rhs != *rhs ) {
+        auto operator!=( heap const &rhs ) const -> decltype( val() != val() ) {
             const T *lhsp = heaped_.get();
             const T *rhsp = rhs.heaped_.get();
 
             return rhsp && lhsp && *rhsp != *lhsp;
+        }
+
+
+        // Tests & sets
+        auto empty() const -> decltype( val().empty() ) {
+            return val().empty();
+        }
+
+        auto size() const -> decltype( val().size() ) {
+            return val().size();
+        }
+
+        auto clear() -> decltype( val().clear() ) {
+            return val().clear();
+        }
+
+        // Iterators
+        auto begin() -> decltype( val().begin() ) {
+            return val().begin();
+        }
+
+        auto begin() const -> decltype( val().begin() ) {
+            return val().begin();
+        }
+
+        auto end() -> decltype( val().end() ) {
+            return val().end();
+        }
+
+        auto end() const -> decltype( val().end() ) {
+            return val().end();
+        }
+
+        // Accessors
+        template<typename U>
+        auto operator[]( U &&u ) -> decltype( val()[std::forward<U>( u )] ) {
+            return val()[std::forward<U>( u )];
+        }
+
+        template<typename U>
+        auto find( U &&u ) -> decltype( val().find( std::forward<U>( u ) ) ) {
+            return val().find( std::forward<U>( u ) );
+        }
+
+        template<typename U>
+        auto find( U &&u ) const -> decltype( val().find( std::forward<U>( u ) ) ) {
+            return val().find( std::forward<U>( u ) );
+        }
+
+        template<typename U>
+        auto erase( U &&u ) -> decltype( val().erase( std::forward<U>( u ) ) ) {
+            return val().erase( std::forward<U>( u ) );
         }
 
         // Json* support.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Optimizing mostly item to reduce load-time allocation by over 20%"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Memory profiling cdda is extremely painful because just getting through load can take a stupid amount of time. Reducing the number of allocations done during load can help with that specifically, but also generally optimizing for allocations is beneficial for performance.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
There's a few things going on here.
- `item` contains several std:: container types. These types are not all `noexcept` movable, so `item` can't be `noexcept` movable either. This means containers of items like vectors have to copy items on move, instead of efficiently moving them, which is a horrendous waste of allocations. Introduce a `heap<>` template wrapper which we can use to put these nested containers into the heap. Although this is another level of indirection, these aren't hotly accessed members, so the penalty is negligible. But, by wrapping the std containers in the `heap<>` type, we can make `item` be `noexcept` movable, which is vastly more performant. This by itself eliminates many millions of allocations.
- Secondarily, because the `heap<>` type operates as `unique_ptr` on move, we don't pay the penalty of reinitializing the containers when they are moved-from. These reinitializations are typically wasted allocations that are immediately freed. This does mean a moved-from `item` is definitely not reusable anymore, but the typical pattern is moved-from objects aren't reusable anyway.
- We can save a few more millions of allocations by introducing an 'externally allocating' version of `utf8_display_split`. The original creates a separate string per non-zero-width utf8 character in mapgen pallettes, afaict. We can instead write a version that pushes `string_view`s into a by-ref `vector` argument. That `vector` of `string_view`s can then be statically allocated in mapgen and cached across calls, resulting in effectively constant allocation space. (Alternatively, using a `cata::small_literal_vector` to stack allocate may work because `string_view` is trivial and qualifies for that helper class).
- Apply `lazy<>` to a few more members, such as `field::_field_type_list` and, notably, `item`'s `safe_reference_anchor` member, also saves noticable amounts of allocs.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Use a gui based `heapprof` like program to instrument the game loading.

Before:

![before_allocs](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/986272aa-8918-4771-9fc0-d6e96d6492cd)

![before_allocs_detail](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/e77b53f8-a945-46b2-b630-a9187a7f5a1c)

After:

![after_allocs](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/03db8ee8-a28e-4e64-8cdf-311147fb9d79)

![after_allocs_detail](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/85ddc45d-d492-4d5e-be0a-6c59479133da)

The number is 'number of allocations made', as in, calls to malloc, not bytes allocated. Most of the savings are in `Item_factory::check_definitions`

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
