### PR TITLE
Fix crash from reachability zones checking dead NPCs.

### DIFF
--- a/src/creature_tracker.cpp
+++ b/src/creature_tracker.cpp
@@ -202,7 +202,7 @@ bool creature_tracker::is_present( Creature *creature ) const
     } else if( creature->is_avatar() ) {
         return true;
     } else if( creature->is_npc() ) {
-        for( auto &cur_npc : active_npc ) {
+        for( const shared_ptr_fast<npc> &cur_npc : active_npc ) {
             if( static_cast<const Creature *>( cur_npc.get() ) == creature ) {
                 return !cur_npc->is_dead();
             }

--- a/src/creature_tracker.cpp
+++ b/src/creature_tracker.cpp
@@ -192,6 +192,25 @@ void creature_tracker::rebuild_cache()
     }
 }
 
+bool creature_tracker::is_present( Creature *creature ) const
+{
+    if( creature->is_monster() ) {
+        if( const auto iter = monsters_by_location.find( creature->get_location() );
+            iter != monsters_by_location.end() ) {
+            return !iter->second->is_dead();
+        }
+    } else if( creature->is_avatar() ) {
+        return true;
+    } else if( creature->is_npc() ) {
+        for( auto &cur_npc : active_npc ) {
+            if( static_cast<const Creature *>( cur_npc.get() ) == creature ) {
+                return !cur_npc->is_dead();
+            }
+        }
+    }
+    return false;
+}
+
 void creature_tracker::swap_positions( monster &first, monster &second )
 {
     if( first.get_location() == second.get_location() ) {

--- a/src/creature_tracker.cpp
+++ b/src/creature_tracker.cpp
@@ -197,7 +197,9 @@ bool creature_tracker::is_present( Creature *creature ) const
     if( creature->is_monster() ) {
         if( const auto iter = monsters_by_location.find( creature->get_location() );
             iter != monsters_by_location.end() ) {
-            return !iter->second->is_dead();
+            if( static_cast<const Creature *>( iter->second.get() ) == creature ) {
+                return !iter->second->is_dead();
+            }
         }
     } else if( creature->is_avatar() ) {
         return true;

--- a/src/creature_tracker.h
+++ b/src/creature_tracker.h
@@ -148,6 +148,9 @@ class creature_tracker
 
         void rebuild_cache();
 
+        // If the creature is in the tracker.
+        bool is_present( Creature *creature ) const;
+
         std::list<shared_ptr_fast<npc>> active_npc; // NOLINT(cata-serialize)
         std::vector<shared_ptr_fast<monster>> monsters_list;
         // NOLINTNEXTLINE(cata-serialize)
@@ -196,16 +199,15 @@ Creature *creature_tracker::find_reachable( const Creature &origin, FactionPredi
                 continue;
             }
             for( std::size_t i = 0; i < creatures.size(); ) {
-                Creature *other = creatures[i].get();
-                if( other->is_dead_state() ) {
-                    using std::swap;
-                    swap( creatures[i], creatures.back() );
-                    creatures.pop_back();
-                } else {
+                if( Creature *other = creatures[i].get(); is_present( other ) ) {
                     if( creature_fn( other ) ) {
                         return other;
                     }
                     ++i;
+                } else {
+                    using std::swap;
+                    swap( creatures[i], creatures.back() );
+                    creatures.pop_back();
                 }
             }
         }

--- a/src/creature_tracker.h
+++ b/src/creature_tracker.h
@@ -195,14 +195,17 @@ Creature *creature_tracker::find_reachable( const Creature &origin, FactionPredi
             if( !faction_fn( faction ) ) {
                 continue;
             }
-            for( std::size_t i = 0; i < creatures.size(); ++i ) {
+            for( std::size_t i = 0; i < creatures.size(); ) {
                 Creature *other = creatures[i].get();
                 if( other->is_dead_state() ) {
                     using std::swap;
                     swap( creatures[i], creatures.back() );
                     creatures.pop_back();
-                } else if( creature_fn( other ) ) {
-                    return other;
+                } else {
+                    if( creature_fn( other ) ) {
+                        return other;
+                    }
+                    ++i;
                 }
             }
         }

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4593,8 +4593,7 @@ bool mattack::parrot( monster *z )
 
 bool mattack::parrot_at_danger( monster *parrot )
 {
-    Creature *other = get_creature_tracker().find_reachable( *parrot, [parrot](
-    Creature * creature ) __declspec( noinline ) {
+    Creature *other = get_creature_tracker().find_reachable( *parrot, [parrot]( Creature * creature ) {
         if( !creature->is_hallucination() && one_in( 20 ) ) {
             if( creature->is_avatar() || creature->is_npc() ) {
                 Character *character = creature->as_character();

--- a/src/monattack.cpp
+++ b/src/monattack.cpp
@@ -4593,7 +4593,8 @@ bool mattack::parrot( monster *z )
 
 bool mattack::parrot_at_danger( monster *parrot )
 {
-    Creature *other = get_creature_tracker().find_reachable( *parrot, [parrot]( Creature * creature ) {
+    Creature *other = get_creature_tracker().find_reachable( *parrot, [parrot](
+    Creature * creature ) __declspec( noinline ) {
         if( !creature->is_hallucination() && one_in( 20 ) ) {
             if( creature->is_avatar() || creature->is_npc() ) {
                 Character *character = creature->as_character();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix crash from reachability zones checking dead NPCs."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #70649

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

NPCs weren't being cleaned out of the zone map. In general this code path is scattered all over `game.cpp` since `game` is a friend class, and trying to manage it manually would be too fragile. Instead, the pointers are swapped to `shared_ptr`s and are removed during iteration if the creature is no longer in the tracker.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Can't reproduce issue after change. Killed a bunch of npcs/monsters and shifted zones and it appears to work.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
