### PR TITLE
`cata_test` does not wait for `--list-tests` anymore

### DIFF
--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -206,7 +206,7 @@ struct CataListener : Catch::TestEventListenerBase {
         error_during_initialization = debug_has_error_been_observed();
 
         DebugLog( D_INFO, DC_ALL ) << "Game data loaded, running Catch2 session:" << std::endl;
-        start = std::chrono::system_clock::now();
+        end = start = std::chrono::system_clock::now();
     }
 
     void testRunEnded( Catch::TestRunStats const & ) override {
@@ -385,6 +385,11 @@ int main( int argc, const char *argv[] )
         DebugLog( D_INFO, DC_ALL ) <<
                                    "Make sure that you're in the correct working directory and your data isn't corrupted.";
         return EXIT_FAILURE;
+    }
+
+    if( world_generator == nullptr ) {
+        // The session run may not have initialized game state because asked to list tests
+        return result;
     }
 
     std::string world_name = world_generator->active_world->world_name;

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -55,26 +55,18 @@ static const mod_id MOD_INFORMATION_dda( "dda" );
 using name_value_pair_t = std::pair<std::string, std::string>;
 using option_overrides_t = std::vector<name_value_pair_t>;
 
-// If tag is found as a prefix of any argument in arg_vec, the argument is
-// removed from arg_vec and the argument suffix after tag is returned.
-// Otherwise, an empty string is returned and arg_vec is unchanged.
-static std::string extract_argument( std::vector<const char *> &arg_vec, const std::string &tag )
-{
-    std::string arg_rest;
-    for( auto iter = arg_vec.begin(); iter != arg_vec.end(); iter++ ) {
-        if( strncmp( *iter, tag.c_str(), tag.length() ) == 0 ) {
-            arg_rest = std::string( &( *iter )[tag.length()] );
-            arg_vec.erase( iter );
-            break;
-        }
-    }
-    return arg_rest;
-}
+std::vector<mod_id> mods;
+std::string user_dir;
+bool dont_save{ false };
+option_overrides_t option_overrides_for_test_suite;
+std::string error_fmt = "human-readable";
 
-static std::vector<mod_id> extract_mod_selection( std::vector<const char *> &arg_vec )
-{
-    std::string mod_string = extract_argument( arg_vec, "--mods=" );
+std::chrono::system_clock::time_point start;
+std::chrono::system_clock::time_point end;
+bool error_during_initialization{ false };
 
+static std::vector<mod_id> extract_mod_selection( const std::string &mod_string )
+{
     std::vector<std::string> mod_names = string_split( mod_string, ',' );
     std::vector<mod_id> ret;
     for( const std::string &mod_name : mod_names ) {
@@ -173,28 +165,6 @@ static void init_global_game_state( const std::vector<mod_id> &mods,
     get_weather().update_weather();
 }
 
-// Checks if any of the flags are in container, removes them all
-static bool check_remove_flags( std::vector<const char *> &cont,
-                                const std::vector<const char *> &flags )
-{
-    bool has_any = false;
-    auto iter = flags.begin();
-    while( iter != flags.end() ) {
-        auto found = std::find_if( cont.begin(), cont.end(),
-        [iter]( const char *c ) {
-            return strcmp( c, *iter ) == 0;
-        } );
-        if( found == cont.end() ) {
-            iter++;
-        } else {
-            cont.erase( found );
-            has_any = true;
-        }
-    }
-
-    return has_any;
-}
-
 // Split s on separator sep, returning parts as a pair. Returns empty string as
 // second value if no separator found.
 static name_value_pair_t split_pair( const std::string &s, const char sep )
@@ -207,13 +177,9 @@ static name_value_pair_t split_pair( const std::string &s, const char sep )
     }
 }
 
-static option_overrides_t extract_option_overrides( std::vector<const char *> &arg_vec )
+static option_overrides_t extract_option_overrides( const std::string& option_overrides_string )
 {
     option_overrides_t ret;
-    std::string option_overrides_string = extract_argument( arg_vec, "--option_overrides=" );
-    if( option_overrides_string.empty() ) {
-        return ret;
-    }
     const char delim = ',';
     const char sep = ':';
     size_t i = 0;
@@ -228,18 +194,6 @@ static option_overrides_t extract_option_overrides( std::vector<const char *> &a
     const std::string part = option_overrides_string.substr( i );
     ret.emplace_back( split_pair( part, sep ) );
     return ret;
-}
-
-static std::string extract_user_dir( std::vector<const char *> &arg_vec )
-{
-    std::string option_user_dir = extract_argument( arg_vec, "--user-dir=" );
-    if( option_user_dir.empty() ) {
-        return "./test_user_dir/";
-    }
-    if( !string_ends_with( option_user_dir, "/" ) ) {
-        option_user_dir += "/";
-    }
-    return option_user_dir;
 }
 
 struct CataListener : Catch::TestEventListenerBase {
@@ -316,18 +270,53 @@ int main( int argc, const char *argv[] )
 
     std::vector<const char *> arg_vec( argv, argv + argc );
 
-    std::vector<mod_id> mods = extract_mod_selection( arg_vec );
+    using namespace Catch::clara;
+    std::string option_overrides;
+    std::string mods_string;
+    std::string check_plural_str;
+    auto cli = session.cli()
+        | Opt( mods_string, "mod1,mod2,…")
+        ["--mods"]
+        ("[CataclysmDDA] Loads the list of mods before executing tests.")
+        | Opt( user_dir, "dirname" )
+        ["--user-dir"]
+        ("[CataclysmDDA] Set user dir (where test world will be created)")
+        | Opt( dont_save )
+        ["--drop-world"] // "-D" conflicts with Catch2 own "--min-duration"
+        ("[CataclysmDDA] Don't save the world on test failure.")
+        | Opt( option_overrides , "n:v[,…]" )
+        ["--option_overrides"]
+        ("[CataclysmDDA] Name-value pairs of game options for tests (overrides config/options.json values).")
+        | Opt( error_fmt, "human-readable|github-action" )
+        ["--error-format"]
+        ("[CataclysmDDA] Format of error messages (default: human-readable)")
+        | Opt( check_plural_str, "none|certain|possbile" )
+        ["--check-plural"]
+        ("[CataclysmDDA] (TBW)")
+        ;
+    session.cli(cli);
+
+    // Note: this must not be invoked before all DDA-specific flags are stripped from arg_vec!
+    int result = session.applyCommandLine( arg_vec.size(), &arg_vec[0] );
+    if( result != 0 || session.configData().showHelp ) {
+        return result;
+    }
+
+    // Validate CDDA arguments
+    mods = extract_mod_selection( mods_string );
     if( std::find( mods.begin(), mods.end(), MOD_INFORMATION_dda ) == mods.end() ) {
         mods.insert( mods.begin(), MOD_INFORMATION_dda ); // @todo move unit test items to core
     }
 
-    option_overrides_t option_overrides_for_test_suite = extract_option_overrides( arg_vec );
+    if (user_dir.empty()) {
+        user_dir = "./test_user_dir/";
+    }
+    if (!string_ends_with(user_dir, "/")) {
+        user_dir += "/";
+    }
 
-    const bool dont_save = check_remove_flags( arg_vec, { "-D", "--drop-world" } );
+    option_overrides_for_test_suite = extract_option_overrides( option_overrides );
 
-    std::string user_dir = extract_user_dir( arg_vec );
-
-    std::string error_fmt = extract_argument( arg_vec, "--error-format=" );
     if( error_fmt == "github-action" ) {
         // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
         error_log_format = error_log_format_t::github_action;
@@ -339,7 +328,6 @@ int main( int argc, const char *argv[] )
         return EXIT_FAILURE;
     }
 
-    std::string check_plural_str = extract_argument( arg_vec, "--check-plural=" );
     if( check_plural_str == "none" ) {
         // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
         check_plural = check_plural_t::none;
@@ -352,21 +340,6 @@ int main( int argc, const char *argv[] )
     } else {
         printf( "Unknown check_plural value %s", check_plural_str.c_str() );
         return EXIT_FAILURE;
-    }
-
-    // Note: this must not be invoked before all DDA-specific flags are stripped from arg_vec!
-    int result = session.applyCommandLine( arg_vec.size(), &arg_vec[0] );
-    if( result != 0 || session.configData().showHelp ) {
-        printf( "CataclysmDDA specific options:\n" );
-        printf( "  --mods=<mod1,mod2,…>         Loads the list of mods before executing tests.\n" );
-        printf( "  --user-dir=<dir>             Set user dir (where test world will be created).\n" );
-        printf( "  -D, --drop-world             Don't save the world on test failure.\n" );
-        printf( "  --option_overrides=n:v[,…]   Name-value pairs of game options for tests.\n" );
-        printf( "                               (overrides config/options.json values)\n" );
-        printf( "  --error-format=<value>       Format of error messages.  Possible values are:\n" );
-        printf( "                                   human-readable (default)\n" );
-        printf( "                                   github-action\n" );
-        return result;
     }
 
     // NOLINTNEXTLINE(cata-tests-must-restore-global-state)

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -177,7 +177,7 @@ static name_value_pair_t split_pair( const std::string &s, const char sep )
     }
 }
 
-static option_overrides_t extract_option_overrides( const std::string& option_overrides_string )
+static option_overrides_t extract_option_overrides( const std::string &option_overrides_string )
 {
     option_overrides_t ret;
     const char delim = ',';
@@ -199,7 +199,7 @@ static option_overrides_t extract_option_overrides( const std::string& option_ov
 struct CataListener : Catch::TestEventListenerBase {
     using TestEventListenerBase::TestEventListenerBase;
 
-    void testRunStarting( Catch::TestRunInfo const& testRunInfo ) {
+    void testRunStarting( Catch::TestRunInfo const & ) override {
         // TODO: Only init game if we're running tests that need it.
         init_global_game_state( mods, option_overrides_for_test_suite, user_dir );
 
@@ -209,7 +209,7 @@ struct CataListener : Catch::TestEventListenerBase {
         start = std::chrono::system_clock::now();
     }
 
-    void testRunEnded( Catch::TestRunStats const& testRunStats ) {
+    void testRunEnded( Catch::TestRunStats const & ) override {
         end = std::chrono::system_clock::now();
     }
 
@@ -290,26 +290,26 @@ int main( int argc, const char *argv[] )
     std::string mods_string;
     std::string check_plural_str;
     auto cli = session.cli()
-        | Opt( mods_string, "mod1,mod2,…")
-        ["--mods"]
-        ("[CataclysmDDA] Loads the list of mods before executing tests.")
-        | Opt( user_dir, "dirname" )
-        ["--user-dir"]
-        ("[CataclysmDDA] Set user dir (where test world will be created)")
-        | Opt( dont_save )
-        ["--drop-world"] // "-D" conflicts with Catch2 own "--min-duration"
-        ("[CataclysmDDA] Don't save the world on test failure.")
-        | Opt( option_overrides , "n:v[,…]" )
-        ["--option_overrides"]
-        ("[CataclysmDDA] Name-value pairs of game options for tests (overrides config/options.json values).")
-        | Opt( error_fmt, "human-readable|github-action" )
-        ["--error-format"]
-        ("[CataclysmDDA] Format of error messages (default: human-readable)")
-        | Opt( check_plural_str, "none|certain|possbile" )
-        ["--check-plural"]
-        ("[CataclysmDDA] (TBW)")
-        ;
-    session.cli(cli);
+               | Opt( mods_string, "mod1,mod2,…" )
+               ["--mods"]
+               ( "[CataclysmDDA] Loads the list of mods before executing tests." )
+               | Opt( user_dir, "dirname" )
+               ["--user-dir"]
+               ( "[CataclysmDDA] Set user dir (where test world will be created)" )
+               | Opt( dont_save )
+               ["--drop-world"] // "-D" conflicts with Catch2 own "--min-duration"
+               ( "[CataclysmDDA] Don't save the world on test failure." )
+               | Opt( option_overrides, "n:v[,…]" )
+               ["--option_overrides"]
+               ( "[CataclysmDDA] Name-value pairs of game options for tests (overrides config/options.json values)." )
+               | Opt( error_fmt, "human-readable|github-action" )
+               ["--error-format"]
+               ( "[CataclysmDDA] Format of error messages (default: human-readable)" )
+               | Opt( check_plural_str, "none|certain|possbile" )
+               ["--check-plural"]
+               ( "[CataclysmDDA] (TBW)" )
+               ;
+    session.cli( cli );
 
     // Note: this must not be invoked before all DDA-specific flags are stripped from arg_vec!
     int result = session.applyCommandLine( arg_vec.size(), &arg_vec[0] );
@@ -323,10 +323,10 @@ int main( int argc, const char *argv[] )
         mods.insert( mods.begin(), MOD_INFORMATION_dda ); // @todo move unit test items to core
     }
 
-    if (user_dir.empty()) {
+    if( user_dir.empty() ) {
         user_dir = "./test_user_dir/";
     }
-    if (!string_ends_with(user_dir, "/")) {
+    if( !string_ends_with( user_dir, "/" ) ) {
         user_dir += "/";
     }
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -185,13 +185,13 @@ static option_overrides_t extract_option_overrides( const std::string_view optio
     size_t i = 0;
     size_t pos = option_overrides_string.find( delim );
     while( pos != std::string::npos ) {
-        std::string part = static_cast<std::string>( option_overrides_string.substr(i, pos) );
+        std::string part = static_cast<std::string>( option_overrides_string.substr( i, pos ) );
         ret.emplace_back( split_pair( part, sep ) );
         i = ++pos;
         pos = option_overrides_string.find( delim, pos );
     }
     // Handle last part
-    const std::string part = static_cast<std::string>( option_overrides_string.substr(i) );
+    const std::string part = static_cast<std::string>( option_overrides_string.substr( i ) );
     ret.emplace_back( split_pair( part, sep ) );
     return ret;
 }
@@ -290,25 +290,25 @@ int main( int argc, const char *argv[] )
     std::string mods_string;
     std::string check_plural_str;
     Parser cli = session.cli()
-               | Opt( mods_string, "mod1,mod2,…" )
-               ["--mods"]
-               ( "[CataclysmDDA] Loads the list of mods before executing tests." )
-               | Opt( user_dir, "dirname" )
-               ["--user-dir"]
-               ( "[CataclysmDDA] Set user dir (where test world will be created)" )
-               | Opt( dont_save )
-               ["--drop-world"] // "-D" conflicts with Catch2 own "--min-duration"
-               ( "[CataclysmDDA] Don't save the world on test failure." )
-               | Opt( option_overrides, "n:v[,…]" )
-               ["--option_overrides"]
-               ( "[CataclysmDDA] Name-value pairs of game options for tests (overrides config/options.json values)." )
-               | Opt( error_fmt, "human-readable|github-action" )
-               ["--error-format"]
-               ( "[CataclysmDDA] Format of error messages (default: human-readable)" )
-               | Opt( check_plural_str, "none|certain|possbile" )
-               ["--check-plural"]
-               ( "[CataclysmDDA] (TBW)" )
-               ;
+                 | Opt( mods_string, "mod1,mod2,…" )
+                 ["--mods"]
+                 ( "[CataclysmDDA] Loads the list of mods before executing tests." )
+                 | Opt( user_dir, "dirname" )
+                 ["--user-dir"]
+                 ( "[CataclysmDDA] Set user dir (where test world will be created)" )
+                 | Opt( dont_save )
+                 ["--drop-world"] // "-D" conflicts with Catch2 own "--min-duration"
+                 ( "[CataclysmDDA] Don't save the world on test failure." )
+                 | Opt( option_overrides, "n:v[,…]" )
+                 ["--option_overrides"]
+                 ( "[CataclysmDDA] Name-value pairs of game options for tests (overrides config/options.json values)." )
+                 | Opt( error_fmt, "human-readable|github-action" )
+                 ["--error-format"]
+                 ( "[CataclysmDDA] Format of error messages (default: human-readable)" )
+                 | Opt( check_plural_str, "none|certain|possbile" )
+                 ["--check-plural"]
+                 ( "[CataclysmDDA] (TBW)" )
+                 ;
     session.cli( cli );
 
     // Note: this must not be invoked before all DDA-specific flags are stripped from arg_vec!


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "cata-test does not wait for --list-tests anymore"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
* `init_global_game_state()` takes time and it is always run even when no test will run
* Porting the `cata_test` command line parser to own `Catch2::Clara`
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- [x] Use Catch2 event listeners to intercept when all tests start and end
- [x] Use those to refactor `main()` logic 
- [x] Simplify command line parsing by using Catch2 own [Clara](https://github.com/catchorg/Catch2/blob/v2.13.7/docs/own-main.md#adding-your-own-command-line-options) parser
- [x] The help message changed but the order is preserved (`[CataclysmDDA]` options at the bottom) 
- [x] Removed `-D` alias for `--drop-world` because conflicts with own Catch2 `--min-duration`
- [x] Automatically added `--check-plural` but description left To Be Written 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Just test for `Catch::ConfigData` like `listTests` and run the session skipping game initialization.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
* Only on Windows 10
* Only `cata_test-tiles.exe` built from CMake windows-tiles-sounds-x64-msvc in RelWithDebInfo
* Only some tests and some tags like `[!mayfail]`, `[overpass]`, `zones_custom`
* Only `--user_dir` and `--drop-world`
* Not tested `--mods`, `--option_overrides`, `--error-format`, `--error-format`, `--check-plural`
* Not tested any shell/CI script using `cata_test` directly or indirectly
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I will fix linting during PR review.
It **may brake** GHA testing if some unforeseen arguments order is require. Please double check, thanks!
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
