### PR TITLE
[Desert region] Simplifies water replacement nests

### DIFF
--- a/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_transportation.json
@@ -41,7 +41,8 @@
     "name": "bridge",
     "sym": "│",
     "color": "white",
-    "see_cost": 2
+    "see_cost": 2,
+    "flags": [ "BRIDGE" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/mods/desert_region/mapgen/waterbody.json
+++ b/data/mods/desert_region/mapgen/waterbody.json
@@ -16,6 +16,7 @@
       "river_c_not_se",
       "river_c_not_sw"
     ],
+    "//": "Weight should be removed if/when lake_shore and river (or their weights) are unhardcoded",
     "weight": 100000000000,
     "object": {
       "fill_ter": "t_mudcrack",
@@ -47,163 +48,24 @@
           "else_chunks": [ "shore_north_east" ],
           "x": 0,
           "y": 0,
-          "neighbors": {
-            "north_east": [
-              "lake_bed",
-              "lake_shore",
-              "river_center",
-              "river_nw",
-              "river_ne",
-              "river_sw",
-              "river_se",
-              "river",
-              "river_c_not_ne",
-              "river_c_not_nw",
-              "river_c_not_se",
-              "river_c_not_sw",
-              "bridge",
-              "bridgehead_ground"
-            ]
-          }
+          "flags": { "north_east": [ "BRIDGE", "LAKE", "RIVER" ] }
         },
         {
           "else_chunks": [ "shore_south_east" ],
           "x": 0,
           "y": 0,
-          "neighbors": {
-            "south_east": [
-              "lake_bed",
-              "lake_shore",
-              "river_center",
-              "river_nw",
-              "river_ne",
-              "river_sw",
-              "river_se",
-              "river",
-              "river_c_not_ne",
-              "river_c_not_nw",
-              "river_c_not_se",
-              "river_c_not_sw",
-              "bridge",
-              "bridgehead_ground"
-            ]
-          }
+          "flags": { "north_east": [ "BRIDGE", "LAKE", "RIVER" ] }
         },
         {
           "else_chunks": [ "shore_south_west" ],
           "x": 0,
           "y": 0,
-          "neighbors": {
-            "south_west": [
-              "lake_bed",
-              "lake_shore",
-              "river_center",
-              "river_nw",
-              "river_ne",
-              "river_sw",
-              "river_se",
-              "river",
-              "river_c_not_ne",
-              "river_c_not_nw",
-              "river_c_not_se",
-              "river_c_not_sw",
-              "bridge",
-              "bridgehead_ground"
-            ]
-          }
+          "flags": { "north_east": [ "BRIDGE", "LAKE", "RIVER" ] }
         },
-        {
-          "else_chunks": [ "shore_north" ],
-          "x": 0,
-          "y": 0,
-          "neighbors": {
-            "north": [
-              "lake_bed",
-              "lake_shore",
-              "river_center",
-              "river_nw",
-              "river_ne",
-              "river_sw",
-              "river_se",
-              "river",
-              "river_c_not_ne",
-              "river_c_not_nw",
-              "river_c_not_se",
-              "river_c_not_sw",
-              "bridge",
-              "bridgehead_ground"
-            ]
-          }
-        },
-        {
-          "else_chunks": [ "shore_east" ],
-          "x": 0,
-          "y": 0,
-          "neighbors": {
-            "east": [
-              "lake_bed",
-              "lake_shore",
-              "river_center",
-              "river_nw",
-              "river_ne",
-              "river_sw",
-              "river_se",
-              "river",
-              "river_c_not_ne",
-              "river_c_not_nw",
-              "river_c_not_se",
-              "river_c_not_sw",
-              "bridge",
-              "bridgehead_ground"
-            ]
-          }
-        },
-        {
-          "else_chunks": [ "shore_south" ],
-          "x": 0,
-          "y": 0,
-          "neighbors": {
-            "south": [
-              "lake_bed",
-              "lake_shore",
-              "river_center",
-              "river_nw",
-              "river_ne",
-              "river_sw",
-              "river_se",
-              "river",
-              "river_c_not_ne",
-              "river_c_not_nw",
-              "river_c_not_se",
-              "river_c_not_sw",
-              "bridge",
-              "bridgehead_ground"
-            ]
-          }
-        },
-        {
-          "else_chunks": [ "shore_west" ],
-          "x": 0,
-          "y": 0,
-          "neighbors": {
-            "west": [
-              "lake_bed",
-              "lake_shore",
-              "river_center",
-              "river_nw",
-              "river_ne",
-              "river_sw",
-              "river_se",
-              "river",
-              "river_c_not_ne",
-              "river_c_not_nw",
-              "river_c_not_se",
-              "river_c_not_sw",
-              "bridge",
-              "bridgehead_ground"
-            ]
-          }
-        }
+        { "else_chunks": [ "shore_north" ], "x": 0, "y": 0, "flags": { "north_east": [ "BRIDGE", "LAKE", "RIVER" ] } },
+        { "else_chunks": [ "shore_east" ], "x": 0, "y": 0, "flags": { "north_east": [ "BRIDGE", "LAKE", "RIVER" ] } },
+        { "else_chunks": [ "shore_south" ], "x": 0, "y": 0, "flags": { "north_east": [ "BRIDGE", "LAKE", "RIVER" ] } },
+        { "else_chunks": [ "shore_west" ], "x": 0, "y": 0, "flags": { "north_east": [ "BRIDGE", "LAKE", "RIVER" ] } }
       ]
     }
   },

--- a/src/omdata.h
+++ b/src/omdata.h
@@ -177,6 +177,7 @@ enum class oter_flags : int {
     water,
     river_tile,
     has_sidewalk,
+    bridge,
     ignore_rotation_for_adjacency,
     line_drawing, // does this tile have 8 versions, including straights, bends, tees, and a fourway?
     subway_connection,

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -688,6 +688,7 @@ std::string enum_to_string<oter_flags>( oter_flags data )
         case oter_flags::known_down: return "KNOWN_DOWN";
         case oter_flags::known_up: return "KNOWN_UP";
         case oter_flags::river_tile: return "RIVER";
+        case oter_flags::bridge: return "BRIDGE";
         case oter_flags::has_sidewalk: return "SIDEWALK";
         case oter_flags::no_rotate: return "NO_ROTATE";
         case oter_flags::should_not_spawn: return "SHOULD_NOT_SPAWN";


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Nest conditionals can use flags now to simplify stuff like this

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds a BRIDGE flag bc I thought giving bridgehead_ground the RIVER flag might have other consequences

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

The map override doesn't even seem to be working for whatever reason so I can't really test, the logic is essentially identical though

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
