### PR TITLE
Outfit matches randomly chosen gender identities.

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -4299,7 +4299,6 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
             outfit = !outfit;
         } else if( action == "CHANGE_GENDER" ) {
             you.male = !you.male;
-            outfit = you.male;
         } else if( action == "CHANGE_START_OF_CATACLYSM" ) {
             const scenario *scen = get_scenario();
             scen->change_start_of_cataclysm( calendar_ui::select_time_point( scen->start_of_cataclysm(),

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -4284,9 +4284,9 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
                 no_name_entered = you.name.empty();
             }
         } else if( action == "RANDOMIZE_CHAR_DESCRIPTION" ) {
-            bool gender_choice = one_in( 2 );
-            you.male = gender_choice;
-            outfit = gender_choice;
+            bool gender_selection = one_in( 2 );
+            you.male = gender_selection;
+            outfit = gender_selection;
             if( !MAP_SHARING::isSharing() ) { // Don't allow random names when sharing maps. We don't need to check at the top as you won't be able to edit the name
                 you.pick_name();
                 no_name_entered = you.name.empty();

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -4284,7 +4284,9 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
                 no_name_entered = you.name.empty();
             }
         } else if( action == "RANDOMIZE_CHAR_DESCRIPTION" ) {
-            you.male = one_in( 2 );
+            bool gender_choice = one_in( 2 );
+            you.male = gender_choice;
+            outfit = gender_choice;
             if( !MAP_SHARING::isSharing() ) { // Don't allow random names when sharing maps. We don't need to check at the top as you won't be able to edit the name
                 you.pick_name();
                 no_name_entered = you.name.empty();
@@ -4297,6 +4299,7 @@ void set_description( tab_manager &tabs, avatar &you, const bool allow_reroll,
             outfit = !outfit;
         } else if( action == "CHANGE_GENDER" ) {
             you.male = !you.male;
+            outfit = you.male;
         } else if( action == "CHANGE_START_OF_CATACLYSM" ) {
             const scenario *scen = get_scenario();
             scen->change_start_of_cataclysm( calendar_ui::select_time_point( scen->start_of_cataclysm(),

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -423,9 +423,9 @@ void avatar::randomize( const bool random_scenario, bool play_now )
     const int max_trait_points = get_option<int>( "MAX_TRAIT_POINTS" );
     // Reset everything to the defaults to have a clean state.
     *this = avatar();
-
-    male = ( rng( 1, 100 ) > 50 );
-    outfit = male;
+    bool gender_selection = ( rng( 1, 100 ) > 50 );
+    male = gender_selection;
+    outfit = gender_selection;
     if( !MAP_SHARING::isSharing() ) {
         play_now ? pick_name() : pick_name( true );
     } else {

--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -423,7 +423,7 @@ void avatar::randomize( const bool random_scenario, bool play_now )
     const int max_trait_points = get_option<int>( "MAX_TRAIT_POINTS" );
     // Reset everything to the defaults to have a clean state.
     *this = avatar();
-    bool gender_selection = ( rng( 1, 100 ) > 50 );
+    bool gender_selection = one_in( 2 );
     male = gender_selection;
     outfit = gender_selection;
     if( !MAP_SHARING::isSharing() ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Randomizing character description will produce a matching outfit"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #70500 

#### Describe the solution
Outfit will be swapped to match gender identity when gender is selected randomly. It will not be changed if gender is changed manually.

#### Describe alternatives you've considered
I was originally planning to have change in gender automatically change outfit to match on the description tab, but if the keypress says "change gender" and not "change gender and outfit", it shouldn't also change the outfit. It should do what it says on the tin, and nothing else.

#### Testing
Created a new character and randomized their description. Outfit changed to match gender identity. It is still possible to change gender and outfit independently.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
