### PR TITLE
Slightly fewer allocations in npc::process_turn

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -11729,11 +11729,11 @@ int Character::count_bionic_with_flag( const json_character_flag &flag ) const
 
 bool Character::has_bodypart_with_flag( const json_character_flag &flag ) const
 {
-    for( const bodypart_id &bp : get_all_body_parts() ) {
-        if( bp->has_flag( flag ) ) {
+    for( const std::pair<const bodypart_str_id, bodypart> &elem : get_body() ) {
+        if( elem.first->has_flag( flag ) ) {
             return true;
         }
-        if( get_part( bp )->has_conditional_flag( flag ) ) {
+        if( elem.second.has_conditional_flag( flag ) ) {
             return true;
         }
     }


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Slightly fewer allocations in npc::process_turn"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Makes `has_bodypart_with_flag` slightly faster, about 5% better turn performance.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The method `Character::has_bodypart_with_flag` is called by `Character::has_flag` (see code snippet below), which in turn is called many times as part of `npc::process_turn`. An example game was measured, which led to 57993 calls to `has_bodypart_with_flag` for 119 npc turns.

Callgrind trace pictured below, measured before this commit:

![has_bodypart_with_flag](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/7c2cbe47-961b-4372-9823-431cbc1d9449)

This commit changes the implementation in `has_bodypart_with_flag` to use `Creature::get_body()` instead of `Creature::get_all_body_parts`, which means that we can use the `bodypart` obj directly without going through `get_part()` while iterating.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

There's also a note at `Character::has_flag` that could be implemented:
https://github.com/CleverRaven/Cataclysm-DDA/blob/2a65f1043c72f1ba8acd6768578f26c2eccb5412/src/character.cpp#L11757-L11765

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

When sleeping in godco with lots of npcs around:

Before:
![before](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/20ef42cf-399e-4517-b969-1521bdbf0110)

After:
![after](https://github.com/CleverRaven/Cataclysm-DDA/assets/123803852/3e26463a-4e76-4610-95bb-be002fc457e9)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
