### PR TITLE
Add `rng_get_first_seed` and use it in `cata_test`

### DIFF
--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -189,11 +189,16 @@ double rng_normal( double lo, double hi )
     return clamp( val, lo, hi );
 }
 
+cata_default_random_engine::result_type rng_get_first_seed()
+{
+    static auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    return static_cast<cata_default_random_engine::result_type>(seed);
+}
+
 cata_default_random_engine &rng_get_engine()
 {
     // NOLINTNEXTLINE(cata-determinism)
-    static cata_default_random_engine eng(
-        std::chrono::high_resolution_clock::now().time_since_epoch().count() );
+    static cata_default_random_engine eng( rng_get_first_seed() );
     return eng;
 }
 

--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -192,7 +192,7 @@ double rng_normal( double lo, double hi )
 cata_default_random_engine::result_type rng_get_first_seed()
 {
     static auto seed = std::chrono::high_resolution_clock::now().time_since_epoch().count();
-    return static_cast<cata_default_random_engine::result_type>(seed);
+    return static_cast<cata_default_random_engine::result_type>( seed );
 }
 
 cata_default_random_engine &rng_get_engine()

--- a/src/rng.h
+++ b/src/rng.h
@@ -25,6 +25,7 @@ class tripoint_range;
 void rng_set_engine_seed( unsigned int seed );
 
 using cata_default_random_engine = std::minstd_rand0;
+cata_default_random_engine::result_type rng_get_first_seed();
 cata_default_random_engine &rng_get_engine();
 unsigned int rng_bits();
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -386,8 +386,7 @@ int main( int argc, const char *argv[] )
         // If the run is terminated due to a crash during initialization, we won't
         // see the seed unless it's printed out in advance, so do that here.
         DebugLog( D_INFO, DC_ALL ) << "Randomness seeded to: " << seed;
-    }
-    else {
+    } else {
         DebugLog( D_INFO, DC_ALL ) << "Default randomness seeded to: " << rng_get_first_seed();
     }
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -387,6 +387,9 @@ int main( int argc, const char *argv[] )
         // see the seed unless it's printed out in advance, so do that here.
         DebugLog( D_INFO, DC_ALL ) << "Randomness seeded to: " << seed;
     }
+    else {
+        DebugLog( D_INFO, DC_ALL ) << "Default randomness seeded to: " << rng_get_first_seed();
+    }
 
     try {
         // TODO: Only init game if we're running tests that need it.
@@ -423,6 +426,8 @@ int main( int argc, const char *argv[] )
     if( seed ) {
         // Also print the seed at the end so it can be easily found
         DebugLog( D_INFO, DC_ALL ) << "Randomness seeded to: " << seed << std::endl;
+    } else {
+        DebugLog( D_INFO, DC_ALL ) << "Default randomness seeded to: " << rng_get_first_seed() << std::endl;
     }
 
     if( error_during_initialization ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Build "Report game's RNG seed during testing"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Running `cata_test` without `--rng-seed` uses the engine default seed, which is based on execution time.
`seed` variable is zero in this case, but calling `rng_set_engine_seed()` with zero do not set the game RNG to zero.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
* Add a function to retrieve the seed used to initialize the game's engine RNG
* Use such function in `test_main.cpp` to report the seed when no `--rng-seed` is used
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Run `cata_test` without `--rng-seed`. You get a message reporting the game's seed.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
GHA always uses `--rng-seed time`. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
