### PR TITLE
Prevent segfault on unload_activity_actor

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -3204,8 +3204,11 @@ void unload_activity_actor::start( player_activity &act, Character & )
 
 void unload_activity_actor::finish( player_activity &act, Character &who )
 {
+    // Need to copy `target` here because `::unload` is static and `this` might be invalidated
+    // after `act.set_to_null()` has been called (so `this.target` might also be invalidated)
+    item_location target_copy = target;
     act.set_to_null();
-    unload( who, target );
+    unload( who, target_copy );
 }
 
 void unload_activity_actor::unload( Character &who, item_location &target )


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Prevent segfault on unload_activity_actor"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

* Prevents segfault that previously happened when pouring liquid to ground from AIM using "examine" menu.
* Fixes #70559 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Previous segfault being fixed:
```
 #0  __gnu_cxx::__atomic_add_dispatch () at /usr/include/c++/13/ext/atomicity.h:111
 #1  std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_add_ref_copy () at /usr/include/c++/13/bits/shared_ptr_base.h:152
 #2  0x00005652b2df5540 in std::shared_ptr<item_location::impl>::shared_ptr () at /usr/include/c++/13/bits/shared_ptr.h:204
 #3  item_location::item_location () at src/item_location.h:30
 #4  item_location::impl::item_in_container::item_in_container () at src/item_location.cpp:612
 #5  item_location::item_location () at src/item_location.cpp:767
 #6  0x00005652b27fa6b1 in unload_activity_actor::unload () at src/activity_actor.cpp:3232
 #7  0x00005652b32eed69 in player_activity::do_turn () at src/player_activity.cpp:383
 #8  0x00005652b2b553e7 in do_turn () at src/do_turn.cpp:487
 #9  0x00005652b25ea589 in main () at src/main.cpp:798
```

The problem before was that the reference to `target` in `unload_activity_actor::unload` was an invalid reference. This was caused by:
1. `unload_activity_actor::finish` calls `act.set_to_null()`.
2. That sets the player activity to `null` type (=no current activity)
3. `unload_activity_actor::unload` is `static`, and takes `target` as a reference.
4. `::unload` calls `Character::add_or_drop_with_msg` which leads to call chain: `liquid_handler::consume_liquid` -> `get_liquid_target` -> `choose_adjacent` -> `choose_direction` -> `temp_hide_advanced_inv` -> `advanced_inventory::temp_hide` -> `advanced_inventory::do_return_entry`
5. `advanced_inventory::do_return_entry` assigns a new `ACT_ADV_INVENTORY` activity. This invalidates the previous `unload_activity_actor` because of pt 2 above.
6. When static method `unload_activity_actor::unload` resumes after its call to `add_or_drop_with_msg`, the reference to `target` is invalid because of pt 5.

This commit attempt to fix the issue with invalidated `target` reference by copying its value before invalidating the activity.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Loaded savegame from #70559 . The specified steps now no longer cause a segfault.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
