### PR TITLE
Visitors Passes and Freight Badges no longer reveal roads

### DIFF
--- a/data/json/items/id_cards.json
+++ b/data/json/items/id_cards.json
@@ -65,9 +65,6 @@
       "radius": 300,
       "message": "You add the facilities to your map.",
       "terrain": [
-        { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
-        "bridge",
         "lab_res_8_SWD_ground",
         "lab_res_8_SED_ground",
         "lab_res_8_SWU_ground",
@@ -125,9 +122,6 @@
       "radius": 300,
       "message": "You add the facilities to your map",
       "terrain": [
-        { "om_terrain": "road", "om_terrain_match_type": "PREFIX" },
-        { "om_terrain": "city_center", "om_terrain_match_type": "TYPE" },
-        "bridge",
         "lab_res_8_SWD_ground",
         "lab_res_8_SED_ground",
         "lab_res_8_SWU_ground",


### PR DESCRIPTION
#### Summary
Balance "Visitors Passes and Freight Badges no longer reveal roads"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I personally feel that it's a little silly to have a full and legible road map, complete with city names, on something that fits in your wallet. Especially after #70480 increases the map radius

#### Describe the solution
These cards will still reveal lab locations, just not roads. I figure you're getting this off a return address on the card.

#### Describe alternatives you've considered
N/A. If the lead devs say it's okay for these cards to reveal roads, then I'll listen to them. This is more a suggestion than anything else.

#### Testing
None.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
