### PR TITLE
Fixed special optional overmap field

### DIFF
--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -5,17 +5,14 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "motel_twd_1_north" },
       { "point": [ 1, 0, 0 ], "overmap": "motel_twd_2_north" },
+      { "point": [ 2, 0, 0 ], "locations": [ "forest" ] },
       { "point": [ 0, 0, 1 ], "overmap": "motel_twd_1_f1_north" },
       { "point": [ 1, 0, 1 ], "overmap": "motel_twd_2_f1_north" },
       { "point": [ 0, 0, 2 ], "overmap": "motel_twd_1_f2_north" }
     ],
-    "connections": [
-      { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ], "existing": true },
-      { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ], "existing": true }
-    ],
     "locations": [ "land" ],
     "city_distance": [ 8, 30 ],
-    "occurrences": [ 0, 2 ],
+    "occurrences": [ 10, 20 ],
     "flags": [ "CLASSIC", "MAN_MADE" ]
   },
   {

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -5,14 +5,17 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "motel_twd_1_north" },
       { "point": [ 1, 0, 0 ], "overmap": "motel_twd_2_north" },
-      { "point": [ 2, 0, 0 ], "locations": [ "forest" ] },
       { "point": [ 0, 0, 1 ], "overmap": "motel_twd_1_f1_north" },
       { "point": [ 1, 0, 1 ], "overmap": "motel_twd_2_f1_north" },
       { "point": [ 0, 0, 2 ], "overmap": "motel_twd_1_f2_north" }
     ],
+    "connections": [
+      { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ], "existing": true },
+      { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ], "existing": true }
+    ],
     "locations": [ "land" ],
     "city_distance": [ 8, 30 ],
-    "occurrences": [ 10, 20 ],
+    "occurrences": [ 0, 2 ],
     "flags": [ "CLASSIC", "MAN_MADE" ]
   },
   {

--- a/doc/OVERMAP.md
+++ b/doc/OVERMAP.md
@@ -439,11 +439,11 @@ Depending on the subtype, there are further relevant fields:
 
 ### Fixed special overmaps
 
-| Identifier  |                                Description                                 |
-| ----------- | -------------------------------------------------------------------------- |
-| `point`     | `[ x, y, z]` of the overmap terrain within the special.                    |
-| `overmap`   | Id of the `overmap_terrain` to place at the location.                      |
-| `locations` | List of `overmap_location` ids that this overmap terrain may be placed on. |
+| Identifier  |                                                                                      Description                                                                                           |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `point`     | `[ x, y, z]` of the overmap terrain within the special.                                                                                                                                    |
+| `overmap`   | Id of the `overmap_terrain` to place at the location. If ommited no overmap_terrain is placed but the point will still be checked for valid locations when deciding if placement is valid. |
+| `locations` | List of `overmap_location` ids that this overmap terrain may be placed on. Overrides the specials overall `locations` field.                                                               |
 
 ### Connections
 
@@ -453,7 +453,7 @@ Depending on the subtype, there are further relevant fields:
 | `terrain`    | Will go away in favor of `connection` eventually. Use `road`, `subway`, `sewer`, etc.              |
 | `connection` | Id of the `overmap_connection` to build. Optional for now, but you should specify it explicitly.   |
 | `from`       | Optional point `[ x, y, z]` within the special to treat as the origin of the connection.           |
-| `existing`   | Boolean, default false. If the special requires a preexisting terrain to spawn.				          	|
+| `existing`   | Boolean, default false. If the special requires a preexisting terrain to spawn.                    |
 
 ### Example mutable special
 

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1422,7 +1422,6 @@ struct fixed_overmap_special_data : overmap_special_data {
 
         for( const overmap_special_terrain &elem : terrains ) {
             const tripoint_om_omt location = origin + om_direction::rotate( elem.p, dir );
-            
             if( !( elem.terrain == oter_str_id::NULL_ID() ) ) {
                 result.omts_used.push_back( location );
                 const oter_id tid = elem.terrain->get_rotated( dir );

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1426,9 +1426,7 @@ struct fixed_overmap_special_data : overmap_special_data {
             if( !( elem.terrain == oter_str_id::NULL_ID() ) ) {
                 result.omts_used.push_back( location );
                 const oter_id tid = elem.terrain->get_rotated( dir );
-
                 om.ter_set( location, tid );
-
                 if( blob ) {
                     for( int x = -2; x <= 2; x++ ) {
                         for( int y = -2; y <= 2; y++ ) {

--- a/src/overmap.cpp
+++ b/src/overmap.cpp
@@ -1422,21 +1422,24 @@ struct fixed_overmap_special_data : overmap_special_data {
 
         for( const overmap_special_terrain &elem : terrains ) {
             const tripoint_om_omt location = origin + om_direction::rotate( elem.p, dir );
-            result.omts_used.push_back( location );
-            const oter_id tid = elem.terrain->get_rotated( dir );
+            
+            if( !( elem.terrain == oter_str_id::NULL_ID() ) ) {
+                result.omts_used.push_back( location );
+                const oter_id tid = elem.terrain->get_rotated( dir );
 
-            om.ter_set( location, tid );
+                om.ter_set( location, tid );
 
-            if( blob ) {
-                for( int x = -2; x <= 2; x++ ) {
-                    for( int y = -2; y <= 2; y++ ) {
-                        const tripoint_om_omt nearby_pos = location + point( x, y );
-                        if( !overmap::inbounds( nearby_pos ) ) {
-                            continue;
-                        }
-                        if( one_in( 1 + std::abs( x ) + std::abs( y ) ) &&
-                            elem.can_be_placed_on( om.ter( nearby_pos ) ) ) {
-                            om.ter_set( nearby_pos, tid );
+                if( blob ) {
+                    for( int x = -2; x <= 2; x++ ) {
+                        for( int y = -2; y <= 2; y++ ) {
+                            const tripoint_om_omt nearby_pos = location + point( x, y );
+                            if( !overmap::inbounds( nearby_pos ) ) {
+                                continue;
+                            }
+                            if( one_in( 1 + std::abs( x ) + std::abs( y ) ) &&
+                                elem.can_be_placed_on( om.ter( nearby_pos ) ) ) {
+                                om.ter_set( nearby_pos, tid );
+                            }
                         }
                     }
                 }
@@ -2755,7 +2758,7 @@ void overmap_special::load( const JsonObject &jo, const std::string &src )
         case overmap_special_subtype::fixed: {
             shared_ptr_fast<fixed_overmap_special_data> fixed_data =
                 make_shared_fast<fixed_overmap_special_data>();
-            mandatory( jo, was_loaded, "overmaps", fixed_data->terrains );
+            optional( jo, was_loaded, "overmaps", fixed_data->terrains );
             if( is_special ) {
                 optional( jo, was_loaded, "connections", fixed_data->connections );
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Closes #70471
Makes #70339 less messy and as a result the eventual PR removing some lake specials easier
Allows a workaround that will deal with #22133 (Will open a PR for this soon)

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Allows neglecting the "overmap" field from fixed specials "overmaps", in which case it acts like mutalbles check_for_locations, preventing placement if the point doesn't adhere to the locations but without placing anything. Could probably be done in a nicer way.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Adjusted the motel_twd special to require a forest and checked it was still checking the locations (also tried without locations to check it isn't placing anything, when it wasn't working while figuring out the code it was placing a % nothing OMT) https://github.com/CleverRaven/Cataclysm-DDA/commit/f0d8236f2a054f9253409e22928c4f0e841f2cbd

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/7ee574bc-256e-434d-bc7a-b28f66fa8e6f)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
