### PR TITLE
Fix: Count charges in all nearby smoking racks to crafting inventory

### DIFF
--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -354,7 +354,13 @@ extern void remove_stale_inventory_quick_shortcuts();
 item *inventory::provide_pseudo_item( const item &tool )
 {
     if( !provisioned_pseudo_tools.insert( tool.typeId() ).second ) {
-        return nullptr; // already provided tool -> bail out
+        // already provided tool -> return existing
+        for( auto &stack : items ) {
+            if( stack.front().typeId() == tool.typeId() ) {
+                return &stack.front();
+            }
+        }
+        return nullptr;
     }
     item *res = &add_item( tool );
     res->set_flag( flag_PSEUDO );

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -38,6 +38,7 @@
 #include "type_id.h"
 #include "value_ptr.h"
 #include "veh_appliance.h"
+#include "veh_type.h"
 #include "vehicle.h"
 
 static const activity_id ACT_CRAFT( "ACT_CRAFT" );
@@ -48,6 +49,7 @@ static const flag_id json_flag_USE_UPS( "USE_UPS" );
 static const itype_id itype_awl_bone( "awl_bone" );
 static const itype_id itype_candle( "candle" );
 static const itype_id itype_cash_card( "cash_card" );
+static const itype_id itype_charcoal( "charcoal" );
 static const itype_id itype_chisel( "chisel" );
 static const itype_id itype_fake_anvil( "fake_anvil" );
 static const itype_id itype_hacksaw( "hacksaw" );
@@ -59,7 +61,9 @@ static const itype_id itype_sheet_cotton( "sheet_cotton" );
 static const itype_id itype_test_cracklins( "test_cracklins" );
 static const itype_id itype_test_gum( "test_gum" );
 static const itype_id itype_thread( "thread" );
+static const itype_id itype_water( "water" );
 static const itype_id itype_water_clean( "water_clean" );
+static const itype_id itype_water_faucet( "water_faucet" );
 
 static const morale_type morale_food_good( "morale_food_good" );
 
@@ -112,6 +116,9 @@ static const skill_id skill_survival( "survival" );
 static const trait_id trait_DEBUG_CNF( "DEBUG_CNF" );
 
 static const vpart_id vpart_ap_test_storage_battery( "ap_test_storage_battery" );
+static const vpart_id vpart_water_faucet( "water_faucet" );
+
+static const vproto_id vehicle_prototype_test_rv( "test_rv" );
 
 TEST_CASE( "recipe_subset" )
 {
@@ -2280,5 +2287,113 @@ TEST_CASE( "variant_crafting_recipes", "[crafting][slow]" )
             }
         }
         CHECK( specific_variant_count == max_iters );
+    }
+}
+
+TEST_CASE( "pseudo_tools_in_crafting_inventory", "[crafting][tools]" )
+{
+    clear_map();
+    map &here = get_map();
+
+    clear_vehicles();
+    clear_avatar();
+    avatar &player = get_avatar();
+    player.setpos( tripoint( 60, 58, 0 ) );
+    const tripoint veh_pos( 60, 60, 0 );
+    const tripoint furn1_pos( 60, 57, 0 );
+    const tripoint furn2_pos( 60, 56, 0 );
+
+    const itype_id pseudo_tool = f_smoking_rack.obj().crafting_pseudo_item;
+
+    GIVEN( "a vehicle with a liquid tank" ) {
+        vehicle *veh = here.add_vehicle( vehicle_prototype_test_rv, veh_pos, 0_degrees, 0, 0 );
+        REQUIRE( veh != nullptr );
+        for( const vpart_reference &door : veh->get_avail_parts( VPFLAG_OPENABLE ) ) {
+            door.part().open = true;
+        }
+
+        WHEN( "the tank contains liquid" ) {
+            REQUIRE( veh->fuel_left( itype_water ) == 0 );
+            int charges = 50;
+            for( const vpart_reference &tank : veh->get_avail_parts( vpart_bitflags::VPFLAG_FLUIDTANK ) ) {
+                tank.part().ammo_set( itype_water, charges );
+                charges = 0;
+            }
+            REQUIRE( veh->fuel_left( itype_water ) == 50 );
+
+            THEN( "crafting inventory does not contain the liquid" ) {
+                player.invalidate_crafting_inventory();
+                CHECK( player.crafting_inventory().count_item( itype_water_faucet ) == 0 );
+                CHECK( player.crafting_inventory().charges_of( itype_water ) == 0 );
+            }
+            WHEN( "the vehicle has a water faucet part" ) {
+                REQUIRE( veh->install_part( point_zero, vpart_water_faucet ) >= 0 );
+                THEN( "crafting inventory contains the liquid" ) {
+                    player.invalidate_crafting_inventory();
+                    CHECK( player.crafting_inventory().count_item( itype_water_faucet ) == 1 );
+                    CHECK( player.crafting_inventory().charges_of( itype_water ) == 50 );
+                }
+            }
+            WHEN( "the vehicle has two water faucets" ) {
+                REQUIRE( veh->install_part( point_south, vpart_water_faucet ) >= 0 );
+                THEN( "crafting inventory contains the liquid" ) {
+                    player.invalidate_crafting_inventory();
+                    CHECK( player.crafting_inventory().count_item( itype_water_faucet ) == 1 );
+                    CHECK( player.crafting_inventory().charges_of( itype_water ) == 50 );
+                }
+            }
+        }
+        clear_vehicles();
+    }
+    GIVEN( "a smoking rack" ) {
+        REQUIRE( here.furn_set( furn1_pos, f_smoking_rack ) );
+        WHEN( "the smoking rack does not contain any charcoal" ) {
+            REQUIRE( here.i_at( furn1_pos ).empty() );
+            THEN( "crafting inventory contains pseudo tool for the smoker, but without any ammo" ) {
+                player.invalidate_crafting_inventory();
+                CHECK( player.crafting_inventory().count_item( pseudo_tool ) == 1 );
+                const int pos = player.crafting_inventory().position_by_type( pseudo_tool );
+                REQUIRE( pos >= 0 );
+                const item &rack = player.crafting_inventory().find_item( pos );
+                CHECK( rack.ammo_remaining() == 0 );
+            }
+        }
+        WHEN( "the smoking rack contains charcoal" ) {
+            here.add_item( furn1_pos, item( itype_charcoal, calendar::turn_zero, 200 ) );
+            THEN( "crafting inventory contains pseudo tool for the smoker, with ammo" ) {
+                player.invalidate_crafting_inventory();
+                CHECK( player.crafting_inventory().count_item( pseudo_tool ) == 1 );
+                const int pos = player.crafting_inventory().position_by_type( pseudo_tool );
+                REQUIRE( pos >= 0 );
+                const item &rack = player.crafting_inventory().find_item( pos );
+                CHECK( rack.ammo_remaining() == 200 );
+            }
+            GIVEN( "an additional smoking rack" ) {
+                REQUIRE( here.furn_set( furn2_pos, f_smoking_rack ) );
+                WHEN( "the second smoking rack does not contain any charcoal" ) {
+                    REQUIRE( here.i_at( furn2_pos ).empty() );
+                    THEN( "crafting inventory contains pseudo tool for smoking rack, with ammo" ) {
+                        player.invalidate_crafting_inventory();
+                        CHECK( player.crafting_inventory().count_item( pseudo_tool ) == 1 );
+                        const int pos = player.crafting_inventory().position_by_type( pseudo_tool );
+                        REQUIRE( pos >= 0 );
+                        const item &rack = player.crafting_inventory().find_item( pos );
+                        CHECK( rack.ammo_remaining() == 200 );
+                    }
+                }
+                WHEN( "the second smoking rack also contains charcoal" ) {
+                    here.add_item( furn2_pos, item( itype_charcoal, calendar::turn_zero, 100 ) );
+                    THEN( "crafting inventory contains pseudo tool for smoking rack, with ammo" ) {
+                        player.invalidate_crafting_inventory();
+                        CHECK( player.crafting_inventory().count_item( pseudo_tool ) == 1 );
+                        const int pos = player.crafting_inventory().position_by_type( pseudo_tool );
+                        REQUIRE( pos >= 0 );
+                        const item &rack = player.crafting_inventory().find_item( pos );
+                        CHECK( rack.ammo_remaining() == 300 );
+                    }
+                }
+            }
+        }
+        clear_map();
     }
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Count charges in all nearby smoking racks to crafting inventory"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Fixes an issue where only the charges from one nearby smoking rack would be counted to the crafting inventory, even if there were other smoking racks nearby that had sufficient charges to perform a selected crafting recipe.
* Fixes #67513 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

See https://github.com/CleverRaven/Cataclysm-DDA/issues/67513#issuecomment-1863279134 for a description of what the issue was before.

This commit instead changes `inventory::provide_pseudo_item` so that if a pseudo tool is provided more than once, the second call will return the pseudo tool from the first call, instead of `nullptr` as before. This makes it possible for `inventory::form_from_map` to keep adding ammo (charcoal charges) to the same pseudo smoking rack as it builds up the crafting inventory, instead of only for the first. In effect, if there are two smoking racks with charges nearby, the crafting inventory will now still contain only one pseudo tool for smoking rack, but its ammo will be the sum of all nearby smoking racks' charges.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

We could also consider removing the field `inventory::provisioned_pseudo_tools` and always allow multiple pseudo tools of each type.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Tested the savegame from #67513 and verifying whether crafting shillelagh shows "basecamp charcoal smoker (100)" as green or red in the crafting screen:
    * Loaded 100 charcoal into the top rack. Crafting screen shows green. ✔
    * Loaded 100 charcoal into only the middle rack. Crafting screen shows green. ✔
    * Loaded 100 charcoal into only the bottom rack. Crafting screen shows green. ✔
    * Loaded 50 charcoal into the top rack. Crafting screen shows red. ✔
    * Loaded 1 charcoal into to top rack, 50 into middle rack and 49 into bottom rack. Crafting screen shows green. ✔
* This commit also adds tests for this situation, and for verifying that water faucets still provide liquid charges from vehicle tanks, since that also uses `inventory::provide_pseudo_item`.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
