### PR TITLE
Handle invalid mod pocket contents

### DIFF
--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -646,7 +646,12 @@ void item_contents::read_mods( const item_contents &read_input )
     for( const item_pocket &pocket : read_input.contents ) {
         if( pocket.saved_type() == pocket_type::MOD ) {
             for( const item *it : pocket.all_items_top() ) {
-                insert_item( *it, pocket_type::MOD );
+                if( it->is_gunmod() || it->is_toolmod() ) {
+                    insert_item( *it, pocket_type::MOD );
+                } else {
+                    debugmsg( "Non-mod %s in MOD pocket!", it->tname() );
+                    insert_item( *it, pocket_type::MIGRATION );
+                }
             }
         }
     }

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -660,6 +660,7 @@ void item_contents::read_mods( const item_contents &read_input )
 void item_contents::combine( const item_contents &read_input, const bool convert,
                              const bool into_bottom, bool restack_charges, bool ignore_contents )
 {
+    std::list<item_pocket> mismatched_pockets;
     std::vector<item> uninserted_items;
     size_t pocket_index = 0;
 
@@ -702,6 +703,11 @@ void item_contents::combine( const item_contents &read_input, const bool convert
             auto current_pocket_iter = contents.begin();
             std::advance( current_pocket_iter, pocket_index );
 
+            if( !current_pocket_iter->is_type( pocket.saved_type() ) ) {
+                mismatched_pockets.push_back( pocket );
+                continue;
+            }
+
             for( const item *it : pocket.all_items_top() ) {
                 const ret_val<item *> inserted = current_pocket_iter->insert_item( *it,
                                                  into_bottom, restack_charges, ignore_contents );
@@ -722,6 +728,17 @@ void item_contents::combine( const item_contents &read_input, const bool convert
             }
         }
         ++pocket_index;
+    }
+
+    for( const item_pocket &pocket : mismatched_pockets ) {
+        for( const item *it : pocket.all_items_top() ) {
+            const ret_val<item *> inserted = insert_item( *it, pocket.saved_type(), ignore_contents );
+            if( !inserted.success() ) {
+                uninserted_items.push_back( *it );
+                debugmsg( "error: item %s cannot fit into any pocket while loading: %s",
+                          it->typeId().str(), inserted.str() );
+            }
+        }
     }
 
     for( const item &uninserted_item : uninserted_items ) {

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1336,7 +1336,6 @@ ret_val<item_pocket::contain_code> item_pocket::is_compatible( const item &it ) 
         return ret_val<item_pocket::contain_code>::make_success();
     }
 
-
     if( data->type == pocket_type::MOD ) {
         if( it.is_toolmod() || it.is_gunmod() ) {
             return ret_val<item_pocket::contain_code>::make_success();

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1331,15 +1331,34 @@ static int charges_per_volume_recursive( const units::volume &max_item_volume,
 
 ret_val<item_pocket::contain_code> item_pocket::is_compatible( const item &it ) const
 {
-    if( it.has_flag( flag_NO_UNWIELD ) ) {
-        return ret_val<item_pocket::contain_code>::make_failure(
-                   contain_code::ERR_MOD, _( "cannot unwield item" ) );
+    if( data->type == pocket_type::MIGRATION ) {
+        // migration pockets need to always succeed
+        return ret_val<item_pocket::contain_code>::make_success();
+    }
+
+
+    if( data->type == pocket_type::MOD ) {
+        if( it.is_toolmod() || it.is_gunmod() ) {
+            return ret_val<item_pocket::contain_code>::make_success();
+        } else {
+            return ret_val<item_pocket::contain_code>::make_failure(
+                       contain_code::ERR_MOD, _( "only mods can go into mod pocket" ) );
+        }
     }
 
     if( data->type == pocket_type::CORPSE ) {
         // corpses can't have items stored in them the normal way,
         // we simply don't want them to "spill"
         return ret_val<item_pocket::contain_code>::make_success();
+    }
+
+    if( data->type == pocket_type::SOFTWARE ) {
+        if( it.has_flag( flag_NO_DROP ) && it.has_flag( flag_IRREMOVABLE ) ) {
+            return ret_val<item_pocket::contain_code>::make_success();
+        } else {
+            return ret_val<item_pocket::contain_code>::make_failure(
+                       contain_code::ERR_MOD, _( "only immaterial items can go into software pocket" ) );
+        }
     }
 
     if( data->type == pocket_type::EBOOK ) {
@@ -1360,13 +1379,9 @@ ret_val<item_pocket::contain_code> item_pocket::is_compatible( const item &it ) 
         }
     }
 
-    if( data->type == pocket_type::MOD ) {
-        if( it.is_toolmod() || it.is_gunmod() ) {
-            return ret_val<item_pocket::contain_code>::make_success();
-        } else {
-            return ret_val<item_pocket::contain_code>::make_failure(
-                       contain_code::ERR_MOD, _( "only mods can go into mod pocket" ) );
-        }
+    if( it.has_flag( flag_NO_UNWIELD ) ) {
+        return ret_val<item_pocket::contain_code>::make_failure(
+                   contain_code::ERR_MOD, _( "cannot unwield item" ) );
     }
 
     if( !data->item_id_restriction.empty() || !data->get_flag_restrictions().empty() ||
@@ -1456,12 +1471,6 @@ ret_val<item_pocket::contain_code> item_pocket::_can_contain( const item &it,
     if( copies_remaining <= 0 ) {
         return ret_val<item_pocket::contain_code>::make_success();
     }
-    if( data->type == pocket_type::CORPSE ) {
-        // corpses can't have items stored in them the normal way,
-        // we simply don't want them to "spill"
-        copies_remaining = 0;
-        return ret_val<item_pocket::contain_code>::make_success();
-    }
     // To prevent debugmsg. Casings can only be inserted in a magazine during firing.
     if( data->type == pocket_type::MAGAZINE && it.has_flag( flag_CASING ) ) {
         copies_remaining = 0;
@@ -1470,6 +1479,10 @@ ret_val<item_pocket::contain_code> item_pocket::_can_contain( const item &it,
 
     if( !compatible.success() ) {
         return compatible;
+    }
+    if( !is_standard_type() ) {
+        copies_remaining = 0;
+        return ret_val<item_pocket::contain_code>::make_success();
     }
 
     if( it.made_of( phase_id::LIQUID ) ) {
@@ -2185,8 +2198,7 @@ std::list<item> &item_pocket::edit_contents()
 ret_val<item *> item_pocket::insert_item( const item &it,
         const bool into_bottom, bool restack_charges, bool ignore_contents )
 {
-    ret_val<item_pocket::contain_code> containable = !is_standard_type() ?
-            ret_val<item_pocket::contain_code>::make_success() : can_contain( it, ignore_contents );
+    ret_val<item_pocket::contain_code> containable = can_contain( it, ignore_contents );
 
     if( !containable.success() ) {
         return ret_val<item *>::make_failure( nullptr, containable.str() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Handle invalid mod pocket contents"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #70156.

#69725 changed many of the guns to rely on item groups to add their MAGAZINE_WELL pockets. The change itself is fine, but it exposed a longstanding issue with `item_contents::combine`'s over-reliance on pocket indices, something that [KorGgenT noted](https://github.com/CleverRaven/Cataclysm-DDA/pull/41006) way back around when pockets were first being added:
> a weakness of this implementation is the following example: an item has multiple pockets, and someone changes the json to rearrange the pockets, or add a MAGAZINE pocket to the front. in this case, most of the items will be moved to the MIGRATION pocket, necessitating the player to pick up the items after they fall to the ground after moving once.

However, it's actually worse than KorGgenT says here, because the game has since gained the special pocket types, including MOD, which always successfully add whatever they're given. This means instead of gracefully failing and getting placed into MIGRATION, items are getting stuck inside of MOD, causing errors.

Another wrinkle is that saves made _before_ 69725 will run into the bug differently than saves made _after_ it. In saves made before, the magazine's save data has the correct pocket type but the wrong index. In saves made after, the magazine's save data has the incorrect pocket type, MOD, but the "correct" index of that MOD pocket.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
To handle saves before 69725, `item_contents::combine` will now check if the saved pocket type matches the current pocket type, and if not, will attempt to re-insert the contents appropriately, falling back to the MIGRATION pocket if all else fails. This ensures that even when an item's pockets are rearranged their contents should end up in the proper place, or spilled in case pockets were outright removed.

To handle saves after 69725, `item_contents::read_mods` will now check if the items its adding are actually mods, and put them in MIGRATION if not. Unlike the previous fix, this can't attempt to re-insert the item because the original pocket type has been lost. This fix could technically be removed after 0.H, as it'll only affect a limited set of saves. Without this change the bugged items inside will be lost, but that's still better than crashing.

As an extra safety measure, `item_pocket::insert_item` now doesn't entirely skip the `can_contain` check for special pockets, now checking `is_compatible` to ensure that only mods are inserted into a MOD pocket.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
That last change to `item_pocket::insert_item` I wrote just above is technically unnecessary - it was originally the main crux of this PR, but after my more targeted fixes it lost relevance. That said, it's a good safety measure against this kinda thing happening again. It could in fact be expanded further - there are other functions that use `is_standard_type()` to skip special pockets, which should no longer be necessary. I decided against increasing the scope like that here, though.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
In addition to the saves everyone provided inside of #70156, I made two versions of the same save specifically for testing this. First making a save in a version from back in November:
[modmags save pre 69725-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/13778195/modmags.save.pre.69725-trimmed.tar.gz)
...then opening it in the current build:
[modmags save post 69725-trimmed.tar.gz](https://github.com/CleverRaven/Cataclysm-DDA/files/13778196/modmags.save.post.69725-trimmed.tar.gz)

Loading the first save will properly re-insert the AR-15s' magazines without throwing an error. Loading the second save will throw the debug error I added and spill the magazines to the ground, all as I intended, no crashes. Everyone else's saves likewise give desired results. Ran a CPU monitor and confirmed that the new checks aren't adding any extra CPU impact during loading or gameplay. Ran `[pocket]` tests locally, all green.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
