### PR TITLE
Remove uniform submap branching

### DIFF
--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4747,7 +4747,7 @@ void submap::store( JsonOut &jsout ) const
     jsout.member( "terrain" );
     jsout.start_array();
     if( is_uniform() ) {
-        _write_rle_terrain( jsout, uniform_ter.id().str(), SEEX * SEEY );
+        _write_rle_terrain( jsout, m->ter[0][0].id().str(), SEEX * SEEY );
         jsout.end_array();
         return;
     }
@@ -4978,26 +4978,26 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
                     const ter_str_id tid( terrain_json.next_string() );
 
                     if( tid == ter_t_rubble ) {
-                        m->ter[i][j] = ter_id( "t_dirt" );
-                        m->frn[i][j] = furn_id( "f_rubble" );
-                        m->itm[i][j].insert( rock );
-                        m->itm[i][j].insert( rock );
+                        owned_m->ter[i][j] = ter_id( "t_dirt" );
+                        owned_m->frn[i][j] = furn_id( "f_rubble" );
+                        owned_m->itm[i][j].insert( rock );
+                        owned_m->itm[i][j].insert( rock );
                     } else if( tid == ter_t_wreckage ) {
-                        m->ter[i][j] = ter_id( "t_dirt" );
-                        m->frn[i][j] = furn_id( "f_wreckage" );
-                        m->itm[i][j].insert( chunk );
-                        m->itm[i][j].insert( chunk );
+                        owned_m->ter[i][j] = ter_id( "t_dirt" );
+                        owned_m->frn[i][j] = furn_id( "f_wreckage" );
+                        owned_m->itm[i][j].insert( chunk );
+                        owned_m->itm[i][j].insert( chunk );
                     } else if( tid == ter_t_ash ) {
-                        m->ter[i][j] = ter_id( "t_dirt" );
-                        m->frn[i][j] = furn_id( "f_ash" );
+                        owned_m->ter[i][j] = ter_id( "t_dirt" );
+                        owned_m->frn[i][j] = furn_id( "f_ash" );
                     } else if( tid == ter_t_pwr_sb_support_l ) {
-                        m->ter[i][j] = ter_id( "t_support_l" );
+                        owned_m->ter[i][j] = ter_id( "t_support_l" );
                     } else if( tid == ter_t_pwr_sb_switchgear_l ) {
-                        m->ter[i][j] = ter_id( "t_switchgear_l" );
+                        owned_m->ter[i][j] = ter_id( "t_switchgear_l" );
                     } else if( tid == ter_t_pwr_sb_switchgear_s ) {
-                        m->ter[i][j] = ter_id( "t_switchgear_s" );
+                        owned_m->ter[i][j] = ter_id( "t_switchgear_s" );
                     } else {
-                        m->ter[i][j] = tid.id();
+                        owned_m->ter[i][j] = tid.id();
                     }
                 }
             }
@@ -5037,7 +5037,7 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
                     } else {
                         --remaining;
                     }
-                    m->ter[i][j] = iid;
+                    owned_m->ter[i][j] = iid;
                 }
             }
             if( remaining ) {
@@ -5062,7 +5062,7 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
         for( JsonArray furniture_entry : furniture_json ) {
             int i = furniture_entry.next_int();
             int j = furniture_entry.next_int();
-            m->frn[i][j] = furn_id( furniture_entry.next_string() );
+            owned_m->frn[i][j] = furn_id( furniture_entry.next_string() );
             if( furniture_entry.size() > 3 ) {
                 furniture_entry.throw_error( "Too many values for furniture entry." );
             }
@@ -5074,11 +5074,11 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
             int j = items_json.next_int();
             const point p( i, j );
 
-            if( !items_json.next_value().read( m->itm[p.x][p.y], false ) ) {
+            if( !items_json.next_value().read( owned_m->itm[p.x][p.y], false ) ) {
                 debugmsg( "Items array is corrupt in submap at: %s, skipping", p.to_string() );
             }
             // some portion could've been read even if error occurred
-            for( item &it : m->itm[p.x][p.y] ) {
+            for( item &it : owned_m->itm[p.x][p.y] ) {
                 if( it.is_emissive() ) {
                     update_lum_add( p, it );
                 }
@@ -5093,7 +5093,7 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
             const point p( i, j );
             // TODO: jsin should support returning an id like jsin.get_id<trap>()
             const trap_str_id trid( trap_entry.next_string() );
-            m->trp[p.x][p.y] = trid.id();
+            owned_m->trp[p.x][p.y] = trid.id();
             if( trap_entry.size() > 3 ) {
                 trap_entry.throw_error( "Too many values for trap entry" );
             }
@@ -5123,7 +5123,7 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
                 } else {
                     ft = field_types::get_field_type_by_legacy_enum( type_int ).id;
                 }
-                if( m->fld[i][j].add_field( ft, intensity, time_duration::from_turns( age ) ) ) {
+                if( owned_m->fld[i][j].add_field( ft, intensity, time_duration::from_turns( age ) ) ) {
                     field_count++;
                 }
             }

--- a/src/submap.h
+++ b/src/submap.h
@@ -58,8 +58,8 @@ struct maptile_soa {
     // This returns a shared uniform maptile constructed with the given ter_id.
     static const maptile_soa *make_uniform( const ter_id &id );
 
-    explicit maptile_soa( const ter_id &id ) : ter( id ), frn( f_null ), lum( 0 ), itm(), fld(),
-        trp( tr_null ), rad( 0 ) {}
+    explicit maptile_soa( const ter_id &id ) : ter( id ), frn( f_null ), lum( 0 ), trp( tr_null ),
+        rad( 0 ) {}
 
     cata::mdarray<ter_id, point_sm_ms>             ter; // Terrain on each square
     cata::mdarray<furn_id, point_sm_ms>            frn; // Furniture on each square

--- a/src/submap.h
+++ b/src/submap.h
@@ -175,7 +175,10 @@ class submap
 
         // TODO: Replace this as it essentially makes itm public
         cata::colony<item> &get_items( const point &p ) {
-            ensure_nonuniform();
+            if( is_uniform() ) {
+                cata::colony<item> static noitems;
+                return noitems;
+            }
             return owned_m->itm[p.x][p.y];
         }
 
@@ -185,7 +188,10 @@ class submap
 
         // TODO: Replace this as it essentially makes fld public
         field &get_field( const point &p ) {
-            ensure_nonuniform();
+            if( is_uniform() ) {
+                field static nofield;
+                return nofield;
+            }
             return owned_m->fld[p.x][p.y];
         }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Remove branching in submap accessors."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

See issue #70399
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Make uniform submaps point to a shared pre-filled submap, instead of having it be a special case. I'm not expecting any large performance changes from this alone, it's just easy to deliver in a PR separate from other tasks.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

I did not change the get_items/get_fields non-const accessors since their behavior is somewhat odd, and has the potential to break things. They should be revisited (and removed) in a future PR.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

All tests pass.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
