### PR TITLE
convert `items` to `entries` in profession itemgroups

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -588,27 +588,29 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "jeans",
-          "gloves_light",
-          "hat_ball",
-          "duffelbag",
-          "backpack",
-          "long_underpants",
-          "boots",
-          "socks_wool",
-          "socks",
-          "hoodie",
-          "folding_poncho",
-          "knit_scarf",
-          "jug_plastic",
-          "can_beans",
-          "pockknife"
-        ],
-        "entries": [ { "group": "charged_cell_phone" }, { "group": "charged_matches" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "gloves_light" },
+          { "item": "hat_ball" },
+          { "item": "duffelbag" },
+          { "item": "backpack" },
+          { "item": "long_underpants" },
+          { "item": "boots" },
+          { "item": "socks_wool" },
+          { "item": "socks" },
+          { "item": "hoodie" },
+          { "item": "folding_poncho" },
+          { "item": "knit_scarf" },
+          { "item": "jug_plastic" },
+          { "item": "can_beans" },
+          { "item": "pockknife" },
+          { "group": "charged_cell_phone" },
+          { "group": "charged_matches" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "boxer_briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -619,11 +621,21 @@
     "points": 0,
     "items": {
       "both": {
-        "items": [ "jeans", "longshirt", "socks", "sneakers", "mbag", "pockknife", "water_clean", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_matches" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "mbag" },
+          { "item": "pockknife" },
+          { "item": "water_clean" },
+          { "item": "wristwatch" },
+          { "group": "charged_smart_phone" },
+          { "group": "charged_matches" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -635,11 +647,23 @@
     "skills": [ { "level": 4, "name": "speech" }, { "level": 4, "name": "computer" } ],
     "items": {
       "both": {
-        "items": [ "jeans", "longshirt", "socks", "sneakers", "backpack", "pockknife", "water_clean", "wearable_camera", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_laptop" }, { "group": "charged_matches" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "backpack" },
+          { "item": "pockknife" },
+          { "item": "water_clean" },
+          { "item": "wearable_camera" },
+          { "item": "wristwatch" },
+          { "group": "charged_smart_phone" },
+          { "group": "charged_laptop" },
+          { "group": "charged_matches" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -662,16 +686,23 @@
     ],
     "items": {
       "both": {
-        "items": [ "mbag", "socks", "sweater", "sneakers", "multitool", "water_clean", "wristwatch" ],
         "entries": [
+          { "item": "mbag" },
+          { "item": "pants" },
+          { "item": "socks" },
+          { "item": "sweater" },
+          { "item": "sneakers" },
+          { "item": "multitool" },
+          { "item": "water_clean" },
+          { "item": "wristwatch" },
           { "group": "charged_smart_phone" },
           { "group": "charged_matches" },
           { "item": "pants", "variant": "pants_black" },
           { "item": "tshirt", "variant": "generic_tshirt" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -686,18 +717,16 @@
     "skills": [ { "level": 3, "name": "gun" }, { "level": 3, "name": "rifle" }, { "level": 3, "name": "pistol" } ],
     "items": {
       "both": {
-        "items": [
-          "molle_pack",
-          "winter_pants_army",
-          "winter_jacket_army",
-          "undershirt",
-          "socks",
-          "boots_combat",
-          "sweatshirt",
-          "knife_folding",
-          "wristwatch"
-        ],
         "entries": [
+          { "item": "molle_pack" },
+          { "item": "winter_pants_army" },
+          { "item": "winter_jacket_army" },
+          { "item": "undershirt" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "sweatshirt" },
+          { "item": "knife_folding" },
+          { "item": "wristwatch" },
           { "group": "charged_two_way_radio" },
           { "group": "charged_matches" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -709,8 +738,8 @@
           { "item": "3006", "charges": 4 }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -734,15 +763,23 @@
     ],
     "items": {
       "both": {
-        "items": [ "mbag", "polo_shirt", "blazer", "socks", "dress_shoes", "knit_scarf", "textbook_tailor", "sf_watch", "hairpin" ],
         "entries": [
+          { "item": "mbag" },
+          { "item": "polo_shirt" },
+          { "item": "blazer" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "knit_scarf" },
+          { "item": "textbook_tailor" },
+          { "item": "sf_watch" },
+          { "item": "hairpin" },
           { "group": "charged_smart_phone" },
           { "item": "tailors_kit", "ammo-item": "thread", "charges": 100 },
           { "item": "pants", "variant": "pants_black" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -762,8 +799,9 @@
     ],
     "items": {
       "both": {
-        "items": [ "socks", "dress_shoes" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "dress_shoes" },
           { "group": "charged_smart_phone" },
           { "item": "knife_butcher", "container-item": "sheath" },
           { "item": "hat_chef", "variant": "white_hat_chef" },
@@ -772,8 +810,8 @@
           { "item": "pants", "variant": "pants_white" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -786,8 +824,9 @@
     "proficiencies": [ "prof_food_prep", "prof_knife_skills", "prof_intro_biology", "prof_wp_basic_bird", "prof_knives_familiar" ],
     "items": {
       "both": {
-        "items": [ "socks", "sneakers" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "sneakers" },
           { "group": "charged_smart_phone" },
           { "item": "knife_butcher", "container-item": "sheath" },
           { "item": "hat_chef", "variant": "white_hat_chef" },
@@ -796,8 +835,8 @@
           { "item": "pants", "variant": "pants_white" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -808,10 +847,18 @@
     "points": 0,
     "items": {
       "both": {
-        "items": [ "footrags", "loincloth", "cloak_wool", "ragpouch", "small_relic", "gloves_wraps", "tunic_rag" ],
-        "entries": [ { "item": "knife_baselard", "container-item": "sheath" } ]
+        "entries": [
+          { "item": "footrags" },
+          { "item": "loincloth" },
+          { "item": "cloak_wool" },
+          { "item": "ragpouch" },
+          { "item": "small_relic" },
+          { "item": "gloves_wraps" },
+          { "item": "tunic_rag" },
+          { "item": "knife_baselard", "container-item": "sheath" }
+        ]
       },
-      "female": [ "chestwrap" ]
+      "female": { "entries": [ { "item": "chestwrap" } ] }
     },
     "proficiencies": [ "prof_fibers", "prof_carving", "prof_leatherworking_basic", "prof_knives_familiar" ],
     "skills": [
@@ -841,11 +888,20 @@
     "proficiencies": [ "prof_intro_chemistry", "prof_intro_biology" ],
     "items": {
       "both": {
-        "items": [ "dress_shirt", "socks", "boots", "coat_lab", "gloves_rubber", "glasses_safety", "wristwatch" ],
-        "entries": [ { "item": "pants", "variant": "pants_stone" }, { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "dress_shirt" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "coat_lab" },
+          { "item": "gloves_rubber" },
+          { "item": "glasses_safety" },
+          { "item": "wristwatch" },
+          { "item": "pants", "variant": "pants_stone" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -858,15 +914,23 @@
     "skills": [ { "level": 4, "name": "mechanics" }, { "level": 4, "name": "driving" } ],
     "items": {
       "both": {
-        "items": [ "slingpack", "tank_top", "jeans", "socks", "boots_steel", "duct_tape", "screwdriver", "wristwatch", "mag_cars" ],
         "entries": [
+          { "item": "slingpack" },
+          { "item": "tank_top" },
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "boots_steel" },
+          { "item": "duct_tape" },
+          { "item": "screwdriver" },
+          { "item": "wristwatch" },
+          { "item": "mag_cars" },
           { "item": "goggles_welding", "custom-flags": [ "no_auto_equip" ] },
           { "group": "charged_smart_phone" },
           { "item": "wrench", "container-item": "tool_belt" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -886,23 +950,24 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "tank_top",
-          "hoodie",
-          "pants_cargo",
-          "socks",
-          "sneakers",
-          "weed",
-          "tobacco",
-          "rolling_paper",
-          "switchblade",
-          "wristwatch",
-          "picklocks"
-        ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "lighter", "charges": 100 } ]
+        "entries": [
+          { "item": "tank_top" },
+          { "item": "hoodie" },
+          { "item": "pants_cargo" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "weed" },
+          { "item": "tobacco" },
+          { "item": "rolling_paper" },
+          { "item": "switchblade" },
+          { "item": "wristwatch" },
+          { "item": "picklocks" },
+          { "group": "charged_smart_phone" },
+          { "item": "lighter", "charges": 100 }
+        ]
       },
-      "male": [ "boxer_briefs" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_briefs" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     },
     "age_lower": 18
   },
@@ -915,21 +980,22 @@
     "skills": [ { "name": "fabrication", "level": 4 }, { "name": "survival", "level": 4 } ],
     "items": {
       "both": {
-        "items": [
-          "beekeeping_hood",
-          "beekeeping_suit",
-          "beekeeping_gloves",
-          "socks",
-          "boots",
-          "tank_top",
-          "honeycomb",
-          "honey_bottled",
-          "honey_bottled"
-        ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "honey_scraper", "container-item": "sheath" } ]
+        "entries": [
+          { "item": "beekeeping_hood" },
+          { "item": "beekeeping_suit" },
+          { "item": "beekeeping_gloves" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "tank_top" },
+          { "item": "honeycomb" },
+          { "item": "honey_bottled" },
+          { "item": "honey_bottled" },
+          { "group": "charged_smart_phone" },
+          { "item": "honey_scraper", "container-item": "sheath" }
+        ]
       },
-      "male": [ "boxer_briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -947,15 +1013,22 @@
     "proficiencies": [ "prof_athlete_basic", "prof_maces_familiar", "prof_maces_pro" ],
     "items": {
       "both": {
-        "items": [ "baseball", "jacket_light", "jeans", "socks", "cleats", "helmet_ball", "sports_drink", "gum" ],
         "entries": [
+          { "item": "baseball" },
+          { "item": "jacket_light" },
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "cleats" },
+          { "item": "helmet_ball" },
+          { "item": "sports_drink" },
+          { "item": "gum" },
           { "group": "charged_smart_phone" },
           { "item": "bat", "custom-flags": [ "auto_wield" ] },
           { "item": "tshirt", "variant": "generic_tshirt" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
     },
     "age_lower": 16
   },
@@ -969,11 +1042,20 @@
     "proficiencies": [ "prof_athlete_basic" ],
     "items": {
       "both": {
-        "items": [ "tank_top", "b_shorts", "socks_ankle", "sneakers", "basketball", "sports_drink", "runner_bag" ],
-        "entries": [ { "item": "jersey", "snippets": [ "basin" ] }, { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "tank_top" },
+          { "item": "b_shorts" },
+          { "item": "socks_ankle" },
+          { "item": "sneakers" },
+          { "item": "basketball" },
+          { "item": "sports_drink" },
+          { "item": "runner_bag" },
+          { "item": "jersey", "snippets": [ "basin" ] },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
     },
     "age_lower": 16
   },
@@ -993,15 +1075,22 @@
     "proficiencies": [ "prof_athlete_basic", "prof_unarmed_familiar" ],
     "items": {
       "both": {
-        "items": [ "helmet_football", "football_armor", "mouthpiece", "socks_ankle", "cleats", "football", "knee_pads", "sports_drink" ],
         "entries": [
+          { "item": "helmet_football" },
+          { "item": "football_armor" },
+          { "item": "mouthpiece" },
+          { "item": "socks_ankle" },
+          { "item": "cleats" },
+          { "item": "football" },
+          { "item": "knee_pads" },
+          { "item": "sports_drink" },
           { "item": "jersey", "snippets": [ "endsville" ] },
           { "group": "charged_smart_phone" },
           { "item": "pants", "variant": "pants_blue" }
         ]
       },
-      "male": [ "under_armor_shorts" ],
-      "female": [ "sports_bra", "panties" ]
+      "male": { "entries": [ { "item": "under_armor_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
     },
     "age_lower": 16
   },
@@ -1015,26 +1104,29 @@
     "skills": [ { "level": 2, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [
-          "pants_cargo",
-          "cape_fp",
-          "dress_shirt",
-          "armguard_hard",
-          "legguard_hard",
-          "gloves_rubber",
-          "socks",
-          "chestguard_hard",
-          "boots_rubber"
-        ],
         "entries": [
-          { "item": "medium_disposable_cell", "ammo-item": "battery", "charges": 1200, "container-item": "foodperson_mask" },
+          { "item": "pants_cargo" },
+          { "item": "cape_fp" },
+          { "item": "dress_shirt" },
+          { "item": "armguard_hard" },
+          { "item": "legguard_hard" },
+          { "item": "gloves_rubber" },
+          { "item": "socks" },
+          { "item": "chestguard_hard" },
+          { "item": "boots_rubber" },
+          {
+            "item": "medium_disposable_cell",
+            "ammo-item": "battery",
+            "charges": 1200,
+            "container-item": "foodperson_mask"
+          },
           { "item": "foodplace_snack_bar", "container-item": "fanny" },
           { "item": "foodplace_snack_bar" },
           { "item": "bat", "custom-flags": [ "auto_wield" ] }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -1047,22 +1139,22 @@
     "skills": [ { "level": 5, "name": "driving" }, { "level": 4, "name": "dodge" } ],
     "items": {
       "both": {
-        "items": [
-          "helmet_bike",
-          "folded_bicycle",
-          "under_armor_shorts",
-          "under_armor",
-          "socks_ankle",
-          "sneakers",
-          "sports_drink",
-          "wristwatch",
-          "fanny",
-          "fancy_sunglasses"
-        ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "helmet_bike" },
+          { "item": "folded_bicycle" },
+          { "item": "under_armor_shorts" },
+          { "item": "under_armor" },
+          { "item": "socks_ankle" },
+          { "item": "sneakers" },
+          { "item": "sports_drink" },
+          { "item": "wristwatch" },
+          { "item": "fanny" },
+          { "item": "fancy_sunglasses" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "panties", "sports_bra" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "panties" }, { "item": "sports_bra" } ] }
     }
   },
   {
@@ -1085,19 +1177,17 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "undershirt",
-          "officer_uniform",
-          "jacket_army_modern",
-          "gloves_liner",
-          "socks",
-          "boots",
-          "beret",
-          "silver_watch",
-          "fancy_sunglasses",
-          "binoculars"
-        ],
         "entries": [
+          { "item": "undershirt" },
+          { "item": "officer_uniform" },
+          { "item": "jacket_army_modern" },
+          { "item": "gloves_liner" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "beret" },
+          { "item": "silver_watch" },
+          { "item": "fancy_sunglasses" },
+          { "item": "binoculars" },
           { "item": "cigar", "entry-wrapper": "case_cigar", "count": 2 },
           { "item": "id_military", "container-item": "wallet_leather" },
           { "item": "water_clean", "container-item": "canteen" },
@@ -1106,8 +1196,8 @@
           { "item": "militarymap" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     },
     "missions": [ "MISSION_SOCIAL_BUTTERFLY" ],
     "age_lower": 45
@@ -1140,18 +1230,16 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "combat_shirt",
-          "jacket_army_modern",
-          "hat_navy",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "boots_combat",
-          "diving_watch",
-          "webbing_belt"
-        ],
         "entries": [
+          { "item": "combat_shirt" },
+          { "item": "jacket_army_modern" },
+          { "item": "hat_navy" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "diving_watch" },
+          { "item": "webbing_belt" },
           { "group": "charged_two_way_radio" },
           { "group": "military_ballistic_vest_pristine" },
           { "item": "tank_top", "variant": "tank_top_camo" },
@@ -1171,8 +1259,8 @@
           }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -1206,17 +1294,15 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "combat_shirt",
-          "jacket_army_modern",
-          "hat_navy",
-          "tool_belt",
-          "nomex_gloves",
-          "nomex_socks",
-          "boots",
-          "diving_watch"
-        ],
         "entries": [
+          { "item": "combat_shirt" },
+          { "item": "jacket_army_modern" },
+          { "item": "hat_navy" },
+          { "item": "tool_belt" },
+          { "item": "nomex_gloves" },
+          { "item": "nomex_socks" },
+          { "item": "boots" },
+          { "item": "diving_watch" },
           { "group": "charged_two_way_radio" },
           { "item": "tank_top", "variant": "tank_top_camo" },
           { "item": "pants_army", "variant": "mil_pants_navy" },
@@ -1226,8 +1312,8 @@
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -1260,16 +1346,14 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "wetsuit_thick",
-          "wetsuit_hood_thick",
-          "goggles_swim",
-          "wetsuit_gloves_thick",
-          "swim_fins",
-          "dive_bag",
-          "diving_watch"
-        ],
         "entries": [
+          { "item": "wetsuit_thick" },
+          { "item": "wetsuit_hood_thick" },
+          { "item": "goggles_swim" },
+          { "item": "wetsuit_gloves_thick" },
+          { "item": "swim_fins" },
+          { "item": "dive_bag" },
+          { "item": "diving_watch" },
           { "group": "full_rebreather_mask" },
           { "group": "charged_heavy_flashlight" },
           { "item": "barometer" },
@@ -1277,8 +1361,8 @@
           { "item": "diveknife", "container-item": "sheath" }
         ]
       },
-      "male": [ "rashguard", "wetsuit_shorts" ],
-      "female": [ "bikini_top", "wetsuit_shorts" ]
+      "male": { "entries": [ { "item": "rashguard" }, { "item": "wetsuit_shorts" } ] },
+      "female": { "entries": [ { "item": "bikini_top" }, { "item": "wetsuit_shorts" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -1304,15 +1388,17 @@
     ],
     "items": {
       "both": {
-        "items": [ "socks", "sneakers", "wristwatch" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "wristwatch" },
           { "group": "charged_smart_phone" },
           { "item": "tshirt", "variant": "generic_tshirt" },
           { "item": "pants", "variant": "pants_black" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -1343,20 +1429,18 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "undershirt",
-          "combat_shirt",
-          "helmet_army",
-          "mask_ski",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "boots_combat",
-          "wristwatch",
-          "molle_pack"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "undershirt" },
+          { "item": "combat_shirt" },
+          { "item": "helmet_army" },
+          { "item": "mask_ski" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "wristwatch" },
+          { "item": "molle_pack" },
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
           { "item": "water_clean", "container-item": "canteen" },
@@ -1372,8 +1456,8 @@
           }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -1399,20 +1483,18 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "undershirt",
-          "combat_shirt",
-          "helmet_army",
-          "mask_ski",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "boots_combat",
-          "wristwatch",
-          "molle_pack"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "undershirt" },
+          { "item": "combat_shirt" },
+          { "item": "helmet_army" },
+          { "item": "mask_ski" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "wristwatch" },
+          { "item": "molle_pack" },
           { "group": "us_ballistic_vest_pristine" },
           { "item": "water_clean", "container-item": "canteen" },
           { "item": "wrench" },
@@ -1424,8 +1506,8 @@
           { "item": "tinyweldtank", "charges": 60, "container-item": "oxy_torch" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -1453,19 +1535,17 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "undershirt",
-          "helmet_army",
-          "mask_ski",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "boots_combat",
-          "wristwatch",
-          "molle_pack"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "undershirt" },
+          { "item": "helmet_army" },
+          { "item": "mask_ski" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "wristwatch" },
+          { "item": "molle_pack" },
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
           { "item": "water_clean", "container-item": "canteen" },
@@ -1473,8 +1553,8 @@
           { "item": "c4", "count": 3 }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -1507,20 +1587,18 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "undershirt",
-          "combat_shirt",
-          "helmet_army",
-          "mask_ski",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "boots_combat",
-          "diving_watch",
-          "molle_pack"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "undershirt" },
+          { "item": "combat_shirt" },
+          { "item": "helmet_army" },
+          { "item": "mask_ski" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "diving_watch" },
+          { "item": "molle_pack" },
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
           { "item": "water_clean", "container-item": "canteen" },
@@ -1536,8 +1614,8 @@
           }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -1569,20 +1647,18 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "undershirt",
-          "combat_shirt",
-          "helmet_army",
-          "mask_ski",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "boots_combat",
-          "wristwatch",
-          "molle_pack"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "undershirt" },
+          { "item": "combat_shirt" },
+          { "item": "helmet_army" },
+          { "item": "mask_ski" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "wristwatch" },
+          { "item": "molle_pack" },
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
           { "item": "water_clean", "container-item": "canteen" },
@@ -1598,8 +1674,8 @@
           }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -1631,20 +1707,18 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "army_top",
-          "combat_shirt",
-          "tac_fullhelmet",
-          "mask_ski",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "diving_watch",
-          "load_bearing_vest",
-          "boots_combat",
-          "webbing_belt"
-        ],
         "entries": [
+          { "item": "army_top" },
+          { "item": "combat_shirt" },
+          { "item": "tac_fullhelmet" },
+          { "item": "mask_ski" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "diving_watch" },
+          { "item": "load_bearing_vest" },
+          { "item": "boots_combat" },
+          { "item": "webbing_belt" },
           { "group": "charged_two_way_radio" },
           { "group": "charged_powered_earmuffs" },
           { "item": "pants_army", "variant": "mil_pants_navy" },
@@ -1656,8 +1730,8 @@
           { "item": "tac338", "ammo-item": "338lapua_fmjbt", "charges": 5, "contents-item": [ "shoulder_strap" ] }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -1691,19 +1765,17 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "combat_shirt",
-          "tac_fullhelmet",
-          "mask_ski",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "diving_watch",
-          "load_bearing_vest",
-          "boots_combat",
-          "webbing_belt"
-        ],
         "entries": [
+          { "item": "combat_shirt" },
+          { "item": "tac_fullhelmet" },
+          { "item": "mask_ski" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "diving_watch" },
+          { "item": "load_bearing_vest" },
+          { "item": "boots_combat" },
+          { "item": "webbing_belt" },
           { "group": "charged_two_way_radio" },
           { "group": "charged_powered_earmuffs" },
           { "item": "tank_top", "variant": "tank_top_camo" },
@@ -1724,8 +1796,8 @@
           }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -1760,20 +1832,18 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "wetsuit",
-          "pants_army",
-          "wetsuit_hood",
-          "tac_helmet",
-          "wetsuit_gloves",
-          "gloves_tactical",
-          "socks",
-          "boots_combat",
-          "dive_bag",
-          "diving_watch",
-          "single_sling"
-        ],
         "entries": [
+          { "item": "wetsuit" },
+          { "item": "pants_army" },
+          { "item": "wetsuit_hood" },
+          { "item": "tac_helmet" },
+          { "item": "wetsuit_gloves" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "dive_bag" },
+          { "item": "diving_watch" },
+          { "item": "single_sling" },
           { "group": "charged_two_way_radio" },
           { "item": "water_clean", "container-item": "canteen" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -1783,8 +1853,8 @@
           { "item": "hk_mp5", "ammo-item": "9mm", "charges": 30, "contents-item": [ "suppressor", "holo_sight" ] }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -1796,12 +1866,30 @@
     "skills": [ { "level": 3, "name": "tailor" }, { "level": 3, "name": "cooking" }, { "level": 3, "name": "driving" } ],
     "proficiencies": [ "prof_food_prep", "prof_closures", "prof_knife_skills", "prof_knives_familiar" ],
     "items": {
-      "both": { "items": [ "pocketwatch", "knife_steak" ], "entries": [ { "group": "charged_smart_phone" } ] },
+      "both": { "entries": [ { "item": "pocketwatch" }, { "item": "knife_steak" }, { "group": "charged_smart_phone" } ] },
       "male": {
-        "items": [ "briefs", "socks", "dress_shoes", "tux", "glasses_monocle", "collarpin" ],
-        "entries": [ { "item": "pants", "variant": "pants_black" } ]
+        "entries": [
+          { "item": "briefs" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "tux" },
+          { "item": "glasses_monocle" },
+          { "item": "collarpin" }
+        ]
       },
-      "female": [ "panties", "bra", "stockings", "garter_belt", "dress_shoes", "maid_dress", "maid_hat", "corset_waist", "fc_hairpin" ]
+      "female": {
+        "entries": [
+          { "item": "panties" },
+          { "item": "bra" },
+          { "item": "stockings" },
+          { "item": "garter_belt" },
+          { "item": "dress_shoes" },
+          { "item": "maid_dress" },
+          { "item": "maid_hat" },
+          { "item": "corset_waist" },
+          { "item": "fc_hairpin" }
+        ]
+      }
     }
   },
   {
@@ -1834,8 +1922,15 @@
     ],
     "items": {
       "both": {
-        "items": [ "armor_farmor", "socks", "boots_fur", "hat_fur", "gloves_fur", "vest", "wristwatch", "bracelet_friendship" ],
         "entries": [
+          { "item": "armor_farmor" },
+          { "item": "socks" },
+          { "item": "boots_fur" },
+          { "item": "hat_fur" },
+          { "item": "gloves_fur" },
+          { "item": "vest" },
+          { "item": "wristwatch" },
+          { "item": "bracelet_friendship" },
           { "item": "knife_combat", "container-item": "sheath" },
           {
             "item": "modular_m4_carbine",
@@ -1850,8 +1945,8 @@
           { "group": "full_gasmask" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -1873,25 +1968,27 @@
     "traits": [ "PROF_MED" ],
     "items": {
       "both": {
-        "items": [
-          "dress_shirt",
-          "gloves_medical",
-          "socks",
-          "dress_shoes",
-          "coat_lab",
-          "badge_doctor",
-          "glasses_safety",
-          "wristwatch",
-          "water_clean",
+        "entries": [
+          { "item": "dress_shirt" },
+          { "item": "gloves_medical" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "coat_lab" },
+          { "item": "badge_doctor" },
+          { "item": "glasses_safety" },
+          { "item": "wristwatch" },
+          { "item": "water_clean" },
           { "item": "bandages", "count": 3 },
           { "item": "adhesive_bandages", "count": 10 },
-          "aspirin",
-          "stethoscope"
-        ],
-        "entries": [ { "item": "pants", "variant": "pants_blue" }, { "group": "charged_smart_phone" }, { "group": "full_1st_aid" } ]
+          { "item": "aspirin" },
+          { "item": "stethoscope" },
+          { "item": "pants", "variant": "pants_blue" },
+          { "group": "charged_smart_phone" },
+          { "group": "full_1st_aid" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -1913,21 +2010,19 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "suit",
-          "bowhat",
-          "socks",
-          "dress_shoes",
-          "knit_scarf",
-          "cig",
-          "switchblade",
-          "mag_porn",
-          "sunglasses",
-          "cestus",
-          "gold_watch",
-          "gold_ring"
-        ],
         "entries": [
+          { "item": "suit" },
+          { "item": "bowhat" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "knit_scarf" },
+          { "item": "cig" },
+          { "item": "switchblade" },
+          { "item": "mag_porn" },
+          { "item": "sunglasses" },
+          { "item": "cestus" },
+          { "item": "gold_watch" },
+          { "item": "gold_ring" },
           { "group": "charged_smart_phone" },
           { "item": "glock_19", "ammo-item": "9mm", "container-item": "holster", "charges": 15 },
           { "item": "glockmag", "ammo-item": "9mm", "charges": 15 },
@@ -1935,8 +2030,8 @@
           { "item": "lighter", "charges": 100 }
         ]
       },
-      "male": [ "boxer_shorts", "gold_dental_grill" ],
-      "female": [ "bra", "panties", "gold_hairpin", "gold_ear" ]
+      "male": { "entries": [ { "item": "boxer_shorts" }, { "item": "gold_dental_grill" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" }, { "item": "gold_hairpin" }, { "item": "gold_ear" } ] }
     }
   },
   {
@@ -1954,8 +2049,14 @@
     ],
     "items": {
       "both": {
-        "items": [ "socks", "boots_combat", "longshirt", "knife_folding", "hat_ball", "wristwatch", "leather_belt" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "longshirt" },
+          { "item": "knife_folding" },
+          { "item": "hat_ball" },
+          { "item": "wristwatch" },
+          { "item": "leather_belt" },
           { "group": "charged_smart_phone" },
           { "group": "charged_flashlight" },
           { "item": "pants", "variant": "pants_black" },
@@ -1966,8 +2067,8 @@
           { "item": "m9mag", "ammo-item": "9mm", "charges": 15 }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -1985,11 +2086,22 @@
     ],
     "items": {
       "both": {
-        "items": [ "tank_top", "jacket_windbreaker", "hat_ball", "gloves_work", "glasses_safety", "socks", "sneakers", "pants_cargo" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "g_shovel" }, { "item": "scabbard", "contents-item": "machete" } ]
+        "entries": [
+          { "item": "tank_top" },
+          { "item": "jacket_windbreaker" },
+          { "item": "hat_ball" },
+          { "item": "gloves_work" },
+          { "item": "glasses_safety" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "pants_cargo" },
+          { "group": "charged_smart_phone" },
+          { "item": "g_shovel" },
+          { "item": "scabbard", "contents-item": "machete" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -2003,27 +2115,25 @@
     "proficiencies": [ "prof_wound_care" ],
     "items": {
       "both": {
-        "items": [
-          "dress_shirt",
-          "gloves_medical",
-          "socks",
-          "dress_shoes",
-          "coat_lab",
-          "water_clean",
+        "entries": [
+          { "item": "dress_shirt" },
+          { "item": "gloves_medical" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "coat_lab" },
+          { "item": "water_clean" },
           { "item": "bandages", "count": 3 },
           { "item": "adhesive_bandages", "count": 10 },
-          "aspirin",
-          "stethoscope",
-          "pudding"
-        ],
-        "entries": [
+          { "item": "aspirin" },
+          { "item": "stethoscope" },
+          { "item": "pudding" },
           { "item": "pants", "variant": "pants_white" },
           { "group": "charged_smart_phone" },
           { "item": "mask_dust", "variant": "white_mask_dust" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -2060,19 +2170,17 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_cargo",
-          "boots",
-          "hat_boonie",
-          "jacket_light",
-          "socks",
-          "backpack",
-          "rope_30",
-          "whistle",
-          "diving_watch",
-          "canteen"
-        ],
         "entries": [
+          { "item": "pants_cargo" },
+          { "item": "boots" },
+          { "item": "hat_boonie" },
+          { "item": "jacket_light" },
+          { "item": "socks" },
+          { "item": "backpack" },
+          { "item": "rope_30" },
+          { "item": "whistle" },
+          { "item": "diving_watch" },
+          { "item": "canteen" },
           { "group": "charged_cell_phone" },
           { "group": "charged_flashlight" },
           { "item": "lighter", "charges": 100 },
@@ -2080,8 +2188,8 @@
           { "item": "tshirt", "variant": "generic_tshirt" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -2092,11 +2200,18 @@
     "points": 0,
     "items": {
       "both": {
-        "items": [ "knit_scarf", "ragpouch", "bindle", "can_beans", "pockknife" ],
-        "entries": [ { "group": "charged_matches" }, { "item": "pants", "variant": "pants_grey" } ]
+        "entries": [
+          { "item": "knit_scarf" },
+          { "item": "ragpouch" },
+          { "item": "bindle" },
+          { "item": "can_beans" },
+          { "item": "pockknife" },
+          { "group": "charged_matches" },
+          { "item": "pants", "variant": "pants_grey" }
+        ]
       },
-      "male": [ "undershirt" ],
-      "female": [ "camisole" ]
+      "male": { "entries": [ { "item": "undershirt" } ] },
+      "female": { "entries": [ { "item": "camisole" } ] }
     },
     "age_lower": 18
   },
@@ -2110,11 +2225,19 @@
     "proficiencies": [ "prof_helicopter_pilot" ],
     "items": {
       "both": {
-        "items": [ "pants_cargo", "socks", "polo_shirt", "boots", "wristwatch", "fancy_sunglasses" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] } ]
+        "entries": [
+          { "item": "pants_cargo" },
+          { "item": "socks" },
+          { "item": "polo_shirt" },
+          { "item": "boots" },
+          { "item": "wristwatch" },
+          { "item": "fancy_sunglasses" },
+          { "group": "charged_smart_phone" },
+          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -2138,8 +2261,16 @@
     "pets": [ { "name": "mon_dog_gshepherd", "amount": 1 } ],
     "items": {
       "both": {
-        "items": [ "pants_army", "socks", "badge_deputy", "police_belt", "boots", "dog_whistle", "wristwatch", "dogfood_dry", "baton" ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "socks" },
+          { "item": "badge_deputy" },
+          { "item": "police_belt" },
+          { "item": "boots" },
+          { "item": "dog_whistle" },
+          { "item": "wristwatch" },
+          { "item": "dogfood_dry" },
+          { "item": "baton" },
           { "group": "charged_smart_phone" },
           { "group": "charged_two_way_radio" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -2149,8 +2280,8 @@
           { "item": "sheriffshirt", "variant": "sheriff" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -2174,19 +2305,17 @@
     "pets": [ { "name": "mon_horse_police", "amount": 1 } ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "socks",
-          "badge_deputy",
-          "police_belt",
-          "boots",
-          "wristwatch",
-          "helmet_bike",
-          "knee_pads",
-          "elbow_pads",
-          "baton"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "socks" },
+          { "item": "badge_deputy" },
+          { "item": "police_belt" },
+          { "item": "boots" },
+          { "item": "wristwatch" },
+          { "item": "helmet_bike" },
+          { "item": "knee_pads" },
+          { "item": "elbow_pads" },
+          { "item": "baton" },
           { "group": "charged_smart_phone" },
           { "group": "charged_two_way_radio" },
           { "group": "holster_supp_usp9", "container-item": "XL_holster" },
@@ -2194,8 +2323,8 @@
           { "item": "sheriffshirt", "variant": "sheriff" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -2209,11 +2338,21 @@
     "pets": [ { "name": "mon_dog", "amount": 2 } ],
     "items": {
       "both": {
-        "items": [ "jeans", "longshirt", "socks", "sneakers", "water_clean", "wristwatch", "petpack", "pet_carrier" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "mbag", "contents-group": "dog_lover_bag" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "water_clean" },
+          { "item": "wristwatch" },
+          { "item": "petpack" },
+          { "item": "pet_carrier" },
+          { "group": "charged_smart_phone" },
+          { "item": "mbag", "contents-group": "dog_lover_bag" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "missions": [ "MISSION_DOG_LOVER" ]
   },
@@ -2243,11 +2382,23 @@
     ],
     "items": {
       "both": {
-        "items": [ "jeans", "longshirt", "socks", "sneakers", "knit_scarf", "pockknife", "water_clean", "wristwatch", "mbag" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_matches" }, { "item": "catfood_dry", "count": 10 } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "knit_scarf" },
+          { "item": "pockknife" },
+          { "item": "water_clean" },
+          { "item": "wristwatch" },
+          { "item": "mbag" },
+          { "group": "charged_smart_phone" },
+          { "group": "charged_matches" },
+          { "item": "catfood_dry", "count": 10 }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -2269,8 +2420,15 @@
     "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_batons_familiar", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
-        "items": [ "pants_army", "socks", "badge_deputy", "police_belt", "boots", "whistle", "wristwatch", "baton" ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "socks" },
+          { "item": "badge_deputy" },
+          { "item": "police_belt" },
+          { "item": "boots" },
+          { "item": "whistle" },
+          { "item": "wristwatch" },
+          { "item": "baton" },
           { "group": "charged_smart_phone" },
           { "group": "charged_two_way_radio" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -2279,8 +2437,8 @@
           { "item": "sheriffshirt", "variant": "sheriff" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -2294,22 +2452,20 @@
     "proficiencies": [ "prof_spotting", "prof_gun_cleaning" ],
     "items": {
       "both": {
-        "items": [
-          "dress_shirt",
-          "tie_skinny",
-          "waistcoat",
-          "trenchcoat",
-          "police_belt",
-          "badge_detective",
-          "gloves_leather",
-          "knit_scarf",
-          "fedora",
-          "wristwatch",
-          "socks",
-          "dress_shoes",
-          "cig"
-        ],
         "entries": [
+          { "item": "dress_shirt" },
+          { "item": "tie_skinny" },
+          { "item": "waistcoat" },
+          { "item": "trenchcoat" },
+          { "item": "police_belt" },
+          { "item": "badge_detective" },
+          { "item": "gloves_leather" },
+          { "item": "knit_scarf" },
+          { "item": "fedora" },
+          { "item": "wristwatch" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "cig" },
           { "group": "charged_smart_phone" },
           { "group": "charged_two_way_radio" },
           { "group": "charged_ref_lighter" },
@@ -2318,8 +2474,8 @@
           { "item": "sw_619", "ammo-item": "357mag_fmj", "charges": 7, "container-item": "holster" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "skills": [
       { "level": 4, "name": "gun" },
@@ -2354,20 +2510,18 @@
     "traits": [ "PROF_SWAT" ],
     "items": {
       "both": {
-        "items": [
-          "socks",
-          "police_belt",
-          "tac_helmet",
-          "boots_combat",
-          "gloves_tactical",
-          "badge_swat",
-          "wristwatch",
-          "pants_tactical",
-          "elbow_pads",
-          "knee_pads",
-          "single_sling"
-        ],
         "entries": [
+          { "item": "socks" },
+          { "item": "police_belt" },
+          { "item": "tac_helmet" },
+          { "item": "boots_combat" },
+          { "item": "gloves_tactical" },
+          { "item": "badge_swat" },
+          { "item": "wristwatch" },
+          { "item": "pants_tactical" },
+          { "item": "elbow_pads" },
+          { "item": "knee_pads" },
+          { "item": "single_sling" },
           { "group": "swat_ballistic_vest_pristine" },
           { "group": "charged_two_way_radio" },
           { "item": "sheriffshirt", "variant": "swat_shirt" },
@@ -2379,8 +2533,8 @@
           { "item": "hk_mp5", "ammo-item": "9mm", "charges": 30, "contents-item": [ "rail_laser_sight" ] }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -2414,18 +2568,16 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "socks",
-          "tac_fullhelmet",
-          "boots_combat",
-          "gloves_tactical",
-          "badge_swat",
-          "wristwatch",
-          "pants_tactical",
-          "elbow_pads",
-          "knee_pads"
-        ],
         "entries": [
+          { "item": "socks" },
+          { "item": "tac_fullhelmet" },
+          { "item": "boots_combat" },
+          { "item": "gloves_tactical" },
+          { "item": "badge_swat" },
+          { "item": "wristwatch" },
+          { "item": "pants_tactical" },
+          { "item": "elbow_pads" },
+          { "item": "knee_pads" },
           { "group": "swat_ballistic_vest_pristine" },
           { "group": "charged_two_way_radio" },
           { "item": "sheriffshirt", "variant": "swat_shirt" },
@@ -2438,8 +2590,8 @@
           { "item": "ksg", "ammo-item": "shot_00", "charges": 7, "contents-item": [ "shoulder_strap" ] }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -2469,19 +2621,17 @@
     "traits": [ "PROF_POLICE" ],
     "items": {
       "both": {
-        "items": [
-          "socks",
-          "pants_army",
-          "police_belt",
-          "sweatshirt",
-          "sneakers",
-          "gloves_tactical",
-          "hat_ball",
-          "badge_deputy",
-          "wristwatch",
-          "tacvest"
-        ],
         "entries": [
+          { "item": "socks" },
+          { "item": "pants_army" },
+          { "item": "police_belt" },
+          { "item": "sweatshirt" },
+          { "item": "sneakers" },
+          { "item": "gloves_tactical" },
+          { "item": "hat_ball" },
+          { "item": "badge_deputy" },
+          { "item": "wristwatch" },
+          { "item": "tacvest" },
           { "group": "charged_two_way_radio" },
           { "item": "glasses_bal", "custom-flags": [ "no_auto_equip" ] },
           { "group": "charged_powered_earmuffs" },
@@ -2492,8 +2642,8 @@
           { "item": "sheriffshirt", "variant": "sheriff" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -2517,19 +2667,17 @@
     "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_batons_familiar", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
-        "items": [
-          "socks",
-          "pants_tactical",
-          "longshirt",
-          "boots_combat",
-          "gloves_tactical",
-          "armor_riot",
-          "helmet_riot",
-          "badge_deputy",
-          "wristwatch",
-          "gasbomb"
-        ],
         "entries": [
+          { "item": "socks" },
+          { "item": "pants_tactical" },
+          { "item": "longshirt" },
+          { "item": "boots_combat" },
+          { "item": "gloves_tactical" },
+          { "item": "armor_riot" },
+          { "item": "helmet_riot" },
+          { "item": "badge_deputy" },
+          { "item": "wristwatch" },
+          { "item": "gasbomb" },
           { "group": "charged_two_way_radio" },
           { "group": "full_gasmask" },
           { "item": "usp_45", "ammo-item": "45_acp", "charges": 12, "container-item": "holster" },
@@ -2538,8 +2686,8 @@
           { "group": "charged_tazer" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -2561,19 +2709,17 @@
     "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_batons_familiar", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
-        "items": [
-          "socks",
-          "police_breeches",
-          "badge_deputy",
-          "undershirt",
-          "police_belt",
-          "motor_police_boots",
-          "whistle",
-          "wristwatch",
-          "baton",
-          { "item": "leather_police_jacket", "variant": "leather_police_jacket" }
-        ],
         "entries": [
+          { "item": "socks" },
+          { "item": "police_breeches" },
+          { "item": "badge_deputy" },
+          { "item": "undershirt" },
+          { "item": "police_belt" },
+          { "item": "motor_police_boots" },
+          { "item": "whistle" },
+          { "item": "wristwatch" },
+          { "item": "baton" },
+          { "item": "leather_police_jacket", "variant": "leather_police_jacket" },
           { "group": "charged_smart_phone" },
           { "group": "charged_two_way_radio" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -2583,8 +2729,8 @@
           { "item": "sheriffshirt", "variant": "sheriff" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -2596,11 +2742,18 @@
     "skills": [ { "level": 5, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [ "suit", "knit_scarf", "socks", "dress_shoes", "gold_watch", "money_strap_fifty" ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "suit" },
+          { "item": "knit_scarf" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "gold_watch" },
+          { "item": "money_strap_fifty" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "briefs", "citrine_gold_cufflinks" ],
-      "female": [ "bra", "panties", "gold_ear" ]
+      "male": { "entries": [ { "item": "briefs" }, { "item": "citrine_gold_cufflinks" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" }, { "item": "gold_ear" } ] }
     }
   },
   {
@@ -2613,26 +2766,24 @@
     "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "archery" }, { "level": 2, "name": "swimming" } ],
     "items": {
       "both": {
-        "items": [
-          "whistle",
-          "socks",
-          "boots_steel",
-          "pants_cargo",
-          "jacket_leather",
-          "fancy_sunglasses",
-          "hat_boonie",
-          "diving_watch",
-          "caff_gum"
-        ],
         "entries": [
+          { "item": "whistle" },
+          { "item": "socks" },
+          { "item": "boots_steel" },
+          { "item": "pants_cargo" },
+          { "item": "jacket_leather" },
+          { "item": "fancy_sunglasses" },
+          { "item": "hat_boonie" },
+          { "item": "diving_watch" },
+          { "item": "caff_gum" },
           { "group": "charged_smart_phone" },
           { "item": "rashguard", "variant": "black_rashguard_shirt" },
           { "item": "takedown_recurbow", "custom-flags": [ "no_auto_equip" ] },
           { "item": "quiver_takedown_bow", "contents-group": "quiver_modern_archer" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     },
     "missions": [ "MISSION_HUNTER" ]
   },
@@ -2651,18 +2802,16 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "knit_scarf",
-          "socks",
-          "boots_steel",
-          "pants_cargo",
-          "jacket_flannel",
-          "bow_sling",
-          "bow_sight_pin",
-          "hat_hunting",
-          "wristwatch"
-        ],
         "entries": [
+          { "item": "knit_scarf" },
+          { "item": "socks" },
+          { "item": "boots_steel" },
+          { "item": "pants_cargo" },
+          { "item": "jacket_flannel" },
+          { "item": "bow_sling" },
+          { "item": "bow_sight_pin" },
+          { "item": "hat_hunting" },
+          { "item": "wristwatch" },
           { "group": "charged_smart_phone" },
           { "item": "compbow_low", "custom-flags": [ "no_auto_equip" ] },
           { "item": "quiver", "contents-group": "quiver_bow_hunter" },
@@ -2670,8 +2819,8 @@
           { "item": "tank_top", "variant": "tank_top_camo" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     },
     "missions": [ "MISSION_HUNTER" ]
   },
@@ -2690,8 +2839,14 @@
     ],
     "items": {
       "both": {
-        "items": [ "knit_scarf", "socks", "boots_steel", "pants_cargo", "jacket_flannel", "hat_hunting", "wristwatch" ],
         "entries": [
+          { "item": "knit_scarf" },
+          { "item": "socks" },
+          { "item": "boots_steel" },
+          { "item": "pants_cargo" },
+          { "item": "jacket_flannel" },
+          { "item": "hat_hunting" },
+          { "item": "wristwatch" },
           { "group": "charged_smart_phone" },
           {
             "item": "compcrossbow",
@@ -2705,8 +2860,8 @@
           { "item": "tank_top", "variant": "tank_top_camo" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     },
     "missions": [ "MISSION_HUNTER" ]
   },
@@ -2720,8 +2875,15 @@
     "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "shotgun" }, { "level": 3, "name": "survival" } ],
     "items": {
       "both": {
-        "items": [ "knit_scarf", "socks", "boots_steel", "pants_cargo", "jacket_flannel", "hat_hunting", "wristwatch", "back_holster" ],
         "entries": [
+          { "item": "knit_scarf" },
+          { "item": "socks" },
+          { "item": "boots_steel" },
+          { "item": "pants_cargo" },
+          { "item": "jacket_flannel" },
+          { "item": "hat_hunting" },
+          { "item": "wristwatch" },
+          { "item": "back_holster" },
           { "group": "charged_smart_phone" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           {
@@ -2736,8 +2898,8 @@
           { "item": "tank_top", "variant": "tank_top_camo" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     },
     "missions": [ "MISSION_HUNTER" ]
   },
@@ -2751,8 +2913,15 @@
     "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "rifle" }, { "level": 3, "name": "survival" } ],
     "items": {
       "both": {
-        "items": [ "knit_scarf", "socks", "boots_steel", "pants_cargo", "jacket_flannel", "hat_hunting", "wristwatch", "back_holster" ],
         "entries": [
+          { "item": "knit_scarf" },
+          { "item": "socks" },
+          { "item": "boots_steel" },
+          { "item": "pants_cargo" },
+          { "item": "jacket_flannel" },
+          { "item": "hat_hunting" },
+          { "item": "wristwatch" },
+          { "item": "back_holster" },
           { "group": "charged_smart_phone" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           {
@@ -2767,8 +2936,8 @@
           { "item": "tank_top", "variant": "tank_top_camo" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     },
     "missions": [ "MISSION_HUNTER" ]
   },
@@ -2782,18 +2951,16 @@
     "skills": [ { "level": 4, "name": "gun" }, { "level": 4, "name": "rifle" }, { "level": 3, "name": "survival" } ],
     "items": {
       "both": {
-        "items": [
-          "army_top",
-          "knit_scarf",
-          "socks",
-          "boots_steel",
-          "pants_cargo",
-          "jacket_flannel",
-          "hat_hunting",
-          "wristwatch",
-          "back_holster"
-        ],
         "entries": [
+          { "item": "army_top" },
+          { "item": "knit_scarf" },
+          { "item": "socks" },
+          { "item": "boots_steel" },
+          { "item": "pants_cargo" },
+          { "item": "jacket_flannel" },
+          { "item": "hat_hunting" },
+          { "item": "wristwatch" },
+          { "item": "back_holster" },
           { "group": "charged_smart_phone" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           {
@@ -2807,8 +2974,8 @@
           { "item": "sheath", "contents-item": "knife_hunting" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     },
     "missions": [ "MISSION_HUNTER" ]
   },
@@ -2828,16 +2995,22 @@
     "vehicle": "extended_pickup",
     "items": {
       "both": {
-        "items": [ "hoodie", "socks", "boots_steel", "jeans", "multitool", "jacket_flannel", "slingpack" ],
         "entries": [
+          { "item": "hoodie" },
+          { "item": "socks" },
+          { "item": "boots_steel" },
+          { "item": "jeans" },
+          { "item": "multitool" },
+          { "item": "jacket_flannel" },
+          { "item": "slingpack" },
           { "group": "charged_smart_phone" },
           { "item": "shot_00", "charges": 25 },
           { "item": "beer", "count": 6 },
           { "item": "remington_870", "ammo-item": "shot_00", "charges": 5, "contents-item": "shoulder_strap_simple" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -2857,8 +3030,11 @@
     "skills": [ { "level": 5, "name": "fabrication" }, { "level": 5, "name": "traps" } ],
     "items": {
       "both": {
-        "items": [ "socks", "boots_steel", "multitool", "wristwatch" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "boots_steel" },
+          { "item": "multitool" },
+          { "item": "wristwatch" },
           { "group": "charged_smart_phone" },
           { "item": "nailgun", "ammo-item": "nail", "charges": 20 },
           { "item": "nail", "charges": 180 },
@@ -2867,8 +3043,8 @@
           { "item": "pants", "variant": "pants_brown" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -2882,15 +3058,20 @@
     "vehicle": "semi_truck_scenario",
     "items": {
       "both": {
-        "items": [ "socks", "boots_steel", "multitool", "wristwatch", "gloves_work", "hat_ball" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "boots_steel" },
+          { "item": "multitool" },
+          { "item": "wristwatch" },
+          { "item": "gloves_work" },
+          { "item": "hat_ball" },
           { "group": "charged_smart_phone" },
           { "item": "pants", "variant": "pants_stone" },
           { "item": "tank_top", "variant": "tank_top_generic" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -2904,11 +3085,18 @@
     "vehicle": "car",
     "items": {
       "both": {
-        "items": [ "sneakers", "socks", "jeans", "longshirt", "wristwatch", "water_clean" ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "sneakers" },
+          { "item": "socks" },
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "wristwatch" },
+          { "item": "water_clean" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "panties", "bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "panties" }, { "item": "bra" } ] }
     }
   },
   {
@@ -2936,26 +3124,24 @@
     "vehicle": "fire_engine",
     "items": {
       "both": {
-        "items": [
-          "boots_bunker",
-          "bunker_coat",
-          "nomex_suit",
-          "bunker_pants",
-          "dress_shirt",
-          "nomex_gloves",
-          "fire_gauntlets",
-          "nomex_hood",
-          "firehelmet",
-          "mask_bunker",
-          "mbag",
-          "nomex_socks",
-          "water_clean",
-          "wristwatch",
-          "syringe",
-          "morphine",
-          "adrenaline_injector"
-        ],
         "entries": [
+          { "item": "boots_bunker" },
+          { "item": "bunker_coat" },
+          { "item": "nomex_suit" },
+          { "item": "bunker_pants" },
+          { "item": "dress_shirt" },
+          { "item": "nomex_gloves" },
+          { "item": "fire_gauntlets" },
+          { "item": "nomex_hood" },
+          { "item": "firehelmet" },
+          { "item": "mask_bunker" },
+          { "item": "mbag" },
+          { "item": "nomex_socks" },
+          { "item": "water_clean" },
+          { "item": "wristwatch" },
+          { "item": "syringe" },
+          { "item": "morphine" },
+          { "item": "adrenaline_injector" },
           { "group": "full_1st_aid" },
           { "group": "charged_smart_phone" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -2980,26 +3166,24 @@
     "vehicle": "cube_van_cheap",
     "items": {
       "both": {
-        "items": [
-          "dress_shirt",
-          "socks",
-          "boots",
-          "multitool",
-          "wristwatch",
-          "mbag",
-          "water_clean",
-          "gloves_work",
-          "hammer",
-          "hat_ball"
-        ],
         "entries": [
+          { "item": "dress_shirt" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "multitool" },
+          { "item": "wristwatch" },
+          { "item": "mbag" },
+          { "item": "water_clean" },
+          { "item": "gloves_work" },
+          { "item": "hammer" },
+          { "item": "hat_ball" },
           { "group": "charged_smart_phone" },
           { "group": "charged_electrical_measuring" },
           { "item": "pants", "variant": "pants_black" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "panties", "bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "panties" }, { "item": "bra" } ] }
     }
   },
   {
@@ -3013,11 +3197,20 @@
     "vehicle": "schoolbus",
     "items": {
       "both": {
-        "items": [ "sneakers", "socks", "jeans", "wristwatch", "jacket_light", "water_clean", "hat_ball" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "sneakers" },
+          { "item": "socks" },
+          { "item": "jeans" },
+          { "item": "wristwatch" },
+          { "item": "jacket_light" },
+          { "item": "water_clean" },
+          { "item": "hat_ball" },
+          { "group": "charged_smart_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "panties", "bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "panties" }, { "item": "bra" } ] }
     }
   },
   {
@@ -3041,8 +3234,16 @@
     "traits": [ "PROF_POLICE" ],
     "items": {
       "both": {
-        "items": [ "pants_army", "socks", "badge_deputy", "police_belt", "boots", "whistle", "kevlar", "baton", "wristwatch" ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "socks" },
+          { "item": "badge_deputy" },
+          { "item": "police_belt" },
+          { "item": "boots" },
+          { "item": "whistle" },
+          { "item": "kevlar" },
+          { "item": "baton" },
+          { "item": "wristwatch" },
           { "group": "charged_smart_phone" },
           { "group": "charged_two_way_radio" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -3051,8 +3252,8 @@
           { "item": "sheriffshirt", "variant": "sheriff" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -3074,23 +3275,21 @@
     "vehicle": "pickup_technical",
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "combat_shirt",
-          "socks",
-          "sweatshirt",
-          "boots",
-          "cig",
-          "elbow_pads",
-          "slingpack",
-          "kevlar",
-          "balclava",
-          "knee_pads",
-          "beret",
-          "wristwatch",
-          "water_clean"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "combat_shirt" },
+          { "item": "socks" },
+          { "item": "sweatshirt" },
+          { "item": "boots" },
+          { "item": "cig" },
+          { "item": "elbow_pads" },
+          { "item": "slingpack" },
+          { "item": "kevlar" },
+          { "item": "balclava" },
+          { "item": "knee_pads" },
+          { "item": "beret" },
+          { "item": "wristwatch" },
+          { "item": "water_clean" },
           { "group": "charged_cell_phone" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "knife_KABAR", "container-item": "sheath" },
@@ -3100,8 +3299,8 @@
           { "group": "modular_ar15", "ammo-item": "223", "charges": 30, "contents-item": [ "shoulder_strap" ] }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     },
     "age_lower": 18
   },
@@ -3124,24 +3323,22 @@
     "vehicle": "pickup",
     "items": {
       "both": {
-        "items": [
-          "boots_hiking",
-          "cowboy_hat",
-          "diving_watch",
-          "e_tool",
-          "hammer",
-          "knife_folding",
-          "multitool",
-          "pants_army",
-          "police_belt",
-          "rollmat",
-          "socks",
-          "travelpack",
-          "vest",
-          "water_clean",
-          "whistle_multitool"
-        ],
         "entries": [
+          { "item": "boots_hiking" },
+          { "item": "cowboy_hat" },
+          { "item": "diving_watch" },
+          { "item": "e_tool" },
+          { "item": "hammer" },
+          { "item": "knife_folding" },
+          { "item": "multitool" },
+          { "item": "pants_army" },
+          { "item": "police_belt" },
+          { "item": "rollmat" },
+          { "item": "socks" },
+          { "item": "travelpack" },
+          { "item": "vest" },
+          { "item": "water_clean" },
+          { "item": "whistle_multitool" },
           { "group": "charged_smart_phone" },
           { "group": "charged_flashlight" },
           { "group": "charged_two_way_radio" },
@@ -3161,8 +3358,8 @@
           { "item": "sheriffshirt", "variant": "sheriff" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -3180,11 +3377,22 @@
     ],
     "items": {
       "both": {
-        "items": [ "jeans", "socks", "boots", "hat_hunting", "jacket_flannel", "knit_scarf", "vest", "wristwatch", "axe_ring" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "ax", "custom-flags": [ "auto_wield" ] } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "hat_hunting" },
+          { "item": "jacket_flannel" },
+          { "item": "knit_scarf" },
+          { "item": "vest" },
+          { "item": "wristwatch" },
+          { "item": "axe_ring" },
+          { "group": "charged_smart_phone" },
+          { "item": "ax", "custom-flags": [ "auto_wield" ] }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -3197,15 +3405,17 @@
     "proficiencies": [ "prof_frying", "prof_knives_familiar" ],
     "items": {
       "both": {
-        "items": [ "sneakers", "socks", "knife_steak" ],
         "entries": [
+          { "item": "sneakers" },
+          { "item": "socks" },
+          { "item": "knife_steak" },
           { "group": "charged_smart_phone" },
           { "item": "tshirt", "variant": "generic_tshirt" },
           { "item": "pants", "variant": "pants_black" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "age_lower": 16
   },
@@ -3219,16 +3429,22 @@
     "skills": [ { "level": 6, "name": "electronics" } ],
     "items": {
       "both": {
-        "items": [ "jumpsuit", "socks", "boots", "tool_belt", "wristwatch", "mbag", "solder_wire" ],
         "entries": [
+          { "item": "jumpsuit" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "tool_belt" },
+          { "item": "wristwatch" },
+          { "item": "mbag" },
+          { "item": "solder_wire" },
           { "group": "charged_smart_phone" },
           { "group": "charged_flashlight" },
           { "group": "charged_soldering_iron" },
           { "group": "charged_electrical_measuring" }
         ]
       },
-      "male": [ "boxer_briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -3240,16 +3456,28 @@
     "skills": [ { "level": 6, "name": "computer" } ],
     "items": {
       "both": {
-        "items": [ "tshirt_text", "socks", "sneakers", "mbag", "caffeine", "caff_gum", "memory_card", "usb_drive" ],
         "entries": [
-          { "item": "light_plus_battery_cell", "ammo-item": "battery", "charges": 150, "container-item": "portable_game" },
+          { "item": "tshirt_text" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "mbag" },
+          { "item": "caffeine" },
+          { "item": "caff_gum" },
+          { "item": "memory_card" },
+          { "item": "usb_drive" },
+          {
+            "item": "light_plus_battery_cell",
+            "ammo-item": "battery",
+            "charges": 150,
+            "container-item": "portable_game"
+          },
           { "item": "pants", "variant": "pants_stone" },
           { "group": "charged_smart_phone" },
           { "group": "charged_laptop" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "sports_bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -3261,11 +3489,20 @@
     "skills": [ { "level": 3, "name": "survival" } ],
     "items": {
       "both": {
-        "items": [ "backpack_hiking", "jeans", "boots_hiking", "knit_scarf", "socks", "wristwatch", "fun_survival" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "backpack_hiking" },
+          { "item": "jeans" },
+          { "item": "boots_hiking" },
+          { "item": "knit_scarf" },
+          { "item": "socks" },
+          { "item": "wristwatch" },
+          { "item": "fun_survival" },
+          { "group": "charged_smart_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -3277,15 +3514,22 @@
     "skills": [ { "level": 2, "name": "chemistry" }, { "level": 2, "name": "computer" } ],
     "items": {
       "both": {
-        "items": [ "socks", "sneakers", "ZSG", "backpack", "wristwatch", "textbook_speech", "story_book", "howto_computer" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "ZSG" },
+          { "item": "backpack" },
+          { "item": "wristwatch" },
+          { "item": "textbook_speech" },
+          { "item": "story_book" },
+          { "item": "howto_computer" },
           { "group": "charged_smart_phone" },
           { "item": "tshirt", "variant": "generic_tshirt" },
           { "item": "pants", "variant": "pants_black" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     },
     "age_lower": 16,
     "age_upper": 25
@@ -3297,7 +3541,7 @@
     "description": "You just stepped out of a nice, hot shower to find the world had ended.  You've got some soap, along with the most massively useful thing ever… a towel.",
     "points": -1,
     "flags": [ "NO_BONUS_ITEMS" ],
-    "items": { "both": { "items": [ "towel_wet" ], "entries": [ { "item": "soap", "custom-flags": [ "auto_wield" ] } ] } }
+    "items": { "both": { "entries": [ { "item": "towel_wet" }, { "item": "soap", "custom-flags": [ "auto_wield" ] } ] } }
   },
   {
     "type": "profession",
@@ -3310,24 +3554,22 @@
     "vehicle": "motorcycle",
     "items": {
       "both": {
-        "items": [
-          "motorbike_pants",
-          "chaps_leather",
-          "socks",
-          "motorbike_boots",
-          "helmet_motor",
-          "leather_police_jacket",
-          "wristwatch",
-          "multitool"
-        ],
         "entries": [
+          { "item": "motorbike_pants" },
+          { "item": "chaps_leather" },
+          { "item": "socks" },
+          { "item": "motorbike_boots" },
+          { "item": "helmet_motor" },
+          { "item": "leather_police_jacket" },
+          { "item": "wristwatch" },
+          { "item": "multitool" },
           { "group": "charged_smart_phone" },
           { "item": "sheath", "contents-item": "knife_trench" },
           { "item": "leg_bag", "variant": "black_leg_bag" }
         ]
       },
-      "male": [ "boxer_shorts", "tank_top" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" }, { "item": "tank_top" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -3338,9 +3580,19 @@
     "points": 0,
     "skills": [ { "level": 3, "name": "dodge" } ],
     "items": {
-      "both": { "items": [ "socks", "knit_scarf", "dance_shoes" ], "entries": [ { "group": "charged_smart_phone" } ] },
-      "male": [ "briefs", "tux", "tourmaline_silver_cufflinks" ],
-      "female": [ "bra", "panties", "dress", "purse", "tourmaline_silver_bracelet" ]
+      "both": {
+        "entries": [ { "item": "socks" }, { "item": "knit_scarf" }, { "item": "dance_shoes" }, { "group": "charged_smart_phone" } ]
+      },
+      "male": { "entries": [ { "item": "briefs" }, { "item": "tux" }, { "item": "tourmaline_silver_cufflinks" } ] },
+      "female": {
+        "entries": [
+          { "item": "bra" },
+          { "item": "panties" },
+          { "item": "dress" },
+          { "item": "purse" },
+          { "item": "tourmaline_silver_bracelet" }
+        ]
+      }
     },
     "age_lower": 16
   },
@@ -3352,11 +3604,17 @@
     "points": -2,
     "items": {
       "both": {
-        "items": [ "jeans", "socks", "sneakers", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "wristwatch" },
+          { "group": "charged_smart_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ],
     "missions": [ "MISSION_PATIENT" ],
@@ -3368,7 +3626,11 @@
     "name": "Unwilling Mutant",
     "description": "You were a human guinea pig, used by laboratory technicians to understand the immense power of mutation.  You are determined to live on, if only to spite them for what they did to you.",
     "points": -1,
-    "items": { "both": [ "subsuit_xl" ], "male": [ "briefs" ], "female": [ "bra", "panties" ] },
+    "items": {
+      "both": [ "subsuit_xl" ],
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
+    },
     "flags": [ "SCEN_ONLY" ],
     "age_lower": 16
   },
@@ -3381,11 +3643,19 @@
     "skills": [ { "level": 4, "name": "chemistry" }, { "level": 4, "name": "electronics" } ],
     "items": {
       "both": {
-        "items": [ "dress_shirt", "socks", "boots", "knit_scarf", "coat_lab", "glasses_safety", "wristwatch" ],
-        "entries": [ { "item": "pants", "variant": "pants_black" } ]
+        "entries": [
+          { "item": "dress_shirt" },
+          { "item": "pants", "variant": "pants_black" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "knit_scarf" },
+          { "item": "coat_lab" },
+          { "item": "glasses_safety" },
+          { "item": "wristwatch" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ],
     "missions": [ "MISSION_MUTANT_VOLUNTEER" ]
@@ -3405,11 +3675,18 @@
     ],
     "items": {
       "both": {
-        "items": [ "dress_shirt", "knit_scarf", "coat_lab", "glasses_safety", "wristwatch", "folded_wheelchair_generic" ],
-        "entries": [ { "item": "pants", "variant": "pants_black" } ]
+        "entries": [
+          { "item": "dress_shirt" },
+          { "item": "knit_scarf" },
+          { "item": "coat_lab" },
+          { "item": "glasses_safety" },
+          { "item": "wristwatch" },
+          { "item": "folded_wheelchair_generic" },
+          { "item": "pants", "variant": "pants_black" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ],
     "missions": [ "MISSION_MUTANT_VOLUNTEER" ]
@@ -3424,11 +3701,18 @@
     "traits": [ "NO_RIGHT_ARM", "NO_LEFT_ARM" ],
     "items": {
       "both": {
-        "items": [ "dress_shirt", "socks", "boots", "knit_scarf", "coat_lab", "glasses_safety" ],
-        "entries": [ { "item": "pants", "variant": "pants_black" } ]
+        "entries": [
+          { "item": "dress_shirt" },
+          { "item": "pants", "variant": "pants_black" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "knit_scarf" },
+          { "item": "coat_lab" },
+          { "item": "glasses_safety" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ],
     "missions": [ "MISSION_MUTANT_VOLUNTEER" ]
@@ -3448,11 +3732,17 @@
     "traits": [ "NO_RIGHT_LEG", "NO_LEFT_LEG", "NO_RIGHT_ARM", "NO_LEFT_ARM" ],
     "items": {
       "both": {
-        "items": [ "dress_shirt", "knit_scarf", "coat_lab", "glasses_safety", "folded_wheelchair_generic" ],
-        "entries": [ { "item": "pants", "variant": "pants_black" } ]
+        "entries": [
+          { "item": "dress_shirt" },
+          { "item": "pants", "variant": "pants_black" },
+          { "item": "knit_scarf" },
+          { "item": "coat_lab" },
+          { "item": "glasses_safety" },
+          { "item": "folded_wheelchair_generic" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ],
     "missions": [ "MISSION_MUTANT_VOLUNTEER" ]
@@ -3465,8 +3755,8 @@
     "points": -1,
     "items": {
       "both": [ "house_coat", "slippers", "towel", "guidebook" ],
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -3480,27 +3770,25 @@
     "recipes": [ "beartrap" ],
     "items": {
       "both": {
-        "items": [
-          "jeans",
-          "socks",
-          "boots",
-          "hat_hunting",
-          "jacket_flannel",
-          "knit_scarf",
-          "beartrap",
-          "wristwatch",
-          "tobacco",
-          "rolling_paper",
-          "backpack"
-        ],
         "entries": [
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "hat_hunting" },
+          { "item": "jacket_flannel" },
+          { "item": "knit_scarf" },
+          { "item": "beartrap" },
+          { "item": "wristwatch" },
+          { "item": "tobacco" },
+          { "item": "rolling_paper" },
+          { "item": "backpack" },
           { "group": "charged_smart_phone" },
           { "group": "charged_matches" },
           { "item": "knife_hunting", "container-item": "sheath" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -3513,11 +3801,20 @@
     "proficiencies": [ "prof_metalworking", "prof_blacksmithing" ],
     "items": {
       "both": {
-        "items": [ "jeans", "socks", "boots", "tank_top", "apron_cut_resistant", "fire_gauntlets", "wristwatch", "hammer" ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "tank_top" },
+          { "item": "apron_cut_resistant" },
+          { "item": "fire_gauntlets" },
+          { "item": "wristwatch" },
+          { "item": "hammer" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -3530,11 +3827,19 @@
     "proficiencies": [ "prof_metalworking", "prof_redsmithing", "prof_fine_metalsmithing", "prof_gem_setting" ],
     "items": {
       "both": {
-        "items": [ "jeans", "socks", "boots", "longshirt", "wristwatch", "apron_leather", "chisel" ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "longshirt" },
+          { "item": "wristwatch" },
+          { "item": "apron_leather" },
+          { "item": "chisel" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -3545,11 +3850,19 @@
     "points": -1,
     "items": {
       "both": {
-        "items": [ "clown_wig", "clown_suit", "clown_nose", "socks", "clownshoes", "airhorn" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "balloon", "count": 20 } ]
+        "entries": [
+          { "item": "clown_wig" },
+          { "item": "clown_suit" },
+          { "item": "clown_nose" },
+          { "item": "socks" },
+          { "item": "clownshoes" },
+          { "item": "airhorn" },
+          { "group": "charged_smart_phone" },
+          { "item": "balloon", "count": 20 }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "missions": [ "MISSION_CLOWN" ]
   },
@@ -3564,8 +3877,14 @@
     "proficiencies": [ "prof_fibers", "prof_fibers_rope" ],
     "items": {
       "both": {
-        "items": [ "bondage_suit", "bondage_mask", "boots", "gloves_leather", "leather_belt" ],
-        "entries": [ { "group": "charged_matches", "custom-flags": [ "auto_wield" ] } ]
+        "entries": [
+          { "item": "bondage_suit" },
+          { "item": "bondage_mask" },
+          { "item": "boots" },
+          { "item": "gloves_leather" },
+          { "item": "leather_belt" },
+          { "group": "charged_matches", "custom-flags": [ "auto_wield" ] }
+        ]
       }
     },
     "missions": [ "MISSION_LOST_SUB" ]
@@ -3579,11 +3898,24 @@
     "points": 0,
     "items": {
       "both": {
-        "items": [ "tobacco", "pipe_tobacco", "socks", "dress_shoes", "knit_scarf", "bellyband", "dentures" ],
-        "entries": [ { "group": "charged_ref_lighter" }, { "item": "cane", "custom-flags": [ "auto_wield" ] } ]
+        "entries": [
+          { "item": "tobacco" },
+          { "item": "pipe_tobacco" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "knit_scarf" },
+          { "item": "bellyband" },
+          { "item": "dentures" },
+          { "group": "charged_ref_lighter" },
+          { "item": "cane", "custom-flags": [ "auto_wield" ] }
+        ]
       },
-      "male": [ "briefs", "dress_shirt", "pants_checkered", "pocketwatch" ],
-      "female": [ "panties", "bra", "dress", "fanny", "gold_watch" ]
+      "male": {
+        "entries": [ { "item": "briefs" }, { "item": "dress_shirt" }, { "item": "pants_checkered" }, { "item": "pocketwatch" } ]
+      },
+      "female": {
+        "entries": [ { "item": "panties" }, { "item": "bra" }, { "item": "dress" }, { "item": "fanny" }, { "item": "gold_watch" } ]
+      }
     },
     "age_lower": 50
   },
@@ -3596,8 +3928,14 @@
     "skills": [ { "level": 2, "name": "tailor" } ],
     "items": {
       "both": {
-        "items": [ "shorts", "socks", "sneakers", "tank_top", "mbag", "mag_animecon", "cheeseburger" ],
         "entries": [
+          { "item": "shorts" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "tank_top" },
+          { "item": "mbag" },
+          { "item": "mag_animecon" },
+          { "item": "cheeseburger" },
           { "group": "charged_smart_phone" },
           {
             "item": "light_plus_battery_cell",
@@ -3613,8 +3951,8 @@
           }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "missions": [ "MISSION_OTAKU" ]
   },
@@ -3625,21 +3963,33 @@
     "description": "The Cataclysm struck on the big day and you escaped with nothing but your wedding attire.  Cold feet?  You'd just like to keep your feet attached!",
     "points": -1,
     "items": {
-      "both": { "items": [ "ring_wedding" ], "entries": [ { "group": "charged_smart_phone" } ] },
-      "male": [ "tux", "socks", "dress_shoes", "briefs", "leather_belt", "tie_bow", "cufflinks_intricate" ],
-      "female": [
-        "veil_wedding",
-        "dress_wedding",
-        "stockings",
-        "garter_belt",
-        "dress_shoes",
-        "bra",
-        "panties",
-        "purse",
-        "long_glove_white",
-        "pearl_silver_tiara",
-        "pearl_silver_earring"
-      ]
+      "both": { "entries": [ { "item": "ring_wedding" }, { "group": "charged_smart_phone" } ] },
+      "male": {
+        "entries": [
+          { "item": "tux" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "briefs" },
+          { "item": "leather_belt" },
+          { "item": "tie_bow" },
+          { "item": "cufflinks_intricate" }
+        ]
+      },
+      "female": {
+        "entries": [
+          { "item": "veil_wedding" },
+          { "item": "dress_wedding" },
+          { "item": "stockings" },
+          { "item": "garter_belt" },
+          { "item": "dress_shoes" },
+          { "item": "bra" },
+          { "item": "panties" },
+          { "item": "purse" },
+          { "item": "long_glove_white" },
+          { "item": "pearl_silver_tiara" },
+          { "item": "pearl_silver_earring" }
+        ]
+      }
     }
   },
   {
@@ -3651,8 +4001,15 @@
     "skills": [ { "level": 2, "name": "speech" }, { "level": 1, "name": "tailor" } ],
     "items": {
       "both": {
-        "items": [ "trenchcoat", "gloves_fingerless", "socks", "boots_combat", "weed", "tobacco", "rolling_paper", "wristwatch" ],
         "entries": [
+          { "item": "trenchcoat" },
+          { "item": "gloves_fingerless" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "weed" },
+          { "item": "tobacco" },
+          { "item": "rolling_paper" },
+          { "item": "wristwatch" },
           { "group": "charged_smart_phone" },
           { "group": "charged_mp3" },
           { "group": "charged_ref_lighter" },
@@ -3660,8 +4017,8 @@
           { "item": "onyx_silver_ring", "variant": "dark_ring" }
         ]
       },
-      "male": [ "pants_cargo", "tank_top", "boxer_shorts" ],
-      "female": [ "skirt", "corset", "boxer_shorts", "stockings" ]
+      "male": { "entries": [ { "item": "pants_cargo" }, { "item": "tank_top" }, { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "skirt" }, { "item": "corset" }, { "item": "boxer_shorts" }, { "item": "stockings" } ] }
     }
   },
   {
@@ -3679,20 +4036,18 @@
     "proficiencies": [ "prof_burn_care" ],
     "items": {
       "both": {
-        "items": [
-          "bunker_pants",
-          "bunker_coat",
-          "nomex_suit",
-          "nomex_socks",
-          "boots_bunker",
-          "nomex_gloves",
-          "fire_gauntlets",
-          "mask_bunker",
-          "nomex_hood",
-          "firehelmet",
-          "pocketwatch"
-        ],
         "entries": [
+          { "item": "bunker_pants" },
+          { "item": "bunker_coat" },
+          { "item": "nomex_suit" },
+          { "item": "nomex_socks" },
+          { "item": "boots_bunker" },
+          { "item": "nomex_gloves" },
+          { "item": "fire_gauntlets" },
+          { "item": "mask_bunker" },
+          { "item": "nomex_hood" },
+          { "item": "firehelmet" },
+          { "item": "pocketwatch" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "halligan", "container-item": "fireman_belt" }
         ]
@@ -3708,11 +4063,23 @@
     "skills": [ { "level": 3, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [ "dress_shirt", "tie_skinny", "sunglasses", "pants", "socks", "dress_shoes", "rolling_paper", "tobacco", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_mp3" }, { "group": "charged_ref_lighter" } ]
+        "entries": [
+          { "item": "dress_shirt" },
+          { "item": "tie_skinny" },
+          { "item": "sunglasses" },
+          { "item": "pants" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "rolling_paper" },
+          { "item": "tobacco" },
+          { "item": "wristwatch" },
+          { "group": "charged_smart_phone" },
+          { "group": "charged_mp3" },
+          { "group": "charged_ref_lighter" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -3724,27 +4091,25 @@
     "skills": [ { "level": 3, "name": "driving" }, { "level": 2, "name": "dodge" } ],
     "items": {
       "both": {
-        "items": [
-          "postman_hat",
-          "postman_shirt",
-          "mbag",
-          "dog_whistle",
-          "wristwatch",
-          "leather_belt",
-          "postman_shorts",
-          "knit_scarf",
-          "socks",
-          "sneakers"
-        ],
         "entries": [
+          { "item": "postman_hat" },
+          { "item": "postman_shirt" },
+          { "item": "mbag" },
+          { "item": "dog_whistle" },
+          { "item": "wristwatch" },
+          { "item": "leather_belt" },
+          { "item": "postman_shorts" },
+          { "item": "knit_scarf" },
+          { "item": "socks" },
+          { "item": "sneakers" },
           { "item": "letter", "container-item": "envelope" },
           { "item": "letter", "container-item": "envelope" },
           { "item": "postcard", "container-item": "envelope" },
           { "group": "charged_smart_phone" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -3762,8 +4127,8 @@
     ],
     "items": {
       "both": [ "striped_shirt", "striped_pants", "sneakers", "socks", "glass_shiv" ],
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -3777,8 +4142,8 @@
     "traits": [ "KILLER" ],
     "items": {
       "both": [ "striped_shirt", "striped_pants", "sneakers", "socks", "glass_shiv" ],
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -3797,14 +4162,17 @@
     "traits": [ "PROF_ASSASSIN_CONVICT" ],
     "items": {
       "both": {
-        "items": [ "striped_shirt", "striped_pants", "sneakers", "socks" ],
         "entries": [
+          { "item": "striped_shirt" },
+          { "item": "striped_pants" },
+          { "item": "sneakers" },
+          { "item": "socks" },
           { "item": "knife_rm42", "container-item": "gartersheath1" },
           { "item": "polaroid_photo", "container-item": "ankle_wallet_pouch" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -3817,8 +4185,8 @@
     "skills": [ { "level": 4, "name": "speech" }, { "level": 3, "name": "computer" } ],
     "items": {
       "both": [ "striped_shirt", "striped_pants", "sneakers", "socks", "rock_sock" ],
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -3831,11 +4199,18 @@
     "skills": [ { "level": 6, "name": "chemistry" }, { "level": 2, "name": "firstaid" } ],
     "items": {
       "both": {
-        "items": [ "striped_shirt", "striped_pants", "sneakers", "socks", "adderall" ],
-        "entries": [ { "item": "condom", "contents-item": "dayquil" }, { "group": "charged_matches" } ]
+        "entries": [
+          { "item": "striped_shirt" },
+          { "item": "striped_pants" },
+          { "item": "sneakers" },
+          { "item": "socks" },
+          { "item": "adderall" },
+          { "item": "condom", "contents-item": "dayquil" },
+          { "group": "charged_matches" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -3848,11 +4223,17 @@
     "skills": [ { "level": 6, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [ "striped_shirt", "striped_pants", "sneakers", "socks", "gum" ],
-        "entries": [ { "group": "charged_cell_phone" } ]
+        "entries": [
+          { "item": "striped_shirt" },
+          { "item": "striped_pants" },
+          { "item": "sneakers" },
+          { "item": "socks" },
+          { "item": "gum" },
+          { "group": "charged_cell_phone" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -3867,8 +4248,8 @@
     "pets": [ { "name": "mon_black_rat", "amount": 13 } ],
     "items": {
       "both": [ "striped_shirt", "striped_pants", "sneakers", "socks", "fried_seeds" ],
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -3882,25 +4263,25 @@
     "skills": [ { "level": 6, "name": "traps" }, { "level": 2, "name": "dodge" } ],
     "items": {
       "both": {
-        "items": [
-          "socks",
-          "sneakers",
-          "striped_shirt",
-          "hoodie",
-          "gloves_light",
-          "mask_ski",
-          "swag_bag",
-          "crowbar",
-          "hacksaw",
-          "wristwatch",
-          "boltcutters",
-          "stethoscope",
-          "picklocks"
-        ],
-        "entries": [ { "item": "pants", "variant": "pants_black_camo" } ]
+        "entries": [
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "striped_shirt" },
+          { "item": "hoodie" },
+          { "item": "gloves_light" },
+          { "item": "mask_ski" },
+          { "item": "swag_bag" },
+          { "item": "crowbar" },
+          { "item": "hacksaw" },
+          { "item": "wristwatch" },
+          { "item": "boltcutters" },
+          { "item": "stethoscope" },
+          { "item": "picklocks" },
+          { "item": "pants", "variant": "pants_black_camo" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -3912,22 +4293,22 @@
     "skills": [ { "level": 6, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [
-          "suit",
-          "tie_necktie",
-          "tieclip",
-          "socks",
-          "dress_shoes",
-          "knit_scarf",
-          "platinum_watch",
-          "briefcase",
-          "money_strap_fifty",
-          "file"
-        ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "suit" },
+          { "item": "tie_necktie" },
+          { "item": "tieclip" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "knit_scarf" },
+          { "item": "platinum_watch" },
+          { "item": "briefcase" },
+          { "item": "money_strap_fifty" },
+          { "item": "file", "count": [ 1, 4 ] },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -3939,11 +4320,18 @@
     "skills": [ { "level": 3, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [ "socks", "dress_shoes", "holybook_bible1" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "holy_symbol", "variant": "general_necklace" } ]
+        "entries": [
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "holybook_bible1" },
+          { "group": "charged_smart_phone" },
+          { "item": "holy_symbol", "variant": "general_necklace" }
+        ]
       },
-      "male": { "items": [ "briefs", "dress_shirt", "suit" ], "entries": [ { "item": "pants", "variant": "pants_black" } ] },
-      "female": [ "dress", "purse", "bra", "panties" ]
+      "male": {
+        "entries": [ { "item": "briefs" }, { "item": "dress_shirt" }, { "item": "suit" }, { "item": "pants", "variant": "pants_black" } ]
+      },
+      "female": { "entries": [ { "item": "dress" }, { "item": "purse" }, { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -3955,11 +4343,34 @@
     "skills": [ { "level": 3, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [ "socks", "dress_shoes", "holybook_bible4" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "holy_symbol", "variant": "catholic_necklace" } ]
+        "entries": [
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "holybook_bible4" },
+          { "group": "charged_smart_phone" },
+          { "item": "holy_symbol", "variant": "catholic_necklace" }
+        ]
       },
-      "male": [ "pants", "longshirt", "cassock", "cape_catholic", "zucchetto", "briefs" ],
-      "female": [ "nun_wimple", "nun_habit", "dress_shirt", "purse", "bra", "panties" ]
+      "male": {
+        "entries": [
+          { "item": "pants" },
+          { "item": "longshirt" },
+          { "item": "cassock" },
+          { "item": "cape_catholic" },
+          { "item": "zucchetto" },
+          { "item": "briefs" }
+        ]
+      },
+      "female": {
+        "entries": [
+          { "item": "nun_wimple" },
+          { "item": "nun_habit" },
+          { "item": "dress_shirt" },
+          { "item": "purse" },
+          { "item": "bra" },
+          { "item": "panties" }
+        ]
+      }
     }
   },
   {
@@ -3971,17 +4382,28 @@
     "skills": [ { "level": 2, "name": "speech" }, { "level": 1, "name": "melee" } ],
     "items": {
       "both": {
-        "items": [ "silver_ring", "leather_belt", "socks", "boots", "holybook_asatru" ],
         "entries": [
+          { "item": "silver_ring" },
+          { "item": "leather_belt" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "holybook_asatru" },
           { "group": "charged_smart_phone" },
           { "item": "holy_symbol", "variant": "odin_necklace1" },
           { "item": "bronze_knife", "container-item": "sheath" }
         ]
       },
-      "male": { "items": [ "cloak", "tunic", "briefs" ], "entries": [ { "item": "pants", "variant": "pants_brown" } ] },
+      "male": {
+        "entries": [ { "item": "cloak" }, { "item": "tunic" }, { "item": "briefs" }, { "item": "pants", "variant": "pants_brown" } ]
+      },
       "female": {
-        "items": [ "silver_hairpin", "bra", "dress", "panties" ],
-        "entries": [ { "item": "altered_apron", "variant": "generic_apron_cotton" } ]
+        "entries": [
+          { "item": "silver_hairpin" },
+          { "item": "bra" },
+          { "item": "dress" },
+          { "item": "panties" },
+          { "item": "altered_apron", "variant": "generic_apron_cotton" }
+        ]
       }
     }
   },
@@ -3994,15 +4416,20 @@
     "skills": [ { "level": 3, "name": "fabrication" }, { "level": 3, "name": "tailor" } ],
     "items": {
       "both": {
-        "items": [ "kariginu", "eboshi", "hakama", "tabi_dress", "geta", "holybook_kojiki" ],
         "entries": [
+          { "item": "kariginu" },
+          { "item": "eboshi" },
+          { "item": "hakama" },
+          { "item": "tabi_dress" },
+          { "item": "geta" },
+          { "item": "holybook_kojiki" },
           { "group": "charged_smart_phone" },
           { "item": "holy_symbol", "variant": "shinto_necklace" },
           { "item": "pants", "variant": "pants_white" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -4014,11 +4441,18 @@
     "skills": [ { "level": 3, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [ "antarvasa", "uttarasanga", "samghati", "flip_flops", "holybook_sutras" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "holy_symbol", "variant": "buddhist_necklace" } ]
+        "entries": [
+          { "item": "antarvasa" },
+          { "item": "uttarasanga" },
+          { "item": "samghati" },
+          { "item": "flip_flops" },
+          { "item": "holybook_sutras" },
+          { "group": "charged_smart_phone" },
+          { "item": "holy_symbol", "variant": "buddhist_necklace" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -4031,16 +4465,20 @@
     "skills": [ { "level": 3, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [ "socks", "kufi", "thawb", "lowtops", "holybook_quran" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "kufi" },
+          { "item": "thawb" },
+          { "item": "lowtops" },
+          { "item": "holybook_quran" },
           { "group": "charged_smart_phone" },
           { "item": "tshirt", "variant": "generic_tshirt" },
           { "item": "holy_symbol", "variant": "muslim_necklace" },
           { "item": "pants", "variant": "pants_white" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -4052,15 +4490,22 @@
     "skills": [ { "level": 3, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [ "leather_belt", "dress_shirt", "socks", "kittel", "kippah", "tallit_gadol", "dress_shoes", "holybook_talmud" ],
         "entries": [
+          { "item": "leather_belt" },
+          { "item": "dress_shirt" },
+          { "item": "socks" },
+          { "item": "kittel" },
+          { "item": "kippah" },
+          { "item": "tallit_gadol" },
+          { "item": "dress_shoes" },
+          { "item": "holybook_talmud" },
           { "group": "charged_smart_phone" },
           { "item": "holy_symbol", "variant": "jewish_necklace1" },
           { "item": "pants", "variant": "pants_black" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -4072,11 +4517,23 @@
     "skills": [ { "level": 5, "name": "speech" }, { "level": 3, "name": "survival" } ],
     "items": {
       "both": {
-        "items": [ "jeans", "socks", "robe", "turban", "waterskin", "pockknife", "mbag", "leathersandals", "holy_symbol", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "robe" },
+          { "item": "turban" },
+          { "item": "waterskin" },
+          { "item": "pockknife" },
+          { "item": "mbag" },
+          { "item": "leathersandals" },
+          { "item": "holy_symbol" },
+          { "item": "wristwatch" },
+          { "group": "charged_smart_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -4088,16 +4545,24 @@
     "skills": [ { "level": 4, "name": "speech" }, { "level": 4, "name": "driving" } ],
     "items": {
       "both": {
-        "items": [ "dress_shirt", "socks", "dress_shoes", "wristwatch", "backpack", "flyer", "flyer", "flyer", "holy_symbol" ],
         "entries": [
+          { "item": "dress_shirt" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "wristwatch" },
+          { "item": "backpack" },
+          { "item": "flyer" },
+          { "item": "flyer" },
+          { "item": "flyer" },
+          { "item": "holy_symbol" },
           { "group": "charged_smart_phone" },
           { "group": "charged_laptop" },
           { "item": "holy_symbol", "variant": "general_necklace" },
           { "item": "pants", "variant": "pants_black" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -4111,11 +4576,17 @@
     "proficiencies": [ "prof_unarmed_familiar" ],
     "items": {
       "both": {
-        "items": [ "karate_gi", "judo_belt_white", "mouthpiece", "socks_ankle", "sneakers" ],
-        "entries": [ { "item": "manual_karate", "custom-flags": [ "auto_wield" ] } ]
+        "entries": [
+          { "item": "karate_gi" },
+          { "item": "judo_belt_white" },
+          { "item": "mouthpiece" },
+          { "item": "socks_ankle" },
+          { "item": "sneakers" },
+          { "item": "manual_karate", "custom-flags": [ "auto_wield" ] }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] }
     },
     "missions": [ "MISSION_BLACK_BELT_GOAL" ]
   },
@@ -4153,8 +4624,8 @@
     ],
     "items": {
       "both": [ "karate_gi", "judo_belt_orange", "mouthpiece", "socks_ankle", "sneakers" ],
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] }
     },
     "missions": [ "MISSION_BLACK_BELT_GOAL" ]
   },
@@ -4192,8 +4663,8 @@
     ],
     "items": {
       "both": [ "karate_gi", "judo_belt_black", "mouthpiece", "geta" ],
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -4205,22 +4676,23 @@
     "skills": [ { "level": 3, "name": "driving" }, { "level": 1, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [
-          "hat_ball",
-          "jeans",
-          "jacket_light",
-          "socks",
-          "sneakers",
-          "pizza_veggy",
-          "pizza_meat",
-          "money_strap_one",
-          "wristwatch",
-          "mbag"
-        ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "hat_ball" },
+          { "item": "jeans" },
+          { "item": "jacket_light" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "pizza_veggy" },
+          { "item": "pizza_meat" },
+          { "item": "money_strap_one" },
+          { "item": "wristwatch" },
+          { "item": "mbag" },
+          { "group": "charged_smart_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -4233,11 +4705,20 @@
     "skills": [ { "level": 2, "name": "driving" }, { "level": 2, "name": "swimming" } ],
     "items": {
       "both": {
-        "items": [ "jeans", "longshirt", "mbag", "pockknife", "water_clean", "wristwatch", "folded_wheelchair_generic" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_matches" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "mbag" },
+          { "item": "pockknife" },
+          { "item": "water_clean" },
+          { "item": "wristwatch" },
+          { "item": "folded_wheelchair_generic" },
+          { "group": "charged_smart_phone" },
+          { "group": "charged_matches" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -4249,11 +4730,19 @@
     "traits": [ "NO_RIGHT_ARM", "NO_LEFT_ARM" ],
     "items": {
       "both": {
-        "items": [ "jeans", "longshirt", "mbag", "water_clean", "socks", "boots" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_matches" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "mbag" },
+          { "item": "water_clean" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "group": "charged_smart_phone" },
+          { "group": "charged_matches" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -4265,11 +4754,18 @@
     "traits": [ "NO_RIGHT_LEG", "NO_LEFT_LEG", "NO_RIGHT_ARM", "NO_LEFT_ARM" ],
     "items": {
       "both": {
-        "items": [ "jeans", "longshirt", "mbag", "water_clean", "folded_wheelchair_generic" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_matches" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "mbag" },
+          { "item": "water_clean" },
+          { "item": "folded_wheelchair_generic" },
+          { "group": "charged_smart_phone" },
+          { "group": "charged_matches" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -4287,28 +4783,26 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "undershirt",
-          "leather_belt",
-          "socks",
-          "boots",
-          "jacket_leather",
-          "knit_scarf",
-          "bullwhip",
-          "mbag",
-          "fedora",
-          "wristwatch",
-          "spiral_stone"
-        ],
         "entries": [
+          { "item": "undershirt" },
+          { "item": "leather_belt" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "jacket_leather" },
+          { "item": "knit_scarf" },
+          { "item": "bullwhip" },
+          { "item": "mbag" },
+          { "item": "fedora" },
+          { "item": "wristwatch" },
+          { "item": "spiral_stone" },
           { "group": "charged_smart_phone" },
           { "group": "speedloaders_s&w619_special" },
           { "item": "sw_619", "ammo-item": "38_special", "charges": 7, "container-item": "holster" },
           { "item": "pants", "variant": "generic_pants" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -4321,28 +4815,25 @@
     "proficiencies": [ "prof_athlete_basic", "prof_driver" ],
     "items": {
       "both": {
-        "items": [
-          "hat_newsboy",
-          "sweatshirt",
-          "peacoat",
-          "socks",
-          "boots_winter",
-          "gloves_wool",
-          "knit_scarf",
-          "mbag",
-          "dog_whistle",
-          "wristwatch",
-          "newest_newspaper",
-          "newest_newspaper",
-          "newest_newspaper",
-          "newest_newspaper",
-          "newest_newspaper",
-          "folded_bicycle"
-        ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "pants", "variant": "pants_blue" } ]
+        "entries": [
+          { "item": "hat_newsboy" },
+          { "item": "sweatshirt" },
+          { "item": "peacoat" },
+          { "item": "socks" },
+          { "item": "boots_winter" },
+          { "item": "gloves_wool" },
+          { "item": "knit_scarf" },
+          { "item": "mbag" },
+          { "item": "dog_whistle" },
+          { "item": "wristwatch" },
+          { "item": "newest_newspaper", "count": [ 5, 10 ] },
+          { "item": "folded_bicycle" },
+          { "group": "charged_smart_phone" },
+          { "item": "pants", "variant": "pants_blue" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -4359,28 +4850,29 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "jeans",
-          "backpack",
-          "knit_scarf",
-          "straw_hat",
-          "multitool",
-          "hoe",
-          "socks",
-          "boots",
-          "wristwatch",
-          "seed_blueberries",
-          "seed_strawberries",
-          "seed_wheat",
-          "seed_hops",
-          "seed_barley",
-          "seed_sugar_beet",
-          "seed_tomato"
-        ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "backpack" },
+          { "item": "knit_scarf" },
+          { "item": "straw_hat" },
+          { "item": "multitool" },
+          { "item": "hoe" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "wristwatch" },
+          { "item": "seed_blueberries" },
+          { "item": "seed_strawberries" },
+          { "item": "seed_wheat" },
+          { "item": "seed_hops" },
+          { "item": "seed_barley" },
+          { "item": "seed_sugar_beet" },
+          { "item": "seed_tomato" },
+          { "group": "charged_smart_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -4402,15 +4894,18 @@
     "proficiencies": [ "prof_wound_care", "prof_gun_cleaning" ],
     "items": {
       "both": {
-        "items": [ "shorts", "socks", "lowtops", "wristwatch" ],
         "entries": [
+          { "item": "shorts" },
+          { "item": "socks" },
+          { "item": "lowtops" },
+          { "item": "wristwatch" },
           { "group": "charged_smart_phone" },
           { "item": "personal_gobag", "custom-flags": [ "FIT" ] },
           { "item": "tshirt", "variant": "generic_tshirt" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -4447,24 +4942,22 @@
     "items": {
       "both": {
         "ammo": 100,
-        "items": [
-          "pants_army",
-          "sleeveless_trenchcoat",
-          "socks",
-          "boots_combat",
-          "tac_helmet",
-          "gloves_tactical",
-          "rucksack",
-          "wristwatch"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "sleeveless_trenchcoat" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "tac_helmet" },
+          { "item": "gloves_tactical" },
+          { "item": "rucksack" },
+          { "item": "wristwatch" },
           { "item": "water_clean", "container-item": "canteen" },
           { "item": "scar_h", "ammo-item": "762_51", "contents-item": "shoulder_strap" },
           { "item": "katana", "container-item": "scabbard" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -4497,20 +4990,18 @@
     "items": {
       "both": {
         "ammo": 100,
-        "items": [
-          "socks",
-          "winter_pants_army",
-          "winter_jacket_army",
-          "balclava",
-          "boots_combat",
-          "winter_gloves_army",
-          "tac_helmet",
-          "canteen",
-          "wristwatch",
-          "quikclot",
-          "mess_kit"
-        ],
         "entries": [
+          { "item": "socks" },
+          { "item": "winter_pants_army" },
+          { "item": "winter_jacket_army" },
+          { "item": "balclava" },
+          { "item": "boots_combat" },
+          { "item": "winter_gloves_army" },
+          { "item": "tac_helmet" },
+          { "item": "canteen" },
+          { "item": "wristwatch" },
+          { "item": "quikclot" },
+          { "item": "mess_kit" },
           { "item": "water_clean", "container-item": "canteen" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "knife_combat_army", "variant": "m9bayonet", "container-item": "sheath" },
@@ -4524,8 +5015,8 @@
           { "item": "chestrig", "contents-group": "army_mags_m4" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -4538,8 +5029,14 @@
     "skills": [ { "level": 2, "name": "melee" }, { "level": 2, "name": "bashing" } ],
     "items": {
       "both": {
-        "items": [ "socks", "boots", "longshirt", "holster", "pockknife", "wristwatch", "leather_belt" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "longshirt" },
+          { "item": "holster" },
+          { "item": "pockknife" },
+          { "item": "wristwatch" },
+          { "item": "leather_belt" },
           { "group": "charged_smart_phone" },
           { "group": "charged_flashlight" },
           { "group": "charged_tazer" },
@@ -4548,8 +5045,8 @@
           { "item": "baton", "custom-flags": [ "auto_wield" ] }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -4588,31 +5085,29 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_fur",
-          "trenchcoat_fur",
-          "backpack_leather",
-          "boots_fur",
-          "gloves_fur",
-          "hat_fur",
-          "scarf_fur",
-          "shortbow",
-          "shelter_kit",
-          "leather_funnel",
-          "clay_pot",
-          "waterskin",
-          "awl_bone",
-          "fur_rollmat"
-        ],
         "entries": [
+          { "item": "pants_fur" },
+          { "item": "trenchcoat_fur" },
+          { "item": "backpack_leather" },
+          { "item": "boots_fur" },
+          { "item": "gloves_fur" },
+          { "item": "hat_fur" },
+          { "item": "scarf_fur" },
+          { "item": "shortbow" },
+          { "item": "shelter_kit" },
+          { "item": "leather_funnel" },
+          { "item": "clay_pot" },
+          { "item": "waterskin" },
+          { "item": "awl_bone" },
+          { "item": "fur_rollmat" },
           { "item": "needle_bone", "ammo-item": "sinew", "charges": 200 },
           { "item": "primitive_knife", "container-item": "sheath" },
           { "item": "quiver", "contents-group": "quiver_naturalist" },
           { "item": "fire_drill", "ammo-item": "notch", "charges": 24 }
         ]
       },
-      "male": [ "chestwrap_fur", "loincloth_fur" ],
-      "female": [ "bikini_top_fur", "hot_pants_fur" ]
+      "male": { "entries": [ { "item": "chestwrap_fur" }, { "item": "loincloth_fur" } ] },
+      "female": { "entries": [ { "item": "bikini_top_fur" }, { "item": "hot_pants_fur" } ] }
     }
   },
   {
@@ -4625,19 +5120,17 @@
     "proficiencies": [ "prof_fibers", "prof_knives_familiar" ],
     "items": {
       "both": {
-        "items": [
-          "jeans",
-          "tank_top",
-          "socks",
-          "fishing_waders",
-          "knit_scarf",
-          "vest",
-          "hat_boonie",
-          "wristwatch",
-          "backpack",
-          "jacket_flannel"
-        ],
         "entries": [
+          { "item": "jeans" },
+          { "item": "tank_top" },
+          { "item": "socks" },
+          { "item": "fishing_waders" },
+          { "item": "knit_scarf" },
+          { "item": "vest" },
+          { "item": "hat_boonie" },
+          { "item": "wristwatch" },
+          { "item": "backpack" },
+          { "item": "jacket_flannel" },
           { "group": "charged_smart_phone" },
           { "item": "fish_trap", "ammo-item": "fish_bait", "charges": 5 },
           { "item": "fish_bait", "charges": 15 },
@@ -4646,8 +5139,8 @@
           { "item": "fishing_rod_professional", "custom-flags": [ "auto_wield" ] }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -4669,25 +5162,28 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "stockings",
-          "pockknife",
-          "pipe_tobacco",
-          "tobacco",
-          "backpack",
-          "knee_high_boots",
-          "breeches",
-          "waistcoat",
-          "peacoat",
-          "leather_belt",
-          "knit_scarf",
-          "tricorne",
-          "hatchet",
-          "hardtack",
-          "pipe_cleaner"
-        ],
         "entries": [
-          { "item": "rifle_flintlock", "ammo-item": "flintlock_ammo", "charges": 1, "contents-item": "shoulder_strap_simple" },
+          { "item": "stockings" },
+          { "item": "pockknife" },
+          { "item": "pipe_tobacco" },
+          { "item": "tobacco" },
+          { "item": "backpack" },
+          { "item": "knee_high_boots" },
+          { "item": "breeches" },
+          { "item": "waistcoat" },
+          { "item": "peacoat" },
+          { "item": "leather_belt" },
+          { "item": "knit_scarf" },
+          { "item": "tricorne" },
+          { "item": "hatchet" },
+          { "item": "hardtack" },
+          { "item": "pipe_cleaner" },
+          {
+            "item": "rifle_flintlock",
+            "ammo-item": "flintlock_ammo",
+            "charges": 1,
+            "contents-item": "shoulder_strap_simple"
+          },
           { "item": "flintlock_pouch", "contents-group": "flintlock_pouch_reenactor" },
           { "item": "flintlock_ammo", "charges": 15 },
           { "item": "vinegar", "container-item": "bottle_plastic_small" },
@@ -4716,24 +5212,22 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "stockings",
-          "pockknife",
-          "pipe_tobacco",
-          "tobacco",
-          "backpack",
-          "dress",
-          "apron_leather",
-          "boots",
-          "gloves_leather",
-          "long_knit_scarf",
-          "hat_fur",
-          "purse",
-          "pot",
-          "cornmeal",
-          "salt"
-        ],
         "entries": [
+          { "item": "stockings" },
+          { "item": "pockknife" },
+          { "item": "pipe_tobacco" },
+          { "item": "tobacco" },
+          { "item": "backpack" },
+          { "item": "dress" },
+          { "item": "apron_leather" },
+          { "item": "boots" },
+          { "item": "gloves_leather" },
+          { "item": "long_knit_scarf" },
+          { "item": "hat_fur" },
+          { "item": "purse" },
+          { "item": "pot" },
+          { "item": "cornmeal" },
+          { "item": "salt" },
           { "item": "needle_wood", "ammo-item": "thread", "charges": 200 },
           { "item": "oil_lamp", "charges": 750 },
           { "group": "charged_smart_phone" },
@@ -4753,22 +5247,23 @@
     "proficiencies": [ "prof_athlete_basic" ],
     "items": {
       "both": {
-        "items": [
-          "hoodie",
-          "jeans",
-          "socks",
-          "elbow_pads",
-          "knee_pads",
-          "gloves_fingerless",
-          "helmet_skid",
-          "roller_blades",
-          "wristwatch",
-          "sports_drink"
-        ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "hoodie" },
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "elbow_pads" },
+          { "item": "knee_pads" },
+          { "item": "gloves_fingerless" },
+          { "item": "helmet_skid" },
+          { "item": "roller_blades" },
+          { "item": "wristwatch" },
+          { "item": "sports_drink" },
+          { "group": "charged_smart_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "boy_shorts" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" } ] }
     },
     "age_lower": 16,
     "age_upper": 21
@@ -4784,23 +5279,24 @@
     "traits": [ "PROF_SKATER" ],
     "items": {
       "both": {
-        "items": [
-          "hoodie",
-          "jeans",
-          "socks",
-          "elbow_pads",
-          "knee_pads",
-          "gloves_fingerless",
-          "helmet_skid",
-          "sneakers",
-          "folded_skateboard_generic",
-          "wristwatch",
-          "sports_drink"
-        ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "hoodie" },
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "elbow_pads" },
+          { "item": "knee_pads" },
+          { "item": "gloves_fingerless" },
+          { "item": "helmet_skid" },
+          { "item": "sneakers" },
+          { "item": "folded_skateboard_generic" },
+          { "item": "wristwatch" },
+          { "item": "sports_drink" },
+          { "group": "charged_smart_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "boy_shorts" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" } ] }
     },
     "age_lower": 16,
     "age_upper": 21
@@ -4821,29 +5317,27 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "hoodie",
-          "jeans",
-          "socks",
-          "sneakers",
-          "gloves_fingerless",
-          "slingpack",
-          "hairpin",
-          "hairpin",
-          "mag_comic",
-          "wristwatch",
-          "marble",
-          "marble",
-          "slingshot"
-        ],
         "entries": [
+          { "item": "hoodie" },
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "gloves_fingerless" },
+          { "item": "slingpack" },
+          { "item": "hairpin" },
+          { "item": "hairpin" },
+          { "item": "mag_comic" },
+          { "item": "wristwatch" },
+          { "item": "marble" },
+          { "item": "marble" },
+          { "item": "slingshot" },
           { "group": "charged_smart_phone" },
           { "group": "charged_matches" },
           { "item": "tshirt", "variant": "generic_tshirt" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "boy_shorts" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" } ] }
     },
     "age_lower": 16,
     "age_upper": 18
@@ -4864,29 +5358,27 @@
     "proficiencies": [ "prof_fibers", "prof_fibers_rope", "prof_lockpicking", "prof_gun_cleaning" ],
     "items": {
       "both": {
-        "items": [
-          "jacket_light",
-          "pants_cargo",
-          "socks",
-          "boots",
-          "knit_scarf",
-          "backpack",
-          "granola",
-          "water_clean",
-          "scissors",
-          "magnifying_glass",
-          "wristwatch",
-          "whistle"
-        ],
         "entries": [
+          { "item": "jacket_light" },
+          { "item": "pants_cargo" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "knit_scarf" },
+          { "item": "backpack" },
+          { "item": "granola" },
+          { "item": "water_clean" },
+          { "item": "scissors" },
+          { "item": "magnifying_glass" },
+          { "item": "wristwatch" },
+          { "item": "whistle" },
           { "group": "charged_cell_phone" },
           { "group": "full_1st_aid" },
           { "group": "charged_flashlight" },
           { "item": "tshirt", "variant": "generic_tshirt" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "boy_shorts" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" } ] }
     },
     "age_lower": 16,
     "age_upper": 18
@@ -4901,11 +5393,19 @@
     "proficiencies": [ "prof_athlete_basic" ],
     "items": {
       "both": {
-        "items": [ "jacket_light", "jeans", "socks_ankle", "lowtops", "slingpack", "juice" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "jacket_light" },
+          { "item": "jeans" },
+          { "item": "socks_ankle" },
+          { "item": "lowtops" },
+          { "item": "slingpack" },
+          { "item": "juice" },
+          { "group": "charged_smart_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "boy_shorts" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" } ] }
     },
     "age_lower": 16,
     "age_upper": 18
@@ -4919,11 +5419,21 @@
     "skills": [ { "level": 2, "name": "fabrication" }, { "level": 2, "name": "mechanics" }, { "level": 2, "name": "chemistry" } ],
     "items": {
       "both": {
-        "items": [ "jacket_light", "jeans", "socks", "sneakers", "knit_scarf", "backpack", "basic_chemistry", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "jacket_light" },
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "knit_scarf" },
+          { "item": "backpack" },
+          { "item": "basic_chemistry" },
+          { "item": "wristwatch" },
+          { "group": "charged_smart_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "panties" } ] }
     },
     "age_lower": 16,
     "age_upper": 18
@@ -4937,21 +5447,21 @@
     "skills": [ { "level": 3, "name": "electronics" }, { "level": 3, "name": "computer" } ],
     "items": {
       "both": {
-        "items": [
-          "linuxtshirt",
-          "jacket_light",
-          "jeans",
-          "socks",
-          "sneakers",
-          "knit_scarf",
-          "backpack",
-          "mag_electronics",
-          "wristwatch"
-        ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "linuxtshirt" },
+          { "item": "jacket_light" },
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "knit_scarf" },
+          { "item": "backpack" },
+          { "item": "mag_electronics" },
+          { "item": "wristwatch" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "panties" } ] }
     },
     "age_lower": 16,
     "age_upper": 18
@@ -4965,15 +5475,22 @@
     "skills": [ { "level": 4, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [ "dress_shirt", "blazer", "socks", "dress_shoes", "tie_skinny", "tieclip", "poetry_book", "wristwatch" ],
         "entries": [
+          { "item": "dress_shirt" },
+          { "item": "blazer" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "tie_skinny" },
+          { "item": "tieclip" },
+          { "item": "poetry_book" },
+          { "item": "wristwatch" },
           { "group": "charged_smart_phone" },
           { "item": "permanent_marker", "charges": 500 },
           { "item": "pants", "variant": "pants_black" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -4985,15 +5502,20 @@
     "skills": [ { "level": 4, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [ "dress_shirt", "blazer", "socks", "dress_shoes", "wristwatch", "camera_bag" ],
         "entries": [
+          { "item": "dress_shirt" },
+          { "item": "blazer" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "wristwatch" },
+          { "item": "camera_bag" },
           { "group": "charged_smart_phone" },
           { "item": "light_disposable_cell", "ammo-item": "battery", "charges": 300, "container-item": "camera_pro" },
           { "item": "pants", "variant": "pants_black" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "bra" } ] }
     }
   },
   {
@@ -5011,11 +5533,21 @@
     ],
     "items": {
       "both": {
-        "items": [ "baseball", "bat", "whistle", "shorts", "socks_ankle", "sneakers", "runner_bag", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tank_top", "variant": "tank_top_generic" } ]
+        "entries": [
+          { "item": "baseball" },
+          { "item": "bat" },
+          { "item": "whistle" },
+          { "item": "shorts" },
+          { "item": "socks_ankle" },
+          { "item": "sneakers" },
+          { "item": "runner_bag" },
+          { "item": "wristwatch" },
+          { "group": "charged_smart_phone" },
+          { "item": "tank_top", "variant": "tank_top_generic" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "sports_bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -5027,19 +5559,17 @@
     "skills": [ { "level": 2, "name": "mechanics" }, { "level": 2, "name": "swimming" } ],
     "items": {
       "both": {
-        "items": [
-          "socks",
-          "boots_steel",
-          "gloves_work",
-          "knee_pads",
-          "jumpsuit",
-          "canteen",
-          "e_tool",
-          "tool_belt",
-          "mbag",
-          "wristwatch"
-        ],
         "entries": [
+          { "item": "socks" },
+          { "item": "boots_steel" },
+          { "item": "gloves_work" },
+          { "item": "knee_pads" },
+          { "item": "jumpsuit" },
+          { "item": "canteen" },
+          { "item": "e_tool" },
+          { "item": "tool_belt" },
+          { "item": "mbag" },
+          { "item": "wristwatch" },
           { "group": "charged_matches" },
           { "group": "full_gasmask" },
           { "group": "charged_smart_phone" },
@@ -5049,8 +5579,8 @@
           { "item": "light_minus_disposable_cell", "charges": 100, "container-item": "miner_hat" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "sports_bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
     }
   },
   {
@@ -5062,8 +5592,16 @@
     "points": 2,
     "items": {
       "both": {
-        "items": [ "socks", "boots_steel", "gloves_work", "jumpsuit", "canteen", "tool_belt", "mbag", "briefcase", "wristwatch" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "boots_steel" },
+          { "item": "gloves_work" },
+          { "item": "jumpsuit" },
+          { "item": "canteen" },
+          { "item": "tool_belt" },
+          { "item": "mbag" },
+          { "item": "briefcase" },
+          { "item": "wristwatch" },
           { "item": "hat_hard", "variant": "yellow_hat_hard" },
           { "group": "charged_matches" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -5072,8 +5610,8 @@
           { "group": "charged_smart_phone" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "sports_bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
     }
   },
   {
@@ -5086,11 +5624,19 @@
     "skills": [ { "level": 6, "name": "dodge" }, { "level": 4, "name": "swimming" } ],
     "items": {
       "both": {
-        "items": [ "hoodie", "pants_cargo", "socks_ankle", "sneakers", "runner_bag", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "hoodie" },
+          { "item": "pants_cargo" },
+          { "item": "socks_ankle" },
+          { "item": "sneakers" },
+          { "item": "runner_bag" },
+          { "item": "wristwatch" },
+          { "group": "charged_smart_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "sports_bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] }
     },
     "age_lower": 18
   },
@@ -5102,27 +5648,25 @@
     "points": 0,
     "items": {
       "both": {
-        "items": [
-          "hat_ball",
-          "knit_scarf",
-          "jacket_light",
-          "gloves_light",
-          "fanny",
-          "socks",
-          "sneakers",
-          "roadmap",
-          "touristmap",
-          "wristwatch"
-        ],
         "entries": [
+          { "item": "hat_ball" },
+          { "item": "knit_scarf" },
+          { "item": "jacket_light" },
+          { "item": "gloves_light" },
+          { "item": "fanny" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "roadmap" },
+          { "item": "touristmap" },
+          { "item": "wristwatch" },
           { "group": "charged_smart_phone" },
           { "item": "light_disposable_cell", "ammo-item": "battery", "charges": 300, "container-item": "camera" },
           { "item": "tshirt", "variant": "generic_tshirt" },
           { "item": "pants", "variant": "pants_black" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -5142,21 +5686,21 @@
     "skills": [ { "level": 4, "name": "survival" }, { "level": 3, "name": "firstaid" } ],
     "items": {
       "both": {
-        "items": [
-          "shorts_cargo",
-          "technician_shirt_gray",
-          "socks",
-          "boots",
-          "hat_boonie",
-          "slingpack",
-          "bucket",
-          "shovel",
-          "wristwatch"
-        ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "shorts_cargo" },
+          { "item": "technician_shirt_gray" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "hat_boonie" },
+          { "item": "slingpack" },
+          { "item": "bucket" },
+          { "item": "shovel" },
+          { "item": "wristwatch" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -5168,10 +5712,19 @@
     "skills": [ { "level": 1, "name": "melee" }, { "level": 1, "name": "cutting" } ],
     "items": {
       "both": {
-        "items": [ "haori", "kimono", "hakama", "loincloth", "tabi_dress", "geta", "bellywrap" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "bokken_inferior", "container-item": "scabbard" } ]
+        "entries": [
+          { "item": "haori" },
+          { "item": "kimono" },
+          { "item": "hakama" },
+          { "item": "loincloth" },
+          { "item": "tabi_dress" },
+          { "item": "geta" },
+          { "item": "bellywrap" },
+          { "group": "charged_smart_phone" },
+          { "item": "bokken_inferior", "container-item": "scabbard" }
+        ]
       },
-      "female": [ "chestwrap" ]
+      "female": { "entries": [ { "item": "chestwrap" } ] }
     },
     "missions": [ "MISSION_URBAN_SAMURAI" ]
   },
@@ -5191,20 +5744,21 @@
     "starting_styles": [ "style_fencing" ],
     "items": {
       "both": {
-        "items": [
-          "fencing_pants",
-          "fencing_jacket",
-          "gauntlet_fencing",
-          "plastron_cotton",
-          "under_armor_shorts",
-          "socks",
-          "sneakers",
-          "fencing_epee",
-          "duffelbag"
-        ],
-        "entries": [ { "item": "fencing_mask", "custom-flags": [ "no_auto_equip" ] }, { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "fencing_pants" },
+          { "item": "fencing_jacket" },
+          { "item": "gauntlet_fencing" },
+          { "item": "plastron_cotton" },
+          { "item": "under_armor_shorts" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "fencing_epee" },
+          { "item": "duffelbag" },
+          { "item": "fencing_mask", "custom-flags": [ "no_auto_equip" ] },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "female": [ "plastron_plastic" ]
+      "female": { "entries": [ { "item": "plastron_plastic" } ] }
     }
   },
   {
@@ -5217,11 +5771,22 @@
     "traits": [ "LIAR" ],
     "items": {
       "both": {
-        "items": [ "suit", "tieclip", "socks_wool", "dress_shoes", "gold_watch", "briefcase", "tie_skinny", "file", "cigar" ],
-        "entries": [ { "group": "charged_ref_lighter" }, { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "suit" },
+          { "item": "tieclip" },
+          { "item": "socks_wool" },
+          { "item": "dress_shoes" },
+          { "item": "gold_watch" },
+          { "item": "briefcase" },
+          { "item": "tie_skinny" },
+          { "item": "file" },
+          { "item": "cigar" },
+          { "group": "charged_ref_lighter" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "boxer_shorts", "opal_platinum_cufflinks" ],
-      "female": [ "bra", "panties", "opal_platinum_earring" ]
+      "male": { "entries": [ { "item": "boxer_shorts" }, { "item": "opal_platinum_cufflinks" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" }, { "item": "opal_platinum_earring" } ] }
     },
     "missions": [ "MISSION_SOCIAL_BUTTERFLY" ]
   },
@@ -5234,28 +5799,28 @@
     "skills": [ { "level": 5, "name": "survival" } ],
     "items": {
       "both": {
-        "items": [
-          "jeans",
-          "leather_belt",
-          "dress_shirt",
-          "jacket_leather",
-          "socks",
-          "cowboy_hat",
-          "boots_western",
-          "wristwatch",
-          "mbag",
-          "horse_tack",
-          "bullwhip",
-          "pockknife",
-          "cattlefodder",
-          "cattlefodder",
-          "cig",
-          "rope_30"
-        ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "leather_belt" },
+          { "item": "dress_shirt" },
+          { "item": "jacket_leather" },
+          { "item": "socks" },
+          { "item": "cowboy_hat" },
+          { "item": "boots_western" },
+          { "item": "wristwatch" },
+          { "item": "mbag" },
+          { "item": "horse_tack" },
+          { "item": "bullwhip" },
+          { "item": "pockknife" },
+          { "item": "cattlefodder" },
+          { "item": "cattlefodder" },
+          { "item": "cig" },
+          { "item": "rope_30" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -5273,11 +5838,23 @@
     "proficiencies": [ "prof_appliance_repair" ],
     "items": {
       "both": {
-        "items": [ "jacket_jean", "tshirt_tour", "jeans", "socks", "boots_steel", "multitool", "wristwatch", "gloves_work", "mbag" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_matches" }, { "group": "charged_soldering_iron" } ]
+        "entries": [
+          { "item": "jacket_jean" },
+          { "item": "tshirt_tour" },
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "boots_steel" },
+          { "item": "multitool" },
+          { "item": "wristwatch" },
+          { "item": "gloves_work" },
+          { "item": "mbag" },
+          { "group": "charged_smart_phone" },
+          { "group": "charged_matches" },
+          { "group": "charged_soldering_iron" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -5291,25 +5868,26 @@
       "both": {
         "ammo": 100,
         "magazine": 100,
-        "items": [
-          "mbag",
-          "tshirt_tour",
-          "shorts_cargo",
-          "socks",
-          "sneakers",
-          "wristwatch",
-          "water_clean",
-          "guitar_electric",
-          "cable_instrument",
-          "plectrum",
-          "plectrum",
-          "plectrum",
-          "joint"
-        ],
-        "entries": [ { "item": "towel", "custom-flags": [ "no_auto_equip" ] }, { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "mbag" },
+          { "item": "tshirt_tour" },
+          { "item": "shorts_cargo" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "wristwatch" },
+          { "item": "water_clean" },
+          { "item": "guitar_electric" },
+          { "item": "cable_instrument" },
+          { "item": "plectrum" },
+          { "item": "plectrum" },
+          { "item": "plectrum" },
+          { "item": "joint" },
+          { "item": "towel", "custom-flags": [ "no_auto_equip" ] },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -5320,11 +5898,18 @@
     "points": 1,
     "items": {
       "both": {
-        "items": [ "sneakers", "socks", "jeans", "longshirt", "wristwatch", "mbag" ],
-        "entries": [ { "group": "full_survival_kit" } ]
+        "entries": [
+          { "item": "sneakers" },
+          { "item": "socks" },
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "wristwatch" },
+          { "item": "mbag" },
+          { "group": "full_survival_kit" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "panties", "bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "panties" }, { "item": "bra" } ] }
     }
   },
   {
@@ -5343,20 +5928,18 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "under_armor",
-          "under_armor_shorts",
-          "cowboy_hat",
-          "socks",
-          "jeans",
-          "chaps_leather",
-          "gloves_leather",
-          "boots_western",
-          "duster",
-          "badge_deputy",
-          "novel_western"
-        ],
         "entries": [
+          { "item": "under_armor" },
+          { "item": "under_armor_shorts" },
+          { "item": "cowboy_hat" },
+          { "item": "socks" },
+          { "item": "jeans" },
+          { "item": "chaps_leather" },
+          { "item": "gloves_leather" },
+          { "item": "boots_western" },
+          { "item": "duster" },
+          { "item": "badge_deputy" },
+          { "item": "novel_western" },
           { "group": "charged_smart_phone" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "whiskey", "container-item": "bottle_glass" },
@@ -5383,26 +5966,42 @@
     "vehicle": "car_sports",
     "items": {
       "both": {
-        "items": [ "gold_watch", "fancy_sunglasses", "water_mineral", "money_strap_twenty", "cig", "mag_porn" ],
-        "entries": [ { "group": "charged_ref_lighter" }, { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "gold_watch" },
+          { "item": "fancy_sunglasses" },
+          { "item": "water_mineral" },
+          { "item": "money_strap_twenty" },
+          { "item": "cig" },
+          { "item": "mag_porn" },
+          { "group": "charged_ref_lighter" },
+          { "group": "charged_smart_phone" }
+        ]
       },
       "male": {
-        "items": [ "boxer_shorts", "dress_shoes", "polo_shirt", "socks", "mag_dude" ],
-        "entries": [ { "item": "pants", "variant": "pants_black" } ]
+        "entries": [
+          { "item": "boxer_shorts" },
+          { "item": "pants", "variant": "pants_black" },
+          { "item": "dress_shoes" },
+          { "item": "polo_shirt" },
+          { "item": "socks" },
+          { "item": "mag_dude" }
+        ]
       },
-      "female": [
-        "polo_shirt",
-        "bra",
-        "panties",
-        "skirt",
-        "heels",
-        "stockings",
-        "purse",
-        "mag_glam",
-        "bracelet_friendship",
-        "opal_gold_ring",
-        "opal_gold_earring"
-      ]
+      "female": {
+        "entries": [
+          { "item": "polo_shirt" },
+          { "item": "bra" },
+          { "item": "panties" },
+          { "item": "skirt" },
+          { "item": "heels" },
+          { "item": "stockings" },
+          { "item": "purse" },
+          { "item": "mag_glam" },
+          { "item": "bracelet_friendship" },
+          { "item": "opal_gold_ring" },
+          { "item": "opal_gold_earring" }
+        ]
+      }
     },
     "age_upper": 25
   },
@@ -5434,20 +6033,18 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "undershirt",
-          "combat_shirt",
-          "helmet_army",
-          "mask_ski",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "boots_combat",
-          "wristwatch",
-          "molle_pack"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "undershirt" },
+          { "item": "combat_shirt" },
+          { "item": "helmet_army" },
+          { "item": "mask_ski" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "wristwatch" },
+          { "item": "molle_pack" },
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
           { "item": "water_clean", "container-item": "canteen" },
@@ -5459,8 +6056,8 @@
           { "group": "army_mags_m17" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -5491,21 +6088,19 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "undershirt",
-          "combat_shirt",
-          "helmet_army",
-          "mask_ski",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "boots_combat",
-          "wristwatch",
-          "pockknife",
-          "molle_pack"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "undershirt" },
+          { "item": "combat_shirt" },
+          { "item": "helmet_army" },
+          { "item": "mask_ski" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "wristwatch" },
+          { "item": "pockknife" },
+          { "item": "molle_pack" },
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
           { "item": "water_clean", "container-item": "canteen" },
@@ -5519,8 +6114,8 @@
           { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -5552,21 +6147,19 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "undershirt",
-          "combat_shirt",
-          "helmet_army",
-          "mask_ski",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "boots_combat",
-          "pockknife",
-          "wristwatch",
-          "molle_pack"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "undershirt" },
+          { "item": "combat_shirt" },
+          { "item": "helmet_army" },
+          { "item": "mask_ski" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "pockknife" },
+          { "item": "wristwatch" },
+          { "item": "molle_pack" },
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
           { "item": "water_clean", "container-item": "canteen" },
@@ -5581,8 +6174,8 @@
           { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -5615,23 +6208,21 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "undershirt",
-          "combat_shirt",
-          "tac_fullhelmet",
-          "armguard_hard",
-          "legguard_hard",
-          "mask_ski",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "boots_combat",
-          "wristwatch",
-          "molle_pack",
-          "hammer_sledge"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "undershirt" },
+          { "item": "combat_shirt" },
+          { "item": "tac_fullhelmet" },
+          { "item": "armguard_hard" },
+          { "item": "legguard_hard" },
+          { "item": "mask_ski" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "wristwatch" },
+          { "item": "molle_pack" },
+          { "item": "hammer_sledge" },
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
           { "item": "water_clean", "container-item": "canteen" },
@@ -5643,8 +6234,8 @@
           { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -5675,21 +6266,19 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "undershirt",
-          "combat_shirt",
-          "helmet_army",
-          "mask_ski",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "boots_combat",
-          "wristwatch",
-          "molle_pack",
-          "cloak"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "undershirt" },
+          { "item": "combat_shirt" },
+          { "item": "helmet_army" },
+          { "item": "mask_ski" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "wristwatch" },
+          { "item": "molle_pack" },
+          { "item": "cloak" },
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
           { "group": "army_mags_m2010" },
@@ -5706,8 +6295,8 @@
           { "item": "legpouch_large", "contents-group": "army_mags_m17" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -5743,22 +6332,20 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "undershirt",
-          "combat_shirt",
-          "helmet_army",
-          "mask_ski",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "boots_combat",
-          "diving_watch",
-          "molle_pack",
-          "multitool",
-          "single_sling"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "undershirt" },
+          { "item": "combat_shirt" },
+          { "item": "helmet_army" },
+          { "item": "mask_ski" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "diving_watch" },
+          { "item": "molle_pack" },
+          { "item": "multitool" },
+          { "item": "single_sling" },
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
           { "group": "army_mags_mp7" },
@@ -5770,8 +6357,8 @@
           { "item": "legpouch_large", "contents-group": "army_mags_1911" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -5795,20 +6382,18 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "scarf",
-          "dress_shirt",
-          "jeans",
-          "longshirt",
-          "kevlar",
-          "mbag",
-          "fancy_sunglasses",
-          "socks",
-          "lowtops",
-          "pockknife",
-          "diving_watch"
-        ],
         "entries": [
+          { "item": "scarf" },
+          { "item": "dress_shirt" },
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "kevlar" },
+          { "item": "mbag" },
+          { "item": "fancy_sunglasses" },
+          { "item": "socks" },
+          { "item": "lowtops" },
+          { "item": "pockknife" },
+          { "item": "diving_watch" },
           { "group": "charged_smart_phone" },
           { "item": "holster", "contents-group": "holster_supp_57" },
           { "item": "suppressor" },
@@ -5816,8 +6401,8 @@
           { "item": "legpouch_large", "contents-group": "army_mags_57" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "sports_bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
     }
   },
   {
@@ -5842,18 +6427,16 @@
     "proficiencies": [ "prof_helicopter_pilot", "prof_spotting", "prof_gun_cleaning", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
-        "items": [
-          "nomex_socks",
-          "boots_combat",
-          "wristwatch",
-          "gloves_tactical",
-          { "item": "flight_helmet", "ammo-item": "light_plus_battery_cell", "charges": 150 },
-          "mil_flight_suit",
-          "chestrig",
-          "webbing_belt",
-          "legpouch_large"
-        ],
         "entries": [
+          { "item": "nomex_socks" },
+          { "item": "boots_combat" },
+          { "item": "wristwatch" },
+          { "item": "gloves_tactical" },
+          { "item": "flight_helmet", "ammo-item": "light_plus_battery_cell", "charges": 150 },
+          { "item": "mil_flight_suit" },
+          { "item": "chestrig" },
+          { "item": "webbing_belt" },
+          { "item": "legpouch_large" },
           { "group": "charged_matches" },
           { "group": "charged_flashlight" },
           { "item": "handflare", "count": 2, "charges": 200 },
@@ -5864,8 +6447,8 @@
           { "item": "p320mag_17rd_9x19mm", "ammo-item": "9mm", "charges": 17 }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] }
     },
     "flags": [ "SCEN_ONLY" ],
     "missions": [ "MISSION_HELICOPTER_PILOT" ]
@@ -5882,21 +6465,22 @@
     "vehicle": "ambulance",
     "items": {
       "both": {
-        "items": [
-          "technician_shirt_gray",
-          "socks",
-          "gloves_medical",
-          "multitool",
-          "wristwatch",
-          "boots",
+        "entries": [
+          { "item": "technician_shirt_gray" },
+          { "item": "socks" },
+          { "item": "gloves_medical" },
+          { "item": "multitool" },
+          { "item": "wristwatch" },
+          { "item": "boots" },
           { "item": "aspirin", "count": 5 },
-          "adrenaline_injector",
-          { "item": "adhesive_bandages", "count": 8 }
-        ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "pants", "variant": "pants_blue" } ]
+          { "item": "adrenaline_injector" },
+          { "item": "adhesive_bandages", "count": 8 },
+          { "group": "charged_smart_phone" },
+          { "item": "pants", "variant": "pants_blue" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -5917,29 +6501,27 @@
     "traits": [ "PROF_MED" ],
     "items": {
       "both": {
-        "items": [
-          "technician_shirt_gray",
-          "socks",
-          "gloves_medical",
-          "wristwatch",
-          "boots",
-          "mbag",
-          { "item": "bandages", "count": 3 },
-          "stethoscope",
-          "scissors",
-          "syringe",
-          "morphine",
-          "adrenaline_injector"
-        ],
         "entries": [
+          { "item": "technician_shirt_gray" },
+          { "item": "socks" },
+          { "item": "gloves_medical" },
+          { "item": "wristwatch" },
+          { "item": "boots" },
+          { "item": "mbag" },
+          { "item": "bandages", "count": 3 },
+          { "item": "stethoscope" },
+          { "item": "scissors" },
+          { "item": "syringe" },
+          { "item": "morphine" },
+          { "item": "adrenaline_injector" },
           { "group": "charged_smart_phone" },
           { "group": "full_1st_aid" },
           { "item": "pants", "variant": "pants_blue" },
           { "item": "mask_dust", "variant": "white_mask_dust" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -5977,28 +6559,26 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "undershirt",
-          "combat_shirt",
-          "helmet_army",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "boots_combat",
-          "wristwatch",
-          "thermometer",
-          { "item": "bandages", "count": 3 },
-          "scalpel",
-          "syringe",
-          "morphine",
-          "aspirin",
-          "antibiotics",
-          "disinfectant",
-          "pepto",
-          "molle_pack"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "undershirt" },
+          { "item": "combat_shirt" },
+          { "item": "helmet_army" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "wristwatch" },
+          { "item": "thermometer" },
+          { "item": "bandages", "count": 3 },
+          { "item": "scalpel" },
+          { "item": "syringe" },
+          { "item": "morphine" },
+          { "item": "aspirin" },
+          { "item": "antibiotics" },
+          { "item": "disinfectant" },
+          { "item": "pepto" },
+          { "item": "molle_pack" },
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
           { "group": "full_ifak" },
@@ -6017,8 +6597,8 @@
           }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -6030,25 +6610,25 @@
     "skills": [ { "level": 3, "name": "firstaid" }, { "level": 1, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [
-          "technician_shirt_gray",
-          "jeans",
-          "socks",
-          "sneakers",
-          "mbag",
+        "entries": [
+          { "item": "technician_shirt_gray" },
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "mbag" },
           { "item": "adhesive_bandages", "count": 10 },
           { "item": "bandages", "count": 3 },
-          "water_clean",
-          "water_clean",
-          "water_clean",
-          "granola",
-          "granola",
-          "granola"
-        ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+          { "item": "water_clean" },
+          { "item": "water_clean" },
+          { "item": "water_clean" },
+          { "item": "granola" },
+          { "item": "granola" },
+          { "item": "granola" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -6062,17 +6642,17 @@
     "vehicle": "superbike",
     "items": {
       "both": {
-        "items": [
-          "helmet_motor",
-          "touring_suit",
-          "under_armor",
-          "under_armor_shorts",
-          "socks",
-          "motorbike_boots",
-          "gloves_leather",
-          "wristwatch"
-        ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "helmet_motor" },
+          { "item": "touring_suit" },
+          { "item": "under_armor" },
+          { "item": "under_armor_shorts" },
+          { "item": "socks" },
+          { "item": "motorbike_boots" },
+          { "item": "gloves_leather" },
+          { "item": "wristwatch" },
+          { "group": "charged_smart_phone" }
+        ]
       }
     }
   },
@@ -6094,11 +6674,20 @@
     "traits": [ "PROF_MED" ],
     "items": {
       "both": {
-        "items": [ "jumpsuit", "hazmat_suit", "socks", "gloves_medical", "wristwatch", "glasses_safety", "scalpel" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "mask_filter", "ammo-item": "gasfilter_sm", "charges": 100 } ]
+        "entries": [
+          { "item": "jumpsuit" },
+          { "item": "hazmat_suit" },
+          { "item": "socks" },
+          { "item": "gloves_medical" },
+          { "item": "wristwatch" },
+          { "item": "glasses_safety" },
+          { "item": "scalpel" },
+          { "group": "charged_smart_phone" },
+          { "item": "mask_filter", "ammo-item": "gasfilter_sm", "charges": 100 }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -6116,14 +6705,21 @@
     ],
     "items": {
       "both": {
-        "items": [ "hoodie", "jeans", "mbag", "socks", "sneakers", "bandana", "gloves_medical", "switchblade" ],
         "entries": [
+          { "item": "hoodie" },
+          { "item": "jeans" },
+          { "item": "mbag" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "bandana" },
+          { "item": "gloves_medical" },
+          { "item": "switchblade" },
           { "group": "charged_cell_phone" },
           { "item": "crack", "count": 25, "container-item": "null", "entry-wrapper": "bag_zipper" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "sports_bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] }
     },
     "traits": [ "LIAR" ]
   },
@@ -6145,17 +6741,15 @@
     "proficiencies": [ "prof_unarmed_familiar", "prof_unarmed_pro", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
-        "items": [
-          "fedora",
-          "socks",
-          "dress_shoes",
-          "gold_watch",
-          "diamond_ring",
-          "diamond_gold_pendant_necklace",
-          "cigar_cutter",
-          "gold_bracelet"
-        ],
         "entries": [
+          { "item": "fedora" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "gold_watch" },
+          { "item": "diamond_ring" },
+          { "item": "diamond_gold_pendant_necklace" },
+          { "item": "cigar_cutter" },
+          { "item": "gold_bracelet" },
           { "group": "charged_cell_phone" },
           { "item": "cigar", "entry-wrapper": "case_cigar", "container-item": "null", "count": 2 },
           { "item": "deagle_44", "ammo-item": "44fmj", "container-item": "holster", "charges": 8 },
@@ -6163,8 +6757,8 @@
           { "item": "knuckle_brass", "container-item": "tux" }
         ]
       },
-      "male": [ "boxer_shorts", "diamond_gold_cufflinks" ],
-      "female": [ "bra", "panties", "diamond_gold_earring" ]
+      "male": { "entries": [ { "item": "boxer_shorts" }, { "item": "diamond_gold_cufflinks" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" }, { "item": "diamond_gold_earring" } ] }
     },
     "traits": [ "LIAR" ],
     "missions": [ "MISSION_MAFIA_BOSS", "MISSION_SOCIAL_BUTTERFLY" ],
@@ -6181,8 +6775,14 @@
     "proficiencies": [ "prof_electromagnetics" ],
     "items": {
       "both": {
-        "items": [ "technician_shirt_gray", "cleansuit", "socks", "gloves_rubber", "tool_belt", "glasses_safety", "camera_bag" ],
         "entries": [
+          { "item": "technician_shirt_gray" },
+          { "item": "cleansuit" },
+          { "item": "socks" },
+          { "item": "gloves_rubber" },
+          { "item": "tool_belt" },
+          { "item": "glasses_safety" },
+          { "item": "camera_bag" },
           { "group": "charged_smart_phone" },
           { "group": "charged_flashlight" },
           { "item": "pants", "variant": "pants_stone" },
@@ -6197,8 +6797,8 @@
           { "item": "light_battery_cell", "ammo-item": "battery", "charges": 100, "container-item": "emf_detector" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -6210,11 +6810,19 @@
     "skills": [ { "level": 3, "name": "survival" } ],
     "items": {
       "both": {
-        "items": [ "jeans", "longshirt", "socks", "sneakers", "mbag", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "binoculars" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "mbag" },
+          { "item": "wristwatch" },
+          { "group": "charged_smart_phone" },
+          { "item": "binoculars" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -6225,8 +6833,10 @@
     "points": 1,
     "items": {
       "both": {
-        "items": [ "xedra_enviro_suit", "socks", "union_suit" ],
         "entries": [
+          { "item": "xedra_enviro_suit" },
+          { "item": "socks" },
+          { "item": "union_suit" },
           { "item": "mask_gas", "ammo-item": "gasfilter_med", "charges": 100 },
           {
             "item": "light_minus_battery_cell",
@@ -6263,14 +6873,20 @@
     "proficiencies": [ "prof_long_swords_familiar" ],
     "items": {
       "both": {
-        "items": [ "hood_ninja", "jacket_ninja", "trousers_ninja", "tabi_dress", "geta", "gloves_wraps", "bellywrap" ],
         "entries": [
+          { "item": "hood_ninja" },
+          { "item": "jacket_ninja" },
+          { "item": "trousers_ninja" },
+          { "item": "tabi_dress" },
+          { "item": "geta" },
+          { "item": "gloves_wraps" },
+          { "item": "bellywrap" },
           { "item": "katana", "container-item": "scabbard" },
           { "item": "grenadebandolier", "contents-group": "ninja_grenade_pouch" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "chestwrap", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "chestwrap" }, { "item": "panties" } ] }
     },
     "traits": [ "LIGHTSTEP" ],
     "missions": [ "MISSION_NINJA" ]
@@ -6284,11 +6900,15 @@
     "skills": [ { "level": 3, "name": "dodge" }, { "level": 3, "name": "swimming" }, { "level": 3, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [ "pom_poms", "socks_ankle", "sneakers" ],
-        "entries": [ { "item": "tank_top", "variant": "tank_top_cheerleader" } ]
+        "entries": [
+          { "item": "pom_poms" },
+          { "item": "socks_ankle" },
+          { "item": "sneakers" },
+          { "item": "tank_top", "variant": "tank_top_cheerleader" }
+        ]
       },
-      "male": [ "briefs", "shorts" ],
-      "female": [ "sports_bra", "panties", "cheerleader_skirt" ]
+      "male": { "entries": [ { "item": "briefs" }, { "item": "shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" }, { "item": "cheerleader_skirt" } ] }
     },
     "missions": [ "MISSION_SOCIAL_BUTTERFLY" ],
     "age_lower": 16,
@@ -6302,16 +6922,25 @@
     "points": -1,
     "items": {
       "both": {
-        "items": [ "american_flag", "socks", "wristwatch" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "mask_dust", "variant": "flag_mask_dust" } ]
+        "entries": [
+          { "item": "american_flag" },
+          { "item": "socks" },
+          { "item": "wristwatch" },
+          { "group": "charged_smart_phone" },
+          { "item": "mask_dust", "variant": "flag_mask_dust" }
+        ]
       },
       "male": {
-        "items": [ "flag_shirt", "sneakers" ],
-        "entries": [ { "item": "flag_swimsuit", "variant": "flag_swimsuit" }, { "item": "pants", "variant": "pants_flag" } ]
+        "entries": [
+          { "item": "flag_shirt" },
+          { "item": "sneakers" },
+          { "item": "flag_swimsuit", "variant": "flag_swimsuit" },
+          { "item": "pants", "variant": "pants_flag" }
+        ]
       },
       "female": {
-        "items": [ "flag_jumpsuit" ],
         "entries": [
+          { "item": "flag_jumpsuit" },
           { "item": "bikini_top", "variant": "flag_bikini_top" },
           { "item": "bikini_bottom", "variant": "flag_bikini_bottom" },
           { "item": "heels", "variant": "heels_flag" }
@@ -6333,8 +6962,9 @@
     ],
     "items": {
       "both": {
-        "items": [ "american_flag", "slippers" ],
         "entries": [
+          { "item": "american_flag" },
+          { "item": "slippers" },
           { "group": "charged_smart_phone" },
           { "item": "mask_dust", "variant": "flag_mask_dust" },
           { "item": "chestrig", "variant": "flag_chestrig", "contents-group": "mags_ruger_arr" },
@@ -6364,33 +6994,31 @@
     "pets": [ { "name": "mon_horse", "amount": 1 } ],
     "items": {
       "both": {
-        "items": [
-          "leather_belt",
-          "dress_shirt",
-          "jacket_leather",
-          "socks",
-          "cowboy_hat",
-          "wristwatch",
-          "backpack_leather",
-          "horse_tack",
-          "bullwhip",
-          "pockknife",
-          "jeans",
-          "chaps_leather",
-          "gloves_leather",
-          "boots_western",
-          "sunglasses",
-          "rope_30"
-        ],
         "entries": [
+          { "item": "leather_belt" },
+          { "item": "dress_shirt" },
+          { "item": "jacket_leather" },
+          { "item": "socks" },
+          { "item": "cowboy_hat" },
+          { "item": "wristwatch" },
+          { "item": "backpack_leather" },
+          { "item": "horse_tack" },
+          { "item": "bullwhip" },
+          { "item": "pockknife" },
+          { "item": "jeans" },
+          { "item": "chaps_leather" },
+          { "item": "gloves_leather" },
+          { "item": "boots_western" },
+          { "item": "sunglasses" },
+          { "item": "rope_30" },
           { "group": "charged_smart_phone" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "sw_619", "ammo-item": "357mag_jhp", "charges": 7 },
           { "item": "western_holster", "contents-group": "bandolier_cowboy" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -6402,14 +7030,23 @@
     "skills": [ { "level": 2, "name": "swimming" } ],
     "items": {
       "both": {
-        "items": [ "sunglasses", "straw_hat", "dive_bag", "beach_volleyball" ],
         "entries": [
-          { "item": "waterproof_smart_phone_case", "variant": "black_smart_phone_case", "contents-group": "charged_smart_phone" },
+          { "item": "sunglasses" },
+          { "item": "straw_hat" },
+          { "item": "dive_bag" },
+          { "item": "beach_volleyball" },
+          {
+            "item": "waterproof_smart_phone_case",
+            "variant": "black_smart_phone_case",
+            "contents-group": "charged_smart_phone"
+          },
           { "item": "towel", "custom-flags": [ "no_auto_equip" ] },
           { "item": "flip_flops", "custom-flags": [ "no_auto_equip" ] }
         ]
       },
-      "male": { "items": [ "trunks", "swim_briefs" ], "entries": [ { "item": "tank_top", "custom-flags": [ "no_auto_equip" ] } ] },
+      "male": {
+        "entries": [ { "item": "trunks" }, { "item": "swim_briefs" }, { "item": "tank_top", "custom-flags": [ "no_auto_equip" ] } ]
+      },
       "female": {
         "entries": [
           { "item": "bikini_top", "variant": "tropical_bikini_top" },
@@ -6429,8 +7066,8 @@
     "skills": [ { "level": 6, "name": "swimming" }, { "level": 2, "name": "dodge" } ],
     "traits": [ "OUTDOORSMAN" ],
     "items": {
-      "both": [ "goggles_swim", "swim_cap" ],
-      "male": [ "speedo" ],
+      "both": { "entries": [ { "item": "goggles_swim" }, { "item": "swim_cap" } ] },
+      "male": { "entries": [ { "item": "speedo" } ] },
       "female": { "entries": [ { "item": "flag_swimsuit", "variant": "generic_swimsuit" } ] }
     },
     "proficiencies": [ "prof_athlete_basic" ]
@@ -6445,9 +7082,9 @@
     "skills": [ { "level": 4, "name": "dodge" }, { "level": 4, "name": "swimming" } ],
     "traits": [ "OUTDOORSMAN" ],
     "items": {
-      "both": [ "swimming_kickboard" ],
-      "male": [ "wetsuit_top", "wetsuit_shorts" ],
-      "female": [ "wetsuit_spring_sleeveless" ]
+      "both": { "entries": [ { "item": "swimming_kickboard" } ] },
+      "male": { "entries": [ { "item": "wetsuit_top" }, { "item": "wetsuit_shorts" } ] },
+      "female": { "entries": [ { "item": "wetsuit_spring_sleeveless" } ] }
     }
   },
   {
@@ -6460,8 +7097,10 @@
     "traits": [ "OUTDOORSMAN" ],
     "proficiencies": [ "prof_wound_care" ],
     "items": {
-      "both": [ "whistle", "sunglasses", "diving_watch" ],
-      "male": { "items": [ "trunks", "swim_briefs" ], "entries": [ { "item": "rashguard", "variant": "lifeguard_rashguard_shirt" } ] },
+      "both": { "entries": [ { "item": "whistle" }, { "item": "sunglasses" }, { "item": "diving_watch" } ] },
+      "male": {
+        "entries": [ { "item": "trunks" }, { "item": "swim_briefs" }, { "item": "rashguard", "variant": "lifeguard_rashguard_shirt" } ]
+      },
       "female": { "entries": [ { "item": "flag_swimsuit", "variant": "lifeguard_swimsuit" } ] }
     }
   },
@@ -6475,8 +7114,15 @@
     "traits": [ "OUTDOORSMAN" ],
     "items": {
       "both": {
-        "items": [ "wetsuit", "wetsuit_hood", "wetsuit_booties", "wetsuit_gloves", "diving_watch", "diveknife" ],
-        "entries": [ { "item": "rebreather", "ammo-item": "rebreather_filter", "charges": 20 } ]
+        "entries": [
+          { "item": "wetsuit" },
+          { "item": "wetsuit_hood" },
+          { "item": "wetsuit_booties" },
+          { "item": "wetsuit_gloves" },
+          { "item": "diving_watch" },
+          { "item": "diveknife" },
+          { "item": "rebreather", "ammo-item": "rebreather_filter", "charges": 20 }
+        ]
       }
     }
   },
@@ -6491,8 +7137,14 @@
     "traits": [ "OUTDOORSMAN" ],
     "items": {
       "both": {
-        "items": [ "trunks", "bastsandals", "dive_bag", "wristwatch", "flotation_vest", "hand_pump", "folded_inflatable_boat" ],
         "entries": [
+          { "item": "trunks" },
+          { "item": "bastsandals" },
+          { "item": "dive_bag" },
+          { "item": "wristwatch" },
+          { "item": "flotation_vest" },
+          { "item": "hand_pump" },
+          { "item": "folded_inflatable_boat" },
           { "item": "rashguard", "variant": "tropical_rashguard_shirt" },
           { "item": "hat_ball", "variant": "generic_hatball" },
           {
@@ -6502,7 +7154,7 @@
           }
         ]
       },
-      "male": [ "swim_briefs" ],
+      "male": { "entries": [ { "item": "swim_briefs" } ] },
       "female": {
         "entries": [
           { "item": "bikini_top", "variant": "tropical_bikini_top" },
@@ -6538,46 +7190,48 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "fancy_sunglasses",
-          "platinum_watch",
-          "knit_scarf_loose",
-          "gloves_liner",
-          "polaroid_photo",
-          "suppressor",
-          "tele_sight_pistol"
-        ],
         "entries": [
+          { "item": "fancy_sunglasses" },
+          { "item": "platinum_watch" },
+          { "item": "knit_scarf_loose" },
+          { "item": "gloves_liner" },
+          { "item": "polaroid_photo" },
+          { "item": "suppressor" },
+          { "item": "tele_sight_pistol" },
           { "group": "charged_cell_phone" },
           { "item": "glock_29", "ammo-item": "10mm_fmj", "charges": 15 },
           { "item": "glock_20mag", "ammo-item": "10mm_fmj", "charges": 15, "container-item": "bbholster" }
         ]
       },
-      "male": [
-        "briefs",
-        "socks",
-        "dress_shoes",
-        "bowhat",
-        "suit",
-        "tie_necktie",
-        "tieclip",
-        "leather_belt",
-        "briefcase",
-        "cufflinks_intricate"
-      ],
-      "female": [
-        "panties",
-        "bra",
-        "stockings",
-        "garter_belt",
-        "heels",
-        "hat_cotton",
-        "dress",
-        "purse",
-        "platinum_ear",
-        "platinum_necklace",
-        "platinum_hairpin"
-      ]
+      "male": {
+        "entries": [
+          { "item": "briefs" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "bowhat" },
+          { "item": "suit" },
+          { "item": "tie_necktie" },
+          { "item": "tieclip" },
+          { "item": "leather_belt" },
+          { "item": "briefcase" },
+          { "item": "cufflinks_intricate" }
+        ]
+      },
+      "female": {
+        "entries": [
+          { "item": "panties" },
+          { "item": "bra" },
+          { "item": "stockings" },
+          { "item": "garter_belt" },
+          { "item": "heels" },
+          { "item": "hat_cotton" },
+          { "item": "dress" },
+          { "item": "purse" },
+          { "item": "platinum_ear" },
+          { "item": "platinum_necklace" },
+          { "item": "platinum_hairpin" }
+        ]
+      }
     },
     "missions": [ "MISSION_ASSASSINATION" ]
   },
@@ -6598,38 +7252,47 @@
     "proficiencies": [ "prof_spotting", "prof_wp_syn_armored", "prof_knives_familiar", "prof_knives_pro", "prof_knives_master" ],
     "items": {
       "both": {
-        "items": [ "fancy_sunglasses", "platinum_watch", "knit_scarf_loose", "gloves_liner", "polaroid_photo", "switchblade" ],
         "entries": [
+          { "item": "fancy_sunglasses" },
+          { "item": "platinum_watch" },
+          { "item": "knit_scarf_loose" },
+          { "item": "gloves_liner" },
+          { "item": "polaroid_photo" },
+          { "item": "switchblade" },
           { "group": "charged_cell_phone" },
           { "item": "knife_combat", "container-item": "gartersheath1" },
           { "item": "leg_sheath6", "contents-group": "leg_sheath6_throwing_knives" }
         ]
       },
-      "male": [
-        "briefs",
-        "socks",
-        "dress_shoes",
-        "bowhat",
-        "suit",
-        "tie_necktie",
-        "tieclip",
-        "leather_belt",
-        "briefcase",
-        "cufflinks_intricate"
-      ],
-      "female": [
-        "panties",
-        "bra",
-        "stockings",
-        "garter_belt",
-        "heels",
-        "hat_cotton",
-        "dress",
-        "purse",
-        "platinum_ear",
-        "platinum_necklace",
-        "platinum_hairpin"
-      ]
+      "male": {
+        "entries": [
+          { "item": "briefs" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "bowhat" },
+          { "item": "suit" },
+          { "item": "tie_necktie" },
+          { "item": "tieclip" },
+          { "item": "leather_belt" },
+          { "item": "briefcase" },
+          { "item": "cufflinks_intricate" }
+        ]
+      },
+      "female": {
+        "entries": [
+          { "item": "panties" },
+          { "item": "bra" },
+          { "item": "stockings" },
+          { "item": "garter_belt" },
+          { "item": "heels" },
+          { "item": "hat_cotton" },
+          { "item": "dress" },
+          { "item": "purse" },
+          { "item": "platinum_ear" },
+          { "item": "platinum_necklace" },
+          { "item": "platinum_hairpin" }
+        ]
+      }
     },
     "missions": [ "MISSION_ASSASSINATION" ]
   },
@@ -6650,18 +7313,16 @@
     "proficiencies": [ "prof_gunsmithing_basic", "prof_spotting", "prof_gun_cleaning", "prof_auto_rifles_familiar" ],
     "items": {
       "both": {
-        "items": [
-          "wristwatch",
-          "jacket_army",
-          "service_medal",
-          "boots_combat",
-          "socks",
-          "officer_uniform",
-          "pipe_tobacco",
-          "tobacco",
-          "beret"
-        ],
         "entries": [
+          { "item": "wristwatch" },
+          { "item": "jacket_army" },
+          { "item": "service_medal" },
+          { "item": "boots_combat" },
+          { "item": "socks" },
+          { "item": "officer_uniform" },
+          { "item": "pipe_tobacco" },
+          { "item": "tobacco" },
+          { "item": "beret" },
           { "item": "pants", "variant": "pants_british_khaki" },
           { "item": "cane", "custom-flags": [ "auto_wield" ] },
           { "group": "charged_ref_lighter" },
@@ -6670,8 +7331,8 @@
           { "item": "m1a", "ammo-item": "762_51", "charges": 20, "contents-item": [ "shoulder_strap_simple" ] }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "boy_shorts", "bra" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "bra" } ] }
     },
     "age_lower": 50
   },
@@ -6685,20 +7346,18 @@
     "proficiencies": [ "prof_lockpicking" ],
     "items": {
       "both": {
-        "items": [
-          "wristwatch",
-          "gloves_fingerless",
-          "socks",
-          "sneakers",
-          "hoodie",
-          "tshirt_text",
-          "crowbar",
-          "camera_bag",
-          "slingpack",
-          "leather_belt",
-          "urbexmap"
-        ],
         "entries": [
+          { "item": "wristwatch" },
+          { "item": "gloves_fingerless" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "hoodie" },
+          { "item": "tshirt_text" },
+          { "item": "crowbar" },
+          { "item": "camera_bag" },
+          { "item": "slingpack" },
+          { "item": "leather_belt" },
+          { "item": "urbexmap" },
           { "group": "charged_smart_phone", "container-item": "pants" },
           { "item": "pants", "variant": "pants_black" },
           { "item": "light_disposable_cell", "ammo-item": "battery", "charges": 300, "container-item": "camera_pro" },
@@ -6710,8 +7369,8 @@
           }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "boy_shorts", "sports_bra" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
     },
     "age_lower": 16
   },
@@ -6730,16 +7389,20 @@
     "addictions": [ { "intensity": 10, "type": "caffeine" } ],
     "items": {
       "both": {
-        "items": [ "dress_shirt", "undershirt", "socks", "tie_clipon", "dress_shoes" ],
         "entries": [
+          { "item": "dress_shirt" },
+          { "item": "undershirt" },
+          { "item": "socks" },
+          { "item": "tie_clipon" },
+          { "item": "dress_shoes" },
           { "group": "charged_smart_phone" },
           { "group": "charged_penblack" },
           { "item": "pants", "variant": "pants_black" },
           { "item": "coffee", "container-item": "coffeepot" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "panties", "bra" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "panties" }, { "item": "bra" } ] }
     }
   },
   {
@@ -6760,15 +7423,22 @@
     "vehicle": "rv",
     "items": {
       "both": {
-        "items": [ "knit_scarf", "socks", "boots_steel", "pants_cargo", "jacket_flannel", "hat_hunting", "wristwatch", "back_holster" ],
         "entries": [
+          { "item": "knit_scarf" },
+          { "item": "socks" },
+          { "item": "boots_steel" },
+          { "item": "pants_cargo" },
+          { "item": "jacket_flannel" },
+          { "item": "hat_hunting" },
+          { "item": "wristwatch" },
+          { "item": "back_holster" },
           { "group": "charged_smart_phone" },
           { "item": "sheath", "contents-item": "knife_hunting" },
           { "item": "tank_top", "variant": "tank_top_camo" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     },
     "missions": [ "MISSION_HUNTER", "MISSION_FIND_RIFLE" ]
   },
@@ -6783,11 +7453,19 @@
     "vehicle": "car_coupe_muscle",
     "items": {
       "both": {
-        "items": [ "jeans", "tshirt", "gosling_jacket", "gloves_fingerless", "socks", "sneakers", "hammer" ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "tshirt" },
+          { "item": "gosling_jacket" },
+          { "item": "gloves_fingerless" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "hammer" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "panties", "bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "panties" }, { "item": "bra" } ] }
     }
   },
   {
@@ -6821,19 +7499,17 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "undershirt",
-          "pants_army",
-          "socks",
-          "boots_combat",
-          "attached_ear_plugs_off",
-          "helmet_eod",
-          "nomex_gloves",
-          "gloves_eod",
-          "trousers_eod",
-          "foot_protectors_eod"
-        ],
         "entries": [
+          { "item": "undershirt" },
+          { "item": "pants_army" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "attached_ear_plugs_off" },
+          { "item": "helmet_eod" },
+          { "item": "nomex_gloves" },
+          { "item": "gloves_eod" },
+          { "item": "trousers_eod" },
+          { "item": "foot_protectors_eod" },
           { "item": "eod_plate", "container-item": "jacket_eod" },
           { "item": "EOD_hotstick", "custom-flags": [ "auto_wield" ] },
           { "item": "water_clean", "container-item": "camelbak" },
@@ -6841,8 +7517,8 @@
           { "item": "m18", "ammo-item": "9mm", "container-item": "holster", "charges": 17 }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   }
 ]

--- a/data/mods/Aftershock/player/professions.json
+++ b/data/mods/Aftershock/player/professions.json
@@ -9,15 +9,19 @@
     "skills": [ { "level": 4, "name": "electronics" }, { "level": 2, "name": "launcher" } ],
     "items": {
       "both": {
-        "items": [ "jumpsuit", "socks", "rope_30", "boots", "afs_herc_rig" ],
         "entries": [
+          { "item": "jumpsuit" },
+          { "item": "socks" },
+          { "item": "rope_30" },
+          { "item": "boots" },
+          { "item": "afs_herc_rig" },
           { "item": "hat_hard", "variant": "blue_hat_hard" },
           { "item": "afs_foamgun", "ammo-item": "afs_foamcrete", "charges": 30 },
           { "item": "afs_foam_tank", "ammo-item": "afs_foamcrete", "charges": 30 }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -31,11 +35,20 @@
     "skills": [ { "level": 3, "name": "electronics" }, { "level": 3, "name": "mechanics" } ],
     "items": {
       "both": {
-        "items": [ "spacer_jumpsuit", "spacer_cap", "socks", "boots", "duct_tape", "screwdriver", "wristwatch" ],
-        "entries": [ { "item": "hat_hard", "variant": "orange_hat_hard" }, { "item": "wrench", "container-item": "tool_belt" } ]
+        "entries": [
+          { "item": "spacer_jumpsuit" },
+          { "item": "spacer_cap" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "duct_tape" },
+          { "item": "screwdriver" },
+          { "item": "wristwatch" },
+          { "item": "hat_hard", "variant": "orange_hat_hard" },
+          { "item": "wrench", "container-item": "tool_belt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "sports_bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -61,17 +74,15 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "glasses_bal",
-          "spacer_jumpsuit",
-          "socks",
-          "webbing_belt",
-          "gloves_tactical",
-          "boots_combat",
-          "spacer_cap",
-          "wristwatch"
-        ],
         "entries": [
+          { "item": "glasses_bal" },
+          { "item": "spacer_jumpsuit" },
+          { "item": "socks" },
+          { "item": "webbing_belt" },
+          { "item": "gloves_tactical" },
+          { "item": "boots_combat" },
+          { "item": "spacer_cap" },
+          { "item": "wristwatch" },
           { "group": "charged_two_way_radio" },
           { "group": "charged_smart_phone" },
           { "item": "afs_rm99_pistol", "container-item": "holster" },
@@ -81,8 +92,8 @@
           { "item": "8mm_hvp" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "sports_bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -126,8 +137,10 @@
     "//": "replace esapu armor with an XL environmentally controlled armor once those exist",
     "items": {
       "both": {
-        "items": [ "xlboots_combat", "xlgloves_tactical", "wristwatch" ],
         "entries": [
+          { "item": "xlboots_combat" },
+          { "item": "xlgloves_tactical" },
+          { "item": "wristwatch" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "sheath", "contents-item": "kukri" },
           {
@@ -141,8 +154,8 @@
           { "item": "legpouch_large", "contents-group": "afs_UICASTA30" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -164,21 +177,23 @@
     "points": 3,
     "skills": [ { "level": 1, "name": "speech" } ],
     "items": {
-      "both": [
-        "dress_shirt",
-        "pants",
-        "dress_shoes",
-        "socks",
-        "mbag",
-        "afs_atomic_smartphone",
-        "atomic_light_off",
-        "atomic_coffeepot",
-        "atomic_lamp_off",
-        "afs_atompot",
-        "energy_drink_atomic"
-      ],
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "both": {
+        "entries": [
+          { "item": "dress_shirt" },
+          { "item": "pants" },
+          { "item": "dress_shoes" },
+          { "item": "socks" },
+          { "item": "mbag" },
+          { "item": "afs_atomic_smartphone" },
+          { "item": "atomic_light_off" },
+          { "item": "atomic_coffeepot" },
+          { "item": "atomic_lamp_off" },
+          { "item": "afs_atompot" },
+          { "item": "energy_drink_atomic" }
+        ]
+      },
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -189,16 +204,20 @@
     "points": 4,
     "items": {
       "both": {
-        "items": [ "socks", "afs_calorie_pill", "afs_atomic_smartphone", "undershirt", "dump_pouch" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "afs_calorie_pill" },
+          { "item": "afs_atomic_smartphone" },
+          { "item": "undershirt" },
+          { "item": "dump_pouch" },
           { "item": "water_clean", "container-item": "camelbak" },
           { "item": "crowbar", "custom-flags": [ "auto_wield" ] },
           { "item": "phase_immersion_suit" },
           { "item": "dimensional_anchor", "ammo-item": "medium_atomic_battery_cell", "charges": 5000 }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "boy_shorts" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -209,9 +228,9 @@
     "points": 3,
     "traits": [ "AFS_BRUTAL_STRENGTH", "SLOWREADER", "LIGHTWEIGHT" ],
     "items": {
-      "both": [ "suit", "dress_shoes", "bootsheath", "ceramic_knife" ],
-      "male": [ "briefs", "undershirt" ],
-      "female": [ "boy_shorts", "bra" ]
+      "both": { "entries": [ { "item": "suit" }, { "item": "dress_shoes" }, { "item": "bootsheath" }, { "item": "ceramic_knife" } ] },
+      "male": { "entries": [ { "item": "briefs" }, { "item": "undershirt" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "bra" } ] }
     }
   },
   {
@@ -223,11 +242,21 @@
     "skills": [ { "level": 4, "name": "electronics" } ],
     "items": {
       "both": {
-        "items": [ "coat_lab", "gloves_medical", "longshirt", "afs_complete_bionic_toolkit", "socks", "boots", "backpack", "jeans" ],
-        "entries": [ { "item": "cash_card", "charges": 50000 }, { "item": "mask_dust", "variant": "white_mask_dust" } ]
+        "entries": [
+          { "item": "coat_lab" },
+          { "item": "gloves_medical" },
+          { "item": "longshirt" },
+          { "item": "afs_complete_bionic_toolkit" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "backpack" },
+          { "item": "jeans" },
+          { "item": "cash_card", "charges": 50000 },
+          { "item": "mask_dust", "variant": "white_mask_dust" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -245,8 +274,14 @@
     "skills": [ { "level": 6, "name": "speech" }, { "level": 6, "name": "computer" } ],
     "items": {
       "both": {
-        "items": [ "tux", "dress_shoes", "socks", "gold_watch", "undershirt", "gasdiscount_platinum", "afs_10mm_smart_template" ],
         "entries": [
+          { "item": "tux" },
+          { "item": "dress_shoes" },
+          { "item": "socks" },
+          { "item": "gold_watch" },
+          { "item": "undershirt" },
+          { "item": "gasdiscount_platinum" },
+          { "item": "afs_10mm_smart_template" },
           { "item": "cash_card", "charges": 200000000 },
           { "item": "cash_card", "charges": 200000000 },
           {
@@ -259,8 +294,8 @@
           { "item": "afs_wraitheon_smartphone" }
         ]
       },
-      "male": [ "briefs", "collarpin", "diamond_ring" ],
-      "female": [ "panties", "hairpin", "pearl_collar" ]
+      "male": { "entries": [ { "item": "briefs" }, { "item": "collarpin" }, { "item": "diamond_ring" } ] },
+      "female": { "entries": [ { "item": "panties" }, { "item": "bra" }, { "item": "hairpin" }, { "item": "pearl_collar" } ] }
     }
   },
   {
@@ -286,24 +321,22 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "under_armor",
-          "under_armor_shorts",
-          "gloves_leather",
-          "pants_cargo",
-          "socks",
-          "boots_combat",
-          "gloves_leather",
-          "webbing_belt",
-          "sweater",
-          "powered_earmuffs",
-          "afs_holo_transposition_caster",
-          "afs_holo_decoy_caster",
-          "afs_holo_field_caster",
-          "afs_holo_flare_caster",
-          "afs_holo_cloak_mk2"
-        ],
         "entries": [
+          { "item": "under_armor" },
+          { "item": "under_armor_shorts" },
+          { "item": "gloves_leather" },
+          { "item": "pants_cargo" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "gloves_leather" },
+          { "item": "webbing_belt" },
+          { "item": "sweater" },
+          { "item": "powered_earmuffs" },
+          { "item": "afs_holo_transposition_caster" },
+          { "item": "afs_holo_decoy_caster" },
+          { "item": "afs_holo_field_caster" },
+          { "item": "afs_holo_flare_caster" },
+          { "item": "afs_holo_cloak_mk2" },
           { "item": "kukri", "container-item": "sheath" },
           { "item": "afs_cam_spy", "ammo-item": "light_minus_atomic_battery_cell", "charges": 500 },
           { "item": "radiocontrol", "ammo-item": "light_atomic_battery_cell", "charges": 1000 },
@@ -321,11 +354,19 @@
     "points": 2,
     "items": {
       "both": {
-        "items": [ "tux", "dress_shoes", "socks", "gold_watch", "undershirt", "gasdiscount_platinum" ],
-        "entries": [ { "item": "cash_card", "charges": 200000000 }, { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "tux" },
+          { "item": "dress_shoes" },
+          { "item": "socks" },
+          { "item": "gold_watch" },
+          { "item": "undershirt" },
+          { "item": "gasdiscount_platinum" },
+          { "item": "cash_card", "charges": 200000000 },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "briefs", "collarpin", "diamond_ring" ],
-      "female": [ "panties", "hairpin", "pearl_collar" ]
+      "male": { "entries": [ { "item": "briefs" }, { "item": "collarpin" }, { "item": "diamond_ring" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" }, { "item": "hairpin" }, { "item": "pearl_collar" } ] }
     }
   },
   {
@@ -346,8 +387,12 @@
     "//": "Need to add XL gear for MASTODON's in more items.",
     "items": {
       "both": {
-        "items": [ "xlswat_armor", "xlboots_combat", "xlgloves_tactical", "badge_swat", "wristwatch" ],
         "entries": [
+          { "item": "xlswat_armor" },
+          { "item": "xlboots_combat" },
+          { "item": "xlgloves_tactical" },
+          { "item": "badge_swat" },
+          { "item": "wristwatch" },
           { "group": "army_mags_usp9" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "bandolier_shotgun", "contents-group": "bandolier_swat_cqc1" },
@@ -362,8 +407,8 @@
           { "item": "baton", "container-item": "xlpolice_belt" }
         ]
       },
-      "male": [ "xlboxer_shorts" ],
-      "female": [ "xlsports_bra", "xlboy_shorts" ]
+      "male": { "entries": [ { "item": "xlboxer_shorts" } ] },
+      "female": { "entries": [ { "item": "xlsports_bra" }, { "item": "xlboy_shorts" } ] }
     }
   },
   {
@@ -395,24 +440,27 @@
     "proficiencies": [ "prof_auto_rifles_familiar", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
-        "items": [
-          "winter_pants_army",
-          "winter_jacket_army",
-          "gloves_tactical",
-          "rucksack",
-          "cloak",
-          "mask_ski",
-          "socks",
-          "boots_combat",
-          "canteen",
-          "wristwatch",
-          "tent_kit",
-          "rollmat",
-          "e_tool",
-          "knife_hunting"
-        ],
         "entries": [
-          { "item": "medium_plus_battery_cell", "ammo-item": "battery", "charges": 600, "container-item": "mil_mess_kit" },
+          { "item": "winter_pants_army" },
+          { "item": "winter_jacket_army" },
+          { "item": "gloves_tactical" },
+          { "item": "rucksack" },
+          { "item": "cloak" },
+          { "item": "mask_ski" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "canteen" },
+          { "item": "wristwatch" },
+          { "item": "tent_kit" },
+          { "item": "rollmat" },
+          { "item": "e_tool" },
+          { "item": "knife_hunting" },
+          {
+            "item": "medium_plus_battery_cell",
+            "ammo-item": "battery",
+            "charges": 600,
+            "container-item": "mil_mess_kit"
+          },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "hat_boonie", "custom-flags": [ "no_auto_equip" ] },
           { "item": "tank_top", "variant": "tank_top_camo" },
@@ -428,8 +476,8 @@
           { "item": "tacvest", "contents-group": [ "army_mags_m2010" ] }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -447,7 +495,7 @@
     ],
     "traits": [ "PROF_MED", "UPLIFTED", "THRESH_CEPHALOPOD", "CEPH_EYES", "GILLS", "INT_UP_2", "LEG_TENTACLES", "SLIMY" ],
     "//": "Need to add underwater gear for this.  See extended leg_tentacles mutation.",
-    "items": { "both": { "items": [ "wetsuit_cecalia", "trident", "dive_bag" ] } }
+    "items": { "both": { "entries": [ { "item": "wetsuit_cecalia" }, { "item": "trident" }, { "item": "dive_bag" } ] } }
   },
   {
     "type": "profession",
@@ -463,8 +511,14 @@
     ],
     "items": {
       "both": {
-        "items": [ "jumpsuit", "hazmat_suit", "mask_gas", "socks", "molle_pack", "wristwatch", "bot_manhack", "bot_manhack" ],
         "entries": [
+          { "item": "jumpsuit" },
+          { "item": "hazmat_suit" },
+          { "item": "mask_gas" },
+          { "item": "socks" },
+          { "item": "molle_pack" },
+          { "item": "wristwatch" },
+          { "item": "bot_manhack", "count": 2 },
           { "group": "charged_smart_phone" },
           { "item": "afs_cartridge", "ammo-item": "battery", "charges": 1500 },
           {
@@ -475,8 +529,8 @@
           }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -495,8 +549,13 @@
     ],
     "items": {
       "both": {
-        "items": [ "spacer_jumpsuit", "afs_herc_rig", "XL_holster", "socks", "boots_combat", "wristwatch" ],
         "entries": [
+          { "item": "spacer_jumpsuit" },
+          { "item": "afs_herc_rig" },
+          { "item": "XL_holster" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "wristwatch" },
           { "group": "charged_smart_phone" },
           { "item": "electrohack", "charges": 100 },
           { "item": "afs_imager", "charges": 500 },
@@ -514,8 +573,8 @@
           { "item": "afs_jetpack", "charges": 10 }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
     }
   },
   {

--- a/data/mods/Isolation-Protocol/Player/profession.json
+++ b/data/mods/Isolation-Protocol/Player/profession.json
@@ -16,15 +16,23 @@
     ],
     "items": {
       "both": {
-        "items": [ "hat_ball", "jeans", "jacket_light", "socks", "sneakers", "pizza_meat", "money_strap_one", "wristwatch", "mbag" ],
         "entries": [
+          { "item": "hat_ball" },
+          { "item": "jeans" },
+          { "item": "jacket_light" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "pizza_meat" },
+          { "item": "money_strap_one" },
+          { "item": "wristwatch" },
+          { "item": "mbag" },
           { "group": "charged_smart_phone" },
           { "item": "tshirt", "variant": "generic_tshirt" },
           { "item": "bat", "custom-flags": [ "auto_wield" ] }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -38,8 +46,15 @@
     "traits": [ "PROF_POLICE", "iso_trait", "iso_backup" ],
     "items": {
       "both": {
-        "items": [ "pants_army", "socks", "badge_deputy", "police_belt", "boots", "whistle", "wristwatch", "baton" ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "socks" },
+          { "item": "badge_deputy" },
+          { "item": "police_belt" },
+          { "item": "boots" },
+          { "item": "whistle" },
+          { "item": "wristwatch" },
+          { "item": "baton" },
           { "group": "charged_smart_phone" },
           { "group": "charged_two_way_radio" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -48,8 +63,8 @@
           { "item": "sheriffshirt", "variant": "sheriff" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     }
   },
   {
@@ -63,9 +78,23 @@
     "proficiencies": [ "prof_elec_soldering", "prof_appliance_repair" ],
     "items": {
       "both": {
-        "items": [ "pants", "tshirt_text", "hoodie", "socks", "sneakers", "mbag", "caffeine", "caff_gum", "memory_card", "usb_drive" ],
         "entries": [
-          { "item": "light_plus_battery_cell", "ammo-item": "battery", "charges": 150, "container-item": "electrohack" },
+          { "item": "pants" },
+          { "item": "tshirt_text" },
+          { "item": "hoodie" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "mbag" },
+          { "item": "caffeine" },
+          { "item": "caff_gum" },
+          { "item": "memory_card" },
+          { "item": "usb_drive" },
+          {
+            "item": "light_plus_battery_cell",
+            "ammo-item": "battery",
+            "charges": 150,
+            "container-item": "electrohack"
+          },
           {
             "item": "light_plus_battery_cell",
             "ammo-item": "battery",
@@ -77,8 +106,8 @@
           { "group": "charged_laptop" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "sports_bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -91,29 +120,27 @@
     "traits": [ "PROF_MED", "iso_trait", "iso_hypo_o" ],
     "items": {
       "both": {
-        "items": [
-          "technician_shirt_gray",
-          "socks",
-          "gloves_medical",
-          "wristwatch",
-          "boots",
-          "mbag",
-          { "item": "bandages", "count": 3 },
-          "stethoscope",
-          "scissors",
-          "syringe",
-          "morphine",
-          "adrenaline_injector"
-        ],
         "entries": [
+          { "item": "technician_shirt_gray" },
+          { "item": "socks" },
+          { "item": "gloves_medical" },
+          { "item": "wristwatch" },
+          { "item": "boots" },
+          { "item": "mbag" },
+          { "item": "bandages", "count": 3 },
+          { "item": "stethoscope" },
+          { "item": "scissors" },
+          { "item": "syringe" },
+          { "item": "morphine" },
+          { "item": "adrenaline_injector" },
           { "group": "charged_smart_phone" },
           { "group": "full_1st_aid" },
           { "item": "pants", "variant": "pants_blue" },
           { "item": "mask_dust", "variant": "white_mask_dust" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   }
 ]

--- a/data/mods/MMA/professions.json
+++ b/data/mods/MMA/professions.json
@@ -14,7 +14,17 @@
       "prof_bionics_familiar"
     ],
     "skills": [ { "level": 3, "name": "unarmed" }, { "level": 3, "name": "melee" }, { "level": 1, "name": "dodge" } ],
-    "items": { "both": { "items": [ "wetsuit", "trenchcoat", "gloves_fingerless", "knee_pads", "boots" ] } },
+    "items": {
+      "both": {
+        "entries": [
+          { "item": "wetsuit" },
+          { "item": "trenchcoat" },
+          { "item": "gloves_fingerless" },
+          { "item": "knee_pads" },
+          { "item": "boots" }
+        ]
+      }
+    },
     "CBMs": [
       "bio_power_storage_mkII",
       "bio_armor_arms",
@@ -37,8 +47,16 @@
     "skills": [ { "level": 3, "name": "cutting" }, { "level": 3, "name": "melee" }, { "level": 1, "name": "dodge" } ],
     "items": {
       "both": {
-        "items": [ "combat_shirt", "cloak", "gloves_fingerless", "antarvasa", "ragpouch", "socks", "boots" ],
-        "entries": [ { "item": "sword_wood", "custom-flags": [ "auto_wield" ] } ]
+        "entries": [
+          { "item": "combat_shirt" },
+          { "item": "cloak" },
+          { "item": "gloves_fingerless" },
+          { "item": "antarvasa" },
+          { "item": "ragpouch" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "sword_wood", "custom-flags": [ "auto_wield" ] }
+        ]
       }
     }
   }

--- a/data/mods/Magiclysm/professions.json
+++ b/data/mods/Magiclysm/professions.json
@@ -19,11 +19,20 @@
     "points": 0,
     "items": {
       "both": {
-        "items": [ "jeans", "gloves_light", "hat_ball", "boots", "socks", "hoodie", "knit_scarf", "wizard_beginner" ],
-        "entries": [ { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "gloves_light" },
+          { "item": "hat_ball" },
+          { "item": "boots" },
+          { "item": "socks" },
+          { "item": "hoodie" },
+          { "item": "knit_scarf" },
+          { "item": "wizard_beginner" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "boxer_briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -35,11 +44,17 @@
     "points": 2,
     "items": {
       "both": {
-        "items": [ "lighter", "sneakers", "pants", "jacket_light", "pyro" ],
-        "entries": [ { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "lighter" },
+          { "item": "sneakers" },
+          { "item": "pants" },
+          { "item": "jacket_light" },
+          { "item": "pyro" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "boxer_briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "traits": [ "PYROMANIA", "KELVINIST" ]
   },
@@ -67,11 +82,21 @@
     "skills": [ { "level": 3, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [ "pants", "longshirt", "socks", "cassock", "dress_shoes", "holy_symbol", "holybook_bible1", "priest_beginner", "mbag" ],
-        "entries": [ { "group": "charged_cell_phone" } ]
+        "entries": [
+          { "item": "pants" },
+          { "item": "longshirt" },
+          { "item": "socks" },
+          { "item": "cassock" },
+          { "item": "dress_shoes" },
+          { "item": "holy_symbol" },
+          { "item": "holybook_bible1" },
+          { "item": "priest_beginner" },
+          { "item": "mbag" },
+          { "group": "charged_cell_phone" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -84,11 +109,21 @@
     "skills": [ { "level": 1, "name": "fabrication" }, { "level": 1, "name": "tailor" } ],
     "items": {
       "both": {
-        "items": [ "kariginu", "eboshi", "pants", "tabi_dress", "geta", "holy_symbol", "holybook_kojiki", "priest_beginner", "mbag" ],
-        "entries": [ { "group": "charged_cell_phone" } ]
+        "entries": [
+          { "item": "kariginu" },
+          { "item": "eboshi" },
+          { "item": "pants" },
+          { "item": "tabi_dress" },
+          { "item": "geta" },
+          { "item": "holy_symbol" },
+          { "item": "holybook_kojiki" },
+          { "item": "priest_beginner" },
+          { "item": "mbag" },
+          { "group": "charged_cell_phone" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -102,11 +137,21 @@
     "skills": [ { "level": 2, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [ "pants", "socks", "kufi", "thawb", "lowtops", "holybook_quran", "priest_beginner", "mbag" ],
-        "entries": [ { "group": "charged_cell_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "pants" },
+          { "item": "socks" },
+          { "item": "kufi" },
+          { "item": "thawb" },
+          { "item": "lowtops" },
+          { "item": "holybook_quran" },
+          { "item": "priest_beginner" },
+          { "item": "mbag" },
+          { "group": "charged_cell_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -119,24 +164,25 @@
     "skills": [ { "level": 2, "name": "speech" }, { "level": 1, "name": "firstaid" } ],
     "items": {
       "both": {
-        "items": [
-          "pants",
-          "leather_belt",
-          "dress_shirt",
-          "socks",
-          "kittel",
-          "kippah",
-          "tallit_gadol",
-          "dress_shoes",
-          "holybook_talmud",
-          "holybook_tanakh",
-          "priest_beginner",
-          "mbag"
-        ],
-        "entries": [ { "group": "charged_cell_phone" }, { "item": "holy_symbol", "variant": "jewish_necklace1" } ]
+        "entries": [
+          { "item": "pants" },
+          { "item": "leather_belt" },
+          { "item": "dress_shirt" },
+          { "item": "socks" },
+          { "item": "kittel" },
+          { "item": "kippah" },
+          { "item": "tallit_gadol" },
+          { "item": "dress_shoes" },
+          { "item": "holybook_talmud" },
+          { "item": "holybook_tanakh" },
+          { "item": "priest_beginner" },
+          { "item": "mbag" },
+          { "group": "charged_cell_phone" },
+          { "item": "holy_symbol", "variant": "jewish_necklace1" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -150,23 +196,24 @@
     "skills": [ { "level": 2, "name": "speech" }, { "level": 1, "name": "survival" } ],
     "items": {
       "both": {
-        "items": [
-          "jeans",
-          "socks",
-          "robe",
-          "turban",
-          "waterskin",
-          "pockknife",
-          "mbag",
-          "leathersandals",
-          "holy_symbol",
-          "wristwatch",
-          "priest_beginner"
-        ],
-        "entries": [ { "group": "charged_cell_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "robe" },
+          { "item": "turban" },
+          { "item": "waterskin" },
+          { "item": "pockknife" },
+          { "item": "mbag" },
+          { "item": "leathersandals" },
+          { "item": "holy_symbol" },
+          { "item": "wristwatch" },
+          { "item": "priest_beginner" },
+          { "group": "charged_cell_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "panties" } ] }
     }
   },
   {
@@ -180,24 +227,24 @@
     "skills": [ { "level": 2, "name": "speech" }, { "level": 1, "name": "driving" }, { "level": 1, "name": "computer" } ],
     "items": {
       "both": {
-        "items": [
-          "dress_shirt",
-          "pants",
-          "socks",
-          "dress_shoes",
-          "wristwatch",
-          "backpack",
-          "laptop",
-          "flyer",
-          "flyer",
-          "flyer",
-          "holy_symbol",
-          "priest_beginner"
-        ],
-        "entries": [ { "group": "charged_cell_phone" } ]
+        "entries": [
+          { "item": "dress_shirt" },
+          { "item": "pants" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "wristwatch" },
+          { "item": "backpack" },
+          { "item": "laptop" },
+          { "item": "flyer" },
+          { "item": "flyer" },
+          { "item": "flyer" },
+          { "item": "holy_symbol" },
+          { "item": "priest_beginner" },
+          { "group": "charged_cell_phone" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -210,16 +257,23 @@
     "skills": [ { "level": 1, "name": "spellcraft" } ],
     "items": {
       "both": {
-        "items": [ "jeans", "gloves_light", "hat_ball", "boots", "socks", "hoodie", "knit_scarf", "leather_belt" ],
         "entries": [
+          { "item": "jeans" },
+          { "item": "gloves_light" },
+          { "item": "hat_ball" },
+          { "item": "boots" },
+          { "item": "socks" },
+          { "item": "hoodie" },
+          { "item": "knit_scarf" },
+          { "item": "leather_belt" },
           { "item": "primitive_knife", "container-item": "sheath" },
           { "item": "tshirt", "variant": "start_a_cult_tshirt" },
           { "item": "onyx_silver_bracelet", "variant": "dark_bracelet" },
           { "item": "onyx_silver_ring", "variant": "dark_ring" }
         ]
       },
-      "male": [ "boxer_briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "traits": [ "ANIMIST" ]
   },
@@ -236,11 +290,19 @@
     "points": 0,
     "items": {
       "both": {
-        "items": [ "jeans", "hat_ball", "sneakers", "socks", "hoodie", "mbag", "novice_stormshaper_book" ],
-        "entries": [ { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "hat_ball" },
+          { "item": "sneakers" },
+          { "item": "socks" },
+          { "item": "hoodie" },
+          { "item": "mbag" },
+          { "item": "novice_stormshaper_book" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "boxer_briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "traits": [ "STORMSHAPER" ]
   },
@@ -253,11 +315,18 @@
     "points": 0,
     "items": {
       "both": {
-        "items": [ "jeans", "boxing_gloves", "hat_ball", "sneakers", "socks", "hoodie" ],
-        "entries": [ { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "boxing_gloves" },
+          { "item": "hat_ball" },
+          { "item": "sneakers" },
+          { "item": "socks" },
+          { "item": "hoodie" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "boxer_briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "traits": [ "EARTHSHAPER" ]
   },
@@ -270,11 +339,18 @@
     "points": 0,
     "items": {
       "both": {
-        "items": [ "jeans", "gloves_light", "hat_ball", "sneakers", "socks", "hoodie" ],
-        "entries": [ { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "gloves_light" },
+          { "item": "hat_ball" },
+          { "item": "sneakers" },
+          { "item": "socks" },
+          { "item": "hoodie" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "boxer_briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "traits": [ "TECHNOMANCER" ]
   },
@@ -290,11 +366,19 @@
     "pets": [ { "name": "mon_dog_bull", "amount": 1 } ],
     "items": {
       "both": {
-        "items": [ "stat_up_spellbook", "leathersandals", "pants_leather", "jacket_leather", "hide_bag", "cloak", "gloves_wraps" ],
-        "entries": [ { "item": "primitive_knife", "container-item": "sheath" } ]
+        "entries": [
+          { "item": "stat_up_spellbook" },
+          { "item": "leathersandals" },
+          { "item": "pants_leather" },
+          { "item": "jacket_leather" },
+          { "item": "hide_bag" },
+          { "item": "cloak" },
+          { "item": "gloves_wraps" },
+          { "item": "primitive_knife", "container-item": "sheath" }
+        ]
       },
-      "male": [ "chestwrap_fur", "loincloth_fur" ],
-      "female": [ "bikini_top_fur", "hot_pants_fur" ]
+      "male": { "entries": [ { "item": "chestwrap_fur" }, { "item": "loincloth_fur" } ] },
+      "female": { "entries": [ { "item": "bikini_top_fur" }, { "item": "hot_pants_fur" } ] }
     }
   },
   {
@@ -306,23 +390,24 @@
     "skills": [ { "level": 2, "name": "melee" }, { "level": 1, "name": "bashing" }, { "level": 1, "name": "gun" } ],
     "items": {
       "both": {
-        "items": [
-          "hoodie",
-          "jeans",
-          "socks",
-          "boots",
-          "wristwatch",
-          "holy_symbol",
-          "mbag",
-          "priest_beginner",
-          "whiskey",
-          "whiskey",
-          "45colt_jhp"
-        ],
-        "entries": [ { "group": "charged_cell_phone" }, { "item": "colt_saa", "ammo-item": "45colt_jhp", "charges": 6 } ]
+        "entries": [
+          { "item": "hoodie" },
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "wristwatch" },
+          { "item": "holy_symbol" },
+          { "item": "mbag" },
+          { "item": "priest_beginner" },
+          { "item": "whiskey" },
+          { "item": "whiskey" },
+          { "item": "45colt_jhp" },
+          { "group": "charged_cell_phone" },
+          { "item": "colt_saa", "ammo-item": "45colt_jhp", "charges": 6 }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "addictions": [ { "intensity": 20, "type": "alcohol" } ]
   },
@@ -349,8 +434,14 @@
     ],
     "items": {
       "both": {
-        "items": [ "hat_boonie", "longshirt", "socks", "jeans", "gloves_light", "boots", "trenchcoat" ],
         "entries": [
+          { "item": "hat_boonie" },
+          { "item": "longshirt" },
+          { "item": "socks" },
+          { "item": "jeans" },
+          { "item": "gloves_light" },
+          { "item": "boots" },
+          { "item": "trenchcoat" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "m47a1", "ammo-item": "38_special", "charges": 6, "container-item": "holster" },
           { "item": "sheath", "contents-item": "knife_combat" },
@@ -358,8 +449,8 @@
           { "item": "ref_lighter", "charges": 50 }
         ]
       },
-      "male": [ "undershirt", "boxer_briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "undershirt" }, { "item": "boxer_briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "traits": [ "TECHNOMANCER" ]
   },
@@ -377,20 +468,21 @@
     "points": 2,
     "items": {
       "both": {
-        "items": [
-          "hot_pants_leather",
-          "chaps_leather",
-          "halter_top",
-          "jacket_leather",
-          "fancy_sunglasses",
-          "dance_shoes",
-          "socks",
-          "purse"
-        ],
-        "entries": [ { "group": "charged_cell_phone" }, { "item": "mask_dust", "variant": "black_mask_dust" } ]
+        "entries": [
+          { "item": "hot_pants_leather" },
+          { "item": "chaps_leather" },
+          { "item": "halter_top" },
+          { "item": "jacket_leather" },
+          { "item": "fancy_sunglasses" },
+          { "item": "dance_shoes" },
+          { "item": "socks" },
+          { "item": "purse" },
+          { "group": "charged_cell_phone" },
+          { "item": "mask_dust", "variant": "black_mask_dust" }
+        ]
       },
-      "male": [ "tank_top" ],
-      "female": [ "bikini_top_leather", "leather_collar" ]
+      "male": { "entries": [ { "item": "tank_top" } ] },
+      "female": { "entries": [ { "item": "bikini_top_leather" }, { "item": "leather_collar" } ] }
     },
     "traits": [ "KELVINIST" ]
   },
@@ -412,23 +504,23 @@
     "skills": [ { "level": 5, "name": "spellcraft" } ],
     "items": {
       "both": {
-        "items": [
-          "copper_circlet",
-          "cloak",
-          "dress_shoes",
-          "socks_wool",
-          "mbag",
-          "wizard_hat",
-          "gloves_liner",
-          "gloves_light",
-          "dress_shirt",
-          "knit_scarf",
-          "pocketwatch"
-        ],
-        "entries": [ { "item": "magi_staff_minor", "custom-flags": [ "auto_wield" ] } ]
+        "entries": [
+          { "item": "copper_circlet" },
+          { "item": "cloak" },
+          { "item": "dress_shoes" },
+          { "item": "socks_wool" },
+          { "item": "mbag" },
+          { "item": "wizard_hat" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_light" },
+          { "item": "dress_shirt" },
+          { "item": "knit_scarf" },
+          { "item": "pocketwatch" },
+          { "item": "magi_staff_minor", "custom-flags": [ "auto_wield" ] }
+        ]
       },
-      "male": [ "boxer_briefs", "pants" ],
-      "female": [ "bra", "panties", "skirt" ]
+      "male": { "entries": [ { "item": "boxer_briefs" }, { "item": "pants" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" }, { "item": "skirt" } ] }
     },
     "traits": [ "MAGUS" ]
   },
@@ -442,26 +534,26 @@
     "skills": [ { "level": 4, "name": "traps" } ],
     "items": {
       "both": {
-        "items": [
-          "socks",
-          "sneakers",
-          "pants",
-          "striped_shirt",
-          "hoodie",
-          "gloves_light",
-          "swag_bag",
-          "crowbar",
-          "hacksaw",
-          "wristwatch",
-          "boltcutters",
-          "stethoscope",
-          "picklocks",
-          "mkey_opening"
-        ],
-        "entries": [ { "item": "mmask_disappearance", "ammo-item": "crystallized_mana", "charges": 1 } ]
+        "entries": [
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "pants" },
+          { "item": "striped_shirt" },
+          { "item": "hoodie" },
+          { "item": "gloves_light" },
+          { "item": "swag_bag" },
+          { "item": "crowbar" },
+          { "item": "hacksaw" },
+          { "item": "wristwatch" },
+          { "item": "boltcutters" },
+          { "item": "stethoscope" },
+          { "item": "picklocks" },
+          { "item": "mkey_opening" },
+          { "item": "mmask_disappearance", "ammo-item": "crystallized_mana", "charges": 1 }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -474,27 +566,29 @@
     "skills": [ { "level": 2, "name": "unarmed" } ],
     "items": {
       "both": {
-        "items": [
-          "jeans",
-          "gloves_light",
-          "hat_ball",
-          "duffelbag",
-          "backpack",
-          "long_underpants",
-          "boots",
-          "socks_wool",
-          "socks",
-          "hoodie",
-          "folding_poncho",
-          "knit_scarf",
-          "can_beans",
-          "pockknife",
-          "mflask_hip_whiskey"
-        ],
-        "entries": [ { "group": "charged_cell_phone" }, { "group": "charged_matches" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "gloves_light" },
+          { "item": "hat_ball" },
+          { "item": "duffelbag" },
+          { "item": "backpack" },
+          { "item": "long_underpants" },
+          { "item": "boots" },
+          { "item": "socks_wool" },
+          { "item": "socks" },
+          { "item": "hoodie" },
+          { "item": "folding_poncho" },
+          { "item": "knit_scarf" },
+          { "item": "can_beans" },
+          { "item": "pockknife" },
+          { "item": "mflask_hip_whiskey" },
+          { "group": "charged_cell_phone" },
+          { "group": "charged_matches" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "boxer_briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -513,8 +607,15 @@
     "traits": [ "EARTHSHAPER" ],
     "items": {
       "both": {
-        "items": [ "socks", "boots_steel", "gloves_work", "knee_pads", "jumpsuit", "tool_belt", "mbag", "wristwatch" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "boots_steel" },
+          { "item": "gloves_work" },
+          { "item": "knee_pads" },
+          { "item": "jumpsuit" },
+          { "item": "tool_belt" },
+          { "item": "mbag" },
+          { "item": "wristwatch" },
           { "group": "full_gasmask" },
           { "group": "charged_smart_phone" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -523,8 +624,8 @@
           { "item": "light_minus_disposable_cell", "charges": 100, "container-item": "miner_hat" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "sports_bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
     }
   },
   {
@@ -544,9 +645,30 @@
     ],
     "traits": [ "MAGUS" ],
     "items": {
-      "both": { "items": [ "pocketwatch", "mteapot" ], "entries": [ { "group": "charged_smart_phone" } ] },
-      "male": [ "briefs", "socks", "dress_shoes", "tux", "glasses_monocle", "collarpin" ],
-      "female": [ "panties", "bra", "stockings", "garter_belt", "dress_shoes", "maid_dress", "maid_hat", "corset_waist", "fc_hairpin" ]
+      "both": { "entries": [ { "item": "pocketwatch" }, { "item": "mteapot" }, { "group": "charged_smart_phone" } ] },
+      "male": {
+        "entries": [
+          { "item": "briefs" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "tux" },
+          { "item": "glasses_monocle" },
+          { "item": "collarpin" }
+        ]
+      },
+      "female": {
+        "entries": [
+          { "item": "panties" },
+          { "item": "bra" },
+          { "item": "stockings" },
+          { "item": "garter_belt" },
+          { "item": "dress_shoes" },
+          { "item": "maid_dress" },
+          { "item": "maid_hat" },
+          { "item": "corset_waist" },
+          { "item": "fc_hairpin" }
+        ]
+      }
     }
   },
   {
@@ -568,8 +690,13 @@
     "traits": [ "ANIMALEMPATH", "SLOWREADER", "DRUID" ],
     "items": {
       "both": {
-        "items": [ "footrags_fur", "boots_fur", "gloves_wraps_fur", "hat_fur", "cloak_fur", "scarf_fur_loose" ],
         "entries": [
+          { "item": "footrags_fur" },
+          { "item": "boots_fur" },
+          { "item": "gloves_wraps_fur" },
+          { "item": "hat_fur" },
+          { "item": "cloak_fur" },
+          { "item": "scarf_fur_loose" },
           { "item": "wolfshead_cufflinks", "ammo-item": "crystallized_mana", "charges": 1 },
           { "item": "leather_pouch", "contents-group": "pouch_wild_druid" },
           { "item": "primitive_knife", "container-item": "sheath" },
@@ -604,17 +731,18 @@
     "traits": [ "DRUID" ],
     "items": {
       "both": {
-        "items": [
-          "robe",
-          "chestwrap",
-          "loincloth",
-          "leathersandals",
-          "gloves_wraps",
-          "straw_hat",
-          "leather_pouch",
-          "sleeping_bag_fur_roll"
-        ],
-        "entries": [ { "item": "water_clean", "container-item": "waterskin" }, { "item": "primitive_knife", "container-item": "sheath" } ]
+        "entries": [
+          { "item": "robe" },
+          { "item": "chestwrap" },
+          { "item": "loincloth" },
+          { "item": "leathersandals" },
+          { "item": "gloves_wraps" },
+          { "item": "straw_hat" },
+          { "item": "leather_pouch" },
+          { "item": "sleeping_bag_fur_roll" },
+          { "item": "water_clean", "container-item": "waterskin" },
+          { "item": "primitive_knife", "container-item": "sheath" }
+        ]
       }
     }
   },
@@ -629,14 +757,23 @@
     "proficiencies": [ "prof_hooking_familiar" ],
     "items": {
       "both": {
-        "items": [ "grim_reaper_robe", "jumpsuit_skeleton_zipped", "gloves_skeleton", "socks", "boots" ],
         "entries": [
-          { "item": "grim_reaper_scythe", "ammo-item": "crystallized_mana", "charges": 3, "custom-flags": [ "auto_wield" ] },
+          { "item": "grim_reaper_robe" },
+          { "item": "jumpsuit_skeleton_zipped" },
+          { "item": "gloves_skeleton" },
+          { "item": "socks" },
+          { "item": "boots" },
+          {
+            "item": "grim_reaper_scythe",
+            "ammo-item": "crystallized_mana",
+            "charges": 3,
+            "custom-flags": [ "auto_wield" ]
+          },
           { "item": "onyx_silver_ring", "variant": "dark_ring" }
         ]
       },
-      "male": [ "undershirt", "boxer_briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "undershirt" }, { "item": "boxer_briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "traits": [ "ANIMIST", "TERRIFYING", "KILLER" ]
   },
@@ -662,8 +799,14 @@
     ],
     "items": {
       "both": {
-        "items": [ "cloak_vampire", "gloves_claws", "dress_shoes", "knit_scarf", "sunglasses", "platinum_watch", "vampire_fangs" ],
         "entries": [
+          { "item": "cloak_vampire" },
+          { "item": "gloves_claws" },
+          { "item": "dress_shoes" },
+          { "item": "knit_scarf" },
+          { "item": "sunglasses" },
+          { "item": "platinum_watch" },
+          { "item": "vampire_fangs" },
           { "group": "charged_smart_phone" },
           { "item": "knife_baselard", "container-item": "sheath" },
           {
@@ -676,15 +819,25 @@
         ]
       },
       "male": {
-        "items": [ "dress_shirt", "pants", "tie_necktie", "tieclip", "briefs", "socks" ],
         "entries": [
+          { "item": "dress_shirt" },
+          { "item": "pants" },
+          { "item": "tie_necktie" },
+          { "item": "tieclip" },
+          { "item": "briefs" },
+          { "item": "socks" },
           { "item": "ruby_silver_cufflinks", "variant": "vampire_cufflinks" },
           { "item": "ruby_silver_bracelet", "variant": "vampire_bracelet" }
         ]
       },
       "female": {
-        "items": [ "sinister_dress", "bra", "panties", "stockings", "garter_belt", "purse" ],
         "entries": [
+          { "item": "sinister_dress" },
+          { "item": "bra" },
+          { "item": "panties" },
+          { "item": "stockings" },
+          { "item": "garter_belt" },
+          { "item": "purse" },
           { "item": "ruby_silver_earring", "variant": "vampire_earring" },
           { "item": "ruby_silver_pendant_necklace", "variant": "vampire_necklace" }
         ]
@@ -713,22 +866,22 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "copper_circlet",
-          "cloak",
-          "dress_shoes",
-          "socks_wool",
-          "beret_wool",
-          "gloves_liner",
-          "gloves_light",
-          "dress_shirt",
-          "knit_scarf",
-          "pocketwatch"
-        ],
-        "entries": [ { "item": "q_staff", "custom-flags": [ "auto_wield" ] } ]
+        "entries": [
+          { "item": "copper_circlet" },
+          { "item": "cloak" },
+          { "item": "dress_shoes" },
+          { "item": "socks_wool" },
+          { "item": "beret_wool" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_light" },
+          { "item": "dress_shirt" },
+          { "item": "knit_scarf" },
+          { "item": "pocketwatch" },
+          { "item": "q_staff", "custom-flags": [ "auto_wield" ] }
+        ]
       },
-      "male": [ "boxer_briefs", "pants" ],
-      "female": [ "bra", "panties", "skirt" ]
+      "male": { "entries": [ { "item": "boxer_briefs" }, { "item": "pants" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" }, { "item": "skirt" } ] }
     },
     "traits": [ "MAGUS" ]
   },
@@ -746,20 +899,20 @@
     "skills": [ { "level": 2, "name": "speech" }, { "level": 2, "name": "spellcraft" } ],
     "items": {
       "both": {
-        "items": [
-          "jacket_leather",
-          "pants_leather",
-          "leather_belt",
-          "socks",
-          "boots",
-          "gloves_fingerless",
-          "guitar_electric",
-          "switchblade"
-        ],
-        "entries": [ { "item": "pepto", "charges": 10, "container-item": "bottle_plastic_small" } ]
+        "entries": [
+          { "item": "jacket_leather" },
+          { "item": "pants_leather" },
+          { "item": "leather_belt" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "gloves_fingerless" },
+          { "item": "guitar_electric" },
+          { "item": "switchblade" },
+          { "item": "pepto", "charges": 10, "container-item": "bottle_plastic_small" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "traits": [ "BIOMANCER" ]
   },
@@ -784,8 +937,13 @@
     "proficiencies": [ "prof_spotting", "prof_gun_cleaning", "prof_batons_familiar", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
-        "items": [ "pants_army", "socks", "badge_deputy", "boots", "whistle", "wristwatch" ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "socks" },
+          { "item": "badge_deputy" },
+          { "item": "boots" },
+          { "item": "whistle" },
+          { "item": "wristwatch" },
           { "group": "charged_cell_phone" },
           { "group": "charged_two_way_radio" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
@@ -793,8 +951,8 @@
           { "item": "sheriffshirt", "variant": "sheriff" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "boy_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boy_shorts" } ] }
     },
     "traits": [ "PROF_POLICE", "STORMSHAPER" ]
   },
@@ -820,9 +978,18 @@
     ],
     "items": {
       "both": {
-        "items": [ "under_armor_shorts", "under_armor", "shorts", "gloves_wraps", "headgear", "mouthpiece", "socks", "sneakers" ]
+        "entries": [
+          { "item": "under_armor_shorts" },
+          { "item": "under_armor" },
+          { "item": "shorts" },
+          { "item": "gloves_wraps" },
+          { "item": "headgear" },
+          { "item": "mouthpiece" },
+          { "item": "socks" },
+          { "item": "sneakers" }
+        ]
       },
-      "female": [ "sports_bra" ]
+      "female": { "entries": [ { "item": "sports_bra" } ] }
     }
   },
   {
@@ -836,15 +1003,22 @@
     "proficiencies": [ "prof_wound_care", "prof_intro_biology", "prof_burn_care" ],
     "items": {
       "both": {
-        "items": [ "longshirt", "pants", "socks", "sneakers", "gloves_medical", "coat_lab", "xacto", "wristwatch" ],
         "entries": [
+          { "item": "longshirt" },
+          { "item": "pants" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "gloves_medical" },
+          { "item": "coat_lab" },
+          { "item": "xacto" },
+          { "item": "wristwatch" },
           { "item": "disinfectant_makeshift", "charges": 10, "container-item": "bottle_plastic_small" },
           { "item": "bandages", "count": 15 },
           { "group": "charged_cell_phone" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "traits": [ "BIOMANCER" ]
   },
@@ -874,19 +1048,19 @@
     "pets": [ { "name": "mon_moose", "amount": 1 } ],
     "items": {
       "both": {
-        "items": [
-          "tunic",
-          "chestwrap_leather",
-          "loincloth_leather",
-          "footrags_fur",
-          "shoes_birchbark",
-          "gloves_wraps_fur",
-          "straw_hat",
-          "shortbow",
-          "stone_chopper",
-          "ragpouch"
-        ],
-        "entries": [ { "item": "quiver_birchbark", "contents-group": "quiver_mooserider" } ]
+        "entries": [
+          { "item": "tunic" },
+          { "item": "chestwrap_leather" },
+          { "item": "loincloth_leather" },
+          { "item": "footrags_fur" },
+          { "item": "shoes_birchbark" },
+          { "item": "gloves_wraps_fur" },
+          { "item": "straw_hat" },
+          { "item": "shortbow" },
+          { "item": "stone_chopper" },
+          { "item": "ragpouch" },
+          { "item": "quiver_birchbark", "contents-group": "quiver_mooserider" }
+        ]
       }
     }
   },
@@ -909,23 +1083,21 @@
     "traits": [ "KELVINIST" ],
     "items": {
       "both": {
-        "items": [
-          "winter_pants_army",
-          "winter_jacket_army",
-          "gloves_tactical",
-          "molle_pack",
-          "socks",
-          "boots_combat",
-          "wristwatch",
-          "ammo_satchel",
-          "attached_ear_plugs_off",
-          "helmet_army",
-          "hatchet",
-          "balclava",
-          "rifle_case_soft",
-          "mess_kit"
-        ],
         "entries": [
+          { "item": "winter_pants_army" },
+          { "item": "winter_jacket_army" },
+          { "item": "gloves_tactical" },
+          { "item": "molle_pack" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "wristwatch" },
+          { "item": "ammo_satchel" },
+          { "item": "attached_ear_plugs_off" },
+          { "item": "helmet_army" },
+          { "item": "hatchet" },
+          { "item": "balclava" },
+          { "item": "rifle_case_soft" },
+          { "item": "mess_kit" },
           { "item": "emer_blanket", "custom-flags": [ "no_auto_equip" ] },
           { "item": "tank_top", "variant": "tank_top_camo" },
           { "group": "charged_two_way_radio" },
@@ -942,8 +1114,8 @@
           { "item": "water_clean", "charges": 6, "container-item": "canteen" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -960,9 +1132,17 @@
     "skills": [ { "level": 3, "name": "spellcraft" } ],
     "traits": [ "KELVINIST" ],
     "items": {
-      "both": { "items": [ "striped_shirt", "striped_pants", "sneakers", "socks", "sugar" ] },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "both": {
+        "entries": [
+          { "item": "striped_shirt" },
+          { "item": "striped_pants" },
+          { "item": "sneakers" },
+          { "item": "socks" },
+          { "item": "sugar" }
+        ]
+      },
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -987,9 +1167,9 @@
     ],
     "traits": [ "DRUID", "PSYCHOPATH" ],
     "items": {
-      "both": { "items": [ "striped_shirt", "striped_pants", "sneakers", "socks" ] },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "both": { "entries": [ { "item": "striped_shirt" }, { "item": "striped_pants" }, { "item": "sneakers" }, { "item": "socks" } ] },
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -1014,16 +1194,27 @@
     "vehicle": "icecream_truck",
     "items": {
       "both": {
-        "items": [ "pants", "socks", "sneakers", "apron_leather", "wristwatch", "dress_shirt", "icecream_scoop" ],
         "entries": [
-          { "item": "icecream_choc", "charges": 17, "container-item": "plastic_bucket", "custom-flags": [ "auto_wield" ] },
+          { "item": "pants" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "apron_leather" },
+          { "item": "wristwatch" },
+          { "item": "dress_shirt" },
+          { "item": "icecream_scoop" },
+          {
+            "item": "icecream_choc",
+            "charges": 17,
+            "container-item": "plastic_bucket",
+            "custom-flags": [ "auto_wield" ]
+          },
           { "item": "plastic_bowl_kids", "count": 5 },
           { "item": "plastic_spoon", "count": 5 },
           { "group": "charged_cell_phone" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "traits": [ "KELVINIST" ]
   },
@@ -1037,11 +1228,17 @@
     "proficiencies": [ "prof_knives_familiar" ],
     "items": {
       "both": {
-        "items": [ "socks", "sneakers", "unitard", "wristwatch", "vest_leather" ],
-        "entries": [ { "item": "mring_blades_lesser", "charges": 5 } ]
+        "entries": [
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "unitard" },
+          { "item": "wristwatch" },
+          { "item": "vest_leather" },
+          { "item": "mring_blades_lesser", "charges": 5 }
+        ]
       },
-      "male": [ "under_armor_shorts" ],
-      "female": [ "sports_bra", "panties" ]
+      "male": { "entries": [ { "item": "under_armor_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
     }
   }
 ]

--- a/data/mods/Military_Professions/prof/army.json
+++ b/data/mods/Military_Professions/prof/army.json
@@ -8,22 +8,20 @@
     "skills": [ { "level": 1, "name": "survival" }, { "level": 1, "name": "gun" }, { "level": 1, "name": "rifle" } ],
     "items": {
       "both": {
-        "items": [
-          "tac_helmet",
-          "jacket_army",
-          "pants_army",
-          "longshirt",
-          "rucksack",
-          "glasses_bal",
-          "dump_pouch",
-          "knee_pads",
-          "elbow_pads",
-          "socks",
-          "boots_combat",
-          "gloves_tactical",
-          "ballistic_vest_esapi"
-        ],
         "entries": [
+          { "item": "tac_helmet" },
+          { "item": "jacket_army" },
+          { "item": "pants_army" },
+          { "item": "longshirt" },
+          { "item": "rucksack" },
+          { "item": "glasses_bal" },
+          { "item": "dump_pouch" },
+          { "item": "knee_pads" },
+          { "item": "elbow_pads" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "gloves_tactical" },
+          { "item": "ballistic_vest_esapi" },
           {
             "item": "modular_m4_carbine",
             "variant": "modular_m4a1",
@@ -37,8 +35,8 @@
           { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "sports_bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
     }
   },
   {
@@ -50,29 +48,32 @@
     "skills": [ { "level": 1, "name": "survival" }, { "level": 2, "name": "gun" }, { "level": 2, "name": "rifle" } ],
     "items": {
       "both": {
-        "items": [
-          "hat_boonie",
-          "jacket_army",
-          "pants_army",
-          "longshirt",
-          "rucksack",
-          "knee_pads",
-          "elbow_pads",
-          "socks",
-          "boots_combat",
-          "gloves_tactical",
-          "ballistic_vest_esapi"
-        ],
         "entries": [
-          { "item": "m14ebr", "ammo-item": "762_51", "charges": 20, "contents-item": [ "acog_scope", "shoulder_strap", "bipod" ] },
+          { "item": "hat_boonie" },
+          { "item": "jacket_army" },
+          { "item": "pants_army" },
+          { "item": "longshirt" },
+          { "item": "rucksack" },
+          { "item": "knee_pads" },
+          { "item": "elbow_pads" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "gloves_tactical" },
+          { "item": "ballistic_vest_esapi" },
+          {
+            "item": "m14ebr",
+            "ammo-item": "762_51",
+            "charges": 20,
+            "contents-item": [ "acog_scope", "shoulder_strap", "bipod" ]
+          },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "tacvest", "contents-group": "army_mags_m14" },
           { "item": "knife_combat", "container-item": "sheath" },
           { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "sports_bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
     }
   },
   {
@@ -84,26 +85,29 @@
     "skills": [ { "level": 1, "name": "survival" }, { "level": 1, "name": "gun" }, { "level": 1, "name": "rifle" } ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "tank_top",
-          "tacvest",
-          "glasses_bal",
-          "knee_pads",
-          "elbow_pads",
-          "socks",
-          "boots_combat",
-          "gloves_tactical"
-        ],
         "entries": [
-          { "item": "m249", "ammo-item": "556", "charges": 200, "contents-item": [ "shoulder_strap", "holo_sight", "bipod" ] },
+          { "item": "pants_army" },
+          { "item": "tank_top" },
+          { "item": "tacvest" },
+          { "item": "glasses_bal" },
+          { "item": "knee_pads" },
+          { "item": "elbow_pads" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "gloves_tactical" },
+          {
+            "item": "m249",
+            "ammo-item": "556",
+            "charges": 200,
+            "contents-item": [ "shoulder_strap", "holo_sight", "bipod" ]
+          },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "556", "charges": 200, "container-item": "belt223" },
           { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "sports_bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
     }
   },
   {
@@ -120,21 +124,19 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "tac_helmet",
-          "pants_army",
-          "tshirt",
-          "rucksack",
-          "glasses_bal",
-          "dump_pouch",
-          "knee_pads",
-          "elbow_pads",
-          "socks",
-          "boots_combat",
-          "gloves_tactical",
-          "ballistic_vest_esapi"
-        ],
         "entries": [
+          { "item": "tac_helmet" },
+          { "item": "pants_army" },
+          { "item": "tshirt" },
+          { "item": "rucksack" },
+          { "item": "glasses_bal" },
+          { "item": "dump_pouch" },
+          { "item": "knee_pads" },
+          { "item": "elbow_pads" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "gloves_tactical" },
+          { "item": "ballistic_vest_esapi" },
           {
             "item": "modular_m4_carbine",
             "variant": "modular_m4a1",
@@ -149,8 +151,8 @@
           { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "sports_bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
     }
   },
   {
@@ -168,22 +170,20 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "tac_fullhelmet",
-          "pants_army",
-          "tshirt",
-          "ballistic_vest_esapi",
-          "armguard_hard",
-          "legguard_hard",
-          "grenadebandolier",
-          "flashbang",
-          "flashbang",
-          "socks",
-          "boots_combat",
-          "gloves_tactical",
-          "hammer_sledge"
-        ],
         "entries": [
+          { "item": "tac_fullhelmet" },
+          { "item": "pants_army" },
+          { "item": "tshirt" },
+          { "item": "ballistic_vest_esapi" },
+          { "item": "armguard_hard" },
+          { "item": "legguard_hard" },
+          { "item": "grenadebandolier" },
+          { "item": "flashbang" },
+          { "item": "flashbang" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "gloves_tactical" },
+          { "item": "hammer_sledge" },
           { "item": "mossberg_500", "ammo-item": "shot_00", "charges": 8, "contents-item": [ "shoulder_strap" ] },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "shot_00", "charges": 12, "container-item": "bandolier_shotgun" },
@@ -191,8 +191,8 @@
           { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "sports_bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
     }
   }
 ]

--- a/data/mods/Military_Professions/prof/spc.json
+++ b/data/mods/Military_Professions/prof/spc.json
@@ -13,22 +13,20 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "tac_helmet",
-          "keffiyeh",
-          "sweatshirt",
-          "pants_cargo",
-          "longshirt",
-          "rucksack",
-          "glasses_bal",
-          "dump_pouch",
-          "socks",
-          "boots_combat",
-          "gloves_tactical",
-          "diving_watch",
-          "ballistic_vest_esapi"
-        ],
         "entries": [
+          { "item": "tac_helmet" },
+          { "item": "keffiyeh" },
+          { "item": "sweatshirt" },
+          { "item": "pants_cargo" },
+          { "item": "longshirt" },
+          { "item": "rucksack" },
+          { "item": "glasses_bal" },
+          { "item": "dump_pouch" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "gloves_tactical" },
+          { "item": "diving_watch" },
+          { "item": "ballistic_vest_esapi" },
           {
             "item": "acr_300blk",
             "ammo-item": "300blk_ss",
@@ -42,8 +40,8 @@
           { "item": "legpouch_large", "contents-group": "army_mags_1911" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "sports_bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
     }
   },
   {
@@ -55,21 +53,24 @@
     "skills": [ { "level": 2, "name": "survival" }, { "level": 4, "name": "gun" }, { "level": 4, "name": "rifle" } ],
     "items": {
       "both": {
-        "items": [
-          "hat_cotton",
-          "jacket_army",
-          "pants_army",
-          "longshirt",
-          "rucksack",
-          "knee_pads",
-          "elbow_pads",
-          "socks",
-          "boots_combat",
-          "gloves_tactical",
-          "cloak"
-        ],
         "entries": [
-          { "item": "M24", "ammo-item": "762_51", "charges": 20, "contents-item": [ "shoulder_strap", "bipod", "suppressor" ] },
+          { "item": "hat_cotton" },
+          { "item": "jacket_army" },
+          { "item": "pants_army" },
+          { "item": "longshirt" },
+          { "item": "rucksack" },
+          { "item": "knee_pads" },
+          { "item": "elbow_pads" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "gloves_tactical" },
+          { "item": "cloak" },
+          {
+            "item": "M24",
+            "ammo-item": "762_51",
+            "charges": 20,
+            "contents-item": [ "shoulder_strap", "bipod", "suppressor" ]
+          },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "chestrig", "contents-group": "army_mags_m14" },
           { "item": "knife_combat", "container-item": "sheath" },
@@ -77,8 +78,8 @@
           { "item": "legpouch_large", "contents-group": "army_mags_1911" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "sports_bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
     }
   },
   {
@@ -96,23 +97,21 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "hat_ball",
-          "scarf",
-          "hoodie",
-          "pants_cargo",
-          "longshirt",
-          "kevlar",
-          "mbag",
-          "glasses_bal",
-          "dump_pouch",
-          "socks",
-          "boots_combat",
-          "gloves_tactical",
-          "multitool",
-          "diving_watch"
-        ],
         "entries": [
+          { "item": "hat_ball" },
+          { "item": "scarf" },
+          { "item": "hoodie" },
+          { "item": "pants_cargo" },
+          { "item": "longshirt" },
+          { "item": "kevlar" },
+          { "item": "mbag" },
+          { "item": "glasses_bal" },
+          { "item": "dump_pouch" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "gloves_tactical" },
+          { "item": "multitool" },
+          { "item": "diving_watch" },
           {
             "item": "hk_mp7",
             "ammo-item": "46mm",
@@ -126,8 +125,8 @@
           { "item": "legpouch_large", "contents-group": "army_mags_1911" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "sports_bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
     }
   },
   {
@@ -144,29 +143,27 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "scarf",
-          "dress_shirt",
-          "jeans",
-          "longshirt",
-          "kevlar",
-          "mbag",
-          "fancy_sunglasses",
-          "socks",
-          "lowtops",
-          "pockknife",
-          "diving_watch",
-          "smart_phone"
-        ],
         "entries": [
+          { "item": "scarf" },
+          { "item": "dress_shirt" },
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "kevlar" },
+          { "item": "mbag" },
+          { "item": "fancy_sunglasses" },
+          { "item": "socks" },
+          { "item": "lowtops" },
+          { "item": "pockknife" },
+          { "item": "diving_watch" },
+          { "item": "smart_phone" },
           { "item": "holster", "contents-group": "holster_supp_57" },
           { "item": "suppressor" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "legpouch_large", "contents-group": "army_mags_57" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "sports_bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
     }
   },
   {
@@ -183,17 +180,15 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "hazmat_suit",
-          "pants_cargo",
-          "longshirt",
-          "dump_pouch",
-          "socks",
-          "gloves_rubber",
-          "diving_watch",
-          "ballistic_vest_esapi"
-        ],
         "entries": [
+          { "item": "hazmat_suit" },
+          { "item": "pants_cargo" },
+          { "item": "longshirt" },
+          { "item": "dump_pouch" },
+          { "item": "socks" },
+          { "item": "gloves_rubber" },
+          { "item": "diving_watch" },
+          { "item": "ballistic_vest_esapi" },
           { "item": "hk_mp5", "ammo-item": "9mm", "charges": 30, "contents-item": [ "shoulder_strap", "suppressor" ] },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "tacvest", "contents-group": "army_mags_mp5" },
@@ -201,8 +196,8 @@
           { "item": "legpouch_large", "contents-group": "army_mags_1911" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "boy_shorts", "sports_bra" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "boy_shorts" }, { "item": "sports_bra" } ] }
     }
   }
 ]

--- a/data/mods/MindOverMatter/professions.json
+++ b/data/mods/MindOverMatter/professions.json
@@ -7,11 +7,21 @@
     "points": 1,
     "items": {
       "both": {
-        "items": [ "jeans", "longshirt", "socks", "sneakers", "mbag", "water_clean", "wristwatch", "matrix_crystal_coruscating" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "group": "charged_matches" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "longshirt" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "mbag" },
+          { "item": "water_clean" },
+          { "item": "wristwatch" },
+          { "item": "matrix_crystal_coruscating" },
+          { "group": "charged_smart_phone" },
+          { "group": "charged_matches" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -35,11 +45,18 @@
     ],
     "items": {
       "both": {
-        "items": [ "jacket_light", "jeans", "socks", "cleats", "sports_drink" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "jacket_light" },
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "cleats" },
+          { "item": "sports_drink" },
+          { "group": "charged_smart_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -58,11 +75,20 @@
     ],
     "items": {
       "both": {
-        "items": [ "jeans", "socks", "robe", "lowtops", "newest_newspaper", "weeks_old_newspaper", "months_old_newspaper" ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "robe" },
+          { "item": "lowtops" },
+          { "item": "newest_newspaper" },
+          { "item": "weeks_old_newspaper" },
+          { "item": "months_old_newspaper" },
+          { "group": "charged_smart_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -88,16 +114,21 @@
     "proficiencies": [ "prof_elec_circuits", "prof_elec_semiconductors", "prof_elec_integrated_circuits" ],
     "items": {
       "both": {
-        "items": [ "socks", "technician_coveralls", "boots", "wristwatch", "mbag", "water_clean" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "technician_coveralls" },
+          { "item": "boots" },
+          { "item": "wristwatch" },
+          { "item": "mbag" },
+          { "item": "water_clean" },
           { "group": "charged_smart_phone" },
           { "group": "charged_electrical_measuring" },
           { "group": "charged_laptop" },
           { "group": "charged_cigs" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -121,16 +152,18 @@
     ],
     "items": {
       "both": {
-        "items": [ "socks", "jeans", "sneakers" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "jeans" },
+          { "item": "sneakers" },
           { "item": "tshirt", "variant": "generic_tshirt" },
           { "item": "deck_of_cards" },
           { "item": "tophat" },
           { "item": "teddy_bear", "variant": "toy_plush_rabbit" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -149,16 +182,18 @@
     ],
     "items": {
       "both": {
-        "items": [ "socks", "jeans", "sneakers" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "jeans" },
+          { "item": "sneakers" },
           { "item": "tshirt", "variant": "generic_tshirt" },
           { "item": "lighter", "charges": 100 },
           { "item": "lighter", "charges": 100 },
           { "group": "charged_matches" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -184,11 +219,18 @@
     "proficiencies": [ "prof_concentration_basic" ],
     "items": {
       "both": {
-        "items": [ "pants_army", "gloves_tactical", "army_top", "boots_combat", "socks" ],
-        "entries": [ { "item": "water_clean", "container-item": "canteen" }, { "item": "knife_combat", "container-item": "sheath" } ]
+        "entries": [
+          { "item": "pants_army" },
+          { "item": "gloves_tactical" },
+          { "item": "army_top" },
+          { "item": "boots_combat" },
+          { "item": "socks" },
+          { "item": "water_clean", "container-item": "canteen" },
+          { "item": "knife_combat", "container-item": "sheath" }
+        ]
       },
-      "male": [ "boxer_briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -208,15 +250,18 @@
     "proficiencies": [ "prof_concentration_basic" ],
     "items": {
       "both": {
-        "items": [ "pants", "dress_shirt", "socks", "dress_shoes" ],
         "entries": [
+          { "item": "pants" },
+          { "item": "dress_shirt" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
           { "item": "water_clean", "container-item": "canteen" },
           { "group": "charged_smart_phone" },
           { "item": "lighter", "charges": 100 }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -242,14 +287,26 @@
     "proficiencies": [ "prof_concentration_basic" ],
     "items": {
       "both": {
-        "items": [ "wristwatch", "pants", "dress_shirt", "socks", "dress_shoes", "officer_uniform", "beret", "holster" ],
         "entries": [
-          { "item": "mom_fusion_pistol", "ammo-item": "mom_fusion_ammo", "charges": 40, "contents-item": [ "mom_fusion_mag" ] },
+          { "item": "wristwatch" },
+          { "item": "pants" },
+          { "item": "dress_shirt" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "officer_uniform" },
+          { "item": "beret" },
+          { "item": "holster" },
+          {
+            "item": "mom_fusion_pistol",
+            "ammo-item": "mom_fusion_ammo",
+            "charges": 40,
+            "contents-item": [ "mom_fusion_mag" ]
+          },
           { "item": "mom_fusion_mag", "ammo-item": "mom_fusion_ammo", "charges": 40 }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -268,11 +325,21 @@
     ],
     "items": {
       "both": {
-        "items": [ "dress_shirt", "pants", "socks", "dress_shoes", "wristwatch", "flyer", "flyer", "flyer", "holy_symbol" ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "dress_shirt" },
+          { "item": "pants" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "wristwatch" },
+          { "item": "flyer" },
+          { "item": "flyer" },
+          { "item": "flyer" },
+          { "item": "holy_symbol" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {

--- a/data/mods/Xedra_Evolved/player/professions.json
+++ b/data/mods/Xedra_Evolved/player/professions.json
@@ -44,19 +44,17 @@
     "proficiencies": [ "prof_spotting", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
-        "items": [
-          "pants",
-          "dress_shirt",
-          "tie_skinny",
-          "blazer",
-          "trenchcoat",
-          "gloves_light",
-          "wristwatch",
-          "socks",
-          "dress_shoes",
-          "cig"
-        ],
         "entries": [
+          { "item": "pants" },
+          { "item": "dress_shirt" },
+          { "item": "tie_skinny" },
+          { "item": "blazer" },
+          { "item": "trenchcoat" },
+          { "item": "gloves_light" },
+          { "item": "wristwatch" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "cig" },
           { "group": "charged_smart_phone" },
           { "group": "charged_two_way_radio" },
           { "group": "charged_ref_lighter" },
@@ -65,8 +63,8 @@
           { "item": "wyld_candy", "count": 10, "container-item": "null", "entry-wrapper": "wrapper_wyld" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -80,20 +78,18 @@
     "proficiencies": [ "prof_spotting", "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
-        "items": [
-          "pants",
-          "dress_shirt",
-          "tie_skinny",
-          "blazer",
-          "trenchcoat",
-          "badge_zebra",
-          "gloves_leather",
-          "wristwatch",
-          "socks",
-          "dress_shoes",
-          "cig"
-        ],
         "entries": [
+          { "item": "pants" },
+          { "item": "dress_shirt" },
+          { "item": "tie_skinny" },
+          { "item": "blazer" },
+          { "item": "trenchcoat" },
+          { "item": "badge_zebra" },
+          { "item": "gloves_leather" },
+          { "item": "wristwatch" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "cig" },
           { "group": "charged_smart_phone" },
           { "group": "charged_two_way_radio" },
           { "group": "charged_ref_lighter" },
@@ -102,8 +98,8 @@
           { "item": "fn57_sup", "ammo-item": "57mm_ss", "charges": 20, "container-item": "shoulder_holster" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -122,15 +118,21 @@
     "proficiencies": [ "prof_auto_pistols_familiar" ],
     "items": {
       "both": {
-        "items": [ "sneakers", "hoodie", "knit_scarf", "diving_watch", "backpack", "wristwatch", "pants_cargo" ],
         "entries": [
+          { "item": "sneakers" },
+          { "item": "hoodie" },
+          { "item": "knit_scarf" },
+          { "item": "diving_watch" },
+          { "item": "backpack" },
+          { "item": "wristwatch" },
+          { "item": "pants_cargo" },
           { "group": "charged_smart_phone" },
           { "item": "tshirt", "variant": "generic_tshirt" },
           { "item": "light_disposable_cell", "ammo-item": "battery", "charges": 300, "container-item": "camera_pro" }
         ]
       },
-      "male": [ "briefs", "socks" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" }, { "item": "socks" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "missions": [ "MISSION_SAFEHOUSE" ]
   },
@@ -154,29 +156,27 @@
     "items": {
       "both": {
         "ammo": 100,
-        "items": [
-          "under_armor",
-          "under_armor_shorts",
-          "tac_helmet",
-          "glasses_bal",
-          "gloves_tactical",
-          "boots_combat",
-          "holster",
-          "wristwatch",
-          "tacvest",
-          "socks",
-          "badge_zebra",
-          "molle_pack"
-        ],
         "entries": [
+          { "item": "under_armor" },
+          { "item": "under_armor_shorts" },
+          { "item": "tac_helmet" },
+          { "item": "glasses_bal" },
+          { "item": "gloves_tactical" },
+          { "item": "boots_combat" },
+          { "item": "holster" },
+          { "item": "wristwatch" },
+          { "item": "tacvest" },
+          { "item": "socks" },
+          { "item": "badge_zebra" },
+          { "item": "molle_pack" },
           { "item": "xedra_jumpsuit", "variant": "xedra_jumpsuit_offworld" },
           { "group": "military_ballistic_vest_light" },
           { "group": "torso_grenade_bandolier_jotunn" },
           { "item": "mgl", "ammo-item": "40x46mm_m433", "charges": 3, "contents-item": "shoulder_strap" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -198,21 +198,19 @@
     "items": {
       "both": {
         "ammo": 100,
-        "items": [
-          "under_armor",
-          "under_armor_shorts",
-          "tac_helmet",
-          "glasses_bal",
-          "gloves_tactical",
-          "boots_combat",
-          "holster",
-          "wristwatch",
-          "legrig",
-          "tacvest",
-          "socks",
-          "badge_zebra"
-        ],
         "entries": [
+          { "item": "under_armor" },
+          { "item": "under_armor_shorts" },
+          { "item": "tac_helmet" },
+          { "item": "glasses_bal" },
+          { "item": "gloves_tactical" },
+          { "item": "boots_combat" },
+          { "item": "holster" },
+          { "item": "wristwatch" },
+          { "item": "legrig" },
+          { "item": "tacvest" },
+          { "item": "socks" },
+          { "item": "badge_zebra" },
           { "item": "xedra_jumpsuit", "variant": "xedra_jumpsuit_offworld" },
           { "item": "water_clean", "ammo-item": "water_clean", "container-item": "canteen" },
           { "item": "signal_flare", "ammo-item": "signal_flare", "count": 5 },
@@ -226,8 +224,8 @@
           { "item": "legpouch_large", "contents-group": "xedra_mags_troll" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -251,21 +249,19 @@
     "items": {
       "both": {
         "ammo": 100,
-        "items": [
-          "under_armor",
-          "under_armor_shorts",
-          "tac_helmet",
-          "glasses_bal",
-          "gloves_tactical",
-          "boots_combat",
-          "holster",
-          "wristwatch",
-          "legrig",
-          "tacvest",
-          "socks",
-          "badge_zebra"
-        ],
         "entries": [
+          { "item": "under_armor" },
+          { "item": "under_armor_shorts" },
+          { "item": "tac_helmet" },
+          { "item": "glasses_bal" },
+          { "item": "gloves_tactical" },
+          { "item": "boots_combat" },
+          { "item": "holster" },
+          { "item": "wristwatch" },
+          { "item": "legrig" },
+          { "item": "tacvest" },
+          { "item": "socks" },
+          { "item": "badge_zebra" },
           { "item": "xedra_jumpsuit", "variant": "xedra_jumpsuit_offworld" },
           { "item": "water_clean", "ammo-item": "water_clean", "container-item": "canteen" },
           { "group": "military_ballistic_vest_light" },
@@ -273,8 +269,8 @@
           { "item": "legpouch_large", "contents-group": "suppressed_fn57" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -300,23 +296,21 @@
     "items": {
       "both": {
         "ammo": 100,
-        "items": [
-          "pants_army",
-          "undershirt",
-          "combat_shirt",
-          "tac_fullhelmet",
-          "armguard_hard",
-          "legguard_hard",
-          "mask_ski",
-          "wristwatch",
-          "gloves_liner",
-          "gloves_tactical",
-          "socks",
-          "boots_combat",
-          "molle_pack",
-          "hammer_sledge"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "undershirt" },
+          { "item": "combat_shirt" },
+          { "item": "tac_fullhelmet" },
+          { "item": "armguard_hard" },
+          { "item": "legguard_hard" },
+          { "item": "mask_ski" },
+          { "item": "wristwatch" },
+          { "item": "gloves_liner" },
+          { "item": "gloves_tactical" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "molle_pack" },
+          { "item": "hammer_sledge" },
           { "item": "xedra_jumpsuit", "variant": "xedra_jumpsuit_eater" },
           { "group": "charged_two_way_radio" },
           { "group": "us_ballistic_vest_pristine" },
@@ -329,8 +323,8 @@
           { "item": "m17", "ammo-item": "9mm", "charges": 17, "container-item": "holster" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -356,20 +350,18 @@
     "items": {
       "both": {
         "ammo": 100,
-        "items": [
-          "under_armor",
-          "under_armor_shorts",
-          "tac_helmet",
-          "glasses_bal",
-          "wristwatch",
-          "gloves_tactical",
-          "boots_combat",
-          "holster",
-          "legrig",
-          "tacvest",
-          "socks"
-        ],
         "entries": [
+          { "item": "under_armor" },
+          { "item": "under_armor_shorts" },
+          { "item": "tac_helmet" },
+          { "item": "glasses_bal" },
+          { "item": "wristwatch" },
+          { "item": "gloves_tactical" },
+          { "item": "boots_combat" },
+          { "item": "holster" },
+          { "item": "legrig" },
+          { "item": "tacvest" },
+          { "item": "socks" },
           { "item": "xedra_jumpsuit", "variant": "xedra_jumpsuit_dreamer" },
           { "item": "water_clean", "ammo-item": "water_clean", "container-item": "canteen" },
           { "group": "military_ballistic_vest_light" },
@@ -377,8 +369,8 @@
           { "item": "legpouch_large", "contents-group": "suppressed_fn57" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -401,20 +393,18 @@
     "items": {
       "both": {
         "ammo": 100,
-        "items": [
-          "under_armor",
-          "under_armor_shorts",
-          "tac_helmet",
-          "glasses_bal",
-          "gloves_tactical",
-          "wristwatch",
-          "boots_combat",
-          "holster",
-          "legrig",
-          "tacvest",
-          "socks"
-        ],
         "entries": [
+          { "item": "under_armor" },
+          { "item": "under_armor_shorts" },
+          { "item": "tac_helmet" },
+          { "item": "glasses_bal" },
+          { "item": "gloves_tactical" },
+          { "item": "wristwatch" },
+          { "item": "boots_combat" },
+          { "item": "holster" },
+          { "item": "legrig" },
+          { "item": "tacvest" },
+          { "item": "socks" },
           { "item": "xedra_jumpsuit", "variant": "xedra_jumpsuit_inventor" },
           { "item": "water_clean", "ammo-item": "water_clean", "container-item": "canteen" },
           { "group": "military_ballistic_vest_light" },
@@ -422,8 +412,8 @@
           { "item": "legpouch_large", "contents-group": "suppressed_fn57" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -440,20 +430,18 @@
     "items": {
       "both": {
         "ammo": 100,
-        "items": [
-          "under_armor",
-          "under_armor_shorts",
-          "tac_helmet",
-          "glasses_bal",
-          "gloves_tactical",
-          "wristwatch",
-          "boots_combat",
-          "holster",
-          "legrig",
-          "tacvest",
-          "socks"
-        ],
         "entries": [
+          { "item": "under_armor" },
+          { "item": "under_armor_shorts" },
+          { "item": "tac_helmet" },
+          { "item": "glasses_bal" },
+          { "item": "gloves_tactical" },
+          { "item": "wristwatch" },
+          { "item": "boots_combat" },
+          { "item": "holster" },
+          { "item": "legrig" },
+          { "item": "tacvest" },
+          { "item": "socks" },
           { "item": "xedra_jumpsuit", "variant": "xedra_jumpsuit_dreamsmith" },
           { "item": "water_clean", "ammo-item": "water_clean", "container-item": "canteen" },
           { "group": "military_ballistic_vest_light" },
@@ -461,8 +449,8 @@
           { "item": "legpouch_large", "contents-group": "suppressed_fn57" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -475,13 +463,18 @@
     "pets": [ { "name": "mon_stoneling", "amount": 1 } ],
     "items": {
       "both": {
-        "items": [ "footrags", "loincloth", "cloak_wool", "ragpouch", "gloves_wraps", "tunic_rag" ],
         "entries": [
+          { "item": "footrags" },
+          { "item": "loincloth" },
+          { "item": "cloak_wool" },
+          { "item": "ragpouch" },
+          { "item": "gloves_wraps" },
+          { "item": "tunic_rag" },
           { "item": "knife_baselard", "container-item": "sheath" },
           { "item": "earthkin_tablet", "custom-flags": [ "auto_wield" ] }
         ]
       },
-      "female": [ "chestwrap" ]
+      "female": { "entries": [ { "item": "chestwrap" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -495,13 +488,18 @@
     "pets": [ { "name": "mon_vineling", "amount": 1 } ],
     "items": {
       "both": {
-        "items": [ "footrags", "loincloth", "cloak_wool", "ragpouch", "gloves_wraps", "tunic_rag" ],
         "entries": [
+          { "item": "footrags" },
+          { "item": "loincloth" },
+          { "item": "cloak_wool" },
+          { "item": "ragpouch" },
+          { "item": "gloves_wraps" },
+          { "item": "tunic_rag" },
           { "item": "knife_baselard", "container-item": "sheath" },
           { "item": "plantkin_parchment", "custom-flags": [ "auto_wield" ] }
         ]
       },
-      "female": [ "chestwrap" ]
+      "female": { "entries": [ { "item": "chestwrap" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -515,13 +513,18 @@
     "pets": [ { "name": "mon_spitting_lizard", "amount": 1 } ],
     "items": {
       "both": {
-        "items": [ "footrags", "loincloth", "cloak_wool", "ragpouch", "gloves_wraps", "tunic_rag" ],
         "entries": [
+          { "item": "footrags" },
+          { "item": "loincloth" },
+          { "item": "cloak_wool" },
+          { "item": "ragpouch" },
+          { "item": "gloves_wraps" },
+          { "item": "tunic_rag" },
           { "item": "knife_baselard", "container-item": "sheath" },
           { "item": "waterkin_tablet", "custom-flags": [ "auto_wield" ] }
         ]
       },
-      "female": [ "chestwrap" ]
+      "female": { "entries": [ { "item": "chestwrap" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -535,13 +538,18 @@
     "pets": [ { "name": "mon_salamander_tiny", "amount": 1 } ],
     "items": {
       "both": {
-        "items": [ "footrags", "loincloth", "cloak_wool", "ragpouch", "gloves_wraps", "tunic_rag" ],
         "entries": [
+          { "item": "footrags" },
+          { "item": "loincloth" },
+          { "item": "cloak_wool" },
+          { "item": "ragpouch" },
+          { "item": "gloves_wraps" },
+          { "item": "tunic_rag" },
           { "item": "knife_baselard", "container-item": "sheath" },
           { "item": "flametouched_parchment", "custom-flags": [ "auto_wield" ] }
         ]
       },
-      "female": [ "chestwrap" ]
+      "female": { "entries": [ { "item": "chestwrap" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -555,13 +563,18 @@
     "pets": [ { "name": "mon_zoomorphic_figure_small", "amount": 1 } ],
     "items": {
       "both": {
-        "items": [ "footrags", "loincloth", "cloak_wool", "ragpouch", "gloves_wraps", "tunic_rag" ],
         "entries": [
+          { "item": "footrags" },
+          { "item": "loincloth" },
+          { "item": "cloak_wool" },
+          { "item": "ragpouch" },
+          { "item": "gloves_wraps" },
+          { "item": "tunic_rag" },
           { "item": "knife_baselard", "container-item": "sheath" },
           { "item": "dollkin_tablet", "custom-flags": [ "auto_wield" ] }
         ]
       },
-      "female": [ "chestwrap" ]
+      "female": { "entries": [ { "item": "chestwrap" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   },
@@ -575,13 +588,18 @@
     "pets": [ { "name": "mon_dragonfly_fae", "amount": 1 } ],
     "items": {
       "both": {
-        "items": [ "footrags", "loincloth", "cloak_wool", "ragpouch", "gloves_wraps", "tunic_rag" ],
         "entries": [
+          { "item": "footrags" },
+          { "item": "loincloth" },
+          { "item": "cloak_wool" },
+          { "item": "ragpouch" },
+          { "item": "gloves_wraps" },
+          { "item": "tunic_rag" },
           { "item": "knife_baselard", "container-item": "sheath" },
           { "item": "sylph_parchment", "custom-flags": [ "auto_wield" ] }
         ]
       },
-      "female": [ "chestwrap" ]
+      "female": { "entries": [ { "item": "chestwrap" } ] }
     },
     "flags": [ "SCEN_ONLY" ]
   }

--- a/data/mods/innawood/professions.json
+++ b/data/mods/innawood/professions.json
@@ -33,8 +33,12 @@
     "pets": [ { "name": "mon_goat", "amount": 2 } ],
     "items": {
       "both": {
-        "items": [ "loincloth_leather", "leather_belt", "socks", "mocassins", "shirt_straw" ],
         "entries": [
+          { "item": "loincloth_leather" },
+          { "item": "leather_belt" },
+          { "item": "socks" },
+          { "item": "mocassins" },
+          { "item": "shirt_straw" },
           { "item": "rope_makeshift_6", "count": 2 },
           { "item": "sheath_birchbark", "contents-item": "primitive_knife" },
           { "item": "bucket_wood", "custom-flags": [ "auto_wield" ] }
@@ -52,7 +56,14 @@
     "proficiencies": [ "prof_fibers", "prof_knapping" ],
     "items": {
       "both": {
-        "items": [ "cloak_leather", "footrags_leather", "chestwrap_leather", "loincloth_fur", "stone_chopper", "straw_basket" ]
+        "entries": [
+          { "item": "cloak_leather" },
+          { "item": "footrags_leather" },
+          { "item": "chestwrap_leather" },
+          { "item": "loincloth_fur" },
+          { "item": "stone_chopper" },
+          { "item": "straw_basket" }
+        ]
       }
     }
   },
@@ -66,18 +77,16 @@
     "proficiencies": [ "prof_wound_care", "prof_wound_care_expert", "prof_intro_biology", "prof_physiology", "prof_burn_care" ],
     "items": {
       "both": {
-        "items": [
-          "straw_basket",
-          "grass_cloak",
-          "shirt_straw",
-          "skirt_grass",
-          "footrags_leather",
-          "grass_keffiyeh",
-          "primitive_knife",
-          "tourniquet_upper",
-          "arm_splint"
-        ],
         "entries": [
+          { "item": "straw_basket" },
+          { "item": "grass_cloak" },
+          { "item": "shirt_straw" },
+          { "item": "skirt_grass" },
+          { "item": "footrags_leather" },
+          { "item": "grass_keffiyeh" },
+          { "item": "primitive_knife" },
+          { "item": "tourniquet_upper" },
+          { "item": "arm_splint" },
           { "item": "bandages_birchbark_adv", "count": 10 },
           { "item": "cattail_jelly", "charges": 7, "container-item": "bowl_clay" }
         ]
@@ -93,8 +102,13 @@
     "skills": [ { "level": 1, "name": "survival" } ],
     "items": {
       "both": {
-        "items": [ "wicker_backpack", "mocassins", "tunic", "footrags_leather" ],
-        "entries": [ { "item": "water_clean", "charges": 6, "container-item": "waterskin" } ]
+        "entries": [
+          { "item": "wicker_backpack" },
+          { "item": "mocassins" },
+          { "item": "tunic" },
+          { "item": "footrags_leather" },
+          { "item": "water_clean", "charges": 6, "container-item": "waterskin" }
+        ]
       }
     }
   },
@@ -106,18 +120,18 @@
     "points": 5,
     "items": {
       "both": {
-        "items": [
-          "primitive_shovel",
-          "bronze_pickaxe",
-          "mocassins",
-          "torch",
-          "waterskin",
-          "tunic",
-          "helmet_larmor",
-          "gloves_wraps_leather",
-          "bigtrapper_pack"
-        ],
-        "entries": [ { "item": "fire_drill", "ammo-item": "notch", "charges": 24 } ]
+        "entries": [
+          { "item": "primitive_shovel" },
+          { "item": "bronze_pickaxe" },
+          { "item": "mocassins" },
+          { "item": "torch" },
+          { "item": "waterskin" },
+          { "item": "tunic" },
+          { "item": "helmet_larmor" },
+          { "item": "gloves_wraps_leather" },
+          { "item": "bigtrapper_pack" },
+          { "item": "fire_drill", "ammo-item": "notch", "charges": 24 }
+        ]
       }
     }
   },
@@ -136,8 +150,11 @@
     ],
     "items": {
       "both": {
-        "items": [ "mocassins", "shirt_straw", "skirt_grass", "longbow" ],
         "entries": [
+          { "item": "mocassins" },
+          { "item": "shirt_straw" },
+          { "item": "skirt_grass" },
+          { "item": "longbow" },
           { "item": "quiver_birchbark", "contents-group": "quiver_bow_hunter" },
           { "item": "sheath_birchbark", "contents-item": "primitive_knife" }
         ]
@@ -161,8 +178,10 @@
     "proficiencies": [ "prof_spears_familiar", "prof_knives_familiar" ],
     "items": {
       "both": {
-        "items": [ "footrags_leather", "shirt_straw", "skirt_grass" ],
         "entries": [
+          { "item": "footrags_leather" },
+          { "item": "shirt_straw" },
+          { "item": "skirt_grass" },
           { "item": "sheath_birchbark", "contents-item": "primitive_knife" },
           { "item": "spear_stone", "custom-flags": [ "auto_wield" ] }
         ]
@@ -185,8 +204,10 @@
     "proficiencies": [ "prof_spears_familiar", "prof_knives_familiar" ],
     "items": {
       "both": {
-        "items": [ "footrags_leather", "shirt_straw", "skirt_grass" ],
         "entries": [
+          { "item": "footrags_leather" },
+          { "item": "shirt_straw" },
+          { "item": "skirt_grass" },
           { "item": "sheath_birchbark", "contents-item": "primitive_knife" },
           { "item": "javelin_bag", "contents-group": "bag_javelin_hunter" }
         ]
@@ -209,8 +230,10 @@
     ],
     "items": {
       "both": {
-        "items": [ "mocassins", "shirt_straw", "skirt_grass" ],
         "entries": [
+          { "item": "mocassins" },
+          { "item": "shirt_straw" },
+          { "item": "skirt_grass" },
           {
             "item": "compositecrossbow",
             "ammo-item": "bolt_simple_wood",
@@ -236,8 +259,12 @@
     "proficiencies": [ "prof_fibers", "prof_knives_familiar" ],
     "items": {
       "both": {
-        "items": [ "wicker_backpack", "footrags_leather", "shirt_straw", "skirt_grass", "straw_hat" ],
         "entries": [
+          { "item": "wicker_backpack" },
+          { "item": "footrags_leather" },
+          { "item": "shirt_straw" },
+          { "item": "skirt_grass" },
+          { "item": "straw_hat" },
           { "item": "primitive_knife", "container-item": "sheath_birchbark" },
           { "item": "fishing_rod_basic", "custom-flags": [ "auto_wield" ] },
           { "item": "fire_drill", "ammo-item": "notch", "charges": 24 }
@@ -257,8 +284,12 @@
     "proficiencies": [ "prof_fibers", "prof_knives_familiar" ],
     "items": {
       "both": {
-        "items": [ "wicker_backpack", "footrags_leather", "shirt_straw", "skirt_grass", "straw_hat" ],
         "entries": [
+          { "item": "wicker_backpack" },
+          { "item": "footrags_leather" },
+          { "item": "shirt_straw" },
+          { "item": "skirt_grass" },
+          { "item": "straw_hat" },
           { "item": "primitive_knife", "container-item": "sheath_birchbark" },
           { "item": "fishing_rod_basic", "custom-flags": [ "auto_wield" ] },
           { "item": "fire_drill", "ammo-item": "notch", "charges": 24 }
@@ -276,21 +307,21 @@
     "proficiencies": [ "prof_metalworking", "prof_redsmithing" ],
     "items": {
       "both": {
-        "items": [
-          "pants",
-          "socks",
-          "mocassins",
-          "longshirt",
-          "apron_leather",
-          "gloves_leather",
-          "primitive_hammer",
-          "copper_knife",
-          "wicker_backpack",
-          "crucible_clay"
+        "entries": [
+          { "item": "pants" },
+          { "item": "socks" },
+          { "item": "mocassins" },
+          { "item": "longshirt" },
+          { "item": "apron_leather" },
+          { "item": "gloves_leather" },
+          { "item": "primitive_hammer" },
+          { "item": "copper_knife" },
+          { "item": "wicker_backpack" },
+          { "item": "crucible_clay" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -301,8 +332,12 @@
     "points": 0,
     "items": {
       "both": {
-        "items": [ "skirt_grass", "shirt_straw", "footrags", "straw_basket", "primitive_knife" ],
         "entries": [
+          { "item": "skirt_grass" },
+          { "item": "shirt_straw" },
+          { "item": "footrags" },
+          { "item": "straw_basket" },
+          { "item": "primitive_knife" },
           { "item": "water_clean", "charges": 6, "container-item": "waterskin" },
           { "item": "fire_drill", "ammo-item": "notch", "charges": 24 }
         ]
@@ -319,21 +354,21 @@
     "proficiencies": [ "prof_fibers", "prof_carving", "prof_traps", "prof_trapsetting", "prof_knives_familiar" ],
     "items": {
       "both": {
-        "items": [
-          "pants",
-          "socks",
-          "mocassins",
-          "hat_fur",
-          "shirt_straw",
-          "cloak_leather",
-          "patchwork_scarf",
-          "light_snare_kit",
-          "wicker_backpack"
-        ],
-        "entries": [ { "item": "copper_knife", "container-item": "sheath" } ]
+        "entries": [
+          { "item": "pants" },
+          { "item": "socks" },
+          { "item": "mocassins" },
+          { "item": "hat_fur" },
+          { "item": "shirt_straw" },
+          { "item": "cloak_leather" },
+          { "item": "patchwork_scarf" },
+          { "item": "light_snare_kit" },
+          { "item": "wicker_backpack" },
+          { "item": "copper_knife", "container-item": "sheath" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -356,21 +391,21 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "straw_basket",
-          "straw_fedora",
-          "longshirt",
-          "pants",
-          "socks",
-          "mocassins",
-          "patchwork_scarf",
-          "awl_bone",
-          "bronze_shears"
-        ],
-        "entries": [ { "item": "needle_bone", "ammo-item": "plant_fibre", "charges": 200 } ]
+        "entries": [
+          { "item": "straw_basket" },
+          { "item": "straw_fedora" },
+          { "item": "longshirt" },
+          { "item": "pants" },
+          { "item": "socks" },
+          { "item": "mocassins" },
+          { "item": "patchwork_scarf" },
+          { "item": "awl_bone" },
+          { "item": "bronze_shears" },
+          { "item": "needle_bone", "ammo-item": "plant_fibre", "charges": 200 }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -388,11 +423,20 @@
     "proficiencies": [ "prof_great_axes_familiar", "prof_hand_axes_familiar", "prof_hand_axes_pro" ],
     "items": {
       "both": {
-        "items": [ "pants", "socks", "mocassins", "straw_hat", "longshirt", "patchwork_scarf", "vest_leather", "rope_makeshift_6" ],
-        "entries": [ { "item": "copper_ax", "custom-flags": [ "auto_wield" ] } ]
+        "entries": [
+          { "item": "pants" },
+          { "item": "socks" },
+          { "item": "mocassins" },
+          { "item": "straw_hat" },
+          { "item": "longshirt" },
+          { "item": "patchwork_scarf" },
+          { "item": "vest_leather" },
+          { "item": "rope_makeshift_6" },
+          { "item": "copper_ax", "custom-flags": [ "auto_wield" ] }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -404,11 +448,18 @@
     "skills": [ { "level": 2, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [ "straw_basket", "shirt_straw", "skirt_grass", "socks", "mocassins", "bone_flute" ],
-        "entries": [ { "item": "water_clean", "charges": 6, "container-item": "waterskin" } ]
+        "entries": [
+          { "item": "straw_basket" },
+          { "item": "shirt_straw" },
+          { "item": "skirt_grass" },
+          { "item": "socks" },
+          { "item": "mocassins" },
+          { "item": "bone_flute" },
+          { "item": "water_clean", "charges": 6, "container-item": "waterskin" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -428,8 +479,12 @@
     ],
     "items": {
       "both": {
-        "items": [ "helmet_larmor", "armor_larmor", "socks", "boots_larmor", "gauntlets_larmor" ],
         "entries": [
+          { "item": "helmet_larmor" },
+          { "item": "armor_larmor" },
+          { "item": "socks" },
+          { "item": "boots_larmor" },
+          { "item": "gauntlets_larmor" },
           { "item": "water_clean", "charges": 6, "container-item": "waterskin" },
           { "item": "quiver_birchbark", "contents-group": "quiver_bow_hunter" },
           { "item": "spear_copper", "container-item": "spearsling" },
@@ -437,8 +492,8 @@
           { "item": "longbow", "contents-item": [ "primitive_bow_silencer" ] }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -456,15 +511,19 @@
     "proficiencies": [ "prof_short_swords_familiar", "prof_short_swords_pro", "prof_knives_familiar" ],
     "items": {
       "both": {
-        "items": [ "helmet_larmor", "armor_larmor", "socks", "boots_larmor", "gauntlets_larmor" ],
         "entries": [
+          { "item": "helmet_larmor" },
+          { "item": "armor_larmor" },
+          { "item": "socks" },
+          { "item": "boots_larmor" },
+          { "item": "gauntlets_larmor" },
           { "item": "water_clean", "charges": 6, "container-item": "waterskin" },
           { "item": "sword_bronze", "container-item": "scabbard" },
           { "item": "copper_knife", "container-item": "sheath_birchbark" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -482,8 +541,14 @@
     ],
     "items": {
       "both": {
-        "items": [ "leathersandals", "helmet_larmor", "vambrace_larmor", "socks", "skirt_grass", "vest_leather", "legguard_larmor" ],
         "entries": [
+          { "item": "leathersandals" },
+          { "item": "helmet_larmor" },
+          { "item": "vambrace_larmor" },
+          { "item": "socks" },
+          { "item": "skirt_grass" },
+          { "item": "vest_leather" },
+          { "item": "legguard_larmor" },
           {
             "item": "compositecrossbow",
             "ammo-item": "bolt_simple_wood",
@@ -495,8 +560,8 @@
           { "item": "copper_knife", "container-item": "sheath_birchbark" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -507,22 +572,22 @@
     "points": 1,
     "items": {
       "both": {
-        "items": [
-          "loincloth_leather",
-          "wicker_backpack",
-          "patchwork_scarf",
-          "straw_hat",
-          "socks",
-          "mocassins",
-          "seed_blueberries",
-          "seed_strawberries",
-          "seed_wheat",
-          "seed_hops",
-          "seed_barley",
-          "seed_sugar_beet",
-          "seed_tomato"
-        ],
-        "entries": [ { "item": "bronze_hoe", "custom-flags": [ "auto_wield" ] } ]
+        "entries": [
+          { "item": "loincloth_leather" },
+          { "item": "wicker_backpack" },
+          { "item": "patchwork_scarf" },
+          { "item": "straw_hat" },
+          { "item": "socks" },
+          { "item": "mocassins" },
+          { "item": "seed_blueberries" },
+          { "item": "seed_strawberries" },
+          { "item": "seed_wheat" },
+          { "item": "seed_hops" },
+          { "item": "seed_barley" },
+          { "item": "seed_sugar_beet" },
+          { "item": "seed_tomato" },
+          { "item": "bronze_hoe", "custom-flags": [ "auto_wield" ] }
+        ]
       }
     }
   },
@@ -536,18 +601,16 @@
     "proficiencies": [ "prof_basketweaving", "prof_pottery", "prof_knives_familiar" ],
     "items": {
       "both": {
-        "items": [
-          "wicker_backpack",
-          "tunic",
-          "mocassins",
-          "cloak",
-          "chaps_leather",
-          "bandana_head",
-          "copper_knife",
-          "shortbow",
-          "loincloth"
-        ],
         "entries": [
+          { "item": "wicker_backpack" },
+          { "item": "tunic" },
+          { "item": "mocassins" },
+          { "item": "cloak" },
+          { "item": "chaps_leather" },
+          { "item": "bandana_head" },
+          { "item": "copper_knife" },
+          { "item": "shortbow" },
+          { "item": "loincloth" },
           { "item": "seed_pumpkin", "count": 5 },
           { "item": "seed_beans", "count": 5 },
           { "item": "seed_corn", "count": 5 },
@@ -569,8 +632,15 @@
     "proficiencies": [ "prof_carving", "prof_carpentry_basic", "prof_hand_axes_familiar" ],
     "items": {
       "both": {
-        "items": [ "wicker_backpack", "tunic", "clogs", "socks", "helmet_larmor", "copper_knife", "primitive_hammer", "loincloth" ],
         "entries": [
+          { "item": "wicker_backpack" },
+          { "item": "tunic" },
+          { "item": "clogs" },
+          { "item": "socks" },
+          { "item": "helmet_larmor" },
+          { "item": "copper_knife" },
+          { "item": "primitive_hammer" },
+          { "item": "loincloth" },
           { "item": "copper_ax", "container-item": "axe_ring" },
           { "item": "primitive_adze", "container-item": "rope_makeshift_6" },
           { "item": "primitive_shovel", "custom-flags": [ "auto_wield" ] }
@@ -587,8 +657,15 @@
     "skills": [ { "level": 3, "name": "fabrication" }, { "level": 1, "name": "survival" } ],
     "items": {
       "both": {
-        "items": [ "trapper_pack", "tunic", "mocassins", "socks", "helmet_larmor", "primitive_hammer", "loincloth", "frame_wood_light" ],
         "entries": [
+          { "item": "trapper_pack" },
+          { "item": "tunic" },
+          { "item": "mocassins" },
+          { "item": "socks" },
+          { "item": "helmet_larmor" },
+          { "item": "primitive_hammer" },
+          { "item": "loincloth" },
+          { "item": "frame_wood_light" },
           { "item": "adobe_brick", "count": 10 },
           { "item": "primitive_knife", "container-item": "sheath_birchbark" },
           { "item": "wood_smoother", "custom-flags": [ "auto_wield" ] }

--- a/data/mods/package_bionic_professions/bionic_professions.json
+++ b/data/mods/package_bionic_professions/bionic_professions.json
@@ -15,21 +15,22 @@
     "CBMs": [ "bio_str_enhancer", "bio_adrenaline", "bio_hydraulics", "bio_metabolics", "bio_power_storage_mkII" ],
     "items": {
       "both": {
-        "items": [
-          "socks_ankle",
-          "under_armor_shorts",
-          "under_armor",
-          "shorts",
-          "lowtops",
-          "fanny",
-          "protein_drink",
-          "wristwatch",
-          "fitness_band"
-        ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "socks_ankle" },
+          { "item": "under_armor_shorts" },
+          { "item": "under_armor" },
+          { "item": "shorts" },
+          { "item": "lowtops" },
+          { "item": "fanny" },
+          { "item": "protein_drink" },
+          { "item": "wristwatch" },
+          { "item": "fitness_band" },
+          { "group": "charged_smart_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "sports_bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -55,16 +56,23 @@
     "proficiencies": [ "prof_spotting" ],
     "items": {
       "both": {
-        "items": [ "tac_fullhelmet", "police_belt", "pants_cargo", "under_armor", "socks", "boots", "badge_marshal", "wristwatch" ],
         "entries": [
+          { "item": "tac_fullhelmet" },
+          { "item": "police_belt" },
+          { "item": "pants_cargo" },
+          { "item": "under_armor" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "badge_marshal" },
+          { "item": "wristwatch" },
           { "group": "charged_two_way_radio" },
           { "group": "charged_smart_phone" },
           { "item": "glock_18c", "ammo-item": "9mmP", "container-item": "holster" },
           { "item": "tacvest", "contents-group": "army_mags_glock17" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -77,16 +85,18 @@
     "skills": [ { "level": 4, "name": "electronics" }, { "level": 2, "name": "fabrication" } ],
     "items": {
       "both": {
-        "items": [ "sneakers", "jacket_light", "mbag" ],
         "entries": [
+          { "item": "sneakers" },
+          { "item": "jacket_light" },
+          { "item": "mbag" },
           { "group": "charged_smart_phone" },
           { "item": "eink_tablet_pc", "contents-item": [ "battery_ups" ] },
           { "item": "mp3", "contents-item": [ "battery_ups" ] },
           { "item": "tshirt", "variant": "generic_tshirt" }
         ]
       },
-      "male": [ "briefs", "socks", "pants" ],
-      "female": [ "bra", "panties", "stockings", "skirt" ]
+      "male": { "entries": [ { "item": "briefs" }, { "item": "socks" }, { "item": "pants" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" }, { "item": "stockings" }, { "item": "skirt" } ] }
     }
   },
   {
@@ -107,20 +117,22 @@
     ],
     "skills": [ { "level": 2, "name": "melee" }, { "level": 1, "name": "firstaid" }, { "level": 1, "name": "swimming" } ],
     "items": {
-      "both": [
-        "bunker_pants",
-        "fireman_belt",
-        "bunker_coat",
-        "nomex_suit",
-        "nomex_socks",
-        "nomex_gloves",
-        "nomex_hood",
-        "boots_bunker",
-        "fire_gauntlets",
-        "firehelmet",
-        "glasses_safety",
-        "pocketwatch"
-      ]
+      "both": {
+        "entries": [
+          { "item": "bunker_pants" },
+          { "item": "fireman_belt" },
+          { "item": "bunker_coat" },
+          { "item": "nomex_suit" },
+          { "item": "nomex_socks" },
+          { "item": "nomex_gloves" },
+          { "item": "nomex_hood" },
+          { "item": "boots_bunker" },
+          { "item": "fire_gauntlets" },
+          { "item": "firehelmet" },
+          { "item": "glasses_safety" },
+          { "item": "pocketwatch" }
+        ]
+      }
     }
   },
   {
@@ -143,8 +155,13 @@
     ],
     "items": {
       "both": {
-        "items": [ "jeans", "polo_shirt", "socks", "dress_shoes", "mbag", "caffeine" ],
         "entries": [
+          { "item": "jeans" },
+          { "item": "polo_shirt" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "mbag" },
+          { "item": "caffeine" },
           { "group": "charged_smart_phone" },
           {
             "item": "light_minus_battery_cell",
@@ -154,8 +171,8 @@
           }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "missions": [ "MISSION_GAME_MASTER" ]
   },
@@ -186,29 +203,27 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "suit",
-          "bowhat",
-          "socks",
-          "dress_shoes",
-          "knit_scarf",
-          "cig",
-          "switchblade",
-          "mag_porn",
-          "sunglasses",
-          "cestus",
-          "gold_watch",
-          "gold_ring",
-          "shot_00"
-        ],
         "entries": [
+          { "item": "suit" },
+          { "item": "bowhat" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "knit_scarf" },
+          { "item": "cig" },
+          { "item": "switchblade" },
+          { "item": "mag_porn" },
+          { "item": "sunglasses" },
+          { "item": "cestus" },
+          { "item": "gold_watch" },
+          { "item": "gold_ring" },
+          { "item": "shot_00" },
           { "group": "charged_ref_lighter" },
           { "item": "glock_19", "ammo-item": "9mm", "container-item": "holster", "charges": 15 },
           { "item": "glockmag", "ammo-item": "9mm", "charges": 15 }
         ]
       },
-      "male": [ "boxer_shorts", "gold_dental_grill" ],
-      "female": [ "bra", "panties", "gold_hairpin", "gold_ear" ]
+      "male": { "entries": [ { "item": "boxer_shorts" }, { "item": "gold_dental_grill" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" }, { "item": "gold_hairpin" }, { "item": "gold_ear" } ] }
     }
   },
   {
@@ -231,11 +246,26 @@
     "skills": [ { "level": 3, "name": "dodge" } ],
     "items": {
       "both": {
-        "items": [ "dress_shoes", "dress_shirt", "knit_scarf", "platinum_watch", "blazer" ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "dress_shoes" },
+          { "item": "dress_shirt" },
+          { "item": "knit_scarf" },
+          { "item": "platinum_watch" },
+          { "item": "blazer" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "briefs", "socks", "pants", "platinum_bracelet" ],
-      "female": [ "bra", "panties", "stockings", "garter_belt", "skirt", "platinum_ear" ]
+      "male": { "entries": [ { "item": "briefs" }, { "item": "socks" }, { "item": "pants" }, { "item": "platinum_bracelet" } ] },
+      "female": {
+        "entries": [
+          { "item": "bra" },
+          { "item": "panties" },
+          { "item": "stockings" },
+          { "item": "garter_belt" },
+          { "item": "skirt" },
+          { "item": "platinum_ear" }
+        ]
+      }
     },
     "missions": [ "MISSION_ASSASSINATION" ]
   },
@@ -250,23 +280,25 @@
     "traits": [ "PROF_AUTODOC" ],
     "items": {
       "both": {
-        "items": [
-          "pants",
-          "dress_shirt",
-          "gloves_medical",
-          "socks",
-          "dress_shoes",
-          "glasses_safety",
-          "coat_lab",
-          "mbag",
+        "entries": [
+          { "item": "pants" },
+          { "item": "dress_shirt" },
+          { "item": "gloves_medical" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "glasses_safety" },
+          { "item": "coat_lab" },
+          { "item": "mbag" },
           { "item": "bandages", "count": 3 },
-          "wristwatch",
-          "stethoscope"
-        ],
-        "entries": [ { "group": "charged_cell_phone" }, { "group": "full_1st_aid" }, { "item": "anesthetic_kit", "charges": 3000 } ]
+          { "item": "wristwatch" },
+          { "item": "stethoscope" },
+          { "group": "charged_cell_phone" },
+          { "group": "full_1st_aid" },
+          { "item": "anesthetic_kit", "charges": 3000 }
+        ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -281,29 +313,27 @@
     "traits": [ "PROF_MED" ],
     "items": {
       "both": {
-        "items": [
-          "gloves_medical",
-          "socks",
-          "dress_shirt",
-          "pants",
-          "dress_shoes",
-          "coat_lab",
-          "glasses_safety",
-          "stethoscope",
-          "bfipowder",
-          "antibiotics",
-          "oxycodone",
-          "wristwatch"
-        ],
         "entries": [
+          { "item": "gloves_medical" },
+          { "item": "socks" },
+          { "item": "dress_shirt" },
+          { "item": "pants" },
+          { "item": "dress_shoes" },
+          { "item": "coat_lab" },
+          { "item": "glasses_safety" },
+          { "item": "stethoscope" },
+          { "item": "bfipowder" },
+          { "item": "antibiotics" },
+          { "item": "oxycodone" },
+          { "item": "wristwatch" },
           { "group": "charged_smart_phone" },
           { "group": "full_1st_aid" },
           { "item": "medium_battery_cell", "charges": 500 },
           { "item": "mask_dust", "variant": "white_mask_dust" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -317,11 +347,20 @@
     "no_bonus": "teleumbrella",
     "items": {
       "both": {
-        "items": [ "socks", "suit", "dress_shoes", "knit_scarf", "briefcase", "file", "teleumbrella", "citrine_gold_bracelet" ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "socks" },
+          { "item": "suit" },
+          { "item": "dress_shoes" },
+          { "item": "knit_scarf" },
+          { "item": "briefcase" },
+          { "item": "file" },
+          { "item": "teleumbrella" },
+          { "item": "citrine_gold_bracelet" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "boxer_shorts", "citrine_gold_cufflinks" ],
-      "female": [ "bra", "panties", "citrine_gold_earring" ]
+      "male": { "entries": [ { "item": "boxer_shorts" }, { "item": "citrine_gold_cufflinks" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" }, { "item": "citrine_gold_earring" } ] }
     }
   },
   {
@@ -333,11 +372,17 @@
     "CBMs": [ "bio_leukocyte", "bio_blood_anal", "bio_blood_filter", "bio_nanobots", "bio_metabolics", "bio_power_storage_mkII" ],
     "items": {
       "both": {
-        "items": [ "jeans", "socks", "sneakers", "wristwatch" ],
-        "entries": [ { "group": "charged_cell_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "jeans" },
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "wristwatch" },
+          { "group": "charged_cell_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "missions": [ "MISSION_PATIENT" ]
   },
@@ -373,20 +418,18 @@
     "proficiencies": [ "prof_fibers", "prof_fibers_rope", "prof_leatherworking", "prof_lockpicking", "prof_short_swords_familiar" ],
     "items": {
       "both": {
-        "items": [
-          "hat_boonie",
-          "gloves_fingerless",
-          "pants_cargo",
-          "socks",
-          "boots",
-          "trenchcoat",
-          "knit_scarf",
-          "backpack",
-          "canteen",
-          "wristwatch",
-          "binoculars"
-        ],
         "entries": [
+          { "item": "hat_boonie" },
+          { "item": "gloves_fingerless" },
+          { "item": "pants_cargo" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "trenchcoat" },
+          { "item": "knit_scarf" },
+          { "item": "backpack" },
+          { "item": "canteen" },
+          { "item": "wristwatch" },
+          { "item": "binoculars" },
           { "group": "charged_smart_phone" },
           { "item": "crossbow", "ammo-item": "bolt_steel", "charges": 1, "contents-item": "shoulder_strap" },
           { "item": "quiver", "contents-group": "quiver_bionic_prepper" },
@@ -394,8 +437,8 @@
           { "item": "tshirt", "variant": "generic_tshirt" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -408,21 +451,22 @@
     "CBMs": [ "bio_adrenaline", "bio_torsionratchet", "bio_power_storage_mkII", "bio_jointservo" ],
     "items": {
       "both": {
-        "items": [
-          "socks_ankle",
-          "under_armor_shorts",
-          "under_armor",
-          "shorts",
-          "lowtops",
-          "fanny",
-          "sports_drink",
-          "wristwatch",
-          "fitness_band"
-        ],
-        "entries": [ { "group": "charged_smart_phone" }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "socks_ankle" },
+          { "item": "under_armor_shorts" },
+          { "item": "under_armor" },
+          { "item": "shorts" },
+          { "item": "lowtops" },
+          { "item": "fanny" },
+          { "item": "sports_drink" },
+          { "item": "wristwatch" },
+          { "item": "fitness_band" },
+          { "group": "charged_smart_phone" },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "sports_bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -461,24 +505,22 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "jacket_army_modern",
-          "gloves_tactical",
-          "rucksack",
-          "cloak",
-          "mask_ski",
-          "socks",
-          "boots_combat",
-          "canteen",
-          "wristwatch",
-          "tent_kit",
-          "rollmat",
-          "e_tool",
-          "knife_hunting",
-          "mess_kit"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "jacket_army_modern" },
+          { "item": "gloves_tactical" },
+          { "item": "rucksack" },
+          { "item": "cloak" },
+          { "item": "mask_ski" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "canteen" },
+          { "item": "wristwatch" },
+          { "item": "tent_kit" },
+          { "item": "rollmat" },
+          { "item": "e_tool" },
+          { "item": "knife_hunting" },
+          { "item": "mess_kit" },
           { "group": "charged_two_way_radio" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "hat_boonie", "custom-flags": [ "no_auto_equip" ] },
@@ -496,8 +538,8 @@
           { "item": "tacvest", "contents-group": [ "army_mags_m2010" ] }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -534,18 +576,16 @@
     ],
     "items": {
       "both": {
-        "items": [
-          "pants_army",
-          "combat_shirt",
-          "gloves_tactical",
-          "mask_ski",
-          "tac_helmet",
-          "socks",
-          "boots_combat",
-          "wristwatch",
-          "molle_pack"
-        ],
         "entries": [
+          { "item": "pants_army" },
+          { "item": "combat_shirt" },
+          { "item": "gloves_tactical" },
+          { "item": "mask_ski" },
+          { "item": "tac_helmet" },
+          { "item": "socks" },
+          { "item": "boots_combat" },
+          { "item": "wristwatch" },
+          { "item": "molle_pack" },
           { "group": "charged_two_way_radio" },
           { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
           { "item": "sheath", "contents-item": "knife_combat" },
@@ -561,8 +601,8 @@
           { "item": "legpouch_large", "contents-group": "army_mags_m4" }
         ]
       },
-      "male": [ "boxer_shorts" ],
-      "female": [ "sports_bra", "boxer_shorts" ]
+      "male": { "entries": [ { "item": "boxer_shorts" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boxer_shorts" } ] }
     }
   },
   {
@@ -583,11 +623,17 @@
     "skills": [ { "level": 2, "name": "speech" } ],
     "items": {
       "both": {
-        "items": [ "dress_shoes", "socks", "knit_scarf", "suit", "silver_watch" ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "dress_shoes" },
+          { "item": "socks" },
+          { "item": "knit_scarf" },
+          { "item": "suit" },
+          { "item": "silver_watch" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "briefs", "emerald_silver_cufflinks" ],
-      "female": [ "bra", "panties", "emerald_silver_earring" ]
+      "male": { "entries": [ { "item": "briefs" }, { "item": "emerald_silver_cufflinks" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" }, { "item": "emerald_silver_earring" } ] }
     }
   },
   {
@@ -599,25 +645,25 @@
     "CBMs": [ "bio_batteries", "bio_power_storage", "bio_int_enhancer", "bio_memory" ],
     "items": {
       "both": {
-        "items": [
-          "dress_shirt",
-          "jacket_light",
-          "pants",
-          "socks",
-          "dress_shoes",
-          "tie_clipon",
-          "tieclip",
-          "fancy_sunglasses",
-          "knit_scarf",
-          "sf_watch",
-          "mbag",
-          "water_mineral",
-          "money_strap_twenty"
-        ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "dress_shirt" },
+          { "item": "jacket_light" },
+          { "item": "pants" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "tie_clipon" },
+          { "item": "tieclip" },
+          { "item": "fancy_sunglasses" },
+          { "item": "knit_scarf" },
+          { "item": "sf_watch" },
+          { "item": "mbag" },
+          { "item": "water_mineral" },
+          { "item": "money_strap_twenty" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "briefs", "cufflinks_intricate" ],
-      "female": [ "panties", "silver_ear" ]
+      "male": { "entries": [ { "item": "briefs" }, { "item": "cufflinks_intricate" } ] },
+      "female": { "entries": [ { "item": "panties" }, { "item": "silver_ear" } ] }
     }
   },
   {
@@ -636,15 +682,22 @@
     ],
     "items": {
       "both": {
-        "items": [ "waistcoat", "pants", "dress_shirt", "socks", "dress_shoes", "knit_scarf", "gold_watch", "diamond_ring" ],
         "entries": [
+          { "item": "waistcoat" },
+          { "item": "pants" },
+          { "item": "dress_shirt" },
+          { "item": "socks" },
+          { "item": "dress_shoes" },
+          { "item": "knit_scarf" },
+          { "item": "gold_watch" },
+          { "item": "diamond_ring" },
           { "group": "charged_smart_phone" },
           { "item": "briefcase_smg", "ammo-item": "9mm", "charges": 30 },
           { "item": "mp5mag", "ammo-item": "9mm", "charges": 30 }
         ]
       },
-      "male": [ "boxer_shorts", "diamond_gold_cufflinks" ],
-      "female": [ "bra", "boxer_shorts", "diamond_gold_earring" ]
+      "male": { "entries": [ { "item": "boxer_shorts" }, { "item": "diamond_gold_cufflinks" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "boxer_shorts" }, { "item": "diamond_gold_earring" } ] }
     }
   },
   {
@@ -666,15 +719,21 @@
     ],
     "items": {
       "both": {
-        "items": [ "socks", "jeans", "leather_belt", "boots_steel", "gloves_work", "glasses_safety", "wristwatch" ],
         "entries": [
+          { "item": "socks" },
+          { "item": "jeans" },
+          { "item": "leather_belt" },
+          { "item": "boots_steel" },
+          { "item": "gloves_work" },
+          { "item": "glasses_safety" },
+          { "item": "wristwatch" },
           { "item": "hat_hard", "variant": "yellow_hat_hard" },
           { "group": "charged_smart_phone" },
           { "item": "tshirt", "variant": "generic_tshirt" }
         ]
       },
-      "male": [ "briefs" ],
-      "female": [ "sports_bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -717,7 +776,11 @@
       "bio_trickle",
       "bio_trickle"
     ],
-    "items": { "both": [ "subsuit_xl", "footrags", "hat_noise_cancelling" ], "male": [ "briefs" ], "female": [ "bra", "panties" ] },
+    "items": {
+      "both": { "entries": [ { "item": "subsuit_xl" }, { "item": "footrags" }, { "item": "hat_noise_cancelling" } ] },
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
+    },
     "missions": [ "MISSION_BIONICS_FAULTY" ]
   },
   {
@@ -742,11 +805,21 @@
     "skills": [ { "level": 1, "name": "electronics" }, { "level": 1, "name": "firstaid" }, { "level": 1, "name": "computer" } ],
     "items": {
       "both": {
-        "items": [ "tank_top", "shorts", "socks", "lowtops", "aspirin", "pockknife", "backpack", "wristwatch" ],
-        "entries": [ { "group": "charged_cell_phone" }, { "item": "anesthetic_kit", "charges": 3000 } ]
+        "entries": [
+          { "item": "tank_top" },
+          { "item": "shorts" },
+          { "item": "socks" },
+          { "item": "lowtops" },
+          { "item": "aspirin" },
+          { "item": "pockknife" },
+          { "item": "backpack" },
+          { "item": "wristwatch" },
+          { "group": "charged_cell_phone" },
+          { "item": "anesthetic_kit", "charges": 3000 }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "camisole", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "camisole" }, { "item": "panties" } ] }
     },
     "missions": [ "MISSION_BIONICS_FAULTY" ]
   },
@@ -783,18 +856,20 @@
       { "level": 2, "name": "survival" }
     ],
     "items": {
-      "both": [
-        "tank_top",
-        "shorts_cargo",
-        "footrags",
-        "gloves_wraps",
-        "hat_cotton",
-        "bandana",
-        "hat_noise_cancelling",
-        "wristwatch"
-      ],
-      "male": [ "briefs" ],
-      "female": [ "panties" ]
+      "both": {
+        "entries": [
+          { "item": "tank_top" },
+          { "item": "shorts_cargo" },
+          { "item": "footrags" },
+          { "item": "gloves_wraps" },
+          { "item": "hat_cotton" },
+          { "item": "bandana" },
+          { "item": "hat_noise_cancelling" },
+          { "item": "wristwatch" }
+        ]
+      },
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "panties" } ] }
     },
     "missions": [ "MISSION_BIONICS_FAULTY" ]
   },
@@ -815,11 +890,17 @@
     ],
     "items": {
       "both": {
-        "items": [ "socks", "sneakers", "jeans", "wristwatch" ],
-        "entries": [ { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] }, { "item": "tshirt", "variant": "generic_tshirt" } ]
+        "entries": [
+          { "item": "socks" },
+          { "item": "sneakers" },
+          { "item": "jeans" },
+          { "item": "wristwatch" },
+          { "item": "ear_plugs", "custom-flags": [ "no_auto_equip" ] },
+          { "item": "tshirt", "variant": "generic_tshirt" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     },
     "missions": [ "MISSION_BIONICS_FAULTY" ]
   },
@@ -833,11 +914,18 @@
     "skills": [ { "level": 2, "name": "computer" } ],
     "items": {
       "both": {
-        "items": [ "jumpsuit", "socks", "boots", "wristwatch", "mbag" ],
-        "entries": [ { "group": "charged_cell_phone" }, { "group": "toy_radio_car" } ]
+        "entries": [
+          { "item": "jumpsuit" },
+          { "item": "socks" },
+          { "item": "boots" },
+          { "item": "wristwatch" },
+          { "item": "mbag" },
+          { "group": "charged_cell_phone" },
+          { "group": "toy_radio_car" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "bra", "panties" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "bra" }, { "item": "panties" } ] }
     }
   },
   {
@@ -851,11 +939,20 @@
     "proficiencies": [ "prof_unarmed_familiar", "prof_claws_familiar", "prof_bionics_familiar" ],
     "items": {
       "both": {
-        "items": [ "socks", "tank_top", "jacket_leather", "pants_leather", "boots", "gloves_fingerless", "wristwatch", "gum" ],
-        "entries": [ { "group": "charged_smart_phone" } ]
+        "entries": [
+          { "item": "socks" },
+          { "item": "tank_top" },
+          { "item": "jacket_leather" },
+          { "item": "pants_leather" },
+          { "item": "boots" },
+          { "item": "gloves_fingerless" },
+          { "item": "wristwatch" },
+          { "item": "gum" },
+          { "group": "charged_smart_phone" }
+        ]
       },
-      "male": [ "briefs" ],
-      "female": [ "sports_bra", "boy_shorts", "ruby_gold_earring" ]
+      "male": { "entries": [ { "item": "briefs" } ] },
+      "female": { "entries": [ { "item": "sports_bra" }, { "item": "boy_shorts" }, { "item": "ruby_gold_earring" } ] }
     }
   }
 ]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
After helping with #70376, i found that ~~itemgroups are terrible~~ we handle itemgroups in very confusing manner, using three different field interchangeably, mixing different stuff up, and overall a lot of stuff works in not obvious ways

While i can't fix it on a global level, by simplifying itemgroup syntax and unifying it, i decided at least unify the itemgroups in profession
#### Describe the solution
Now itemgroups in profs are not divided between `items` and `entries`, but always use `entries` with advanced syntax
#### Testing
Made a world with most mods, checked profession so they actually give items they should, looks good for me
#### Additional context
We probably need to make some generic clothing groups and use them instead of specifying briefs and panties manually for each prof