### PR TITLE
Highlight OMTs revealed by maps

### DIFF
--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -1159,6 +1159,13 @@
   },
   {
     "type": "keybinding",
+    "id": "TOGGLE_MAP_REVEALS",
+    "category": "OVERMAP",
+    "name": "Toggle highlighting map reveals",
+    "bindings": [ { "input_method": "keyboard_char", "key": "V" }, { "input_method": "keyboard_code", "key": "v", "mod": [ "shift" ] } ]
+  },
+  {
+    "type": "keybinding",
     "id": "TOGGLE_HORDES",
     "category": "OVERMAP",
     "name": "Toggle hordes",

--- a/src/character.h
+++ b/src/character.h
@@ -1653,6 +1653,7 @@ class Character : public Creature, public visitable
         int get_mod_stat_from_bionic( const character_stat &Stat ) const;
         // route for overmap-scale traveling
         std::vector<tripoint_abs_omt> omt_path;
+        std::vector<tripoint_abs_omt> revealed_omts;
         bool is_using_bionic_weapon() const;
         bionic_uid get_weapon_bionic_uid() const;
 

--- a/src/character.h
+++ b/src/character.h
@@ -1653,7 +1653,8 @@ class Character : public Creature, public visitable
         int get_mod_stat_from_bionic( const character_stat &Stat ) const;
         // route for overmap-scale traveling
         std::vector<tripoint_abs_omt> omt_path;
-        std::vector<tripoint_abs_omt> revealed_omts;
+        // Container of OMTs to highlight as having been revealed
+        std::vector<tripoint_abs_omt> map_revealed_omts;
         bool is_using_bionic_weapon() const;
         bionic_uid get_weapon_bionic_uid() const;
 

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -355,6 +355,7 @@ void uistatedata::serialize( JsonOut &json ) const
     json.member( "overmap_show_land_use_codes", overmap_show_land_use_codes );
     json.member( "overmap_show_city_labels", overmap_show_city_labels );
     json.member( "overmap_show_hordes", overmap_show_hordes );
+    json.member( "overmap_show_revealed_omts", overmap_show_revealed_omts );
     json.member( "overmap_show_forest_trails", overmap_show_forest_trails );
     json.member( "vmenu_show_items", vmenu_show_items );
     json.member( "list_item_sort", list_item_sort );
@@ -434,6 +435,7 @@ void uistatedata::deserialize( const JsonObject &jo )
     jo.read( "overmap_show_land_use_codes", overmap_show_land_use_codes );
     jo.read( "overmap_show_city_labels", overmap_show_city_labels );
     jo.read( "overmap_show_hordes", overmap_show_hordes );
+    jo.read( "overmap_show_revealed_omts", overmap_show_revealed_omts );
     jo.read( "overmap_show_forest_trails", overmap_show_forest_trails );
     jo.read( "hidden_recipes", hidden_recipes );
     jo.read( "favorite_recipes", favorite_recipes );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1192,6 +1192,8 @@ void reveal_map_actor::reveal_targets( const tripoint_abs_omt &center,
                         target.second );
     for( const tripoint_abs_omt &place : places ) {
         overmap_buffer.reveal( place, reveal_distance );
+        // Should be replaced with the character using the item passed as an argument if NPCs ever learn to use maps
+        get_avatar().revealed_omts.emplace_back( place );
     }
 }
 
@@ -1206,6 +1208,8 @@ std::optional<int> reveal_map_actor::use( Character *p, item &it, const tripoint
     }
     const tripoint_abs_omt center( it.get_var( "reveal_map_center_omt",
                                    p->global_omt_location().raw() ) );
+    // Clear previously revealed OMTs before revealing new ones
+    p->revealed_omts.clear();
     for( const auto &omt : omt_types ) {
         for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
             reveal_targets( tripoint_abs_omt( center.xy(), z ), omt, 0 );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1193,7 +1193,7 @@ void reveal_map_actor::reveal_targets( const tripoint_abs_omt &center,
     for( const tripoint_abs_omt &place : places ) {
         overmap_buffer.reveal( place, reveal_distance );
         // Should be replaced with the character using the item passed as an argument if NPCs ever learn to use maps
-        get_avatar().revealed_omts.emplace_back( place );
+        get_avatar().map_revealed_omts.emplace_back( place );
     }
 }
 
@@ -1208,8 +1208,8 @@ std::optional<int> reveal_map_actor::use( Character *p, item &it, const tripoint
     }
     const tripoint_abs_omt center( it.get_var( "reveal_map_center_omt",
                                    p->global_omt_location().raw() ) );
-    // Clear previously revealed OMTs before revealing new ones
-    p->revealed_omts.clear();
+    // Clear highlight on previously revealed OMTs before revealing new ones
+    p->map_revealed_omts.clear();
     for( const auto &omt : omt_types ) {
         for( int z = -OVERMAP_DEPTH; z <= OVERMAP_HEIGHT; z++ ) {
             reveal_targets( tripoint_abs_omt( center.xy(), z ), omt, 0 );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -646,8 +646,8 @@ static void draw_ascii(
         size_t count = 0;
     };
     std::unordered_set<tripoint_abs_omt> npc_path_route;
-    std::unordered_set<tripoint_abs_omt> newly_revealed( player_character.revealed_omts.begin(),
-            player_character.revealed_omts.end() )  ;
+    std::unordered_set<tripoint_abs_omt> newly_revealed( player_character.map_revealed_omts.begin(),
+            player_character.map_revealed_omts.end() )  ;
     std::unordered_map<point_abs_omt, int> player_path_route;
     std::unordered_map<tripoint_abs_omt, npc_coloring> npc_color;
     auto npcs_near_player = overmap_buffer.get_npcs_near_player( sight_points );

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -554,6 +554,7 @@ static void draw_ascii(
                              100;
     // Whether showing hordes is currently enabled
     const bool showhordes = uistate.overmap_show_hordes;
+    const bool show_map_revealed = uistate.overmap_show_revealed_omts;
 
     const oter_id forest = oter_forest.id();
 
@@ -645,6 +646,8 @@ static void draw_ascii(
         size_t count = 0;
     };
     std::unordered_set<tripoint_abs_omt> npc_path_route;
+    std::unordered_set<tripoint_abs_omt> newly_revealed( player_character.revealed_omts.begin(),
+            player_character.revealed_omts.end() )  ;
     std::unordered_map<point_abs_omt, int> player_path_route;
     std::unordered_map<tripoint_abs_omt, npc_coloring> npc_color;
     auto npcs_near_player = overmap_buffer.get_npcs_near_player( sight_points );
@@ -782,6 +785,11 @@ static void draw_ascii(
                 // npc path
                 ter_color = c_red;
                 ter_sym = "!";
+            } else if( blink && show_map_revealed &&
+                       newly_revealed.find( omp ) != newly_revealed.end() ) {
+                // Revealed maps
+                ter_color = c_magenta;
+                ter_sym = "&";
             } else if( blink && showhordes &&
                        overmap_buffer.get_horde_size( omp ) >= HORDE_VISIBILITY_SIZE &&
                        ( get_and_assign_los( los, player_character, omp, sight_points ) ||
@@ -1213,6 +1221,7 @@ static void draw_om_sidebar(
         print_hint( "TOGGLE_LAND_USE_CODES", uistate.overmap_show_land_use_codes ? c_pink : c_magenta );
         print_hint( "TOGGLE_CITY_LABELS", uistate.overmap_show_city_labels ? c_pink : c_magenta );
         print_hint( "TOGGLE_HORDES", uistate.overmap_show_hordes ? c_pink : c_magenta );
+        print_hint( "TOGGLE_MAP_REVEALS", uistate.overmap_show_revealed_omts ? c_pink : c_magenta );
         print_hint( "TOGGLE_EXPLORED", is_explored ? c_pink : c_magenta );
         print_hint( "TOGGLE_FAST_SCROLL", fast_scroll ? c_pink : c_magenta );
         print_hint( "TOGGLE_FOREST_TRAILS", uistate.overmap_show_forest_trails ? c_pink : c_magenta );
@@ -1818,6 +1827,7 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
     ictxt.register_action( "TOGGLE_HORDES" );
     ictxt.register_action( "TOGGLE_LAND_USE_CODES" );
     ictxt.register_action( "TOGGLE_CITY_LABELS" );
+    ictxt.register_action( "TOGGLE_MAP_REVEALS" );
     ictxt.register_action( "TOGGLE_EXPLORED" );
     ictxt.register_action( "TOGGLE_FAST_SCROLL" );
     ictxt.register_action( "TOGGLE_OVERMAP_WEATHER" );
@@ -1978,6 +1988,8 @@ static tripoint_abs_omt display( const tripoint_abs_omt &orig,
             uistate.overmap_show_hordes = !uistate.overmap_show_hordes;
         } else if( action == "TOGGLE_CITY_LABELS" ) {
             uistate.overmap_show_city_labels = !uistate.overmap_show_city_labels;
+        } else if( action == "TOGGLE_MAP_REVEALS" ) {
+            uistate.overmap_show_revealed_omts = !uistate.overmap_show_revealed_omts;
         } else if( action == "TOGGLE_EXPLORED" ) {
             overmap_buffer.toggle_explored( curs );
         } else if( action == "TOGGLE_OVERMAP_WEATHER" ) {

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -925,10 +925,10 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                                      0, 0, ll, false );
             }
 
-            if( blink && show_map_revealed ) {
-                for( tripoint_abs_omt map_reveals : get_avatar().map_revealed_omts ) {
-                    draw_from_id_string( "highlight", map_reveals.raw(), 0, 0, lit_level::LIT, false );
-                }
+            std::vector<tripoint_abs_omt> &revealed_highlights = get_avatar().map_revealed_omts;
+            auto it = std::find( revealed_highlights.begin(), revealed_highlights.end(), omp );
+            if( blink && show_map_revealed && it != revealed_highlights.end() ) {
+                draw_from_id_string( "highlight", omp.raw(), 0, 0, lit_level::LIT, false );
             }
 
             if( see ) {

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -879,6 +879,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                              you.overmap_sight_range( g->light_level( you.posz() ) ) :
                              100;
     const bool showhordes = uistate.overmap_show_hordes;
+    const bool show_map_revealed = uistate.overmap_show_revealed_omts;
     const bool viewing_weather = uistate.overmap_debug_weather || uistate.overmap_visible_weather;
     o = origin.raw().xy();
 
@@ -922,6 +923,12 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
             if( !mx.is_empty() && mx->autonote ) {
                 draw_from_id_string( mx.str(), TILE_CATEGORY::MAP_EXTRA, "map_extra", omp.raw(),
                                      0, 0, ll, false );
+            }
+
+            if( blink && show_map_revealed ) {
+                for( tripoint_abs_omt map_reveals : get_avatar().map_revealed_omts ) {
+                    draw_from_id_string( "highlight", map_reveals.raw(), 0, 0, lit_level::LIT, false );
+                }
             }
 
             if( see ) {

--- a/src/uistate.h
+++ b/src/uistate.h
@@ -134,6 +134,7 @@ class uistatedata
         bool overmap_show_land_use_codes = false; // toggle land use code sym/color for terrain
         bool overmap_show_city_labels = true;
         bool overmap_show_hordes = true;
+        bool overmap_show_revealed_omts = true;
         bool overmap_show_forest_trails = true;
         bool overmap_visible_weather = false;
         bool overmap_debug_weather = false;


### PR DESCRIPTION
#### Summary
Features "Toggle to highlight OMTs revealed by maps"

#### Purpose of change
A lot of people have mentioned using a map and not being able to find what, if anything, these maps revealed.

#### Describe the solution
Store a list of OMTs that the *last map* revealed, make it blink on the map screen. Add a toggle to turn this on/off. (Also respects blinking rules)

NB: Using a new map clears the list of tiles known to have been revealed by the previous map. This is to prevent them from sticking around forever.

#### Describe alternatives you've considered
@Procyonae was bouncing ideas back and forth with me and has a branch at https://github.com/Procyonae/Cataclysm-DDA/compare/master...Procyonae:Cataclysm-DDA:MapActionHint

Their branch(not functional? as of this writing) would only highlight *newly revealed* tiles. This is a change that might be worth considering, if it can be made to work.

#### Testing

https://github.com/CleverRaven/Cataclysm-DDA/assets/84619419/e263afdf-bfae-43b4-becb-16f61ea9e283



#### Additional context
Known deficiencies:
-Any map tagged by the map will be counted as revealed regardless of whether or not it could be seen before. So you could use a map, reveal exactly 0 new tiles, and still have hundreds (or more) tiles marked as having been revealed.

-Since the `map_revealed_omts` container is added to by any function using reveal_map_actor::reveal_targets, missions and other things that reveal tiles(e.g. evac shelter computer) will also be added to it. And subsequently, can/will only be be cleared of highlighting by using a map.