### PR TITLE
Make mi-go 8x less likely to bark

### DIFF
--- a/data/json/speech.json
+++ b/data/json/speech.json
@@ -2456,79 +2456,13 @@
   },
   {
     "type": "speech",
-    "speaker": [ "mon_dog", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
-    "sound": "BARK!",
-    "volume": 40
-  },
-  {
-    "type": "speech",
-    "speaker": [ "mon_dog_bull", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
-    "sound": "BARK!",
-    "volume": 40
-  },
-  {
-    "type": "speech",
-    "speaker": [ "mon_dog_pitbullmix", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
-    "sound": "BARK!",
-    "volume": 40
-  },
-  {
-    "type": "speech",
-    "speaker": [ "mon_dog_beagle", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
-    "sound": "YAP!",
-    "volume": 30
-  },
-  {
-    "type": "speech",
-    "speaker": [ "mon_dog_bcollie", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
-    "sound": "BARK!",
-    "volume": 40
-  },
-  {
-    "type": "speech",
-    "speaker": [ "mon_dog_boxer", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
-    "sound": "BARK!",
-    "volume": 40
-  },
-  {
-    "type": "speech",
-    "speaker": [ "mon_dog_chihuahua", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
-    "sound": "YAP!",
-    "volume": 30
-  },
-  {
-    "type": "speech",
-    "speaker": [ "mon_dog_dachshund", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
-    "sound": "YAP!",
-    "volume": 30
-  },
-  {
-    "type": "speech",
-    "speaker": [ "mon_dog_gshepherd", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
-    "sound": "BARK!",
-    "volume": 40
-  },
-  {
-    "type": "speech",
-    "speaker": [ "mon_dog_gpyrenees", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
-    "sound": "WOOF!",
-    "volume": 40
-  },
-  {
-    "type": "speech",
-    "speaker": [ "mon_dog_rottweiler", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
-    "sound": "WOOF!",
-    "volume": 40
-  },
-  {
-    "type": "speech",
-    "speaker": [ "mon_dog_auscattle", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
-    "sound": "BARK!",
-    "volume": 40
-  },
-  {
-    "type": "speech",
     "speaker": [
+      "mon_dog",
+      "mon_dog_bull",
+      "mon_dog_pitbullmix",
+      "mon_dog_bcollie",
+      "mon_dog_boxer",
+      "mon_dog_auscattle",
       "mon_dog_samoyed",
       "mon_dog_mutant_mongrel",
       "mon_dog_mutant_loper",
@@ -2537,6 +2471,26 @@
       "mon_mi_go_myrmidon"
     ],
     "sound": "BARK!",
+    "volume": 40
+  },
+  {
+    "type": "speech",
+    "speaker": [
+      "mon_dog_beagle",
+      "mon_dog_chihuahua",
+      "mon_dog_dachshund",
+      "mon_dog_gshepherd",
+      "mon_mi_go",
+      "mon_mi_go_slaver",
+      "mon_mi_go_myrmidon"
+    ],
+    "sound": "YAP!",
+    "volume": 30
+  },
+  {
+    "type": "speech",
+    "speaker": [ "mon_dog_gpyrenees", "mon_dog_rottweiler", "mon_mi_go", "mon_mi_go_slaver", "mon_mi_go_myrmidon" ],
+    "sound": "WOOF!",
     "volume": 40
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Basically when there was no array support for the speaker field a BARK/WOOF/YAP entry was added for each dog, then in 
two later PRs when it was, peeps paying no attention added mi-gos as speakers to all of them resulting in migos barking alot

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Merges all the identical sounding dog noises

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Decided not to mess with the file any more than this bc I think it would benefit greatly from being reformatted #70645

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
