### PR TITLE
fix 2000 bags with 1 sand

### DIFF
--- a/data/json/itemgroups/supplies.json
+++ b/data/json/itemgroups/supplies.json
@@ -55,32 +55,38 @@
   {
     "id": "sandbag",
     "type": "item_group",
-    "items": [ { "item": "material_sand", "count": 2000, "container-item": "bag_durasack" } ]
+    "container-item": "bag_durasack",
+    "items": [ { "item": "material_sand", "count": 2000 } ]
   },
   {
     "id": "sandbag_part",
     "type": "item_group",
-    "items": [ { "item": "material_sand", "count": [ 400, 1500 ], "container-item": "bag_durasack" } ]
+    "container-item": "bag_durasack",
+    "items": [ { "item": "material_sand", "count": [ 400, 1500 ] } ]
   },
   {
     "id": "gravelbag",
     "type": "item_group",
-    "items": [ { "item": "material_gravel", "count": 2000, "container-item": "bag_durasack" } ]
+    "container-item": "bag_durasack",
+    "items": [ { "item": "material_gravel", "count": 2000 } ]
   },
   {
     "id": "gravelbag_part",
     "type": "item_group",
-    "items": [ { "item": "material_gravel", "count": [ 400, 1500 ], "container-item": "bag_durasack" } ]
+    "container-item": "bag_durasack",
+    "items": [ { "item": "material_gravel", "count": [ 400, 1500 ] } ]
   },
   {
     "id": "earthbag",
     "type": "item_group",
-    "items": [ { "item": "material_soil", "count": 3, "container-item": "bag_durasack" } ]
+    "container-item": "bag_durasack",
+    "items": [ { "item": "material_soil", "count": 3 } ]
   },
   {
     "id": "earthbag_part",
     "type": "item_group",
-    "items": [ { "item": "material_soil", "count": [ 1, 2 ], "container-item": "bag_durasack" } ]
+    "container-item": "bag_durasack",
+    "items": [ { "item": "material_soil", "count": [ 1, 2 ] } ]
   },
   {
     "id": "paintcans",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
after #70370 it was revealed that itemgroup was made incorrectly, and spawned 2000 bags with 1 sand instead of 1 bag with 2000 sand
fix #70435
#### Describe the solution
Swap the placement of container-item
#### Testing
Smashed sandbag wall, spawns 20 bags as expected