### PR TITLE
Fix impassable broken vehicle parts

### DIFF
--- a/data/json/vehicleparts/seats.json
+++ b/data/json/vehicleparts/seats.json
@@ -103,6 +103,7 @@
     "description": "A soft, wide seat with a high back, the kind often used in back seats or older cars.  It might be a decent place to sleep.",
     "floor_bedding_warmth": 500,
     "item": "seat_bench",
+    "size": "95 L",
     "name": { "str": "bench seat" },
     "extend": { "flags": [ "BED" ] },
     "type": "vehicle_part"
@@ -181,7 +182,7 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": "vehicle_weld_removal" },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
-    "size": "62500 ml",
+    "size": "95 L",
     "type": "vehicle_part"
   }
 ]

--- a/data/json/vehicleparts/seats.json
+++ b/data/json/vehicleparts/seats.json
@@ -182,7 +182,6 @@
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "30 m", "using": "vehicle_weld_removal" },
       "repair": { "skills": [ [ "mechanics", 2 ] ], "time": "60 m", "using": [ [ "repair_welding_standard", 2 ] ] }
     },
-    "size": "95 L",
     "type": "vehicle_part"
   }
 ]

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -213,7 +213,7 @@
     "damage_modifier": 60,
     "durability": 95,
     "description": "A small but comfortable bed.",
-    "size": "100  L",
+    "size": "100 L",
     "item": "mattress",
     "comfort": 4,
     "floor_bedding_warmth": 700,

--- a/data/json/vehicleparts/vehicle_parts.json
+++ b/data/json/vehicleparts/vehicle_parts.json
@@ -1199,7 +1199,7 @@
     "looks_like": "inflatable_airbag",
     "categories": [ "hull" ],
     "color": "green",
-    "size": "15 L",
+    "size": "85 L",
     "durability": 50,
     "item": "inflatable_section",
     "location": "structure",
@@ -2565,7 +2565,7 @@
     "comfort": 1,
     "item": "frame_wood",
     "location": "center",
-    "size": "62500 ml",
+    "size": "85 L",
     "requirements": {
       "install": { "skills": [ [ "mechanics", 1 ] ], "time": "30 m", "using": [ [ "vehicle_nail_install", 1 ] ] },
       "removal": { "skills": [ [ "mechanics", 2 ] ], "time": "15 m", "using": [ [ "vehicle_nail_removal", 1 ] ] },
@@ -2582,6 +2582,7 @@
     "name": { "str": "wooden bench" },
     "copy-from": "seat_wood",
     "durability": 150,
+    "size": "95 L",
     "description": "A benchlike place to sit."
   },
   {
@@ -3039,7 +3040,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
     },
-    "flags": [ "PLANTER", "PROTRUSION", "CARGO", "EXTRA_DRAG" ],
+    "flags": [ "PLANTER", "PROTRUSION", "CARGO", "EXTRA_DRAG", "CARGO_PASSABLE" ],
     "breaks_into": [ { "item": "plastic_chunk", "count": [ 1, 2 ] }, { "item": "scrap", "count": [ 1, 2 ] } ],
     "damage_reduction": { "all": 16 },
     "variants": [ { "symbols": "8", "symbols_broken": "*" } ]
@@ -3072,7 +3073,7 @@
       },
       "repair": { "skills": [ [ "mechanics", 5 ] ], "time": "10 m", "using": [ [ "repair_welding_standard", 6 ] ] }
     },
-    "flags": [ "PLANTER", "PROTRUSION", "CARGO", "ADVANCED_PLANTER", "EXTRA_DRAG" ],
+    "flags": [ "PLANTER", "PROTRUSION", "CARGO", "ADVANCED_PLANTER", "EXTRA_DRAG", "CARGO_PASSABLE" ],
     "breaks_into": [
       { "item": "cable", "charges": [ 3, 6 ] },
       { "item": "e_scrap", "count": [ 4, 10 ] },

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10904,7 +10904,7 @@ void Character::process_effects()
         terminating_effects.pop();
     }
 
-  // Being stuck in tight spaces sucks. TODO: could be expanded to apply to non-vehicle conditions.
+    // Being stuck in tight spaces sucks. TODO: could be expanded to apply to non-vehicle conditions.
     if( has_effect( effect_cramped_space ) ) {
         map &here = get_map();
         const tripoint your_pos = pos();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10912,8 +10912,8 @@ void Character::process_effects()
         if( !vp_there ) {
             remove_effect( effect_cramped_space );
             return;
-            }
-            if( is_npc() && !has_effect( effect_narcosis ) && has_effect( effect_cramped_space ) ) {
+        }
+        if( is_npc() && !has_effect( effect_narcosis ) && has_effect( effect_cramped_space ) ) {
             npc &as_npc = dynamic_cast<npc &>( *this );
             as_npc.complain_about( "cramped_vehicle", 30_minutes, "<cramped_vehicle>", false );
             }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -8006,8 +8006,8 @@ bool Character::move_in_vehicle( Creature *c, const tripoint &dest_loc ) const
         }
         const optional_vpart_position vp = m.veh_at( dest_loc );
         // Sufficiently gigantic characters aren't comfortable in stock seats, roof or no.
-        if( in_vehicle && get_size() == creature_size::huge && !vp.part_with_feature( "AISLE", true ) &&
-            !vp.part_with_feature( "HUGE_OK", true ) && !has_effect( effect_cramped_space ) ) {
+        if( in_vehicle && get_size() == creature_size::huge && !vp.part_with_feature( "AISLE", false ) &&
+            !vp.part_with_feature( "HUGE_OK", false ) && !has_effect( effect_cramped_space ) ) {
             add_msg_if_player( m_warning, _( "You barely fit in this tiny human vehicle." ) );
             add_msg_if_npc( m_warning, _( "%s has to really cram their huge body to fit." ), c->disp_name() );
             c->add_effect( effect_cramped_space, 2_turns, true );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7969,7 +7969,7 @@ bool Character::move_in_vehicle( Creature *c, const tripoint &dest_loc ) const
         vehicle &veh = vp_there->vehicle();
         units::volume capacity = 0_ml;
         units::volume free_cargo = 0_ml;
-        auto cargo_parts = veh.get_parts_at( dest_loc, "CARGO", part_status_flag::any );
+        auto cargo_parts = veh.get_parts_at( dest_loc, "CARGO", part_status_flag::working );
         for( vehicle_part *&part : cargo_parts ) {
             vehicle_stack contents = veh.get_items( *part );
             const vpart_info &vpinfo = part->info();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10928,7 +10928,7 @@ void Character::process_effects()
             if( !vp.part_with_feature( "CARGO_PASSABLE", false ) ) {
                 capacity += contents.max_volume();
                 free_cargo += contents.free_volume();
-                }
+            }
             const creature_size size = get_size();
             if( capacity > 0_ml ) {
                 // Open-topped vehicle parts have more room.

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10909,7 +10909,7 @@ void Character::process_effects()
         map &here = get_map();
         const tripoint your_pos = pos();
         const optional_vpart_position vp_there = here.veh_at( your_pos );
-            if( !vp_there ) {
+        if( !vp_there ) {
             remove_effect( effect_cramped_space );
             return;
             }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -10916,7 +10916,7 @@ void Character::process_effects()
         if( is_npc() && !has_effect( effect_narcosis ) && has_effect( effect_cramped_space ) ) {
             npc &as_npc = dynamic_cast<npc &>( *this );
             as_npc.complain_about( "cramped_vehicle", 30_minutes, "<cramped_vehicle>", false );
-            }
+        }
         bool is_cramped_space = false;
         vehicle &veh = vp_there->vehicle();
         units::volume capacity = 0_ml;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7969,16 +7969,15 @@ bool Character::move_in_vehicle( Creature *c, const tripoint &dest_loc ) const
         vehicle &veh = vp_there->vehicle();
         units::volume capacity = 0_ml;
         units::volume free_cargo = 0_ml;
-        auto cargo_parts = veh.get_parts_at( dest_loc, "CARGO", part_status_flag::working );
+        auto cargo_parts = veh.get_parts_at( dest_loc, "CARGO", part_status_flag::any );
         for( vehicle_part *&part : cargo_parts ) {
             vehicle_stack contents = veh.get_items( *part );
-            const vpart_info &vpinfo = part->info();
             const optional_vpart_position vp = m.veh_at( dest_loc );
             // Check for obstacles and appliances to prevent squishing when the part is
             // not a vehicle or when the player is not actually entering the tile IE grabbing.
             if( !vp.part_with_feature( "CARGO_PASSABLE", false ) &&
                 !vp.part_with_feature( "APPLIANCE", false ) && !vp.part_with_feature( "OBSTACLE", false ) ) {
-                capacity += vpinfo.size;
+                capacity += contents.max_volume();
                 free_cargo += contents.free_volume();
             }
         }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -175,13 +175,12 @@ bool monster::monster_move_in_vehicle( const tripoint &p ) const
         vehicle &veh = vp->vehicle();
         units::volume capacity = 0_ml;
         units::volume free_cargo = 0_ml;
-        auto cargo_parts = veh.get_parts_at( p, "CARGO", part_status_flag::working );
+        auto cargo_parts = veh.get_parts_at( p, "CARGO", part_status_flag::any );
         for( vehicle_part *&part : cargo_parts ) {
             vehicle_stack contents = veh.get_items( *part );
-            const vpart_info &vpinfo = part->info();
             if( !vp.part_with_feature( "CARGO_PASSABLE", false ) &&
                 !vp.part_with_feature( "APPLIANCE", false ) && !vp.part_with_feature( "OBSTACLE", false ) ) {
-                capacity += vpinfo.size;
+                capacity += contents.max_volume();
                 free_cargo += contents.free_volume();
             }
         }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -203,7 +203,7 @@ bool monster::monster_move_in_vehicle( const tripoint &p ) const
                     ( size == creature_size::medium && free_cargo < 46875_ml ) ||
                     ( size == creature_size::large && free_cargo < 93750_ml ) ||
                     ( size == creature_size::huge && free_cargo < 187500_ml ) ||
-                    ( get_volume() > 850000_ml && !vp.part_with_feature( "HUGE_OK", true ) ) ) {
+                    ( get_volume() > 850000_ml && !vp.part_with_feature( "HUGE_OK", false ) ) ) {
                     return false; // Return false if there's just no room whatsoever. Anything over 850 liters will simply never fit in a vehicle part that isn't specifically made for it.
                     // I'm sorry but you can't let a kaiju ride shotgun.
                 }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -243,10 +243,6 @@ bool monster::will_move_to( const tripoint &p ) const
         }
     }
 
-    if( here.veh_at( p ).part_with_feature( VPFLAG_CARGO, true ) && !monster_move_in_vehicle( p ) ) {
-        return false;
-    }
-
     if( digs() && !here.has_flag( ter_furn_flag::TFLAG_DIGGABLE, p ) &&
         !here.has_flag( ter_furn_flag::TFLAG_BURROWABLE, p ) ) {
         return false;
@@ -1884,6 +1880,10 @@ bool monster::move_to( const tripoint &p, bool force, bool step_on_critter,
         if( here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, pos() ) ) {
             destination = find_closest_stair( p, ter_furn_flag::TFLAG_GOES_UP );
         }
+    }
+
+    if( here.veh_at( p ).part_with_feature( VPFLAG_CARGO, true ) && !monster_move_in_vehicle( p ) ) {
+        return false;
     }
 
     // Allows climbing monsters to move on terrain with movecost <= 0

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -214,8 +214,8 @@ bool monster::monster_move_in_vehicle( const tripoint &p ) const
                 critter.add_effect( effect_cramped_space, 2_turns, true );
                 return true; // Otherwise we add the effect and return true.
             }
-            if( size == creature_size::huge && !vp.part_with_feature( "AISLE", true ) &&
-                !vp.part_with_feature( "HUGE_OK", true ) ) {
+            if( size == creature_size::huge && !vp.part_with_feature( "AISLE", false ) &&
+                !vp.part_with_feature( "HUGE_OK", false ) ) {
                 critter.add_effect( effect_cramped_space, 2_turns, true );
                 return true; // Sufficiently gigantic creatures have trouble in stock seats, roof or no.
             }

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -175,11 +175,12 @@ bool monster::monster_move_in_vehicle( const tripoint &p ) const
         vehicle &veh = vp->vehicle();
         units::volume capacity = 0_ml;
         units::volume free_cargo = 0_ml;
-        auto cargo_parts = veh.get_parts_at( p, "CARGO", part_status_flag::any );
+        auto cargo_parts = veh.get_parts_at( p, "CARGO", part_status_flag::working );
         for( vehicle_part *&part : cargo_parts ) {
             vehicle_stack contents = veh.get_items( *part );
             const vpart_info &vpinfo = part->info();
-            if( !vp.part_with_feature( "CARGO_PASSABLE", true ) ) {
+            if( !vp.part_with_feature( "CARGO_PASSABLE", false ) &&
+                !vp.part_with_feature( "APPLIANCE", false ) && !vp.part_with_feature( "OBSTACLE", false ) ) {
                 capacity += vpinfo.size;
                 free_cargo += contents.free_volume();
             }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3355,7 +3355,7 @@ void monster::process_effects()
         for( vehicle_part *&part : cargo_parts ) {
             vehicle_stack contents = veh.get_items( *part );
             const vpart_info &vpinfo = part->info();
-            if( !vp.part_with_feature( "CARGO_PASSABLE", true ) ) {
+            if( !vp.part_with_feature( "CARGO_PASSABLE", false ) ) {
                 capacity += vpinfo.size;
                 free_cargo += contents.free_volume();
             }
@@ -3381,8 +3381,8 @@ void monster::process_effects()
                 return;
             }
         }
-        if( get_size() == creature_size::huge && !vp.part_with_feature( "AISLE", true ) &&
-            !vp.part_with_feature( "HUGE_OK", true ) ) {
+        if( get_size() == creature_size::huge && !vp.part_with_feature( "AISLE", false ) &&
+            !vp.part_with_feature( "HUGE_OK", false ) ) {
             if( !has_effect( effect_cramped_space ) ) {
                 add_effect( effect_cramped_space, 2_turns, true );
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix impassable broken vehicle parts"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
fixes #70555 
fixes #70564 

Vehicle part passability wasn't properly checking for whether certain parts were or were not broken when deciding whether to see if you could move through them. This was my fault!

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
The check for free cargo space is now bypassed if the part is broken (it can't hold anything if it's broken and shouldn't obstruct anyone based on its contents). The check for cargo_passable also still runs if the part is broken.

Also adjusts some vehicle part sizes that I missed.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
We could do more in-depth checks on broken parts. Right now they just get a pass as the game sets their capacity to 0 ml which skips the passability check. This allows IE a hulk to smash its way into a car without having to completely delete the tile, though said hulk will still get the cramped space debuff since it's huge. The bucket seat is no longer obstructing the space, but you're still cramming yourself in a too-small vehicle. IMO that makes enough sense that we shouldn't worry about it, but it could be made more granular in the future if desired.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
- Stepped on an empty cargo tile.
- Stepped on a broken cargo tile.
- Put a body in a cargo tile, and became unable to step there.
- Stepped on a broken door.
- Stepped on a working door.
- Spawned a zombie and had it do the same.
- Checked that the special case penalties for huge creatures being in vehicles still applied properly in broken parts.
- Checked that inflatable boats are usable again.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
