### PR TITLE
Optimize item::stacks_with for further load time gains

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1486,9 +1486,8 @@ bool item::stacks_with( const item &rhs, bool check_components, bool combine_liq
     }
     // Guns that differ only by dirt/shot_counter can still stack,
     // but other item_vars such as label/note will prevent stacking
-    const std::vector<std::string> ignore_keys = { "dirt", "shot_counter", "spawn_location_omt" };
-    if( map_without_keys( *item_vars, ignore_keys ) != map_without_keys( *rhs.item_vars,
-            ignore_keys ) ) {
+    static const std::set<std::string> ignore_keys = { "dirt", "shot_counter", "spawn_location_omt" };
+    if( !map_equal_ignoring_keys( item_vars, rhs.item_vars, ignore_keys ) ) {
         return false;
     }
     const std::string omt_loc_var = "spawn_location_omt";

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1434,7 +1434,8 @@ bool item::stacks_with( const item &rhs, bool check_components, bool combine_liq
           itype_variant().id != rhs.itype_variant().id ) ) {
         return false;
     }
-    if( ammo_remaining() != 0 && rhs.ammo_remaining() != 0 && is_money() ) {
+    const std::set<ammotype> ammo = ammo_types();
+    if( is_money( ammo ) && ammo_remaining( ammo ) != 0 && rhs.ammo_remaining() != 0 ) {
         // Dealing with nonempty cash cards
         // TODO: Fix cash cards not showing total value. Until that is fixed do not stack cash cards.
         // When that is fixed just change this to true.
@@ -1490,7 +1491,7 @@ bool item::stacks_with( const item &rhs, bool check_components, bool combine_liq
     if( !map_equal_ignoring_keys( item_vars, rhs.item_vars, ignore_keys ) ) {
         return false;
     }
-    const std::string omt_loc_var = "spawn_location_omt";
+    static const std::string omt_loc_var = "spawn_location_omt";
     const bool this_has_location = has_var( omt_loc_var );
     const bool that_has_location = has_var( omt_loc_var );
     if( this_has_location != that_has_location ) {
@@ -8599,7 +8600,12 @@ bool item::ready_to_revive( map &here, const tripoint &pos ) const
 
 bool item::is_money() const
 {
-    return ammo_types().count( ammo_money );
+    return is_money( ammo_types() );
+}
+
+bool item::is_money( const std::set<ammotype> &ammo ) const
+{
+    return ammo.count( ammo_money );
 }
 
 bool item::is_cash_card() const
@@ -10668,7 +10674,8 @@ int item::shots_remaining( const Character *carrier ) const
     return ret;
 }
 
-int item::ammo_remaining( const Character *carrier, const bool include_linked ) const
+int item::ammo_remaining( const std::set<ammotype> &ammo, const Character *carrier,
+                          const bool include_linked ) const
 {
     int ret = 0;
 
@@ -10690,7 +10697,6 @@ int item::ammo_remaining( const Character *carrier, const bool include_linked ) 
         }
     }
 
-    std::set<ammotype> ammo = ammo_types();
     // Non ammo using item that uses charges
     if( ammo.empty() ) {
         ret += charges;
@@ -10726,6 +10732,11 @@ int item::ammo_remaining( const Character *carrier, const bool include_linked ) 
     }
 
     return ret;
+}
+int item::ammo_remaining( const Character *carrier, const bool include_linked ) const
+{
+    std::set<ammotype> ammo = ammo_types();
+    return ammo_remaining( ammo, carrier, include_linked );
 }
 
 int item::ammo_remaining( const bool include_linked ) const

--- a/src/item.h
+++ b/src/item.h
@@ -353,6 +353,10 @@ class item : public visitable
         bool ready_to_revive( map &here, const tripoint &pos ) const;
 
         bool is_money() const;
+    private:
+        bool is_money( const std::set<ammotype> &ammo ) const;
+    public:
+
         bool is_cash_card() const;
         bool is_software() const;
         bool is_software_storage() const;
@@ -2376,6 +2380,10 @@ class item : public visitable
          */
         int ammo_remaining( const Character *carrier = nullptr, bool include_linked = false ) const;
         int ammo_remaining( bool include_linked ) const;
+    private:
+        int ammo_remaining( const std::set<ammotype> &ammo, const Character *carrier = nullptr,
+                            bool include_linked = false ) const;
+    public:
 
         /**
          * ammo capacity for a specific ammo

--- a/tests/cata_utility_test.cpp
+++ b/tests/cata_utility_test.cpp
@@ -278,6 +278,76 @@ TEST_CASE( "map_without_keys", "[map][filter]" )
     CHECK_FALSE( map_without_keys( map_dirt_2, dirt ) == map_without_keys( map_name_a_dirt_2, dirt ) );
 }
 
+TEST_CASE( "map_equal_ignoring_keys", "[map][filter]" )
+{
+    std::map<std::string, std::string> map_empty;
+    std::map<std::string, std::string> map_name_a = {
+        { "name", "a" }
+    };
+    std::map<std::string, std::string> map_name_b = {
+        { "name", "b" }
+    };
+    std::map<std::string, std::string> map_dirt_1 = {
+        { "dirt", "1" }
+    };
+    std::map<std::string, std::string> map_dirt_2 = {
+        { "dirt", "2" }
+    };
+    std::map<std::string, std::string> map_name_a_dirt_1 = {
+        { "name", "a" },
+        { "dirt", "1" }
+    };
+    std::map<std::string, std::string> map_name_a_dirt_2 = {
+        { "name", "a" },
+        { "dirt", "2" }
+    };
+    std::set<std::string> dirt = { "dirt" };
+
+    // Empty maps compare equal to maps with all keys filtered out
+    CHECK( map_equal_ignoring_keys( map_empty, map_dirt_1, dirt ) );
+    CHECK( map_equal_ignoring_keys( map_empty, map_dirt_2, dirt ) );
+
+    // Maps are equal when all differing keys are filtered out
+    // (same name, dirt filtered out)
+    CHECK( map_equal_ignoring_keys( map_name_a, map_name_a_dirt_1, dirt ) );
+    CHECK( map_equal_ignoring_keys( map_name_a, map_name_a_dirt_2, dirt ) );
+
+    // Maps are different if some different keys remain after filtering
+    // (different name, no dirt to filter out)
+    CHECK_FALSE( map_equal_ignoring_keys( map_name_a, map_name_b, dirt ) );
+    CHECK_FALSE( map_equal_ignoring_keys( map_name_b, map_name_a, dirt ) );
+    // (different name, dirt filtered out)
+    CHECK_FALSE( map_equal_ignoring_keys( map_dirt_1, map_name_a_dirt_1, dirt ) );
+    CHECK_FALSE( map_equal_ignoring_keys( map_dirt_2, map_name_a_dirt_2, dirt ) );
+
+    // Maps with different ignored keys are equal after filtering them out.
+    std::map<std::string, std::string> rock_and_beer = {
+        { "rock", "granite" },
+        { "beer", "stout" }
+    };
+    std::map<std::string, std::string> beer_and_stone = {
+        { "beer", "stout" },
+        { "stone", "boulder" }
+    };
+    std::map<std::string, std::string> lagers_are_best = {
+        { "beer", "lager" },
+        { "rock", "schist" },
+        { "stone", "pebble" }
+    };
+    std::map<std::string, std::string> major_lager = {
+        {"beer", "lager" }
+    };
+    std::set<std::string> rock_and_stone = { "rock", "stone" };
+    CHECK( map_equal_ignoring_keys( rock_and_beer, beer_and_stone, rock_and_stone ) );
+
+    // Tests still work when one map has more keys than the other, as long as all are ignored.
+    CHECK( map_equal_ignoring_keys( major_lager, lagers_are_best, rock_and_stone ) );
+    CHECK( map_equal_ignoring_keys( lagers_are_best, major_lager, rock_and_stone ) );
+
+    CHECK_FALSE( map_equal_ignoring_keys( rock_and_beer, lagers_are_best, rock_and_stone ) );
+    CHECK_FALSE( map_equal_ignoring_keys( lagers_are_best, beer_and_stone, rock_and_stone ) );
+}
+
 TEST_CASE( "check_debug_menu_string_methods", "[debug_menu]" )
 {
     std::map<std::string, std::vector<std::string>> split_expect = {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Performance "Optimize hot item function to save ~6.7% of game load time"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
`item::stacks_with` is called a _lot_, especially during item verification. Making things even marginally faster makes things in aggregate noticeably faster as a result.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
- Cache the result of `ammo_types()` which is used at least twice, and reorder tests to exit early on a cheap check related to stacking money/cash cards.
- Implement an allocation-free map comparison function to replace creating two temporary maps with certain keys filtered out, even if they don't exist. This was both slow and a lot of allocations (which secondarily helps with memory instrumentation).
- `static` a couple constants to avoid recreating them every time.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Load the same game repeatedly before/after. These results are on top of #70423 which mostly focuses on allocation optimizations inside `item` but also a couple other hot stacks in the load path.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/425a98c2-aa42-4ba5-9e2d-5c781c2fbd2c)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
