### PR TITLE
Made PC construction prefer empty containers

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1775,8 +1775,34 @@ static bool construction_activity( Character &you, const zone_data * /*zone*/,
     // Set the trap that has the examine function
     // Use up the components
     for( const std::vector<item_comp> &it : built_chosen.requirements->get_components() ) {
-        std::list<item> tmp = you.consume_items( it, 1, is_crafting_component );
-        used.splice( used.end(), tmp );
+        for( const item_comp &comp : it ) {
+            comp_selection<item_comp> sel;
+            sel.use_from = usage_from::both;
+            sel.comp = comp;
+            std::list<item> empty_consumed = you.consume_items( sel, 1, is_empty_crafting_component );
+
+            int left_to_consume = 0;
+
+            if( !empty_consumed.empty() && empty_consumed.front().count_by_charges() ) {
+                int consumed = 0;
+                for( item &itm : empty_consumed ) {
+                    consumed += itm.charges;
+                }
+                left_to_consume = comp.count - consumed;
+            } else if( empty_consumed.size() < static_cast<size_t>( comp.count ) ) {
+                left_to_consume = comp.count - empty_consumed.size();
+            }
+
+            if( left_to_consume > 0 ) {
+                comp_selection<item_comp> remainder = sel;
+                remainder.comp.count = 1;
+                std::list<item>used_consumed = you.consume_items( remainder,
+                                               left_to_consume, is_crafting_component );
+                empty_consumed.splice( empty_consumed.end(), used_consumed );
+            }
+
+            used.splice( used.end(), empty_consumed );
+        }
     }
     pc.components = used;
     // TODO: fix point types

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -902,11 +902,6 @@ bool basecamp_action_components::choose_components()
     return true;
 }
 
-static bool is_empty_component( const item &it )
-{
-    return is_crafting_component( it ) && it.is_container_empty();
-}
-
 void basecamp_action_components::consume_components()
 {
     map &target_map = base_.get_camp_map();
@@ -918,7 +913,7 @@ void basecamp_action_components::consume_components()
     }
     for( const comp_selection<item_comp> &sel : item_selections_ ) {
         std::list<item> empty_consumed = player_character.consume_items( target_map, sel, batch_size_,
-                                         is_empty_component, src );
+                                         is_empty_crafting_component, src );
         int left_to_consume = 0;
 
         if( !empty_consumed.empty() && empty_consumed.front().count_by_charges() ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -962,11 +962,6 @@ bool can_construct( const construction &con )
     return false;
 }
 
-static bool is_empty_component( const item &it )
-{
-    return is_crafting_component( it ) && it.is_container_empty();
-}
-
 void place_construction( std::vector<construction_group_str_id> const &groups )
 {
     avatar &player_character = get_avatar();
@@ -1036,7 +1031,8 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
                 comp_selection<item_comp> sel;
                 sel.use_from = usage_from::both;
                 sel.comp = comp;
-                std::list<item> empty_consumed = player_character.consume_items( sel, 1, is_empty_component );
+                std::list<item> empty_consumed = player_character.consume_items( sel, 1,
+                                                 is_empty_crafting_component );
 
                 int left_to_consume = 0;
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -962,6 +962,11 @@ bool can_construct( const construction &con )
     return false;
 }
 
+static bool is_empty_component( const item &it )
+{
+    return is_crafting_component( it ) && it.is_container_empty();
+}
+
 void place_construction( std::vector<construction_group_str_id> const &groups )
 {
     avatar &player_character = get_avatar();
@@ -1026,9 +1031,35 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
         }
     } else {
         // Use up the components
-        for( const auto &it : con.requirements->get_components() ) {
-            std::list<item> tmp = player_character.consume_items( it, 1, is_crafting_component );
-            used.splice( used.end(), tmp );
+        for( const std::vector<item_comp> &it : con.requirements->get_components() ) {
+            for( const item_comp &comp : it ) {
+                comp_selection<item_comp> sel;
+                sel.use_from = usage_from::both;
+                sel.comp = comp;
+                std::list<item> empty_consumed = player_character.consume_items( sel, 1, is_empty_component );
+
+                int left_to_consume = 0;
+
+                if( !empty_consumed.empty() && empty_consumed.front().count_by_charges() ) {
+                    int consumed = 0;
+                    for( item &itm : empty_consumed ) {
+                        consumed += itm.charges;
+                    }
+                    left_to_consume = comp.count - consumed;
+                } else if( empty_consumed.size() < comp.count ) {
+                    left_to_consume = comp.count - empty_consumed.size();
+                }
+
+                if( left_to_consume > 0 ) {
+                    comp_selection<item_comp> remainder = sel;
+                    remainder.comp.count = 1;
+                    std::list<item>used_consumed = player_character.consume_items( remainder,
+                                                   left_to_consume, is_crafting_component );
+                    empty_consumed.splice( empty_consumed.end(), used_consumed );
+                }
+
+                used.splice( used.end(), empty_consumed );
+            }
         }
     }
     pc.components = used;

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1046,7 +1046,7 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
                         consumed += itm.charges;
                     }
                     left_to_consume = comp.count - consumed;
-                } else if( empty_consumed.size() < static_cast<size_t>(comp.count) ) {
+                } else if( empty_consumed.size() < static_cast<size_t>( comp.count ) ) {
                     left_to_consume = comp.count - empty_consumed.size();
                 }
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1046,7 +1046,7 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
                         consumed += itm.charges;
                     }
                     left_to_consume = comp.count - consumed;
-                } else if( empty_consumed.size() < comp.count ) {
+                } else if( empty_consumed.size() < static_cast<size_t>(comp.count) ) {
                     left_to_consume = comp.count - empty_consumed.size();
                 }
 

--- a/src/item.h
+++ b/src/item.h
@@ -3183,4 +3183,12 @@ inline bool is_crafting_component( const item &component )
            !component.is_filthy();
 }
 
+/**
+ * Filter for empty crafting components first pass searches
+ */
+inline bool is_empty_crafting_component( const item &component )
+{
+    return component.is_container_empty() && is_crafting_component( component );
+}
+
 #endif // CATA_SRC_ITEM_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Changed PC construction to first select empty containers and only use used ones when no empty ones are available within range.

Fix #69893: Covered companion zone construction as well.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Copy the solution from the PC/companion crafting case. This also meant ditching the inventory collection and instead let the component consumption code locate and consume stuff.

Copy the solution above for the companion zone construction case.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Trying to modify the component consumption code used to allow you to bypass the "failure" case of not finding all the components you want when first looking for empty ones only. Seemed complicated to add yet another parameter to operations full of default parameters.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Spawn 8 pipes and 8 60 L tanks.
- Construct metal charcoal kiln (from the construction menu).
- Verify you have 4 pipes and 4 tanks left.
- Spawn two more tanks.
- Fill one tank with water from the canteen and another with antiseptic (because that were the liquids my character happened to carry).
- Drop the tanks and move two empty tanks one tile to the east together with the antiseptic containing tank.
- Construct another kiln.
- Verify that you have the two used tanks left, but the empty ones are gone.
- Spawn 4 pipes and two tanks.
- Build another kiln (and see that the tank line in the displayed recipe remains displayed in magenta, although there's no reason it should have changed).
- Verify that you're prompted to get rid of the liquids.
- Not tested with any "by charges" items as I don't know of any constructions that uses such components. The code copied worked with the crafting of a balaclava (using thread), so the logic ought to be sound...

- Tested the middle test case above (4 empty tanks, two used tanks split over two tiles) for the companion zone construction case by first adding a kiln construction zone and ordering a companion to do construction tasks (after having tested that my character could successfully perform the task using the "O" menu to perform the construction).

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

There's still code using the component construction I stopped using.  have no idea if they ought to change.
There are also other cases where empty containers ought to be preferred, such as crafting failures.
There is something weird going on, as I not only get CTDs on attempts to explicitly wield tanks (to fill them, worked around by refilling them instead), but also on attempts to trade tools required for construction with a companion (worked around by dropping tools on a tile I'm dropping construction materials on).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
