### PR TITLE
[Xedra Evolved] Move vampire lodge to it's own special

### DIFF
--- a/data/mods/Xedra_Evolved/mapgen/overmap_special.json
+++ b/data/mods/Xedra_Evolved/mapgen/overmap_special.json
@@ -283,5 +283,25 @@
     "occurrences": [ 5, 100 ],
     "flags": [ "UNIQUE", "WILDERNESS" ],
     "spawns": { "group": "GROUP_GENIUS_HOMULLUS", "population": [ 10, 30 ], "radius": [ 1, 3 ] }
+  },
+  {
+    "type": "overmap_special",
+    "id": "Vampire Hunting Lodge",
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "lodgev_ground1_north" },
+      { "point": [ 1, 0, 0 ], "overmap": "lodgev_ground2_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "lodgev_2ndfloor1_north" },
+      { "point": [ 1, 0, 1 ], "overmap": "lodgev_2ndfloor2_north" },
+      { "point": [ 0, 0, 2 ], "overmap": "lodgev_roof1_north" },
+      { "point": [ 1, 0, 2 ], "overmap": "lodgev_roof2_north" },
+      { "point": [ 0, 0, -1 ], "overmap": "lodgev_basement_residential1_north" },
+      { "point": [ 1, 0, -1 ], "overmap": "lodgev_basement_residential2_north" }
+    ],
+    "connections": [ { "point": [ -1, 0, 0 ], "terrain": "road", "from": [ 0, 0, 0 ] } ],
+    "locations": [ "forest" ],
+    "city_distance": [ 30, -1 ],
+    "city_sizes": [ 0, 12 ],
+    "occurrences": [ 5, 100 ],
+    "flags": [ "CLASSIC", "MAN_MADE", "UNIQUE" ]
   }
 ]

--- a/data/mods/Xedra_Evolved/mapgen/overmap_terrain.json
+++ b/data/mods/Xedra_Evolved/mapgen/overmap_terrain.json
@@ -159,5 +159,25 @@
     "looks_like": "standing_stones",
     "see_cost": 5,
     "mondensity": 2
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "lodgev_ground1", "lodgev_ground2" ],
+    "copy-from": "lodge_ground1"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "lodgev_2ndfloor1", "lodgev_2ndfloor2" ],
+    "copy-from": "lodge_2ndfloor1"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "lodgev_roof1", "lodgev_roof2" ],
+    "copy-from": "lodge_roof1"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": [ "lodgev_basement_residential1", "lodgev_basement_residential2" ],
+    "copy-from": "lodge_basement_residential1"
   }
 ]

--- a/data/mods/Xedra_Evolved/mapgen/vampire_locations.json
+++ b/data/mods/Xedra_Evolved/mapgen/vampire_locations.json
@@ -2,8 +2,7 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ [ "lodge_ground1", "lodge_ground2" ] ],
-    "weight": 100,
+    "om_terrain": [ [ "lodgev_ground1", "lodgev_ground2" ] ],
     "object": {
       "fill_ter": "t_floor",
       "rows": [
@@ -47,8 +46,7 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ [ "lodge_2ndfloor1", "lodge_2ndfloor2" ] ],
-    "weight": 100,
+    "om_terrain": [ [ "lodgev_2ndfloor1", "lodgev_2ndfloor2" ] ],
     "object": {
       "fill_ter": "t_open_air",
       "rows": [
@@ -104,8 +102,7 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ [ "lodge_roof1", "lodge_roof2" ] ],
-    "weight": 100,
+    "om_terrain": [ [ "lodgev_roof1", "lodgev_roof2" ] ],
     "object": {
       "fill_ter": "t_flat_roof",
       "rows": [
@@ -145,8 +142,7 @@
   {
     "type": "mapgen",
     "method": "json",
-    "om_terrain": [ [ "lodge_basement_residential1", "lodge_basement_residential2" ] ],
-    "weight": 100,
+    "om_terrain": [ [ "lodgev_basement_residential1", "lodgev_basement_residential2" ] ],
     "object": {
       "fill_ter": "t_soil",
       "rows": [


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

The vampire lodge was spawning in bits as part of the hunting lodge

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Makes the vampire lodge its own special to prevent the two mixing

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Replacing the hunting lodge special with this
Giving it a different look on the map

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked it spawned ok

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
