### PR TITLE
Add `resolved_id<T>` to represent IDs that are already resolved.

### DIFF
--- a/src/achievement.cpp
+++ b/src/achievement.cpp
@@ -402,7 +402,7 @@ void achievement::load_achievement( const JsonObject &jo, const std::string &src
 
 void achievement::finalize()
 {
-    for( achievement &a : const_cast<std::vector<achievement>&>( achievement::get_all() ) ) {
+    for( achievement &a : const_cast<std::deque<achievement>&>( achievement::get_all() ) ) {
         for( achievement_requirement &req : a.requirements_ ) {
             req.finalize();
         }
@@ -414,7 +414,7 @@ void achievement::check_consistency()
     achievement_factory.check();
 }
 
-const std::vector<achievement> &achievement::get_all()
+const std::deque<achievement> &achievement::get_all()
 {
     return achievement_factory.get_all();
 }

--- a/src/achievement.h
+++ b/src/achievement.h
@@ -66,7 +66,7 @@ class achievement
         static void load_achievement( const JsonObject &, const std::string & );
         static void finalize();
         static void check_consistency();
-        static const std::vector<achievement> &get_all();
+        static const std::deque<achievement> &get_all();
         static void reset();
 
         achievement_id id;

--- a/src/achievement.h
+++ b/src/achievement.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_ACHIEVEMENT_H
 
 #include <array>
+#include <deque>
 #include <functional>
 #include <iosfwd>
 #include <memory>

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1215,10 +1215,10 @@ void hacksaw_activity_actor::start( player_activity &act, Character &/*who*/ )
     int moves_before_quality;
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const resolved_furn_id furn_type = here.furn( target );
         if( !furn_type->hacksaw->valid() ) {
             if( !testing ) {
-                debugmsg( "%s hacksaw is invalid", furn_type.id().str() );
+                debugmsg( "%s hacksaw is invalid", furn_type->id.str() );
             }
             act.set_to_null();
             return;
@@ -1226,10 +1226,10 @@ void hacksaw_activity_actor::start( player_activity &act, Character &/*who*/ )
 
         moves_before_quality = to_moves<int>( furn_type->hacksaw->duration() );
     } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+        const resolved_ter_id ter_type = here.ter( target );
         if( !ter_type->hacksaw->valid() ) {
             if( !testing ) {
-                debugmsg( "%s hacksaw is invalid", ter_type.id().str() );
+                debugmsg( "%s hacksaw is invalid", ter_type->id.str() );
             }
             act.set_to_null();
             return;
@@ -1295,10 +1295,10 @@ void hacksaw_activity_actor::finish( player_activity &act, Character &who )
     const activity_data_common *data;
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const resolved_furn_id furn_type = here.furn( target );
         if( !furn_type->hacksaw->valid() ) {
             if( !testing ) {
-                debugmsg( "%s hacksaw is invalid", furn_type.id().str() );
+                debugmsg( "%s hacksaw is invalid", furn_type->id.str() );
             }
             act.set_to_null();
             return;
@@ -1316,10 +1316,10 @@ void hacksaw_activity_actor::finish( player_activity &act, Character &who )
         data = static_cast<const activity_data_common *>( &*furn_type->hacksaw );
         here.furn_set( target, new_furn );
     } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+        const resolved_ter_id ter_type = here.ter( target );
         if( !ter_type->hacksaw->valid() ) {
             if( !testing ) {
-                debugmsg( "%s hacksaw is invalid", ter_type.id().str() );
+                debugmsg( "%s hacksaw is invalid", ter_type->id.str() );
             }
             act.set_to_null();
             return;
@@ -2253,10 +2253,10 @@ void boltcutting_activity_actor::start( player_activity &act, Character &/*who*/
     const map &here = get_map();
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const resolved_furn_id furn_type = here.furn( target );
         if( !furn_type->boltcut->valid() ) {
             if( !testing ) {
-                debugmsg( "%s boltcut is invalid", furn_type.id().str() );
+                debugmsg( "%s boltcut is invalid", furn_type->id.str() );
             }
             act.set_to_null();
             return;
@@ -2264,10 +2264,10 @@ void boltcutting_activity_actor::start( player_activity &act, Character &/*who*/
 
         act.moves_total = to_moves<int>( furn_type->boltcut->duration() );
     } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+        const resolved_ter_id ter_type = here.ter( target );
         if( !ter_type->boltcut->valid() ) {
             if( !testing ) {
-                debugmsg( "%s boltcut is invalid", ter_type.id().str() );
+                debugmsg( "%s boltcut is invalid", ter_type->id.str() );
             }
             act.set_to_null();
             return;
@@ -2306,10 +2306,10 @@ void boltcutting_activity_actor::finish( player_activity &act, Character &who )
     const activity_data_common *data;
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const resolved_furn_id furn_type = here.furn( target );
         if( !furn_type->boltcut->valid() ) {
             if( !testing ) {
-                debugmsg( "%s boltcut is invalid", furn_type.id().str() );
+                debugmsg( "%s boltcut is invalid", furn_type->id.str() );
             }
             act.set_to_null();
             return;
@@ -2327,10 +2327,10 @@ void boltcutting_activity_actor::finish( player_activity &act, Character &who )
         data = static_cast<const activity_data_common *>( &*furn_type->boltcut );
         here.furn_set( target, new_furn );
     } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+        const resolved_ter_id ter_type = here.ter( target );
         if( !ter_type->boltcut->valid() ) {
             if( !testing ) {
-                debugmsg( "%s boltcut is invalid", ter_type.id().str() );
+                debugmsg( "%s boltcut is invalid", ter_type->id.str() );
             }
             act.set_to_null();
             return;
@@ -2454,8 +2454,8 @@ void lockpick_activity_actor::finish( player_activity &act, Character &who )
 
     map &here = get_map();
     const tripoint target = here.getlocal( this->target );
-    const ter_id ter_type = here.ter( target );
-    const furn_id furn_type = here.furn( target );
+    const resolved_ter_id ter_type = here.ter( target );
+    const resolved_furn_id furn_type = here.furn( target );
     optional_vpart_position const veh = here.veh_at( target );
     int locked_part = -1;
     ter_id new_ter_type;
@@ -2621,7 +2621,7 @@ std::optional<tripoint> lockpick_activity_actor::select_location( avatar &you )
         return target;
     }
 
-    const ter_id terr_type = get_map().ter( *target );
+    const resolved_ter_id terr_type = get_map().ter( *target );
     if( *target == you.pos() ) {
         you.add_msg_if_player( m_info, _( "You pick your nose and your sinuses swing open." ) );
     } else if( get_creature_tracker().creature_at<npc>( *target ) ) {
@@ -3950,7 +3950,7 @@ void harvest_activity_actor::start( player_activity &act, Character &who )
     map &here = get_map();
 
     if( here.has_furn( target ) ) {
-        const furn_id furn = here.furn( target );
+        const resolved_furn_id furn = here.furn( target );
 
         if( furn->has_examine( iexamine::harvest_furn ) ) {
             exam_furn = true;
@@ -5004,10 +5004,10 @@ void oxytorch_activity_actor::start( player_activity &act, Character &/*who*/ )
     const map &here = get_map();
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const resolved_furn_id furn_type = here.furn( target );
         if( !furn_type->oxytorch->valid() ) {
             if( !testing ) {
-                debugmsg( "%s oxytorch is invalid", furn_type.id().str() );
+                debugmsg( "%s oxytorch is invalid", furn_type->id.str() );
             }
             act.set_to_null();
             return;
@@ -5015,10 +5015,10 @@ void oxytorch_activity_actor::start( player_activity &act, Character &/*who*/ )
 
         act.moves_total = to_moves<int>( furn_type->oxytorch->duration() );
     } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+        const resolved_ter_id ter_type = here.ter( target );
         if( !ter_type->oxytorch->valid() ) {
             if( !testing ) {
-                debugmsg( "%s oxytorch is invalid", ter_type.id().str() );
+                debugmsg( "%s oxytorch is invalid", ter_type->id.str() );
             }
             act.set_to_null();
             return;
@@ -5061,10 +5061,10 @@ void oxytorch_activity_actor::finish( player_activity &act, Character &who )
     const activity_data_common *data;
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const resolved_furn_id furn_type = here.furn( target );
         if( !furn_type->oxytorch->valid() ) {
             if( !testing ) {
-                debugmsg( "%s oxytorch is invalid", furn_type.id().str() );
+                debugmsg( "%s oxytorch is invalid", furn_type->id.str() );
             }
             act.set_to_null();
             return;
@@ -5082,10 +5082,10 @@ void oxytorch_activity_actor::finish( player_activity &act, Character &who )
         data = static_cast<const activity_data_common *>( &*furn_type->oxytorch );
         here.furn_set( target, new_furn );
     } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+        const resolved_ter_id ter_type = here.ter( target );
         if( !ter_type->oxytorch->valid() ) {
             if( !testing ) {
-                debugmsg( "%s oxytorch is invalid", ter_type.id().str() );
+                debugmsg( "%s oxytorch is invalid", ter_type->id.str() );
             }
             act.set_to_null();
             return;
@@ -5374,10 +5374,10 @@ void prying_activity_actor::start( player_activity &act, Character &who )
     const map &here = get_map();
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const resolved_furn_id furn_type = here.furn( target );
         if( !furn_type->prying->valid() ) {
             if( !testing ) {
-                debugmsg( "%s prying is invalid", furn_type.id().str() );
+                debugmsg( "%s prying is invalid", furn_type->id.str() );
             }
             act.set_to_null();
             return;
@@ -5387,10 +5387,10 @@ void prying_activity_actor::start( player_activity &act, Character &who )
         act.moves_total = to_moves<int>(
                               prying_time( *furn_type->prying, tool, who ) );
     } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+        const resolved_ter_id ter_type = here.ter( target );
         if( !ter_type->prying->valid() ) {
             if( !testing ) {
-                debugmsg( "%s prying is invalid", ter_type.id().str() );
+                debugmsg( "%s prying is invalid", ter_type->id.str() );
             }
             act.set_to_null();
             return;
@@ -5487,10 +5487,10 @@ void prying_activity_actor::handle_prying( Character &who )
     };
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const resolved_furn_id furn_type = here.furn( target );
         if( !furn_type->prying->valid() ) {
             if( !testing ) {
-                debugmsg( "%s prying is invalid", furn_type.id().str() );
+                debugmsg( "%s prying is invalid", furn_type->id.str() );
             }
             return;
         }
@@ -5511,10 +5511,10 @@ void prying_activity_actor::handle_prying( Character &who )
 
         here.furn_set( target, new_furn );
     } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+        const resolved_ter_id ter_type = here.ter( target );
         if( !ter_type->prying->valid() ) {
             if( !testing ) {
-                debugmsg( "%s prying is invalid", ter_type.id().str() );
+                debugmsg( "%s prying is invalid", ter_type->id.str() );
             }
             return;
         }
@@ -5576,10 +5576,10 @@ void prying_activity_actor::handle_prying_nails( Character &who )
     const activity_data_common *data;
 
     if( here.has_furn( target ) ) {
-        const furn_id furn_type = here.furn( target );
+        const resolved_furn_id furn_type = here.furn( target );
         if( !furn_type->prying->valid() ) {
             if( !testing ) {
-                debugmsg( "%s prying is invalid", furn_type.id().str() );
+                debugmsg( "%s prying is invalid", furn_type->id.str() );
             }
             return;
         }
@@ -5595,10 +5595,10 @@ void prying_activity_actor::handle_prying_nails( Character &who )
         data = static_cast<const activity_data_common *>( &*furn_type->prying );
         here.furn_set( target, new_furn );
     } else if( !here.ter( target )->is_null() ) {
-        const ter_id ter_type = here.ter( target );
+        const resolved_ter_id ter_type = here.ter( target );
         if( !ter_type->prying->valid() ) {
             if( !testing ) {
-                debugmsg( "%s prying is invalid", ter_type.id().str() );
+                debugmsg( "%s prying is invalid", ter_type->id.str() );
             }
             return;
         }

--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -824,11 +824,11 @@ construction const *_find_prereq( tripoint_bub_ms const &loc, construction_id co
 bool already_done( construction const &build, tripoint_bub_ms const &loc )
 {
     map &here = get_map();
-    const furn_id furn = here.furn( loc );
-    const ter_id ter = here.ter( loc );
+    const resolved_furn_id furn = here.furn( loc );
+    const resolved_ter_id ter = here.ter( loc );
     return !build.post_terrain.empty() &&
-           ( ( !build.post_is_furniture && ter_id( build.post_terrain ) == ter ) ||
-             ( build.post_is_furniture && furn_id( build.post_terrain ) == furn ) );
+           ( ( !build.post_is_furniture && resolved_ter_id( build.post_terrain ) == ter ) ||
+             ( build.post_is_furniture && resolved_furn_id( build.post_terrain ) == furn ) );
 }
 
 } // namespace
@@ -2448,7 +2448,7 @@ static bool chop_tree_activity( Character &you, const tripoint_bub_ms &src_loc )
         you.consume_charges( best_qual, best_qual.type->charges_to_use() );
     }
     map &here = get_map();
-    const ter_id ter = here.ter( src_loc );
+    const resolved_ter_id ter = here.ter( src_loc );
     if( here.has_flag( ter_furn_flag::TFLAG_TREE, src_loc ) ) {
         you.assign_activity( chop_tree_activity_actor( moves, item_location( you, &best_qual ) ) );
         you.activity.placement = here.getglobal( src_loc );
@@ -2644,7 +2644,7 @@ static std::unordered_set<tripoint_abs_ms> generic_multi_activity_locations(
             continue;
         }
         if( act_id == ACT_MULTIPLE_FISH ) {
-            const ter_id terrain_id = here.ter( set_pt );
+            const resolved_ter_id terrain_id = here.ter( set_pt );
             if( !terrain_id.obj().has_flag( ter_furn_flag::TFLAG_DEEP_WATER ) ) {
                 it2 = src_set.erase( it2 );
             } else {

--- a/src/addiction.cpp
+++ b/src/addiction.cpp
@@ -51,7 +51,7 @@ void add_type::reset()
     add_type_factory.reset();
 }
 
-const std::vector<add_type> &add_type::get_all()
+const std::deque<add_type> &add_type::get_all()
 {
     return add_type_factory.get_all();
 }

--- a/src/addiction.h
+++ b/src/addiction.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_ADDICTION_H
 #define CATA_SRC_ADDICTION_H
 
+#include <deque>
 #include <iosfwd>
 
 #include "calendar.h"

--- a/src/addiction.h
+++ b/src/addiction.h
@@ -28,7 +28,7 @@ struct add_type {
         static void reset();
         static void check_add_types();
         void load( const JsonObject &jo, std::string_view src );
-        static const std::vector<add_type> &get_all();
+        static const std::deque<add_type> &get_all();
 
         const translation &get_name() const {
             return _name;

--- a/src/ammo_effect.cpp
+++ b/src/ammo_effect.cpp
@@ -169,7 +169,7 @@ void ammo_effects::reset()
     get_all_ammo_effects().reset();
 }
 
-const std::vector<ammo_effect> &ammo_effects::get_all()
+const std::deque<ammo_effect> &ammo_effects::get_all()
 {
     return get_all_ammo_effects().get_all();
 }

--- a/src/ammo_effect.h
+++ b/src/ammo_effect.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_AMMO_EFFECT_H
 
 #include <cstddef>
+#include <deque>
 #include <iosfwd>
 #include <string>
 #include <vector>

--- a/src/ammo_effect.h
+++ b/src/ammo_effect.h
@@ -64,7 +64,7 @@ void finalize_all();
 void check_consistency();
 void reset();
 
-const std::vector<ammo_effect> &get_all();
+const std::deque<ammo_effect> &get_all();
 
 } // namespace ammo_effects
 

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -913,27 +913,27 @@ void game::draw_radiation_override( const tripoint &, const int )
 #endif
 
 #if defined(TILES)
-void game::draw_terrain_override( const tripoint &p, const ter_id &id )
+void game::draw_terrain_override( const tripoint &p, const resolved_ter_id &id )
 {
     if( use_tiles ) {
         tilecontext->init_draw_terrain_override( p, id );
     }
 }
 #else
-void game::draw_terrain_override( const tripoint &, const ter_id & )
+void game::draw_terrain_override( const tripoint &, const resolved_ter_id & )
 {
 }
 #endif
 
 #if defined(TILES)
-void game::draw_furniture_override( const tripoint &p, const furn_id &id )
+void game::draw_furniture_override( const tripoint &p, const resolved_furn_id &id )
 {
     if( use_tiles ) {
         tilecontext->init_draw_furniture_override( p, id );
     }
 }
 #else
-void game::draw_furniture_override( const tripoint &, const furn_id & )
+void game::draw_furniture_override( const tripoint &, const resolved_furn_id & )
 {
 }
 #endif

--- a/src/avatar.cpp
+++ b/src/avatar.cpp
@@ -1893,8 +1893,8 @@ void avatar::try_to_sleep( const time_duration &dur )
     map &here = get_map();
     const optional_vpart_position vp = here.veh_at( pos() );
     const trap &trap_at_pos = here.tr_at( pos() );
-    const ter_id ter_at_pos = here.ter( pos() );
-    const furn_id furn_at_pos = here.furn( pos() );
+    const resolved_ter_id ter_at_pos = here.ter( pos() );
+    const resolved_furn_id furn_at_pos = here.furn( pos() );
     bool plantsleep = false;
     bool fungaloid_cosplay = false;
     bool websleep = false;

--- a/src/avatar.h
+++ b/src/avatar.h
@@ -66,7 +66,7 @@ struct monster_visible_info {
     // 6 8 2    0-7 are provide by direction_from()
     // 5 4 3    8 is used for local monsters (for when we explain them below)
     std::array<std::vector<npc *>, 9> unique_types;
-    std::array<std::vector<std::pair<const mtype *, int>>, 9> unique_mons;
+    std::array<std::vector<std::pair<mtype_id, int>>, 9> unique_mons;
 
     // If the monster visible in this direction is dangerous
     std::array<bool, 8> dangerous = {};

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -487,7 +487,7 @@ void bionic_data::finalize_bionic()
     bionic_factory.finalize();
 }
 
-const std::vector<bionic_data> &bionic_data::get_all()
+const std::deque<bionic_data> &bionic_data::get_all()
 {
     return bionic_factory.get_all();
 }

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -193,7 +193,7 @@ struct bionic_data {
     void finalize();
     static void load_bionic( const JsonObject &jo, const std::string &src );
     static void finalize_bionic();
-    static const std::vector<bionic_data> &get_all();
+    static const std::deque<bionic_data> &get_all();
     static void check_bionic_consistency();
 
     static std::map<bionic_id, bionic_id> migrations;

--- a/src/bionics.h
+++ b/src/bionics.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_BIONICS_H
 
 #include <cstddef>
+#include <deque>
 #include <iosfwd>
 #include <map>
 #include <new>

--- a/src/bodygraph.cpp
+++ b/src/bodygraph.cpp
@@ -45,7 +45,7 @@ void bodygraph::reset()
     bodygraph_factory.reset();
 }
 
-const std::vector<bodygraph> &bodygraph::get_all()
+const std::deque<bodygraph> &bodygraph::get_all()
 {
     return bodygraph_factory.get_all();
 }

--- a/src/bodygraph.h
+++ b/src/bodygraph.h
@@ -57,7 +57,7 @@ struct bodygraph {
     static void finalize_all();
     static void check_all();
     static void reset();
-    static const std::vector<bodygraph> &get_all();
+    static const std::deque<bodygraph> &get_all();
     void load( const JsonObject &jo, std::string_view src );
     void finalize();
     void check() const;

--- a/src/bodygraph.h
+++ b/src/bodygraph.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_BODYGRAPH_H
 #define CATA_SRC_BODYGRAPH_H
 
+#include <deque>
 #include <vector>
 
 #include "color.h"

--- a/src/bodypart.cpp
+++ b/src/bodypart.cpp
@@ -149,7 +149,7 @@ void limb_score::reset()
     limb_score_factory.reset();
 }
 
-const std::vector<limb_score> &limb_score::get_all()
+const std::deque<limb_score> &limb_score::get_all()
 {
     return limb_score_factory.get_all();
 }
@@ -276,7 +276,7 @@ sub_bodypart_id body_part_type::random_sub_part( bool secondary ) const
     return sub_bodypart_id();
 }
 
-const std::vector<body_part_type> &body_part_type::get_all()
+const std::deque<body_part_type> &body_part_type::get_all()
 {
     return body_part_factory.get_all();
 }

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -112,7 +112,7 @@ struct limb_score {
         static void load_limb_scores( const JsonObject &jo, const std::string &src );
         static void reset();
         void load( const JsonObject &jo, std::string_view src );
-        static const std::vector<limb_score> &get_all();
+        static const std::deque<limb_score> &get_all();
 
         const limb_score_id &getId() const {
             return id;
@@ -342,7 +342,7 @@ struct body_part_type {
         void check() const;
 
         static void load_bp( const JsonObject &jo, const std::string &src );
-        static const std::vector<body_part_type> &get_all();
+        static const std::deque<body_part_type> &get_all();
 
         // Clears all bps
         static void reset();

--- a/src/bodypart.h
+++ b/src/bodypart.h
@@ -5,6 +5,7 @@
 #include <array>
 #include <climits>
 #include <cstddef>
+#include <deque>
 #include <initializer_list>
 #include <iosfwd>
 #include <set>

--- a/src/build_reqs.h
+++ b/src/build_reqs.h
@@ -40,6 +40,6 @@ struct parameterized_build_reqs {
 
 build_reqs get_build_reqs_for_furn_ter_ids(
     const std::pair<std::map<ter_id, int>, std::map<furn_id, int>> &changed_ids,
-    ter_id const &base_ter = t_dirt );
+    ter_id const &base_ter = t_dirt->id );
 
 #endif // CATA_SRC_BUILD_REQS_H

--- a/src/butchery_requirements.cpp
+++ b/src/butchery_requirements.cpp
@@ -37,7 +37,7 @@ void butchery_requirements::load_butchery_req( const JsonObject &jo, const std::
     butchery_req_factory.load( jo, src );
 }
 
-const std::vector<butchery_requirements> &butchery_requirements::get_all()
+const std::deque<butchery_requirements> &butchery_requirements::get_all()
 {
     return butchery_req_factory.get_all();
 }

--- a/src/butchery_requirements.h
+++ b/src/butchery_requirements.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_BUTCHERY_REQUIREMENTS_H
 #define CATA_SRC_BUTCHERY_REQUIREMENTS_H
 
+#include <deque>
 #include <iosfwd>
 #include <map>
 #include <utility>

--- a/src/butchery_requirements.h
+++ b/src/butchery_requirements.h
@@ -34,7 +34,7 @@ class butchery_requirements
 
         static void load_butchery_req( const JsonObject &jo, const std::string &src );
         void load( const JsonObject &jo, std::string_view );
-        static const std::vector<butchery_requirements> &get_all();
+        static const std::deque<butchery_requirements> &get_all();
         static void check_consistency();
         static void reset();
         bool is_valid() const;

--- a/src/cata_tiles.h
+++ b/src/cata_tiles.h
@@ -497,13 +497,13 @@ class cata_tiles
         static void get_connect_values( const tripoint &p, int &subtile, int &rotation,
                                         const std::bitset<NUM_TERCONN> &connect_group,
                                         const std::bitset<NUM_TERCONN> &rotate_to_group,
-                                        const std::map<tripoint, ter_id> &ter_override );
+                                        const std::map<tripoint, resolved_ter_id> &ter_override );
         static void get_furn_connect_values( const tripoint &p, int &subtile, int &rotation,
                                              const std::bitset<NUM_TERCONN> &connect_group,
                                              const std::bitset<NUM_TERCONN> &rotate_to_group,
-                                             const std::map<tripoint, furn_id> &furn_override );
+                                             const std::map<tripoint, resolved_furn_id> &furn_override );
         void get_terrain_orientation( const tripoint &p, int &rota, int &subtile,
-                                      const std::map<tripoint, ter_id> &ter_override,
+                                      const std::map<tripoint, resolved_ter_id> &ter_override,
                                       const std::array<bool, 5> &invisible,
                                       const std::bitset<NUM_TERCONN> &rotate_group );
 
@@ -614,10 +614,10 @@ class cata_tiles
         void init_draw_radiation_override( const tripoint &p, int rad );
         void void_radiation_override();
 
-        void init_draw_terrain_override( const tripoint &p, const ter_id &id );
+        void init_draw_terrain_override( const tripoint &p, const resolved_ter_id &id );
         void void_terrain_override();
 
-        void init_draw_furniture_override( const tripoint &p, const furn_id &id );
+        void init_draw_furniture_override( const tripoint &p, const resolved_furn_id &id );
         void void_furniture_override();
 
         void init_draw_graffiti_override( const tripoint &p, bool has );
@@ -781,8 +781,8 @@ class cata_tiles
         point op;
 
         std::map<tripoint, int> radiation_override;
-        std::map<tripoint, ter_id> terrain_override;
-        std::map<tripoint, furn_id> furniture_override;
+        std::map<tripoint, resolved_ter_id> terrain_override;
+        std::map<tripoint, resolved_furn_id> furniture_override;
         std::map<tripoint, bool> graffiti_override;
         std::map<tripoint, trap_id> trap_override;
         std::map<tripoint, field_type_id> field_override;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5540,8 +5540,8 @@ Character::comfort_response_t Character::base_comfort_value( const tripoint &p )
     const optional_vpart_position vp = here.veh_at( p );
     const maptile tile = here.maptile_at( p );
     const trap &trap_at_pos = tile.get_trap_t();
-    const ter_id ter_at_pos = tile.get_ter();
-    const furn_id furn_at_pos = tile.get_furn();
+    const resolved_ter_id ter_at_pos = tile.get_ter();
+    const resolved_furn_id furn_at_pos = tile.get_furn();
 
     int web = here.get_field_intensity( p, fd_web );
 
@@ -9154,8 +9154,8 @@ units::temperature_delta Character::floor_bedding_warmth( const tripoint &pos )
 {
     map &here = get_map();
     const trap &trap_at_pos = here.tr_at( pos );
-    const ter_id ter_at_pos = here.ter( pos );
-    const furn_id furn_at_pos = here.furn( pos );
+    const resolved_ter_id ter_at_pos = here.ter( pos );
+    const resolved_furn_id furn_at_pos = here.furn( pos );
 
     const optional_vpart_position vp = here.veh_at( pos );
     const std::optional<vpart_reference> boardable = vp.part_with_feature( "BOARDABLE", true );

--- a/src/character_body.cpp
+++ b/src/character_body.cpp
@@ -436,7 +436,7 @@ void Character::update_bodytemp()
     const int climate_control_heat = climate_control.first;
     const int climate_control_chill = climate_control.second;
     const bool use_floor_warmth = can_use_floor_warmth();
-    const furn_id furn_at_pos = here.furn( pos() );
+    const resolved_furn_id furn_at_pos = here.furn( pos() );
     const std::optional<vpart_reference> boardable = vp.part_with_feature( "BOARDABLE", true );
     // This means which temperature is comfortable for a naked person
     // Ambient normal temperature is lower while asleep

--- a/src/character_modifier.cpp
+++ b/src/character_modifier.cpp
@@ -48,7 +48,7 @@ void character_modifier::reset()
     character_modifier_factory.reset();
 }
 
-const std::vector<character_modifier> &character_modifier::get_all()
+const std::deque<character_modifier> &character_modifier::get_all()
 {
     return character_modifier_factory.get_all();
 }

--- a/src/character_modifier.h
+++ b/src/character_modifier.h
@@ -20,7 +20,7 @@ struct character_modifier {
         static void load_character_modifiers( const JsonObject &jo, const std::string &src );
         static void reset();
         void load( const JsonObject &jo, std::string_view src );
-        static const std::vector<character_modifier> &get_all();
+        static const std::deque<character_modifier> &get_all();
 
         // Use this to obtain the calculated modifier
         float modifier( const Character &c, const skill_id &skill = skill_id::NULL_ID() ) const;

--- a/src/character_modifier.h
+++ b/src/character_modifier.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_CHARACTER_MODIFIER_H
 #define CATA_SRC_CHARACTER_MODIFIER_H
 
+#include <deque>
 #include <vector>
 
 #include "bodypart.h"

--- a/src/city.cpp
+++ b/src/city.cpp
@@ -41,7 +41,7 @@ void city::load_city( const JsonObject &jo, const std::string &src )
 
 void city::finalize()
 {
-    for( city &c : const_cast<std::vector<city>&>( city::get_all() ) ) {
+    for( city &c : const_cast<std::deque<city>&>( city::get_all() ) ) {
         if( c.name.empty() ) {
             c.name = Name::get( nameFlags::IsTownName );
         }
@@ -59,7 +59,7 @@ void city::check_consistency()
     get_city_factory().check();
 }
 
-const std::vector<city> &city::get_all()
+const std::deque<city> &city::get_all()
 {
     return get_city_factory().get_all();
 }

--- a/src/city.h
+++ b/src/city.h
@@ -19,7 +19,7 @@ struct city {
     static void load_city( const JsonObject &, const std::string & );
     static void finalize();
     static void check_consistency();
-    static const std::vector<city> &get_all();
+    static const std::deque<city> &get_all();
     static void reset();
 
     city_id id;

--- a/src/city.h
+++ b/src/city.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_CITY_H
 #define CATA_SRC_CITY_H
 
+#include <deque>
 #include <string>         // for string, basic_string
 #include <vector>         // for vector
 

--- a/src/climbing.cpp
+++ b/src/climbing.cpp
@@ -71,7 +71,7 @@ int_id<climbing_aid>::int_id( const string_id<climbing_aid> &id ) : _id( id.id()
 {
 }
 
-const std::vector<climbing_aid> &climbing_aid::get_all()
+const std::deque<climbing_aid> &climbing_aid::get_all()
 {
     return climbing_aid_factory.get_all();
 }

--- a/src/climbing.h
+++ b/src/climbing.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_CLIMBING_H
 #define CATA_SRC_CLIMBING_H
 
+#include <deque>
 #include <iosfwd>
 #include <new>
 #include <optional>

--- a/src/climbing.h
+++ b/src/climbing.h
@@ -71,7 +71,7 @@ class climbing_aid
         using aid_list = std::vector<const climbing_aid *>;
 
 
-        static const std::vector<climbing_aid> &get_all();
+        static const std::deque<climbing_aid> &get_all();
         // static void check_climbing_aid_consistency(); TODO
         bool was_loaded = false;
 

--- a/src/clothing_mod.cpp
+++ b/src/clothing_mod.cpp
@@ -140,7 +140,7 @@ void clothing_mods::reset()
     clothing_mods_by_type.clear();
 }
 
-const std::vector<clothing_mod> &clothing_mods::get_all()
+const std::deque<clothing_mod> &clothing_mods::get_all()
 {
     return all_clothing_mods.get_all();
 }

--- a/src/clothing_mod.h
+++ b/src/clothing_mod.h
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <cstddef>
+#include <deque>
 #include <iosfwd>
 #include <vector>
 

--- a/src/clothing_mod.h
+++ b/src/clothing_mod.h
@@ -76,7 +76,7 @@ constexpr std::array<clothing_mod_type, 9> all_clothing_mod_types = {{
 void load( const JsonObject &jo, const std::string &src );
 void reset();
 
-const std::vector<clothing_mod> &get_all();
+const std::deque<clothing_mod> &get_all();
 const std::vector<clothing_mod> &get_all_with( clothing_mod_type type );
 
 std::string string_from_clothing_mod_type( clothing_mod_type type );

--- a/src/clzones.cpp
+++ b/src/clzones.cpp
@@ -185,7 +185,7 @@ bool string_id<zone_type>::is_valid() const
     return zone_type_factory.is_valid( *this );
 }
 
-const std::vector<zone_type> &zone_type::get_all()
+const std::deque<zone_type> &zone_type::get_all()
 {
     return zone_type_factory.get_all();
 }

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_CLZONES_H
 #define CATA_SRC_CLZONES_H
 
+#include <deque>
 #include <functional>
 #include <cstddef>
 #include <iosfwd>

--- a/src/clzones.h
+++ b/src/clzones.h
@@ -66,7 +66,7 @@ class zone_type
         /**
          * All spells in the game.
          */
-        static const std::vector<zone_type> &get_all();
+        static const std::deque<zone_type> &get_all();
         bool is_valid() const;
 };
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -919,7 +919,8 @@ bool player_can_see_to_build( Character &you, const construction_group_str_id &g
     return false;
 }
 
-bool can_construct_furn_ter( const construction &con, furn_id const &f, ter_id const &t )
+bool can_construct_furn_ter( const construction &con, resolved_furn_id const &f,
+                             resolved_ter_id const &t )
 {
     return std::all_of( con.pre_flags.begin(), con.pre_flags.end(), [&f, &t]( auto const & flag ) {
         const bool use_ter = flag.second || f == f_null;
@@ -931,8 +932,8 @@ bool can_construct_furn_ter( const construction &con, furn_id const &f, ter_id c
 bool can_construct( const construction &con, const tripoint_bub_ms &p )
 {
     const map &here = get_map();
-    const furn_id f = here.furn( p );
-    const ter_id t = here.ter( p );
+    const resolved_furn_id f = here.furn( p );
+    const resolved_ter_id t = here.ter( p );
 
     if( !con.pre_special( p ) ||                 // pre-function
         !has_pre_terrain( con, p ) ||            // terrain type

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -421,7 +421,7 @@ construction_id construction_menu( const bool blueprint )
     ctxt.register_action( "FILTER" );
     ctxt.register_action( "RESET_FILTER" );
 
-    const std::vector<construction_category> &construct_cat = construction_categories::get_all();
+    const std::deque<construction_category> &construct_cat = construction_categories::get_all();
     const int tabcount = static_cast<int>( construction_category::count() );
 
     std::string filter;

--- a/src/construction.h
+++ b/src/construction.h
@@ -124,7 +124,8 @@ void load_construction( const JsonObject &jo );
 void reset_constructions();
 construction_id construction_menu( bool blueprint );
 void complete_construction( Character *you );
-bool can_construct_furn_ter( const construction &con, furn_id const &furn, ter_id const &ter );
+bool can_construct_furn_ter( const construction &con, resolved_furn_id const &furn,
+                             resolved_ter_id const &ter );
 bool can_construct( const construction &con, const tripoint_bub_ms &p );
 bool player_can_build( Character &you, const read_only_visitable &inv, const construction &con,
                        bool can_construct_skip = false );

--- a/src/construction_category.cpp
+++ b/src/construction_category.cpp
@@ -70,7 +70,7 @@ void construction_categories::reset()
     all_construction_categories.reset();
 }
 
-const std::vector<construction_category> &construction_categories::get_all()
+const std::deque<construction_category> &construction_categories::get_all()
 {
     return all_construction_categories.get_all();
 }

--- a/src/construction_category.h
+++ b/src/construction_category.h
@@ -33,7 +33,7 @@ namespace construction_categories
 void load( const JsonObject &jo, const std::string &src );
 void reset();
 
-const std::vector<construction_category> &get_all();
+const std::deque<construction_category> &get_all();
 
 } // namespace construction_categories
 

--- a/src/construction_category.h
+++ b/src/construction_category.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_CONSTRUCTION_CATEGORY_H
 
 #include <cstddef>
+#include <deque>
 #include <iosfwd>
 #include <vector>
 

--- a/src/construction_group.cpp
+++ b/src/construction_group.cpp
@@ -75,7 +75,7 @@ void construction_groups::reset()
     all_construction_groups.reset();
 }
 
-const std::vector<construction_group> &construction_groups::get_all()
+const std::deque<construction_group> &construction_groups::get_all()
 {
     return all_construction_groups.get_all();
 }

--- a/src/construction_group.h
+++ b/src/construction_group.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_CONSTRUCTION_GROUP_H
 
 #include <cstddef>
+#include <deque>
 #include <iosfwd>
 #include <vector>
 

--- a/src/construction_group.h
+++ b/src/construction_group.h
@@ -32,7 +32,7 @@ namespace construction_groups
 void load( const JsonObject &jo, const std::string &src );
 void reset();
 
-const std::vector<construction_group> &get_all();
+const std::deque<construction_group> &get_all();
 
 } // namespace construction_groups
 

--- a/src/damage.cpp
+++ b/src/damage.cpp
@@ -21,7 +21,7 @@
 #include "translations.h"
 #include "units.h"
 
-static std::map<damage_info_order::info_type, std::vector<damage_info_order>> sorted_order_lists;
+static std::map<damage_info_order::info_type, std::deque<damage_info_order>> sorted_order_lists;
 
 namespace
 {
@@ -69,7 +69,7 @@ void damage_type::reset()
     damage_type_factory.reset();
 }
 
-const std::vector<damage_type> &damage_type::get_all()
+const std::deque<damage_type> &damage_type::get_all()
 {
     return damage_type_factory.get_all();
 }
@@ -85,12 +85,12 @@ void damage_info_order::reset()
     sorted_order_lists.clear();
 }
 
-const std::vector<damage_info_order> &damage_info_order::get_all()
+const std::deque<damage_info_order> &damage_info_order::get_all()
 {
     return damage_info_order_factory.get_all();
 }
 
-const std::vector<damage_info_order> &damage_info_order::get_all( info_type sort_by )
+const std::deque<damage_info_order> &damage_info_order::get_all( info_type sort_by )
 {
     return sorted_order_lists.at( sort_by );
 }
@@ -156,7 +156,7 @@ void damage_type::load( const JsonObject &jo, std::string_view )
 void damage_type::check()
 {
     for( const damage_type &dt : damage_type::get_all() ) {
-        const std::vector<damage_info_order> &dio_list = damage_info_order::get_all();
+        const std::deque<damage_info_order> &dio_list = damage_info_order::get_all();
         auto iter = std::find_if( dio_list.begin(), dio_list.end(),
         [&dt]( const damage_info_order & dio ) {
             return dt.id == dio.dmg_type;
@@ -200,7 +200,7 @@ void damage_info_order::load( const JsonObject &jo, std::string_view )
     }
 }
 
-static void prepare_sorted_lists( std::vector<damage_info_order> &list,
+static void prepare_sorted_lists( std::deque<damage_info_order> &list,
                                   damage_info_order::info_type sb )
 {
     for( auto iter = list.begin(); iter != list.end(); ) {
@@ -774,7 +774,7 @@ std::unordered_map<damage_type_id, float> load_damage_map( const JsonObject &jo,
 void finalize_damage_map( std::unordered_map<damage_type_id, float> &damage_map, bool force_derive,
                           float default_value )
 {
-    const std::vector<damage_type> &dams = damage_type::get_all();
+    const std::deque<damage_type> &dams = damage_type::get_all();
     if( dams.empty() ) {
         debugmsg( "called before damage_types have been loaded." );
         return;

--- a/src/damage.h
+++ b/src/damage.h
@@ -55,7 +55,7 @@ struct damage_type {
     static void reset();
     static void check();
     void load( const JsonObject &jo, std::string_view );
-    static const std::vector<damage_type> &get_all();
+    static const std::deque<damage_type> &get_all();
 };
 
 struct damage_info_order {
@@ -93,8 +93,8 @@ struct damage_info_order {
     static void finalize_all();
     void finalize();
     void load( const JsonObject &jo, std::string_view src );
-    static const std::vector<damage_info_order> &get_all();
-    static const std::vector<damage_info_order> &get_all( info_type sort_by );
+    static const std::deque<damage_info_order> &get_all();
+    static const std::deque<damage_info_order> &get_all( info_type sort_by );
 };
 
 struct barrel_desc {

--- a/src/damage.h
+++ b/src/damage.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_DAMAGE_H
 
 #include <array>
+#include <deque>
 #include <iosfwd>
 #include <map>
 #include <unordered_map>

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1386,7 +1386,8 @@ static void teleport_overmap( bool specific_coordinates = false )
 
 static void teleport_city()
 {
-    std::vector<city> cities( city::get_all() );
+    const std::deque<city> &all_cities = city::get_all();
+    std::vector<city> cities( all_cities.begin(), all_cities.end() );
     const auto cities_cmp_population = []( const city & a, const city & b ) {
         return std::tie( a.population, a.name ) > std::tie( b.population, b.name );
     };
@@ -3385,7 +3386,7 @@ void debug()
             static_cast<void>( raise( SIGSEGV ) );
             break;
         case debug_menu_index::ACTIVATE_EOC: {
-            const std::vector<effect_on_condition> &eocs = effect_on_conditions::get_all();
+            const std::deque<effect_on_condition> &eocs = effect_on_conditions::get_all();
             uilist eoc_menu;
             for( const effect_on_condition &eoc : eocs ) {
                 eoc_menu.addentry( -1, true, -1, eoc.id.str() );

--- a/src/descriptions.cpp
+++ b/src/descriptions.cpp
@@ -112,7 +112,7 @@ void game::extended_description( const tripoint &p )
                 if( !u.sees( p ) || !m.has_furn( p ) ) {
                     desc = _( "You do not see any furniture here." );
                 } else {
-                    const furn_id fid = m.furn( p );
+                    const resolved_furn_id fid = m.furn( p );
                     const std::string mod_src = enumerate_as_string( fid->src.begin(),
                     fid->src.end(), []( const std::pair<furn_str_id, mod_id> &source ) {
                         return string_format( "'%s'", source.second->name() );
@@ -124,7 +124,7 @@ void game::extended_description( const tripoint &p )
                 if( !u.sees( p ) ) {
                     desc = _( "You can't see the terrain here." );
                 } else {
-                    const ter_id tid = m.ter( p );
+                    const resolved_ter_id tid = m.ter( p );
                     const std::string mod_src = enumerate_as_string( tid->src.begin(),
                     tid->src.end(), []( const std::pair<ter_str_id, mod_id> &source ) {
                         return string_format( "'%s'", source.second->name() );

--- a/src/disease.cpp
+++ b/src/disease.cpp
@@ -47,7 +47,7 @@ void disease_type::reset()
     disease_factory.reset();
 }
 
-const std::vector<disease_type> &disease_type::get_all()
+const std::deque<disease_type> &disease_type::get_all()
 {
     return disease_factory.get_all();
 }

--- a/src/disease.h
+++ b/src/disease.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_DISEASE_H
 #define CATA_SRC_DISEASE_H
 
+#include <deque>
 #include <iosfwd>
 #include <new>
 #include <optional>

--- a/src/disease.h
+++ b/src/disease.h
@@ -19,7 +19,7 @@ class disease_type
         static void load_disease_type( const JsonObject &jo, const std::string &src );
         static void reset();
         void load( const JsonObject &jo, std::string_view );
-        static const std::vector<disease_type> &get_all();
+        static const std::deque<disease_type> &get_all();
         static void check_disease_consistency();
         bool was_loaded = false;
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1712,7 +1712,7 @@ void display::print_mon_info( const avatar &u, const catacurses::window &w, int 
         }
     }
     std::array<std::vector<std::pair<mtype_id, int>>, 9> mons_at;
-    for( const std::pair<mtype_id, nearest_loc_and_cnt> &mon : all_mons ) {
+    for( const std::pair<const mtype_id, nearest_loc_and_cnt> &mon : all_mons ) {
         mons_at[mon.second.nearest_loc].emplace_back( mon.first, mon.second.cnt );
     }
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1456,6 +1456,12 @@ std::string display::colorized_compass_text( const cardinal_direction dir, int w
     return get_compass_for_direction( dir, width );
 }
 
+struct mtype_id_string_less {
+    bool operator()( const mtype_id &lhs, const mtype_id &rhs ) const {
+        return lhs.str() < rhs.str();
+    }
+};
+
 std::string display::colorized_compass_legend_text( int width, int max_height, int &height )
 {
     const monster_visible_info &mon_visible = get_avatar().get_mon_visible();
@@ -1479,8 +1485,8 @@ std::string display::colorized_compass_legend_text( int width, int max_height, i
         }
     }
     // Note that the order here is significant. Some widget tests depend on the
-    // monsters being displayed in the order the underlying string IDs were interned.
-    std::map<mtype_id, int> mlist;
+    // monsters being displayed in this order.
+    std::map<mtype_id, int, mtype_id_string_less> mlist;
     for( const auto &mv : mon_visible.unique_mons ) {
         for( const std::pair<mtype_id, int> &m : mv ) {
             mlist[m.first] += m.second;
@@ -1697,8 +1703,8 @@ void display::print_mon_info( const avatar &u, const catacurses::window &w, int 
         int cnt;
     };
     // Note that the order here is significant. Some widget tests depend on the
-    // monsters being displayed in the order the underlying string IDs were interned.
-    std::map<mtype_id, nearest_loc_and_cnt> all_mons;
+    // monsters being displayed in this order.
+    std::map<mtype_id, nearest_loc_and_cnt, mtype_id_string_less> all_mons;
     for( int loc = 0; loc < 9; loc++ ) {
         for( const std::pair<mtype_id, int> &mon : unique_mons[loc] ) {
             const auto mon_it = all_mons.find( mon.first );

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1458,6 +1458,7 @@ std::string display::colorized_compass_text( const cardinal_direction dir, int w
 
 struct mtype_id_string_less {
     bool operator()( const mtype_id &lhs, const mtype_id &rhs ) const {
+        // NOLINTNEXTLINE(cata-use-localized-sorting)
         return lhs.str() < rhs.str();
     }
 };

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1433,7 +1433,7 @@ static std::string get_compass_for_direction( const cardinal_direction dir, int 
                 break;
         }
     }
-    for( const std::pair<const mtype *, int> &m : mon_visible.unique_mons[d] ) {
+    for( const std::pair<mtype_id, int> &m : mon_visible.unique_mons[d] ) {
         syms.emplace_back( m.first->sym, m.first->color );
     }
 
@@ -1478,9 +1478,11 @@ std::string display::colorized_compass_legend_text( int width, int max_height, i
             names.emplace_back( name );
         }
     }
-    std::map<const mtype *, int> mlist;
+    // Note that the order here is significant. Some widget tests depend on the
+    // monsters being displayed in the order the underlying string IDs were interned.
+    std::map<mtype_id, int> mlist;
     for( const auto &mv : mon_visible.unique_mons ) {
-        for( const std::pair<const mtype *, int> &m : mv ) {
+        for( const std::pair<mtype_id, int> &m : mv ) {
             mlist[m.first] += m.second;
         }
     }
@@ -1694,9 +1696,11 @@ void display::print_mon_info( const avatar &u, const catacurses::window &w, int 
         int nearest_loc;
         int cnt;
     };
-    std::map<const mtype *, nearest_loc_and_cnt> all_mons;
+    // Note that the order here is significant. Some widget tests depend on the
+    // monsters being displayed in the order the underlying string IDs were interned.
+    std::map<mtype_id, nearest_loc_and_cnt> all_mons;
     for( int loc = 0; loc < 9; loc++ ) {
-        for( const std::pair<const mtype *, int> &mon : unique_mons[loc] ) {
+        for( const std::pair<mtype_id, int> &mon : unique_mons[loc] ) {
             const auto mon_it = all_mons.find( mon.first );
             if( mon_it == all_mons.end() ) {
                 all_mons.emplace( mon.first, nearest_loc_and_cnt{ loc, mon.second } );
@@ -1707,8 +1711,8 @@ void display::print_mon_info( const avatar &u, const catacurses::window &w, int 
             }
         }
     }
-    std::array<std::vector<std::pair<const mtype *, int>>, 9> mons_at;
-    for( const std::pair<const mtype *const, nearest_loc_and_cnt> &mon : all_mons ) {
+    std::array<std::vector<std::pair<mtype_id, int>>, 9> mons_at;
+    for( const std::pair<mtype_id, nearest_loc_and_cnt> &mon : all_mons ) {
         mons_at[mon.second.nearest_loc].emplace_back( mon.first, mon.second.cnt );
     }
 
@@ -1724,8 +1728,8 @@ void display::print_mon_info( const avatar &u, const catacurses::window &w, int 
     for( int j = 8; j >= 0 && pr.y < maxheight; j-- ) {
         // Separate names by some number of spaces (more for local monsters).
         int namesep = j == 8 ? 2 : 1;
-        for( const std::pair<const mtype *, int> &mon : mons_at[j] ) {
-            const mtype *const type = mon.first;
+        for( const std::pair<mtype_id, int> &mon : mons_at[j] ) {
+            const mtype_id &type = mon.first;
             const int count = mon.second;
             if( pr.y >= maxheight ) {
                 // no space to print to anyway

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -231,7 +231,7 @@ void editmap_hilight::draw( editmap &em, bool update )
                 char t_sym = terrain.symbol();
                 nc_color t_col = terrain.color();
 
-                if( here.furn( p ).to_i() > 0 ) {
+                if( here.furn( p )->id.id().to_i() > 0 ) {
                     const furn_t &furniture_type = here.furn( p ).obj();
                     t_sym = furniture_type.symbol();
                     t_col = furniture_type.color();
@@ -668,7 +668,7 @@ void editmap::draw_main_ui_overlay()
             std::map<tripoint, std::tuple<mtype_id, int, bool, Creature::Attitude>> spawns;
             for( int x = 0; x < 2; x++ ) {
                 for( int y = 0; y < 2; y++ ) {
-                    submap *sm = tmpmap.get_submap_at_grid( { x, y, target.z } );
+                    submap *sm = tmpmap.get_submap_at_grid( tripoint { x, y, target.z } );
                     if( sm ) {
                         const tripoint sm_origin = origin_p + tripoint( x * SEEX, y * SEEY, target.z );
                         for( const spawn_point &sp : sm->spawns ) {
@@ -727,15 +727,15 @@ void editmap::update_view_with_help( const std::string &txt, const std::string &
     mvwprintz( w_info, point( 2, 0 ), c_light_gray, "< %d,%d,%d >", target.x, target.y, target.z );
 
     mvwputch( w_info, point( 2, off ), terrain_type.color(), terrain_type.symbol() );
-    mvwprintw( w_info, point( 4, off ), _( "%d: %s; move cost %d" ), here.ter( target ).to_i(),
+    mvwprintw( w_info, point( 4, off ), _( "%d: %s; move cost %d" ), here.ter( target )->id.id().to_i(),
                static_cast<std::string>( terrain_type.id ),
                terrain_type.movecost
              );
     off++; // 2
-    if( here.furn( target ).to_i() > 0 ) {
+    if( here.furn( target )->id.id().to_i() > 0 ) {
         mvwputch( w_info, point( 2, off ), furniture_type.color(), furniture_type.symbol() );
         mvwprintw( w_info, point( 4, off ), _( "%d: %s; move cost %d movestr %d" ),
-                   here.furn( target ).to_i(),
+                   here.furn( target )->id.id().to_i(),
                    static_cast<std::string>( furniture_type.id ),
                    furniture_type.movecost,
                    furniture_type.move_str_req
@@ -898,13 +898,13 @@ static T_id feature( const tripoint &p );
 template<>
 ter_id feature<ter_id>( const tripoint &p )
 {
-    return get_map().ter( p );
+    return get_map().ter( p )->id;
 }
 
 template<>
 furn_id feature<furn_id>( const tripoint &p )
 {
-    return get_map().furn( p );
+    return get_map().furn( p )->id;
 }
 
 template<>
@@ -2011,7 +2011,7 @@ vehicle *editmap::mapgen_veh_query( const tripoint_abs_omt &omt_tgt )
     std::vector<vehicle *> possible_vehicles;
     for( int x = 0; x < 2; x++ ) {
         for( int y = 0; y < 2; y++ ) {
-            submap *destsm = target_bay.get_submap_at_grid( { x, y, target.z } );
+            submap *destsm = target_bay.get_submap_at_grid( tripoint { x, y, target.z } );
             if( destsm == nullptr ) {
                 debugmsg( "Tried to get vehicles at (%d,%d,%d) but the submap is not loaded", x, y, target.z );
                 continue;
@@ -2048,7 +2048,7 @@ bool editmap::mapgen_veh_destroy( const tripoint_abs_omt &omt_tgt, vehicle *car_
     target_bay.load( project_to<coords::sm>( omt_tgt ), false );
     for( int x = 0; x < 2; x++ ) {
         for( int y = 0; y < 2; y++ ) {
-            submap *destsm = target_bay.get_submap_at_grid( { x, y, target.z } );
+            submap *destsm = target_bay.get_submap_at_grid( tripoint { x, y, target.z } );
             if( destsm == nullptr ) {
                 debugmsg( "Tried to destroy vehicle at (%d,%d,%d) but the submap is not loaded", x, y, target.z );
                 continue;

--- a/src/effect_on_condition.cpp
+++ b/src/effect_on_condition.cpp
@@ -473,7 +473,7 @@ void effect_on_condition::check() const
 {
 }
 
-const std::vector<effect_on_condition> &effect_on_conditions::get_all()
+const std::deque<effect_on_condition> &effect_on_conditions::get_all()
 {
     return effect_on_condition_factory.get_all();
 }

--- a/src/effect_on_condition.h
+++ b/src/effect_on_condition.h
@@ -71,7 +71,7 @@ struct effect_on_condition {
 namespace effect_on_conditions
 {
 /** Get all currently loaded effect_on_conditions */
-const std::vector<effect_on_condition> &get_all();
+const std::deque<effect_on_condition> &get_all();
 /** Finalize all loaded effect_on_conditions */
 void finalize_all();
 /** Clear all loaded effects on condition (invalidating any pointers) */

--- a/src/effect_on_condition.h
+++ b/src/effect_on_condition.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_EFFECT_ON_CONDITION_H
 #define CATA_SRC_EFFECT_ON_CONDITION_H
 
+#include <deque>
 #include <string>
 #include <climits>
 #include <optional>

--- a/src/event_statistics.cpp
+++ b/src/event_statistics.cpp
@@ -134,7 +134,7 @@ void score::check_consistency()
     score_factory.check();
 }
 
-const std::vector<score> &score::get_all()
+const std::deque<score> &score::get_all()
 {
     return score_factory.get_all();
 }

--- a/src/event_statistics.h
+++ b/src/event_statistics.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_EVENT_STATISTICS_H
 #define CATA_SRC_EVENT_STATISTICS_H
 
+#include <deque>
 #include <iosfwd>
 #include <memory>
 #include <unordered_map>

--- a/src/event_statistics.h
+++ b/src/event_statistics.h
@@ -109,7 +109,7 @@ class score
         void check() const;
         static void load_score( const JsonObject &, const std::string & );
         static void check_consistency();
-        static const std::vector<score> &get_all();
+        static const std::deque<score> &get_all();
         static void reset();
 
         string_id<score> id;

--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -3285,7 +3285,7 @@ static std::pair<size_t, std::string> farm_action( const tripoint_abs_omt &omt_t
         return ( bay1.ter( pos ) == t_dirtmound ) && ( !bay2.has_furn( pos ) );
     };
     const auto is_unplowed = []( const tripoint & pos, tinymap & farm_map ) {
-        const ter_id &farm_ter = farm_map.ter( pos );
+        const resolved_ter_id &farm_ter = farm_map.ter( pos );
         return farm_ter->has_flag( ter_furn_flag::TFLAG_PLOWABLE );
     };
 

--- a/src/field_type.cpp
+++ b/src/field_type.cpp
@@ -403,7 +403,7 @@ void field_types::load_immunity( const JsonObject &jid, field_immunity_data &fd 
     }
 }
 
-const std::vector<field_type> &field_types::get_all()
+const std::deque<field_type> &field_types::get_all()
 {
     return get_all_field_types().get_all();
 }

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <iosfwd>
 #include <set>
 #include <string>

--- a/src/field_type.h
+++ b/src/field_type.h
@@ -275,7 +275,7 @@ void reset();
 
 void load_immunity( const JsonObject &jid, field_immunity_data &fd );
 
-const std::vector<field_type> &get_all();
+const std::deque<field_type> &get_all();
 field_type get_field_type_by_legacy_enum( int legacy_enum_id );
 
 } // namespace field_types

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -451,7 +451,7 @@ bool json_flag::is_ready()
     return !json_flags_all.empty();
 }
 
-const std::vector<json_flag> &json_flag::get_all()
+const std::deque<json_flag> &json_flag::get_all()
 {
     return json_flags_all.get_all();
 }

--- a/src/flag.h
+++ b/src/flag.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_FLAG_H
 #define CATA_SRC_FLAG_H
 
+#include <deque>
 #include <iosfwd>
 #include <set>
 #include <string>

--- a/src/flag.h
+++ b/src/flag.h
@@ -449,7 +449,7 @@ class json_flag
         /** true, if flags were loaded */
         static bool is_ready();
 
-        static const std::vector<json_flag> &get_all();
+        static const std::deque<json_flag> &get_all();
 
     private:
         translation info_;

--- a/src/flexbuffer_json-inl.h
+++ b/src/flexbuffer_json-inl.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_FLEXBUFFER_JSON_INL_H
 #define CATA_SRC_FLEXBUFFER_JSON_INL_H
 
+#include <deque>
 #include <optional>
 #include <string>
 #include <type_traits>

--- a/src/flexbuffer_json.h
+++ b/src/flexbuffer_json.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_FLEXBUFFER_JSON_H
 #define CATA_SRC_FLEXBUFFER_JSON_H
 
+#include <deque>
 #include <optional>
 #include <string>
 #include <type_traits>

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -10528,9 +10528,9 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
             } else {
                 add_msg( m_warning, _( "Moving onto this %s is slow!" ), m.name( dest_loc ) );
                 if( m.has_furn( dest_loc ) ) {
-                    sfx::do_obstacle( m.furn( dest_loc ).id().str() );
+                    sfx::do_obstacle( m.furn( dest_loc )->id.str() );
                 } else {
-                    sfx::do_obstacle( m.ter( dest_loc ).id().str() );
+                    sfx::do_obstacle( m.ter( dest_loc )->id.str() );
                 }
             }
         } else {
@@ -10541,9 +10541,9 @@ bool game::walk_move( const tripoint &dest_loc, const bool via_ramp, const bool 
             } else {
                 add_msg( m_warning, _( "Moving off of this %s is slow!" ), m.name( u.pos() ) );
                 if( m.has_furn( u.pos() ) ) {
-                    sfx::do_obstacle( m.furn( u.pos() ).id().str() );
+                    sfx::do_obstacle( m.furn( u.pos() )->id.str() );
                 } else {
-                    sfx::do_obstacle( m.ter( u.pos() ).id().str() );
+                    sfx::do_obstacle( m.ter( u.pos() )->id.str() );
                 }
             }
         }
@@ -11892,7 +11892,7 @@ void game::vertical_move( int movez, bool force, bool peeking )
     // > and < are used for diving underwater.
     if( here.has_flag( ter_furn_flag::TFLAG_SWIMMABLE, u.pos() ) ) {
         swimming = true;
-        const ter_id &target_ter = here.ter( u.pos() + tripoint( 0, 0, movez ) );
+        const resolved_ter_id &target_ter = here.ter( u.pos() + tripoint( 0, 0, movez ) );
 
         // If we're in a water tile that has both air above and deep enough water to submerge in...
         if( here.has_flag( ter_furn_flag::TFLAG_DEEP_WATER, u.pos() ) &&
@@ -13582,7 +13582,7 @@ void avatar_moves( const tripoint &old_abs_pos, const avatar &u, const map &m )
     if( u.is_mounted() ) {
         mount_type = u.mounted_creature->type->id;
     }
-    get_event_bus().send<event_type::avatar_moves>( mount_type, m.ter( new_pos ).id(),
+    get_event_bus().send<event_type::avatar_moves>( mount_type, m.ter( new_pos )->id,
             u.current_movement_mode(), u.is_underwater(), new_pos.z );
 
     // TODO: fix point types

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4648,13 +4648,13 @@ void game::mon_info_update( )
                 }
             }
 
-            std::vector<std::pair<const mtype *, int>> &vec = unique_mons[index];
+            std::vector<std::pair<mtype_id, int>> &vec = unique_mons[index];
             const auto mon_it = std::find_if( vec.begin(), vec.end(),
-            [&]( const std::pair<const mtype *, int> &elem ) {
-                return elem.first == critter.type;
+            [&]( const std::pair<mtype_id, int> &elem ) {
+                return &elem.first.obj() == critter.type;
             } );
             if( mon_it == vec.end() ) {
-                vec.emplace_back( critter.type, 1 );
+                vec.emplace_back( critter.type->id, 1 );
             } else {
                 mon_it->second++;
             }

--- a/src/game.h
+++ b/src/game.h
@@ -778,8 +778,8 @@ class game
         void draw_async_anim( const tripoint &p, const std::string &tile_id, const std::string &ncstr = "",
                               const nc_color &nccol = c_black );
         void draw_radiation_override( const tripoint &p, int rad );
-        void draw_terrain_override( const tripoint &p, const ter_id &id );
-        void draw_furniture_override( const tripoint &p, const furn_id &id );
+        void draw_terrain_override( const tripoint &p, const resolved_ter_id &id );
+        void draw_furniture_override( const tripoint &p, const resolved_furn_id &id );
         void draw_graffiti_override( const tripoint &p, bool has );
         void draw_trap_override( const tripoint &p, const trap_id &id );
         void draw_field_override( const tripoint &p, const field_type_id &id );

--- a/src/gates.cpp
+++ b/src/gates.cpp
@@ -75,7 +75,7 @@ struct gate_data {
 
 gate_id get_gate_id( const tripoint &pos )
 {
-    return gate_id( get_map().ter( pos ).id().str() );
+    return gate_id( get_map().ter( pos )->id.str() );
 }
 
 generic_factory<gate_data> gates_data( "gate type" );
@@ -131,9 +131,9 @@ void gate_data::check() const
 
 bool gate_data::is_suitable_wall( const tripoint &pos ) const
 {
-    const ter_id wid = get_map().ter( pos );
+    const resolved_ter_id wid = get_map().ter( pos );
     const auto iter = std::find_if( walls.begin(), walls.end(), [ wid ]( const ter_str_id & wall ) {
-        return wall.id() == wid;
+        return wall == wid->id;
     } );
     return iter != walls.end();
 }
@@ -206,7 +206,7 @@ void gates::open_gate( const tripoint &pos )
             if( !close ) { // Opening the gate...
                 tripoint cur_pos = gate_pos;
                 while( true ) {
-                    const ter_id ter = here.ter( cur_pos );
+                    const resolved_ter_id ter = here.ter( cur_pos );
 
                     if( ter == gate.door.id() ) {
                         here.ter_set( cur_pos, gate.floor.id() );

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <bitset>
+#include <deque>
 #include <set>
 #include <unordered_map>
 #include <vector>
@@ -137,7 +138,8 @@ class generic_factory
         }
 
     protected:
-        std::vector<T> list;
+        // Pointers need to be stable, so vector is unsafe.
+        std::deque<T> list;
         std::unordered_map<string_id<T>, int_id<T>> map;
         std::unordered_map<std::string, T> abstracts;
 
@@ -180,7 +182,7 @@ class generic_factory
             }
         }
 
-        const T dummy_obj;
+        std::unique_ptr<T> dummy_obj;
 
     public:
         const bool initialized;
@@ -197,7 +199,7 @@ class generic_factory
             : type_name( type_name ),
               id_member_name( id_member_name ),
               alias_member_name( alias_member_name ),
-              dummy_obj(),
+              dummy_obj( std::make_unique<T>() ),
               initialized( true ) {
         }
 
@@ -440,7 +442,7 @@ class generic_factory
         /**
          * Returns all the loaded objects. It can be used to iterate over them.
          */
-        const std::vector<T> &get_all() const {
+        const std::deque<T> &get_all() const {
             return list;
         }
         /**
@@ -461,7 +463,7 @@ class generic_factory
         const T &obj( const int_id<T> &id ) const {
             if( !is_valid( id ) ) {
                 debugmsg( "invalid %s id \"%d\"", type_name, id.to_i() );
-                return dummy_obj;
+                return *dummy_obj;
             }
             return list[id.to_i()];
         }
@@ -476,7 +478,7 @@ class generic_factory
             int_id<T> i_id;
             if( !find_id( id, i_id ) ) {
                 debugmsg( "invalid %s id \"%s\"", type_name, id.c_str() );
-                return dummy_obj;
+                return *dummy_obj;
             }
             return list[i_id.to_i()];
         }

--- a/src/handle_action.cpp
+++ b/src/handle_action.cpp
@@ -636,7 +636,7 @@ static void open()
     if( didit ) {
         player_character.add_msg_if_player( _( "You open the %s." ), here.name( openp ) );
     } else {
-        const ter_str_id tid = here.ter( openp ).id();
+        const ter_str_id tid = here.ter( openp )->id;
 
         if( here.has_flag( ter_furn_flag::TFLAG_LOCKED, openp ) ) {
             add_msg( m_info, _( "The door is locked!" ) );
@@ -884,7 +884,7 @@ static void smash()
         smash_floor = true;
     }
     get_event_bus().send<event_type::character_smashes_tile>(
-        player_character.getID(), here.ter( smashp ).id(), here.furn( smashp ).id() );
+        player_character.getID(), here.ter( smashp )->id, here.furn( smashp )->id );
     if( player_character.is_mounted() ) {
         monster *crit = player_character.mounted_creature.get();
         if( crit->has_flag( mon_flag_RIDEABLE_MECH ) ) {

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -130,7 +130,7 @@ void harvest_drop_type::load( const JsonObject &jo, const std::string_view )
     }
 }
 
-const std::vector<harvest_drop_type> &harvest_drop_type::get_all()
+const std::deque<harvest_drop_type> &harvest_drop_type::get_all()
 {
     return harvest_drop_type_factory.get_all();
 }
@@ -185,7 +185,7 @@ void harvest_list::load_harvest_list( const JsonObject &jo, const std::string &s
     harvest_list_factory.load( jo, src );
 }
 
-const std::vector<harvest_list> &harvest_list::get_all()
+const std::deque<harvest_list> &harvest_list::get_all()
 {
     return harvest_list_factory.get_all();
 }

--- a/src/harvest.h
+++ b/src/harvest.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_HARVEST_H
 #define CATA_SRC_HARVEST_H
 
+#include <deque>
 #include <iosfwd>
 #include <list>
 #include <map>

--- a/src/harvest.h
+++ b/src/harvest.h
@@ -24,7 +24,7 @@ class harvest_drop_type
         static void load_harvest_drop_types( const JsonObject &jo, const std::string &src );
         static void reset();
         void load( const JsonObject &jo, std::string_view src );
-        static const std::vector<harvest_drop_type> &get_all();
+        static const std::deque<harvest_drop_type> &get_all();
 
         const harvest_drop_type_id &getId() {
             return id;
@@ -146,7 +146,7 @@ class harvest_list
         bool was_loaded = false;
         void load( const JsonObject &obj, std::string_view );
         static void load_harvest_list( const JsonObject &jo, const std::string &src );
-        static const std::vector<harvest_list> &get_all();
+        static const std::deque<harvest_list> &get_all();
 
     private:
         std::list<harvest_entry> entries_;

--- a/src/iexamine.cpp
+++ b/src/iexamine.cpp
@@ -1624,7 +1624,7 @@ static std::pair<itype_id, const deploy_tent_actor *> find_tent_itype( const fur
 void iexamine::portable_structure( Character &you, const tripoint &examp )
 {
     map &here = get_map();
-    const furn_str_id fid = here.furn( examp ).id();
+    const furn_str_id fid = here.furn( examp )->id;
     const std::pair<itype_id, const deploy_tent_actor *> tent_item_type = find_tent_itype( fid );
     if( tent_item_type.first.is_null() ) {
         debugmsg( "unknown furniture %s: don't know how to transform it into an item", fid.str() );
@@ -2046,7 +2046,7 @@ void iexamine::fswitch( Character &you, const tripoint &examp )
         none( you, examp );
         return;
     }
-    ter_id terid = here.ter( examp );
+    resolved_ter_id terid = here.ter( examp );
     you.moves -= to_moves<int>( 1_seconds );
     tripoint tmp;
     tmp.z = examp.z;
@@ -2729,7 +2729,7 @@ void iexamine::fertilize_plant( Character &you, const tripoint &tile,
     // The plant furniture has the NOITEM token which prevents adding items on that square,
     // spawned items are moved to an adjacent field instead, but the fertilizer token
     // must be on the square of the plant, therefore this hack:
-    const furn_id old_furn = here.furn( tile );
+    const resolved_furn_id old_furn = here.furn( tile );
     here.furn_set( tile, f_null );
     here.spawn_item( tile, itype_fertilizer, 1, 1, calendar::turn );
     here.furn_set( tile, old_furn );
@@ -2812,15 +2812,15 @@ void iexamine::aggie_plant( Character &you, const tripoint &examp )
 void iexamine::kiln_empty( Character &you, const tripoint &examp )
 {
     map &here = get_map();
-    furn_id cur_kiln_type = here.furn( examp );
-    furn_id next_kiln_type = f_null;
+    resolved_furn_id cur_kiln_type = here.furn( examp );
+    resolved_furn_id next_kiln_type = f_null;
     if( cur_kiln_type == f_kiln_empty ) {
         next_kiln_type = f_kiln_full;
     } else if( cur_kiln_type == f_kiln_metal_empty ) {
         next_kiln_type = f_kiln_metal_full;
     } else {
         debugmsg( "Examined furniture has action kiln_empty, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  here.furn( examp )->id.str() );
         return;
     }
 
@@ -2905,15 +2905,15 @@ void iexamine::kiln_empty( Character &you, const tripoint &examp )
 void iexamine::kiln_full( Character &, const tripoint &examp )
 {
     map &here = get_map();
-    furn_id cur_kiln_type = here.furn( examp );
-    furn_id next_kiln_type = f_null;
+    resolved_furn_id cur_kiln_type = here.furn( examp );
+    resolved_furn_id next_kiln_type = f_null;
     if( cur_kiln_type == f_kiln_full ) {
         next_kiln_type = f_kiln_empty;
     } else if( cur_kiln_type == f_kiln_metal_full ) {
         next_kiln_type = f_kiln_metal_empty;
     } else {
         debugmsg( "Examined furniture has action kiln_full, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  here.furn( examp )->id.str() );
         return;
     }
     map_stack items = here.i_at( examp );
@@ -2965,13 +2965,13 @@ void iexamine::kiln_full( Character &, const tripoint &examp )
 void iexamine::arcfurnace_empty( Character &you, const tripoint &examp )
 {
     map &here = get_map();
-    furn_id cur_arcfurnace_type = here.furn( examp );
-    furn_id next_arcfurnace_type = f_null;
+    resolved_furn_id cur_arcfurnace_type = here.furn( examp );
+    resolved_furn_id next_arcfurnace_type = f_null;
     if( cur_arcfurnace_type == f_arcfurnace_empty ) {
         next_arcfurnace_type = f_arcfurnace_full;
     } else {
         debugmsg( "Examined furniture has action arcfurnace_empty, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  here.furn( examp )->id.c_str() );
         return;
     }
 
@@ -3038,13 +3038,13 @@ void iexamine::arcfurnace_empty( Character &you, const tripoint &examp )
 void iexamine::arcfurnace_full( Character &, const tripoint &examp )
 {
     map &here = get_map();
-    furn_id cur_arcfurnace_type = here.furn( examp );
-    furn_id next_arcfurnace_type = f_null;
+    resolved_furn_id cur_arcfurnace_type = here.furn( examp );
+    resolved_furn_id next_arcfurnace_type = f_null;
     if( cur_arcfurnace_type == f_arcfurnace_full ) {
         next_arcfurnace_type = f_arcfurnace_empty;
     } else {
         debugmsg( "Examined furniture has action arcfurnace_full, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  here.furn( examp )->id.str() );
         return;
     }
 
@@ -3097,13 +3097,13 @@ void iexamine::arcfurnace_full( Character &, const tripoint &examp )
 void iexamine::stook_empty( Character &, const tripoint &examp )
 {
     map &here = get_map();
-    furn_id cur_stook_type = here.furn( examp );
-    furn_id next_stook_type = f_null;
+    resolved_furn_id cur_stook_type = here.furn( examp );
+    resolved_furn_id next_stook_type = f_null;
     if( cur_stook_type == f_stook_empty ) {
         next_stook_type = f_stook_full;
     } else {
         debugmsg( "Examined furniture has action stook_empty, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  here.furn( examp )->id.str() );
         return;
     }
 
@@ -3139,13 +3139,13 @@ void iexamine::stook_empty( Character &, const tripoint &examp )
 void iexamine::stook_full( Character &, const tripoint &examp )
 {
     map &here = get_map();
-    furn_id cur_stook_type = here.furn( examp );
-    furn_id next_stook_type = f_null;
+    resolved_furn_id cur_stook_type = here.furn( examp );
+    resolved_furn_id next_stook_type = f_null;
     if( cur_stook_type == f_stook_full ) {
         next_stook_type = f_null;
     } else {
         debugmsg( "Examined furniture has action stook_full, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  here.furn( examp )->id.str() );
         return;
     }
     map_stack items = here.i_at( examp );
@@ -3186,13 +3186,13 @@ void iexamine::stook_full( Character &, const tripoint &examp )
 void iexamine::autoclave_empty( Character &you, const tripoint &examp )
 {
     map &here = get_map();
-    furn_id cur_autoclave_type = here.furn( examp );
-    furn_id next_autoclave_type = f_null;
+    resolved_furn_id cur_autoclave_type = here.furn( examp );
+    resolved_furn_id next_autoclave_type = f_null;
     if( cur_autoclave_type == furn_id( "f_autoclave" ) ) {
         next_autoclave_type = furn_id( "f_autoclave_full" );
     } else {
         debugmsg( "Examined furniture has action autoclave_empty, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  here.furn( examp )->id.c_str() );
         return;
     }
 
@@ -3246,13 +3246,13 @@ void iexamine::autoclave_empty( Character &you, const tripoint &examp )
 void iexamine::autoclave_full( Character &, const tripoint &examp )
 {
     map &here = get_map();
-    furn_id cur_autoclave_type = here.furn( examp );
-    furn_id next_autoclave_type = f_null;
+    resolved_furn_id cur_autoclave_type = here.furn( examp );
+    resolved_furn_id next_autoclave_type = f_null;
     if( cur_autoclave_type == furn_id( "f_autoclave_full" ) ) {
         next_autoclave_type = furn_id( "f_autoclave" );
     } else {
         debugmsg( "Examined furniture has action autoclave_full, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  here.furn( examp )->id.c_str() );
         return;
     }
 
@@ -3436,7 +3436,7 @@ void iexamine::fireplace( Character &you, const tripoint &examp )
 static void fvat_set_empty( const tripoint &pos )
 {
     map &here = get_map();
-    furn_id furn = here.furn( pos );
+    resolved_furn_id furn = here.furn( pos );
     if( furn == f_fvat_wood_empty || furn == f_fvat_wood_full ) {
         here.furn_set( pos, f_fvat_wood_empty );
     } else {
@@ -3447,7 +3447,7 @@ static void fvat_set_empty( const tripoint &pos )
 static void fvat_set_full( const tripoint &pos )
 {
     map &here = get_map();
-    furn_id furn = here.furn( pos );
+    resolved_furn_id furn = here.furn( pos );
     if( furn == f_fvat_wood_empty || furn == f_fvat_wood_full ) {
         here.furn_set( pos, f_fvat_wood_full );
     } else {
@@ -3681,7 +3681,7 @@ static void displace_items_except_one_liquid( const tripoint &examp )
 {
     map &here = get_map();
     // Temporarily replace the real furniture with a fake furniture with NOITEM
-    const furn_id previous_furn = here.furn( examp );
+    const resolved_furn_id previous_furn = here.furn( examp );
     here.furn_set( examp, furn_id( "f_no_item" ) );
 
     bool liquid_present = false;
@@ -3899,7 +3899,7 @@ bool iexamine::pour_into_keg( const tripoint &pos, item &liquid )
 }
 
 static void pick_plant( Character &you, const tripoint &examp,
-                        const itype_id &itemType, ter_id new_ter, bool seeds = false )
+                        const itype_id &itemType, resolved_ter_id new_ter, bool seeds = false )
 {
     map &here = get_map();
     bool auto_forage = get_option<bool>( "AUTO_FEATURES" ) &&
@@ -4511,7 +4511,7 @@ void iexamine::curtains( Character &you, const tripoint &examp )
         return;
     }
 
-    const ter_id ter = here.ter( examp );
+    const resolved_ter_id ter = here.ter( examp );
 
     // Peek through the curtains, or tear them down.
     uilist window_menu;
@@ -4602,7 +4602,7 @@ static int getNearPumpCount( const tripoint &p, fuel_station_fuel_type &fuel_typ
     int result = 0;
     map &here = get_map();
     for( const tripoint &tmp : here.points_in_radius( p, 12 ) ) {
-        const ter_id t = here.ter( tmp );
+        const resolved_ter_id t = here.ter( tmp );
         if( t == ter_t_gas_pump || t == ter_t_gas_pump_a ) {
             result++;
             fuel_type = FUEL_TYPE_GASOLINE;
@@ -4623,8 +4623,7 @@ std::optional<tripoint> iexamine::getNearFilledGasTank( const tripoint &center, 
 
     map &here = get_map();
     for( const tripoint &tmp : here.points_in_radius( center, SEEX * 2 ) ) {
-
-        furn_id check_for_fuel_tank = here.furn( tmp );
+        resolved_furn_id check_for_fuel_tank = here.furn( tmp );
 
         if( ( fuel_type == FUEL_TYPE_GASOLINE && check_for_fuel_tank != furn_f_gas_tank ) ||
             ( fuel_type == FUEL_TYPE_DIESEL && check_for_fuel_tank != furn_f_diesel_tank ) ) {
@@ -4727,7 +4726,7 @@ std::optional<tripoint> iexamine::getGasPumpByNumber( const tripoint &p, int num
     int k = 0;
     map &here = get_map();
     for( const tripoint &tmp : here.points_in_radius( p, 12 ) ) {
-        const ter_id t = here.ter( tmp );
+        const resolved_ter_id t = here.ter( tmp );
         if( ( t == ter_t_gas_pump || t == ter_t_gas_pump_a
               || t == ter_t_diesel_pump || t == ter_t_diesel_pump_a ) && number == k++ ) {
             return tmp;
@@ -4774,8 +4773,8 @@ static int fromPumpFuel( const tripoint &dst, const tripoint &src )
             item liq_d( item_it->type, calendar::turn, amount );
 
             // add the charges to the destination
-            const ter_id backup_ter = here.ter( dst );
-            const furn_id backup_furn = here.furn( dst );
+            const resolved_ter_id backup_ter = here.ter( dst );
+            const resolved_furn_id backup_furn = here.furn( dst );
             here.ter_set( dst, ter_str_id::NULL_ID() );
             here.furn_set( dst, furn_str_id::NULL_ID() );
             here.add_item_or_charges( dst, liq_d );
@@ -4795,7 +4794,7 @@ static void turnOnSelectedPump( const tripoint &p, int number, fuel_station_fuel
     int k = 0;
     map &here = get_map();
     for( const tripoint &tmp : here.points_in_radius( p, 12 ) ) {
-        const ter_id t = here.ter( tmp );
+        const resolved_ter_id t = here.ter( tmp );
         if( fuel_type == FUEL_TYPE_GASOLINE ) {
             if( t == ter_t_gas_pump || t == ter_t_gas_pump_a ) {
                 if( number == k++ ) {
@@ -5688,15 +5687,15 @@ static int get_milled_amount( const itype_id &milled_id, const tripoint &examp,
 static void mill_activate( Character &you, const tripoint &examp )
 {
     map &here = get_map();
-    const furn_id cur_mill_type = here.furn( examp );
-    furn_id next_mill_type = f_null;
+    const resolved_furn_id cur_mill_type = here.furn( examp );
+    resolved_furn_id next_mill_type = f_null;
     if( cur_mill_type == f_wind_mill ) {
         next_mill_type = f_wind_mill_active;
     } else if( cur_mill_type == f_water_mill ) {
         next_mill_type = f_water_mill_active;
     } else {
         debugmsg( "Examined furniture has action mill_activate, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  here.furn( examp )->id.str() );
         return;
     }
     bool food_present = false;
@@ -5764,8 +5763,8 @@ static void mill_activate( Character &you, const tripoint &examp )
 static void smoker_activate( Character &you, const tripoint &examp )
 {
     map &here = get_map();
-    furn_id cur_smoker_type = here.furn( examp );
-    furn_id next_smoker_type = f_null;
+    resolved_furn_id cur_smoker_type = here.furn( examp );
+    resolved_furn_id next_smoker_type = f_null;
     const bool portable = here.furn( examp ) == furn_f_metal_smoking_rack ||
                           here.furn( examp ) == furn_f_metal_smoking_rack_active;
     if( cur_smoker_type == f_smoking_rack ) {
@@ -5774,7 +5773,7 @@ static void smoker_activate( Character &you, const tripoint &examp )
         next_smoker_type = f_metal_smoking_rack_active;
     } else {
         debugmsg( "Examined furniture has action smoker_activate, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  here.furn( examp )->id.str() );
         return;
     }
     bool food_present = false;
@@ -5878,15 +5877,15 @@ static void smoker_activate( Character &you, const tripoint &examp )
 void iexamine::mill_finalize( Character &, const tripoint &examp, const time_point &start_time )
 {
     map &here = get_map();
-    const furn_id cur_mill_type = here.furn( examp );
-    furn_id next_mill_type = f_null;
+    const resolved_furn_id cur_mill_type = here.furn( examp );
+    resolved_furn_id next_mill_type = f_null;
     if( cur_mill_type == f_wind_mill_active ) {
         next_mill_type = f_wind_mill;
     } else if( cur_mill_type == f_water_mill_active ) {
         next_mill_type = f_water_mill;
     } else {
         debugmsg( "Furniture executed action mill_finalize, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  here.furn( examp )->id.str() );
         return;
     }
 
@@ -5978,15 +5977,15 @@ void iexamine::mill_finalize( Character &, const tripoint &examp, const time_poi
 static void smoker_finalize( Character &, const tripoint &examp, const time_point &start_time )
 {
     map &here = get_map();
-    furn_id cur_smoker_type = here.furn( examp );
-    furn_id next_smoker_type = f_null;
+    resolved_furn_id cur_smoker_type = here.furn( examp );
+    resolved_furn_id next_smoker_type = f_null;
     if( cur_smoker_type == f_smoking_rack_active ) {
         next_smoker_type = f_smoking_rack;
     } else if( cur_smoker_type == f_metal_smoking_rack_active ) {
         next_smoker_type = f_metal_smoking_rack;
     } else {
         debugmsg( "Furniture executed action smoker_finalize, but is of type %s",
-                  here.furn( examp ).id().c_str() );
+                  here.furn( examp )->id.c_str() );
         return;
     }
 
@@ -6044,7 +6043,7 @@ static void smoker_load_food( Character &you, const tripoint &examp,
         return;
     }
 
-    furn_id rack = here.furn( examp );
+    resolved_furn_id rack = here.furn( examp );
     units::volume total_capacity = rack == furn_f_metal_smoking_rack ?
                                    sm_rack::MAX_FOOD_VOLUME_PORTABLE :
                                    sm_rack::MAX_FOOD_VOLUME;

--- a/src/iexamine_actors.cpp
+++ b/src/iexamine_actors.cpp
@@ -143,8 +143,8 @@ bool cardreader_examine_actor::apply( const tripoint &examp ) const
         open = false;
         const tripoint_range<tripoint> points = here.points_in_radius( examp, radius );
         for( const tripoint &tmp : points ) {
-            const auto ter_iter = terrain_changes.find( here.ter( tmp ).id() );
-            const auto furn_iter = furn_changes.find( here.furn( tmp ).id() );
+            const auto ter_iter = terrain_changes.find( here.ter( tmp )->id );
+            const auto furn_iter = furn_changes.find( here.furn( tmp )->id );
             if( ter_iter != terrain_changes.end() ) {
                 here.ter_set( tmp, ter_iter->second );
                 open = true;
@@ -252,7 +252,7 @@ std::unique_ptr<iexamine_actor> cardreader_examine_actor::clone() const
 void eoc_examine_actor::call( Character &you, const tripoint &examp ) const
 {
     dialogue d( get_talker_for( you ), nullptr );
-    d.set_value( "npctalk_var_this", get_map().furn( examp ).id().str() );
+    d.set_value( "npctalk_var_this", get_map().furn( examp )->id.str() );
     d.set_value( "npctalk_var_pos", get_map().getglobal( examp ).to_string() );
     for( const effect_on_condition_id &eoc : eocs ) {
         eoc->activate( d );

--- a/src/item_category.cpp
+++ b/src/item_category.cpp
@@ -35,7 +35,7 @@ void zone_priority_data::load( const JsonObject &jo )
     optional( jo, was_loaded, "filthy", filthy, false );
 }
 
-const std::vector<item_category> &item_category::get_all()
+const std::deque<item_category> &item_category::get_all()
 {
     return item_category_factory.get_all();
 }

--- a/src/item_category.h
+++ b/src/item_category.h
@@ -81,7 +81,7 @@ class item_category
         // generic_factory stuff
         bool was_loaded = false;
 
-        static const std::vector<item_category> &get_all();
+        static const std::deque<item_category> &get_all();
         static void load_item_cat( const JsonObject &jo, const std::string &src );
         static void reset();
         void load( const JsonObject &jo, std::string_view );

--- a/src/item_category.h
+++ b/src/item_category.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_ITEM_CATEGORY_H
 #define CATA_SRC_ITEM_CATEGORY_H
 
+#include <deque>
 #include <iosfwd>
 #include <new>
 #include <optional>

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -377,7 +377,8 @@ bool pocket_favorite_callback::key( const input_context &ctxt, const input_event
         return true;
     } else if( action == "FAV_CATEGORY" ) {
         // Get all categories and sort by name
-        std::vector<item_category> all_cat = item_category::get_all();
+        const std::deque<item_category> &all_categories = item_category::get_all();
+        std::vector<item_category> all_cat( all_categories.begin(), all_categories.end() );
         const cata::flat_set<item_category_id> &listed_cat = whitelist
                 ? selected_pocket->settings.get_category_whitelist()
                 : selected_pocket->settings.get_category_blacklist();

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1224,7 +1224,7 @@ void item_pocket::contents_info( std::vector<iteminfo> &info, int pocket_number,
             info.back().bNewLine = true;
 
             size_t idx = 0;
-            const std::vector<damage_info_order> &all_ablate = damage_info_order::get_all(
+            const std::deque<damage_info_order> &all_ablate = damage_info_order::get_all(
                         damage_info_order::info_type::ABLATE );
             for( const damage_info_order &dio : all_ablate ) {
                 std::string label = string_format( idx == 0 ? _( "<bold>Protection</bold>: %s: " ) :

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -4839,13 +4839,13 @@ std::optional<int> iuse::chop_logs( Character *p, item *it, const tripoint & )
         return std::nullopt;
     }
 
-    const std::set<ter_id> allowed_ter_id {
+    const std::set<resolved_ter_id> allowed_ter_id {
         t_trunk,
         t_stump
     };
     map &here = get_map();
     const std::function<bool( const tripoint & )> f = [&allowed_ter_id, &here]( const tripoint & pnt ) {
-        const ter_id type = here.ter( pnt );
+        const resolved_ter_id type = here.ter( pnt );
         const bool is_allowed_terrain = allowed_ter_id.find( type ) != allowed_ter_id.end();
         return is_allowed_terrain;
     };
@@ -6031,7 +6031,7 @@ static std::string colorized_ter_name_flags_at( const tripoint &point,
         const std::vector<std::string> &flags, const std::vector<ter_str_id> &ter_whitelist )
 {
     map &here = get_map();
-    const ter_id ter = here.ter( point );
+    const resolved_ter_id ter = here.ter( point );
     std::string name = colorize( ter->name(), ter->color() );
     const std::string &graffiti_message = here.graffiti_at( point );
 
@@ -6067,7 +6067,7 @@ static std::string colorized_feature_description_at( const tripoint &center_poin
 {
     item_found = false;
     map &here = get_map();
-    const furn_id furn = here.furn( center_point );
+    const resolved_furn_id furn = here.furn( center_point );
     if( furn != f_null && furn.is_valid() ) {
         std::string furn_str = colorize( furn->name(), c_yellow );
         std::string sign_message = here.get_signage( center_point );
@@ -6490,8 +6490,8 @@ static item::extended_photo_def photo_def_for_camera_point( const tripoint &aim_
         found_item_aim_point = !item.is_null();
     }
 
-    const ter_id ter_aim = here.ter( aim_point );
-    const furn_id furn_aim = here.furn( aim_point );
+    const resolved_ter_id ter_aim = here.ter( aim_point );
+    const resolved_furn_id furn_aim = here.furn( aim_point );
 
     if( !description_figures_status.empty() ) {
         std::string names = enumerate_as_string( description_figures_status.begin(),

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5337,7 +5337,7 @@ bool deploy_tent_actor::check_intact( const tripoint &center ) const
 {
     map &here = get_map();
     for( const tripoint &dest : here.points_in_radius( center, radius ) ) {
-        const furn_id fid = here.furn( dest );
+        const resolved_furn_id fid = here.furn( dest );
         if( dest == center && floor_center ) {
             if( fid != *floor_center ) {
                 return false;

--- a/src/json.h
+++ b/src/json.h
@@ -6,6 +6,7 @@
 #include <bitset>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <iostream>
 #include <iterator>
 #include <map>

--- a/src/json.h
+++ b/src/json.h
@@ -22,6 +22,7 @@
 #include "json_error.h"
 #include "int_id.h"
 #include "memory_fast.h"
+#include "resolved_id.h"
 #include "string_id.h"
 
 /* Cataclysm-DDA homegrown JSON tools
@@ -834,6 +835,11 @@ class JsonOut
         template <typename T>
         auto write( const int_id<T> &thing ) {
             write( thing.id().str() );
+        }
+
+        template <typename T>
+        auto write( const resolved_id<T> &thing ) {
+            write( thing->id );
         }
 
         // enum ~> string

--- a/src/lightmap.cpp
+++ b/src/lightmap.cpp
@@ -461,11 +461,11 @@ void map::generate_lightmap( const int zlev )
                         add_light_from_items( p, i_at( p ) );
                     }
 
-                    const ter_id terrain = cur_submap->get_ter( { sx, sy } );
+                    const resolved_ter_id terrain = cur_submap->get_ter( { sx, sy } );
                     if( terrain->light_emitted > 0 ) {
                         add_light_source( p, terrain->light_emitted );
                     }
-                    const furn_id furniture = cur_submap->get_furn( {sx, sy } );
+                    const resolved_furn_id furniture = cur_submap->get_furn( {sx, sy } );
                     if( furniture->light_emitted > 0 ) {
                         add_light_source( p, furniture->light_emitted );
                     }

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -634,7 +634,7 @@ void spell_type::check_consistency()
     }
 }
 
-const std::vector<spell_type> &spell_type::get_all()
+const std::deque<spell_type> &spell_type::get_all()
 {
     return spell_factory.get_all();
 }

--- a/src/magic.h
+++ b/src/magic.h
@@ -363,7 +363,7 @@ class spell_type
         /**
          * All spells in the game.
          */
-        static const std::vector<spell_type> &get_all();
+        static const std::deque<spell_type> &get_all();
         static void check_consistency();
         static void reset_all();
         bool is_valid() const;

--- a/src/magic.h
+++ b/src/magic.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_MAGIC_H
 #define CATA_SRC_MAGIC_H
 
+#include <deque>
 #include <functional>
 #include <iosfwd>
 #include <map>

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -606,7 +606,7 @@ static void magical_polymorph( monster &victim, Creature &caster, const spell &s
     // if effect_str is empty, we become a random monster of close difficulty
     if( new_id.is_empty() ) {
         int victim_diff = victim.type->difficulty;
-        const std::vector<mtype> &mtypes = MonsterGenerator::generator().get_all_mtypes();
+        const std::deque<mtype> &mtypes = MonsterGenerator::generator().get_all_mtypes();
         for( int difficulty_variance = 1; difficulty_variance < 2048; difficulty_variance *= 2 ) {
             unsigned int random_entry = rng( 0, mtypes.size() );
             unsigned int iter = random_entry + 1;

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -54,7 +54,7 @@ bool ter_furn_transform::is_valid() const
     return ter_furn_transform_factory.is_valid( this->id );
 }
 
-const std::vector<ter_furn_transform> &ter_furn_transform::get_all()
+const std::deque<ter_furn_transform> &ter_furn_transform::get_all()
 {
     return ter_furn_transform_factory.get_all();
 }

--- a/src/magic_ter_fur_transform.cpp
+++ b/src/magic_ter_fur_transform.cpp
@@ -216,10 +216,10 @@ std::optional<std::pair<trap_str_id, std::pair<translation, bool>>> ter_furn_tra
 void ter_furn_transform::transform( map &m, const tripoint_bub_ms &location ) const
 {
     avatar &you = get_avatar();
-    const ter_id ter_at_loc = m.ter( location );
+    const resolved_ter_id ter_at_loc = m.ter( location );
     std::optional<std::pair<ter_str_id, std::pair<translation, bool>>> ter_potential = next_ter(
                 ter_at_loc->id );
-    const furn_id furn_at_loc = m.furn( location );
+    const resolved_furn_id furn_at_loc = m.furn( location );
     std::optional<std::pair<furn_str_id, std::pair<translation, bool>>> furn_potential = next_furn(
                 furn_at_loc->id );
     const trap_str_id trap_at_loc = m.maptile_at( location ).get_trap().id();

--- a/src/magic_ter_furn_transform.h
+++ b/src/magic_ter_furn_transform.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_MAGIC_TER_FURN_TRANSFORM_H
 #define CATA_SRC_MAGIC_TER_FURN_TRANSFORM_H
 
+#include <deque>
 #include <map>
 #include <optional>
 #include <vector>

--- a/src/magic_ter_furn_transform.h
+++ b/src/magic_ter_furn_transform.h
@@ -84,7 +84,7 @@ class ter_furn_transform
         static void load_transform( const JsonObject &jo, const std::string &src );
         void load( const JsonObject &jo, std::string_view );
 
-        static const std::vector<ter_furn_transform> &get_all();
+        static const std::deque<ter_furn_transform> &get_all();
         static void reset_all();
         bool is_valid() const;
 };

--- a/src/map.h
+++ b/src/map.h
@@ -786,8 +786,10 @@ class map
         vehicle *move_vehicle( vehicle &veh, const tripoint &dp, const tileray &facing );
 
         // Furniture
-        void set( const tripoint &p, const ter_id &new_terrain, const furn_id &new_furniture );
-        void set( const point &p, const ter_id &new_terrain, const furn_id &new_furniture ) {
+        void set( const tripoint &p, const resolved_ter_id &new_terrain,
+                  const resolved_furn_id &new_furniture );
+        void set( const point &p, const resolved_ter_id &new_terrain,
+                  const resolved_furn_id &new_furniture ) {
             furn_set( p, new_furniture );
             ter_set( p, new_terrain );
         }
@@ -810,9 +812,9 @@ class map
             return has_furn( tripoint( p, abs_sub.z() ) );
         }
         // TODO: fix point types (remove the first overload)
-        furn_id furn( const tripoint &p ) const;
-        furn_id furn( const tripoint_bub_ms &p ) const;
-        furn_id furn( const point &p ) const {
+        resolved_furn_id furn( const tripoint &p ) const;
+        resolved_furn_id furn( const tripoint_bub_ms &p ) const;
+        resolved_furn_id furn( const point &p ) const {
             return furn( tripoint( p, abs_sub.z() ) );
         }
         /**
@@ -820,11 +822,12 @@ class map
         * when the player is grab-moving furniture
         */
         // TODO: fix point types (remove the first overload)
-        bool furn_set( const tripoint &p, const furn_id &new_furniture, bool furn_reset = false,
+        bool furn_set( const tripoint &p, const resolved_furn_id &new_furniture, bool furn_reset = false,
                        bool avoid_creatures = false );
-        bool furn_set( const tripoint_bub_ms &p, const furn_id &new_furniture,
+        bool furn_set( const tripoint_bub_ms &p, const resolved_furn_id &new_furniture,
                        bool furn_reset = false, bool avoid_creatures = false );
-        bool furn_set( const point &p, const furn_id &new_furniture, bool avoid_creatures = false ) {
+        bool furn_set( const point &p, const resolved_furn_id &new_furniture,
+                       bool avoid_creatures = false ) {
             return furn_set( tripoint( p, abs_sub.z() ), new_furniture, false, avoid_creatures );
         }
         void furn_clear( const tripoint &p ) {
@@ -843,9 +846,9 @@ class map
 
         // Terrain
         // TODO: fix point types (remove the first overload)
-        ter_id ter( const tripoint &p ) const;
-        ter_id ter( const tripoint_bub_ms &p ) const;
-        ter_id ter( const point &p ) const {
+        resolved_ter_id ter( const tripoint &p ) const;
+        resolved_ter_id ter( const tripoint_bub_ms &p ) const;
+        resolved_ter_id ter( const point &p ) const {
             return ter( tripoint( p, abs_sub.z() ) );
         }
 
@@ -860,10 +863,10 @@ class map
         // at specific positions. This is used to display terrain overview in
         // the map editor.
         uint8_t get_known_connections( const tripoint &p, const std::bitset<NUM_TERCONN> &connect_group,
-                                       const std::map<tripoint, ter_id> &override = {} ) const;
+                                       const std::map<tripoint, resolved_ter_id> &override = {} ) const;
         // as above, but for furniture
         uint8_t get_known_connections_f( const tripoint &p, const std::bitset<NUM_TERCONN> &connect_group,
-                                         const std::map<tripoint, furn_id> &override = {} ) const;
+                                         const std::map<tripoint, resolved_furn_id> &override = {} ) const;
 
         // Return a bitfield of the adjacent tiles which rotate towards the given
         // connect_group.  From least-significant bit the order is south, east,
@@ -873,11 +876,11 @@ class map
         // Additional overrides can be passed in to override terrain
         // at specific positions.
         uint8_t get_known_rotates_to( const tripoint &p, const std::bitset<NUM_TERCONN> &rotate_to_group,
-                                      const std::map<tripoint, ter_id> &override = {} ) const;
+                                      const std::map<tripoint, resolved_ter_id> &override = {} ) const;
         // as above, but for furniture (considers neighbouring terrain and furniture)
         uint8_t get_known_rotates_to_f( const tripoint &p, const std::bitset<NUM_TERCONN> &rotate_to_group,
-                                        const std::map<tripoint, ter_id> &override = {},
-                                        const std::map<tripoint, furn_id> &override_f = {} ) const;
+                                        const std::map<tripoint, resolved_ter_id> &override = {},
+                                        const std::map<tripoint, resolved_furn_id> &override_f = {} ) const;
 
         /**
          * Returns the full harvest list, for spawning.
@@ -890,13 +893,15 @@ class map
         ter_id get_ter_transforms_into( const tripoint &p ) const;
 
         // TODO: fix point types (remove the first overload)
-        bool ter_set( const tripoint &p, const ter_id &new_terrain, bool avoid_creatures = false );
-        bool ter_set( const tripoint_bub_ms &, const ter_id &new_terrain, bool avoid_creatures = false );
+        bool ter_set( const tripoint &p, const resolved_ter_id &new_terrain, bool avoid_creatures = false );
+        bool ter_set( const tripoint_bub_ms &, const resolved_ter_id &new_terrain,
+                      bool avoid_creatures = false );
         // TODO: fix point types (remove the first overload)
-        bool ter_set( const point &p, const ter_id &new_terrain, bool avoid_creatures = false ) {
+        bool ter_set( const point &p, const resolved_ter_id &new_terrain, bool avoid_creatures = false ) {
             return ter_set( tripoint( p, abs_sub.z() ), new_terrain, avoid_creatures );
         }
-        bool ter_set( const point_bub_ms &p, const ter_id &new_terrain, bool avoid_creatures = false ) {
+        bool ter_set( const point_bub_ms &p, const resolved_ter_id &new_terrain,
+                      bool avoid_creatures = false ) {
             return ter_set( tripoint_bub_ms( p, abs_sub.z() ), new_terrain, avoid_creatures );
         }
 
@@ -921,7 +926,7 @@ class map
         /**
          * Checks whether a specific terrain is nearby.
         */
-        bool has_nearby_ter( const tripoint &p, const ter_id &type, int radius = 1 ) const;
+        bool has_nearby_ter( const tripoint &p, const resolved_ter_id &type, int radius = 1 ) const;
         /**
          * Check if creature can see some items at p. Includes:
          * - check for items at this location (has_items(p))
@@ -1073,9 +1078,9 @@ class map
         // Rubble
         /** Generates rubble at the given location, if overwrite is true it just writes on top of what currently exists
          *  floor_type is only used if there is a non-bashable wall at the location or with overwrite = true */
-        void make_rubble( const tripoint &p, const furn_id &rubble_type, bool items,
-                          const ter_id &floor_type, bool overwrite = false );
-        void make_rubble( const tripoint &p, const furn_id &rubble_type, bool items ) {
+        void make_rubble( const tripoint &p, const resolved_furn_id &rubble_type, bool items,
+                          const resolved_ter_id &floor_type, bool overwrite = false );
+        void make_rubble( const tripoint &p, const resolved_furn_id &rubble_type, bool items ) {
             make_rubble( p, rubble_type, items, t_dirt, false );
         }
         void make_rubble( const tripoint &p ) {
@@ -1133,36 +1138,37 @@ class map
         point random_outdoor_tile() const;
         // mapgen
 
-        void draw_line_ter( const ter_id &type, const point &p1, const point &p2,
+        void draw_line_ter( const resolved_ter_id &type, const point &p1, const point &p2,
                             bool avoid_creature = false );
-        void draw_line_furn( const furn_id &type, const point &p1, const point &p2,
+        void draw_line_furn( const resolved_furn_id &type, const point &p1, const point &p2,
                              bool avoid_creatures = false );
-        void draw_fill_background( const ter_id &type );
-        void draw_fill_background( ter_id( *f )() );
-        void draw_fill_background( const weighted_int_list<ter_id> &f );
+        void draw_fill_background( const resolved_ter_id &type );
+        void draw_fill_background( resolved_ter_id( *f )() );
+        void draw_fill_background( const weighted_int_list<resolved_ter_id> &f );
 
-        void draw_square_ter( const ter_id &type, const point &p1, const point &p2,
+        void draw_square_ter( const resolved_ter_id &type, const point &p1, const point &p2,
                               bool avoid_creature = false );
-        void draw_square_furn( const furn_id &type, const point &p1, const point &p2,
+        void draw_square_furn( const resolved_furn_id &type, const point &p1, const point &p2,
                                bool avoid_creatures = false );
-        void draw_square_ter( ter_id( *f )(), const point &p1, const point &p2,
+        void draw_square_ter( resolved_ter_id( *f )(), const point &p1, const point &p2,
                               bool avoid_creatures = false );
-        void draw_square_ter( const weighted_int_list<ter_id> &f, const point &p1,
+        void draw_square_ter( const weighted_int_list<resolved_ter_id> &f, const point &p1,
                               const point &p2, bool avoid_creatures = false );
-        void draw_rough_circle_ter( const ter_id &type, const point &p, int rad );
-        void draw_rough_circle_furn( const furn_id &type, const point &p, int rad );
-        void draw_circle_ter( const ter_id &type, const rl_vec2d &p, double rad );
-        void draw_circle_ter( const ter_id &type, const point &p, int rad );
-        void draw_circle_furn( const furn_id &type, const point &p, int rad );
+        void draw_rough_circle_ter( const resolved_ter_id &type, const point &p, int rad );
+        void draw_rough_circle_furn( const resolved_furn_id &type, const point &p, int rad );
+        void draw_circle_ter( const resolved_ter_id &type, const rl_vec2d &p, double rad );
+        void draw_circle_ter( const resolved_ter_id &type, const point &p, int rad );
+        void draw_circle_furn( const resolved_furn_id &type, const point &p, int rad );
 
         void add_corpse( const tripoint &p );
 
         // Terrain changing functions
         // Change all instances of $from->$to
-        void translate( const ter_id &from, const ter_id &to );
+        void translate( const resolved_ter_id &from, const resolved_ter_id &to );
         // Change all instances $from->$to within this radius, optionally limited to locations in the same submap.
         // Optionally toggles instances $from->$to & $to->$from
-        void translate_radius( const ter_id &from, const ter_id &to, float radi, const tripoint &p,
+        void translate_radius( const resolved_ter_id &from, const resolved_ter_id &to, float radi,
+                               const tripoint &p,
                                bool same_submap = false, bool toggle_between = false );
         void transform_radius( const ter_furn_transform_id &transform, int radi,
                                const tripoint_abs_ms &p );
@@ -2185,7 +2191,7 @@ class map
         // Gets the roof type of the tile at p
         // Second argument refers to whether we have to get a roof (we're over an unpassable tile)
         // or can just return air because we bashed down an entire floor tile
-        ter_id get_roof( const tripoint &p, bool allow_air ) const;
+        resolved_ter_id get_roof( const tripoint &p, bool allow_air ) const;
 
     public:
         void process_items();
@@ -2381,7 +2387,7 @@ class fake_map : public tinymap
     private:
         std::vector<std::unique_ptr<submap>> temp_submaps_;
     public:
-        explicit fake_map( const ter_id &ter_type = t_dirt );
+        explicit fake_map( const resolved_ter_id &ter_type = t_dirt );
         ~fake_map() override;
         static constexpr int fake_map_z = -OVERMAP_DEPTH;
 };

--- a/src/map_extras.cpp
+++ b/src/map_extras.cpp
@@ -229,22 +229,22 @@ static void dead_vegetation_parser( map &m, const tripoint &loc )
         m.spawn_item( loc, itype_withered );
     }
     // terrain specific conversions
-    const ter_id tid = m.ter( loc );
-    static const std::map<ter_id, ter_str_id> dies_into {{
-            {t_grass, ter_t_grass_dead},
-            {t_grass_long, ter_t_grass_dead},
-            {t_grass_tall, ter_t_grass_dead},
-            {t_moss, ter_t_grass_dead},
-            {t_tree_pine, ter_t_tree_deadpine},
-            {t_tree_birch, ter_t_tree_birch_harvested},
-            {t_tree_willow, ter_t_tree_dead},
-            {t_tree_hickory, ter_t_tree_hickory_dead},
-            {t_tree_hickory_harvested, ter_t_tree_hickory_dead},
-            {t_grass_golf, ter_t_grass_dead},
-            {t_grass_white, ter_t_grass_dead},
+    const resolved_ter_id tid = m.ter( loc );
+    static const std::map<ter_str_id, ter_str_id> dies_into {{
+            {t_grass->id, ter_t_grass_dead},
+            {t_grass_long->id, ter_t_grass_dead},
+            {t_grass_tall->id, ter_t_grass_dead},
+            {t_moss->id, ter_t_grass_dead},
+            {t_tree_pine->id, ter_t_tree_deadpine},
+            {t_tree_birch->id, ter_t_tree_birch_harvested},
+            {t_tree_willow->id, ter_t_tree_dead},
+            {t_tree_hickory->id, ter_t_tree_hickory_dead},
+            {t_tree_hickory_harvested->id, ter_t_tree_hickory_dead},
+            {t_grass_golf->id, ter_t_grass_dead},
+            {t_grass_white->id, ter_t_grass_dead},
         }};
 
-    const auto iter = dies_into.find( tid );
+    const auto iter = dies_into.find( tid->id );
     if( iter != dies_into.end() ) {
         m.ter_set( loc, iter->second );
     }
@@ -1118,7 +1118,7 @@ static bool mx_grove( map &m, const tripoint &abs_sub )
     // This map extra finds the first tree in the area, and then converts all trees, young trees,
     // and shrubs in the area into that type of tree.
 
-    ter_id tree;
+    resolved_ter_id tree;
     bool found_tree = false;
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
@@ -1153,7 +1153,7 @@ static bool mx_shrubbery( map &m, const tripoint &abs_sub )
     // This map extra finds the first shrub in the area, and then converts all trees, young trees,
     // and shrubs in the area into that type of shrub.
 
-    ter_id shrubbery;
+    resolved_ter_id shrubbery;
     bool found_shrubbery = false;
     for( int i = 0; i < SEEX * 2; i++ ) {
         for( int j = 0; j < SEEY * 2; j++ ) {
@@ -1320,7 +1320,7 @@ static bool mx_point_dead_vegetation( map &m, const tripoint &abs_sub )
 static void burned_ground_parser( map &m, const tripoint &loc )
 {
     const furn_t &fid = m.furn( loc ).obj();
-    const ter_id tid = m.ter( loc );
+    const resolved_ter_id tid = m.ter( loc );
     const ter_t &tr = tid.obj();
 
     VehicleList vehs = m.get_vehicles();
@@ -1358,17 +1358,17 @@ static void burned_ground_parser( map &m, const tripoint &loc )
     // grass is converted separately
     // this method is deliberate to allow adding new post-terrains
     // (TODO: expand this list when new destroyed terrain is added)
-    static const std::map<ter_id, ter_str_id> dies_into {{
-            {t_grass, ter_t_grass_dead},
-            {t_grass_long, ter_t_grass_dead},
-            {t_grass_tall, ter_t_grass_dead},
-            {t_moss, ter_t_grass_dead},
-            {t_fungus, ter_t_dirt},
-            {t_grass_golf, ter_t_grass_dead},
-            {t_grass_white, ter_t_grass_dead},
+    static const std::map<ter_str_id, ter_str_id> dies_into {{
+            {t_grass->id, ter_t_grass_dead},
+            {t_grass_long->id, ter_t_grass_dead},
+            {t_grass_tall->id, ter_t_grass_dead},
+            {t_moss->id, ter_t_grass_dead},
+            {t_fungus->id, ter_t_dirt},
+            {t_grass_golf->id, ter_t_grass_dead},
+            {t_grass_white->id, ter_t_grass_dead},
         }};
 
-    const auto iter = dies_into.find( tid );
+    const auto iter = dies_into.find( tid->id );
     if( iter != dies_into.end() ) {
         if( one_in( 6 ) ) {
             m.ter_set( loc, t_dirt );
@@ -1524,7 +1524,7 @@ static bool mx_reed( map &m, const tripoint &abs_sub )
         return false;
     };
 
-    weighted_int_list<furn_id> vegetation;
+    weighted_int_list<resolved_furn_id> vegetation;
     vegetation.add( f_cattails, 15 );
     vegetation.add( f_lotus, 5 );
     vegetation.add( furn_id( "f_purple_loosestrife" ), 1 );
@@ -1534,7 +1534,7 @@ static bool mx_reed( map &m, const tripoint &abs_sub )
             const tripoint loc( i, j, abs_sub.z );
             if( ( m.ter( loc ) == t_water_sh || m.ter( loc ) == t_water_moving_sh ) &&
                 one_in( intensity ) ) {
-                m.furn_set( loc, vegetation.pick()->id() );
+                m.furn_set( loc, *vegetation.pick() );
             }
             // tall grass imitates reed
             if( ( m.ter( loc ) == t_dirt || m.ter( loc ) == t_grass ) &&
@@ -1566,12 +1566,12 @@ static bool mx_roadworks( map &m, const tripoint &abs_sub )
     const bool road_at_east = east->get_type_id() == oter_type_road;
 
     // defect types
-    weighted_int_list<ter_id> road_defects;
+    weighted_int_list<resolved_ter_id> road_defects;
     road_defects.add( t_pit_shallow, 15 );
     road_defects.add( t_dirt, 15 );
     road_defects.add( t_dirtmound, 15 );
     road_defects.add( t_pavement, 55 );
-    const weighted_int_list<ter_id> defects = road_defects;
+    const weighted_int_list<resolved_ter_id> defects = road_defects;
 
     // location holders
     point defects_from; // road defects square start

--- a/src/map_field.cpp
+++ b/src/map_field.cpp
@@ -1144,7 +1144,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
         }
     }
     // If the flames are in a pit, it can't spread to non-pit
-    const bool in_pit = ter.id.id() == t_pit;
+    const bool in_pit = ter.id == t_pit->id;
 
     // Count adjacent fires, to optimize out needless smoke and hot air
     int adjacent_fires = 0;
@@ -1301,7 +1301,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             // Allow weaker fires to spread occasionally
             const int power = cur.get_field_intensity() + one_in( 5 );
             if( can_spread && rng( 1, 100 ) < spread_chance &&
-                ( in_pit == ( dster.id.id() == t_pit ) ) &&
+                ( in_pit == ( dster.id == t_pit->id ) ) &&
                 (
                     ( power >= 2 && ( ter_furn_has_flag( dster, dsfrn, ter_furn_flag::TFLAG_FLAMMABLE ) &&
                                       one_in( 2 ) ) ) ||
@@ -1361,7 +1361,7 @@ void field_processor_fd_fire( const tripoint &p, field_entry &cur, field_proc_da
             // Allow weaker fires to spread occasionally
             const int power = cur.get_field_intensity() + one_in( 5 );
             if( can_spread && rng( 1, 100 ) < spread_chance &&
-                ( in_pit == ( dster.id.id() == t_pit ) ) &&
+                ( in_pit == ( dster.id == t_pit->id ) ) &&
                 (
                     ( power >= 2 && ( ter_furn_has_flag( dster, dsfrn, ter_furn_flag::TFLAG_FLAMMABLE ) &&
                                       one_in( 2 ) ) ) ||

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -36,7 +36,9 @@ const units::volume DEFAULT_MAX_VOLUME_IN_SQUARE = units::from_liter( 1000 );
 generic_factory<ter_t> terrain_data( "terrain" );
 generic_factory<furn_t> furniture_data( "furniture" );
 
+// NOLINTNEXTLINE(cata-static-int_id-constants)
 ter_id null_ter;
+// NOLINTNEXTLINE(cata-static-int_id-constants)
 furn_id null_furn;
 
 ter_t invalid_ter;
@@ -757,7 +759,7 @@ void map_data_common_t::set_groups( std::bitset<NUM_TERCONN> &bits,
     }
 }
 
-ter_str_id t_str_null( "t_null" );
+const ter_str_id ter_t_null( "t_null" );
 
 resolved_ter_id t_null,
                 t_hole, // Real nothingness; makes you fall a z-level
@@ -883,7 +885,7 @@ resolved_ter_id t_null,
 
 void set_ter_ids()
 {
-    t_null = null_ter = t_str_null;
+    t_null = null_ter = ter_t_null;
     t_hole = ter_id( "t_hole" );
     t_dirt = ter_id( "t_dirt" );
     t_sand = ter_id( "t_sand" );
@@ -1192,7 +1194,7 @@ void reset_furn_ter()
     furniture_data.reset();
 }
 
-static furn_str_id f_str_null( "f_null" );
+static const furn_str_id furn_t_null( "f_null" );
 
 resolved_furn_id f_null, f_clear,
                  f_hay,
@@ -1242,7 +1244,7 @@ resolved_furn_id f_null, f_clear,
 
 void set_furn_ids()
 {
-    f_null = null_furn = f_str_null;
+    f_null = null_furn = furn_t_null;
     f_clear = furn_id( "f_clear" );
     f_hay = furn_id( "f_hay" );
     f_rubble = furn_id( "f_rubble" );
@@ -1805,7 +1807,7 @@ void activity_data_ter::load( const JsonObject &jo )
 
 void activity_data_furn::load( const JsonObject &jo )
 {
-    optional( jo, was_loaded, "result", result_, f_str_null );
+    optional( jo, was_loaded, "result", result_, furn_t_null );
     activity_data_common::load( jo );
     valid_ = true;
 }

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -26,7 +26,11 @@
 #include "trap.h"
 #include "type_id.h"
 
+static const furn_str_id furn_f_null( "f_null" );
+
 static const item_group_id Item_spawn_data_EMPTY_GROUP( "EMPTY_GROUP" );
+
+const ter_str_id ter_t_null( "t_null" );
 
 namespace
 {
@@ -759,8 +763,6 @@ void map_data_common_t::set_groups( std::bitset<NUM_TERCONN> &bits,
     }
 }
 
-const ter_str_id ter_t_null( "t_null" );
-
 resolved_ter_id t_null,
                 t_hole, // Real nothingness; makes you fall a z-level
                 // Ground
@@ -1193,8 +1195,6 @@ void reset_furn_ter()
     terrain_data.reset();
     furniture_data.reset();
 }
-
-static const furn_str_id furn_f_null( "f_null" );
 
 resolved_furn_id f_null, f_clear,
                  f_hay,

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -36,11 +36,17 @@ const units::volume DEFAULT_MAX_VOLUME_IN_SQUARE = units::from_liter( 1000 );
 generic_factory<ter_t> terrain_data( "terrain" );
 generic_factory<furn_t> furniture_data( "furniture" );
 
+ter_id null_ter;
+furn_id null_furn;
+
+ter_t invalid_ter;
+furn_t invalid_furn;
+
 } // namespace
 
 /** @relates int_id */
 template<>
-inline bool int_id<ter_t>::is_valid() const
+bool int_id<ter_t>::is_valid() const
 {
     return terrain_data.is_valid( *this );
 }
@@ -63,7 +69,7 @@ const string_id<ter_t> &int_id<ter_t>::id() const
 template<>
 int_id<ter_t> string_id<ter_t>::id() const
 {
-    return terrain_data.convert( *this, t_null );
+    return terrain_data.convert( *this, null_ter );
 }
 
 /** @relates int_id */
@@ -84,6 +90,12 @@ template<>
 bool string_id<ter_t>::is_valid() const
 {
     return terrain_data.is_valid( *this );
+}
+
+template<>
+const ter_t &resolved_id<ter_t>::invalid_obj() const
+{
+    return invalid_ter;
 }
 
 /** @relates int_id */
@@ -125,13 +137,19 @@ const furn_t &string_id<furn_t>::obj() const
 template<>
 int_id<furn_t> string_id<furn_t>::id() const
 {
-    return furniture_data.convert( *this, f_null );
+    return furniture_data.convert( *this, null_furn );
 }
 
 /** @relates int_id */
 template<>
 int_id<furn_t>::int_id( const string_id<furn_t> &id ) : _id( id.id() )
 {
+}
+
+template<>
+const furn_t &resolved_id<furn_t>::invalid_obj() const
+{
+    return invalid_furn;
 }
 
 namespace io
@@ -739,131 +757,133 @@ void map_data_common_t::set_groups( std::bitset<NUM_TERCONN> &bits,
     }
 }
 
-ter_id t_null,
-       t_hole, // Real nothingness; makes you fall a z-level
-       // Ground
-       t_dirt, t_sand, t_clay, t_dirtmound, t_pit_shallow, t_pit, t_grave, t_grave_new,
-       t_pit_corpsed, t_pit_covered, t_pit_spiked, t_pit_spiked_covered, t_pit_glass, t_pit_glass_covered,
-       t_rock_floor,
-       t_grass, t_grass_long, t_grass_tall, t_grass_golf, t_grass_dead, t_grass_white, t_moss,
-       t_grass_alien,
-       t_metal_floor,
-       t_pavement, t_pavement_y, t_sidewalk, t_concrete, t_zebra,
-       t_thconc_floor, t_thconc_floor_olight, t_strconc_floor,
-       t_floor, t_floor_waxed,
-       t_dirtfloor,//Dirt floor(Has roof)
-       t_carpet_red, t_carpet_yellow, t_carpet_purple, t_carpet_green,
-       t_linoleum_white, t_linoleum_gray,
-       t_grate,
-       t_slime,
-       t_bridge,
-       t_covered_well,
-       // Lighting related
-       t_utility_light,
-       // Walls
-       t_wall_log_half, t_wall_log, t_wall_log_chipped, t_wall_log_broken, t_palisade, t_palisade_gate,
-       t_palisade_gate_o,
-       t_wall_half, t_wall_wood, t_wall_wood_chipped, t_wall_wood_broken,
-       t_wall, t_concrete_wall, t_brick_wall,
-       t_wall_metal,
-       t_scrap_wall,
-       t_scrap_wall_halfway,
-       t_wall_glass,
-       t_wall_glass_alarm,
-       t_reinforced_glass, t_reinforced_glass_shutter, t_reinforced_glass_shutter_open,
-       t_laminated_glass, t_ballistic_glass,
-       t_reinforced_door_glass_o, t_reinforced_door_glass_c,
-       t_bars,
-       t_reb_cage,
-       t_door_c, t_door_c_peep, t_door_b, t_door_b_peep, t_door_o, t_door_o_peep, t_rdoor_c, t_rdoor_b,
-       t_rdoor_o, t_door_locked_interior, t_door_locked, t_door_locked_peep, t_door_locked_alarm,
-       t_door_frame,
-       t_chaingate_l, t_fencegate_c, t_fencegate_o, t_chaingate_c, t_chaingate_o,
-       t_retractable_gate_c, t_retractable_gate_l, t_retractable_gate_o,
-       t_door_boarded, t_door_boarded_damaged, t_door_boarded_peep, t_rdoor_boarded,
-       t_rdoor_boarded_damaged, t_door_boarded_damaged_peep,
-       t_door_metal_c, t_door_metal_o, t_door_metal_locked, t_door_metal_pickable, t_mdoor_frame,
-       t_door_bar_c, t_door_bar_o, t_door_bar_locked,
-       t_door_glass_c, t_door_glass_o, t_door_glass_frosted_c, t_door_glass_frosted_o,
-       t_portcullis,
-       t_recycler, t_window, t_window_taped, t_window_domestic, t_window_domestic_taped, t_window_open,
-       t_curtains, t_window_bars_curtains, t_window_bars_domestic,
-       t_window_alarm, t_window_alarm_taped, t_window_empty, t_window_frame, t_window_boarded,
-       t_window_boarded_noglass, t_window_reinforced, t_window_reinforced_noglass, t_window_enhanced,
-       t_window_enhanced_noglass, t_window_bars_alarm, t_window_bars,
-       t_metal_grate_window, t_metal_grate_window_with_curtain, t_metal_grate_window_with_curtain_open,
-       t_metal_grate_window_noglass, t_metal_grate_window_with_curtain_noglass,
-       t_metal_grate_window_with_curtain_open_noglass,
-       t_window_stained_green, t_window_stained_red, t_window_stained_blue,
-       t_window_no_curtains, t_window_no_curtains_open, t_window_no_curtains_taped,
-       t_rock, t_fault,
-       t_paper,
-       t_rock_wall, t_rock_wall_half,
-       // Tree
-       t_tree, t_tree_young, t_tree_apple, t_tree_apple_harvested, t_tree_coffee, t_tree_coffee_harvested,
-       t_tree_pear, t_tree_pear_harvested, t_tree_cherry, t_tree_cherry_harvested,
-       t_tree_peach, t_tree_peach_harvested, t_tree_apricot, t_tree_apricot_harvested, t_tree_plum,
-       t_tree_plum_harvested,
-       t_tree_pine, t_tree_blackjack, t_tree_birch, t_tree_willow, t_tree_maple, t_tree_maple_tapped,
-       t_tree_hickory, t_tree_hickory_dead, t_tree_hickory_harvested, t_tree_deadpine, t_underbrush,
-       t_shrub, t_shrub_blueberry, t_shrub_strawberry, t_trunk, t_stump,
-       t_root_wall,
-       t_wax, t_floor_wax,
-       t_fence, t_chainfence, t_chainfence_posts,
-       t_fence_post, t_fence_wire, t_fence_barbed, t_fence_rope,
-       t_railing,
-       // Nether
-       t_marloss, t_fungus_floor_in, t_fungus_floor_sup, t_fungus_floor_out, t_fungus_wall,
-       t_fungus_mound, t_fungus, t_shrub_fungal, t_tree_fungal, t_tree_fungal_young, t_marloss_tree,
-       // Water, lava, etc.
-       t_water_moving_dp, t_water_moving_sh, t_water_sh, t_water_dp, t_swater_sh, t_swater_dp,
-       t_swater_surf, t_water_pool, t_sewage,
-       t_lava,
-       // More embellishments than you can shake a stick at.
-       t_sandbox, t_slide, t_monkey_bars, t_backboard,
-       t_gas_pump, t_gas_pump_smashed,
-       t_diesel_pump, t_diesel_pump_smashed,
-       t_atm,
-       t_missile, t_missile_exploded,
-       t_radio_tower, t_radio_controls,
-       t_gates_mech_control, t_gates_control_concrete, t_gates_control_brick,
-       t_barndoor, t_palisade_pulley,
-       t_gates_control_metal,
-       t_sewage_pipe, t_sewage_pump,
-       t_column,
-       t_vat,
-       t_rootcellar,
-       t_cvdbody, t_cvdmachine,
-       t_water_pump,
-       t_conveyor,
-       t_improvised_shelter,
-       // Staircases etc.
-       t_stairs_down, t_stairs_up, t_manhole, t_ladder_up, t_ladder_down, t_slope_down,
-       t_slope_up, t_rope_up,
-       t_manhole_cover,
-       // Special
-       t_card_science, t_card_military, t_card_industrial, t_card_reader_broken, t_slot_machine,
-       t_elevator_control, t_elevator_control_off, t_elevator, t_pedestal_wyrm,
-       t_pedestal_temple,
-       // Temple tiles
-       t_rock_red, t_rock_green, t_rock_blue, t_floor_red, t_floor_green, t_floor_blue,
-       t_switch_rg, t_switch_gb, t_switch_rb, t_switch_even, t_open_air,
-       t_pavement_bg_dp, t_pavement_y_bg_dp, t_sidewalk_bg_dp, t_guardrail_bg_dp,
-       t_rad_platform,
-       // Railroad and subway
-       t_railroad_rubble,
-       t_buffer_stop, t_railroad_crossing_signal, t_crossbuck_wood, t_crossbuck_metal,
-       t_railroad_tie, t_railroad_tie_h, t_railroad_tie_v, t_railroad_tie_d,
-       t_railroad_track, t_railroad_track_h, t_railroad_track_v, t_railroad_track_d, t_railroad_track_d1,
-       t_railroad_track_d2,
-       t_railroad_track_on_tie, t_railroad_track_h_on_tie, t_railroad_track_v_on_tie,
-       t_railroad_track_d_on_tie;
+ter_str_id t_str_null( "t_null" );
+
+resolved_ter_id t_null,
+                t_hole, // Real nothingness; makes you fall a z-level
+                // Ground
+                t_dirt, t_sand, t_clay, t_dirtmound, t_pit_shallow, t_pit, t_grave, t_grave_new,
+                t_pit_corpsed, t_pit_covered, t_pit_spiked, t_pit_spiked_covered, t_pit_glass, t_pit_glass_covered,
+                t_rock_floor,
+                t_grass, t_grass_long, t_grass_tall, t_grass_golf, t_grass_dead, t_grass_white, t_moss,
+                t_grass_alien,
+                t_metal_floor,
+                t_pavement, t_pavement_y, t_sidewalk, t_concrete, t_zebra,
+                t_thconc_floor, t_thconc_floor_olight, t_strconc_floor,
+                t_floor, t_floor_waxed,
+                t_dirtfloor,//Dirt floor(Has roof)
+                t_carpet_red, t_carpet_yellow, t_carpet_purple, t_carpet_green,
+                t_linoleum_white, t_linoleum_gray,
+                t_grate,
+                t_slime,
+                t_bridge,
+                t_covered_well,
+                // Lighting related
+                t_utility_light,
+                // Walls
+                t_wall_log_half, t_wall_log, t_wall_log_chipped, t_wall_log_broken, t_palisade, t_palisade_gate,
+                t_palisade_gate_o,
+                t_wall_half, t_wall_wood, t_wall_wood_chipped, t_wall_wood_broken,
+                t_wall, t_concrete_wall, t_brick_wall,
+                t_wall_metal,
+                t_scrap_wall,
+                t_scrap_wall_halfway,
+                t_wall_glass,
+                t_wall_glass_alarm,
+                t_reinforced_glass, t_reinforced_glass_shutter, t_reinforced_glass_shutter_open,
+                t_laminated_glass, t_ballistic_glass,
+                t_reinforced_door_glass_o, t_reinforced_door_glass_c,
+                t_bars,
+                t_reb_cage,
+                t_door_c, t_door_c_peep, t_door_b, t_door_b_peep, t_door_o, t_door_o_peep, t_rdoor_c, t_rdoor_b,
+                t_rdoor_o, t_door_locked_interior, t_door_locked, t_door_locked_peep, t_door_locked_alarm,
+                t_door_frame,
+                t_chaingate_l, t_fencegate_c, t_fencegate_o, t_chaingate_c, t_chaingate_o,
+                t_retractable_gate_c, t_retractable_gate_l, t_retractable_gate_o,
+                t_door_boarded, t_door_boarded_damaged, t_door_boarded_peep, t_rdoor_boarded,
+                t_rdoor_boarded_damaged, t_door_boarded_damaged_peep,
+                t_door_metal_c, t_door_metal_o, t_door_metal_locked, t_door_metal_pickable, t_mdoor_frame,
+                t_door_bar_c, t_door_bar_o, t_door_bar_locked,
+                t_door_glass_c, t_door_glass_o, t_door_glass_frosted_c, t_door_glass_frosted_o,
+                t_portcullis,
+                t_recycler, t_window, t_window_taped, t_window_domestic, t_window_domestic_taped, t_window_open,
+                t_curtains, t_window_bars_curtains, t_window_bars_domestic,
+                t_window_alarm, t_window_alarm_taped, t_window_empty, t_window_frame, t_window_boarded,
+                t_window_boarded_noglass, t_window_reinforced, t_window_reinforced_noglass, t_window_enhanced,
+                t_window_enhanced_noglass, t_window_bars_alarm, t_window_bars,
+                t_metal_grate_window, t_metal_grate_window_with_curtain, t_metal_grate_window_with_curtain_open,
+                t_metal_grate_window_noglass, t_metal_grate_window_with_curtain_noglass,
+                t_metal_grate_window_with_curtain_open_noglass,
+                t_window_stained_green, t_window_stained_red, t_window_stained_blue,
+                t_window_no_curtains, t_window_no_curtains_open, t_window_no_curtains_taped,
+                t_rock, t_fault,
+                t_paper,
+                t_rock_wall, t_rock_wall_half,
+                // Tree
+                t_tree, t_tree_young, t_tree_apple, t_tree_apple_harvested, t_tree_coffee, t_tree_coffee_harvested,
+                t_tree_pear, t_tree_pear_harvested, t_tree_cherry, t_tree_cherry_harvested,
+                t_tree_peach, t_tree_peach_harvested, t_tree_apricot, t_tree_apricot_harvested, t_tree_plum,
+                t_tree_plum_harvested,
+                t_tree_pine, t_tree_blackjack, t_tree_birch, t_tree_willow, t_tree_maple, t_tree_maple_tapped,
+                t_tree_hickory, t_tree_hickory_dead, t_tree_hickory_harvested, t_tree_deadpine, t_underbrush,
+                t_shrub, t_shrub_blueberry, t_shrub_strawberry, t_trunk, t_stump,
+                t_root_wall,
+                t_wax, t_floor_wax,
+                t_fence, t_chainfence, t_chainfence_posts,
+                t_fence_post, t_fence_wire, t_fence_barbed, t_fence_rope,
+                t_railing,
+                // Nether
+                t_marloss, t_fungus_floor_in, t_fungus_floor_sup, t_fungus_floor_out, t_fungus_wall,
+                t_fungus_mound, t_fungus, t_shrub_fungal, t_tree_fungal, t_tree_fungal_young, t_marloss_tree,
+                // Water, lava, etc.
+                t_water_moving_dp, t_water_moving_sh, t_water_sh, t_water_dp, t_swater_sh, t_swater_dp,
+                t_swater_surf, t_water_pool, t_sewage,
+                t_lava,
+                // More embellishments than you can shake a stick at.
+                t_sandbox, t_slide, t_monkey_bars, t_backboard,
+                t_gas_pump, t_gas_pump_smashed,
+                t_diesel_pump, t_diesel_pump_smashed,
+                t_atm,
+                t_missile, t_missile_exploded,
+                t_radio_tower, t_radio_controls,
+                t_gates_mech_control, t_gates_control_concrete, t_gates_control_brick,
+                t_barndoor, t_palisade_pulley,
+                t_gates_control_metal,
+                t_sewage_pipe, t_sewage_pump,
+                t_column,
+                t_vat,
+                t_rootcellar,
+                t_cvdbody, t_cvdmachine,
+                t_water_pump,
+                t_conveyor,
+                t_improvised_shelter,
+                // Staircases etc.
+                t_stairs_down, t_stairs_up, t_manhole, t_ladder_up, t_ladder_down, t_slope_down,
+                t_slope_up, t_rope_up,
+                t_manhole_cover,
+                // Special
+                t_card_science, t_card_military, t_card_industrial, t_card_reader_broken, t_slot_machine,
+                t_elevator_control, t_elevator_control_off, t_elevator, t_pedestal_wyrm,
+                t_pedestal_temple,
+                // Temple tiles
+                t_rock_red, t_rock_green, t_rock_blue, t_floor_red, t_floor_green, t_floor_blue,
+                t_switch_rg, t_switch_gb, t_switch_rb, t_switch_even, t_open_air,
+                t_pavement_bg_dp, t_pavement_y_bg_dp, t_sidewalk_bg_dp, t_guardrail_bg_dp,
+                t_rad_platform,
+                // Railroad and subway
+                t_railroad_rubble,
+                t_buffer_stop, t_railroad_crossing_signal, t_crossbuck_wood, t_crossbuck_metal,
+                t_railroad_tie, t_railroad_tie_h, t_railroad_tie_v, t_railroad_tie_d,
+                t_railroad_track, t_railroad_track_h, t_railroad_track_v, t_railroad_track_d, t_railroad_track_d1,
+                t_railroad_track_d2,
+                t_railroad_track_on_tie, t_railroad_track_h_on_tie, t_railroad_track_v_on_tie,
+                t_railroad_track_d_on_tie;
 
 // TODO: Put this crap into an inclusion, which should be generated automatically using JSON data
 
 void set_ter_ids()
 {
-    t_null = ter_id( "t_null" );
+    t_null = null_ter = t_str_null;
     t_hole = ter_id( "t_hole" );
     t_dirt = ter_id( "t_dirt" );
     t_sand = ter_id( "t_sand" );
@@ -1172,55 +1192,57 @@ void reset_furn_ter()
     furniture_data.reset();
 }
 
-furn_id f_null, f_clear,
-        f_hay,
-        f_rubble, f_rubble_rock, f_wreckage, f_ash,
-        f_barricade_road, f_sandbag_half, f_sandbag_wall,
-        f_bulletin,
-        f_indoor_plant,
-        f_bed, f_toilet, f_makeshift_bed, f_straw_bed,
-        f_sink, f_oven, f_woodstove, f_fireplace, f_bathtub,
-        f_chair, f_armchair, f_sofa, f_cupboard, f_trashcan, f_desk, f_exercise,
-        f_bench, f_table, f_pool_table,
-        f_counter,
-        f_fridge, f_glass_fridge, f_dresser, f_locker,
-        f_rack, f_bookcase,
-        f_washer, f_dryer,
-        f_vending_c, f_vending_o, f_dumpster, f_dive_block,
-        f_crate_c, f_crate_o, f_coffin_c, f_coffin_o,
-        f_gunsafe_ml, f_gunsafe_mj, f_gun_safe_el,
-        f_large_canvas_wall, f_canvas_wall, f_canvas_door, f_canvas_door_o, f_groundsheet,
-        f_fema_groundsheet, f_large_groundsheet,
-        f_large_canvas_door, f_large_canvas_door_o, f_center_groundsheet, f_skin_wall, f_skin_door,
-        f_skin_door_o, f_skin_groundsheet,
-        f_mutpoppy, f_flower_fungal, f_fungal_mass, f_fungal_clump,
-        f_cattails, f_lotus, f_lilypad,
-        f_safe_c, f_safe_l, f_safe_o,
-        f_plant_seed, f_plant_seedling, f_plant_mature, f_plant_harvest,
-        f_fvat_empty, f_fvat_full, f_fvat_wood_empty, f_fvat_wood_full,
-        f_wood_keg,
-        f_standing_tank,
-        f_egg_sackbw, f_egg_sackcs, f_egg_sackws, f_egg_sacke,
-        f_flower_marloss,
-        f_tatami,
-        f_kiln_empty, f_kiln_full, f_kiln_metal_empty, f_kiln_metal_full,
-        f_arcfurnace_empty, f_arcfurnace_full,
-        f_smoking_rack, f_smoking_rack_active, f_metal_smoking_rack, f_metal_smoking_rack_active,
-        f_water_mill, f_water_mill_active,
-        f_wind_mill, f_wind_mill_active,
-        f_robotic_arm, f_vending_reinforced,
-        f_brazier,
-        f_firering,
-        f_tourist_table,
-        f_camp_chair,
-        f_sign,
-        f_stook_empty, f_stook_full,
-        f_street_light, f_traffic_light, f_flagpole, f_wooden_flagpole,
-        f_console, f_console_broken;
+static furn_str_id f_str_null( "f_null" );
+
+resolved_furn_id f_null, f_clear,
+                 f_hay,
+                 f_rubble, f_rubble_rock, f_wreckage, f_ash,
+                 f_barricade_road, f_sandbag_half, f_sandbag_wall,
+                 f_bulletin,
+                 f_indoor_plant,
+                 f_bed, f_toilet, f_makeshift_bed, f_straw_bed,
+                 f_sink, f_oven, f_woodstove, f_fireplace, f_bathtub,
+                 f_chair, f_armchair, f_sofa, f_cupboard, f_trashcan, f_desk, f_exercise,
+                 f_bench, f_table, f_pool_table,
+                 f_counter,
+                 f_fridge, f_glass_fridge, f_dresser, f_locker,
+                 f_rack, f_bookcase,
+                 f_washer, f_dryer,
+                 f_vending_c, f_vending_o, f_dumpster, f_dive_block,
+                 f_crate_c, f_crate_o, f_coffin_c, f_coffin_o,
+                 f_gunsafe_ml, f_gunsafe_mj, f_gun_safe_el,
+                 f_large_canvas_wall, f_canvas_wall, f_canvas_door, f_canvas_door_o, f_groundsheet,
+                 f_fema_groundsheet, f_large_groundsheet,
+                 f_large_canvas_door, f_large_canvas_door_o, f_center_groundsheet, f_skin_wall, f_skin_door,
+                 f_skin_door_o, f_skin_groundsheet,
+                 f_mutpoppy, f_flower_fungal, f_fungal_mass, f_fungal_clump,
+                 f_cattails, f_lotus, f_lilypad,
+                 f_safe_c, f_safe_l, f_safe_o,
+                 f_plant_seed, f_plant_seedling, f_plant_mature, f_plant_harvest,
+                 f_fvat_empty, f_fvat_full, f_fvat_wood_empty, f_fvat_wood_full,
+                 f_wood_keg,
+                 f_standing_tank,
+                 f_egg_sackbw, f_egg_sackcs, f_egg_sackws, f_egg_sacke,
+                 f_flower_marloss,
+                 f_tatami,
+                 f_kiln_empty, f_kiln_full, f_kiln_metal_empty, f_kiln_metal_full,
+                 f_arcfurnace_empty, f_arcfurnace_full,
+                 f_smoking_rack, f_smoking_rack_active, f_metal_smoking_rack, f_metal_smoking_rack_active,
+                 f_water_mill, f_water_mill_active,
+                 f_wind_mill, f_wind_mill_active,
+                 f_robotic_arm, f_vending_reinforced,
+                 f_brazier,
+                 f_firering,
+                 f_tourist_table,
+                 f_camp_chair,
+                 f_sign,
+                 f_stook_empty, f_stook_full,
+                 f_street_light, f_traffic_light, f_flagpole, f_wooden_flagpole,
+                 f_console, f_console_broken;
 
 void set_furn_ids()
 {
-    f_null = furn_id( "f_null" );
+    f_null = null_furn = f_str_null;
     f_clear = furn_id( "f_clear" );
     f_hay = furn_id( "f_hay" );
     f_rubble = furn_id( "f_rubble" );
@@ -1783,7 +1805,7 @@ void activity_data_ter::load( const JsonObject &jo )
 
 void activity_data_furn::load( const JsonObject &jo )
 {
-    optional( jo, was_loaded, "result", result_, f_null.id() );
+    optional( jo, was_loaded, "result", result_, f_str_null );
     activity_data_common::load( jo );
     valid_ = true;
 }

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -1194,7 +1194,7 @@ void reset_furn_ter()
     furniture_data.reset();
 }
 
-static const furn_str_id furn_t_null( "f_null" );
+static const furn_str_id furn_f_null( "f_null" );
 
 resolved_furn_id f_null, f_clear,
                  f_hay,
@@ -1244,7 +1244,7 @@ resolved_furn_id f_null, f_clear,
 
 void set_furn_ids()
 {
-    f_null = null_furn = furn_t_null;
+    f_null = null_furn = furn_f_null;
     f_clear = furn_id( "f_clear" );
     f_hay = furn_id( "f_hay" );
     f_rubble = furn_id( "f_rubble" );
@@ -1807,7 +1807,7 @@ void activity_data_ter::load( const JsonObject &jo )
 
 void activity_data_furn::load( const JsonObject &jo )
 {
-    optional( jo, was_loaded, "result", result_, furn_t_null );
+    optional( jo, was_loaded, "result", result_, furn_f_null );
     activity_data_common::load( jo );
     valid_ = true;
 }

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -690,8 +690,9 @@ provided for terrains added by mods. A string equivalent is always present, i.e.
 t_basalt
 "t_basalt"
 */
+extern ter_str_id t_str_null;
 // NOLINTNEXTLINE(cata-static-int_id-constants)
-extern ter_id t_null,
+extern resolved_ter_id t_null,
        t_hole, // Real nothingness; makes you fall a z-level
        // Ground
        t_dirt, t_sand, t_clay, t_dirtmound, t_pit_shallow, t_pit, t_grave, t_grave_new,
@@ -817,7 +818,7 @@ furn_id refers to a position in the furnlist[] where the furn_t struct is stored
 about ter_id above.
 */
 // NOLINTNEXTLINE(cata-static-int_id-constants)
-extern furn_id f_null, f_clear,
+extern resolved_furn_id f_null, f_clear,
        f_hay, f_cattails, f_lotus, f_lilypad,
        f_rubble, f_rubble_rock, f_wreckage, f_ash,
        f_barricade_road, f_sandbag_half, f_sandbag_wall,

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -690,8 +690,8 @@ provided for terrains added by mods. A string equivalent is always present, i.e.
 t_basalt
 "t_basalt"
 */
-extern ter_str_id t_str_null;
-// NOLINTNEXTLINE(cata-static-int_id-constants)
+extern const ter_str_id ter_t_null;
+// NOLINTNEXTLINE(cata-static-resolved_id-constants)
 extern resolved_ter_id t_null,
        t_hole, // Real nothingness; makes you fall a z-level
        // Ground
@@ -817,7 +817,7 @@ runtime index: furn_id
 furn_id refers to a position in the furnlist[] where the furn_t struct is stored. See note
 about ter_id above.
 */
-// NOLINTNEXTLINE(cata-static-int_id-constants)
+// NOLINTNEXTLINE(cata-static-resolved_id-constants)
 extern resolved_furn_id f_null, f_clear,
        f_hay, f_cattails, f_lotus, f_lilypad,
        f_rubble, f_rubble_rock, f_wreckage, f_ash,

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -825,7 +825,7 @@ mapgen_function_json::mapgen_function_json( const JsonObject &jsobj,
         dbl_or_var w, const std::string &context, const point &grid_offset, const point &grid_total )
     : mapgen_function( std::move( w ) )
     , mapgen_function_json_base( jsobj, context )
-    , fill_ter( t_str_null )
+    , fill_ter( ter_t_null )
     , rotation( 0 )
     , fallback_predecessor_mapgen_( oter_str_id::NULL_ID() )
 {
@@ -4352,7 +4352,7 @@ bool mapgen_function_json::setup_internal( const JsonObject &jo )
 
     jo.read( "fallback_predecessor_mapgen", fallback_predecessor_mapgen_ );
 
-    return fill_ter != t_str_null || predecessor_mapgen != oter_str_id::NULL_ID() ||
+    return fill_ter != ter_t_null || predecessor_mapgen != oter_str_id::NULL_ID() ||
            fallback_predecessor_mapgen_ != oter_str_id::NULL_ID();
 }
 
@@ -5120,7 +5120,7 @@ static bool apply_mapgen_in_phases(
 void mapgen_function_json::generate( mapgendata &md )
 {
     map *const m = &md.m;
-    if( fill_ter != t_str_null ) {
+    if( fill_ter != ter_t_null ) {
         m->draw_fill_background( fill_ter );
     }
     const oter_t &ter = *md.terrain_type();
@@ -7653,7 +7653,7 @@ bool update_mapgen_function_json::setup_update( const JsonObject &jo )
 
 bool update_mapgen_function_json::setup_internal( const JsonObject &/*jo*/ )
 {
-    fill_ter = t_str_null;
+    fill_ter = ter_t_null;
     /* update_mapgen doesn't care about fill_ter or rows */
     return true;
 }

--- a/src/mapgen.h
+++ b/src/mapgen.h
@@ -521,7 +521,7 @@ class update_mapgen_function_json : public mapgen_function_json_base
 
     protected:
         bool setup_internal( const JsonObject &/*jo*/ ) override;
-        ter_id fill_ter;
+        ter_str_id fill_ter;
 };
 
 class mapgen_function_json_nested : public mapgen_function_json_base
@@ -636,19 +636,20 @@ enum room_type {
 // helpful functions
 bool connects_to( const oter_id &there, int dir );
 // wrappers for map:: functions
-void line( map *m, const ter_id &type, const point &p1, const point &p2 );
-void line_furn( map *m, const furn_id &type, const point &p1, const point &p2 );
-void fill_background( map *m, const ter_id &type );
-void fill_background( map *m, ter_id( *f )() );
-void square( map *m, const ter_id &type, const point &p1, const point &p2 );
-void square( map *m, ter_id( *f )(), const point &p1, const point &p2 );
-void square( map *m, const weighted_int_list<ter_id> &f, const point &p1, const point &p2 );
-void square_furn( map *m, const furn_id &type, const point &p1, const point &p2 );
-void rough_circle( map *m, const ter_id &type, const point &, int rad );
-void rough_circle_furn( map *m, const furn_id &type, const point &, int rad );
-void circle( map *m, const ter_id &type, double x, double y, double rad );
-void circle( map *m, const ter_id &type, const point &, int rad );
-void circle_furn( map *m, const furn_id &type, const point &, int rad );
+void line( map *m, const resolved_ter_id &type, const point &p1, const point &p2 );
+void line_furn( map *m, const resolved_furn_id &type, const point &p1, const point &p2 );
+void fill_background( map *m, const resolved_ter_id &type );
+void fill_background( map *m, resolved_ter_id( *f )() );
+void square( map *m, const resolved_ter_id &type, const point &p1, const point &p2 );
+void square( map *m, resolved_ter_id( *f )(), const point &p1, const point &p2 );
+void square( map *m, const weighted_int_list<resolved_ter_id> &f, const point &p1,
+             const point &p2 );
+void square_furn( map *m, const resolved_furn_id &type, const point &p1, const point &p2 );
+void rough_circle( map *m, const resolved_ter_id &type, const point &, int rad );
+void rough_circle_furn( map *m, const resolved_furn_id &type, const point &, int rad );
+void circle( map *m, const resolved_ter_id &type, double x, double y, double rad );
+void circle( map *m, const resolved_ter_id &type, const point &, int rad );
+void circle_furn( map *m, const resolved_furn_id &type, const point &, int rad );
 void add_corpse( map *m, const point & );
 
 extern std::map<nested_mapgen_id, nested_mapgen> nested_mapgens;

--- a/src/mapgen_functions.cpp
+++ b/src/mapgen_functions.cpp
@@ -121,7 +121,7 @@ building_gen_pointer get_mapgen_cfunction( const std::string &ident )
     return iter == pointers.end() ? nullptr : iter->second;
 }
 
-ter_id grass_or_dirt()
+resolved_ter_id grass_or_dirt()
 {
     if( one_in( 4 ) ) {
         return t_grass;
@@ -129,7 +129,7 @@ ter_id grass_or_dirt()
     return t_dirt;
 }
 
-ter_id clay_or_sand()
+resolved_ter_id clay_or_sand()
 {
     if( one_in( 16 ) ) {
         return t_sand;
@@ -1260,7 +1260,7 @@ void mapgen_forest( mapgendata &dat )
     * @param p: The point to place the dependent feature, if one is selected.
     */
     const auto set_terrain_dependent_furniture =
-    [&self_biome, &m]( const ter_id & tid, const point & p ) {
+    [&self_biome, &m]( const resolved_ter_id & tid, const point & p ) {
         const auto terrain_dependent_furniture_it = self_biome.terrain_dependent_furniture.find(
                     tid );
         if( terrain_dependent_furniture_it == self_biome.terrain_dependent_furniture.end() ) {
@@ -2358,13 +2358,13 @@ void mremove_fields( map *m, const point &p )
 void resolve_regional_terrain_and_furniture( const mapgendata &dat )
 {
     for( const tripoint &p : dat.m.points_on_zlevel() ) {
-        const ter_id tid_before = dat.m.ter( p );
-        const ter_id tid_after = dat.region.region_terrain_and_furniture.resolve( tid_before );
+        const resolved_ter_id tid_before = dat.m.ter( p );
+        const resolved_ter_id tid_after = dat.region.region_terrain_and_furniture.resolve( tid_before );
         if( tid_after != tid_before ) {
             dat.m.ter_set( p, tid_after );
         }
-        const furn_id fid_before = dat.m.furn( p );
-        const furn_id fid_after = dat.region.region_terrain_and_furniture.resolve( fid_before );
+        const resolved_furn_id fid_before = dat.m.furn( p );
+        const resolved_furn_id fid_after = dat.region.region_terrain_and_furniture.resolve( fid_before );
         if( fid_after != fid_before ) {
             dat.m.furn_set( p, fid_after );
         }

--- a/src/mapgen_functions.h
+++ b/src/mapgen_functions.h
@@ -32,8 +32,8 @@ int terrain_type_to_nesw_array( oter_id terrain_type, std::array<bool, 4> &array
 
 using building_gen_pointer = void ( * )( mapgendata & );
 building_gen_pointer get_mapgen_cfunction( const std::string &ident );
-ter_id grass_or_dirt();
-ter_id clay_or_sand();
+resolved_ter_id grass_or_dirt();
+resolved_ter_id clay_or_sand();
 
 // helper functions for mapgen.cpp, so that we can avoid having a massive switch statement (sorta)
 void mapgen_null( mapgendata &dat );
@@ -72,7 +72,7 @@ bool run_mapgen_func( const std::string &mapgen_id, mapgendata &dat );
 std::pair<std::map<ter_id, int>, std::map<furn_id, int>>
         get_changed_ids_from_update(
             const update_mapgen_id &, const mapgen_arguments &,
-            ter_id const &base_ter = t_dirt );
+            ter_id const &base_ter = t_dirt->id );
 mapgen_parameters get_map_special_params( const std::string &mapgen_id );
 
 void resolve_regional_terrain_and_furniture( const mapgendata &dat );

--- a/src/mapgendata.cpp
+++ b/src/mapgendata.cpp
@@ -238,9 +238,9 @@ bool mapgendata::has_flag( jmapgen_flags f ) const
     return mapgen_flags_.test( f );
 }
 
-ter_id mapgendata::groundcover() const
+resolved_ter_id mapgendata::groundcover() const
 {
-    const ter_id *tid = default_groundcover.pick();
+    const resolved_ter_id *tid = default_groundcover.pick();
     return tid != nullptr ? *tid : t_null;
 }
 

--- a/src/mapgendata.h
+++ b/src/mapgendata.h
@@ -131,7 +131,7 @@ class mapgendata
 
         map &m;
 
-        weighted_int_list<ter_id> default_groundcover;
+        weighted_int_list<resolved_ter_id> default_groundcover;
 
         struct dummy_settings_t {};
         static constexpr dummy_settings_t dummy_settings = {};
@@ -226,7 +226,7 @@ class mapgendata
         const oter_id &neighbor_at( direction ) const;
         void fill_groundcover() const;
         void square_groundcover( const point &p1, const point &p2 ) const;
-        ter_id groundcover() const;
+        resolved_ter_id groundcover() const;
         bool is_groundcover( const ter_id &iid ) const;
 
         bool has_flag( jmapgen_flags ) const;

--- a/src/mapgenformat.cpp
+++ b/src/mapgenformat.cpp
@@ -11,7 +11,7 @@ namespace mapf
 {
 
 void formatted_set_simple( map *m, const point &start, const char *cstr,
-                           const format_effect<ter_id> &ter_b, const format_effect<furn_id> &furn_b )
+                           const format_effect<resolved_ter_id> &ter_b, const format_effect<resolved_furn_id> &furn_b )
 {
     const char *p = cstr;
     point p2( start );
@@ -20,8 +20,8 @@ void formatted_set_simple( map *m, const point &start, const char *cstr,
             p2.y++;
             p2.x = start.x;
         } else {
-            const ter_id ter = ter_b.translate( *p );
-            const furn_id furn = furn_b.translate( *p );
+            const resolved_ter_id ter = ter_b.translate( *p );
+            const resolved_furn_id furn = furn_b.translate( *p );
             if( ter != t_null ) {
                 m->ter_set( p2, ter );
             }
@@ -58,5 +58,7 @@ ID format_effect<ID>::translate( const char c ) const
 
 template class format_effect<furn_id>;
 template class format_effect<ter_id>;
+template class format_effect<resolved_furn_id>;
+template class format_effect<resolved_ter_id>;
 
 }//END NAMESPACE mapf

--- a/src/mapgenformat.h
+++ b/src/mapgenformat.h
@@ -29,7 +29,7 @@ class format_effect;
  * @param start Coordinates in the map where to start drawing \p cstr.
  */
 void formatted_set_simple( map *m, const point &start, const char *cstr,
-                           const format_effect<ter_id> &ter_b, const format_effect<furn_id> &furn_b );
+                           const format_effect<resolved_ter_id> &ter_b, const format_effect<resolved_furn_id> &furn_b );
 
 template<typename ID>
 class format_effect
@@ -64,24 +64,24 @@ class format_effect
 /**@{*/
 template<size_t N, typename ...Args>
 // NOLINTNEXTLINE(modernize-avoid-c-arrays)
-inline format_effect<ter_id> ter_bind( const char ( &characters )[N], Args... ids )
+inline format_effect<resolved_ter_id> ter_bind( const char ( &characters )[N], Args... ids )
 {
     // Note to self: N contains the 0-char at the end of a string literal!
     static_assert( N % 2 == 0, "list of characters to bind to must be odd, e.g. \"a b c\"" );
     static_assert( N / 2 == sizeof...( Args ),
                    "list of characters to bind to must match the size of the remaining arguments" );
-    return format_effect<ter_id>( characters, { std::forward<Args>( ids )... } );
+    return format_effect<resolved_ter_id>( characters, { std::forward<Args>( ids )... } );
 }
 
 template<size_t N, typename ...Args>
 // NOLINTNEXTLINE(modernize-avoid-c-arrays)
-inline format_effect<furn_id> furn_bind( const char ( &characters )[N], Args... ids )
+inline format_effect<resolved_furn_id> furn_bind( const char ( &characters )[N], Args... ids )
 {
     // Note to self: N contains the 0-char at the end of a string literal!
     static_assert( N % 2 == 0, "list of characters to bind to must be odd, e.g. \"a b c\"" );
     static_assert( N / 2 == sizeof...( Args ),
                    "list of characters to bind to must match the size of the remaining arguments" );
-    return format_effect<furn_id>( characters, { std::forward<Args>( ids )... } );
+    return format_effect<resolved_furn_id>( characters, { std::forward<Args>( ids )... } );
 }
 /**@}*/
 

--- a/src/martialarts.cpp
+++ b/src/martialarts.cpp
@@ -89,7 +89,7 @@ void weapon_category::load( const JsonObject &jo, const std::string_view )
     mandatory( jo, was_loaded, "name", name_ );
 }
 
-const std::vector<weapon_category> &weapon_category::get_all()
+const std::deque<weapon_category> &weapon_category::get_all()
 {
     return weapon_category_factory.get_all();
 }

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_MARTIALARTS_H
 
 #include <cstddef>
+#include <deque>
 #include <iosfwd>
 #include <set>
 #include <string>

--- a/src/martialarts.h
+++ b/src/martialarts.h
@@ -34,7 +34,7 @@ class weapon_category
 
         void load( const JsonObject &jo, std::string_view src );
 
-        static const std::vector<weapon_category> &get_all();
+        static const std::deque<weapon_category> &get_all();
 
         const weapon_category_id &getId() const {
             return id;

--- a/src/material.h
+++ b/src/material.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_MATERIAL_H
 
 #include <cstddef>
+#include <deque>
 #include <iosfwd>
 #include <map>
 #include <new>

--- a/src/material.h
+++ b/src/material.h
@@ -21,7 +21,7 @@ class material_type;
 class JsonObject;
 
 using mat_burn_products = std::vector<std::pair<itype_id, float>>;
-using material_list = std::vector<material_type>;
+using material_list = std::deque<material_type>;
 using material_id_list = std::vector<material_id>;
 
 // values for how breathable a material is

--- a/src/math_parser_jmath.cpp
+++ b/src/math_parser_jmath.cpp
@@ -36,7 +36,7 @@ void jmath_func::reset()
     get_all_jmath_func().reset();
 }
 
-std::vector<jmath_func> const &jmath_func::get_all()
+std::deque<jmath_func> const &jmath_func::get_all()
 {
     return get_all_jmath_func().get_all();
 }

--- a/src/math_parser_jmath.h
+++ b/src/math_parser_jmath.h
@@ -24,7 +24,7 @@ struct jmath_func {
     static void load_func( const JsonObject &jo, std::string const &src );
     static void finalize();
     static void reset();
-    static const std::vector<jmath_func> &get_all();
+    static const std::deque<jmath_func> &get_all();
 
     mutable std::string _str;
     mutable math_exp _exp;

--- a/src/math_parser_jmath.h
+++ b/src/math_parser_jmath.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_MATH_PARSER_JMATH_H
 #define CATA_SRC_MATH_PARSER_JMATH_H
 
+#include <deque>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/src/mission.h
+++ b/src/mission.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_MISSION_H
 #define CATA_SRC_MISSION_H
 
+#include <deque>
 #include <functional>
 #include <iosfwd>
 #include <map>

--- a/src/mission.h
+++ b/src/mission.h
@@ -251,7 +251,7 @@ struct mission_type {
         /**
          * Get all mission types at once.
          */
-        static const std::vector<mission_type> &get_all();
+        static const std::deque<mission_type> &get_all();
 
         bool test_goal_condition( struct dialogue &d ) const;
 

--- a/src/mission_companion.cpp
+++ b/src/mission_companion.cpp
@@ -2767,7 +2767,7 @@ std::set<item> talk_function::loot_building( const tripoint_abs_omt &site,
     creature_tracker &creatures = get_creature_tracker();
     std::set<item> return_items;
     for( const tripoint &p : bay.points_on_zlevel() ) {
-        const ter_id t = bay.ter( p );
+        const resolved_ter_id t = bay.ter( p );
         //Open all the doors, doesn't need to be exhaustive
         if( t == t_door_c || t == t_door_c_peep || t == t_door_b
             || t == t_door_boarded || t == t_door_boarded_damaged

--- a/src/missiondef.cpp
+++ b/src/missiondef.cpp
@@ -533,7 +533,7 @@ const mission_type *mission_type::get( const mission_type_id &id )
     return &id.obj();
 }
 
-const std::vector<mission_type> &mission_type::get_all()
+const std::deque<mission_type> &mission_type::get_all()
 {
     return mission_type_factory.get_all();
 }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -1649,7 +1649,7 @@ bool mattack::growplants( monster *z )
         return true;
     }
     for( const tripoint &p : here.points_in_radius( z->pos(), 5 ) ) {
-        const ter_id ter = here.ter( p );
+        const resolved_ter_id ter = here.ter( p );
         if( ter != t_tree_young && ter != t_underbrush ) {
             // Skip as soon as possible to avoid all the checks
             continue;

--- a/src/monfaction.cpp
+++ b/src/monfaction.cpp
@@ -208,7 +208,7 @@ void monfaction::load( const JsonObject &jo, const std::string_view )
     attitude_map.emplace( id, MFA_FRIENDLY );
 }
 
-const std::vector<monfaction> &monfactions::get_all()
+const std::deque<monfaction> &monfactions::get_all()
 {
     return faction_factory.get_all();
 }

--- a/src/monfaction.h
+++ b/src/monfaction.h
@@ -39,7 +39,7 @@ static_assert( std::numeric_limits<mfaction_att_vec::value_type>::max() >
 
 namespace monfactions
 {
-const std::vector<monfaction> &get_all();
+const std::deque<monfaction> &get_all();
 void reset();
 void finalize();
 void load_monster_faction( const JsonObject &jo, const std::string &src );

--- a/src/monfaction.h
+++ b/src/monfaction.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_MONFACTION_H
 
 #include <cstdint>
+#include <deque>
 #include <iosfwd>
 #include <limits>
 #include <map>

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -305,7 +305,7 @@ bool monster::know_danger_at( const tripoint &p ) const
     // before hitting simple or complex but this is more explicit
     if( avoid_fire || avoid_fall || avoid_simple ||
         avoid_complex || avoid_traps || avoid_sharp ) {
-        const ter_id target = here.ter( p );
+        const resolved_ter_id target = here.ter( p );
         if( !here.has_vehicle_floor( p ) ) {
             // Don't enter lava if we have any concept of heat being bad
             if( avoid_fire && target == t_lava ) {

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2702,7 +2702,7 @@ void monster::process_turn()
                 if( zap != pos() ) {
                     explosion_handler::emp_blast( zap ); // Fries electronics due to the intensity of the field
                 }
-                const ter_id t = here.ter( zap );
+                const resolved_ter_id t = here.ter( zap );
                 if( t == ter_t_gas_pump || t == ter_t_gas_pump_a ) {
                     if( one_in( 4 ) ) {
                         explosion_handler::explosion( this, pos(), 40, 0.8, true );

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1246,12 +1246,12 @@ void mon_flag::load( const JsonObject &jo, std::string_view )
     mandatory( jo, was_loaded, "id", id );
 }
 
-const std::vector<mtype> &MonsterGenerator::get_all_mtypes() const
+const std::deque<mtype> &MonsterGenerator::get_all_mtypes() const
 {
     return mon_templates->get_all();
 }
 
-const std::vector<mon_flag> &mon_flag::get_all()
+const std::deque<mon_flag> &mon_flag::get_all()
 {
     return mon_flags.get_all();
 }

--- a/src/monstergenerator.h
+++ b/src/monstergenerator.h
@@ -73,7 +73,7 @@ class MonsterGenerator
         void check_monster_definitions() const;
 
         std::optional<mon_action_death> get_death_function( const std::string &f ) const;
-        const std::vector<mtype> &get_all_mtypes() const;
+        const std::deque<mtype> &get_all_mtypes() const;
         mtype_id get_valid_hallucination() const;
         friend struct mtype;
         friend struct species_type;

--- a/src/monstergenerator.h
+++ b/src/monstergenerator.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_MONSTERGENERATOR_H
 
 #include <array>
+#include <deque>
 #include <iosfwd>
 #include <map>
 #include <memory>

--- a/src/mood_face.cpp
+++ b/src/mood_face.cpp
@@ -47,7 +47,7 @@ void mood_face::load( const JsonObject &jo, const std::string_view )
     } );
 }
 
-const std::vector<mood_face> &mood_face::get_all()
+const std::deque<mood_face> &mood_face::get_all()
 {
     return mood_face_factory.get_all();
 }

--- a/src/mood_face.h
+++ b/src/mood_face.h
@@ -20,7 +20,7 @@ class mood_face
 
         void load( const JsonObject &jo, std::string_view src );
 
-        static const std::vector<mood_face> &get_all();
+        static const std::deque<mood_face> &get_all();
 
         const mood_face_id &getId() const {
             return id;

--- a/src/mood_face.h
+++ b/src/mood_face.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_MOOD_FACE_H
 #define CATA_SRC_MOOD_FACE_H
 
+#include <deque>
 #include <vector>
 
 #include "type_id.h"

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -71,7 +71,7 @@ struct mon_flag {
     void load( const JsonObject &jo, std::string_view src );
     static void load_mon_flags( const JsonObject &jo, const std::string &src );
     static void reset();
-    static const std::vector<mon_flag> &get_all();
+    static const std::deque<mon_flag> &get_all();
 };
 
 /** Used to store monster effects placed on attack */

--- a/src/mtype.h
+++ b/src/mtype.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_MTYPE_H
 #define CATA_SRC_MTYPE_H
 
+#include <deque>
 #include <iosfwd>
 #include <array>
 #include <map>

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -472,7 +472,7 @@ struct mutation_branch {
          * All known mutations. Key is the mutation id, value is the mutation_branch that you would
          * also get by calling @ref get.
          */
-        static const std::vector<mutation_branch> &get_all();
+        static const std::deque<mutation_branch> &get_all();
         // For init.cpp: reset (clear) the mutation data
         static void reset_all();
         // For init.cpp: load mutation data from json

--- a/src/mutation.h
+++ b/src/mutation.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_MUTATION_H
 
 #include <climits>
+#include <deque>
 #include <iosfwd>
 #include <map>
 #include <new>

--- a/src/mutation_data.cpp
+++ b/src/mutation_data.cpp
@@ -923,7 +923,7 @@ const mutation_variant *mutation_branch::pick_variant_menu() const
     return options[menu.ret];
 }
 
-const std::vector<mutation_branch> &mutation_branch::get_all()
+const std::deque<mutation_branch> &mutation_branch::get_all()
 {
     return trait_factory.get_all();
 }

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -4308,7 +4308,8 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
         } else if( action == "RESET_CALENDAR" ) {
             get_scenario()->reset_calendar();
         } else if( action == "CHOOSE_CITY" ) {
-            std::vector<city> cities( city::get_all() );
+            const std::deque<city> &all_cities = city::get_all();
+            std::vector<city> cities( all_cities.begin(), all_cities.end() );
             const auto cities_cmp_population = []( const city & a, const city & b ) {
                 return std::tie( a.population, a.name ) > std::tie( b.population, b.name );
             };

--- a/src/npc_class.cpp
+++ b/src/npc_class.cpp
@@ -382,7 +382,7 @@ const npc_class_id &npc_class::from_legacy_int( int i )
     return legacy_ids[ i ];
 }
 
-const std::vector<npc_class> &npc_class::get_all()
+const std::deque<npc_class> &npc_class::get_all()
 {
     return npc_class_factory.get_all();
 }

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -146,7 +146,7 @@ class npc_class
 
         static void load_npc_class( const JsonObject &jo, const std::string &src );
 
-        static const std::vector<npc_class> &get_all();
+        static const std::deque<npc_class> &get_all();
 
         static void reset_npc_classes();
 

--- a/src/npc_class.h
+++ b/src/npc_class.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_NPC_CLASS_H
 #define CATA_SRC_NPC_CLASS_H
 
+#include <deque>
 #include <functional>
 #include <iosfwd>
 #include <map>

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3442,14 +3442,14 @@ void talk_effect_fun_t::set_location_variable( const JsonObject &jo, std::string
                     continue;
                 }
                 if( search_type.value() == "terrain" ) {
-                    if( here.ter( search_loc ).id().c_str() == cur_search_target ) {
+                    if( here.ter( search_loc )->id.str() == cur_search_target ) {
                         target_pos = here.getabs( search_loc );
                         found = true;
                         break;
                     }
                 } else if( search_type.value() == "furniture" ) {
-                    if( here.furn( search_loc ).id().c_str() == cur_search_target ||
-                        ( !here.furn( search_loc ).id().is_null() && cur_search_target.empty() ) ) {
+                    if( here.furn( search_loc )->id.str() == cur_search_target ||
+                        ( !here.furn( search_loc )->id.is_null() && cur_search_target.empty() ) ) {
                         target_pos = here.getabs( search_loc );
                         found = true;
                         break;

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -6,6 +6,7 @@
 #include <climits>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <iosfwd>
 #include <list>
 #include <new>

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -652,7 +652,7 @@ void check_consistency();
 void finalize();
 void reset();
 
-const std::vector<oter_t> &get_all();
+const std::deque<oter_t> &get_all();
 
 } // namespace overmap_terrains
 
@@ -664,7 +664,7 @@ void finalize();
 void check_consistency();
 void reset();
 
-const std::vector<overmap_land_use_code> &get_all();
+const std::deque<overmap_land_use_code> &get_all();
 
 } // namespace overmap_land_use_codes
 
@@ -677,7 +677,7 @@ void finalize_mapgen_parameters();
 void check_consistency();
 void reset();
 
-const std::vector<overmap_special> &get_all();
+const std::deque<overmap_special> &get_all();
 
 overmap_special_batch get_default_batch( const point_abs_om &origin );
 /**

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -82,7 +82,7 @@ void option_slider::reset()
     option_slider_factory.reset();
 }
 
-const std::vector<option_slider> &option_slider::get_all()
+const std::deque<option_slider> &option_slider::get_all()
 {
     return option_slider_factory.get_all();
 }

--- a/src/options.h
+++ b/src/options.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_OPTIONS_H
 
 #include <algorithm>
+#include <deque>
 #include <functional>
 #include <iosfwd>
 #include <map>

--- a/src/options.h
+++ b/src/options.h
@@ -423,7 +423,7 @@ struct option_slider {
         static void check_consistency();
         void load( const JsonObject &jo, std::string_view src );
         void check() const;
-        static const std::vector<option_slider> &get_all();
+        static const std::deque<option_slider> &get_all();
 
         void reorder_opts() {
             std::sort( _levels.begin(), _levels.end(),

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -492,7 +492,7 @@ void overmap_land_use_codes::reset()
     land_use_codes.reset();
 }
 
-const std::vector<overmap_land_use_code> &overmap_land_use_codes::get_all()
+const std::deque<overmap_land_use_code> &overmap_land_use_codes::get_all()
 {
     return land_use_codes.get_all();
 }
@@ -559,7 +559,7 @@ void overmap_specials::reset()
     specials.reset();
 }
 
-const std::vector<overmap_special> &overmap_specials::get_all()
+const std::deque<overmap_special> &overmap_specials::get_all()
 {
     return specials.get_all();
 }
@@ -1076,7 +1076,7 @@ void overmap_terrains::reset()
     terrains.reset();
 }
 
-const std::vector<oter_t> &overmap_terrains::get_all()
+const std::deque<oter_t> &overmap_terrains::get_all()
 {
     return terrains.get_all();
 }
@@ -7402,8 +7402,8 @@ void overmap_special_migration::check()
 
 bool overmap_special_migration::migrated( const overmap_special_id &os_id )
 {
-    std::vector<overmap_special_migration> migs = migrations.get_all();
-    return std::find_if( migs.begin(), migs.end(), [&os_id]( overmap_special_migration & m ) {
+    const std::deque<overmap_special_migration> &migs = migrations.get_all();
+    return std::find_if( migs.begin(), migs.end(), [&os_id]( const overmap_special_migration & m ) {
         return os_id == overmap_special_id( m.id.str() );
     } ) != migs.end();
 }

--- a/src/pixel_minimap.cpp
+++ b/src/pixel_minimap.cpp
@@ -92,7 +92,7 @@ SDL_Color get_map_color_at( const tripoint &p )
         return curses_color_to_SDL( vd.color );
     }
 
-    if( const furn_id furn_id = here.furn( p ) ) {
+    if( const resolved_furn_id furn_id = here.furn( p ); furn_id != f_null ) {
         return curses_color_to_SDL( furn_id->color() );
     }
 

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -279,14 +279,15 @@ const profession *profession::generic()
     return &generic_profession_id.obj();
 }
 
-const std::vector<profession> &profession::get_all()
+const std::deque<profession> &profession::get_all()
 {
     return all_profs.get_all();
 }
 
 std::vector<string_id<profession>> profession::get_all_hobbies()
 {
-    std::vector<profession> all = profession::get_all();
+    const std::deque<profession> &all_professions = profession::get_all();
+    std::vector<profession> all( all_professions.begin(), all_professions.end() );
     std::vector<profession_id> ret;
 
     // remove all non-hobbies from list of professions

--- a/src/profession.h
+++ b/src/profession.h
@@ -98,7 +98,7 @@ class profession
 
         // these should be the only ways used to get at professions
         static const profession *generic(); // points to the generic, default profession
-        static const std::vector<profession> &get_all();
+        static const std::deque<profession> &get_all();
         static std::vector<string_id<profession>> get_all_hobbies();
 
         static bool has_initialized();

--- a/src/profession.h
+++ b/src/profession.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_PROFESSION_H
 #define CATA_SRC_PROFESSION_H
 
+#include <deque>
 #include <iosfwd>
 #include <list>
 #include <map>

--- a/src/profession_group.cpp
+++ b/src/profession_group.cpp
@@ -32,7 +32,7 @@ void profession_group::load( const JsonObject &jo, const std::string_view & )
 
 }
 
-const std::vector<profession_group> &profession_group::get_all()
+const std::deque<profession_group> &profession_group::get_all()
 {
     return profession_group_factory.get_all();
 }

--- a/src/profession_group.h
+++ b/src/profession_group.h
@@ -2,6 +2,8 @@
 #ifndef CATA_SRC_PROFESSION_GROUP_H
 #define CATA_SRC_PROFESSION_GROUP_H
 
+#include <deque>
+
 #include "type_id.h"
 #include "json.h"
 

--- a/src/profession_group.h
+++ b/src/profession_group.h
@@ -9,7 +9,7 @@ struct profession_group {
 
         static void load_profession_group( const JsonObject &jo, const std::string &src );
         void load( const JsonObject &jo, const std::string_view & );
-        static const std::vector<profession_group> &get_all();
+        static const std::deque<profession_group> &get_all();
         static void check_profession_group_consistency();
         bool was_loaded;
 

--- a/src/proficiency.cpp
+++ b/src/proficiency.cpp
@@ -126,12 +126,12 @@ void proficiency_category::load( const JsonObject &jo, const std::string_view )
     mandatory( jo, was_loaded, "description", _description );
 }
 
-const std::vector<proficiency> &proficiency::get_all()
+const std::deque<proficiency> &proficiency::get_all()
 {
     return proficiency_factory.get_all();
 }
 
-const std::vector<proficiency_category> &proficiency_category::get_all()
+const std::deque<proficiency_category> &proficiency_category::get_all()
 {
     return proficiency_category_factory.get_all();
 }

--- a/src/proficiency.h
+++ b/src/proficiency.h
@@ -56,7 +56,7 @@ struct proficiency_category {
     static void load_proficiency_categories( const JsonObject &jo, const std::string &src );
     static void reset();
     void load( const JsonObject &jo, std::string_view src );
-    static const std::vector<proficiency_category> &get_all();
+    static const std::deque<proficiency_category> &get_all();
 };
 
 class proficiency
@@ -92,7 +92,7 @@ class proficiency
         static void reset();
         void load( const JsonObject &jo, std::string_view src );
 
-        static const std::vector<proficiency> &get_all();
+        static const std::deque<proficiency> &get_all();
 
         bool can_learn() const;
         bool ignore_focus() const;

--- a/src/proficiency.h
+++ b/src/proficiency.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_PROFICIENCY_H
 #define CATA_SRC_PROFICIENCY_H
 
+#include <deque>
 #include <iosfwd>
 #include <map>
 #include <optional>

--- a/src/regional_settings.cpp
+++ b/src/regional_settings.cpp
@@ -976,9 +976,9 @@ void region_terrain_and_furniture_settings::finalize()
     }
 }
 
-ter_id region_terrain_and_furniture_settings::resolve( const ter_id &tid ) const
+resolved_ter_id region_terrain_and_furniture_settings::resolve( const resolved_ter_id &tid ) const
 {
-    ter_id result = tid;
+    resolved_ter_id result = tid;
     auto region_list = terrain.find( result );
     while( region_list != terrain.end() ) {
         result = *region_list->second.pick();
@@ -987,9 +987,9 @@ ter_id region_terrain_and_furniture_settings::resolve( const ter_id &tid ) const
     return result;
 }
 
-furn_id region_terrain_and_furniture_settings::resolve( const furn_id &fid ) const
+resolved_furn_id region_terrain_and_furniture_settings::resolve( const resolved_furn_id &fid ) const
 {
-    furn_id result = fid;
+    resolved_furn_id result = fid;
     auto region_list = furniture.find( result );
     while( region_list != furniture.end() ) {
         result = *region_list->second.pick();

--- a/src/regional_settings.h
+++ b/src/regional_settings.h
@@ -80,8 +80,8 @@ struct city_settings {
 };
 
 struct ter_furn_id {
-    ter_id ter;
-    furn_id furn;
+    resolved_ter_id ter;
+    resolved_furn_id furn;
     ter_furn_id();
 };
 
@@ -97,7 +97,7 @@ struct groundcover_extra {
     std::map<std::string, double> boosted_percent_str;
     std::map<int, ter_furn_id>    weightlist;
     std::map<int, ter_furn_id>    boosted_weightlist;
-    ter_id default_ter               = t_null;
+    resolved_ter_id default_ter   = t_null;
     int mpercent_coverage         = 0; // % coverage where this is applied (*10000)
     int boost_chance              = 0;
     int boosted_mpercent_coverage = 0;
@@ -133,10 +133,10 @@ struct forest_biome {
     std::map<std::string, forest_biome_component> unfinalized_biome_components;
     std::vector<forest_biome_component> biome_components;
     std::map<std::string, int> unfinalized_groundcover;
-    weighted_int_list<ter_id> groundcover;
+    weighted_int_list<resolved_ter_id> groundcover;
     std::map<std::string, forest_biome_terrain_dependent_furniture>
     unfinalized_terrain_dependent_furniture;
-    std::map<ter_id, forest_biome_terrain_dependent_furniture> terrain_dependent_furniture;
+    std::map<resolved_ter_id, forest_biome_terrain_dependent_furniture> terrain_dependent_furniture;
     int sparseness_adjacency_factor = 0;
     int item_group_chance = 0;
     int item_spawn_iterations = 0;
@@ -246,12 +246,12 @@ struct map_extras {
 struct region_terrain_and_furniture_settings {
     std::map<std::string, std::map<std::string, int>> unfinalized_terrain;
     std::map<std::string, std::map<std::string, int>> unfinalized_furniture;
-    std::map<ter_id, weighted_int_list<ter_id>> terrain;
-    std::map<furn_id, weighted_int_list<furn_id>> furniture;
+    std::map<resolved_ter_id, weighted_int_list<resolved_ter_id>> terrain;
+    std::map<resolved_furn_id, weighted_int_list<resolved_furn_id>> furniture;
 
     void finalize();
-    ter_id resolve( const ter_id & ) const;
-    furn_id resolve( const furn_id & ) const;
+    resolved_ter_id resolve( const resolved_ter_id & ) const;
+    resolved_furn_id resolve( const resolved_furn_id & ) const;
     region_terrain_and_furniture_settings() = default;
 };
 
@@ -263,7 +263,7 @@ struct regional_settings {
     std::string id;           //
     std::array<oter_str_id, OVERMAP_LAYERS> default_oter;
     double river_scale = 1;
-    weighted_int_list<ter_id> default_groundcover; // i.e., 'grass_or_dirt'
+    weighted_int_list<resolved_ter_id> default_groundcover; // i.e., 'grass_or_dirt'
     shared_ptr_fast<weighted_int_list<ter_str_id>> default_groundcover_str;
 
     city_settings     city_spec;      // put what where in a city of what kind

--- a/src/relic.cpp
+++ b/src/relic.cpp
@@ -832,7 +832,7 @@ bool operator==( const relic &source_relic, const relic &target_relic )
     return is_the_same;
 }
 
-const std::vector<relic_procgen_data> &relic_procgen_data::get_all()
+const std::deque<relic_procgen_data> &relic_procgen_data::get_all()
 {
     return relic_procgen_data_factory.get_all();
 }

--- a/src/relic.h
+++ b/src/relic.h
@@ -131,7 +131,7 @@ class relic_procgen_data
 
         bool was_loaded = false;
 
-        static const std::vector<relic_procgen_data> &get_all();
+        static const std::deque<relic_procgen_data> &get_all();
         static void load_relic_procgen_data( const JsonObject &jo, const std::string &src );
         static void reset();
         void load( const JsonObject &jo, std::string_view = {} );

--- a/src/relic.h
+++ b/src/relic.h
@@ -4,6 +4,7 @@
 
 #include <climits>
 #include <cmath>
+#include <deque>
 #include <iosfwd>
 #include <utility>
 #include <vector>

--- a/src/resolved_id.h
+++ b/src/resolved_id.h
@@ -1,0 +1,118 @@
+#pragma once
+#ifndef CATA_SRC_RESOLVED_ID_H
+#define CATA_SRC_RESOLVED_ID_H
+
+#include <functional>
+#include <string>
+#include <type_traits>
+
+#include "string_id.h"
+#include "int_id.h"
+
+/**
+ * Just like the @ref string_id and @red int_id, this is a wrapper for identifiers. The main difference
+ * is that this represents an already resolved ID, valid or not, and as such is fast to access. This
+ * requires addresses returned from int_id::obj to be stable.
+ *
+ * The template parameter T specifies what kind of object it identifies (e.g. a trap type, monster
+ * type, ...)
+ *
+ * See `string_id` for documentation on usage.
+ */
+template<typename T>
+class resolved_id
+{
+    public:
+        /**
+         * Default constructor constructs a 0-id. No id value is special to this class, 0 as id
+         * is just as normal as any other integer value.
+         */
+        resolved_id() : resolved_id( 0 ) { }
+
+        /**
+         * Explicit constructor to make it stand out in the code, so one can easily search for all
+         * places that use it.
+         */
+        explicit resolved_id( int id ) : resolved_id( int_id<T>( id ) ) { }
+
+        /**
+         * Construct a resolved id from the matching int based id.
+         */
+        // NOLINTNEXTLINE(google-explicit-constructor)
+        resolved_id( const int_id<T> &id ) : ptr_( id.is_valid() ? & id.obj() : & invalid_obj() ) {}
+
+        /**
+         * Forwarding constructor, forwards any parameter to the string_id
+         * constructor to create the resolved id. This allows plain C-strings,
+         * and std::strings to be used.
+         */
+        template<typename S, class =
+                 std::enable_if_t< std::is_convertible_v<S, std::string >> >
+        explicit resolved_id( S && id ) : resolved_id( string_id<T>( std::forward<S>( id ) ) ) {}
+
+
+        /**
+         * Construct a resolved id from the matching string based id.
+         */
+        // NOLINTNEXTLINE(google-explicit-constructor)
+        resolved_id( const string_id<T> &id ) : ptr_( id.is_valid() ? & id.obj() : & invalid_obj() ) {}
+
+        /**
+         * Comparison, only useful when the id is used in std::map or std::set as key.
+         */
+        bool operator<( const resolved_id &rhs ) const {
+            return ptr_ < rhs.ptr_;
+        }
+        /**
+         * The usual comparator, compares the resolved id as usual
+         */
+        bool operator==( const resolved_id &rhs ) const {
+            return ptr_ == rhs.ptr_;
+        }
+        /**
+         * The usual comparator, compares the resolved id as usual
+         */
+        bool operator!=( const resolved_id &rhs ) const {
+            return ptr_ != rhs.ptr_;
+        }
+
+        explicit operator bool() const {
+            return is_valid();
+        }
+
+        const T &obj() const {
+            return *ptr_;
+        }
+
+        const T &operator*() const {
+            return obj();
+        }
+
+        const T *operator->() const {
+            return ptr_;
+        }
+
+        /**
+         * Returns whether this id is valid, that means whether it refers to an existing object.
+         */
+        bool is_valid() const {
+            return ptr_ != &invalid_obj();
+        }
+
+    private:
+        // This must be defined per type in an appropriate location.
+        const T &invalid_obj() const;
+
+        const T *ptr_;
+};
+
+// Support hashing of resolved ids by forwarding the hash of the ptr.
+template<typename T>
+// NOLINTNEXTLINE(cert-dcl58-cpp)
+struct std::hash<resolved_id<T>> {
+    std::size_t operator()( const resolved_id<T> &v ) const noexcept {
+        return hash<const T *>()( &v.obj() );
+    }
+};
+
+#endif // CATA_SRC_RESOLVED_ID_H

--- a/src/resolved_id.h
+++ b/src/resolved_id.h
@@ -76,10 +76,6 @@ class resolved_id
             return ptr_ != rhs.ptr_;
         }
 
-        explicit operator bool() const {
-            return is_valid();
-        }
-
         const T &obj() const {
             return *ptr_;
         }

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -4747,7 +4747,7 @@ void submap::store( JsonOut &jsout ) const
     jsout.member( "terrain" );
     jsout.start_array();
     if( is_uniform() ) {
-        _write_rle_terrain( jsout, uniform_ter.id().str(), SEEX * SEEY );
+        _write_rle_terrain( jsout, uniform_ter->id.str(), SEEX * SEEY );
         jsout.end_array();
         return;
     }
@@ -4818,7 +4818,7 @@ void submap::store( JsonOut &jsout ) const
         for( int i = 0; i < SEEX; i++ ) {
             const point p( i, j );
             // Save furniture
-            if( get_furn( p ) ) {
+            if( get_furn( p ) != f_null ) {
                 jsout.start_array();
                 jsout.write( p.x );
                 jsout.write( p.y );
@@ -5004,7 +5004,7 @@ void submap::load( const JsonValue &jv, const std::string &member_name, int vers
         } else {
             // terrain is encoded using simple RLE
             int remaining = 0;
-            int_id<ter_t> iid;
+            resolved_ter_id iid;
             for( int j = 0; j < SEEY; j++ ) {
                 // NOLINTNEXTLINE(modernize-loop-convert)
                 for( int i = 0; i < SEEX; i++ ) {

--- a/src/scenario.cpp
+++ b/src/scenario.cpp
@@ -199,7 +199,7 @@ const scenario *scenario::weighted_random()
     }
 }
 
-const std::vector<scenario> &scenario::get_all()
+const std::deque<scenario> &scenario::get_all()
 {
     return all_scenarios.get_all();
 }
@@ -398,7 +398,7 @@ std::vector<string_id<profession>> scenario::permitted_professions() const
         return cached_permitted_professions;
     }
 
-    const std::vector<profession> &all = profession::get_all();
+    const std::deque<profession> &all = profession::get_all();
     std::vector<string_id<profession>> &res = cached_permitted_professions;
     for( const profession &p : all ) {
         if( p.is_hobby() ) {

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -78,7 +78,7 @@ class scenario
         static const scenario *generic(); // points to the generic, default profession
         // return a random scenario, weighted for use w/ random character creation
         static const scenario *weighted_random();
-        static const std::vector<scenario> &get_all();
+        static const std::deque<scenario> &get_all();
 
         // clear scenario map, every scenario pointer becomes invalid!
         static void reset();

--- a/src/scenario.h
+++ b/src/scenario.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_SCENARIO_H
 #define CATA_SRC_SCENARIO_H
 
+#include <deque>
 #include <iosfwd>
 #include <set>
 #include <string>

--- a/src/scent_map.cpp
+++ b/src/scent_map.cpp
@@ -287,7 +287,7 @@ void scent_type::load( const JsonObject &jo, const std::string_view )
     assign( jo, "receptive_species", receptive_species );
 }
 
-const std::vector<scent_type> &scent_type::get_all()
+const std::deque<scent_type> &scent_type::get_all()
 {
     return scent_factory.get_all();
 }

--- a/src/scent_map.h
+++ b/src/scent_map.h
@@ -31,7 +31,7 @@ class scent_type
     public:
         static void load_scent_type( const JsonObject &jo, const std::string &src );
         void load( const JsonObject &jo, std::string_view );
-        static const std::vector<scent_type> &get_all();
+        static const std::deque<scent_type> &get_all();
         static void check_scent_consistency();
         bool was_loaded = false;
 

--- a/src/scent_map.h
+++ b/src/scent_map.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_SCENT_MAP_H
 
 #include <array>
+#include <deque>
 #include <iosfwd>
 #include <optional>
 #include <set>

--- a/src/shop_cons_rate.cpp
+++ b/src/shop_cons_rate.cpp
@@ -50,7 +50,7 @@ void shopkeeper_blacklist::reset()
     shop_blacklist_factory.reset();
 }
 
-std::vector<shopkeeper_blacklist> const &shopkeeper_blacklist::get_all()
+std::deque<shopkeeper_blacklist> const &shopkeeper_blacklist::get_all()
 {
     return shop_blacklist_factory.get_all();
 }
@@ -74,7 +74,7 @@ void shopkeeper_cons_rates::reset()
     shop_cons_rate_factory.reset();
 }
 
-std::vector<shopkeeper_cons_rates> const &shopkeeper_cons_rates::get_all()
+std::deque<shopkeeper_cons_rates> const &shopkeeper_cons_rates::get_all()
 {
     return shop_cons_rate_factory.get_all();
 }

--- a/src/shop_cons_rate.h
+++ b/src/shop_cons_rate.h
@@ -52,7 +52,7 @@ struct shopkeeper_cons_rates {
     shopkeeper_cons_rates() = default;
 
     static void reset();
-    static const std::vector<shopkeeper_cons_rates> &get_all();
+    static const std::deque<shopkeeper_cons_rates> &get_all();
     static void load_rate( const JsonObject &jo, std::string const &src );
     static void check_all();
     void load( const JsonObject &jo, std::string_view src );
@@ -69,7 +69,7 @@ struct shopkeeper_blacklist {
     std::vector<icg_entry> entries;
 
     static void reset();
-    static const std::vector<shopkeeper_blacklist> &get_all();
+    static const std::deque<shopkeeper_blacklist> &get_all();
     static void load_blacklist( const JsonObject &jo, std::string const &src );
     void load( const JsonObject &jo, std::string_view src );
     icg_entry const *matches( item const &it, npc const &beta ) const;

--- a/src/shop_cons_rate.h
+++ b/src/shop_cons_rate.h
@@ -2,6 +2,8 @@
 #ifndef CATA_SRC_SHOP_CONS_RATE_H
 #define CATA_SRC_SHOP_CONS_RATE_H
 
+#include <deque>
+
 #include "generic_factory.h"
 #include "type_id.h"
 #include "units.h"

--- a/src/skill_boost.cpp
+++ b/src/skill_boost.cpp
@@ -14,7 +14,7 @@ namespace
 generic_factory<skill_boost> all_skill_boosts( "skill boost", "stat" );
 } // namespace
 
-const std::vector<skill_boost> &skill_boost::get_all()
+const std::deque<skill_boost> &skill_boost::get_all()
 {
     return all_skill_boosts.get_all();
 }

--- a/src/skill_boost.h
+++ b/src/skill_boost.h
@@ -25,7 +25,7 @@ class skill_boost
         static void load_boost( const JsonObject &jo, const std::string &src );
         static void reset();
 
-        static const std::vector<skill_boost> &get_all();
+        static const std::deque<skill_boost> &get_all();
         static std::optional<skill_boost> get( const std::string &stat_str );
 
     private:

--- a/src/skill_boost.h
+++ b/src/skill_boost.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_SKILL_BOOST_H
 #define CATA_SRC_SKILL_BOOST_H
 
+#include <deque>
 #include <iosfwd>
 #include <optional>
 #include <vector>

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1696,7 +1696,7 @@ void sfx::do_footstep()
     if( std::chrono::duration_cast<std::chrono::milliseconds> ( sfx_time ).count() > 400 ) {
         const Character &player_character = get_player_character();
         int heard_volume = sfx::get_heard_volume( player_character.pos() );
-        const auto terrain = get_map().ter( player_character.pos() )->id;
+        const ter_str_id terrain = get_map().ter( player_character.pos() )->id;
         static const std::set<ter_str_id> grass = {
             ter_t_grass,
             ter_t_shrub,

--- a/src/sounds.cpp
+++ b/src/sounds.cpp
@@ -1696,7 +1696,7 @@ void sfx::do_footstep()
     if( std::chrono::duration_cast<std::chrono::milliseconds> ( sfx_time ).count() > 400 ) {
         const Character &player_character = get_player_character();
         int heard_volume = sfx::get_heard_volume( player_character.pos() );
-        const auto terrain = get_map().ter( player_character.pos() ).id();
+        const auto terrain = get_map().ter( player_character.pos() )->id;
         static const std::set<ter_str_id> grass = {
             ter_t_grass,
             ter_t_shrub,

--- a/src/speed_description.cpp
+++ b/src/speed_description.cpp
@@ -41,7 +41,7 @@ void speed_description::load( const JsonObject &jo, const std::string_view )
     } );
 }
 
-const std::vector<speed_description> &speed_description::get_all()
+const std::deque<speed_description> &speed_description::get_all()
 {
     return speed_description_factory.get_all();
 }

--- a/src/speed_description.h
+++ b/src/speed_description.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_SPEED_DESCRIPTION_H
 #define CATA_SRC_SPEED_DESCRIPTION_H
 
+#include <deque>
 #include <string>
 #include <vector>
 

--- a/src/speed_description.h
+++ b/src/speed_description.h
@@ -21,7 +21,7 @@ class speed_description
 
         void load( const JsonObject &jo, std::string_view src );
 
-        static const std::vector<speed_description> &get_all();
+        static const std::deque<speed_description> &get_all();
 
         const std::vector<speed_description_value> &values() const {
             return values_;

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -555,7 +555,7 @@ void start_locations::reset()
     all_start_locations.reset();
 }
 
-const std::vector<start_location> &start_locations::get_all()
+const std::deque<start_location> &start_locations::get_all()
 {
     return all_start_locations.get_all();
 }

--- a/src/start_location.cpp
+++ b/src/start_location.cpp
@@ -164,7 +164,7 @@ static void board_up( map &m, const tripoint_range<tripoint> &range )
     std::vector<tripoint> boardables;
     for( const tripoint &p : range ) {
         bool must_board_around = false;
-        const ter_id t = m.ter( p );
+        const resolved_ter_id t = m.ter( p );
         if( t == t_window_domestic || t == t_window || t == t_window_no_curtains ) {
             // Windows are always to the outside and must be boarded
             must_board_around = true;

--- a/src/start_location.h
+++ b/src/start_location.h
@@ -110,7 +110,7 @@ void finalize_all();
 void check_consistency();
 void reset();
 
-const std::vector<start_location> &get_all();
+const std::deque<start_location> &get_all();
 
 } // namespace start_locations
 

--- a/src/start_location.h
+++ b/src/start_location.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_START_LOCATION_H
 
 #include <cstddef>
+#include <deque>
 #include <iosfwd>
 #include <set>
 #include <string>

--- a/src/submap.cpp
+++ b/src/submap.cpp
@@ -215,7 +215,7 @@ bool submap::contains_vehicle( vehicle *veh )
 
 bool submap::is_open_air( const point &p ) const
 {
-    ter_id t = get_ter( p );
+    resolved_ter_id t = get_ter( p );
     return t->trap == tr_ledge;
 }
 

--- a/src/submap.h
+++ b/src/submap.h
@@ -55,8 +55,8 @@ struct spawn_point {
 // Suppression due to bug in clang-tidy 12
 // NOLINTNEXTLINE(bugprone-reserved-identifier,cert-dcl37-c,cert-dcl51-cpp)
 struct maptile_soa {
-    cata::mdarray<ter_id, point_sm_ms>             ter; // Terrain on each square
-    cata::mdarray<furn_id, point_sm_ms>            frn; // Furniture on each square
+    cata::mdarray<resolved_ter_id, point_sm_ms>    ter; // Terrain on each square
+    cata::mdarray<resolved_furn_id, point_sm_ms>   frn; // Furniture on each square
     cata::mdarray<std::uint8_t, point_sm_ms>       lum; // Num items emitting light on each square
     cata::mdarray<cata::colony<item>, point_sm_ms> itm; // Items on each square
     cata::mdarray<field, point_sm_ms>              fld; // Field on each square
@@ -107,19 +107,19 @@ class submap
             std::uninitialized_fill_n( &m->trp[0][0], elements, trap );
         }
 
-        furn_id get_furn( const point &p ) const {
+        resolved_furn_id get_furn( const point &p ) const {
             if( is_uniform() ) {
                 return f_null;
             }
             return m->frn[p.x][p.y];
         }
 
-        void set_furn( const point &p, furn_id furn ) {
+        void set_furn( const point &p, resolved_furn_id furn ) {
             ensure_nonuniform();
             m->frn[p.x][p.y] = furn;
         }
 
-        void set_all_furn( const furn_id &furn ) {
+        void set_all_furn( const resolved_furn_id &furn ) {
             ensure_nonuniform();
             std::uninitialized_fill_n( &m->frn[0][0], elements, furn );
         }
@@ -135,19 +135,19 @@ class submap
             ephemeral_data[p] = { dmg };
         }
 
-        ter_id get_ter( const point &p ) const {
+        resolved_ter_id get_ter( const point &p ) const {
             if( is_uniform() ) {
                 return uniform_ter;
             }
             return m->ter[p.x][p.y];
         }
 
-        void set_ter( const point &p, ter_id terr ) {
+        void set_ter( const point &p, resolved_ter_id terr ) {
             ensure_nonuniform();
             m->ter[p.x][p.y] = terr;
         }
 
-        void set_all_ter( const ter_id &terr, bool uniform_ok = false ) {
+        void set_all_ter( const resolved_ter_id &terr, bool uniform_ok = false ) {
             if( !uniform_ok ) {
                 ensure_nonuniform();
             }
@@ -315,7 +315,7 @@ class submap
         std::map<point, computer> computers;
         std::unique_ptr<computer> legacy_computer;
         std::unique_ptr<maptile_soa> m;
-        ter_id uniform_ter = t_null;
+        resolved_ter_id uniform_ter = t_null;
         int temperature_mod = 0; // delta in F
 
         void update_legacy_computer();
@@ -360,11 +360,11 @@ class maptile_impl
             return sm->get_trap( pos() );
         }
 
-        furn_id get_furn() const {
+        resolved_furn_id get_furn() const {
             return sm->get_furn( pos() );
         }
 
-        ter_id get_ter() const {
+        resolved_ter_id get_ter() const {
             return sm->get_ter( pos() );
         }
 

--- a/src/talker_item.cpp
+++ b/src/talker_item.cpp
@@ -4,6 +4,7 @@
 #include "item.h"
 #include "itype.h"
 #include "magic.h"
+#include "map.h"
 #include "npc.h"
 #include "pimpl.h"
 #include "point.h"

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -196,7 +196,8 @@ void timed_event::actualize()
         case timed_event_type::TEMPLE_FLOOD: {
             bool flooded = false;
 
-            cata::mdarray<resolved_ter_id, point_bub_ms> flood_buf;
+            std::vector<std::vector<resolved_ter_id>> flood_buf( MAPSIZE_X,
+                                                   std::vector<resolved_ter_id>( MAPSIZE_Y, t_null ) );
             for( const tripoint &p : here.points_on_zlevel() ) {
                 flood_buf[p.x][p.y] = here.ter( p );
             }

--- a/src/timed_event.cpp
+++ b/src/timed_event.cpp
@@ -196,7 +196,7 @@ void timed_event::actualize()
         case timed_event_type::TEMPLE_FLOOD: {
             bool flooded = false;
 
-            cata::mdarray<ter_id, point_bub_ms> flood_buf;
+            cata::mdarray<resolved_ter_id, point_bub_ms> flood_buf;
             for( const tripoint &p : here.points_on_zlevel() ) {
                 flood_buf[p.x][p.y] = here.ter( p );
             }

--- a/src/trapfunc.cpp
+++ b/src/trapfunc.cpp
@@ -1335,7 +1335,7 @@ bool trapfunc::temple_toggle( const tripoint &p, Creature *c, item * )
     if( c->is_avatar() ) {
         add_msg( _( "You hear the grinding of shifting rock." ) );
         map &here = get_map();
-        const ter_id type = here.ter( p );
+        const resolved_ter_id type = here.ter( p );
         tripoint tmp = p;
         int &i = tmp.x;
         int &j = tmp.y;

--- a/src/type_id.h
+++ b/src/type_id.h
@@ -5,6 +5,7 @@
 // IWYU pragma: begin_exports
 #include "int_id.h"
 #include "string_id.h"
+#include "resolved_id.h"
 // IWYU pragma: end_exports
 
 class achievement;
@@ -98,6 +99,7 @@ using field_type_str_id = string_id<field_type>;
 struct furn_t;
 using furn_id = int_id<furn_t>;
 using furn_str_id = string_id<furn_t>;
+using resolved_furn_id = resolved_id<furn_t>;
 
 class climbing_aid;
 using climbing_aid_id = string_id<climbing_aid>;
@@ -257,6 +259,7 @@ using proficiency_id = string_id<proficiency>;
 struct ter_t;
 using ter_id = int_id<ter_t>;
 using ter_str_id = string_id<ter_t>;
+using resolved_ter_id = resolved_id<ter_t>;
 
 class ter_furn_transform;
 using ter_furn_transform_id = string_id<ter_furn_transform>;

--- a/src/veh_type.cpp
+++ b/src/veh_type.cpp
@@ -953,7 +953,7 @@ void vehicles::parts::reset()
     vpart_info_factory.reset();
 }
 
-const std::vector<vpart_info> &vehicles::parts::get_all()
+const std::deque<vpart_info> &vehicles::parts::get_all()
 {
     return vpart_info_factory.get_all();
 }
@@ -1241,7 +1241,7 @@ void vehicles::load_prototype( const JsonObject &jo, const std::string &src )
     vehicle_prototype_factory.load( jo, src );
 }
 
-const std::vector<vehicle_prototype> &vehicles::get_all_prototypes()
+const std::deque<vehicle_prototype> &vehicles::get_all_prototypes()
 {
     return vehicle_prototype_factory.get_all();
 }

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 #include <bitset>
+#include <deque>
 #include <iosfwd>
 #include <map>
 #include <memory>

--- a/src/veh_type.h
+++ b/src/veh_type.h
@@ -40,7 +40,7 @@ constexpr char variant_separator = '#';
 void load_prototype( const JsonObject &jo, const std::string &src );
 void reset_prototypes();
 void finalize_prototypes();
-const std::vector<vehicle_prototype> &get_all_prototypes();
+const std::deque<vehicle_prototype> &get_all_prototypes();
 
 namespace parts
 {
@@ -48,7 +48,7 @@ void load( const JsonObject &jo, const std::string &src );
 void check();
 void reset();
 void finalize();
-const std::vector<vpart_info> &get_all();
+const std::deque<vpart_info> &get_all();
 } // namespace parts
 } // namespace vehicles
 

--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -689,12 +689,12 @@ bool vehicle::autodrive_controller::check_drivable( tripoint pt ) const
 
     // check for furniture that hinders movement; furniture with 0 move cost
     // can be driven on
-    const furn_id furniture = here.furn( pt );
+    const resolved_furn_id furniture = here.furn( pt );
     if( furniture != f_null && furniture.obj().movecost != 0 ) {
         return false;
     }
 
-    const ter_id terrain = here.ter( pt );
+    const resolved_ter_id terrain = here.ter( pt );
     if( terrain == t_null ) {
         return false;
     }

--- a/src/vehicle_move.cpp
+++ b/src/vehicle_move.cpp
@@ -1675,7 +1675,7 @@ void vehicle::precalculate_vehicle_turning( units::angle new_turn_dir, bool chec
 
             // special case for rails
             if( check_rail_direction ) {
-                ter_id terrain_at_wheel = here.ter( wheel_tripoint );
+                resolved_ter_id terrain_at_wheel = here.ter( wheel_tripoint );
                 // check is it correct tile to turn into
                 if( !is_diagonal_movement &&
                     ( terrain_at_wheel == t_railroad_track_d || terrain_at_wheel == t_railroad_track_d1 ||

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1034,11 +1034,11 @@ void vehicle::transform_terrain()
             }
         }
         if( prereq_fulfilled ) {
-            const ter_id new_ter = ter_id( ttd.post_terrain );
+            const resolved_ter_id new_ter = ter_id( ttd.post_terrain );
             if( new_ter != t_null ) {
                 here.ter_set( start_pos, new_ter );
             }
-            const furn_id new_furn = furn_id( ttd.post_furniture );
+            const resolved_furn_id new_furn = furn_id( ttd.post_furniture );
             if( new_furn != f_null ) {
                 here.furn_set( start_pos, new_furn );
             }

--- a/src/weakpoint.cpp
+++ b/src/weakpoint.cpp
@@ -64,7 +64,7 @@ void weakpoints::reset()
     weakpoints_factory.reset();
 }
 
-const std::vector<weakpoints> &weakpoints::get_all()
+const std::deque<weakpoints> &weakpoints::get_all()
 {
     return weakpoints_factory.get_all();
 }

--- a/src/weakpoint.h
+++ b/src/weakpoint.h
@@ -186,7 +186,7 @@ struct weakpoints {
     static void load_weakpoint_sets( const JsonObject &jo, const std::string &src );
     static void reset();
     static void finalize_all();
-    static const std::vector<weakpoints> &get_all();
+    static const std::deque<weakpoints> &get_all();
 };
 
 #endif // CATA_SRC_WEAKPOINT_H

--- a/src/weakpoint.h
+++ b/src/weakpoint.h
@@ -3,6 +3,7 @@
 #define CATA_SRC_WEAKPOINT_H
 
 #include <array>
+#include <deque>
 #include <map>
 #include <unordered_map>
 #include <optional>

--- a/src/weather_type.cpp
+++ b/src/weather_type.cpp
@@ -154,7 +154,7 @@ void weather_types::finalize_all()
     }
 }
 
-const std::vector<weather_type> &weather_types::get_all()
+const std::deque<weather_type> &weather_types::get_all()
 {
     return weather_type_factory.get_all();
 }

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -127,7 +127,7 @@ struct weather_type {
 namespace weather_types
 {
 /** Get all currently loaded weather types */
-const std::vector<weather_type> &get_all();
+const std::deque<weather_type> &get_all();
 /** Finalize all loaded weather types */
 void finalize_all();
 /** Clear all loaded weather types (invalidating any pointers) */

--- a/src/weather_type.h
+++ b/src/weather_type.h
@@ -4,6 +4,7 @@
 
 #include <climits>
 #include <cstdint>
+#include <deque>
 #include <iosfwd>
 #include <new>
 #include <optional>

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -46,7 +46,7 @@ void widget::reset()
     widget_factory.reset();
 }
 
-const std::vector<widget> &widget::get_all()
+const std::deque<widget> &widget::get_all()
 {
     return widget_factory.get_all();
 }
@@ -1069,7 +1069,7 @@ bool widget::uses_text_function() const
 // Simple workaround from the copied widget from the panel to set the widget's height globally
 static void set_height_for_widget( const widget_id &id, int height )
 {
-    const std::vector<widget> &wlist = widget::get_all();
+    const std::deque<widget> &wlist = widget::get_all();
     auto iter = std::find_if( wlist.begin(), wlist.end(), [&id]( const widget & w ) {
         return w.getId() == id;
     } );

--- a/src/widget.h
+++ b/src/widget.h
@@ -300,7 +300,7 @@ class widget
         // Reset to defaults using generic widget_factory
         static void reset();
         // Get all widget instances from the factory
-        static const std::vector<widget> &get_all();
+        static const std::deque<widget> &get_all();
         // Get this widget's id
         const widget_id &getId() const;
 

--- a/src/widget.h
+++ b/src/widget.h
@@ -2,6 +2,7 @@
 #ifndef CATA_SRC_WIDGET_H
 #define CATA_SRC_WIDGET_H
 
+#include <deque>
 #include <string>
 #include <vector>
 

--- a/tests/act_build_test.cpp
+++ b/tests/act_build_test.cpp
@@ -209,7 +209,7 @@ void run_test_case( Character &u )
         tripoint_bub_ms const tri_window( tripoint_south );
         construction const build =
             setup_testcase( u, "test_constr_window_boarded", tri_window, tripoint_bub_ms() );
-        ter_id const ter_pre = here.ter( tri_window );
+        resolved_ter_id const ter_pre = here.ter( tri_window );
         partial_con pc;
         pc.id = get_construction( "test_constr_door" ).id;
         here.partial_con_set( tri_window, pc );

--- a/tests/cardio_test.cpp
+++ b/tests/cardio_test.cpp
@@ -53,7 +53,7 @@ static void verify_default_cardio_options()
 }
 
 // Count the number of steps (tiles) until character runs out of stamina or becomes winded.
-static int running_steps( Character &they, const ter_id &terrain = t_pavement )
+static int running_steps( Character &they, const resolved_ter_id &terrain = t_pavement )
 {
     map &here = get_map();
     // Please take off your shoes when entering, and no NPCs allowed

--- a/tests/eoc_test.cpp
+++ b/tests/eoc_test.cpp
@@ -147,7 +147,7 @@ void complete_activity( Character &u )
     }
 }
 
-void check_ter_in_radius( tripoint_abs_ms const &center, int range, ter_id const &ter )
+void check_ter_in_radius( tripoint_abs_ms const &center, int range, resolved_ter_id const &ter )
 {
     map tm;
     tm.load( project_to<coords::sm>( center - point{ range, range } ), false, false );
@@ -160,7 +160,7 @@ void check_ter_in_radius( tripoint_abs_ms const &center, int range, ter_id const
 }
 
 void check_ter_in_line( tripoint_abs_ms const &first, tripoint_abs_ms const &second,
-                        ter_id const &ter )
+                        resolved_ter_id const &ter )
 {
     map tm;
     tripoint_abs_ms const orig = coord_min( first, second );

--- a/tests/generic_factory_test.cpp
+++ b/tests/generic_factory_test.cpp
@@ -35,7 +35,7 @@ struct test_obj {
 test_obj invalid;
 test_id test_int_id_null( -1 );
 
-generic_factory<test_obj> *current_factory;
+generic_factory<test_obj> *current_factory = nullptr;
 
 } // namespace
 
@@ -78,6 +78,7 @@ TEST_CASE( "generic_factory_insert_convert_valid", "[generic_factory]" )
     test_obj_id id_2( "id_2" );
 
     generic_factory<test_obj> test_factory( "test_factory" );
+    restore_on_out_of_scope<generic_factory<test_obj>*> current_factory_prev( current_factory );
     current_factory = &test_factory;
 
     REQUIRE_FALSE( test_factory.is_valid( id_0 ) );
@@ -175,6 +176,7 @@ TEST_CASE( "generic_factory_repeated_invalidation", "[generic_factory]" )
     // if id is static, factory must be static (or singleton by other means)
     static test_obj_id id_1( "id_1" );
     static generic_factory<test_obj> test_factory( "test_factory" );
+    restore_on_out_of_scope<generic_factory<test_obj>*> current_factory_prev( current_factory );
     current_factory = &test_factory;
 
     for( int i = 0; i < 10; i++ ) {

--- a/tests/generic_factory_test.cpp
+++ b/tests/generic_factory_test.cpp
@@ -44,7 +44,6 @@ template<> int_id<test_obj> string_id<test_obj>::id() const
 {
     return current_factory->convert( *this, test_int_id_null );
 }
-template<> int_id<test_obj>::int_id( const string_id<test_obj> &id ) : _id( id.id() ) {}
 template<> const test_obj &int_id<test_obj>::obj() const
 {
     return current_factory->obj( *this );
@@ -362,14 +361,6 @@ template<> int_id<stat_test_obj> string_id<stat_test_obj>::id() const
     return stat_test_obj_factory.convert( *this, stat_int_id_null );
 }
 template<> int_id<stat_test_obj>::int_id( const string_id<stat_test_obj> &id ) : _id( id.id() ) {}
-template<> const stat_test_obj &int_id<stat_test_obj>::obj() const
-{
-    return stat_test_obj_factory.obj( *this );
-}
-template<> bool int_id<stat_test_obj>::is_valid() const
-{
-    return stat_test_obj_factory.is_valid( *this );
-}
 template<> const stat_test_obj &string_id<stat_test_obj>::obj() const
 {
     return stat_test_obj_factory.obj( *this );

--- a/tests/ground_destroy_test.cpp
+++ b/tests/ground_destroy_test.cpp
@@ -17,7 +17,7 @@
 // https://github.com/CleverRaven/Cataclysm-DDA/issues/24707
 TEST_CASE( "pavement_destroy", "[.]" )
 {
-    const ter_id flat_roof_id = ter_id( "t_flat_roof" );
+    const resolved_ter_id flat_roof_id = ter_id( "t_flat_roof" );
     REQUIRE( flat_roof_id != t_null );
 
     clear_map_and_put_player_underground();
@@ -27,7 +27,7 @@ TEST_CASE( "pavement_destroy", "[.]" )
 
     // Destroy it
     here.destroy( tripoint_zero, true );
-    ter_id after_destroy = here.ter( tripoint_zero );
+    resolved_ter_id after_destroy = here.ter( tripoint_zero );
     if( after_destroy == flat_roof_id ) {
         FAIL( flat_roof_id.obj().name() << " found after destroying pavement" );
     } else {
@@ -40,7 +40,7 @@ TEST_CASE( "pavement_destroy", "[.]" )
 // https://github.com/CleverRaven/Cataclysm-DDA/issues/23250
 TEST_CASE( "explosion_on_ground", "[.]" )
 {
-    ter_id flat_roof_id = ter_id( "t_flat_roof" );
+    resolved_ter_id flat_roof_id = ter_id( "t_flat_roof" );
     REQUIRE( flat_roof_id != t_null );
 
     clear_map_and_put_player_underground();
@@ -70,7 +70,7 @@ TEST_CASE( "explosion_on_ground", "[.]" )
     for( int x = 0; x < area_dim; x++ ) {
         for( int y = 0; y < area_dim; y++ ) {
             tripoint pt( x, y, 0 );
-            ter_id t_id = here.ter( pt );
+            resolved_ter_id t_id = here.ter( pt );
             if( t_id == flat_roof_id ) {
                 FAIL( "After explosion, " << t_id.obj().name() << " found at " << x << "," << y );
             }
@@ -83,10 +83,10 @@ TEST_CASE( "explosion_on_ground", "[.]" )
 // the defined roof of a t_rock-floor).
 TEST_CASE( "explosion_on_floor_with_rock_floor_basement", "[.]" )
 {
-    ter_id flat_roof_id = ter_id( "t_flat_roof" );
-    ter_id floor_id = ter_id( "t_floor" );
-    ter_id rock_floor_id = ter_id( "t_rock_floor" );
-    ter_id open_air_id = ter_id( "t_open_air" );
+    resolved_ter_id flat_roof_id = ter_id( "t_flat_roof" );
+    resolved_ter_id floor_id = ter_id( "t_floor" );
+    resolved_ter_id rock_floor_id = ter_id( "t_rock_floor" );
+    resolved_ter_id open_air_id = ter_id( "t_open_air" );
 
     REQUIRE( flat_roof_id != t_null );
     REQUIRE( floor_id != t_null );
@@ -117,7 +117,7 @@ TEST_CASE( "explosion_on_floor_with_rock_floor_basement", "[.]" )
     for( int x = 0; x < area_dim; x++ ) {
         for( int y = 0; y < area_dim; y++ ) {
             tripoint pt( x, y, 0 );
-            ter_id t_id = here.ter( pt );
+            resolved_ter_id t_id = here.ter( pt );
             INFO( "t " << t_id.obj().name() << " at " << x << "," << y );
             if( t_id == open_air_id ) {
                 found_open_air = true;
@@ -140,10 +140,10 @@ TEST_CASE( "collapse_checks", "[.]" )
 {
     constexpr int wall_size = 5;
 
-    const ter_id floor_id = ter_id( "t_floor" );
-    const ter_id dirt_id = ter_id( "t_dirt" );
-    const ter_id wall_id = ter_id( "t_wall" );
-    const ter_id open_air_id = ter_id( "t_open_air" );
+    const resolved_ter_id floor_id = ter_id( "t_floor" );
+    const resolved_ter_id dirt_id = ter_id( "t_dirt" );
+    const resolved_ter_id wall_id = ter_id( "t_wall" );
+    const resolved_ter_id open_air_id = ter_id( "t_open_air" );
 
     REQUIRE( floor_id != t_null );
     REQUIRE( dirt_id != t_null );
@@ -206,7 +206,7 @@ TEST_CASE( "collapse_checks", "[.]" )
         if( pt.z == 0 ) {
             continue;
         }
-        const ter_id t_id = here.ter( pt );
+        const resolved_ter_id t_id = here.ter( pt );
         tile_count += 1;
         if( t_id == t_open_air ) {
             open_air_count += 1;

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -55,7 +55,7 @@ void wipe_map_terrain( map *target )
     map &here = target ? *target : get_map();
     const int mapsize = here.getmapsize() * SEEX;
     for( int z = -1; z <= OVERMAP_HEIGHT; ++z ) {
-        ter_id terrain = z == 0 ? t_grass : z < 0 ? t_rock : t_open_air;
+        resolved_ter_id terrain = z == 0 ? t_grass : z < 0 ? t_rock : t_open_air;
         for( int x = 0; x < mapsize; ++x ) {
             for( int y = 0; y < mapsize; ++y ) {
                 here.set( { x, y, z}, terrain, f_null );

--- a/tests/map_test.cpp
+++ b/tests/map_test.cpp
@@ -107,9 +107,9 @@ TEST_CASE( "map_bounds_checking" )
                 if( x < 0 || x >= MAPSIZE_X ||
                     y < 0 || y >= MAPSIZE_Y ||
                     z < -OVERMAP_DEPTH || z > OVERMAP_HEIGHT ) {
-                    CHECK( !m.ter( tripoint{ x, y, z } ) );
+                    CHECK( m.ter( tripoint{ x, y, z } ) == t_null );
                 } else {
-                    CHECK( m.ter( tripoint{ x, y, z } ) );
+                    CHECK( m.ter( tripoint{ x, y, z } ) != t_null );
                 }
             }
         }
@@ -133,9 +133,9 @@ TEST_CASE( "tinymap_bounds_checking" )
                 if( x < 0 || x >= SEEX * 2 ||
                     y < 0 || y >= SEEY * 2 ||
                     z < -OVERMAP_DEPTH || z > OVERMAP_HEIGHT ) {
-                    CHECK( !m.ter( tripoint{ x, y, z } ) );
+                    CHECK( m.ter( tripoint{ x, y, z } ) == t_null );
                 } else {
-                    CHECK( m.ter( tripoint{ x, y, z } ) );
+                    CHECK( m.ter( tripoint{ x, y, z } ) != t_null );
                 }
             }
         }

--- a/tests/npc_talk_test.cpp
+++ b/tests/npc_talk_test.cpp
@@ -458,7 +458,7 @@ TEST_CASE( "npc_talk_mission_goal", "[npc_talk]" )
     d.add_topic( "TALK_TEST_MISSION_GOAL" );
     gen_response_lines( d, 1 );
     CHECK( d.responses[0].text == "This is a basic test response." );
-    const std::vector<mission_type> &all_missions = mission_type::get_all();
+    const std::deque<mission_type> &all_missions = mission_type::get_all();
     bool set_mission = false;
     for( const mission_type &some_mission : all_missions ) {
         if( some_mission.goal == MGOAL_ASSASSINATE ) {

--- a/tests/submap_load_test.cpp
+++ b/tests/submap_load_test.cpp
@@ -894,16 +894,16 @@ TEST_CASE( "submap_terrain_rle_load", "[submap][load]" )
 
     REQUIRE( is_normal_submap( sm, checks ) );
 
-    const ter_id ter_nw = sm.get_ter( corner_nw );
-    const ter_id ter_ne = sm.get_ter( corner_ne );
-    const ter_id ter_sw = sm.get_ter( corner_sw );
-    const ter_id ter_se = sm.get_ter( corner_se );
+    const resolved_ter_id ter_nw = sm.get_ter( corner_nw );
+    const resolved_ter_id ter_ne = sm.get_ter( corner_ne );
+    const resolved_ter_id ter_sw = sm.get_ter( corner_sw );
+    const resolved_ter_id ter_se = sm.get_ter( corner_se );
 
     // We placed a unique terrain in each of the corners. Check that those are correct
-    INFO( string_format( "nw: %s", ter_nw.id().str() ) );
-    INFO( string_format( "ne: %s", ter_ne.id().str() ) );
-    INFO( string_format( "sw: %s", ter_sw.id().str() ) );
-    INFO( string_format( "se: %s", ter_se.id().str() ) );
+    INFO( string_format( "nw: %s", ter_nw->id.str() ) );
+    INFO( string_format( "ne: %s", ter_ne->id.str() ) );
+    INFO( string_format( "sw: %s", ter_sw->id.str() ) );
+    INFO( string_format( "se: %s", ter_se->id.str() ) );
     // Require to prevent the lower CHECK from being spammy
     REQUIRE( ter_nw == t_floor_green );
     REQUIRE( ter_ne == t_floor_red );
@@ -947,7 +947,7 @@ TEST_CASE( "submap_terrain_load_invalid_ter_ids_as_t_dirt", "[submap][load]" )
         for( int y = 0; y < SEEY; y++ ) {
             CAPTURE( x, y );
             // expect t_rock_floor patch in a corner
-            const ter_id expected = ( ( x == 11 ) && ( y == 11 ) ) ? t_rock_floor : t_dirt;
+            const resolved_ter_id expected = ( ( x == 11 ) && ( y == 11 ) ) ? t_rock_floor : t_dirt;
             CHECK( sm.get_ter( {x, y} ) == expected );
         }
     }
@@ -962,18 +962,18 @@ TEST_CASE( "submap_furniture_load", "[submap][load]" )
 
     REQUIRE( is_normal_submap( sm, checks ) );
 
-    const furn_id furn_nw = sm.get_furn( corner_nw );
-    const furn_id furn_ne = sm.get_furn( corner_ne );
-    const furn_id furn_sw = sm.get_furn( corner_sw );
-    const furn_id furn_se = sm.get_furn( corner_se );
-    const furn_id furn_ra = sm.get_furn( random_pt );
+    const resolved_furn_id furn_nw = sm.get_furn( corner_nw );
+    const resolved_furn_id furn_ne = sm.get_furn( corner_ne );
+    const resolved_furn_id furn_sw = sm.get_furn( corner_sw );
+    const resolved_furn_id furn_se = sm.get_furn( corner_se );
+    const resolved_furn_id furn_ra = sm.get_furn( random_pt );
 
     // We placed a unique furniture in a couple pf place. Check that those are correct
-    INFO( string_format( "nw: %s", furn_nw.id().str() ) );
-    INFO( string_format( "ne: %s", furn_ne.id().str() ) );
-    INFO( string_format( "sw: %s", furn_sw.id().str() ) );
-    INFO( string_format( "se: %s", furn_se.id().str() ) );
-    INFO( string_format( "ra: %s", furn_ra.id().str() ) );
+    INFO( string_format( "nw: %s", furn_nw->id.str() ) );
+    INFO( string_format( "ne: %s", furn_ne->id.str() ) );
+    INFO( string_format( "sw: %s", furn_sw->id.str() ) );
+    INFO( string_format( "se: %s", furn_se->id.str() ) );
+    INFO( string_format( "ra: %s", furn_ra->id.str() ) );
     // Require to prevent the lower CHECK from being spammy
     REQUIRE( furn_nw == f_coffin_c );
     REQUIRE( furn_ne == f_bookcase );

--- a/tests/vehicle_efficiency_test.cpp
+++ b/tests/vehicle_efficiency_test.cpp
@@ -232,7 +232,7 @@ static int test_efficiency( const vproto_id &veh_id, int &expected_mass,
         // If the vehicle starts skidding, the effects become random and test is RUINED
         REQUIRE( !veh.skidding );
         for( const tripoint &pos : veh.get_points() ) {
-            REQUIRE( here.ter( pos ) );
+            REQUIRE( here.ter( pos ) != t_null );
         }
         // How much it moved
         tiles_travelled += square_dist( starting_point, veh.global_pos3() );

--- a/tests/vehicle_ramp_test.cpp
+++ b/tests/vehicle_ramp_test.cpp
@@ -150,7 +150,7 @@ static void ramp_transition_angled( const vproto_id &veh_id, const units::angle 
         // If the vehicle starts skidding, the effects become random and test is RUINED
         REQUIRE( !veh.skidding );
         for( const tripoint &pos : veh.get_points() ) {
-            REQUIRE( here.ter( pos ) );
+            REQUIRE( here.ter( pos ) != t_null );
         }
         for( const vpart_reference &vp : veh.get_all_parts() ) {
             if( vp.info().location != "structure" ) {

--- a/tests/water_movement_test.cpp
+++ b/tests/water_movement_test.cpp
@@ -973,7 +973,7 @@ TEST_CASE( "export_profession_swim_cost_and_distance", "[.]" )
     testfile.open( fs::u8path( "swim-profession.csv" ), std::ofstream::trunc );
     testfile << "profession, move cost, steps" << std::endl;
 
-    const std::vector<profession> &all = profession::get_all();
+    const std::deque<profession> &all = profession::get_all();
     for( const profession &prof : all ) {
         std::vector<trait_id> traits;
         std::vector<std::string> trait_ids;

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -1780,8 +1780,6 @@ TEST_CASE( "compass_widget", "[widget][compass]" )
                "N: <color_c_white>+</color>                                " );
         CHECK( c5s_N_nodir_nowidth.layout( ava, sidebar_width ) ==
                "N:                                  " );
-        // Note that the order here is sensitive to monster ID order. If you are seeing errors here, you may have changed
-        // this order and these need to be rearranged.
         CHECK( c5s_legend1.layout( ava, sidebar_width ) ==
                "<color_c_white>B</color> <color_c_dark_gray>monster producing CBMs when disse…</color>" );
         CHECK( c5s_legend3.layout( ava, sidebar_width ) ==
@@ -2125,8 +2123,6 @@ TEST_CASE( "Dynamic_height_for_multiline_widgets", "[widget]" )
         REQUIRE( ava.sees( mon2 ) );
         REQUIRE( ava.get_mon_visible().unique_mons[static_cast<int>( cardinal_direction::NORTH )].size() ==
                  2 );
-        // Note that the order here is sensitive to monster ID order. If you are seeing errors here, you may have changed
-        // this order and these need to be rearranged.
         CHECK( c5s_legend3.layout( ava, sidebar_width ) ==
                "<color_c_white>B</color> <color_c_dark_gray>monster producing CBMs when dissected</color>\n"
                "<color_c_white>B</color> <color_c_dark_gray>monster producing cattle samples when dissected</color>" );
@@ -2146,8 +2142,6 @@ TEST_CASE( "Dynamic_height_for_multiline_widgets", "[widget]" )
         REQUIRE( ava.sees( mon3 ) );
         REQUIRE( ava.get_mon_visible().unique_mons[static_cast<int>( cardinal_direction::NORTH )].size() ==
                  3 );
-        // Note that the order here is sensitive to monster ID order. If you are seeing errors here, you may have changed
-        // this order and these need to be rearranged.
         CHECK( c5s_legend3.layout( ava, sidebar_width ) ==
                "<color_c_white>B</color> <color_c_dark_gray>monster producing CBMs when dissected</color>\n"
                "<color_c_white>B</color> <color_c_dark_gray>monster producing cattle samples when dissected</color>\n"

--- a/tests/widget_test.cpp
+++ b/tests/widget_test.cpp
@@ -1780,16 +1780,18 @@ TEST_CASE( "compass_widget", "[widget][compass]" )
                "N: <color_c_white>+</color>                                " );
         CHECK( c5s_N_nodir_nowidth.layout( ava, sidebar_width ) ==
                "N:                                  " );
+        // Note that the order here is sensitive to monster ID order. If you are seeing errors here, you may have changed
+        // this order and these need to be rearranged.
         CHECK( c5s_legend1.layout( ava, sidebar_width ) ==
-               "<color_c_white>S</color> <color_c_dark_gray>shearable monster</color>                 " );
+               "<color_c_white>B</color> <color_c_dark_gray>monster producing CBMs when disse…</color>" );
         CHECK( c5s_legend3.layout( ava, sidebar_width ) ==
-               "<color_c_white>S</color> <color_c_dark_gray>shearable monster</color>                 \n"
+               "<color_c_white>B</color> <color_c_dark_gray>monster producing CBMs when dissected</color>\n"
                "<color_c_white>B</color> <color_c_dark_gray>monster producing cattle samples when dissected</color>\n"
-               "<color_c_white>B</color> <color_c_dark_gray>monster producing CBMs when dissected</color>" );
+               "<color_c_white>S</color> <color_c_dark_gray>shearable monster</color>                 " );
         CHECK( c5s_legend5.layout( ava, sidebar_width ) ==
-               "<color_c_white>S</color> <color_c_dark_gray>shearable monster</color>                 \n"
+               "<color_c_white>B</color> <color_c_dark_gray>monster producing CBMs when dissected</color>\n"
                "<color_c_white>B</color> <color_c_dark_gray>monster producing cattle samples when dissected</color>\n"
-               "<color_c_white>B</color> <color_c_dark_gray>monster producing CBMs when dissected</color>" );
+               "<color_c_white>S</color> <color_c_dark_gray>shearable monster</color>                 " );
     }
 }
 
@@ -2123,9 +2125,11 @@ TEST_CASE( "Dynamic_height_for_multiline_widgets", "[widget]" )
         REQUIRE( ava.sees( mon2 ) );
         REQUIRE( ava.get_mon_visible().unique_mons[static_cast<int>( cardinal_direction::NORTH )].size() ==
                  2 );
+        // Note that the order here is sensitive to monster ID order. If you are seeing errors here, you may have changed
+        // this order and these need to be rearranged.
         CHECK( c5s_legend3.layout( ava, sidebar_width ) ==
-               "<color_c_white>B</color> <color_c_dark_gray>monster producing cattle samples when dissected</color>\n"
-               "<color_c_white>B</color> <color_c_dark_gray>monster producing CBMs when dissected</color>" );
+               "<color_c_white>B</color> <color_c_dark_gray>monster producing CBMs when dissected</color>\n"
+               "<color_c_white>B</color> <color_c_dark_gray>monster producing cattle samples when dissected</color>" );
         CHECK( get_height_from_widget_factory( c5s_legend3.getId() ) == 2 );
     }
 
@@ -2142,10 +2146,12 @@ TEST_CASE( "Dynamic_height_for_multiline_widgets", "[widget]" )
         REQUIRE( ava.sees( mon3 ) );
         REQUIRE( ava.get_mon_visible().unique_mons[static_cast<int>( cardinal_direction::NORTH )].size() ==
                  3 );
+        // Note that the order here is sensitive to monster ID order. If you are seeing errors here, you may have changed
+        // this order and these need to be rearranged.
         CHECK( c5s_legend3.layout( ava, sidebar_width ) ==
-               "<color_c_white>S</color> <color_c_dark_gray>shearable monster</color>                 \n"
+               "<color_c_white>B</color> <color_c_dark_gray>monster producing CBMs when dissected</color>\n"
                "<color_c_white>B</color> <color_c_dark_gray>monster producing cattle samples when dissected</color>\n"
-               "<color_c_white>B</color> <color_c_dark_gray>monster producing CBMs when dissected</color>" );
+               "<color_c_white>S</color> <color_c_dark_gray>shearable monster</color>                 " );
         CHECK( get_height_from_widget_factory( c5s_legend3.getId() ) == 3 );
     }
 }

--- a/tools/clang-tidy-plugin/CMakeLists.txt
+++ b/tools/clang-tidy-plugin/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CataAnalyzerSrc
         StaticDeclarationsCheck.cpp
         StaticInitializationOrderCheck.cpp
         StaticIntIdConstantsCheck.cpp
+	StaticResolvedIdConstantsCheck.cpp
         StaticStringIdConstantsCheck.cpp
         StringLiteralIterator.cpp
         TestFilenameCheck.cpp

--- a/tools/clang-tidy-plugin/CMakeLists.txt
+++ b/tools/clang-tidy-plugin/CMakeLists.txt
@@ -25,7 +25,7 @@ set(CataAnalyzerSrc
         StaticDeclarationsCheck.cpp
         StaticInitializationOrderCheck.cpp
         StaticIntIdConstantsCheck.cpp
-	StaticResolvedIdConstantsCheck.cpp
+        StaticResolvedIdConstantsCheck.cpp
         StaticStringIdConstantsCheck.cpp
         StringLiteralIterator.cpp
         TestFilenameCheck.cpp

--- a/tools/clang-tidy-plugin/CataTidyModule.cpp
+++ b/tools/clang-tidy-plugin/CataTidyModule.cpp
@@ -22,6 +22,7 @@
 #include "StaticDeclarationsCheck.h"
 #include "StaticInitializationOrderCheck.h"
 #include "StaticIntIdConstantsCheck.h"
+#include "StaticResolvedIdConstantsCheck.h"
 #include "StaticStringIdConstantsCheck.h"
 #include "TestFilenameCheck.h"
 #include "TestsMustRestoreGlobalStateCheck.h"
@@ -88,6 +89,8 @@ class CataModule : public ClangTidyModule
             CheckFactories.registerCheck<StaticDeclarationsCheck>( "cata-static-declarations" );
             CheckFactories.registerCheck<StaticIntIdConstantsCheck>(
                 "cata-static-int_id-constants" );
+            CheckFactories.registerCheck<StaticResolvedIdConstantsCheck>(
+                "cata-static-resolved_id-constants" );
             CheckFactories.registerCheck<StaticStringIdConstantsCheck>(
                 "cata-static-string_id-constants" );
             CheckFactories.registerCheck<TestFilenameCheck>( "cata-test-filename" );

--- a/tools/clang-tidy-plugin/StaticResolvedIdConstantsCheck.cpp
+++ b/tools/clang-tidy-plugin/StaticResolvedIdConstantsCheck.cpp
@@ -1,0 +1,75 @@
+#include "StaticResolvedIdConstantsCheck.h"
+#include "Utils.h"
+#include <unordered_map>
+
+using namespace clang::ast_matchers;
+
+namespace clang::tidy::cata
+{
+
+void StaticResolvedIdConstantsCheck::registerMatchers( MatchFinder *Finder )
+{
+    Finder->addMatcher(
+        varDecl(
+            hasType(
+                namedDecl(
+                    anyOf(
+                        hasName( "resolved_id" ),
+                        typedefNameDecl(
+                            hasType(
+                                hasCanonicalType(
+                                    hasDeclaration( namedDecl( hasName( "resolved_id" ) ) )
+                                )
+                            )
+                        )
+                    )
+                ).bind( "typeDecl" )
+            )
+        ).bind( "varDecl" ),
+        this
+    );
+}
+
+static void CheckConstructor( StaticResolvedIdConstantsCheck &Check,
+                              const MatchFinder::MatchResult &Result )
+{
+    const VarDecl *ResolvedIdVarDecl = Result.Nodes.getNodeAs<VarDecl>( "varDecl" );
+    const TypeDecl *ResolvedIdTypeDecl = Result.Nodes.getNodeAs<TypeDecl>( "typeDecl" );
+    if( !ResolvedIdVarDecl || !ResolvedIdTypeDecl ) {
+        return;
+    }
+
+    const VarDecl *PreviousDecl = dyn_cast_or_null<VarDecl>( ResolvedIdVarDecl->getPreviousDecl() );
+
+    if( PreviousDecl ) {
+        // Only complain about each variable once
+        return;
+    }
+
+    std::string Adjective;
+
+    if( ResolvedIdVarDecl->hasGlobalStorage() ) {
+        Adjective = "Global";
+    }
+
+    if( ResolvedIdVarDecl->isStaticDataMember() || ResolvedIdVarDecl->isStaticLocal() ) {
+        Adjective = "Static";
+    }
+
+    if( Adjective.empty() ) {
+        return;
+    }
+
+    Check.diag(
+        ResolvedIdVarDecl->getBeginLoc(),
+        "%2 declaration of %0 is dangerous because %1 is a specialization of resolved_id and it "
+        "will not update automatically when game data changes.  Consider switching to a string_id."
+    ) << ResolvedIdVarDecl << ResolvedIdTypeDecl << Adjective;
+}
+
+void StaticResolvedIdConstantsCheck::check( const MatchFinder::MatchResult &Result )
+{
+    CheckConstructor( *this, Result );
+}
+
+} // namespace clang::tidy::cata

--- a/tools/clang-tidy-plugin/StaticResolvedIdConstantsCheck.h
+++ b/tools/clang-tidy-plugin/StaticResolvedIdConstantsCheck.h
@@ -1,0 +1,33 @@
+#ifndef CATA_TOOLS_CLANG_TIDY_PLUGIN_STATICRESOLVEDIDCONSTANTSCHECK_H
+#define CATA_TOOLS_CLANG_TIDY_PLUGIN_STATICRESOLVEDIDCONSTANTSCHECK_H
+
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+#include <llvm/ADT/StringRef.h>
+
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
+
+namespace clang
+{
+
+namespace tidy
+{
+class ClangTidyContext;
+
+namespace cata
+{
+
+class StaticResolvedIdConstantsCheck : public ClangTidyCheck
+{
+    public:
+        StaticResolvedIdConstantsCheck( StringRef Name, ClangTidyContext *Context )
+            : ClangTidyCheck( Name, Context ) {}
+        void registerMatchers( ast_matchers::MatchFinder *Finder ) override;
+        void check( const ast_matchers::MatchFinder::MatchResult &Result ) override;
+};
+
+} // namespace cata
+} // namespace tidy
+} // namespace clang
+
+#endif // CATA_TOOLS_CLANG_TIDY_PLUGIN_STATICRESOLVEDIDCONSTANTSCHECK_H

--- a/tools/clang-tidy-plugin/test/static-resolved_id-constants.cpp
+++ b/tools/clang-tidy-plugin/test/static-resolved_id-constants.cpp
@@ -1,0 +1,41 @@
+// RUN: %check_clang_tidy -allow-stdinc %s cata-static-resolved_id-constants %t -- --load=%cata_plugin -- -isystem %cata_include
+
+#include "type_id.h"
+
+extern resolved_furn_id f_hay;
+// CHECK-MESSAGES: warning: Global declaration of 'f_hay' is dangerous because 'resolved_furn_id' is a specialization of resolved_id and it will not update automatically when game data changes.  Consider switching to a string_id. [cata-static-resolved_id-constants]
+
+// No warning for second decl os same variable.
+resolved_furn_id f_hay;
+
+static resolved_id<furn_t> f_ball_mach;
+// CHECK-MESSAGES: warning: Global declaration of 'f_ball_mach' is dangerous because 'resolved_id<furn_t>' is a specialization of resolved_id and it will not update automatically when game data changes.  Consider switching to a string_id. [cata-static-resolved_id-constants]
+
+namespace foo
+{
+
+const resolved_furn_id f_dahlia;
+// CHECK-MESSAGES: warning: Global declaration of 'f_dahlia' is dangerous because 'resolved_furn_id' is a specialization of resolved_id and it will not update automatically when game data changes.  Consider switching to a string_id. [cata-static-resolved_id-constants]
+
+} // namespace foo
+
+class A
+{
+        static resolved_furn_id f_bluebell;
+        // CHECK-MESSAGES: warning: Static declaration of 'f_bluebell' is dangerous because 'resolved_furn_id' is a specialization of resolved_id and it will not update automatically when game data changes.  Consider switching to a string_id. [cata-static-resolved_id-constants]
+
+        // No warning for regular class data members
+        resolved_furn_id my_furn;
+};
+
+void f()
+{
+    static resolved_furn_id f_floor_canvas;
+    // CHECK-MESSAGES: warning: Static declaration of 'f_floor_canvas' is dangerous because 'resolved_furn_id' is a specialization of resolved_id and it will not update automatically when game data changes.  Consider switching to a string_id. [cata-static-resolved_id-constants]
+
+    // No warning for regular local variables
+    resolved_furn_id f;
+
+    // No warning for other types
+    static int i;
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Add `resolved_id<T>` to represent IDs that are already resolved."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

See issue #70399
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Introduce `resolved_id` which is a thin wrapper around a pointer, and acts as a companion to `int_id` and `string_id`. It avoids the branching and indirection in resolving an id. The branch is almost always true and is easily predicted, so the main win is removing a layer of indirection and generating less code (no debug message!) in an _extremely_ common function.

As this requires the objects in `generic_factory` to not move in memory, the internal `vector` was swapped for `deque`. This is why 100+ files are touched. The downside is that this adds a layer of indirection to `int_id`/`string_id` look ups, but performance sensitive code (and global hardcoded ids) will be migrated to use `resolved_id`.

This also adds two uses of the class: `resolved_ter_id` and `resolved_furn_id`. Replaced some `int_id` usage with these new types. As a side effect, also fixed a source of potential bugs: there were a few static maps that saved `int_id`s, but those are not stable between loads. They now store `string_id`s and are stable.

Finally, added a clang-tidy check to warn about global `resolved_id`s, as they are not stable between loads.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Refactor `int_id` to ensure it is always valid. There are way too many cases of constructing it from an `int` for this to be feasible, or even desirable.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Added tests for `resolved_id`, and the new clang-tidy check.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

These were taken with #70274 and #70546 merged, as they add a lot of noise. Two samples before and after, since the profiles are now much more stable.

Before:
<img width="247" alt="Screenshot 2024-01-01 124026" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/2677507/e524f620-f202-45ef-8ee3-c68220947a1d">
<img width="244" alt="Screenshot 2024-01-01 124324" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/2677507/81ecd168-8404-4ed4-aa60-33ad66aba86f">

After:
<img width="243" alt="Screenshot 2024-01-01 130308" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/2677507/270d52ef-50e1-4a38-a27d-c05918005c43">
<img width="246" alt="Screenshot 2024-01-01 130522" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/2677507/6b41a12d-323e-4972-9b03-d7194c00e4af">


Fun fact: with MSVC the resulting binary is 30kB smaller. That isn't a whole lot, but since it almost entirely consists of replacing setting up registers + a call instruction for `int_id::obj()` with a single pointer dereference, it's kind of crazy how often this function is called with just terrain and furniture.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
