### PR TITLE
Added a pocket for photographs to lockets.

### DIFF
--- a/data/json/items/armor/jewelry.json
+++ b/data/json/items/armor/jewelry.json
@@ -346,6 +346,16 @@
     "symbol": "[",
     "looks_like": "silver_necklace",
     "color": "brown",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "holster": true,
+        "max_contains_weight": "12 mg",
+        "max_contains_volume": "1 ml",
+        "description": "Slot for a photograph",
+        "item_restriction": [ "wallet_photo" ]
+      }
+    ],
     "flags": [ "NO_WEAR_EFFECT" ]
   },
   {
@@ -917,6 +927,16 @@
     "material": [ "gold" ],
     "symbol": "[",
     "color": "yellow",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "holster": true,
+        "max_contains_weight": "12 mg",
+        "max_contains_volume": "1 ml",
+        "description": "Slot for a photograph",
+        "item_restriction": [ "wallet_photo" ]
+      }
+    ],
     "flags": [ "FANCY", "NO_WEAR_EFFECT" ]
   },
   {
@@ -1624,6 +1644,16 @@
     "material": [ "platinum" ],
     "symbol": "[",
     "color": "white",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "holster": true,
+        "max_contains_weight": "12 mg",
+        "max_contains_volume": "1 ml",
+        "description": "Slot for a photograph",
+        "item_restriction": [ "wallet_photo" ]
+      }
+    ],
     "flags": [ "FANCY", "NO_WEAR_EFFECT" ]
   },
   {
@@ -1794,6 +1824,16 @@
     "material": [ "silver" ],
     "symbol": "[",
     "color": "light_gray",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "holster": true,
+        "max_contains_weight": "12 mg",
+        "max_contains_volume": "1 ml",
+        "description": "Slot for a photograph",
+        "item_restriction": [ "wallet_photo" ]
+      }
+    ],
     "flags": [ "FANCY", "NO_WEAR_EFFECT" ]
   },
   {


### PR DESCRIPTION
#### Summary
Content "Lockets can store photographs"


#### Purpose of change

Had this thought when I looked at the description of the lockets, and compared the size of a photo to the size of one I was wearing ingame. Just made sense to me.

#### Describe the solution

All 4 locket types have a pocket that's just big enough to stick a photograph in.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
