### PR TITLE
Add missing was_loaded initialization

### DIFF
--- a/src/profession_group.h
+++ b/src/profession_group.h
@@ -11,7 +11,7 @@ struct profession_group {
         void load( const JsonObject &jo, const std::string_view & );
         static const std::vector<profession_group> &get_all();
         static void check_profession_group_consistency();
-        bool was_loaded;
+        bool was_loaded = false;
 
         std::vector<profession_id> get_professions() const;
         profession_group_id get_id() const;

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -301,7 +301,7 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
     point_abs_omt origin;
     map &main_map = get_map();
 
-    for( const point_abs_omt &p : closest_points_first( origin, 0, 15 * OMAPX - 1 ) ) {
+    for( const point_abs_omt &p : closest_points_first( origin, 0, 10 * OMAPX - 1 ) ) {
         // We need to avoid OMTs that overlap with the 'main' map, so we start at a
         // non-zero minimum radius and ensure that the 'main' map is inside that
         // minimum radius.

--- a/tests/overmap_test.cpp
+++ b/tests/overmap_test.cpp
@@ -301,7 +301,7 @@ TEST_CASE( "overmap_terrain_coverage", "[overmap][slow]" )
     point_abs_omt origin;
     map &main_map = get_map();
 
-    for( const point_abs_omt &p : closest_points_first( origin, 0, 10 * OMAPX - 1 ) ) {
+    for( const point_abs_omt &p : closest_points_first( origin, 0, 15 * OMAPX - 1 ) ) {
         // We need to avoid OMTs that overlap with the 'main' map, so we start at a
         // non-zero minimum radius and ensure that the 'main' map is inside that
         // minimum radius.


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

We forgot to initialize was_loaded in profession_group

I found this bug thanks to UndefinedBehaviorSanitizer
```c++
src/profession_group.h:8:8: runtime error: load of value 60, which is not a valid value for type 'bool'
    #0 0x6fa4312 in profession_group::profession_group(profession_group const&) src/profession_group.h:8
    #1 0x6fb241e in void std::__new_allocator<profession_group>::construct<profession_group, profession_group const&>(profession_group*, profession_group const&) /usr/include/c++/13/bits/new_allocator.h:187
    #2 0x6fb241e in void std::allocator_traits<std::allocator<profession_group> >::construct<profession_group, profession_group const&>(std::allocator<profession_group>&, profession_group*, profession_group const&) /usr/include/c++/13/bits/alloc_traits.h:537
    #3 0x6fb241e in void std::vector<profession_group, std::allocator<profession_group> >::_M_realloc_insert<profession_group const&>(__gnu_cxx::__normal_iterator<profession_group*, std::vector<profession_group, std::allocator<profession_group> > >, profession_group const&) /usr/include/c++/13/bits/vector.tcc:468
    #4 0x6fb2911 in std::vector<profession_group, std::allocator<profession_group> >::push_back(profession_group const&) /usr/include/c++/13/bits/stl_vector.h:1289
    #5 0x6fb2c14 in generic_factory<profession_group>::insert(profession_group const&) src/generic_factory.h:391
    #6 0x6fb61a7 in generic_factory<profession_group>::load(JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) src/generic_factory.h:304
    #7 0x6fa0efd in profession_group::load_profession_group(JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) src/profession_group.cpp:25
    #8 0x4294940 in void std::__invoke_impl<void, void (*&)(JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(std::__invoke_other, void (*&)(JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /usr/include/c++/13/bits/invoke.h:61
    #9 0x4294976 in std::enable_if<is_invocable_r_v<void, void (*&)(JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>, void>::type std::__invoke_r<void, void (*&)(JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(void (*&)(JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /usr/include/c++/13/bits/invoke.h:111
    #10 0x4294976 in std::_Function_handler<void (JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&), void (*)(JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::_M_invoke(std::_Any_data const&, JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /usr/include/c++/13/bits/std_function.h:290
    #11 0x4290c79 in std::function<void (JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::operator()(JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const /usr/include/c++/13/bits/std_function.h:591
    #12 0x426934f in operator() src/init.cpp:227
    #13 0x426934f in __invoke_impl<void, DynamicDataLoader::add(const std::string&, const std::function<void(const JsonObject&, const std::__cxx11::basic_string<char>&)>&)::<lambda(const JsonObject&, const std::string&, const cata_path&, const cata_path&)>&, const JsonObject&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, const cata_path&, const cata_path&> /usr/include/c++/13/bits/invoke.h:61
    #14 0x426934f in __invoke_r<void, DynamicDataLoader::add(const std::string&, const std::function<void(const JsonObject&, const std::__cxx11::basic_string<char>&)>&)::<lambda(const JsonObject&, const std::string&, const cata_path&, const cata_path&)>&, const JsonObject&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, const cata_path&, const cata_path&> /usr/include/c++/13/bits/invoke.h:111
    #15 0x426934f in _M_invoke /usr/include/c++/13/bits/std_function.h:290
    #16 0x42904f3 in std::function<void (JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, cata_path const&, cata_path const&)>::operator()(JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, cata_path const&, cata_path const&) const /usr/include/c++/13/bits/std_function.h:591
    #17 0x4284949 in DynamicDataLoader::load_object(JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, cata_path const&, cata_path const&) src/init.cpp:137
    #18 0x4285c32 in DynamicDataLoader::load_all_from_json(JsonValue const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, loading_ui&, cata_path const&, cata_path const&) src/init.cpp:540
    #19 0x4286744 in DynamicDataLoader::load_data_from_path(cata_path const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, loading_ui&) src/init.cpp:521
    #20 0x3ca25fa in game::load_data_from_dir(cata_path const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, loading_ui&) src/game.cpp:571
    #21 0x3d21130 in game::load_packs(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<string_id<MOD_INFORMATION>, std::allocator<string_id<MOD_INFORMATION> > > const&, loading_ui&) src/game.cpp:3265
    #22 0x3d518b5 in game::load_world_modfiles(loading_ui&) src/game.cpp:3235
    #23 0x3e055d0 in game::setup() src/game.cpp:756
    #24 0x5111cc3 in main_menu::new_character_tab() src/main_menu.cpp:972
    #25 0x5127aea in main_menu::opening_screen() src/main_menu.cpp:863
    #26 0x50f1e5e in main src/main.cpp:792
    #27 0x7f7a489cfb89 in __libc_start_call_main (/lib64/libc.so.6+0x27b89) (BuildId: f888be5f5e7d58e04cabb8c675c7ab94e77dd68c)
    #28 0x7f7a489cfc4a in __libc_start_main_alias_2 (/lib64/libc.so.6+0x27c4a) (BuildId: f888be5f5e7d58e04cabb8c675c7ab94e77dd68c)
    #29 0x1bec804 in _start (/home/cdda/git/Cataclysm-DDA/cataclysm-tiles+0x1bec804) (BuildId: 1a0225eb0946b150a1f9b1759d512b53fde7f1d0)
```

#### Describe the solution

Initialize was_loaded in the struct definition. This appears to be consistent with what we usually do with was_loaded.

#### TODO: open the next pull request after this one is merged