### PR TITLE
Simplify generic mine mutable definition

### DIFF
--- a/data/json/mapgen/mine/mine_generic.json
+++ b/data/json/mapgen/mine/mine_generic.json
@@ -104,10 +104,8 @@
         "@": { "chunks": [ [ "mine_lava", 1 ], [ "null", 15 ] ] }
       },
       "place_nested": [
-        { "chunks": [ "transition_down" ], "joins": { "below": "-2_to_-3" }, "x": 11, "y": 12 },
-        { "chunks": [ "transition_up" ], "joins": { "above": "-2_to_-3" }, "x": 11, "y": 12 },
-        { "chunks": [ "transition_down" ], "joins": { "below": "-3_to_-4" }, "x": 11, "y": 12 },
-        { "chunks": [ "transition_up" ], "joins": { "above": "-3_to_-4" }, "x": 11, "y": 12 },
+        { "chunks": [ "transition_down" ], "joins": { "below": "tunnel_ramp" }, "x": 11, "y": 12 },
+        { "chunks": [ "transition_up" ], "joins": { "above": "tunnel_ramp" }, "x": 11, "y": 12 },
         { "chunks": [ "mine_tunnel_bounds_h" ], "x": [ 4, 6 ], "y": 12 },
         { "chunks": [ "mine_tunnel_bounds_h" ], "x": [ 4, 6 ], "y": 13 },
         { "chunks": [ "mine_tunnel_bounds_h" ], "x": [ 4, 6 ], "y": 14 },

--- a/data/json/overmap/overmap_mutable/mine_mutable.json
+++ b/data/json/overmap/overmap_mutable/mine_mutable.json
@@ -19,37 +19,22 @@
       [ [ -1, 1, -2 ], [ "subterranean_empty" ] ],
       [ [ -2, 1, -2 ], [ "subterranean_empty" ] ]
     ],
-    "joins": [
-      "parking_lot_to_entrance",
-      "surface_to_shaft",
-      "shaft_lower_to_shaft_middle",
-      "tunnel_entrance_to_tunnels",
-      "tunnel_to_tunnel",
-      "-2_to_-3",
-      "-3_tunnel_to_-3_tunnel",
-      "-3_to_-4",
-      "-4_tunnel_to_-4_tunnel",
-      "-4_tunnel_to_finale"
-    ],
+    "joins": [ "parking_lot_to_entrance", "tunnel_to_tunnel", "tunnel_ramp" ],
     "overmaps": {
       "parking_lot": {
         "overmap": "s_lot_no_sidewalk_east",
         "south": "parking_lot_to_entrance",
         "connections": { "east": { "connection": "local_road" } }
       },
-      "mine_entrance": { "overmap": "mine_entrance_north", "north": "parking_lot_to_entrance", "below": "surface_to_shaft" },
+      "mine_entrance": { "overmap": "mine_entrance_north", "north": "parking_lot_to_entrance" },
       "mine_entrance_roof": { "overmap": "mine_entrance_roof_north" },
-      "loading_zone": {
-        "overmap": "mine_entrance_loading_zone_north",
-        "below": "surface_to_shaft",
-        "connections": { "north": { "connection": "local_road" } }
-      },
+      "loading_zone": { "overmap": "mine_entrance_loading_zone_north", "connections": { "north": { "connection": "local_road" } } },
       "loading_zone_roof": { "overmap": "mine_entrance_loading_zone_roof_north" },
-      "shaft_west": { "overmap": "mine_shaft_middle_north", "above": "surface_to_shaft", "below": "shaft_lower_to_shaft_middle" },
-      "shaft_east": { "overmap": "mine_shaft_middle_east_north", "above": "surface_to_shaft", "below": "shaft_lower_to_shaft_middle" },
-      "tunnels_west": { "overmap": "mine_shaft_lower_north", "above": "shaft_lower_to_shaft_middle", "west": "tunnel_entrance_to_tunnels" },
-      "tunnels_east": { "overmap": "mine_shaft_lower_east_north", "above": "shaft_lower_to_shaft_middle" },
-      "tunnel_entrance": { "overmap": "mine_tunnel_ew", "east": "tunnel_entrance_to_tunnels", "west": "tunnel_to_tunnel" },
+      "shaft_west": { "overmap": "mine_shaft_middle_north" },
+      "shaft_east": { "overmap": "mine_shaft_middle_east_north" },
+      "tunnels_west": { "overmap": "mine_shaft_lower_north" },
+      "tunnels_east": { "overmap": "mine_shaft_lower_east_north" },
+      "tunnel_entrance": { "overmap": "mine_tunnel_ew", "west": "tunnel_to_tunnel" },
       "tee": { "overmap": "mine_tunnel_nes", "north": "tunnel_to_tunnel", "east": "tunnel_to_tunnel", "south": "tunnel_to_tunnel" },
       "cross": {
         "overmap": "mine_tunnel_nesw",
@@ -61,44 +46,9 @@
       "straight_tunnel": { "overmap": "mine_tunnel_ns", "north": "tunnel_to_tunnel", "south": "tunnel_to_tunnel" },
       "corner": { "overmap": "mine_tunnel_ne", "north": "tunnel_to_tunnel", "east": "tunnel_to_tunnel" },
       "dead_end": { "overmap": "mine_tunnel_end_south", "north": "tunnel_to_tunnel" },
-      "slope_down_to_-3": { "overmap": "mine_tunnel_end_south", "north": "tunnel_to_tunnel", "below": "-2_to_-3" },
-      "-3_tee": {
-        "overmap": "mine_tunnel_nes",
-        "north": "-3_tunnel_to_-3_tunnel",
-        "east": "-3_tunnel_to_-3_tunnel",
-        "south": "-3_tunnel_to_-3_tunnel"
-      },
-      "-3_cross": {
-        "overmap": "mine_tunnel_nesw",
-        "north": "-3_tunnel_to_-3_tunnel",
-        "east": "-3_tunnel_to_-3_tunnel",
-        "south": "-3_tunnel_to_-3_tunnel",
-        "west": "-3_tunnel_to_-3_tunnel"
-      },
-      "-3_straight_tunnel": { "overmap": "mine_tunnel_ns", "north": "-3_tunnel_to_-3_tunnel", "south": "-3_tunnel_to_-3_tunnel" },
-      "-3_corner": { "overmap": "mine_tunnel_ne", "north": "-3_tunnel_to_-3_tunnel", "east": "-3_tunnel_to_-3_tunnel" },
-      "-3_dead_end": { "overmap": "mine_tunnel_end_south", "north": "-3_tunnel_to_-3_tunnel" },
-      "slope_up_to_-2": { "overmap": "mine_tunnel_end_south", "north": "-3_tunnel_to_-3_tunnel", "above": "-2_to_-3" },
-      "slope_down_to_-4": { "overmap": "mine_tunnel_end_south", "north": "-3_tunnel_to_-3_tunnel", "below": "-3_to_-4" },
-      "-4_tee": {
-        "overmap": "mine_tunnel_nes",
-        "north": "-4_tunnel_to_-4_tunnel",
-        "east": "-4_tunnel_to_-4_tunnel",
-        "south": "-4_tunnel_to_-4_tunnel"
-      },
-      "-4_cross": {
-        "overmap": "mine_tunnel_nesw",
-        "north": "-4_tunnel_to_-4_tunnel",
-        "east": "-4_tunnel_to_-4_tunnel",
-        "south": "-4_tunnel_to_-4_tunnel",
-        "west": "-4_tunnel_to_-4_tunnel"
-      },
-      "-4_straight_tunnel": { "overmap": "mine_tunnel_ns", "north": "-4_tunnel_to_-4_tunnel", "south": "-4_tunnel_to_-4_tunnel" },
-      "-4_corner": { "overmap": "mine_tunnel_ne", "north": "-4_tunnel_to_-4_tunnel", "east": "-4_tunnel_to_-4_tunnel" },
-      "-4_dead_end": { "overmap": "mine_tunnel_end_south", "north": "-4_tunnel_to_-4_tunnel" },
-      "slope_up_to_-3": { "overmap": "mine_tunnel_end_south", "north": "-4_tunnel_to_-4_tunnel", "above": "-3_to_-4" },
-      "tunnel_to_finale": { "overmap": "mine_tunnel_ns", "north": "-4_tunnel_to_finale", "south": "-4_tunnel_to_-4_tunnel" },
-      "finale": { "overmap": "mine_finale_north", "south": "-4_tunnel_to_finale" }
+      "ramp_down": { "overmap": "mine_tunnel_end_south", "north": "tunnel_to_tunnel", "below": "tunnel_ramp" },
+      "ramp_up": { "overmap": "mine_tunnel_end_south", "north": "tunnel_to_tunnel", "above": "tunnel_ramp" },
+      "finale": { "overmap": "mine_finale_north", "south": "tunnel_to_tunnel" }
     },
     "root": "parking_lot",
     "phases": [
@@ -124,13 +74,7 @@
         { "overmap": "corner", "max": { "poisson": 5 } },
         { "overmap": "tee", "max": { "poisson": 10 } }
       ],
-      [
-        {
-          "name": "-2_to_-3",
-          "chunk": [ { "overmap": "slope_down_to_-3", "pos": [ 0, 0, -2 ] }, { "overmap": "slope_up_to_-2", "pos": [ 0, 0, -3 ] } ],
-          "max": 1
-        }
-      ],
+      [ { "overmap": "ramp_down", "max": 1 } ],
       [
         { "overmap": "dead_end", "weight": 2000 },
         { "overmap": "straight_tunnel", "weight": 100 },
@@ -138,43 +82,33 @@
         { "overmap": "tee", "weight": 10 },
         { "overmap": "cross", "weight": 1 }
       ],
+      [ { "overmap": "ramp_up", "max": 1 } ],
       [
-        { "overmap": "-3_straight_tunnel", "max": { "poisson": 20 } },
-        { "overmap": "-3_corner", "max": { "poisson": 5 } },
-        { "overmap": "-3_tee", "max": { "poisson": 10 } }
+        { "overmap": "straight_tunnel", "max": { "poisson": 20 } },
+        { "overmap": "corner", "max": { "poisson": 5 } },
+        { "overmap": "tee", "max": { "poisson": 10 } }
       ],
+      [ { "overmap": "ramp_down", "max": 1 } ],
       [
-        {
-          "name": "-3_to_-4",
-          "chunk": [ { "overmap": "slope_down_to_-4", "pos": [ 0, 0, -3 ] }, { "overmap": "slope_up_to_-3", "pos": [ 0, 0, -4 ] } ],
-          "max": 1
-        }
+        { "overmap": "dead_end", "weight": 2000 },
+        { "overmap": "straight_tunnel", "weight": 100 },
+        { "overmap": "corner", "weight": 100 },
+        { "overmap": "tee", "weight": 10 },
+        { "overmap": "cross", "weight": 1 }
       ],
+      [ { "overmap": "ramp_up", "max": 1 } ],
       [
-        { "overmap": "-3_dead_end", "weight": 2000 },
-        { "overmap": "-3_straight_tunnel", "weight": 100 },
-        { "overmap": "-3_corner", "weight": 100 },
-        { "overmap": "-3_tee", "weight": 10 },
-        { "overmap": "-3_cross", "weight": 1 }
+        { "overmap": "straight_tunnel", "max": { "poisson": 20 } },
+        { "overmap": "corner", "max": { "poisson": 5 } },
+        { "overmap": "tee", "max": { "poisson": 10 } }
       ],
+      [ { "overmap": "finale", "max": 1 } ],
       [
-        { "overmap": "-4_straight_tunnel", "max": { "poisson": 20 } },
-        { "overmap": "-4_corner", "max": { "poisson": 5 } },
-        { "overmap": "-4_tee", "max": { "poisson": 10 } }
-      ],
-      [
-        {
-          "name": "finale",
-          "chunk": [ { "overmap": "tunnel_to_finale", "pos": [ 0, 0, -4 ] }, { "overmap": "finale", "pos": [ 0, -1, -4 ] } ],
-          "max": 1
-        }
-      ],
-      [
-        { "overmap": "-4_dead_end", "weight": 2000 },
-        { "overmap": "-4_straight_tunnel", "weight": 100 },
-        { "overmap": "-4_corner", "weight": 100 },
-        { "overmap": "-4_tee", "weight": 10 },
-        { "overmap": "-4_cross", "weight": 1 }
+        { "overmap": "dead_end", "weight": 2000 },
+        { "overmap": "straight_tunnel", "weight": 100 },
+        { "overmap": "corner", "weight": 100 },
+        { "overmap": "tee", "weight": 10 },
+        { "overmap": "cross", "weight": 1 }
       ]
     ]
   }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

@Maleclypse  asked me to look at #69553 which they're basing off the generic mine mutable but looking at it the base mutable is overcomplicated

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Simplifies the mutable definition without any functional change in the way it spawns. Made sure to find in files all the joins in case they had some weird other usage but they don't appear anywhere else.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked that the map is still spawning normally without errors and is fully navigable

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
