### PR TITLE
General refinements to the link/cable code

### DIFF
--- a/data/json/items/tool/cables.json
+++ b/data/json/items/tool/cables.json
@@ -14,8 +14,8 @@
     "category": "tools",
     "price": 1,
     "price_postapoc": 100,
-    "max_charges": 3,
-    "initial_charges": 3,
+    "max_charges": 2,
+    "initial_charges": 2,
     "use_action": { "type": "link_up", "menu_text": "Plug in / Manage connections", "targets": [ "vehicle_port" ] },
     "flags": [ "CABLE_SPOOL", "NO_DROP", "SINGLE_USE" ],
     "melee_damage": { "bash": 2 }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5264,9 +5264,9 @@ void reel_cable_activity_actor::start( player_activity &act, Character & )
 
 void reel_cable_activity_actor::finish( player_activity &act, Character &who )
 {
-    cable->link->length = 0;
-    cable->link->source = link_state::no_link;
-    cable->link->target = link_state::no_link;
+    cable->link().length = 0;
+    cable->link().source = link_state::no_link;
+    cable->link().target = link_state::no_link;
     cable->reset_link( &who, -2 );
     who.add_msg_if_player( m_info,
                            string_format( cable->has_flag( flag_CABLE_SPOOL ) ? _( "You reel in the %s and wind it up." ) :

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5265,9 +5265,7 @@ void reel_cable_activity_actor::start( player_activity &act, Character & )
 void reel_cable_activity_actor::finish( player_activity &act, Character &who )
 {
     cable->force_reset_link( &who, -2 );
-    who.add_msg_if_player( m_info,
-                           string_format( cable->has_flag( flag_CABLE_SPOOL ) ? _( "You reel in the %s and wind it up." ) :
-                                          _( "You reel in the %s's cable and wind it up." ), cable->type_name() ) );
+    who.add_msg_if_player( m_info, _( "You reel in the %s and wind it up." ), cable->link_name() );
     if( cable->has_flag( flag_NO_DROP ) ) {
         cable.remove_item();
     }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5264,7 +5264,7 @@ void reel_cable_activity_actor::start( player_activity &act, Character & )
 
 void reel_cable_activity_actor::finish( player_activity &act, Character &who )
 {
-    cable->force_reset_link( &who, -2 );
+    cable->reset_link( false, &who, -2 );
     who.add_msg_if_player( m_info, _( "You reel in the %s and wind it up." ), cable->link_name() );
     if( cable->has_flag( flag_NO_DROP ) ) {
         cable.remove_item();

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5264,10 +5264,7 @@ void reel_cable_activity_actor::start( player_activity &act, Character & )
 
 void reel_cable_activity_actor::finish( player_activity &act, Character &who )
 {
-    cable->link().length = 0;
-    cable->link().source = link_state::no_link;
-    cable->link().target = link_state::no_link;
-    cable->reset_link( &who, -2 );
+    cable->force_reset_link( &who, -2 );
     who.add_msg_if_player( m_info,
                            string_format( cable->has_flag( flag_CABLE_SPOOL ) ? _( "You reel in the %s and wind it up." ) :
                                           _( "You reel in the %s's cable and wind it up." ), cable->type_name() ) );

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -5265,8 +5265,8 @@ void reel_cable_activity_actor::start( player_activity &act, Character & )
 void reel_cable_activity_actor::finish( player_activity &act, Character &who )
 {
     cable->link->length = 0;
-    cable->link->s_state = link_state::no_link;
-    cable->link->t_state = link_state::no_link;
+    cable->link->source = link_state::no_link;
+    cable->link->target = link_state::no_link;
     cable->reset_link( &who, -2 );
     who.add_msg_if_player( m_info,
                            string_format( cable->has_flag( flag_CABLE_SPOOL ) ? _( "You reel in the %s and wind it up." ) :

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2535,8 +2535,7 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
                                            fix.tname() );
         ammotype current_ammo;
         std::string ammo_name;
-        if( used_tool->has_flag( flag_USE_UPS ) ||
-            ( used_tool->can_link_up() && used_tool->has_link_data() ) ) {
+        if( used_tool->has_flag( flag_USE_UPS ) || used_tool->has_link_data() ) {
             ammo_name = _( "battery" );
             current_ammo = ammo_battery;
         } else if( used_tool->has_flag( flag_USES_BIONIC_POWER ) ) {

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -2535,7 +2535,8 @@ void repair_item_finish( player_activity *act, Character *you, bool no_menu )
                                            fix.tname() );
         ammotype current_ammo;
         std::string ammo_name;
-        if( used_tool->link || used_tool->has_flag( flag_USE_UPS ) ) {
+        if( used_tool->has_flag( flag_USE_UPS ) ||
+            ( used_tool->can_link_up() && used_tool->has_link_data() ) ) {
             ammo_name = _( "battery" );
             current_ammo = ammo_battery;
         } else if( used_tool->has_flag( flag_USES_BIONIC_POWER ) ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1200,7 +1200,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
                                _( "You need a jumper cable connected to a power source to drain power from it." ) );
         } else {
             for( const item *cable : cables ) {
-                if( !cable->has_no_links() ) {
+                if( cable->has_no_links() ) {
                     free_cable = true;
                 } else if( cable->link_has_states( link_state::no_link, link_state::bio_cable ) ) {
                     add_msg_if_player( m_info,

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -3497,10 +3497,10 @@ std::vector<vehicle *> Character::get_cable_vehicle() const
     map &here = get_map();
 
     for( const item *cable : cables ) {
-        if( cable->link->t_veh ) {
-            remote_vehicles.emplace_back( cable->link->t_veh.get() );
+        if( cable->link().t_veh ) {
+            remote_vehicles.emplace_back( cable->link().t_veh.get() );
         } else {
-            const optional_vpart_position vp = here.veh_at( cable->link->t_abs_pos );
+            const optional_vpart_position vp = here.veh_at( cable->link().t_abs_pos );
             if( vp ) {
                 remote_vehicles.emplace_back( &vp->vehicle() );
             }

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -3497,8 +3497,8 @@ std::vector<vehicle *> Character::get_cable_vehicle() const
     map &here = get_map();
 
     for( const item *cable : cables ) {
-        if( cable->link->t_veh_safe ) {
-            remote_vehicles.emplace_back( cable->link->t_veh_safe.get() );
+        if( cable->link->t_veh ) {
+            remote_vehicles.emplace_back( cable->link->t_veh.get() );
         } else {
             const optional_vpart_position vp = here.veh_at( cable->link->t_abs_pos );
             if( vp ) {

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -1200,33 +1200,33 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
                                _( "You need a jumper cable connected to a power source to drain power from it." ) );
         } else {
             for( const item *cable : cables ) {
-                if( !cable->link || cable->link->has_no_links() ) {
+                if( !cable->has_no_links() ) {
                     free_cable = true;
-                } else if( cable->link->has_states( link_state::no_link, link_state::bio_cable ) ) {
+                } else if( cable->link_has_states( link_state::no_link, link_state::bio_cable ) ) {
                     add_msg_if_player( m_info,
                                        _( "You have a cable attached to your CBM but it also has to be connected to a power source." ) );
-                } else if( cable->link->has_states( link_state::solarpack, link_state::bio_cable ) ) {
+                } else if( cable->link_has_states( link_state::solarpack, link_state::bio_cable ) ) {
                     add_msg_activate();
                     success = true;
                     add_msg_if_player( m_info,
                                        _( "You are attached to a solar pack.  It will charge you if it's unfolded and in sunlight." ) );
-                } else if( cable->link->has_states( link_state::ups, link_state::bio_cable ) ) {
+                } else if( cable->link_has_states( link_state::ups, link_state::bio_cable ) ) {
                     add_msg_activate();
                     success = true;
                     add_msg_if_player( m_info,
                                        _( "You are attached to a UPS.  It will charge you if it has some juice in it." ) );
-                } else if( cable->link->has_states( link_state::bio_cable, link_state::vehicle_battery ) ||
-                           cable->link->has_states( link_state::bio_cable, link_state::vehicle_port ) ) {
+                } else if( cable->link_has_states( link_state::bio_cable, link_state::vehicle_battery ) ||
+                           cable->link_has_states( link_state::bio_cable, link_state::vehicle_port ) ) {
                     add_msg_activate();
                     success = true;
                     add_msg_if_player( m_info,
                                        _( "You are attached to a vehicle.  It will charge you if it has some juice in it." ) );
-                } else if( cable->link->s_state == link_state::solarpack ||
-                           cable->link->s_state == link_state::ups ) {
+                } else if( cable->link_has_states( link_state::solarpack, link_state::automatic ) ||
+                           cable->link_has_states( link_state::ups, link_state::automatic ) ) {
                     add_msg_if_player( m_info,
                                        _( "You have a cable attached to a portable power source, but you also need to connect it to your CBM." ) );
-                } else if( cable->link->t_state == link_state::vehicle_battery ||
-                           cable->link->t_state == link_state::vehicle_port ) {
+                } else if( cable->link_has_states( link_state::automatic, link_state::vehicle_battery ) ||
+                           cable->link_has_states( link_state::automatic, link_state::vehicle_port ) ) {
                     add_msg_if_player( m_info,
                                        _( "You have a cable attached to a vehicle, but you also need to connect it to your CBM." ) );
                 }
@@ -3422,7 +3422,7 @@ std::vector<item *> Character::get_cable_ups()
     std::vector<item *> stored_fuels;
 
     int n = cache_get_items_with( flag_CABLE_SPOOL, []( const item & it ) {
-        return it.link && it.link->has_states( link_state::ups, link_state::bio_cable );
+        return it.link_has_states( link_state::ups, link_state::bio_cable );
     } ).size();
     if( n == 0 ) {
         return stored_fuels;
@@ -3454,7 +3454,7 @@ std::vector<item *> Character::get_cable_solar()
     std::vector<item *> solar_sources;
 
     int n = cache_get_items_with( flag_CABLE_SPOOL, []( const item & it ) {
-        return it.link && it.link->has_states( link_state::solarpack, link_state::bio_cable );
+        return it.link_has_states( link_state::solarpack, link_state::bio_cable );
     } ).size();
     if( n == 0 ) {
         return solar_sources;
@@ -3485,9 +3485,9 @@ std::vector<vehicle *> Character::get_cable_vehicle() const
 
     std::vector<const item *> cables = cache_get_items_with( flag_CABLE_SPOOL,
     []( const item & it ) {
-        return it.link && it.link->has_state( link_state::bio_cable ) &&
-               ( it.link->has_state( link_state::vehicle_battery ) ||
-                 it.link->has_state( link_state::vehicle_port ) );
+        return it.link_has_state( link_state::bio_cable ) &&
+               ( it.link_has_state( link_state::vehicle_battery ) ||
+                 it.link_has_state( link_state::vehicle_port ) );
     } );
     int n = cables.size();
     if( n == 0 ) {

--- a/src/enums.h
+++ b/src/enums.h
@@ -475,23 +475,15 @@ struct enum_traits<aggregate_type> {
 };
 
 enum class link_state : int {
-    // Utility states
-    no_link = 0,   // No connection, the default state
-    needs_reeling, // Cable has been disconnected and needs to be manually reeled in before it can be used again
-    automatic,     // Use in link_to to automatically set the type of connection based on the connected vehicle part
-
-    // States of a cable's link at the end represented by the item (source)
-    ups,       // Linked to a UPS the cable holder is holding
-    solarpack, // Linked to a solarpack the cable holder is wearing
-
-    // States of a cable's link at the end represented by t_abs_pos (target)
-    vehicle_port, // Linked to a vehicle's cable ports / electrical controls or an appliance
+    no_link = 0,     // No connection, the default state
+    needs_reeling,   // Cable has been disconnected and needs to be manually reeled in before it can be used again
+    ups,             // Linked to a UPS the cable holder is holding
+    solarpack,       // Linked to a solarpack the cable holder is wearing
+    vehicle_port,    // Linked to a vehicle's cable ports / electrical controls or an appliance
     vehicle_battery, // Linked to a vehicle's battery or an appliance
-
-    // States of a link that could be at either the source or the target
-    bio_cable,   // Linked to the cable holder's cable system bionic - source if connected to a vehicle, target otherwise
-    vehicle_tow, // Linked to a valid tow point on a vehicle - source if it's the towing vehicle, target if the towed one
-
+    bio_cable,       // Linked to the cable holder's cable system bionic - source if connected to a vehicle, target otherwise
+    vehicle_tow,     // Linked to a valid tow point on a vehicle - source if it's the towing vehicle, target if the towed one
+    automatic,       // Use in link_to() to automatically set the type of connection based on the connected vehicle part. Is always true as a link_has_states() parameter.
     last
 };
 template<>

--- a/src/enums.h
+++ b/src/enums.h
@@ -480,17 +480,17 @@ enum class link_state : int {
     needs_reeling, // Cable has been disconnected and needs to be manually reeled in before it can be used again
     automatic,     // Use in link_to to automatically set the type of connection based on the connected vehicle part
 
-    // States of a cable's link at the end represented by the item (s_state)
+    // States of a cable's link at the end represented by the item (source)
     ups,       // Linked to a UPS the cable holder is holding
     solarpack, // Linked to a solarpack the cable holder is wearing
 
-    // States of a cable's link at the end represented by t_abs_pos (t_state)
+    // States of a cable's link at the end represented by t_abs_pos (target)
     vehicle_port, // Linked to a vehicle's cable ports / electrical controls or an appliance
     vehicle_battery, // Linked to a vehicle's battery or an appliance
 
     // States of a link that could be at either the source or the target
-    bio_cable,   // Linked to the cable holder's cable system bionic - s_state if connected to a vehicle, t_state otherwise
-    vehicle_tow, // Linked to a valid tow point on a vehicle - s_state if it's the towing vehicle, t_state if the towed one
+    bio_cable,   // Linked to the cable holder's cable system bionic - source if connected to a vehicle, target otherwise
+    vehicle_tow, // Linked to a valid tow point on a vehicle - source if it's the towing vehicle, target if the towed one
 
     last
 };

--- a/src/enums.h
+++ b/src/enums.h
@@ -478,6 +478,7 @@ enum class link_state : int {
     // Utility states
     no_link = 0,   // No connection, the default state
     needs_reeling, // Cable has been disconnected and needs to be manually reeled in before it can be used again
+    automatic,     // Use in link_to to automatically set the type of connection based on the connected vehicle part
 
     // States of a cable's link at the end represented by the item (s_state)
     ups,       // Linked to a UPS the cable holder is holding

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13367,10 +13367,12 @@ ret_val<void> item::link_to( vehicle &veh, const point &mount, link_state link_t
         }
     }
 
-    if( has_no_links() ) {
+    bool bio_link = link_has_states( link_state::no_link, link_state::bio_cable );
+    if( bio_link || has_no_links() ) {
 
         // No link exists, so start a new link to a vehicle/appliance.
 
+        link().source = bio_link ? link_state::bio_cable : link_state::no_link;
         link().target = link_type;
         link().t_veh = veh.get_safe_reference();
         link().t_abs_pos = get_map().getglobal( link().t_veh->global_pos3() );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13775,6 +13775,20 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
     return link().charge_rate;
 }
 
+bool item::force_reset_link( Character *p, int vpart_index,
+                             const bool loose_message, const tripoint cable_position )
+{
+    if( !can_link_up() || !has_link_data() ) {
+        return has_flag( flag_NO_DROP );
+    }
+    link().length = 0;
+    if( link_has_state( link_state::needs_reeling ) ) {
+        link().source = link_state::no_link;
+        link().target = link_state::no_link;
+    }
+    return reset_link( p, vpart_index, loose_message, cable_position );
+}
+
 bool item::reset_link( Character *p, int vpart_index,
                        const bool loose_message, const tripoint cable_position )
 {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13306,6 +13306,11 @@ bool item::has_no_links() const
            link_->source == link_state::no_link && link_->target == link_state::no_link;
 }
 
+std::string item::link_name() const
+{
+    return has_flag( flag_CABLE_SPOOL ) ? label( 1 ) : string_format( " %s's cable", label( 1 ) );
+}
+
 ret_val<void> item::link_to( const optional_vpart_position &linked_vp, link_state link_type )
 {
     return linked_vp ? link_to( linked_vp->vehicle(), linked_vp->mount(), link_type ) :
@@ -13542,9 +13547,8 @@ bool item::process_link( map &here, Character *carrier, const tripoint &pos )
     // Handle links to items in the inventory.
     if( link().source == link_state::solarpack ) {
         if( carrier == nullptr || !carrier->worn_with_flag( flag_SOLARPACK_ON ) ) {
-            add_msg_if_player_sees( pos, m_bad,
-                                    string_format( is_cable_item ? _( "The %s has come loose from the solar pack." ) :
-                                                   _( "The %s's cable has come loose from the solar pack." ), type_name() ) );
+            add_msg_if_player_sees( pos, m_bad, _( "The %s has come loose from the solar pack." ),
+                                    link_name() );
             reset_link( carrier );
             return false;
         }
@@ -13554,9 +13558,7 @@ bool item::process_link( map &here, Character *carrier, const tripoint &pos )
     };
     if( link().source == link_state::ups ) {
         if( carrier == nullptr || !carrier->cache_has_item_with( flag_IS_UPS, used_ups ) ) {
-            add_msg_if_player_sees( pos, m_bad,
-                                    string_format( is_cable_item ? _( "The %s has come loose from the UPS." ) :
-                                                   _( "The %s's cable has come loose from the UPS." ), type_name() ) );
+            add_msg_if_player_sees( pos, m_bad, _( "The %s has come loose from the UPS." ), link_name() );
             reset_link( carrier );
             return false;
         }
@@ -13583,20 +13585,16 @@ bool item::process_link( map &here, Character *carrier, const tripoint &pos )
                            link().length, link().max_length );
         }
         if( link().length > link().max_length ) {
+            std::string cable_name = is_cable_item ? string_format( "over-extended %s", label( 1 ) ) :
+                                     string_format( "%s's over-extended cable", label( 1 ) );
             if( carrier != nullptr ) {
-                carrier->add_msg_if_player( m_bad,
-                                            string_format( is_cable_item ? _( "Your over-extended %s breaks loose!" ) :
-                                                    _( "Your %s's over-extended cable breaks loose!" ), type_name() ) );
+                carrier->add_msg_if_player( m_bad, _( "Your %s breaks loose!" ), cable_name );
             } else {
-                add_msg_if_player_sees( pos, m_bad,
-                                        string_format( is_cable_item ? _( "The over-extended %s breaks loose!" ) :
-                                                       _( "The %s's over-extended cable breaks loose!" ), type_name() ) );
+                add_msg_if_player_sees( pos, m_bad, _( "Your %s breaks loose!" ), cable_name );
             }
             return true;
         } else if( new_length + M_SQRT2 >= link().max_length + 1 && carrier != nullptr ) {
-            carrier->add_msg_if_player( m_warning,
-                                        string_format( is_cable_item ? _( "Your %s is stretched to its limit!" ) :
-                                                _( "Your %s's cable is stretched to its limit!" ), type_name() ) );
+            carrier->add_msg_if_player( m_warning, _( "Your %s is stretched to its limit!" ), link_name() );
         }
         return false;
     };
@@ -13843,13 +13841,9 @@ bool item::reset_link( Character *p, int vpart_index,
 
     if( loose_message ) {
         if( p != nullptr ) {
-            p->add_msg_if_player( m_warning,
-                                  string_format( is_cable_item ? _( "Your %s has come loose." ) :
-                                                 _( "Your %s's cable has come loose." ), type_name() ) );
+            p->add_msg_if_player( m_warning, _( "Your %s has come loose." ), link_name() );
         } else {
-            add_msg_if_player_sees( cable_position, m_warning,
-                                    string_format( is_cable_item ? _( "The %s has come loose." ) :
-                                                   _( "The %s's cable has come loose." ), type_name() ) );
+            add_msg_if_player_sees( cable_position, m_warning, _( "The %s has come loose." ), link_name() );
         }
     }
 
@@ -13860,9 +13854,7 @@ bool item::reset_link( Character *p, int vpart_index,
     }
 
     if( loose_message && p ) {
-        p->add_msg_if_player( m_info, string_format( is_cable_item ?
-                              _( "You reel in the %s and wind it up." ) :
-                              _( "You reel in the %s's cable and wind it up." ), tname() ) );
+        p->add_msg_if_player( m_info, _( "You reel in the %s and wind it up." ), link_name() );
     }
 
     link_.reset();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13778,7 +13778,7 @@ int item::charge_linked_batteries( vehicle &linked_veh, int turns_elapsed )
 bool item::force_reset_link( Character *p, int vpart_index,
                              const bool loose_message, const tripoint cable_position )
 {
-    if( !can_link_up() || !has_link_data() ) {
+    if( !has_link_data() ) {
         return has_flag( flag_NO_DROP );
     }
     link().length = 0;
@@ -13792,7 +13792,7 @@ bool item::force_reset_link( Character *p, int vpart_index,
 bool item::reset_link( Character *p, int vpart_index,
                        const bool loose_message, const tripoint cable_position )
 {
-    if( !can_link_up() || !has_link_data() ) {
+    if( !has_link_data() ) {
         return has_flag( flag_NO_DROP );
     }
     // Cables that need reeling should be reset with a reel_cable_activity_actor instead.

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13841,8 +13841,7 @@ bool item::reset_link( Character *p, int vpart_index,
         }
     }
 
-    const int respool_threshold = 6;
-    if( link().length > respool_threshold ) {
+    if( link().length > LINK_RESPOOL_THRESHOLD ) {
         // Cables that are too long need to be manually rewound before reuse.
         link().source = link_state::needs_reeling;
         return false;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13259,7 +13259,7 @@ item::link_data &item::link()
         return *link_;
     }
     if( !can_link_up() ) {
-        debugmsg( "%s is creating link_data even though it doesn't have a link_up action! can_link_up() should be checked before using link().",
+        debugmsg( "%s is creating link_data even though it doesn't have a link_up action!  can_link_up() should be checked before using link().",
                   tname() );
     }
     return *( link_ = cata::make_value<item::link_data>() );
@@ -13271,7 +13271,7 @@ const item::link_data &item::link() const
         return *link_;
     }
     if( !can_link_up() ) {
-        debugmsg( "%s is creating link_data even though it doesn't have a link_up action! can_link_up() should be checked before using link().",
+        debugmsg( "%s is creating link_data even though it doesn't have a link_up action!  can_link_up() should be checked before using link().",
                   tname() );
     }
     return *( link_ = cata::make_value<item::link_data>() );
@@ -13293,11 +13293,11 @@ bool item::link_has_state( link_state state ) const
            link_->source == state || link_->target == state;
 }
 
-bool item::link_has_states( link_state s_state_, link_state t_state_ ) const
+bool item::link_has_states( link_state source, link_state target ) const
 {
-    return !has_link_data() ? s_state_ == link_state::no_link && t_state_ == link_state::no_link :
-           ( link_->source == s_state_ || link_->source == link_state::automatic ) &&
-           ( link_->target == t_state_ || link_->target == link_state::automatic );
+    return !has_link_data() ? source == link_state::no_link && target == link_state::no_link :
+           ( link_->source == source || link_->source == link_state::automatic ) &&
+           ( link_->target == target || link_->target == link_state::automatic );
 }
 
 bool item::has_no_links() const

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -13257,7 +13257,7 @@ bool item::can_link_up() const
     return !!link || type->can_use( "link_up" );
 }
 
-void item::set_link_traits( const bool assign_t_state )
+void item::update_link_traits( const bool assign_t_state )
 {
     if( !can_link_up() ) {
         return;
@@ -13647,7 +13647,7 @@ bool item::reset_link( Character *p, int vpart_index,
     if( !cables().empty() ) {
         // If there are extensions, keep link active to maintain max_length.
         link = cata::make_value<item::link_data>();
-        set_link_traits();
+        update_link_traits();
     }
     return has_flag( flag_NO_DROP );
 }

--- a/src/item.h
+++ b/src/item.h
@@ -1480,6 +1480,9 @@ class item : public visitable
         /// Returns true if the item has no active link, or if both link states are link_state::no_link.
         bool has_no_links() const;
 
+        /// Name to use for describing the link, whether it's its own item, like "extension cord", or secondary, like "smart phone's cable".
+        std::string link_name() const;
+
         /**
          * @brief Initializes the item's link_data and starts a connection to the specified vehicle position.
          * @param linked_vp An optional_vpart_position to connect the item to.

--- a/src/item.h
+++ b/src/item.h
@@ -1542,6 +1542,17 @@ class item : public visitable
          */
         bool reset_link( Character *p = nullptr, int vpart_index = -1,
                          bool loose_message = false, tripoint cable_position = tripoint_zero );
+        /**
+         * Resets a cable item back to its initial state. Will never become unspooled, even if it's long enough.
+         * @param p Set to character that's holding the linked item, nullptr if none.
+         * @param vpart_index The index of the vehicle part the cable is attached to, so it can have `linked_flag` removed.
+         * @param * At -1, the default, this function will look up the index itself. At -2, skip modifying the part's flags entirely.
+         * @param loose_message If there should be a notification that the link was disconnected.
+         * @param cable_position Position of the linked item, used to determine if the player can see the link becoming loose.
+         * @return True if the cable should be deleted.
+         */
+        bool force_reset_link( Character *p = nullptr, int vpart_index = -1,
+                               bool loose_message = false, tripoint cable_position = tripoint_zero );
 
         /**
         * @brief Exchange power between an item's batteries and the vehicle/appliance it's linked to.

--- a/src/item.h
+++ b/src/item.h
@@ -1537,7 +1537,8 @@ class item : public visitable
         int link_sort_key() const;
 
         /**
-         * Resets a cable item back to its initial state, or become unspooled if it's too long.
+         * Resets a cable item back to its initial state.
+         * @param unspool_if_too_long If true, a long-enough cable will be put into an unspooled state instead of being fully reset.
          * @param p Set to character that's holding the linked item, nullptr if none.
          * @param vpart_index The index of the vehicle part the cable is attached to, so it can have `linked_flag` removed.
          * @param * At -1, the default, this function will look up the index itself. At -2, skip modifying the part's flags entirely.
@@ -1545,19 +1546,8 @@ class item : public visitable
          * @param cable_position Position of the linked item, used to determine if the player can see the link becoming loose.
          * @return True if the cable should be deleted.
          */
-        bool reset_link( Character *p = nullptr, int vpart_index = -1,
+        bool reset_link( bool unspool_if_too_long = true, Character *p = nullptr, int vpart_index = -1,
                          bool loose_message = false, tripoint cable_position = tripoint_zero );
-        /**
-         * Resets a cable item back to its initial state. Will never become unspooled, even if it's long enough.
-         * @param p Set to character that's holding the linked item, nullptr if none.
-         * @param vpart_index The index of the vehicle part the cable is attached to, so it can have `linked_flag` removed.
-         * @param * At -1, the default, this function will look up the index itself. At -2, skip modifying the part's flags entirely.
-         * @param loose_message If there should be a notification that the link was disconnected.
-         * @param cable_position Position of the linked item, used to determine if the player can see the link becoming loose.
-         * @return True if the cable should be deleted.
-         */
-        bool force_reset_link( Character *p = nullptr, int vpart_index = -1,
-                               bool loose_message = false, tripoint cable_position = tripoint_zero );
 
         /**
         * @brief Exchange power between an item's batteries and the vehicle/appliance it's linked to.

--- a/src/item.h
+++ b/src/item.h
@@ -1432,9 +1432,9 @@ class item : public visitable
         bool leak( map &here, Character *carrier, const tripoint &pos, item_pocket *pocke = nullptr );
 
         struct link_data {
-            /// State of the link's source, the end usually represented by the cable item. @ref link_state.
+            /// State of the link's source connection, the end usually represented by the device/cable item itself. @ref link_state.
             link_state source = link_state::no_link;
-            /// State of the link's target, the end represented by t_abs_pos, @ref link_state.
+            /// State of the link's target connection, the end represented by t_abs_pos. @ref link_state.
             link_state target = link_state::no_link;
             /// A safe reference to the link's target vehicle. Will recreate itself whenever possible.
             safe_reference<vehicle> t_veh; // NOLINT(cata-serialize)

--- a/src/item.h
+++ b/src/item.h
@@ -1460,6 +1460,8 @@ class item : public visitable
             void serialize( JsonOut &jsout ) const;
             void deserialize( const JsonObject &data );
         };
+        /// Disconnecting a cable beyond this length will leave it unspooled, requiring respooling to be usable again.
+        static const int LINK_RESPOOL_THRESHOLD = 6;
 
         /// Gets the item's link data, initializing it if needed. Will throw an error if used on items that fail can_link_up().
         /// To avoid unnecessary link_data initialization, simple boolean link functions should be used instead if possible.

--- a/src/item.h
+++ b/src/item.h
@@ -1469,9 +1469,9 @@ class item : public visitable
         const item::link_data &link() const;
         /// Returns true if the item has valid link_data. Does not mean the link actually connects to anything; use has_no_links() for that.
         bool has_link_data() const;
-
-        /// Returns true if the item is/has a cable that can link up to other things.
+        /// Returns true if the item is/has a cable that can link up to other things. Should usually be called before using link().
         bool can_link_up() const;
+
         /// Returns true if either of the link's ends have the specified state.
         bool link_has_state( link_state state ) const;
         /// Returns true if both of the item's link connections match the specified states.

--- a/src/item.h
+++ b/src/item.h
@@ -1461,6 +1461,13 @@ class item : public visitable
             void deserialize( const JsonObject &data );
         };
 
+        /// Gets the item's link data, initializing it if needed. Will throw an error if used on items that fail can_link_up().
+        /// To avoid unnecessary link_data initialization, simple boolean link functions should be used instead if possible.
+        item::link_data &link();
+        const item::link_data &link() const;
+        /// Returns true if the item has valid link_data. Does not mean the link actually connects to anything; use has_no_links() for that.
+        bool has_link_data() const;
+
         /// Returns true if the item is/has a cable that can link up to other things.
         bool can_link_up() const;
         /// Returns true if either of the link's ends have the specified state.
@@ -1525,7 +1532,7 @@ class item : public visitable
         int link_sort_key() const;
 
         /**
-         * Brings a cable item back to its initial state.
+         * Resets a cable item back to its initial state, or become unspooled if it's too long.
          * @param p Set to character that's holding the linked item, nullptr if none.
          * @param vpart_index The index of the vehicle part the cable is attached to, so it can have `linked_flag` removed.
          * @param * At -1, the default, this function will look up the index itself. At -2, skip modifying the part's flags entirely.
@@ -1538,8 +1545,8 @@ class item : public visitable
 
         /**
         * @brief Exchange power between an item's batteries and the vehicle/appliance it's linked to.
-        * @brief A positive link.charge_rate will charge the item at the expense of the vehicle,
-        * while a negative link.charge_rate will charge the vehicle at the expense of the item.
+        * @brief A positive link().charge_rate will charge the item at the expense of the vehicle,
+        * while a negative link().charge_rate will charge the vehicle at the expense of the item.
         *
         * @param linked_veh The vehicle the item is connected to.
         * @param turns_elapsed The number of turns the link has spent outside the reality bubble. Default 1.
@@ -3073,7 +3080,6 @@ class item : public visitable
     public:
         // any relic data specific to this item
         cata::value_ptr<relic> relic_data;
-        cata::value_ptr<link_data> link;
         int charges = 0;
         units::energy energy = 0_mJ; // Amount of energy currently stored in a battery
 
@@ -3140,6 +3146,7 @@ class item : public visitable
         int degradation_ = 0;
         light_emission light = nolight;
         mutable std::optional<float> cached_relative_encumbrance;
+        mutable cata::value_ptr<link_data> link_;
 
         // additional encumbrance this specific item has
         units::volume additional_encumbrance = 0_ml;

--- a/src/item.h
+++ b/src/item.h
@@ -1433,11 +1433,11 @@ class item : public visitable
 
         struct link_data {
             /// State of the link's source, the end usually represented by the cable item. @ref link_state.
-            link_state s_state = link_state::no_link;
+            link_state source = link_state::no_link;
             /// State of the link's target, the end represented by t_abs_pos, @ref link_state.
-            link_state t_state = link_state::no_link;
+            link_state target = link_state::no_link;
             /// A safe reference to the link's target vehicle. Will recreate itself whenever possible.
-            safe_reference<vehicle> t_veh_safe; // NOLINT(cata-serialize)
+            safe_reference<vehicle> t_veh; // NOLINT(cata-serialize)
             /// Absolute position of the linked target vehicle/appliance.
             tripoint_abs_ms t_abs_pos = tripoint_abs_ms( tripoint_min );
             /// The linked part's mount offset on the target vehicle.
@@ -1467,7 +1467,7 @@ class item : public visitable
         bool link_has_state( link_state state ) const;
         /// Returns true if both of the item's link connections match the specified states.
         /// link_state::automatic will always match.
-        bool link_has_states( link_state s_state_, link_state t_state_ ) const;
+        bool link_has_states( link_state source, link_state target ) const;
         /// Returns true if the item has no active link, or if both link states are link_state::no_link.
         bool has_no_links() const;
 

--- a/src/item.h
+++ b/src/item.h
@@ -1457,23 +1457,19 @@ class item : public visitable
             /// How long it takes to charge 1 kW, the unit batteries use.
             int charge_interval = 0;
 
-            bool has_state( link_state state ) const {
-                return s_state == state || t_state == state;
-            }
-            bool has_states( link_state s_state_, link_state t_state_ ) const {
-                return s_state == s_state_ && t_state == t_state_;
-            }
-            bool has_no_links() const {
-                return s_state == link_state::no_link && t_state == link_state::no_link;
-            }
-
             void serialize( JsonOut &jsout ) const;
             void deserialize( const JsonObject &data );
         };
-        /**
-         * @brief Returns true if the item is/has a cable that can link up to other things.
-         */
+
+        /// Returns true if the item is/has a cable that can link up to other things.
         bool can_link_up() const;
+        /// Returns true if either of the link's ends have the specified state.
+        bool link_has_state( link_state state ) const;
+        /// Returns true if both of the item's link connections match the specified states.
+        /// link_state::automatic will always match.
+        bool link_has_states( link_state s_state_, link_state t_state_ ) const;
+        /// Returns true if the item has no active link, or if both link states are link_state::no_link.
+        bool has_no_links() const;
 
         /**
          * @brief Initializes the item's link_data and starts a connection to the specified vehicle position.

--- a/src/item.h
+++ b/src/item.h
@@ -1484,6 +1484,16 @@ class item : public visitable
         ret_val<void> link_to( const optional_vpart_position &linked_vp,
                                link_state link_type = link_state::no_link );
         /**
+         * @brief Initializes the item's link_data and starts a connection between the first specified vehicle position and the second.
+         * @param first_linked_vp An optional_vpart_position to connect the item to first.
+         * @param second_linked_vp An optional_vpart_position to connect the item to second.
+         * @param link_type What type of connection to make. If set to link_state::automatic, will automatically determine which type to use. Defaults to link_state::no_link.
+         * @return true if the item was successfully connected.
+         */
+        ret_val<void> link_to( const optional_vpart_position &first_linked_vp,
+                               const optional_vpart_position &second_linked_vp,
+                               link_state link_type = link_state::no_link );
+        /**
          * @brief Initializes the item's link_data and starts a connection to the specified vehicle and mount point.
          * @param veh The vehicle to connect the item to.
          * @param mount The mount point of the part being connected to.

--- a/src/item.h
+++ b/src/item.h
@@ -1480,7 +1480,7 @@ class item : public visitable
          * @brief efficiency is set to the product of all efficiencies multiplied together.
          * @param assign_t_state If true, set the t_state based on the parts at the connection point. Defaults to false.
          */
-        void set_link_traits( bool assign_t_state = false );
+        void update_link_traits( bool assign_t_state = false );
 
         /**
          * @return The link's current length.

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3883,6 +3883,8 @@ std::string enum_to_string<link_state>( link_state data )
             return "no_link";
         case link_state::needs_reeling:
             return "needs_reeling";
+        case link_state::automatic:
+            return "automatic";
         case link_state::vehicle_port:
             return "vehicle_port";
         case link_state::vehicle_battery:

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -170,7 +170,6 @@ std::optional<int> pack_item( Character *, item *, const tripoint & );
 std::optional<int> pick_lock( Character *p, item *it, const tripoint &pos );
 std::optional<int> pickaxe( Character *, item *, const tripoint & );
 std::optional<int> play_game( Character *, item *, const tripoint & );
-std::optional<int> plug_in( Character *, item *, const tripoint & );
 std::optional<int> portable_game( Character *, item *, const tripoint & );
 std::optional<int> portal( Character *, item *, const tripoint & );
 std::optional<int> radglove( Character *, item *, const tripoint & );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4944,7 +4944,7 @@ std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
         selected = game_menus::inv::titled_filter_menu( filter, *you, _( "Extend which cable?" ), -1,
                    _( "You don't have a compatible cable." ) );
     } else {
-        const auto filter = [&it]( const item & inv ) {
+        const auto filter = []( const item & inv ) {
             if( !inv.can_link_up() || inv.link_has_state( link_state::needs_reeling ) ||
                 !inv.has_flag( flag_CABLE_SPOOL ) ) {
                 return false;

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4843,7 +4843,6 @@ std::optional<int> link_up_actor::link_to_veh_app( Character *p, item &it,
             return 0;
         }
         if( p->has_item( it ) ) {
-            //~ %1$s - first vehicle name, %2$s - second vehicle name - %3$s - cable name,
             p->add_msg_if_player( m_good, result.str() );
         }
 
@@ -4912,7 +4911,6 @@ std::optional<int> link_up_actor::link_tow_cable( Character *p, item &it,
             return 0;
         }
         if( p->has_item( it ) ) {
-            //~ %1$s - first vehicle name, %2$s - second vehicle name - %3$s - tow cable name,
             p->add_msg_if_player( m_good, result.str() );
         }
 

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4467,11 +4467,10 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
     const std::string cable_name = is_cable_item ? it.type_name() :
                                    string_format( _( "%s's cable" ), it.type_name() );
 
-    const int respool_threshold = 6;
     const int respool_time_per_square = 200;
-    const int respool_time_total = it.link().length < respool_threshold ? 0 :
-                                   ( it.link().length - respool_threshold ) * respool_time_per_square;
-    const bool past_respool_threshold = it.link_length() > respool_threshold;
+    const bool past_respool_threshold = it.link_length() > item::LINK_RESPOOL_THRESHOLD;
+    const int respool_time_total = !past_respool_threshold ? 0 :
+                                   ( it.link_length() - item::LINK_RESPOOL_THRESHOLD ) * respool_time_per_square;
     const bool unspooled = it.link_length() == -1;
     const bool has_loose_end = !unspooled && is_cable_item ?
                                it.link_has_state( link_state::no_link ) : it.has_no_links();

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4639,7 +4639,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
             t_veh->linked_item_epower_this_turn += units::from_milliwatt( power_draw );
         }
 
-        it.reset_link( p );
+        it.reset_link( true, p );
         // Cables that are too long need to be manually rewound before reuse.
         if( it.link_length() == -1 ) {
             p->assign_activity( player_activity( reel_cable_activity_actor( respool_time_total, item_location{*p, &it} ) ) );
@@ -4849,7 +4849,7 @@ std::optional<int> link_up_actor::link_to_veh_app( Character *p, item &it,
 
         if( it.typeId() != itype_power_cord ) {
             // Remove linked_flag from attached parts - the just-added cable vehicle parts do the same thing.
-            it.reset_link( p );
+            it.reset_link( true, p );
         }
         p->moves -= move_cost;
         return 1; // Let the cable be destroyed.
@@ -5066,7 +5066,7 @@ std::optional<int> link_up_actor::remove_extensions( Character *p, item &it ) co
         cable_main_copy.link() = it.link();
         cable_main_copy.update_link_traits();
         cable_main_copy.process( get_map(), p, p->pos() );
-        it.reset_link( p );
+        it.reset_link( true, p );
     }
 
     p->i_add_or_drop( cable_main_copy );

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4945,11 +4945,9 @@ std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
     if( is_cable_item ) {
         const bool can_extend_devices = can_extend.find( "ELECTRICAL_DEVICES" ) != can_extend.end();
         const auto filter = [this, &it, &can_extend_devices]( const item & inv ) {
-            if( it.link_length() >= 0 || inv.link_has_state( link_state::needs_reeling ) ) {
+            if( !inv.can_link_up() || inv.link_has_state( link_state::needs_reeling ) ||
+                ( !inv.has_flag( flag_CABLE_SPOOL ) && !can_extend_devices ) ) {
                 return false;
-            }
-            if( !inv.has_flag( flag_CABLE_SPOOL ) ) {
-                return can_extend_devices && inv.can_link_up();
             }
             return can_extend.find( inv.typeId().c_str() ) != can_extend.end() && &inv != &it;
         };
@@ -4957,8 +4955,8 @@ std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
                    _( "You don't have a compatible cable." ) );
     } else {
         const auto filter = [&it]( const item & inv ) {
-            if( !inv.has_flag( flag_CABLE_SPOOL ) || !inv.can_link_up() ||
-                ( it.link_length() >= 0 || inv.link_has_state( link_state::needs_reeling ) ) ) {
+            if( !inv.can_link_up() || inv.link_has_state( link_state::needs_reeling ) ||
+                !inv.has_flag( flag_CABLE_SPOOL ) ) {
                 return false;
             }
             const link_up_actor *actor = static_cast<const link_up_actor *>

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4417,7 +4417,7 @@ void link_up_actor::info( const item &it, std::vector<iteminfo> &dump ) const
     const bool no_extensions = it.cables().empty();
     item dummy( it );
     dummy.link = cata::make_value<item::link_data>();
-    dummy.set_link_traits();
+    dummy.update_link_traits();
 
     std::string length_all_info = string_format( _( "<bold>Cable length</bold>: %d" ),
                                   dummy.max_link_length() );
@@ -4692,7 +4692,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
             it.link->s_state = link_state::bio_cable;
             p->add_msg_if_player( m_good, _( "You are now plugged into the vehicle." ) );
         }
-        it.set_link_traits();
+        it.update_link_traits();
         it.link->last_processed = calendar::turn;
         p->moves -= move_cost;
         it.process( here, p, p->pos() );
@@ -4731,7 +4731,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
         }
         it.link->s_state = link_state::ups;
         loc->set_var( "cable", "plugged_in" );
-        it.set_link_traits();
+        it.update_link_traits();
         it.link->last_processed = calendar::turn;
         p->moves -= move_cost;
         it.process( here, p, p->pos() );
@@ -4770,7 +4770,7 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
         }
         it.link->s_state = link_state::solarpack;
         loc->set_var( "cable", "plugged_in" );
-        it.set_link_traits();
+        it.update_link_traits();
         it.link->last_processed = calendar::turn;
         p->moves -= move_cost;
         it.process( here, p, p->pos() );
@@ -4847,7 +4847,7 @@ std::optional<int> link_up_actor::link_to_veh_app( Character *p, item &it,
         it.link->t_state = to_ports ? link_state::vehicle_port : link_state::vehicle_battery;
         it.link->t_abs_pos = here.getglobal( s_vp->vehicle().global_pos3() );
         it.link->t_mount = s_vp->mount();
-        it.set_link_traits();
+        it.update_link_traits();
         it.link->last_processed = calendar::turn;
         p->moves -= move_cost;
         it.process( here, p, p->pos() );
@@ -5007,7 +5007,7 @@ std::optional<int> link_up_actor::link_tow_cable( Character *p, item &it,
         it.link->t_abs_pos = here.getglobal( s_vp->vehicle().global_pos3() );
         it.link->t_mount = s_vp->mount();
         it.link->max_length = cable_length != -1 ? cable_length : it.type->maximum_charges();
-        it.set_link_traits();
+        it.update_link_traits();
         it.link->last_processed = calendar::turn;
         p->moves -= move_cost;
         it.process( here, p, p->pos() );
@@ -5187,7 +5187,7 @@ std::optional<int> link_up_actor::link_extend_cable( Character *p, item &it,
     if( extension->link ) {
         extended_ptr->link = extension->link;
     }
-    extended_ptr->set_link_traits();
+    extended_ptr->update_link_traits();
 
     if( extended_copy ) {
         // Check if there's another pocket on the same container that can hold the extended item, respecting pocket settings.
@@ -5258,7 +5258,7 @@ std::optional<int> link_up_actor::remove_extensions( Character *p, item &it ) co
     if( it.link ) {
         // If the item was linked, keep the extension cables linked.
         cable_main_copy.link = it.link;
-        cable_main_copy.set_link_traits();
+        cable_main_copy.update_link_traits();
         cable_main_copy.process( get_map(), p, p->pos() );
         it.reset_link( p );
     }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -5035,8 +5035,7 @@ std::optional<int> link_up_actor::link_tow_cable( Character *p, item &it,
                     ( it.link->t_abs_pos + prev_veh->coord_translate( it.link->t_mount ) ).raw(),
                     it.link->t_abs_pos.raw() );
 
-        if( trigdist ? trig_dist( prev_part_target.first, sel_part_target.first ) > it.link->max_length :
-            square_dist( prev_part_target.first, sel_part_target.first ) > it.link->max_length ) {
+        if( rl_dist( prev_part_target.first, sel_part_target.first ) > it.link->max_length ) {
             p->add_msg_if_player( m_warning, _( "The %1$s can't stretch that far!" ), it.type_name() );
             return std::nullopt;
         }

--- a/src/iuse_actor.cpp
+++ b/src/iuse_actor.cpp
@@ -4474,9 +4474,8 @@ std::optional<int> link_up_actor::use( Character *p, item &it, const tripoint &p
                                    ( it.link->length - respool_threshold ) * respool_time_per_square;
     const bool past_respool_threshold = it.link_length() > respool_threshold;
     const bool unspooled = it.link_length() == -1;
-    const bool has_loose_end = !unspooled && is_cable_item ? !it.link ||
-                               it.link->has_state( link_state::no_link ) :
-                               !it.link || it.link->has_no_links();
+    const bool has_loose_end = !it.link || ( !unspooled && is_cable_item ?
+                               it.link->has_state( link_state::no_link ) : it.link->has_no_links() );
 
     uilist link_menu;
     if( !is_cable_item || !it.link || it.link->has_no_links() ) {

--- a/src/iuse_actor.h
+++ b/src/iuse_actor.h
@@ -1099,10 +1099,10 @@ class link_up_actor : public iuse_actor
 
         ~link_up_actor() override = default;
         void load( const JsonObject &jo ) override;
-        std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
         std::unique_ptr<iuse_actor> clone() const override;
-        void info( const item &, std::vector<iteminfo> & ) const override;
         std::string get_name() const override;
+        void info( const item &, std::vector<iteminfo> & ) const override;
+        std::optional<int> use( Character *p, item &it, const tripoint &pnt ) const override;
 };
 
 class deploy_tent_actor : public iuse_actor

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -3028,11 +3028,11 @@ void item::io( Archive &archive )
     static const cata::value_ptr<relic> null_relic_ptr = nullptr;
     archive.io( "relic_data", relic_data, null_relic_ptr );
     static const cata::value_ptr<link_data> null_link_ptr = nullptr;
-    archive.io( "link_data", link, null_link_ptr );
-    if( link ) {
-        const optional_vpart_position vp = get_map().veh_at( link->t_abs_pos );
+    archive.io( "link_data", link_, null_link_ptr );
+    if( has_link_data() ) {
+        const optional_vpart_position vp = get_map().veh_at( link().t_abs_pos );
         if( vp ) {
-            link->t_veh = vp.value().vehicle().get_safe_reference();
+            link().t_veh = vp.value().vehicle().get_safe_reference();
         }
     }
 

--- a/src/savegame_json.cpp
+++ b/src/savegame_json.cpp
@@ -2878,8 +2878,8 @@ void item::craft_data::deserialize( const JsonObject &obj )
 void item::link_data::serialize( JsonOut &jsout ) const
 {
     jsout.start_object();
-    jsout.member( "link_i_state", s_state );
-    jsout.member( "link_t_state", t_state );
+    jsout.member( "link_i_state", source );
+    jsout.member( "link_t_state", target );
     jsout.member( "link_t_abs_pos", t_abs_pos );
     jsout.member( "link_t_mount", t_mount );
     jsout.member( "link_length", length );
@@ -2895,8 +2895,8 @@ void item::link_data::deserialize( const JsonObject &data )
 {
     data.allow_omitted_members();
 
-    data.read( "link_i_state", s_state );
-    data.read( "link_t_state", t_state );
+    data.read( "link_i_state", source );
+    data.read( "link_t_state", target );
     data.read( "link_t_abs_pos", t_abs_pos );
     data.read( "link_t_mount", t_mount );
     data.read( "link_length", length );
@@ -3032,7 +3032,7 @@ void item::io( Archive &archive )
     if( link ) {
         const optional_vpart_position vp = get_map().veh_at( link->t_abs_pos );
         if( vp ) {
-            link->t_veh_safe = vp.value().vehicle().get_safe_reference();
+            link->t_veh = vp.value().vehicle().get_safe_reference();
         }
     }
 

--- a/src/veh_appliance.cpp
+++ b/src/veh_appliance.cpp
@@ -507,7 +507,11 @@ void veh_app_interact::plug()
 {
     const int part = veh->part_at( a_point );
     const tripoint pos = veh->global_part_pos3( part );
-    veh->plug_in( pos );
+    item cord( "power_cord" );
+    cord.link_to( *veh, a_point, link_state::automatic );
+    if( cord.get_use( "link_up" ) ) {
+        cord.type->get_use( "link_up" )->call( &get_player_character(), cord, pos );
+    }
 }
 
 void veh_app_interact::merge()

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6729,7 +6729,7 @@ void vehicle::invalidate_towing( bool first_vehicle, Character *remover )
             drop.set_damage( 0 );
             const int other_tow_cable_idx = other_veh ? other_veh->get_tow_part() : -1;
             if( other_tow_cable_idx > -1 ) {
-                drop.reset_link();
+                drop.force_reset_link();
                 drop.link_to( *other_veh, other_veh->part( other_tow_cable_idx ).mount );
                 if( is_towing() ) {
                     drop.link().source = link_state::no_link;
@@ -8068,7 +8068,7 @@ item vehicle::part_to_item( const vehicle_part &vp ) const
     // stored, and if a cable actually drops, it should be half-connected.
     // Tow cables are handled inside of invalidate_towing instead.
     if( tmp.has_flag( flag_CABLE_SPOOL ) && !tmp.has_flag( flag_TOW_CABLE ) ) {
-        tmp.reset_link();
+        tmp.force_reset_link();
         const std::optional<vpart_reference> remote = get_remote_part( vp );
         if( remote &&
             tmp.link_to( remote->vehicle(), remote->part().mount, link_state::automatic ).success() ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -2722,6 +2722,19 @@ int vehicle::avail_part_with_feature( const point &pt, const std::string &flag )
     return -1;
 }
 
+int vehicle::avail_linkable_part( const point &pt, bool to_ports ) const
+{
+    const std::string link_flag = to_ports ? "CABLE_PORTS" : "BATTERY";
+    for( const int p : parts_at_relative( pt, /* use_cache = */ false ) ) {
+        const vehicle_part &vp_here = this->part( p );
+        if( !vp_here.is_broken() &&
+            ( vp_here.info().has_flag( "APPLIANCE" ) || vp_here.info().has_flag( link_flag ) ) ) {
+            return p;
+        }
+    }
+    return -1;
+}
+
 bool vehicle::has_part( const std::string &flag, bool enabled ) const
 {
     for( const vpart_reference &vpr : get_all_parts() ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6729,14 +6729,14 @@ void vehicle::invalidate_towing( bool first_vehicle, Character *remover )
             drop.set_damage( 0 );
             const int other_tow_cable_idx = other_veh ? other_veh->get_tow_part() : -1;
             if( other_tow_cable_idx > -1 ) {
-                drop.link.reset();
+                drop.reset_link();
                 drop.link_to( *other_veh, other_veh->part( other_tow_cable_idx ).mount );
                 if( is_towing() ) {
-                    drop.link->source = link_state::no_link;
-                    drop.link->target = link_state::vehicle_tow;
+                    drop.link().source = link_state::no_link;
+                    drop.link().target = link_state::vehicle_tow;
                 } else {
-                    drop.link->source = link_state::vehicle_tow;
-                    drop.link->target = link_state::no_link;
+                    drop.link().source = link_state::vehicle_tow;
+                    drop.link().target = link_state::no_link;
                 }
             } else {
                 drop.reset_link();
@@ -8068,11 +8068,11 @@ item vehicle::part_to_item( const vehicle_part &vp ) const
     // stored, and if a cable actually drops, it should be half-connected.
     // Tow cables are handled inside of invalidate_towing instead.
     if( tmp.has_flag( flag_CABLE_SPOOL ) && !tmp.has_flag( flag_TOW_CABLE ) ) {
-        tmp.link.reset();
+        tmp.reset_link();
         const std::optional<vpart_reference> remote = get_remote_part( vp );
         if( remote &&
             tmp.link_to( remote->vehicle(), remote->part().mount, link_state::automatic ).success() ) {
-            tmp.link->t_abs_pos = tripoint_abs_ms( vp.target.second );
+            tmp.link().t_abs_pos = tripoint_abs_ms( vp.target.second );
         } else {
             // The linked vehicle can't be found, so this part shouldn't exist.
             tmp.set_flag( flag_NO_DROP );

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6742,7 +6742,7 @@ void vehicle::invalidate_towing( bool first_vehicle, Character *remover )
             drop.set_damage( 0 );
             const int other_tow_cable_idx = other_veh ? other_veh->get_tow_part() : -1;
             if( other_tow_cable_idx > -1 ) {
-                drop.force_reset_link();
+                drop.reset_link( false );
                 drop.link_to( *other_veh, other_veh->part( other_tow_cable_idx ).mount );
                 if( is_towing() ) {
                     drop.link().source = link_state::no_link;
@@ -8081,7 +8081,7 @@ item vehicle::part_to_item( const vehicle_part &vp ) const
     // stored, and if a cable actually drops, it should be half-connected.
     // Tow cables are handled inside of invalidate_towing instead.
     if( tmp.has_flag( flag_CABLE_SPOOL ) && !tmp.has_flag( flag_TOW_CABLE ) ) {
-        tmp.force_reset_link();
+        tmp.reset_link( false );
         const std::optional<vpart_reference> remote = get_remote_part( vp );
         if( remote &&
             tmp.link_to( remote->vehicle(), remote->part().mount, link_state::automatic ).success() ) {

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6729,6 +6729,7 @@ void vehicle::invalidate_towing( bool first_vehicle, Character *remover )
             drop.set_damage( 0 );
             const int other_tow_cable_idx = other_veh ? other_veh->get_tow_part() : -1;
             if( other_tow_cable_idx > -1 ) {
+                drop.link.reset();
                 drop.link_to( *other_veh, other_veh->part( other_tow_cable_idx ).mount );
                 if( is_towing() ) {
                     drop.link->s_state = link_state::no_link;
@@ -8067,9 +8068,10 @@ item vehicle::part_to_item( const vehicle_part &vp ) const
     // stored, and if a cable actually drops, it should be half-connected.
     // Tow cables are handled inside of invalidate_towing instead.
     if( tmp.has_flag( flag_CABLE_SPOOL ) && !tmp.has_flag( flag_TOW_CABLE ) ) {
+        tmp.link.reset();
         const std::optional<vpart_reference> remote = get_remote_part( vp );
-        if( remote ) {
-            tmp.link_to( remote->vehicle(), remote->part().mount, link_state::automatic );
+        if( remote &&
+            tmp.link_to( remote->vehicle(), remote->part().mount, link_state::automatic ).success() ) {
             tmp.link->t_abs_pos = tripoint_abs_ms( vp.target.second );
         } else {
             // The linked vehicle can't be found, so this part shouldn't exist.

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -8085,7 +8085,7 @@ item vehicle::part_to_item( const vehicle_part &vp ) const
             tmp.link->t_abs_pos = tripoint_abs_ms( vp.target.second );
         }
 
-        tmp.set_link_traits( true );
+        tmp.update_link_traits( true );
         tmp.link->last_processed = calendar::turn;
     }
 

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6732,11 +6732,11 @@ void vehicle::invalidate_towing( bool first_vehicle, Character *remover )
                 drop.link.reset();
                 drop.link_to( *other_veh, other_veh->part( other_tow_cable_idx ).mount );
                 if( is_towing() ) {
-                    drop.link->s_state = link_state::no_link;
-                    drop.link->t_state = link_state::vehicle_tow;
+                    drop.link->source = link_state::no_link;
+                    drop.link->target = link_state::vehicle_tow;
                 } else {
-                    drop.link->s_state = link_state::vehicle_tow;
-                    drop.link->t_state = link_state::no_link;
+                    drop.link->source = link_state::vehicle_tow;
+                    drop.link->target = link_state::no_link;
                 }
             } else {
                 drop.reset_link();

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1214,6 +1214,16 @@ class vehicle
         *  @returns part index or -1
         */
         int avail_part_with_feature( int p, vpart_bitflags f ) const;
+        /**
+        *  Returns index of part at mount point \p pt which has link connection
+        *  and is_available(), or -1 if no such part or it's not is_available()
+        *  @note does not use relative_parts cache
+        *  @param pt only returns parts from this mount point
+        *  @param to_ports if true, look for part with CABLE_PORTS flag. If false, BATTERY.
+        *  Either way, will also look for APPLIANCE
+        *  @returns part index or -1
+        */
+        int avail_linkable_part( const point &pt, bool to_ports ) const;
 
         /**
          *  Check if vehicle has at least one unbroken part with specified flag

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1114,8 +1114,7 @@ class vehicle
          * Useful for, e.g. power cables that have a vehicle part on both sides.
          * @param vp_local Vehicle part that is connected to the remote part.
          */
-        std::optional<std::pair<vehicle *, vehicle_part *>> get_remote_part(
-                    const vehicle_part &vp_local ) const;
+        std::optional<vpart_reference> get_remote_part( const vehicle_part &vp_local ) const;
         /**
          * Remove the part on a targeted remote vehicle that a part is targeting.
          */

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -994,8 +994,6 @@ class vehicle
         // Stop any kind of automatic vehicle control and apply the brakes.
         void stop_autodriving( bool apply_brakes = true );
 
-        item init_cord( const tripoint &pos );
-        void plug_in( const tripoint &pos );
         void connect( const tripoint &source_pos, const tripoint &target_pos );
 
         bool precollision_check( units::angle &angle, map &here, bool follow_protocol );

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -561,8 +561,6 @@ void vehicle::connect( const tripoint &source_pos, const tripoint &target_pos )
     if( !sel_vp ) {
         return;
     }
-    vehicle *const sel_veh = &sel_vp->vehicle();
-    vehicle *const prev_veh = &prev_vp->vehicle();
     if( &sel_vp->vehicle() == &prev_vp->vehicle() ) {
         return ;
     }

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -559,7 +559,7 @@ item vehicle::init_cord( const tripoint &pos )
     cord.link->t_state = link_state::vehicle_port;
     cord.link->t_veh_safe = get_safe_reference();
     cord.link->t_abs_pos = get_map().getglobal( pos );
-    cord.set_link_traits();
+    cord.update_link_traits();
     cord.link->max_length = 2;
 
     return cord;

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -563,38 +563,14 @@ void vehicle::connect( const tripoint &source_pos, const tripoint &target_pos )
     }
     vehicle *const sel_veh = &sel_vp->vehicle();
     vehicle *const prev_veh = &prev_vp->vehicle();
-    if( prev_veh == sel_veh ) {
+    if( &sel_vp->vehicle() == &prev_vp->vehicle() ) {
         return ;
     }
 
     item cord( "power_cord" );
-    if( !cord.link_to( prev_vp, link_state::vehicle_port ).success() ) {
+    if( !cord.link_to( prev_vp, sel_vp, link_state::vehicle_port ).success() ) {
         debugmsg( "Failed to connect the %s, it tried to make an invalid connection!", cord.tname() );
     }
-    const vpart_id vpid( cord.typeId().str() );
-
-    // Prepare target tripoints for the cable parts that'll be added to the selected/previous vehicles
-    const std::pair<tripoint, tripoint> prev_part_target = std::make_pair(
-                here.getabs( target_pos ),
-                sel_veh->global_square_location().raw() );
-    const std::pair<tripoint, tripoint> sel_part_target = std::make_pair(
-                ( cord.link->t_abs_pos + prev_veh->coord_translate( cord.link->t_mount ) ).raw(),
-                cord.link->t_abs_pos.raw() );
-
-    const point vcoords1 = cord.link->t_mount;
-    const point vcoords2 = sel_vp->mount();
-
-    vehicle_part prev_veh_part( vpid, item( cord ) );
-    prev_veh_part.target.first = prev_part_target.first;
-    prev_veh_part.target.second = prev_part_target.second;
-    prev_veh->install_part( vcoords1, std::move( prev_veh_part ) );
-    prev_veh->precalc_mounts( 1, prev_veh->pivot_rotation[1], prev_veh->pivot_anchor[1] );
-
-    vehicle_part sel_veh_part( vpid, item( cord ) );
-    sel_veh_part.target.first = sel_part_target.first;
-    sel_veh_part.target.second = sel_part_target.second;
-    sel_veh->install_part( vcoords2, std::move( sel_veh_part ) );
-    sel_veh->precalc_mounts( 1, sel_veh->pivot_rotation[1], sel_veh->pivot_anchor[1] );
 }
 
 double vehicle::engine_cold_factor( const vehicle_part &vp ) const

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -552,33 +552,9 @@ void vehicle::toggle_tracking()
     }
 }
 
-item vehicle::init_cord( const tripoint &pos )
-{
-    item cord( "power_cord" );
-    cord.link = cata::make_value<item::link_data>();
-    cord.link->t_state = link_state::vehicle_port;
-    cord.link->t_veh_safe = get_safe_reference();
-    cord.link->t_abs_pos = get_map().getglobal( pos );
-    cord.update_link_traits();
-    cord.link->max_length = 2;
-
-    return cord;
-}
-
-void vehicle::plug_in( const tripoint &pos )
-{
-    item cord = init_cord( pos );
-
-    if( cord.get_use( "link_up" ) ) {
-        cord.type->get_use( "link_up" )->call( &get_player_character(), cord, pos );
-    }
-}
-
 void vehicle::connect( const tripoint &source_pos, const tripoint &target_pos )
 {
-    item cord = init_cord( source_pos );
     map &here = get_map();
-
     const optional_vpart_position sel_vp = here.veh_at( target_pos );
     const optional_vpart_position prev_vp = here.veh_at( source_pos );
 
@@ -591,6 +567,10 @@ void vehicle::connect( const tripoint &source_pos, const tripoint &target_pos )
         return ;
     }
 
+    item cord( "power_cord" );
+    if( !cord.link_to( prev_vp, link_state::vehicle_port ).success() ) {
+        debugmsg( "Failed to connect the %s, it tried to make an invalid connection!", cord.tname() );
+    }
     const vpart_id vpid( cord.typeId().str() );
 
     // Prepare target tripoints for the cable parts that'll be added to the selected/previous vehicles

--- a/tests/bionics_test.cpp
+++ b/tests/bionics_test.cpp
@@ -473,9 +473,8 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         dummy.worn.wear_item( dummy, item( "backpack" ), false, false );
         item_location ups = dummy.i_add( item( "UPS_ON" ) );
         item_location cable = dummy.i_add( item( "jumper_cable" ) );
-        cable->link = cata::make_value<item::link_data>();
-        cable->link->source = link_state::ups;
-        cable->link->target = link_state::bio_cable;
+        cable->link().source = link_state::ups;
+        cable->link().target = link_state::bio_cable;
         ups->set_var( "cable", "plugged_in" );
         cable->active = true;
 
@@ -532,9 +531,8 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         item_location solar_pack = dummy.top_items_loc()[1];
         REQUIRE( solar_pack->typeId() == itype_solarpack_on );
         item_location cable = dummy.i_add( item( "jumper_cable" ) );
-        cable->link = cata::make_value<item::link_data>();
-        cable->link->source = link_state::solarpack;
-        cable->link->target = link_state::bio_cable;
+        cable->link().source = link_state::solarpack;
+        cable->link().target = link_state::bio_cable;
         solar_pack->set_var( "cable", "plugged_in" );
         cable->active = true;
 

--- a/tests/bionics_test.cpp
+++ b/tests/bionics_test.cpp
@@ -474,8 +474,8 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         item_location ups = dummy.i_add( item( "UPS_ON" ) );
         item_location cable = dummy.i_add( item( "jumper_cable" ) );
         cable->link = cata::make_value<item::link_data>();
-        cable->link->s_state = link_state::ups;
-        cable->link->t_state = link_state::bio_cable;
+        cable->link->source = link_state::ups;
+        cable->link->target = link_state::bio_cable;
         ups->set_var( "cable", "plugged_in" );
         cable->active = true;
 
@@ -533,8 +533,8 @@ TEST_CASE( "fueled_bionics", "[bionics] [item]" )
         REQUIRE( solar_pack->typeId() == itype_solarpack_on );
         item_location cable = dummy.i_add( item( "jumper_cable" ) );
         cable->link = cata::make_value<item::link_data>();
-        cable->link->s_state = link_state::solarpack;
-        cable->link->t_state = link_state::bio_cable;
+        cable->link->source = link_state::solarpack;
+        cable->link->target = link_state::bio_cable;
         solar_pack->set_var( "cable", "plugged_in" );
         cable->active = true;
 

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -387,7 +387,7 @@ static void give_tools( const std::vector<item> &tools, const bool plug_in )
                 added_tool->link->last_processed = calendar::turn;
                 added_tool->link->t_veh_safe = get_map().veh_at( player_character.pos() +
                                                tripoint_north )->vehicle().get_safe_reference();
-                added_tool->set_link_traits();
+                added_tool->update_link_traits();
                 REQUIRE( added_tool->link->t_veh_safe );
             }
         } else {

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -381,14 +381,8 @@ static void give_tools( const std::vector<item> &tools, const bool plug_in )
             item_location added_tool = player_character.i_add( gear );
             REQUIRE( added_tool );
             if( plug_in && added_tool->can_link_up() ) {
-                added_tool->link = cata::make_value<item::link_data>();
-                added_tool->link->t_state = link_state::vehicle_port;
-                added_tool->link->t_abs_pos = get_map().getglobal( player_character.pos() + tripoint_north );
-                added_tool->link->last_processed = calendar::turn;
-                added_tool->link->t_veh_safe = get_map().veh_at( player_character.pos() +
-                                               tripoint_north )->vehicle().get_safe_reference();
-                added_tool->update_link_traits();
-                REQUIRE( added_tool->link->t_veh_safe );
+                REQUIRE( added_tool->link_to( get_map().veh_at( player_character.pos() + tripoint_north ),
+                                              link_state::automatic ).success() );
             }
         } else {
             boil.emplace_back( gear );

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -47,7 +47,7 @@ static void test_repair( const std::vector<item> &tools, bool plug_in_tools, boo
         if( plug_in_tools && added_tool->can_link_up() ) {
             added_tool->link_to( get_map().veh_at( player_character.pos() + tripoint_north_west ),
                                  link_state::automatic );
-            REQUIRE( added_tool->link->t_veh );
+            REQUIRE( added_tool->link().t_veh );
         }
     }
     player_character.set_skill_level( skill_mechanics, 10 );

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -47,7 +47,7 @@ static void test_repair( const std::vector<item> &tools, bool plug_in_tools, boo
         if( plug_in_tools && added_tool->can_link_up() ) {
             added_tool->link_to( get_map().veh_at( player_character.pos() + tripoint_north_west ),
                                  link_state::automatic );
-            REQUIRE( added_tool->link->t_veh_safe );
+            REQUIRE( added_tool->link->t_veh );
         }
     }
     player_character.set_skill_level( skill_mechanics, 10 );

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -45,13 +45,8 @@ static void test_repair( const std::vector<item> &tools, bool plug_in_tools, boo
     for( const item &gear : tools ) {
         item_location added_tool = player_character.i_add( gear );
         if( plug_in_tools && added_tool->can_link_up() ) {
-            added_tool->link = cata::make_value<item::link_data>();
-            added_tool->link->t_state = link_state::vehicle_port;
-            added_tool->link->t_abs_pos = get_map().getglobal( player_character.pos() + tripoint_north_west );
-            added_tool->link->last_processed = calendar::turn;
-            added_tool->link->t_veh_safe = get_map().veh_at( player_character.pos() +
-                                           tripoint_north_west )->vehicle().get_safe_reference();
-            added_tool->update_link_traits();
+            added_tool->link_to( get_map().veh_at( player_character.pos() + tripoint_north_west ),
+                                 link_state::automatic );
             REQUIRE( added_tool->link->t_veh_safe );
         }
     }

--- a/tests/vehicle_interact_test.cpp
+++ b/tests/vehicle_interact_test.cpp
@@ -51,7 +51,7 @@ static void test_repair( const std::vector<item> &tools, bool plug_in_tools, boo
             added_tool->link->last_processed = calendar::turn;
             added_tool->link->t_veh_safe = get_map().veh_at( player_character.pos() +
                                            tripoint_north_west )->vehicle().get_safe_reference();
-            added_tool->set_link_traits();
+            added_tool->update_link_traits();
             REQUIRE( added_tool->link->t_veh_safe );
         }
     }

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -429,35 +429,12 @@ static void connect_power_line( const tripoint &src_pos, const tripoint &dst_pos
 
     const optional_vpart_position target_vp = here.veh_at( dst_pos );
     const optional_vpart_position source_vp = here.veh_at( src_pos );
-    if( !target_vp ) {
+    if( !target_vp || !source_vp || &target_vp->vehicle() == &source_vp->vehicle() ) {
         return;
     }
 
-    vehicle *const target_veh = &target_vp->vehicle();
-    vehicle *const source_veh = &source_vp->vehicle();
-    if( source_veh == target_veh ) {
-        return ;
-    }
-
     item cord( itm );
-    cord.link_to( source_vp, link_state::vehicle_port );
-
-    tripoint target_global = here.getabs( dst_pos );
-    const vpart_id vpid( cord.typeId().str() );
-
-    point vcoords = source_vp->mount();
-    vehicle_part source_part( vpid, item( cord ) );
-    source_part.target.first = target_global;
-    source_part.target.second = target_veh->global_square_location().raw();
-    source_veh->install_part( vcoords, std::move( source_part ) );
-    source_veh->precalc_mounts( 1, source_veh->pivot_rotation[1], source_veh->pivot_anchor[1] );
-
-    vcoords = target_vp->mount();
-    vehicle_part target_part( vpid, item( cord ) );
-    target_part.target.first = cord.link->t_abs_pos.raw();
-    target_part.target.second = source_veh->global_square_location().raw();
-    target_veh->install_part( vcoords, std::move( target_part ) );
-    target_veh->precalc_mounts( 1, target_veh->pivot_rotation[1], target_veh->pivot_anchor[1] );
+    cord.link_to( target_vp, source_vp, link_state::vehicle_port );
 }
 
 TEST_CASE( "power_cable_stretch_disconnect" )

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -430,7 +430,7 @@ static void connect_power_line( const tripoint &src_pos, const tripoint &dst_pos
     cord.link = cata::make_value<item::link_data>();
     cord.link->t_state = link_state::vehicle_port;
     cord.link->t_abs_pos = here.getglobal( src_pos );
-    cord.set_link_traits();
+    cord.update_link_traits();
 
     const optional_vpart_position target_vp = here.veh_at( dst_pos );
     const optional_vpart_position source_vp = here.veh_at( src_pos );

--- a/tests/vehicle_test.cpp
+++ b/tests/vehicle_test.cpp
@@ -426,23 +426,21 @@ static void connect_power_line( const tripoint &src_pos, const tripoint &dst_pos
                                 const itype_id &itm )
 {
     map &here = get_map();
-    item cord( itm );
-    cord.link = cata::make_value<item::link_data>();
-    cord.link->t_state = link_state::vehicle_port;
-    cord.link->t_abs_pos = here.getglobal( src_pos );
-    cord.update_link_traits();
 
     const optional_vpart_position target_vp = here.veh_at( dst_pos );
     const optional_vpart_position source_vp = here.veh_at( src_pos );
-
     if( !target_vp ) {
         return;
     }
+
     vehicle *const target_veh = &target_vp->vehicle();
     vehicle *const source_veh = &source_vp->vehicle();
     if( source_veh == target_veh ) {
         return ;
     }
+
+    item cord( itm );
+    cord.link_to( source_vp, link_state::vehicle_port );
 
     tripoint target_global = here.getabs( dst_pos );
     const vpart_id vpid( cord.typeId().str() );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "General refinements to the item link/cable code"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Links have been in the game for a little while now, and there are a number of quibbles I've come to have with them:

1. There's no specific function for initializing a link, meaning the same code has to be duplicated everywhere it's needed.
2. Since `item.link` is a value_ptr you need to check that it contains a value every time you want to access it to avoid segfaulting, and since it's mutable it can be modified in const functions. This is dangerous and bloaty.
3. The `has_state` functions are part of link_data, meaning they can't be called without initializing the link_data value_ptr first, even though they're all feasible to use on unlinked items, particularly `has_no_links()`.
4. A number of names are overly clunky or obtuse, particularly `t_veh_safe` and `t_state/s_state`.
5. `reset_link()` has no way to avoid respooling it if it's too long, a problem since some functions require a complete reset.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

1. Creates a `link_to()` function that is used every time a link is made, both when starting a connection and for connecting two vehicles.
2. Creates a `link()` function for accessing the now private link_data, which will automatically initialize the value_ptr if needed. Also has a const version so const-ness is maintained.
3. Move them all outside of link_data.
4. Renames them to `t_veh` and `target/source`. `target/source` is a tad misleading because it's only the link_state enum and not the actual linked vehicle/item, but these variables read quite understandably in use because the enum describes what the connected object is (`link()->target = link_state::vehicle_port`).
5. Adds a `unspool_if_too_long` bool parameter.

There are other miscellaneous fixes too that the commit text should explain well enough.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I determined that it's possible to replace t_veh with an item_location of the connected part's base item, which could potentially make item-to-item connections possible as well as unify parts of the code. While promising, it'd be a major rework, and I just don't have it in me after all the reworks I already did for this PR.

Now that `link_up` brought link creation out of iuse_actor, it'd be a lot easier to make more cable-related tests, I'm still not great at writing up tests from scratch myself, though, so I'd want to do that separately, if I do it at all. `power_cable_stretch_disconnect` still covers a lot of the bases, at least.

`process_link` should probably be called every movement step rather than every in-game second - if your character is fast enough you can bypass the stretched-to-its-limit warning. Doing this could also lead to potential uses like cables that restrict movement or can't break away from their device.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Ran all the cable related tests, all green. Toyed around with cables a bunch in various fashions, it all works. Loaded up a save made in the November 29 build, all cables loaded correctly and stayed connected.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
