### PR TITLE
Fix flexbuffer cache post-c++-17 migration

### DIFF
--- a/src/flexbuffer_cache.cpp
+++ b/src/flexbuffer_cache.cpp
@@ -40,6 +40,18 @@ void try_find_and_throw_json_error( TextJsonValue &jv )
     }
 }
 
+fs::file_time_type get_file_mtime_millis( const fs::path &path, std::error_code &ec )
+{
+    fs::file_time_type ret = fs::last_write_time( path, ec );
+    if( ec ) {
+        return ret;
+    }
+    // Truncate to nearest millisecond.
+    ret = fs::file_time_type( std::chrono::milliseconds(
+                                  std::chrono::duration_cast<std::chrono::milliseconds>( ret.time_since_epoch() ).count() ) );
+    return ret;
+}
+
 std::vector<uint8_t> parse_json_to_flexbuffer_(
     const char *buffer,
     const char *source_filename_opt ) noexcept( false )
@@ -162,7 +174,7 @@ struct file_flexbuffer : parsed_flexbuffer {
 
         bool is_stale() const override {
             std::error_code ec;
-            fs::file_time_type mtime = fs::last_write_time( source_file_path_, ec );
+            fs::file_time_type mtime = get_file_mtime_millis( source_file_path_, ec );
             if( ec ) {
                 // Assume yes out of date.
                 return true;
@@ -296,7 +308,11 @@ class flexbuffer_disk_cache
                 return storage;
             }
 
-            fs::file_time_type source_mtime = fs::last_write_time( lexically_normal_json_source_path );
+            std::error_code ec;
+            fs::file_time_type source_mtime = get_file_mtime_millis( lexically_normal_json_source_path, ec );
+            if( ec ) {
+                return storage;
+            }
 
             // Does the source file's mtime match what we cached previously
             if( source_mtime != disk_entry->second.mtime ) {
@@ -322,12 +338,13 @@ class flexbuffer_disk_cache
                            const std::vector<uint8_t> &flexbuffer_binary ) {
             std::error_code ec;
             std::string json_source_path_string = lexically_normal_json_source_path.u8string();
-            fs::file_time_type mtime = fs::last_write_time( lexically_normal_json_source_path );
-            int64_t mtime_ms = std::chrono::duration_cast<std::chrono::milliseconds>
-                               ( mtime.time_since_epoch() ).count();
+            fs::file_time_type mtime = get_file_mtime_millis( lexically_normal_json_source_path, ec );
             if( ec ) {
                 return false;
             }
+
+            int64_t mtime_ms = std::chrono::duration_cast<std::chrono::milliseconds>
+                               ( mtime.time_since_epoch() ).count();
 
             // Doing some variable reuse to avoid copies.
             fs::path flexbuffer_path = ( cache_path_ / lexically_normal_json_source_path.lexically_relative(
@@ -396,7 +413,8 @@ std::shared_ptr<parsed_flexbuffer> flexbuffer_cache::parse( fs::path json_source
 
     std::error_code ec;
     // If we got this far we can get the mtime.
-    fs::file_time_type mtime = fs::last_write_time( json_source_path, ec );
+    fs::file_time_type mtime = get_file_mtime_millis( json_source_path, ec );
+    ( void )ec;
 
     return std::make_shared<file_flexbuffer>(
                std::move( storage ),
@@ -415,10 +433,8 @@ std::shared_ptr<parsed_flexbuffer> flexbuffer_cache::parse_and_cache(
                     lexically_normal_json_source_path );
         if( cached_storage ) {
             std::error_code ec;
-            fs::file_time_type mtime = fs::last_write_time( lexically_normal_json_source_path, ec );
-            if( ec ) {
-                // Whatever.
-            }
+            fs::file_time_type mtime = get_file_mtime_millis( lexically_normal_json_source_path, ec );
+            ( void )ec;
 
             return std::make_shared<file_flexbuffer>( std::move( cached_storage ),
                     std::move( lexically_normal_json_source_path ), mtime, offset );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Windows native <filesystem> returns mtimes in microseconds. This is a problem because we only persist the mtime for flexbuffer json sources in milliseconds. This meant cache was always 'missing' because of the extra precision.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Move all the mtime-accessing functions into a single helper function that performs the truncation to milliseconds automatically.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/667719/27804f0a-2155-4502-9bc7-c1aa9d408a37)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
