### PR TITLE
Adds craftable crude & fancy monocles

### DIFF
--- a/data/json/items/armor/eyewear.json
+++ b/data/json/items/armor/eyewear.json
@@ -156,6 +156,124 @@
     "armor": [ { "coverage": 20, "covers": [ "eyes" ], "rigid_layer_only": true } ]
   },
   {
+    "id": "glasses_monocle_crude_concave",
+    "type": "ARMOR",
+    "name": { "str": "crude reading monocle" },
+    "//": "Handmade monocle. It's not pretty, but it gets the job done. Takes a long while to craft, and the heavy encumbrance partially simulates the flaws in the magnification. That said, simple optics are remarkably easy to make, dating back to at least the 14th century, and at most the 12th.",
+    "description": "A rather crude imitation of a monocle that just barely manages to help with reading, if you have no alternative. The large glass lens is difficult to keep in place, especially during moments of activity. It has a metal rim, supposedly to reduce worn discomfort.",
+    "weight": "32 g",
+    "volume": "15 ml",
+    "price": 500,
+    "price_postapoc": 25,
+    "to_hit": -2,
+    "material": [ "glass", "steel" ],
+    "symbol": "[",
+    "looks_like": "glasses_monocle",
+    "color": "cyan",
+    "material_thickness": 1,
+    "environmental_protection": 0,
+    "flags": [ "FIX_FARSIGHT", "FRAGILE", "SKINTIGHT", "TRANSPARENT", "NO_SALVAGE", "HARD" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "glass", "covered_by_mat": 100, "thickness": 0.5 },
+          { "type": "steel", "covered_by_mat": 2, "thickness": 0.2 }
+        ],
+        "covers": [ "eyes" ],
+        "coverage": 35,
+        "encumbrance": 18
+      }
+    ]
+  },
+  {
+    "id": "glasses_monocle_crude_convex",
+    "type": "ARMOR",
+    "copy-from": "glasses_monocle_crude_concave",
+    "name": { "str": "crude monocle" },
+    "description": "A rather crude imitation of a monocle, designed to be worn for as long as one needs the visual acuity, and not a second more.  The large glass lens is difficult to keep in place, especially during moments of activity. It has a metal rim, supposedly to reduce worn discomfort.",
+    "flags": [ "FIX_NEARSIGHT", "FRAGILE", "SKINTIGHT", "TRANSPARENT", "NO_SALVAGE", "HARD" ]
+  },
+  {
+    "id": "glasses_monocle_polished_concave",
+    "type": "ARMOR",
+    "//": "Handmade monocle. It's pretty and gets the job done. Less encumbering and more comfortable due to the care and effort put into it.",
+    "copy-from": "glasses_monocle_crude_concave",
+    "name": { "str": "hand-crafted reading monocle" },
+    "description": "While this is still clearly a hand-crafted monocle, the quality is actually rather decent. with noticeable effort put towards the comfort of the user. It has a very fancy metal rim, alongside a chain that connects to your clothes.  Perfect for reading literary classics or advanced technical manuals on an armchair, next to a fireplace.",
+    "weight": "16 g",
+    "volume": "5 ml",
+    "price": 2500,
+    "price_postapoc": 250,
+    "material": [ "glass", "gold" ],
+    "color": "yellow",
+    "flags": [ "SUPER_FANCY", "FIX_FARSIGHT", "FRAGILE", "SKINTIGHT", "TRANSPARENT", "NO_SALVAGE" ],
+    "armor": [
+      {
+        "material": [
+          { "type": "glass", "covered_by_mat": 100, "thickness": 0.25 },
+          { "type": "gold", "covered_by_mat": 5, "thickness": 0.15 }
+        ],
+        "covers": [ "eyes" ],
+        "coverage": 25,
+        "encumbrance": 10
+      }
+    ],
+    "use_action": {
+      "type": "transform",
+      "msg": "You take the monocle off, allowing it to hang loosely on your clothing.",
+      "target": "glasses_monocle_polished_concave_loose",
+      "menu_text": "Hang loose",
+      "need_worn": true
+    }
+  },
+  {
+    "id": "glasses_monocle_polished_concave_loose",
+    "type": "ARMOR",
+    "name": { "str": "hand-crafted reading monocle (loose)" },
+    "looks_like": "",
+    "copy-from": "glasses_monocle_polished_concave",
+    "use_action": {
+      "type": "transform",
+      "msg": "You put the monocle back on.",
+      "target": "glasses_monocle_polished_concave",
+      "menu_text": "Wear",
+      "need_worn": true
+    },
+    "flags": [ "FANCY", "FRAGILE", "TRANSPARENT", "NO_SALVAGE" ],
+    "//": "You can still keep the monocle around your clothing as a fashion statement, but it won't be as impressive.",
+    "armor": [  ],
+    "//2": "No coverage."
+  },
+  {
+    "id": "glasses_monocle_polished_convex",
+    "type": "ARMOR",
+    "copy-from": "glasses_monocle_polished_concave",
+    "name": { "str": "hand-crafted monocle" },
+    "description": "While this is still clearly a hand-crafted monocle, the quality is actually rather decent. with noticeable effort put towards the comfort of the user. It has a very fancy metal rim, alongside a chain that connects to your clothes. Perfect for hunting the most dangerous game of all.",
+    "flags": [ "SUPER_FANCY", "FIX_NEARSIGHT", "FRAGILE", "SKINTIGHT", "TRANSPARENT", "NO_SALVAGE" ],
+    "use_action": {
+      "type": "transform",
+      "msg": "You take the monocle off, allowing it to hang loosely on your clothing.",
+      "target": "glasses_monocle_polished_convex_loose",
+      "menu_text": "Hang loose",
+      "need_worn": true
+    }
+  },
+  {
+    "id": "glasses_monocle_polished_convex_loose",
+    "type": "ARMOR",
+    "name": { "str": "hand-crafted monocle (loose)" },
+    "description": "While this is still clearly a hand-crafted monocle, the quality is actually rather decent. with noticeable effort put towards the comfort of the user. It has a very fancy metal rim, alongside a chain that connects to your clothes. Perfect for hunting the most dangerous game of all.",
+    "copy-from": "glasses_monocle_polished_concave_loose",
+    "use_action": {
+      "type": "transform",
+      "msg": "You put the monocle back on.",
+      "target": "glasses_monocle_polished_convex",
+      "menu_text": "Wear",
+      "need_worn": true
+    }
+  },
+  {
     "id": "glasses_reading",
     "type": "ARMOR",
     "name": { "str": "pair of reading glasses", "str_pl": "pairs of reading glasses" },

--- a/data/json/items/armor/eyewear.json
+++ b/data/json/items/armor/eyewear.json
@@ -160,7 +160,7 @@
     "type": "ARMOR",
     "name": { "str": "crude reading monocle" },
     "//": "Handmade monocle. It's not pretty, but it gets the job done. Takes a long while to craft, and the heavy encumbrance partially simulates the flaws in the magnification. That said, simple optics are remarkably easy to make, dating back to at least the 14th century, and at most the 12th.",
-    "description": "A rather crude imitation of a monocle that just barely manages to help with reading, if you have no alternative. The large glass lens is difficult to keep in place, especially during moments of activity. It has a metal rim, supposedly to reduce worn discomfort.",
+    "description": "A rather crude imitation of a monocle that just barely manages to help with reading, if you have no alternative.  The large glass lens is difficult to keep in place, especially during moments of activity.  It has a metal rim, supposedly to reduce worn discomfort.",
     "weight": "32 g",
     "volume": "15 ml",
     "price": 500,
@@ -190,7 +190,7 @@
     "type": "ARMOR",
     "copy-from": "glasses_monocle_crude_concave",
     "name": { "str": "crude monocle" },
-    "description": "A rather crude imitation of a monocle, designed to be worn for as long as one needs the visual acuity, and not a second more.  The large glass lens is difficult to keep in place, especially during moments of activity. It has a metal rim, supposedly to reduce worn discomfort.",
+    "description": "A rather crude imitation of a monocle, designed to be worn for as long as one needs the visual acuity, and not a second more.  The large glass lens is difficult to keep in place, especially during moments of activity.  It has a metal rim, supposedly to reduce worn discomfort.",
     "flags": [ "FIX_NEARSIGHT", "FRAGILE", "SKINTIGHT", "TRANSPARENT", "NO_SALVAGE", "HARD" ]
   },
   {
@@ -199,7 +199,7 @@
     "//": "Handmade monocle. It's pretty and gets the job done. Less encumbering and more comfortable due to the care and effort put into it.",
     "copy-from": "glasses_monocle_crude_concave",
     "name": { "str": "hand-crafted reading monocle" },
-    "description": "While this is still clearly a hand-crafted monocle, the quality is actually rather decent. with noticeable effort put towards the comfort of the user. It has a very fancy metal rim, alongside a chain that connects to your clothes.  Perfect for reading literary classics or advanced technical manuals on an armchair, next to a fireplace.",
+    "description": "While this is still clearly a hand-crafted monocle, the quality is actually rather decent.  with noticeable effort put towards the comfort of the user.  It has a very fancy metal rim, alongside a chain that connects to your clothes.  Perfect for reading literary classics or advanced technical manuals on an armchair, next to a fireplace.",
     "weight": "16 g",
     "volume": "5 ml",
     "price": 2500,
@@ -249,7 +249,7 @@
     "type": "ARMOR",
     "copy-from": "glasses_monocle_polished_concave",
     "name": { "str": "hand-crafted monocle" },
-    "description": "While this is still clearly a hand-crafted monocle, the quality is actually rather decent. with noticeable effort put towards the comfort of the user. It has a very fancy metal rim, alongside a chain that connects to your clothes. Perfect for hunting the most dangerous game of all.",
+    "description": "While this is still clearly a hand-crafted monocle, the quality is actually rather decent, with noticeable effort put towards the comfort of the user.  It has a very fancy metal rim, alongside a chain that connects to your clothes.  Perfect for hunting the most dangerous game of all.",
     "flags": [ "SUPER_FANCY", "FIX_NEARSIGHT", "FRAGILE", "SKINTIGHT", "TRANSPARENT", "NO_SALVAGE" ],
     "use_action": {
       "type": "transform",
@@ -263,7 +263,7 @@
     "id": "glasses_monocle_polished_convex_loose",
     "type": "ARMOR",
     "name": { "str": "hand-crafted monocle (loose)" },
-    "description": "While this is still clearly a hand-crafted monocle, the quality is actually rather decent. with noticeable effort put towards the comfort of the user. It has a very fancy metal rim, alongside a chain that connects to your clothes. Perfect for hunting the most dangerous game of all.",
+    "description": "While this is still clearly a hand-crafted monocle, the quality is actually rather decent, with noticeable effort put towards the comfort of the user.  It has a very fancy metal rim, alongside a chain that connects to your clothes.  Perfect for hunting the most dangerous game of all.",
     "copy-from": "glasses_monocle_polished_concave_loose",
     "use_action": {
       "type": "transform",

--- a/data/json/items/armor/eyewear.json
+++ b/data/json/items/armor/eyewear.json
@@ -229,7 +229,7 @@
   {
     "id": "glasses_monocle_polished_concave_loose",
     "type": "ARMOR",
-    "name": { "str": "hand-crafted reading monocle (loose)" },
+    "name": { "str": "hand-crafted reading monocle (loose)", "str_pl": "hand-crafted reading monocles (loose)" },
     "looks_like": "",
     "copy-from": "glasses_monocle_polished_concave",
     "use_action": {
@@ -262,7 +262,7 @@
   {
     "id": "glasses_monocle_polished_convex_loose",
     "type": "ARMOR",
-    "name": { "str": "hand-crafted monocle (loose)" },
+    "name": { "str": "hand-crafted monocle (loose)", "str_pl": "hand-crafted monocles (loose)" },
     "description": "While this is still clearly a hand-crafted monocle, the quality is actually rather decent, with noticeable effort put towards the comfort of the user.  It has a very fancy metal rim, alongside a chain that connects to your clothes.  Perfect for hunting the most dangerous game of all.",
     "copy-from": "glasses_monocle_polished_concave_loose",
     "use_action": {

--- a/data/json/recipes/armor/head.json
+++ b/data/json/recipes/armor/head.json
@@ -305,6 +305,79 @@
     "proficiencies": [ { "proficiency": "prof_glassblowing" }, { "proficiency": "prof_leatherworking_basic" } ]
   },
   {
+    "result": "glasses_monocle_crude_concave",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HEAD",
+    "skill_used": "fabrication",
+    "difficulty": 4,
+    "time": "6 h",
+    "autolearn": true,
+    "tools": [
+      [ [ "metalworking_tongs", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
+      [ [ "sheet_metal", -1 ], [ "sheet_metal_small", -1 ] ],
+      [ [ "forge", 25 ] ]
+    ],
+    "components": [
+      [ [ "lens", 1 ], [ "lens_small", 2 ], [ "lens_crude", 5 ] ],
+      [ [ "lead", 2 ], [ "copper", 2 ], [ "scrap", 2 ], [ "scrap_bronze", 2 ], [ "wire", 1 ] ]
+    ],
+    "byproducts": [ [ "glass_shard", 1 ] ],
+    "//": "The 5 crude lensi are for repeatedly trying until one gets a decent lens. Also where the shards come from.",
+    "proficiencies": [ { "proficiency": "prof_glassblowing" }, { "proficiency": "prof_metalworking" } ]
+  },
+  {
+    "result": "glasses_monocle_crude_convex",
+    "type": "recipe",
+    "tools": [
+      [ [ "metalworking_tongs", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
+      [ [ "sheet_metal", -1 ], [ "sheet_metal_small", -1 ] ],
+      [ [ "forge", 25 ] ]
+    ],
+    "components": [
+      [ [ "lens", 1 ], [ "lens_small", 2 ], [ "lens_crude", 5 ] ],
+      [ [ "lead", 2 ], [ "copper", 2 ], [ "scrap", 2 ], [ "scrap_bronze", 2 ], [ "wire", 1 ] ]
+    ],
+    "copy-from": "glasses_monocle_crude_concave"
+  },
+  {
+    "result": "glasses_monocle_polished_concave",
+    "type": "recipe",
+    "copy-from": "glasses_monocle_crude_concave",
+    "difficulty": 8,
+    "time": "18 h",
+    "tools": [
+      [ [ "metalworking_tongs", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
+      [ [ "sheet_metal", -1 ], [ "sheet_metal_small", -1 ] ],
+      [ [ "forge", 75 ] ]
+    ],
+    "components": [
+      [ [ "cordage", 1, "LIST" ], [ "wire", 1 ] ],
+      [ [ "lens", 1 ], [ "lens_small", 2 ], [ "lens_crude", 10 ] ],
+      [ [ "gold_small", 2 ], [ "silver_small", 2 ], [ "platinum_small", 2 ], [ "wire", 1 ] ]
+    ]
+  },
+  {
+    "result": "glasses_monocle_polished_convex",
+    "type": "recipe",
+    "tools": [
+      [ [ "metalworking_tongs", -1 ] ],
+      [ [ "crucible", -1 ], [ "crucible_clay", -1 ] ],
+      [ [ "sheet_metal", -1 ], [ "sheet_metal_small", -1 ] ],
+      [ [ "forge", 75 ] ]
+    ],
+    "components": [
+      [ [ "cordage", 1, "LIST" ], [ "wire", 1 ] ],
+      [ [ "lens", 1 ], [ "lens_small", 2 ], [ "lens_crude", 10 ] ],
+      [ [ "gold_small", 2 ], [ "silver_small", 2 ], [ "platinum_small", 2 ], [ "wire", 1 ] ]
+    ],
+    "copy-from": "glasses_monocle_polished_concave"
+  },
+  {
     "result": "goggles_swim",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -7097,5 +7097,22 @@
       "qt_esbi_plate"
     ],
     "difficulty": 5
+  },
+  {
+    "id": "nested_monocles",
+    "type": "nested_category",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_HEAD",
+    "name": "monocles",
+    "description": "Recipes related to the construction of handmade monocles.",
+    "skill_used": "fabrication",
+    "nested_category_data": [
+      "glasses_monocle_polished_convex",
+      "glasses_monocle_polished_concave",
+      "glasses_monocle_crude_convex",
+      "glasses_monocle_crude_concave"
+    ],
+    "difficulty": 5
   }
 ]

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -1930,6 +1930,8 @@ monicked
 monocrystalline
 monomeric
 monomolecular
+monocle
+monocles
 moonflower
 moonflowers
 moorhen


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Adds craftable crude & fancy monocles"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Adds a way to create monocles, and a way to create lens for x-sighted traits. Adds an use for crude lens.

The biggest reason for this PR is to give Innawoods characters the ability to mend their sight problems. However, there's no reason this can't apply to the basegame as well, as it contains some unique content that doesn't have true alternatives.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

There's two types of monocles this PR adds.
- Crude monocles, which are large, uncomfortable, very bulky. They help you read things, or be on the lookout for targets, but when doing anything important you'll probably want to be rid of them ASAP.
- Handcrafted monocles, which are similar to the above, but much more comfortable and less encumbering. They even have a chain so you can easily take them on and off! Of course that also means they're harder to get.

Crude monocles require level four fabrication at least, what I see as 'journeyman' glassblowing skill. (If there's a way to unlock recipes with proficiencies let me know!). They take six hours to make, and a lot more if you count the crude lens' crafting time as well. I think that means something like 10 hours total but I'm typing this in gitlens and don't want to change git tabs in case that wipes my description (it has happened before)
Handcrafted monocles are medieval or early industrial aristocrat tier, the kind of work a master glassblower could make. Thus, they're locked behind level 7, take 34 hours (10 with the crude lens craft time) to make. They're immaculately fine, with a beautiful 'fanciful metal' rim, and a string or wire to hook onto clothing when not in use.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Making this an Innawoods only recipe. Decided not to because this is interesting as a base-game thing as well. Especially if you consider the possiblity of the handcrafted monocle being displayed on museums, pawn shops, etc. as a historical artefact.

Just making the base monocle craftable. Decided not to because, while it's very much possible to make a basic lens by hand, you're not going to make a modern monocle by hand, not one that's so convenient to wear.

Only having one craftable monocle. Decided not to because I like the idea of a rudimentary survival lens on one hand and a finely crafted 'best we're gonna get' monocle.

Bifocal monocles. Decided not to because that's 1. overcomplicating it (stylish bifocal transition monocles, anyone?), 2. damages the concept of these being lesser imitations of modern spectacles.

The monocles both come in concave and convex, AKA reading and, uh, normal (how do you refer to optical aids for the nearsighted generally??), AKA nearsighted and farsighted.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned myself in, spawned the monocles in. Ensured the recipes had proper requirements. Ensured the monocles worked properly. Ensured the handcrafted chains had no bugs when transforming the item. Ensured the sprite properly copied from monocles for tilesets (Thanks Guardian and Renech!)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

https://en.wikipedia.org/wiki/Glasses#History

> Robert Grosseteste's treatise De iride (On the Rainbow), written between 1220 and 1235, mentions using optics to "read the smallest letters at incredible distances".[23] A few years later in 1262, Roger Bacon is also known to have written on the magnifying properties of lenses.[24][25] The development of the first eyeglasses took place in northern Italy in the second half of the 13th century.[26]

Believe it or not, spectacles have been around in some way or another since the 13th century, at least. They're not impossible to make, as evidenced by two people creating them independently at around the same time. The quality will not be great, but that is already simulated here with the encumbrance.

I wanted to make the crude monocle uncomfortable, but the code prevents this by the HARD flag not doing anything, the c++ function limiting small and light items from being uncomfy, so I just decided not to bother.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
