### PR TITLE
Using visitor's pass or freight badge tries to reveal TCL in larger radius

### DIFF
--- a/data/json/items/id_cards.json
+++ b/data/json/items/id_cards.json
@@ -62,10 +62,11 @@
     "category": "keys",
     "use_action": {
       "type": "reveal_map",
-      "radius": 90,
+      "radius": 300,
       "message": "You add the facilities to your map.",
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bridge",
         "lab_res_8_SWD_ground",
         "lab_res_8_SED_ground",
@@ -121,10 +122,11 @@
     "flags": [ "SCIENCE_CARD_TRANSPORT_1", "CREDIT_CARD_SHAPED" ],
     "use_action": {
       "type": "reveal_map",
-      "radius": 90,
+      "radius": 300,
       "message": "You add the facilities to your map",
       "terrain": [
         { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
         "bridge",
         "lab_res_8_SWD_ground",
         "lab_res_8_SED_ground",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Using visitor's pass or freight badge tries to reveal TCL in larger radius"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
With current rarity of TCL, the reveal radius of 90 on visitor's pass / freight  badge will very rarely reveal a TCL. This helps a bit.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Bump reveal radius to 300 from 90. I tested out a handful of values and this seemed to be in the ballpark for lowest that reliably revealed a TCL in my test attempts. I also made the passes reveal town centers because a map showing town names seems pretty reasonable.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested with 200 and 300 to see which was the more reliable value. This seemed to be it, but my sample size isn't massive since there isn't an easy automatic way of testing this.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
Downside is revealing can take several seconds on a 2017 mobile i7, but it's better than the map not working. It can also reveal quite bit of map you haven't seen yet.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
