### PR TITLE
fix performance of the map view after reading a map

### DIFF
--- a/src/character.h
+++ b/src/character.h
@@ -1657,7 +1657,7 @@ class Character : public Creature, public visitable
         // route for overmap-scale traveling
         std::vector<tripoint_abs_omt> omt_path;
         // Container of OMTs to highlight as having been revealed
-        std::vector<tripoint_abs_omt> map_revealed_omts;
+        std::unordered_set<tripoint_abs_omt> map_revealed_omts;
         bool is_using_bionic_weapon() const;
         bionic_uid get_weapon_bionic_uid() const;
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -1193,7 +1193,7 @@ void reveal_map_actor::reveal_targets( const tripoint_abs_omt &center,
     for( const tripoint_abs_omt &place : places ) {
         overmap_buffer.reveal( place, reveal_distance );
         // Should be replaced with the character using the item passed as an argument if NPCs ever learn to use maps
-        get_avatar().map_revealed_omts.emplace_back( place );
+        get_avatar().map_revealed_omts.emplace( place );
     }
 }
 

--- a/src/overmap_ui.cpp
+++ b/src/overmap_ui.cpp
@@ -646,8 +646,7 @@ static void draw_ascii(
         size_t count = 0;
     };
     std::unordered_set<tripoint_abs_omt> npc_path_route;
-    std::unordered_set<tripoint_abs_omt> newly_revealed( player_character.map_revealed_omts.begin(),
-            player_character.map_revealed_omts.end() )  ;
+    std::unordered_set<tripoint_abs_omt> &revealed_highlights = get_avatar().map_revealed_omts;
     std::unordered_map<point_abs_omt, int> player_path_route;
     std::unordered_map<tripoint_abs_omt, npc_coloring> npc_color;
     auto npcs_near_player = overmap_buffer.get_npcs_near_player( sight_points );
@@ -786,8 +785,8 @@ static void draw_ascii(
                 ter_color = c_red;
                 ter_sym = "!";
             } else if( blink && show_map_revealed &&
-                       newly_revealed.find( omp ) != newly_revealed.end() ) {
-                // Revealed maps
+                       revealed_highlights.find( omp ) != revealed_highlights.end() ) {
+                // Revealed map tiles
                 ter_color = c_magenta;
                 ter_sym = "&";
             } else if( blink && showhordes &&

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -880,6 +880,7 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                              100;
     const bool showhordes = uistate.overmap_show_hordes;
     const bool show_map_revealed = uistate.overmap_show_revealed_omts;
+    std::unordered_set<tripoint_abs_omt> &revealed_highlights = get_avatar().map_revealed_omts;
     const bool viewing_weather = uistate.overmap_debug_weather || uistate.overmap_visible_weather;
     o = origin.raw().xy();
 
@@ -925,10 +926,11 @@ void cata_tiles::draw_om( const point &dest, const tripoint_abs_omt &center_abs_
                                      0, 0, ll, false );
             }
 
-            std::vector<tripoint_abs_omt> &revealed_highlights = get_avatar().map_revealed_omts;
-            auto it = std::find( revealed_highlights.begin(), revealed_highlights.end(), omp );
-            if( blink && show_map_revealed && it != revealed_highlights.end() ) {
-                draw_from_id_string( "highlight", omp.raw(), 0, 0, lit_level::LIT, false );
+            if( blink && show_map_revealed ) {
+                auto it = revealed_highlights.find( omp );
+                if( it != revealed_highlights.end() ) {
+                    draw_from_id_string( "highlight", omp.raw(), 0, 0, lit_level::LIT, false );
+                }
             }
 
             if( see ) {


### PR DESCRIPTION
#### Summary
Performance "fix performance of map view after reading a map"

#### Purpose of change
When you read a map, we now keep track of what overmap tiles the map revealed to you, so that we can blink them in the map view. Unfortunately the initial implementation of this feature turned out to be rather slow.

#### Describe the solution
I’ve changed it from a vector of coordinates to an unordered_set, so that membership testing is O(1), greatly improving performance.

fixes #70540