### PR TITLE
Move hobby randomization after set_body()

### DIFF
--- a/src/newcharacter.cpp
+++ b/src/newcharacter.cpp
@@ -453,7 +453,6 @@ void avatar::randomize( const bool random_scenario, bool play_now )
 
     prof = get_scenario()->weighted_random_profession();
     init_age = rng( this->prof->age_lower, this->prof->age_upper );
-    randomize_hobbies();
     starting_city = std::nullopt;
     world_origin = std::nullopt;
     random_start_location = true;
@@ -464,6 +463,7 @@ void avatar::randomize( const bool random_scenario, bool play_now )
     per_max = rng( 6, HIGH_STAT - 2 );
 
     set_body();
+    randomize_hobbies();
 
     int num_gtraits = 0;
     int num_btraits = 0;


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Fix #68211

#### Describe the solution

randomize hobbies after the body is populated instead of before

#### Testing

Used gdb to replace random values with the right values to trigger this bug -> the code no longer produces an error.
