### PR TITLE
[MoM] Add new telekinesis power--knockdown

### DIFF
--- a/data/mods/MindOverMatter/powers/telekinesis.json
+++ b/data/mods/MindOverMatter/powers/telekinesis.json
@@ -86,6 +86,59 @@
     "learn_spells": { "telekinetic_wave": 7, "telekinetic_hammer": 10, "telekinetic_strength": 13, "telekinetic_explosion": 15 }
   },
   {
+    "id": "telekinetic_slam_down",
+    "type": "SPELL",
+    "name": "[Ψ]Flatten",
+    "description": "Knock something down with a burst of telekinetic force, doing a small amount of damage and downing them.",
+    "message": "Your target is slammed to the ground.",
+    "teachable": false,
+    "valid_targets": [ "ally", "hostile", "ground" ],
+    "spell_class": "TELEKINETIC",
+    "skill": "metaphysics",
+    "flags": [ "PSIONIC", "CONCENTRATE", "RANDOM_DAMAGE", "NO_HANDS", "NO_LEGS", "NO_EXPLOSION_SFX" ],
+    "difficulty": 2,
+    "max_level": { "math": [ "int_to_level(1)" ] },
+    "effect": "attack",
+    "effect_str": "downed",
+    "extra_effects": [ { "id": "psionic_drained_difficulty_two", "hit_self": true } ],
+    "shape": "blast",
+    "damage_type": "psi_telekinetic_damage",
+    "min_damage": {
+      "math": [
+        "( (u_spell_level('telekinetic_slam_down') * 0.5) + 5) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "max_damage": {
+      "math": [
+        "( (u_spell_level('telekinetic_slam_down') * 1.2) + 15) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "min_duration": {
+      "math": [
+        "( (u_spell_level('telekinetic_slam_down') * 25) + 100) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "max_duration": {
+      "math": [
+        "( (u_spell_level('telekinetic_slam_down') * 95) + 400) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling"
+      ]
+    },
+    "min_range": {
+      "math": [
+        "min( (( (u_spell_level('telekinetic_slam_down') * 0.5) + 2) * (scaling_factor(u_val('intelligence') ) ) * u_nether_attunement_power_scaling), 40)"
+      ]
+    },
+    "max_range": 40,
+    "energy_source": "STAMINA",
+    "base_energy_cost": 2500,
+    "final_energy_cost": 850,
+    "energy_increment": -65,
+    "base_casting_time": 75,
+    "final_casting_time": 30,
+    "casting_time_increment": -3,
+    "ignored_monster_species": [ "PSI_NULL" ]
+  },
+  {
     "id": "telekinetic_momentum",
     "type": "SPELL",
     "name": "[Ψ]Momentum Alteration (C)",
@@ -305,13 +358,13 @@
     "spell_class": "TELEKINETIC",
     "skill": "metaphysics",
     "flags": [ "PSIONIC", "CONCENTRATE", "NO_PROJECTILE", "RANDOM_DAMAGE", "NO_HANDS", "NO_LEGS" ],
+    "difficulty": 5,
+    "max_level": { "math": [ "int_to_level(1)" ] },
     "extra_effects": [
       { "id": "tele_mindhammer_bash", "hit_self": false, "max_level": 20 },
       { "id": "psionic_drained_difficulty_five", "hit_self": true }
     ],
     "damage_type": "psi_telekinetic_damage",
-    "difficulty": 5,
-    "max_level": { "math": [ "int_to_level(1)" ] },
     "effect": "attack",
     "shape": "blast",
     "min_damage": {

--- a/data/mods/MindOverMatter/powers/telekinesis.json
+++ b/data/mods/MindOverMatter/powers/telekinesis.json
@@ -88,9 +88,9 @@
   {
     "id": "telekinetic_slam_down",
     "type": "SPELL",
-    "name": "[Ψ]Flatten",
-    "description": "Knock something down with a burst of telekinetic force, doing a small amount of damage and downing them.",
-    "message": "Your target is slammed to the ground.",
+    "name": "[Ψ]Knockdown",
+    "description": "Slam something to the ground with a burst of telekinetic force, doing a small amount of damage and downing them.",
+    "message": "Your target is knocked to the ground.",
     "teachable": false,
     "valid_targets": [ "ally", "hostile", "ground" ],
     "spell_class": "TELEKINETIC",

--- a/data/mods/MindOverMatter/recipes/practice/telekinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/telekinesis_practice.json
@@ -141,36 +141,15 @@
     "flags": [ "SECRET", "BLIND_HARD" ],
     "result_eocs": [
       {
-        "id": "EOC_PRACTICE_TELEKIN_PUSH",
-        "condition": {
-          "and": [
-            { "math": [ "u_spell_level('telekinetic_slam_down')", ">=", "1" ] },
-            { "math": [ "u_spell_exp('telekinetic_slam_down')", "<=", "(difficulty_two_contemplation(1))" ] }
-          ]
-        },
+        "id": "EOC_PRACTICE_TELEKIN_SLAM_DOWN",
+        "condition": { "math": [ "u_spell_level('telekinetic_slam_down')", ">=", "1" ] },
         "effect": [
           { "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge." },
           { "math": [ "u_spell_exp('telekinetic_slam_down')", "+=", "(contemplation_factor(1))" ] },
           { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 0,2 )" ] },
           { "math": [ "u_val('stored_kcal')", "-=", "psionics_contemplation_kcal_cost(2)" ] },
           { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
-        ],
-        "false_effect": {
-          "run_eocs": [
-            {
-              "id": "EOC_PRACTICE_TELEKIN_PUSH_FALSE",
-              "condition": { "math": [ "u_spell_level('telekinetic_slam_down')", ">=", "1" ] },
-              "effect": [
-                { "u_message": "Your knowledge of your powers is so deep that mere contemplation is of no further use to you." },
-                { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
-              ],
-              "false_effect": [
-                { "u_message": "Without even a basic understanding of the power, your meditation is nothing but idle musings." },
-                { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
-              ]
-            }
-          ]
-        }
+        ]
       }
     ]
   },

--- a/data/mods/MindOverMatter/recipes/practice/telekinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/telekinesis_practice.json
@@ -12,6 +12,7 @@
     "nested_category_data": [
       "practice_telekinetic_pull",
       "practice_telekinetic_push",
+      "practice_telekinetic_slam_down",
       "practice_telekinetic_momentum",
       "practice_telekinetic_slowfall",
       "practice_telekinetic_wave",
@@ -110,6 +111,55 @@
             {
               "id": "EOC_PRACTICE_TELEKIN_PUSH_FALSE",
               "condition": { "math": [ "u_spell_level('telekinetic_push')", ">=", "1" ] },
+              "effect": [
+                { "u_message": "Your knowledge of your powers is so deep that mere contemplation is of no further use to you." },
+                { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+              ],
+              "false_effect": [
+                { "u_message": "Without even a basic understanding of the power, your meditation is nothing but idle musings." },
+                { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  {
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "name": "contemplation: flatten",
+    "id": "practice_telekinetic_slam_down",
+    "description": "Contemplate your powers and improve your ability to knock your targets over.",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "metaphysics",
+    "difficulty": 1,
+    "time": "30 m",
+    "autolearn": false,
+    "tools": [ [ [ "matrix_crystal_drained", -1 ] ] ],
+    "flags": [ "SECRET", "BLIND_HARD" ],
+    "result_eocs": [
+      {
+        "id": "EOC_PRACTICE_TELEKIN_PUSH",
+        "condition": {
+          "and": [
+            { "math": [ "u_spell_level('telekinetic_slam_down')", ">=", "1" ] },
+            { "math": [ "u_spell_exp('telekinetic_slam_down')", "<=", "(difficulty_two_contemplation(1))" ] }
+          ]
+        },
+        "effect": [
+          { "u_message": "You spend some time meditating and contemplating your powers and emerge with new knowledge." },
+          { "math": [ "u_spell_exp('telekinetic_slam_down')", "+=", "(contemplation_factor(1))" ] },
+          { "math": [ "u_vitamin('vitamin_psionic_drain')", "+=", "rng( 0,2 )" ] },
+          { "math": [ "u_val('stored_kcal')", "-=", "psionics_contemplation_kcal_cost(2)" ] },
+          { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }
+        ],
+        "false_effect": {
+          "run_eocs": [
+            {
+              "id": "EOC_PRACTICE_TELEKIN_PUSH_FALSE",
+              "condition": { "math": [ "u_spell_level('telekinetic_slam_down')", ">=", "1" ] },
               "effect": [
                 { "u_message": "Your knowledge of your powers is so deep that mere contemplation is of no further use to you." },
                 { "run_eocs": "EOC_PSI_PRACTICE_FOCUS_MOD" }

--- a/data/mods/MindOverMatter/recipes/practice/telekinesis_practice.json
+++ b/data/mods/MindOverMatter/recipes/practice/telekinesis_practice.json
@@ -128,7 +128,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "name": "contemplation: flatten",
+    "name": "contemplation: knockdown",
     "id": "practice_telekinetic_slam_down",
     "description": "Contemplate your powers and improve your ability to knock your targets over.",
     "category": "CC_*",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[MoM] Add new telekinesis power--knockdown"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Working on the telekinetic learning overhaul and thought of a new power, so I spun that off into this PR.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds the Knockdown power. Does a bit of damage and downs the target. That's it. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

The power works. It effectively allows you to lock down a single target while your stamina lasts, but I also learned that feral mechanics can bullseye you with thrown rocks even while prone, so good for them. 

Lack of route to learning it is intentional since telekinetic learning revamp is coming after teleportation
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
