### PR TITLE
No accidental full-time deconstruct for simple furniture

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -20,7 +20,6 @@
     "time": "10 s",
     "pre_note": "Certain terrain and furniture can be deconstructed without any tools.",
     "pre_flags": "EASY_DECONSTRUCT",
-    "pre_special": "check_deconstruct",
     "post_flags": [ "keep_items" ],
     "post_special": "done_deconstruct"
   },

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1260,7 +1260,7 @@ bool construct::check_deconstruct( const tripoint_bub_ms &p )
 {
     map &here = get_map();
     if( here.has_furn( p ) ) {
-        // Can deconstruct furniture here, make sure regular deconstruction isn't available as long as the furniture is
+        // Can deconstruct furniture here, make sure regular deconstruction isn't available if easy deconstruction is possible
         if( here.has_flag_furn( ter_furn_flag::TFLAG_EASY_DECONSTRUCT, p ) ) {
             return false;
         }

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1259,11 +1259,11 @@ bool construct::check_nofloor_above( const tripoint_bub_ms &p )
 bool construct::check_deconstruct( const tripoint_bub_ms &p )
 {
     map &here = get_map();
-    // Can deconstruct furniture here, make sure regular deconstruction isn't available as long as the furniture is
-    if( here.has_flag_furn( ter_furn_flag::TFLAG_EASY_DECONSTRUCT, p ) ) {
-        return false;
-    }
     if( here.has_furn( p ) ) {
+        // Can deconstruct furniture here, make sure regular deconstruction isn't available as long as the furniture is
+        if( here.has_flag_furn( ter_furn_flag::TFLAG_EASY_DECONSTRUCT, p ) ) {
+            return false;
+        }
         return here.furn( p ).obj().deconstruct.can_do;
     }
     // terrain can only be deconstructed when there is no furniture in the way

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1259,6 +1259,10 @@ bool construct::check_nofloor_above( const tripoint_bub_ms &p )
 bool construct::check_deconstruct( const tripoint_bub_ms &p )
 {
     map &here = get_map();
+    // Can deconstruct furniture here, make sure regular deconstruction isn't available as long as the furniture is
+    if( here.has_flag_furn( ter_furn_flag::TFLAG_EASY_DECONSTRUCT, p ) ) {
+        return false;
+    }
     if( here.has_furn( p ) ) {
         return here.furn( p ).obj().deconstruct.can_do;
     }


### PR DESCRIPTION
#### Summary
Interface "Can't accidentally select full deconstruction if simple deconstruction is available"

#### Purpose of change
"Can we do something to make it impossible to do a regular deconstruct on somwthing that requires simple deconstruct? Spending 20min to put a chair on its side is a pain"

#### Describe the solution
Make it impossible to do regular deconstruct when simple deconstruct is an option

#### Describe alternatives you've considered
It would be nice if either option was selectable (for muscle memory/ease of use) and it simply forwards to easy deconstruct, but the deconstruction definitions live in json and we'd have to build an entire infrastructure to support it.

#### Testing
Can't select full deconstruct on furniture that can be simply deconstructed, can select simple. Simple returns their relevant item. Deconstructing regular terrain still works as expected.

Let's see if the tests like it

#### Additional context
This doesn't cover cases where *terrain* would have the `EASY_DECONSTRUCT` flag but afaik we have no terrains which do, and I struggle to imagine any terrain which would want it.