### PR TITLE
Banish SDL_main

### DIFF
--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_SDL_WRAPPERS_H
 #define CATA_SRC_SDL_WRAPPERS_H
 
+#define SDL_MAIN_HANDLED
 // IWYU pragma: begin_exports
 #if defined(_MSC_VER) && defined(USE_VCPKG)
 #   include <SDL2/SDL.h>


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
So it appears our main function worked only because we never directly or indirectly included `SDL.h` in `test_main.cpp`. With `SDL.h` included, the main function is renamed to `SDL_main`, which in the process also changed the linkage of the function to c++, which does not match the declaration in `SDL.h`, causing the error in #70415.

Fixes #70415.

#### Describe the solution
Define `SDL_MAIN_HANDLED` before including SDL headers as suggested by @ZhilkinSerg in #70415.

#### Describe alternatives you've considered


#### Testing
If my theory is correct it should fix the error in the CI.

#### Additional context
