### PR TITLE
Road connections for specials always start on land

### DIFF
--- a/data/json/overmap/overmap_mutable/mine_mutable.json
+++ b/data/json/overmap/overmap_mutable/mine_mutable.json
@@ -8,6 +8,7 @@
     "occurrences": [ 0, 2 ],
     "flags": [ "MAN_MADE" ],
     "check_for_locations": [
+      [ [ 0, -1, 0 ], [ "land", "road" ] ],
       [ [ 0, 0, 0 ], [ "land" ] ],
       [ [ 1, 0, 0 ], [ "land" ] ],
       [ [ 0, 1, 0 ], [ "land" ] ],

--- a/data/json/overmap/overmap_special/specials.json
+++ b/data/json/overmap/overmap_special/specials.json
@@ -64,7 +64,8 @@
     "id": "Boat Rental",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "boat_rental_north", "locations": [ "lake_shore" ] },
-      { "point": [ 0, 0, 1 ], "overmap": "boat_rental_roof_north", "locations": [ "open_air" ] }
+      { "point": [ 0, 0, 1 ], "overmap": "boat_rental_roof_north", "locations": [ "open_air" ] },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road" } ],
     "city_distance": [ 5, 40 ],
@@ -76,7 +77,8 @@
     "id": "Boat Rental 1",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "boat_rental_1_north", "locations": [ "lake_shore" ] },
-      { "point": [ 0, 0, 1 ], "overmap": "boat_rental_1_roof_north", "locations": [ "open_air" ] }
+      { "point": [ 0, 0, 1 ], "overmap": "boat_rental_1_roof_north", "locations": [ "open_air" ] },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road" } ],
     "city_distance": [ 5, 40 ],
@@ -88,7 +90,8 @@
     "id": "Boat Rental 2",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "boat_rental_2_north", "locations": [ "lake_shore" ] },
-      { "point": [ 0, 0, 1 ], "overmap": "boat_rental_2_roof_north", "locations": [ "open_air" ] }
+      { "point": [ 0, 0, 1 ], "overmap": "boat_rental_2_roof_north", "locations": [ "open_air" ] },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road" } ],
     "city_distance": [ 5, 40 ],
@@ -281,7 +284,9 @@
       { "point": [ -1, -5, 3 ], "overmap": "radio_tower_odd_north" },
       { "point": [ -1, -5, 4 ], "overmap": "radio_tower_even_north" },
       { "point": [ -1, -5, 5 ], "overmap": "radio_tower_odd_north" },
-      { "point": [ -1, -5, 6 ], "overmap": "radio_tower_top_north" }
+      { "point": [ -1, -5, 6 ], "overmap": "radio_tower_top_north" },
+      { "point": [ -1, -6, 0 ], "locations": [ "land", "road" ] },
+      { "point": [ 0, -5, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [
       { "point": [ -1, -6, 0 ], "terrain": "road", "connection": "local_road" },
@@ -322,7 +327,9 @@
       { "point": [ 2, 0, -1 ], "overmap": "office_tower_collapse_b_a2_north" },
       { "point": [ 0, 1, -1 ], "overmap": "office_tower_collapse_b_b0_north" },
       { "point": [ 1, 1, -1 ], "overmap": "office_tower_collapse_b_b1_north" },
-      { "point": [ 2, 1, -1 ], "overmap": "office_tower_collapse_b_b2_north" }
+      { "point": [ 2, 1, -1 ], "overmap": "office_tower_collapse_b_b2_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] },
+      { "point": [ 2, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [
       { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road" },
@@ -408,7 +415,8 @@
       { "point": [ 2, 0, -1 ], "overmap": "sewage_treatment_2_0_-1_north" },
       { "point": [ 0, 1, -1 ], "overmap": "sewage_treatment_0_1_-1_north" },
       { "point": [ 1, 1, -1 ], "overmap": "sewage_treatment_1_1_-1_north" },
-      { "point": [ 2, 1, -1 ], "overmap": "sewage_treatment_2_1_-1_north" }
+      { "point": [ 2, 1, -1 ], "overmap": "sewage_treatment_2_1_-1_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "locations": [ "land" ],
     "connections": [
@@ -470,7 +478,8 @@
     "id": "Rural Gas Station",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "s_gas_rural_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "s_gas_rural_roof_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "s_gas_rural_roof_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "connection": "local_road", "terrain": "road", "existing": true, "from": [ 0, 0, 0 ] } ],
     "locations": [ "land" ],
@@ -489,7 +498,8 @@
       { "point": [ 0, 0, 2 ], "overmap": "lodge_roof1_north" },
       { "point": [ 1, 0, 2 ], "overmap": "lodge_roof2_north" },
       { "point": [ 0, 0, -1 ], "overmap": "lodge_basement_residential1_north" },
-      { "point": [ 1, 0, -1 ], "overmap": "lodge_basement_residential2_north" }
+      { "point": [ 1, 0, -1 ], "overmap": "lodge_basement_residential2_north" },
+      { "point": [ -1, 0, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ -1, 0, 0 ], "terrain": "road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "forest" ],
@@ -509,7 +519,8 @@
       { "point": [ 0, 0, 2 ], "overmap": "lodge_roof1_north" },
       { "point": [ 1, 0, 2 ], "overmap": "lodge_roof2_north" },
       { "point": [ 0, 0, -1 ], "overmap": "lodge_basement_residential3_north" },
-      { "point": [ 1, 0, -1 ], "overmap": "lodge_basement_residential4_north" }
+      { "point": [ 1, 0, -1 ], "overmap": "lodge_basement_residential4_north" },
+      { "point": [ -1, 0, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ -1, 0, 0 ], "terrain": "road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "forest" ],
@@ -529,7 +540,8 @@
       { "point": [ 0, 0, 2 ], "overmap": "lodge_roof1_north" },
       { "point": [ 1, 0, 2 ], "overmap": "lodge_roof2_north" },
       { "point": [ 0, 0, -1 ], "overmap": "lodge_basement_residential1_north" },
-      { "point": [ 1, 0, -1 ], "overmap": "lodge_basement_residential2_north" }
+      { "point": [ 1, 0, -1 ], "overmap": "lodge_basement_residential2_north" },
+      { "point": [ -1, 0, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ -1, 0, 0 ], "terrain": "road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "forest" ],
@@ -659,7 +671,8 @@
       { "point": [ 0, 0, 1 ], "overmap": "cabin_roof_1_north" },
       { "point": [ 0, 1, 0 ], "overmap": "cabin_liam_driveway_north" },
       { "point": [ 0, 2, 0 ], "overmap": "dirt_road_forest_north" },
-      { "point": [ 0, 3, 0 ], "overmap": "dirt_road_forest_north" }
+      { "point": [ 0, 3, 0 ], "overmap": "dirt_road_forest_north" },
+      { "point": [ 0, 4, 0 ], "locations": [ "land", "road" ] }
     ],
     "locations": [ "forest" ],
     "city_distance": [ 25, 10 ],
@@ -698,7 +711,8 @@
     "overmaps": [
       { "point": [ 0, -1, 0 ], "overmap": "sugar_house_parking_north" },
       { "point": [ 0, 0, 0 ], "overmap": "sugar_house_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "sugar_house_roof_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "sugar_house_roof_north" },
+      { "point": [ 0, -2, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -2, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, -1, 0 ] } ],
     "locations": [ "forest" ],
@@ -736,7 +750,7 @@
   {
     "type": "overmap_special",
     "id": "Lab",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "lab_stairs" } ],
+    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "lab_stairs" }, { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] } ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road" } ],
     "locations": [ "field", "forest_without_trail" ],
     "city_distance": [ 10, -1 ],
@@ -746,7 +760,11 @@
   {
     "type": "overmap_special",
     "id": "Lab with Anthill",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "lab_stairs" }, { "point": [ 3, 1, 0 ], "overmap": "anthill_north" } ],
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "lab_stairs" },
+      { "point": [ 3, 1, 0 ], "overmap": "anthill_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
+    ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road" } ],
     "locations": [ "field", "forest_without_trail" ],
     "city_distance": [ 10, -1 ],
@@ -808,7 +826,7 @@
   {
     "type": "overmap_special",
     "id": "Ice Lab",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "ice_lab_stairs" } ],
+    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "ice_lab_stairs" }, { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] } ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road" } ],
     "locations": [ "field", "forest_without_trail" ],
     "city_distance": [ 10, -1 ],
@@ -827,7 +845,8 @@
       { "point": [ 2, 1, 0 ], "overmap": "fema_2_3_north" },
       { "point": [ 0, 2, 0 ], "overmap": "fema_3_1_north" },
       { "point": [ 1, 2, 0 ], "overmap": "fema_3_2_north" },
-      { "point": [ 2, 2, 0 ], "overmap": "fema_3_3_north" }
+      { "point": [ 2, 2, 0 ], "overmap": "fema_3_3_north" },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -848,7 +867,8 @@
       { "point": [ 2, 1, 0 ], "overmap": "FEMA_re_north" },
       { "point": [ 0, 2, 0 ], "overmap": "FEMA_blc_north" },
       { "point": [ 1, 2, 0 ], "overmap": "FEMA_entrance_north" },
-      { "point": [ 2, 2, 0 ], "overmap": "FEMA_brc_north" }
+      { "point": [ 2, 2, 0 ], "overmap": "FEMA_brc_north" },
+      { "point": [ 1, 3, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 1, 3, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 2, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -863,7 +883,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "bunker_south" },
       { "point": [ 0, 0, -1 ], "overmap": "bunker_basement_1_south" },
-      { "point": [ 0, 0, 1 ], "overmap": "bunker_roof_south" }
+      { "point": [ 0, 0, 1 ], "overmap": "bunker_roof_south" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "forest" ],
@@ -902,7 +923,8 @@
       { "point": [ 0, 0, -2 ], "overmap": "silo_2" },
       { "point": [ 0, 0, -3 ], "overmap": "silo_3" },
       { "point": [ 0, 0, -4 ], "overmap": "silo_4" },
-      { "point": [ 0, 0, -5 ], "overmap": "silo_finale" }
+      { "point": [ 0, 0, -5 ], "overmap": "silo_finale" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -921,7 +943,8 @@
       { "point": [ 0, 0, 3 ], "overmap": "radio_tower_odd_north" },
       { "point": [ 0, 0, 4 ], "overmap": "radio_tower_even_north" },
       { "point": [ 0, 0, 5 ], "overmap": "radio_tower_odd_north" },
-      { "point": [ 0, 0, 6 ], "overmap": "radio_tower_top_north" }
+      { "point": [ 0, 0, 6 ], "overmap": "radio_tower_top_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "land" ],
@@ -939,7 +962,8 @@
       { "point": [ 0, 0, 3 ], "overmap": "radio_tower_odd_north" },
       { "point": [ 0, 0, 4 ], "overmap": "radio_tower_even_north" },
       { "point": [ 0, 0, 5 ], "overmap": "radio_tower_odd_north" },
-      { "point": [ 0, 0, 6 ], "overmap": "radio_tower_top_north" }
+      { "point": [ 0, 0, 6 ], "overmap": "radio_tower_top_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "land" ],
@@ -984,7 +1008,8 @@
       { "point": [ -1, -1, 0 ], "overmap": "special_field" },
       { "point": [ -1, 1, 0 ], "overmap": "special_field" },
       { "point": [ 3, -1, 0 ], "overmap": "special_field" },
-      { "point": [ 3, 1, 0 ], "overmap": "special_field" }
+      { "point": [ 3, 1, 0 ], "overmap": "special_field" },
+      { "point": [ 1, -5, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 1, -5, 0 ], "terrain": "road", "connection": "local_road", "existing": true } ],
     "locations": [ "field" ],
@@ -1003,7 +1028,8 @@
       { "point": [ 0, 0, 4 ], "overmap": "wasp_tower_even_2_north" },
       { "point": [ 0, 0, 5 ], "overmap": "wasp_tower_odd_2_north" },
       { "point": [ 0, 0, 6 ], "overmap": "wasp_tower_top_north" },
-      { "point": [ 0, 0, 7 ], "overmap": "wasp_tower_roof_north" }
+      { "point": [ 0, 0, 7 ], "overmap": "wasp_tower_roof_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "land" ],
@@ -1023,7 +1049,8 @@
       { "point": [ 0, 0, 4 ], "overmap": "wasp_tower_even_2_north" },
       { "point": [ 0, 0, 5 ], "overmap": "wasp_tower_odd_2_north" },
       { "point": [ 0, 0, 6 ], "overmap": "wasp_tower_top_north" },
-      { "point": [ 0, 0, 7 ], "overmap": "wasp_tower_roof_north" }
+      { "point": [ 0, 0, 7 ], "overmap": "wasp_tower_roof_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "land" ],
@@ -1071,7 +1098,8 @@
       { "point": [ 2, 1, 2 ], "overmap": "prison_1_3f_4_north" },
       { "point": [ 0, 2, 2 ], "overmap": "prison_1_3f_9_north" },
       { "point": [ 1, 2, 2 ], "overmap": "prison_1_3f_8_north" },
-      { "point": [ 2, 2, 2 ], "overmap": "prison_1_3f_7_north" }
+      { "point": [ 2, 2, 2 ], "overmap": "prison_1_3f_7_north" },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "land" ],
@@ -1391,7 +1419,8 @@
       { "point": [ 2, 1, 2 ], "overmap": "prison_1_3f_4_north" },
       { "point": [ 0, 2, 2 ], "overmap": "prison_1_3f_9_north" },
       { "point": [ 1, 2, 2 ], "overmap": "prison_1_3f_8_north" },
-      { "point": [ 2, 2, 2 ], "overmap": "prison_1_3f_7_north" }
+      { "point": [ 2, 2, 2 ], "overmap": "prison_1_3f_7_north" },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -1496,7 +1525,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1511,7 +1541,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_1_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_1_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1526,7 +1557,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_1b_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_1b_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1b_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1b_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1541,7 +1573,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_2_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_2_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_2_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_2_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1556,7 +1589,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_survivor_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1571,7 +1605,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_1_survivor_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_1_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1586,7 +1621,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_1b_survivor_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_1b_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1b_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1b_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1601,7 +1637,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_2_survivor_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_2_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_2_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_2_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1616,7 +1653,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_vandal_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_vandal_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1631,7 +1669,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_1_vandal_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_1_vandal_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1646,7 +1685,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_1b_vandal_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_1b_vandal_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1b_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1b_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1661,7 +1701,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_2_vandal_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_2_vandal_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_2_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_2_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1675,7 +1716,8 @@
     "id": "Evac Shelter Unfinished",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_unfinished_north" },
-      { "point": [ 0, 0, -1 ], "overmap": "shelter_under_unfinished_north" }
+      { "point": [ 0, 0, -1 ], "overmap": "shelter_under_unfinished_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1689,7 +1731,8 @@
     "id": "Evac Shelter Unfinished 1",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_1_unfinished_north" },
-      { "point": [ 0, 0, -1 ], "overmap": "shelter_under_1_unfinished_north" }
+      { "point": [ 0, 0, -1 ], "overmap": "shelter_under_1_unfinished_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1703,7 +1746,8 @@
     "id": "Evac Shelter Unfinished 1b",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_1b_unfinished_north" },
-      { "point": [ 0, 0, -1 ], "overmap": "shelter_under_1b_unfinished_north" }
+      { "point": [ 0, 0, -1 ], "overmap": "shelter_under_1b_unfinished_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1717,7 +1761,8 @@
     "id": "Evac Shelter Unfinished 2",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_2_unfinished_north" },
-      { "point": [ 0, 0, -1 ], "overmap": "shelter_under_2_unfinished_north" }
+      { "point": [ 0, 0, -1 ], "overmap": "shelter_under_2_unfinished_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1732,7 +1777,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_infested_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_infested_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1747,7 +1793,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_1_infested_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_1_infested_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1762,7 +1809,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_1b_infested_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_1b_infested_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1b_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_1b_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1777,7 +1825,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shelter_2_infested_north" },
       { "point": [ 0, 0, -1 ], "overmap": "shelter_under_2_infested_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_2_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "shelter_roof_2_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -1839,7 +1888,8 @@
       { "point": [ 1, 0, -2 ], "overmap": "haz_sar_b_1_north" },
       { "point": [ 0, 0, -2 ], "overmap": "haz_sar_b_2_north" },
       { "point": [ 1, 1, -2 ], "overmap": "haz_sar_b_3_north" },
-      { "point": [ 0, 1, -2 ], "overmap": "haz_sar_b_4_north" }
+      { "point": [ 0, 1, -2 ], "overmap": "haz_sar_b_4_north" },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -2281,7 +2331,8 @@
       { "point": [ 7, 10, -4 ], "overmap": "special_deep_rock" },
       { "point": [ 8, 10, -4 ], "overmap": "special_deep_rock" },
       { "point": [ 9, 10, -4 ], "overmap": "special_deep_rock" },
-      { "point": [ 10, 10, -4 ], "overmap": "special_deep_rock" }
+      { "point": [ 10, 10, -4 ], "overmap": "special_deep_rock" },
+      { "point": [ 7, 15, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 7, 15, 0 ], "terrain": "road", "connection": "local_road", "from": [ 7, 14, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -2354,7 +2405,8 @@
       { "point": [ -1, 5, 1 ], "overmap": "godco_8_1_north" },
       { "point": [ 0, 5, 1 ], "overmap": "godco_7_1_north" },
       { "point": [ -1, 3, 2 ], "overmap": "godco_2_2_north" },
-      { "point": [ 0, 3, 2 ], "overmap": "godco_1_2_north" }
+      { "point": [ 0, 3, 2 ], "overmap": "godco_1_2_north" },
+      { "point": [ -1, 0, 0 ], "locations": [ "land", "road" ] }
     ],
     "locations": [ "forest" ],
     "connections": [ { "point": [ -1, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ -1, 1, 0 ] } ],
@@ -2430,7 +2482,7 @@
   {
     "type": "overmap_special",
     "id": "sai",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "sai_north" } ],
+    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "sai_north" }, { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] } ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road" } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
@@ -2442,7 +2494,7 @@
     "type": "overmap_special",
     "id": "solar_farm",
     "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "solar_farm_north" } ],
-    "connections": [ { "point": [ 0, 1, 0 ], "terrain": "road", "connection": "local_road" } ],
+    "connections": [ { "point": [ 0, 1, 0 ], "terrain": "road", "connection": "local_road", "existing": true } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 2 ],
     "city_sizes": [ 4, -1 ],
@@ -2453,7 +2505,11 @@
   {
     "type": "overmap_special",
     "id": "power_station_small",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "pwr_sub_s_north" }, { "point": [ 0, 0, 1 ], "overmap": "pwr_sub_s_roof_north" } ],
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "pwr_sub_s_north" },
+      { "point": [ 0, 0, 1 ], "overmap": "pwr_sub_s_roof_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
+    ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road" } ],
     "locations": [ "land" ],
     "city_distance": [ -1, 10 ],
@@ -2471,7 +2527,8 @@
       { "point": [ -1, 1, 0 ], "overmap": "pwr_large_2_north" },
       { "point": [ -1, 1, 1 ], "overmap": "pwr_large_2_roof_north" },
       { "point": [ -1, 0, 0 ], "overmap": "pwr_large_3_north" },
-      { "point": [ 0, 0, 0 ], "overmap": "pwr_large_4_north" }
+      { "point": [ 0, 0, 0 ], "overmap": "pwr_large_4_north" },
+      { "point": [ 0, 2, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, 2, 0 ], "terrain": "road", "connection": "local_road" } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -2575,7 +2632,8 @@
       { "point": [ 5, 8, 0 ], "overmap": "ranch_camp_78_north" },
       { "point": [ 6, 8, 0 ], "overmap": "ranch_camp_79_north" },
       { "point": [ 7, 8, 0 ], "overmap": "ranch_camp_80_north" },
-      { "point": [ 8, 8, 0 ], "overmap": "ranch_camp_81_north" }
+      { "point": [ 8, 8, 0 ], "overmap": "ranch_camp_81_north" },
+      { "point": [ 4, 9, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 4, 9, 0 ], "terrain": "road", "connection": "local_road", "from": [ 4, 8, 0 ] } ],
     "locations": [ "wilderness" ],
@@ -2682,7 +2740,8 @@
       { "point": [ 0, 1, 1 ], "overmap": "pump_station_2_roof_north" },
       { "point": [ 0, -1, -1 ], "overmap": "pump_station_3_north" },
       { "point": [ 0, 0, -1 ], "overmap": "pump_station_4_north" },
-      { "point": [ 0, 1, -1 ], "overmap": "pump_station_5_north" }
+      { "point": [ 0, 1, -1 ], "overmap": "pump_station_5_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [
       { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] },
@@ -2724,7 +2783,8 @@
       { "point": [ 1, 0, 0 ], "overmap": "cemetery_4square_10_north" },
       { "point": [ 0, 1, 0 ], "overmap": "cemetery_4square_01_north" },
       { "point": [ 1, 1, 0 ], "overmap": "cemetery_4square_11_north" },
-      { "point": [ 1, 1, 1 ], "overmap": "cemetery_4square_11_roof_north" }
+      { "point": [ 1, 1, 1 ], "overmap": "cemetery_4square_11_roof_north" },
+      { "point": [ 0, 2, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, 2, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 1, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -2798,7 +2858,8 @@
       { "point": [ 2, 3, 0 ], "overmap": "orchard_tree_apple_north" },
       { "point": [ 3, 3, 0 ], "overmap": "orchard_tree_apple_north" },
       { "point": [ 0, 0, 1 ], "overmap": "orchard_processing_roof_north" },
-      { "point": [ 0, 1, 1 ], "overmap": "orchard_stall_roof_north" }
+      { "point": [ 0, 1, 1 ], "overmap": "orchard_stall_roof_north" },
+      { "point": [ -1, 1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ -1, 1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 1, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -2815,7 +2876,8 @@
       { "point": [ 0, 1, 0 ], "overmap": "dairy_farm_SW_north" },
       { "point": [ 0, 1, 1 ], "overmap": "dairy_farm_SW_roof_north" },
       { "point": [ 1, 1, 0 ], "overmap": "dairy_farm_SE_north" },
-      { "point": [ 1, 1, 1 ], "overmap": "dairy_farm_SE_roof_north" }
+      { "point": [ 1, 1, 1 ], "overmap": "dairy_farm_SE_roof_north" },
+      { "point": [ 0, 2, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, 2, 0 ], "terrain": "road", "connection": "local_road" } ],
     "locations": [ "field" ],
@@ -2830,7 +2892,8 @@
       { "point": [ 0, 0, 0 ], "overmap": "state_park_0_0_north" },
       { "point": [ 1, 0, 0 ], "overmap": "state_park_1_0_north" },
       { "point": [ 0, 1, 0 ], "overmap": "state_park_0_1_north" },
-      { "point": [ 1, 1, 0 ], "overmap": "state_park_1_1_north" }
+      { "point": [ 1, 1, 0 ], "overmap": "state_park_1_1_north" },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "forest" ],
@@ -2898,7 +2961,8 @@
       { "point": [ 2, 1, -1 ], "overmap": "mansion_t6d_west" },
       { "point": [ 0, 2, -1 ], "overmap": "mansion_c4d_west" },
       { "point": [ 1, 2, -1 ], "overmap": "mansion_t7d_north" },
-      { "point": [ 2, 2, -1 ], "overmap": "mansion_c1d_south" }
+      { "point": [ 2, 2, -1 ], "overmap": "mansion_c1d_south" },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "land" ],
@@ -2947,7 +3011,8 @@
       { "point": [ 2, 1, -1 ], "overmap": "mansion_t2d_west" },
       { "point": [ 0, 2, -1 ], "overmap": "mansion_c2d_west" },
       { "point": [ 1, 2, -1 ], "overmap": "mansion_t2d_north" },
-      { "point": [ 2, 2, -1 ], "overmap": "mansion_c4d_south" }
+      { "point": [ 2, 2, -1 ], "overmap": "mansion_c4d_south" },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "land" ],
@@ -2995,7 +3060,8 @@
       { "point": [ 2, 1, -1 ], "overmap": "mansion_t4d_west" },
       { "point": [ 0, 2, -1 ], "overmap": "mansion_c5d_west" },
       { "point": [ 1, 2, -1 ], "overmap": "mansion_t1d_north" },
-      { "point": [ 2, 2, -1 ], "overmap": "mansion_c4d_south" }
+      { "point": [ 2, 2, -1 ], "overmap": "mansion_c4d_south" },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "land" ],
@@ -3044,7 +3110,8 @@
       { "point": [ 2, 1, -1 ], "overmap": "mansion_t6d_west" },
       { "point": [ 0, 2, -1 ], "overmap": "mansion_c4d_west" },
       { "point": [ 1, 2, -1 ], "overmap": "mansion_t7d_north" },
-      { "point": [ 2, 2, -1 ], "overmap": "mansion_c3d_south" }
+      { "point": [ 2, 2, -1 ], "overmap": "mansion_c3d_south" },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "land" ],
@@ -3091,7 +3158,8 @@
       { "point": [ 2, 1, -1 ], "overmap": "mansion_boarded_t2d_west" },
       { "point": [ 0, 2, -1 ], "overmap": "mansion_c2d_west" },
       { "point": [ 1, 2, -1 ], "overmap": "mansion_boarded_t2d_start_north" },
-      { "point": [ 2, 2, -1 ], "overmap": "mansion_c4d_south" }
+      { "point": [ 2, 2, -1 ], "overmap": "mansion_c4d_south" },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "land" ],
@@ -3108,7 +3176,9 @@
       { "point": [ 1, 0, 0 ], "overmap": "junkyard_1b_north" },
       { "point": [ 1, 0, 1 ], "overmap": "junkyard_roof_1b_north" },
       { "point": [ 0, 1, 0 ], "overmap": "junkyard_2a_north" },
-      { "point": [ 1, 1, 0 ], "overmap": "junkyard_2b_north" }
+      { "point": [ 1, 1, 0 ], "overmap": "junkyard_2b_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [
       { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] },
@@ -3138,7 +3208,8 @@
     "overmaps": [
       { "point": [ 0, 0, 1 ], "overmap": "Cemetery_1a_roof_north" },
       { "point": [ 0, 0, 0 ], "overmap": "Cemetery_1a_north" },
-      { "point": [ 1, 0, 0 ], "overmap": "Cemetery_1b_north" }
+      { "point": [ 1, 0, 0 ], "overmap": "Cemetery_1b_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road" } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -3150,7 +3221,11 @@
   {
     "type": "overmap_special",
     "id": "tree farm",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "TreeFarm_1a_north" }, { "point": [ 1, 0, 0 ], "overmap": "TreeFarm_1b_north" } ],
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "TreeFarm_1a_north" },
+      { "point": [ 1, 0, 0 ], "overmap": "TreeFarm_1b_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
+    ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road" } ],
     "locations": [ "forest" ],
     "city_distance": [ 5, 40 ],
@@ -3163,7 +3238,8 @@
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "shootingrange_1a_north" },
       { "point": [ 0, 0, 1 ], "overmap": "shootingrange_1a_roof_north" },
-      { "point": [ 0, 1, 0 ], "overmap": "shootingrange_2a_north" }
+      { "point": [ 0, 1, 0 ], "overmap": "shootingrange_2a_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -3180,7 +3256,8 @@
       { "point": [ 1, 0, 0 ], "overmap": "campground_1b_north" },
       { "point": [ 0, 1, 0 ], "overmap": "campground_2a_north" },
       { "point": [ 1, 1, 0 ], "overmap": "campground_2b_north" },
-      { "point": [ 1, 0, 1 ], "overmap": "campground_roof_north" }
+      { "point": [ 1, 0, 1 ], "overmap": "campground_roof_north" },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "forest" ],
@@ -3204,7 +3281,8 @@
       { "point": [ 0, 0, 0 ], "overmap": "bandit_garage_1_north" },
       { "point": [ 1, 0, 0 ], "overmap": "bandit_garage_2_north" },
       { "point": [ 0, 0, 1 ], "overmap": "bandit_garage_1_roof_north" },
-      { "point": [ 1, 0, 1 ], "overmap": "bandit_garage_2_roof_north" }
+      { "point": [ 1, 0, 1 ], "overmap": "bandit_garage_2_roof_north" },
+      { "point": [ -1, 0, 0 ], "locations": [ "land", "road" ] }
     ],
     "locations": [ "forest" ],
     "connections": [ { "point": [ -1, 0, 0 ], "terrain": "road", "connection": "local_road" } ],
@@ -3230,7 +3308,8 @@
       { "point": [ 3, 1, 0 ], "overmap": "golfcourse_31_north" },
       { "point": [ 3, 1, 1 ], "overmap": "golfcourse_31_2ndfloor_north" },
       { "point": [ 3, 1, 2 ], "overmap": "golfcourse_31_roof_north" },
-      { "point": [ 3, 2, 0 ], "overmap": "golfcourse_32_north" }
+      { "point": [ 3, 2, 0 ], "overmap": "golfcourse_32_north" },
+      { "point": [ 3, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 3, -1, 0 ], "terrain": "road", "from": [ 3, 0, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -3286,7 +3365,8 @@
       { "point": [ 2, 0, 1 ], "overmap": "car_theater_2_0_1_north" },
       { "point": [ 0, 0, 2 ], "overmap": "car_theater_0_0_2_north" },
       { "point": [ 1, 0, 2 ], "overmap": "car_theater_1_0_2_north" },
-      { "point": [ 2, 0, 2 ], "overmap": "car_theater_2_0_2_north" }
+      { "point": [ 2, 0, 2 ], "overmap": "car_theater_2_0_2_north" },
+      { "point": [ 3, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 3, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 3, 0, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -3302,7 +3382,8 @@
       { "point": [ 0, 1, 0 ], "overmap": "dirt_road_forest_north" },
       { "point": [ 0, 2, 0 ], "overmap": "dirt_road_forest_north" },
       { "point": [ 0, 3, 0 ], "overmap": "house_farm_north" },
-      { "point": [ 0, 3, 1 ], "overmap": "house_farm_roof_north" }
+      { "point": [ 0, 3, 1 ], "overmap": "house_farm_roof_north" },
+      { "point": [ 0, 0, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 1, 0 ] } ],
     "locations": [ "forest" ],
@@ -3317,7 +3398,8 @@
       { "point": [ 0, 1, 0 ], "overmap": "dirt_road_forest_north" },
       { "point": [ 0, 2, 0 ], "overmap": "dirt_road_turn_forest_south" },
       { "point": [ 1, 2, 0 ], "overmap": "house_farm_west" },
-      { "point": [ 1, 2, 1 ], "overmap": "house_farm_roof_west" }
+      { "point": [ 1, 2, 1 ], "overmap": "house_farm_roof_west" },
+      { "point": [ 0, 0, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 1, 0 ] } ],
     "locations": [ "forest" ],
@@ -3334,7 +3416,8 @@
       { "point": [ -1, 2, 0 ], "overmap": "yard_east" },
       { "point": [ 0, 3, 0 ], "overmap": "dirt_road_turn_forest_south" },
       { "point": [ 1, 3, 0 ], "overmap": "house_farm_west" },
-      { "point": [ 1, 3, 1 ], "overmap": "house_farm_roof_west" }
+      { "point": [ 1, 3, 1 ], "overmap": "house_farm_roof_west" },
+      { "point": [ 0, 0, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 1, 0 ] } ],
     "locations": [ "forest" ],
@@ -3491,7 +3574,9 @@
       { "point": [ 10, 7, -2 ], "overmap": "lab_subway_vent_shaft-4" },
       { "point": [ 11, 7, -2 ], "overmap": "subway_ns" },
       { "point": [ 11, 8, -2 ], "overmap": "microlab_sub_connector_south" },
-      { "point": [ 11, -6, -2 ], "overmap": "microlab_sub_connector_north" }
+      { "point": [ 11, -6, -2 ], "overmap": "microlab_sub_connector_north" },
+      { "point": [ 10, 1, 0 ], "locations": [ "land", "road" ] },
+      { "point": [ 4, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [
       { "point": [ 10, 1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 10, 2, 0 ] },
@@ -3513,7 +3598,8 @@
       { "point": [ 0, 1, 0 ], "overmap": "isolated_house_farm_blacksmith" },
       { "point": [ 1, 0, 1 ], "overmap": "isolated_house_farm_roof_gunsmith" },
       { "point": [ 0, 1, 1 ], "overmap": "isolated_house_farm_roof_blacksmith" },
-      { "point": [ 1, 1, 0 ], "overmap": "isolated_road_field_1" }
+      { "point": [ 1, 1, 0 ], "overmap": "isolated_road_field_1" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "field" ],
@@ -3684,7 +3770,8 @@
       { "point": [ 1, 4, -2 ], "overmap": "special_rock" },
       { "point": [ 2, 4, -2 ], "overmap": "special_rock" },
       { "point": [ 3, 4, -2 ], "overmap": "special_rock" },
-      { "point": [ 4, 4, -2 ], "overmap": "special_rock" }
+      { "point": [ 4, 4, -2 ], "overmap": "special_rock" },
+      { "point": [ 2, 0, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 2, 0, 0 ], "terrain": "road", "connection": "local_road", "from": [ 2, 1, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -3942,7 +4029,8 @@
       { "point": [ 0, 3, 0 ], "overmap": "ws_regional_dump_0_3_north" },
       { "point": [ 1, 3, 0 ], "overmap": "ws_regional_dump_1_3_north" },
       { "point": [ 2, 3, 0 ], "overmap": "ws_regional_dump_2_3_north" },
-      { "point": [ 3, 3, 0 ], "overmap": "ws_regional_dump_3_3_north" }
+      { "point": [ 3, 3, 0 ], "overmap": "ws_regional_dump_3_3_north" },
+      { "point": [ 2, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 2, -1, 0 ], "terrain": "road", "from": [ 2, 0, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -3971,7 +4059,8 @@
       { "point": [ 0, 3, 0 ], "overmap": "ws_biker_dump_0_3_north" },
       { "point": [ 1, 3, 0 ], "overmap": "ws_biker_dump_1_3_north" },
       { "point": [ 2, 3, 0 ], "overmap": "ws_biker_dump_2_3_north" },
-      { "point": [ 3, 3, 0 ], "overmap": "ws_biker_dump_3_3_north" }
+      { "point": [ 3, 3, 0 ], "overmap": "ws_biker_dump_3_3_north" },
+      { "point": [ 2, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 2, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 2, 0, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -4134,7 +4223,8 @@
       { "point": [ 1, 4, 4 ], "overmap": "lab_surface_brick_block5B4_north" },
       { "point": [ 2, 4, 4 ], "overmap": "lab_surface_brick_block5C4_north" },
       { "point": [ 3, 4, 4 ], "overmap": "lab_surface_brick_block5D4_north" },
-      { "point": [ 4, 4, 4 ], "overmap": "lab_surface_brick_block5E4_north" }
+      { "point": [ 4, 4, 4 ], "overmap": "lab_surface_brick_block5E4_north" },
+      { "point": [ 2, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 2, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 2, 0, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -4164,7 +4254,10 @@
       { "point": [ 2, 1, 1 ], "overmap": "irradiator_1_4_roof_north" },
       { "point": [ 0, 2, 1 ], "overmap": "irradiator_1_9_roof_north" },
       { "point": [ 1, 2, 1 ], "overmap": "irradiator_1_8_roof_north" },
-      { "point": [ 2, 2, 1 ], "overmap": "irradiator_1_7_roof_north" }
+      { "point": [ 2, 2, 1 ], "overmap": "irradiator_1_7_roof_north" },
+      { "point": [ 0, 3, 0 ], "locations": [ "land", "road" ] },
+      { "point": [ 1, 3, 0 ], "locations": [ "land", "road" ] },
+      { "point": [ 2, 3, 0 ], "locations": [ "land", "road" ] }
     ],
     "locations": [ "field", "forest_without_trail" ],
     "connections": [
@@ -4207,7 +4300,8 @@
       { "point": [ 7, 1, 0 ], "overmap": "runway_end_north" },
       { "point": [ 8, 1, 0 ], "overmap": "special_field" },
       { "point": [ 5, 0, 0 ], "overmap": "fuel_station_north" },
-      { "point": [ 5, 0, 1 ], "overmap": "fuel_station_roof_north" }
+      { "point": [ 5, 0, 1 ], "overmap": "fuel_station_roof_north" },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 0, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -4238,7 +4332,9 @@
       { "point": [ 3, 2, 0 ], "overmap": "lumbermill_dforest_north", "locations": [ "forest" ] },
       { "point": [ 0, 3, 0 ], "overmap": "lumbermill_dforest_north", "locations": [ "forest" ] },
       { "point": [ 1, 3, 0 ], "overmap": "lumbermill_dforest_north", "locations": [ "forest" ] },
-      { "point": [ 2, 3, 0 ], "overmap": "lumbermill_dforest_north", "locations": [ "forest" ] }
+      { "point": [ 2, 3, 0 ], "overmap": "lumbermill_dforest_north", "locations": [ "forest" ] },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [
       { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road" },
@@ -4268,7 +4364,7 @@
   {
     "type": "overmap_special",
     "id": "trailhead_basic",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "trailhead_north" } ],
+    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "trailhead_north" }, { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] } ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "city_sizes": [ 1, -1 ],
     "//": "These actually get placed by some C++ trailhead placement code, so [0, 0] occurrences is deliberate.",
@@ -4280,7 +4376,8 @@
     "id": "trailhead_outhouse",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "trailhead_outhouse_z0_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "trailhead_outhouse_z1_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "trailhead_outhouse_z1_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "city_sizes": [ 1, -1 ],
@@ -4293,7 +4390,8 @@
     "id": "trailhead_shack",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "trailhead_shack_z0_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "trailhead_shack_z1_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "trailhead_shack_z1_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "city_sizes": [ 1, -1 ],
@@ -5100,7 +5198,8 @@
       { "point": [ 0, 3, 0 ], "overmap": "marina_20_north" },
       { "point": [ 0, 2, 1 ], "overmap": "marina_15_roof_north" },
       { "point": [ 4, 2, 1 ], "overmap": "marina_11_roof_north" },
-      { "point": [ 3, 2, 1 ], "overmap": "marina_12_roof_north" }
+      { "point": [ 3, 2, 1 ], "overmap": "marina_12_roof_north" },
+      { "point": [ 2, 4, 0 ], "locations": [ "land", "road" ] }
     ],
     "locations": [ "land", "lake_shore" ],
     "city_distance": [ 5, -1 ],
@@ -6071,7 +6170,8 @@
       { "point": [ 26, 29, 0 ], "overmap": "special_forest" },
       { "point": [ 27, 29, 0 ], "overmap": "special_forest" },
       { "point": [ 28, 29, 0 ], "overmap": "special_forest" },
-      { "point": [ 29, 29, 0 ], "overmap": "special_forest_thick" }
+      { "point": [ 29, 29, 0 ], "overmap": "special_forest_thick" },
+      { "point": [ -1, 15, 0 ], "locations": [ "land", "road" ] }
     ],
     "locations": [ "land", "road" ],
     "occurrences": [ 35, 100 ],
@@ -6187,7 +6287,8 @@
       { "point": [ 0, 4, 2 ], "overmap": "steel_mill_4_1_3_north" },
       { "point": [ 1, 4, 2 ], "overmap": "steel_mill_4_2_3_north" },
       { "point": [ 2, 4, 2 ], "overmap": "steel_mill_4_3_3_north" },
-      { "point": [ 3, 4, 2 ], "overmap": "steel_mill_rail_2_3_north" }
+      { "point": [ 3, 4, 2 ], "overmap": "steel_mill_rail_2_3_north" },
+      { "point": [ 2, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "locations": [ "field", "forest_without_trail" ],
     "connections": [ { "point": [ 2, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 2, 0, 0 ] } ],
@@ -6208,7 +6309,8 @@
       { "point": [ 0, 0, 1 ], "overmap": "miniaturerailway_0_0_1_north" },
       { "point": [ 0, 1, 1 ], "overmap": "miniaturerailway_0_1_1_north" },
       { "point": [ 1, 0, 1 ], "overmap": "miniaturerailway_1_0_1_north" },
-      { "point": [ 1, 1, 1 ], "overmap": "miniaturerailway_1_1_1_north" }
+      { "point": [ 1, 1, 1 ], "overmap": "miniaturerailway_1_1_1_north" },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "locations": [ "field", "forest_without_trail" ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 1, 0 ] } ],
@@ -6232,7 +6334,8 @@
       { "point": [ 2, 1, 0 ], "overmap": "luna_park_2_1_0_north" },
       { "point": [ 0, 1, 1 ], "overmap": "luna_park_0_1_1_north" },
       { "point": [ 1, 1, 1 ], "overmap": "luna_park_1_1_1_north" },
-      { "point": [ 2, 1, 1 ], "overmap": "luna_park_2_1_1_north" }
+      { "point": [ 2, 1, 1 ], "overmap": "luna_park_2_1_1_north" },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "locations": [ "field", "forest_without_trail" ],
     "connections": [ { "point": [ 1, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 1, 0 ] } ],
@@ -6276,7 +6379,9 @@
       { "point": [ 2, 1, 2 ], "overmap": "p_resort_ree_north" },
       { "point": [ 0, 2, 2 ], "overmap": "p_resort_rsw_north" },
       { "point": [ 1, 2, 2 ], "overmap": "p_resort_rss_north" },
-      { "point": [ 2, 2, 2 ], "overmap": "p_resort_rse_north" }
+      { "point": [ 2, 2, 2 ], "overmap": "p_resort_rse_north" },
+      { "point": [ 1, 4, 0 ], "locations": [ "land", "road" ] },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [
       { "point": [ 1, 4, 0 ], "terrain": "road", "connection": "local_road", "from": [ 1, 3, 0 ] },
@@ -6304,7 +6409,8 @@
       { "point": [ 0, 0, 2 ], "overmap": "helipad_roof_nw_north" },
       { "point": [ 1, 0, 2 ], "overmap": "helipad_roof_ne_north" },
       { "point": [ 0, 1, 2 ], "overmap": "helipad_roof_sw_north" },
-      { "point": [ 1, 1, 2 ], "overmap": "helipad_roof_se_north" }
+      { "point": [ 1, 1, 2 ], "overmap": "helipad_roof_se_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "locations": [ "land" ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
@@ -6546,7 +6652,8 @@
       { "point": [ 7, 10, 1 ], "overmap": "mil_base_8k1_north" },
       { "point": [ 2, 8, 2 ], "overmap": "mil_base_3i2_north" },
       { "point": [ 2, 8, 3 ], "overmap": "mil_base_3i3_north" },
-      { "point": [ 2, 8, 4 ], "overmap": "mil_base_3i4_north" }
+      { "point": [ 2, 8, 4 ], "overmap": "mil_base_3i4_north" },
+      { "point": [ 3, -2, 0 ], "locations": [ "land", "road" ] }
     ],
     "locations": [ "field" ],
     "connections": [ { "point": [ 3, -2, 0 ], "terrain": "road", "connection": "local_road", "from": [ 3, -1, 0 ] } ],
@@ -6581,7 +6688,10 @@
       { "point": [ 3, 1, 0 ], "overmap": "s_air_runway_B_south" },
       { "point": [ 4, 1, 0 ], "overmap": "s_air_runway_B_south" },
       { "point": [ 5, 1, 0 ], "overmap": "s_air_runway_l_south" },
-      { "point": [ 6, 1, 0 ], "overmap": "special_field" }
+      { "point": [ 6, 1, 0 ], "overmap": "special_field" },
+      { "point": [ -1, -1, 0 ], "locations": [ "land", "road" ] },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [
       { "point": [ -1, -1, 0 ], "terrain": "road", "connection": "local_road" },
@@ -6607,7 +6717,8 @@
       { "point": [ 1, 1, 0 ], "overmap": "s_lightindustry_10_south" },
       { "point": [ 1, 1, 1 ], "overmap": "s_lightindustry_10_roof_south" },
       { "point": [ 0, 1, 0 ], "overmap": "s_lightindustry_11_south" },
-      { "point": [ 0, 1, 1 ], "overmap": "s_lightindustry_11_roof_south" }
+      { "point": [ 0, 1, 1 ], "overmap": "s_lightindustry_11_roof_south" },
+      { "point": [ -1, 0, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ -1, 0, 0 ], "terrain": "road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -6648,7 +6759,8 @@
       { "point": [ 2, 1, 2 ], "overmap": "karting_1_2_2_north" },
       { "point": [ 0, 2, 2 ], "overmap": "karting_2_0_2_north" },
       { "point": [ 1, 2, 2 ], "overmap": "karting_2_1_2_north" },
-      { "point": [ 2, 2, 2 ], "overmap": "karting_2_2_2_north" }
+      { "point": [ 2, 2, 2 ], "overmap": "karting_2_2_2_north" },
+      { "point": [ -1, 0, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ -1, 0, 0 ], "terrain": "road", "from": [ -1, 1, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -6722,7 +6834,9 @@
     "id": "Occupied Chem Lab",
     "overmaps": [
       { "point": [ 0, 0, 0 ], "overmap": "chemical_lab_ocu_north" },
-      { "point": [ 0, 0, 1 ], "overmap": "chemical_lab_roof_ocu_north" }
+      { "point": [ 0, 0, 1 ], "overmap": "chemical_lab_roof_ocu_north" },
+      { "point": [ -1, -1, 0 ], "locations": [ "land", "road" ] },
+      { "point": [ -1, 0, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [
       { "point": [ -1, -1, 0 ], "terrain": "road", "connection": "local_road" },
@@ -6737,7 +6851,10 @@
   {
     "type": "overmap_special",
     "id": "Occupied Scrap Yard",
-    "overmaps": [ { "point": [ 0, 0, 0 ], "overmap": "smallscrapyard_ocu_north" } ],
+    "overmaps": [
+      { "point": [ 0, 0, 0 ], "overmap": "smallscrapyard_ocu_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] }
+    ],
     "connections": [ { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "field" ],
     "city_distance": [ 5, 40 ],
@@ -6767,7 +6884,9 @@
       { "point": [ 3, 2, 0 ], "overmap": "lumbermill_dforest_north", "locations": [ "forest" ] },
       { "point": [ 0, 3, 0 ], "overmap": "lumbermill_dforest_north", "locations": [ "forest" ] },
       { "point": [ 1, 3, 0 ], "overmap": "lumbermill_dforest_north", "locations": [ "forest" ] },
-      { "point": [ 2, 3, 0 ], "overmap": "lumbermill_dforest_north", "locations": [ "forest" ] }
+      { "point": [ 2, 3, 0 ], "overmap": "lumbermill_dforest_north", "locations": [ "forest" ] },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [
       { "point": [ 0, -1, 0 ], "terrain": "road", "connection": "local_road" },
@@ -6813,7 +6932,8 @@
       { "point": [ 1, 1, 0 ], "overmap": "s_lightindustry_scen_10_south" },
       { "point": [ 1, 1, 1 ], "overmap": "s_lightindustry_scen_10_roof_south" },
       { "point": [ 0, 1, 0 ], "overmap": "s_lightindustry_scen_11_south" },
-      { "point": [ 0, 1, 1 ], "overmap": "s_lightindustry_scen_11_roof_south" }
+      { "point": [ 0, 1, 1 ], "overmap": "s_lightindustry_scen_11_roof_south" },
+      { "point": [ -1, 0, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ -1, 0, 0 ], "terrain": "road", "from": [ 0, 0, 0 ] } ],
     "locations": [ "field", "forest_without_trail" ],
@@ -6912,7 +7032,8 @@
       { "point": [ 0, 2, -3 ], "overmap": "nursing_home_lab9_north" },
       { "point": [ 1, 2, -3 ], "overmap": "nursing_home_lab10_north" },
       { "point": [ 2, 2, -3 ], "overmap": "nursing_home_lab11_north" },
-      { "point": [ 3, 2, -3 ], "overmap": "nursing_home_lab12_north" }
+      { "point": [ 3, 2, -3 ], "overmap": "nursing_home_lab12_north" },
+      { "point": [ 3, 3, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 3, 3, 0 ], "terrain": "road", "connection": "local_road", "from": [ 3, 2, 0 ] } ],
     "city_distance": [ 0, 10 ],
@@ -6941,7 +7062,8 @@
       { "point": [ 2, 0, 1 ], "overmap": "nursing_home_3_roof_north" },
       { "point": [ 0, 1, 1 ], "overmap": "nursing_home_4_roof_north" },
       { "point": [ 1, 1, 1 ], "overmap": "nursing_home_5_roof_north" },
-      { "point": [ 2, 1, 1 ], "overmap": "nursing_home_6_roof_north" }
+      { "point": [ 2, 1, 1 ], "overmap": "nursing_home_6_roof_north" },
+      { "point": [ 3, 3, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [ { "point": [ 3, 3, 0 ], "terrain": "road", "connection": "local_road", "from": [ 3, 2, 0 ] } ],
     "city_distance": [ 0, 5 ],
@@ -7099,7 +7221,8 @@
       { "point": [ 5, 5, -1 ], "overmap": "sewer_wn" },
       { "point": [ 2, 6, -1 ], "overmap": "sewer_ns" },
       { "point": [ 2, 7, -1 ], "overmap": "sewer_ne" },
-      { "point": [ 3, 7, -1 ], "overmap": "retirement_community_sewer_north" }
+      { "point": [ 3, 7, -1 ], "overmap": "retirement_community_sewer_north" },
+      { "point": [ 3, 8, 0 ], "locations": [ "land", "road" ] }
     ],
     "connections": [
       { "point": [ 3, 8, 0 ], "terrain": "road", "connection": "local_road", "from": [ 3, 7, 0 ] },
@@ -7122,7 +7245,9 @@
       { "point": [ 0, 1, 0 ], "overmap": "farm_supply_3_north" },
       { "point": [ 0, 1, 1 ], "overmap": "farm_supply_roof_3_north" },
       { "point": [ 1, 1, 0 ], "overmap": "farm_supply_4_north" },
-      { "point": [ 1, 1, 1 ], "overmap": "farm_supply_roof_4_north" }
+      { "point": [ 1, 1, 1 ], "overmap": "farm_supply_roof_4_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "occurrences": [ 25, 100 ],
     "connections": [
@@ -7144,7 +7269,9 @@
       { "point": [ 0, 1, 0 ], "overmap": "farm_supply_looted_3_north" },
       { "point": [ 0, 1, 1 ], "overmap": "farm_supply_roof_3_north" },
       { "point": [ 1, 1, 0 ], "overmap": "farm_supply_looted_4_north" },
-      { "point": [ 1, 1, 1 ], "overmap": "farm_supply_roof_4_north" }
+      { "point": [ 1, 1, 1 ], "overmap": "farm_supply_roof_4_north" },
+      { "point": [ 0, -1, 0 ], "locations": [ "land", "road" ] },
+      { "point": [ 1, -1, 0 ], "locations": [ "land", "road" ] }
     ],
     "occurrences": [ 10, 100 ],
     "connections": [
@@ -7254,7 +7381,8 @@
       { "point": [ 7, 6, 1 ], "overmap": "speedway_7_6_1_north" },
       { "point": [ 5, 7, 1 ], "overmap": "speedway_5_7_1_north" },
       { "point": [ 6, 7, 1 ], "overmap": "speedway_6_7_1_north" },
-      { "point": [ 6, 7, 2 ], "overmap": "speedway_6_7_2_north" }
+      { "point": [ 6, 7, 2 ], "overmap": "speedway_6_7_2_north" },
+      { "point": [ 5, 10, 0 ], "locations": [ "land", "road" ] }
     ],
     "occurrences": [ 50, 100 ],
     "connections": [ { "point": [ 5, 10, 0 ], "terrain": "road", "from": [ 5, 9, 0 ] } ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Road connections for specials always start on land"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Workaround for #22133, a neater solution would still be nice

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Teled along a winding river from my starting OM to (87, 1978, 0) without finding a single borked bridge before getting bored

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

While this appears to add quite a mess to specials.json for a workaround the whole lot can be removed with a single regex replace of
,\s+\{.*"point":\s+\[\s+-?[0-9]+,\s+-?[0-9]+,\s-?[0-9]+\s+\],\s+"locations":\s+\[\s+"land",\s+"road"\s+\]\s+\}
with notepad++ for example

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
