### PR TITLE
Remove an unused data member

### DIFF
--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -333,7 +333,6 @@ struct connect_group {
         std::set<ter_furn_flag> connects_to_flags;
         std::set<ter_furn_flag> rotates_to_flags;
 
-        bool was_loaded;
         static void load( const JsonObject &jo );
         static void reset();
 };

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -207,8 +207,8 @@ bool monster::monster_move_in_vehicle( const tripoint &p ) const
                     return false; // Return false if there's just no room whatsoever. Anything over 850 liters will simply never fit in a vehicle part that isn't specifically made for it.
                     // I'm sorry but you can't let a kaiju ride shotgun.
                 }
-                if( ( type->bodytype == "snake" || type->bodytype == "blob" || type->bodytype == "fish" ||
-                      has_flag( mon_flag_PLASTIC ) || has_flag( mon_flag_SMALL_HIDER ) ) ) {
+                if( type->bodytype == "snake" || type->bodytype == "blob" || type->bodytype == "fish" ||
+                    has_flag( mon_flag_PLASTIC ) || has_flag( mon_flag_SMALL_HIDER ) ) {
                     return true; // Return true if we're wiggly enough to be fine with cramped space.
                 }
                 critter.add_effect( effect_cramped_space, 2_turns, true );

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -651,7 +651,7 @@ void monster::refill_udders()
         // already full up
         return;
     }
-    if( ( !has_flag( mon_flag_EATS ) || has_effect( effect_critter_well_fed ) ) ) {
+    if( !has_flag( mon_flag_EATS ) || has_effect( effect_critter_well_fed ) ) {
         if( calendar::turn - udder_timer > 1_days ) {
             // You milk once a day. Monsters with the EATS flag need to be well fed or they won't refill their udders.
             ammo.begin()->second = type->starting_ammo.begin()->second;
@@ -3460,9 +3460,8 @@ bool monster::is_nether() const
 // The logic is If PSI_NULL, no -> If HAS_MIND, yes -> if ZOMBIE, no -> if HUMAN, yes -> else, no
 bool monster::has_mind() const
 {
-    return ( ( !in_species( species_PSI_NULL ) && has_flag( mon_flag_HAS_MIND ) ) ||
-             ( !in_species( species_PSI_NULL ) && !in_species( species_ZOMBIE ) &&
-               has_flag( mon_flag_HUMAN ) ) );
+    return !in_species( species_PSI_NULL ) && has_flag( mon_flag_HAS_MIND ) ||
+           !in_species( species_PSI_NULL ) && !in_species( species_ZOMBIE ) && has_flag( mon_flag_HUMAN );
 }
 
 field_type_id monster::bloodType() const

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3460,8 +3460,8 @@ bool monster::is_nether() const
 // The logic is If PSI_NULL, no -> If HAS_MIND, yes -> if ZOMBIE, no -> if HUMAN, yes -> else, no
 bool monster::has_mind() const
 {
-    return !in_species( species_PSI_NULL ) && has_flag( mon_flag_HAS_MIND ) ||
-           !in_species( species_PSI_NULL ) && !in_species( species_ZOMBIE ) && has_flag( mon_flag_HUMAN );
+    return ( !in_species( species_PSI_NULL ) && has_flag( mon_flag_HAS_MIND ) ) ||
+           ( !in_species( species_PSI_NULL ) && !in_species( species_ZOMBIE ) && has_flag( mon_flag_HUMAN ) );
 }
 
 field_type_id monster::bloodType() const


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

I wanted to use the [sanitizer](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fsanitize_003dundefined) to troubleshoot a different bug, but it crashes with an error "load of value 60, which is not a valid value for type 'bool'"

connect_group had bool a member called `was_loaded` and we forgot to initialize it in [`connect_group::load`](https://github.com/CleverRaven/Cataclysm-DDA/blob/641e7f003a784fd3439fbb5de4adc5efa60b07ce/src/mapdata.cpp#L286-L326)

I tried removing `was_loaded` - the game compiles fine without it. This means `was_loaded` was unused (unless we are using some very sneaky template magic somewhere).

#### Describe the solution

Remove the unused variable

#### Describe alternatives you've considered

Initialize `was_loaded` to `true`

#### Testing

The game compiles

#### TODO: open the next pull request *after* this one is merged
