### PR TITLE
more and better zed miner drops

### DIFF
--- a/data/json/monsterdrops/zombie_technician.json
+++ b/data/json/monsterdrops/zombie_technician.json
@@ -15,16 +15,84 @@
     ]
   },
   {
+    "id": "worker_kitted_hard_hat",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "item": "attachable_ear_muffs", "damage": [ 1, 3 ], "prob": 50 },
+      {
+        "distribution": [ { "item": "nape_protector", "damage": [ 1, 3 ] }, { "item": "mesh_nape_protector", "damage": [ 1, 3 ] } ],
+        "prob": 60
+      },
+      {
+        "distribution": [
+          { "item": "shield_visor", "damage": [ 1, 3 ] },
+          { "item": "face_shield", "damage": [ 1, 3 ] },
+          { "item": "face_shield_plastic", "damage": [ 1, 3 ] }
+        ],
+        "prob": 60
+      }
+    ]
+  },
+  {
     "id": "mon_zombie_miner_death_drops",
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "group": "clothing_work_boots", "damage": [ 1, 4 ] },
+      { "group": "clothing_work_boots", "prob": 60, "damage": [ 1, 4 ] },
       { "group": "clothing_work_glasses", "prob": 60, "damage": [ 1, 4 ] },
-      { "group": "clothing_work_gloves", "prob": 75, "damage": [ 1, 4 ] },
+      { "group": "clothing_work_gloves", "prob": 50, "damage": [ 1, 4 ] },
       { "group": "clothing_work_mask", "prob": 40, "damage": [ 1, 4 ] },
-      { "item": "ear_plugs", "prob": 15, "damage": [ 1, 4 ] },
+      { "group": "default_zombie_items_pockets", "prob": 80, "damage": [ 0, 2 ] },
       { "item": "tool_belt", "prob": 25, "damage": [ 1, 4 ] },
+      {
+        "distribution": [ { "item": "pickaxe", "prob": 10, "damage": [ 1, 3 ] }, { "item": "shovel", "prob": 50, "damage": [ 1, 3 ] } ],
+        "prob": 40
+      },
+      {
+        "distribution": [
+          {
+            "collection": [
+              {
+                "distribution": [
+                  { "item": "hat_hard", "variant": "yellow_hat_hard", "damage": [ 1, 3 ], "contents-group": "worker_kitted_hard_hat" },
+                  {
+                    "item": "hat_hard",
+                    "variant": "green_hat_hard",
+                    "damage": [ 1, 3 ],
+                    "prob": 10,
+                    "contents-group": "worker_kitted_hard_hat"
+                  },
+                  {
+                    "collection": [
+                      { "item": "hat_hard", "variant": "white_hat_hard", "damage": [ 1, 3 ], "contents-group": "worker_kitted_hard_hat" },
+                      {
+                        "distribution": [ { "group": "used_1st_aid", "prob": 70 }, { "group": "full_1st_aid", "prob": 30 } ]
+                      }
+                    ],
+                    "prob": 5
+                  }
+                ]
+              },
+              {
+                "distribution": [
+                  { "item": "ear_plugs", "prob": 15, "damage": [ 1, 4 ] },
+                  { "group": "tools_lighting_industrial", "damage": [ 1, 3 ] },
+                  { "item": "electric_lantern", "charges": [ 0, 100 ], "damage": [ 1, 3 ] }
+                ]
+              }
+            ]
+          },
+          {
+            "item": "miner_hat",
+            "charges": [ 50, 100 ],
+            "damage": [ 1, 4 ],
+            "contents-group": "worker_kitted_hard_hat"
+          }
+        ]
+      },
+      { "item": "glowstick", "prob": 30, "count": [ 1, 3 ], "charges": 1400 },
+      { "item": "multitool", "prob": 10 },
       {
         "distribution": [
           {
@@ -35,8 +103,7 @@
           { "item": "technician_coveralls_h", "prob": 10, "damage": [ 1, 4 ] }
         ]
       },
-      { "group": "underwear", "damage": [ 1, 4 ] },
-      { "item": "miner_hat", "prob": 90, "damage": [ 1, 4 ] }
+      { "group": "underwear", "damage": [ 1, 4 ] }
     ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I dislike zombie miners cause they don't have anything on them, never.

give them more drops, tools like shovels and pickaxes, pocket trash, custom hard hats, lighting tools - more things for them in general, increase probs here and there

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
some samples
![Screenshot from 2023-12-31 21-46-17](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/8176e027-cb23-47eb-987a-45dc0e2a1681)
![Screenshot from 2023-12-31 21-47-29](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/2d87333d-9f13-459c-b6b1-b27ead3b6607)
![Screenshot from 2023-12-31 21-48-10](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/3cd42099-e1fe-40dc-b37b-4451a4eec737)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
there's a little detail to do with colors
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
