### PR TITLE
Oops. We forgot the error code

### DIFF
--- a/src/flexbuffer_cache.cpp
+++ b/src/flexbuffer_cache.cpp
@@ -162,7 +162,7 @@ struct file_flexbuffer : parsed_flexbuffer {
 
         bool is_stale() const override {
             std::error_code ec;
-            fs::file_time_type mtime = fs::last_write_time( source_file_path_ );
+            fs::file_time_type mtime = fs::last_write_time( source_file_path_, ec );
             if( ec ) {
                 // Assume yes out of date.
                 return true;


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

This code *looks like* it meant to pass error_code to last_write_time, but forgot. Ping @akrieger Did I get this right?

#### Describe the solution

Add the missing argument

#### Testing

**None**