### PR TITLE
[MOM] Wakeful Rest Removes Sleep Deprivation and Fatigue

### DIFF
--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -119,7 +119,7 @@
     "type": "effect_on_condition",
     "id": "EOC_VITAKIN_STOP_BLEEDING_ITEM_03",
     "effect": [
-      {
+      {F
         "u_run_inv_eocs": "random",
         "search_data": [ { "id": "vita_bandages_03" } ],
         "true_eocs": [ { "id": "EOC_VITAKIN_STOP_BLEEDING_ITEM_03_ACTIVATE", "effect": { "u_activate": "heal" } } ]
@@ -176,7 +176,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VITAKIN_SLEEP_DEPRIVATION",
-    "condition": { "math": [ "u_val('sleep_deprivation')", ">=", "5" ] },
+    "condition": { "math": [ "u_val('sleep_deprivation')", ">=", "0" ] },
     "effect": { "math": [ "u_val('sleep_deprivation')", "-=", "1" ] }
   },
   {

--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -119,7 +119,7 @@
     "type": "effect_on_condition",
     "id": "EOC_VITAKIN_STOP_BLEEDING_ITEM_03",
     "effect": [
-      {F
+      {
         "u_run_inv_eocs": "random",
         "search_data": [ { "id": "vita_bandages_03" } ],
         "true_eocs": [ { "id": "EOC_VITAKIN_STOP_BLEEDING_ITEM_03_ACTIVATE", "effect": { "u_activate": "heal" } } ]

--- a/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
+++ b/data/mods/MindOverMatter/powers/vitakinesis_eoc.json
@@ -129,7 +129,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VITAKIN_SLEEP",
-    "condition": { "or": [ { "math": [ "u_val('fatigue')", ">=", "0" ] } ] },
+    "condition": { "or": [ { "math": [ "u_val('fatigue') + u_val('sleep_deprivation')", ">=", "0" ] } ] },
     "effect": [ { "u_assign_activity": "ACT_VITAKIN_WAKEFUL_REST_MEDITATE", "duration": "510 minutes" } ],
     "false_effect": [ { "u_message": "You're feeling refreshed and have no need to meditate.", "type": "mixed" } ]
   },
@@ -146,7 +146,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_VITAKIN_WAKEFUL_REST_MEDITATE",
-    "condition": { "math": [ "u_val('fatigue')", ">=", "0" ] },
+    "condition": { "math": [ "u_val('fatigue') + u_val('sleep_deprivation')", ">=", "0" ] },
     "effect": [ { "run_eocs": [ "EOC_VITAKIN_SLEEP_FATIGUE", "EOC_VITAKIN_SLEEP_DEPRIVATION" ] } ],
     "false_effect": [
       {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Make Wakeful Rest check sleep deprivation when starting"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Wakeful rest removes both sleep deprivation and fatigue when meditating.  However, it only checks fatigue when triggering / continuing the meditation, which means that if the user has sleep deprivation but no fatigue they are unable to use the ability to remove it.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add sleep_deprivation to value that is compared against.  Therefore, if either sleep deprivation or fatigue is above zero the user can meditate to remove it.  Negative values aren't an issue because the sub EOC's only remove fatigue / sleep deprivation if they are above 0.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1) Used character with large amounts of sleep deprivation and no fatigue
2) Used wakeful rest
3) Successfully meditated and removed sleep deprivation
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
