### PR TITLE
Do not redefine SDL_MAIN_HANDLED

### DIFF
--- a/src/sdl_wrappers.h
+++ b/src/sdl_wrappers.h
@@ -2,7 +2,9 @@
 #ifndef CATA_SRC_SDL_WRAPPERS_H
 #define CATA_SRC_SDL_WRAPPERS_H
 
+#ifndef SDL_MAIN_HANDLED
 #define SDL_MAIN_HANDLED
+#endif
 // IWYU pragma: begin_exports
 #if defined(_MSC_VER) && defined(USE_VCPKG)
 #   include <SDL2/SDL.h>


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/issues/70415#issuecomment-1870619332

#### Describe the solution
Skip the definition if already defined.

#### Testing
Before: https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/7326894681/job/19953089843 (search `C4005` for the warning)
After: https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/7347181452/job/20003177433?pr=70492 warning no longer appears.

#### Additional context
