### PR TITLE
External option for latitude and longitude

### DIFF
--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -485,14 +485,14 @@
   {
     "type": "EXTERNAL_OPTION",
     "name": "LATITUDE",
-    "info": "Sets the latitude used for sunrise/sunset times. Defaults to Boston.",
+    "info": "Sets the latitude used for sunrise/sunset times.  Defaults to Boston.",
     "stype": "float",
     "value": 42.36
   },
   {
     "type": "EXTERNAL_OPTION",
     "name": "LONGITUDE",
-    "info": "Sets the longitude used for sunrise/sunset times. Defaults to Boston.",
+    "info": "Sets the longitude used for sunrise/sunset times.  Defaults to Boston.",
     "stype": "float",
     "value": -71.06
   }

--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -481,5 +481,19 @@
     "info": "When mutating, displays a menu which allows players to pick from a list of possible mutations.",
     "stype": "bool",
     "value": false
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "LATITUDE",
+    "info": "Sets the latitude used for sunrise/sunset times. Defaults to Boston.",
+    "stype": "float",
+    "value": 42.36
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "LONGITUDE",
+    "info": "Sets the longitude used for sunrise/sunset times. Defaults to Boston.",
+    "stype": "float",
+    "value": -71.06
   }
 ]

--- a/data/mods/TropiCataclysm/modinfo.json
+++ b/data/mods/TropiCataclysm/modinfo.json
@@ -13,14 +13,14 @@
   {
     "type": "EXTERNAL_OPTION",
     "name": "LATITUDE",
-    "info": "Sets the latitude used for sunrise/sunset times. Set to the Honduran/Nicaraguan border.",
+    "info": "Sets the latitude used for sunrise/sunset times.  Set to the Honduran/Nicaraguan border.",
     "stype": "float",
     "value": 14.34
   },
   {
     "type": "EXTERNAL_OPTION",
     "name": "LONGITUDE",
-    "info": "Sets the longitude used for sunrise/sunset times. Set to the Honduran/Nicaraguan border.",
+    "info": "Sets the longitude used for sunrise/sunset times.  Set to the Honduran/Nicaraguan border.",
     "stype": "float",
     "value": -84.75
   }

--- a/data/mods/TropiCataclysm/modinfo.json
+++ b/data/mods/TropiCataclysm/modinfo.json
@@ -9,5 +9,19 @@
     "dependencies": [ "dda" ],
     "version": "0.80",
     "obsolete": false
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "LATITUDE",
+    "info": "Sets the latitude used for sunrise/sunset times. Set to the Honduran/Nicaraguan border.",
+    "stype": "float",
+    "value": 14.34
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "LONGITUDE",
+    "info": "Sets the longitude used for sunrise/sunset times. Set to the Honduran/Nicaraguan border.",
+    "stype": "float",
+    "value": -84.75
   }
 ]

--- a/data/mods/classic_zombies/modinfo.json
+++ b/data/mods/classic_zombies/modinfo.json
@@ -34,5 +34,19 @@
     "//": "Adding a variable flag to the player allows certain dialogue to be changed that otherwise is hard to change in a mod.",
     "condition": { "not": { "u_has_var": "modded", "type": "flag", "value": "ddotd" } },
     "effect": [ { "u_add_var": "modded", "type": "flag", "value": "ddotd" } ]
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "LATITUDE",
+    "info": "Sets the latitude used for sunrise/sunset times. Set to Edmonton, Alberta.",
+    "stype": "float",
+    "value": 53.55
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "LONGITUDE",
+    "info": "Sets the longitude used for sunrise/sunset times. Set to Edmonton, Alberta.",
+    "stype": "float",
+    "value": -113.49
   }
 ]

--- a/data/mods/classic_zombies/modinfo.json
+++ b/data/mods/classic_zombies/modinfo.json
@@ -38,14 +38,14 @@
   {
     "type": "EXTERNAL_OPTION",
     "name": "LATITUDE",
-    "info": "Sets the latitude used for sunrise/sunset times. Set to Edmonton, Alberta.",
+    "info": "Sets the latitude used for sunrise/sunset times.  Set to Edmonton, Alberta.",
     "stype": "float",
     "value": 53.55
   },
   {
     "type": "EXTERNAL_OPTION",
     "name": "LONGITUDE",
-    "info": "Sets the longitude used for sunrise/sunset times. Set to Edmonton, Alberta.",
+    "info": "Sets the longitude used for sunrise/sunset times.  Set to Edmonton, Alberta.",
     "stype": "float",
     "value": -113.49
   }

--- a/data/mods/desert_region/modinfo.json
+++ b/data/mods/desert_region/modinfo.json
@@ -10,5 +10,19 @@
     "dependencies": [ "dda" ],
     "version": "0.1",
     "obsolete": true
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "LATITUDE",
+    "info": "Sets the latitude used for sunrise/sunset times. Set to Las Vegas.",
+    "stype": "float",
+    "value": 36.17
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "LONGITUDE",
+    "info": "Sets the longitude used for sunrise/sunset times. Set to Las Vegas.",
+    "stype": "float",
+    "value": -115.14
   }
 ]

--- a/data/mods/desert_region/modinfo.json
+++ b/data/mods/desert_region/modinfo.json
@@ -14,14 +14,14 @@
   {
     "type": "EXTERNAL_OPTION",
     "name": "LATITUDE",
-    "info": "Sets the latitude used for sunrise/sunset times. Set to Las Vegas.",
+    "info": "Sets the latitude used for sunrise/sunset times.  Set to Las Vegas.",
     "stype": "float",
     "value": 36.17
   },
   {
     "type": "EXTERNAL_OPTION",
     "name": "LONGITUDE",
-    "info": "Sets the longitude used for sunrise/sunset times. Set to Las Vegas.",
+    "info": "Sets the longitude used for sunrise/sunset times.  Set to Las Vegas.",
     "stype": "float",
     "value": -115.14
   }

--- a/src/calendar.cpp
+++ b/src/calendar.cpp
@@ -32,6 +32,7 @@ static bool is_eternal_season = false;
 static bool is_eternal_night = false;
 static bool is_eternal_day = false;
 static int cur_season_length = 1;
+static lat_long location = { 42.36_degrees, -71.06_degrees };
 
 time_point calendar::start_of_cataclysm = calendar::turn_zero;
 time_point calendar::start_of_game = calendar::turn_zero;
@@ -189,7 +190,6 @@ std::pair<units::angle, units::angle> sun_azimuth_altitude(
     time_point ti )
 {
     const season_effective_time t = season_effective_time( ti );
-    const lat_long location = location_boston;
     units::angle right_ascension;
     units::angle declination;
     time_duration timezone = angle_to_time( location.longitude );
@@ -276,8 +276,8 @@ static units::angle offset_to_sun_altitude(
     time_duration timezone = angle_to_time( longitude );
     std::tie( ra, declination ) = sun_ra_declination( approx_time, timezone );
     double cos_hour_angle =
-        ( sin( altitude ) - sin( location_boston.latitude ) * sin( declination ) ) /
-        cos( location_boston.latitude ) / cos( declination );
+        ( sin( altitude ) - sin( location.latitude ) * sin( declination ) ) /
+        cos( location.latitude ) / cos( declination );
     if( std::abs( cos_hour_angle ) > 1 ) {
         // It doesn't actually reach that angle, so we pretend that it does at
         // its maximum possible angle
@@ -289,7 +289,7 @@ static units::angle offset_to_sun_altitude(
     }
     const units::angle target_sidereal_time = hour_angle + ra;
     const units::angle sidereal_time_at_approx_time =
-        sidereal_time_at( approx_time, location_boston.longitude, timezone );
+        sidereal_time_at( approx_time, location.longitude, timezone );
     return normalize( target_sidereal_time - sidereal_time_at_approx_time );
 }
 
@@ -318,22 +318,22 @@ static time_point sun_at_altitude( const units::angle &altitude, const units::an
 
 time_point sunrise( const time_point &p )
 {
-    return sun_at_altitude( sunrise_angle, location_boston.longitude, p, false );
+    return sun_at_altitude( sunrise_angle, location.longitude, p, false );
 }
 
 time_point sunset( const time_point &p )
 {
-    return sun_at_altitude( sunrise_angle, location_boston.longitude, p, true );
+    return sun_at_altitude( sunrise_angle, location.longitude, p, true );
 }
 
 time_point night_time( const time_point &p )
 {
-    return sun_at_altitude( civil_dawn, location_boston.longitude, p, true );
+    return sun_at_altitude( civil_dawn, location.longitude, p, true );
 }
 
 time_point daylight_time( const time_point &p )
 {
-    return sun_at_altitude( civil_dawn, location_boston.longitude, p, false );
+    return sun_at_altitude( civil_dawn, location.longitude, p, false );
 }
 
 bool is_night( const time_point &p )
@@ -725,6 +725,10 @@ void calendar::set_eternal_day( bool is_eternal )
 void calendar::set_season_length( const int dur )
 {
     cur_season_length = dur;
+}
+void calendar::set_location( float latitude, float longitude )
+{
+    location = { units::from_degrees( latitude ), units::from_degrees( longitude ) };
 }
 
 static constexpr int real_world_season_length = 91;

--- a/src/calendar.h
+++ b/src/calendar.h
@@ -122,6 +122,8 @@ time_duration year_length();
 time_duration season_length();
 void set_season_length( int dur );
 
+void set_location( float latitude, float longitude );
+
 /// @returns relative length of game season to real life season.
 float season_ratio();
 

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -766,6 +766,8 @@ void game::setup()
     calendar::set_eternal_night( ::get_option<std::string>( "ETERNAL_TIME_OF_DAY" ) == "night" );
     calendar::set_eternal_day( ::get_option<std::string>( "ETERNAL_TIME_OF_DAY" ) == "day" );
 
+    calendar::set_location( ::get_option<float>( "LATITUDE" ), ::get_option<float>( "LONGITUDE" ) );
+
     weather.weather_id = WEATHER_CLEAR;
     // Weather shift in 30
     weather.nextweather = calendar::start_of_game + 30_minutes;

--- a/src/units_utility.h
+++ b/src/units_utility.h
@@ -5,7 +5,6 @@
 #ifndef CATA_SRC_UNITS_UTILITY_H
 #define CATA_SRC_UNITS_UTILITY_H
 
-#include "options.h"
 #include "units.h"
 
 /** Divide @p num by @p den, rounding up
@@ -49,12 +48,6 @@ struct lat_long {
     units::angle latitude;
     units::angle longitude;
 };
-
-units::angle external_latitude = units::from_degrees( get_option<float>( "LATITUDE" ) );
-units::angle external_longitude = units::from_degrees( get_option<float>( "LONGITUDE" ) );
-
-
-lat_long location_boston = { external_latitude, external_longitude };
 
 /**
  * Create a units label for a weight value.

--- a/src/units_utility.h
+++ b/src/units_utility.h
@@ -5,6 +5,7 @@
 #ifndef CATA_SRC_UNITS_UTILITY_H
 #define CATA_SRC_UNITS_UTILITY_H
 
+#include "options.h"
 #include "units.h"
 
 /** Divide @p num by @p den, rounding up
@@ -49,7 +50,11 @@ struct lat_long {
     units::angle longitude;
 };
 
-constexpr lat_long location_boston{ 42.36_degrees, -71.06_degrees };
+units::angle external_latitude = units::from_degrees( get_option<float>( "LATITUDE" ) );
+units::angle external_longitude = units::from_degrees( get_option<float>( "LONGITUDE" ) );
+
+
+lat_long location_boston = { external_latitude, external_longitude };
 
 /**
  * Create a units label for a weight value.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "[Mods] Non NE region mods have different day/night times dependant on their setting"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Latitude and longitude handling exists in the code for sunrise/sunset purposes but the location used is hardcoded to Boston

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Unhardcodes the location used to 2 external options, one for each latitude and longitude (this seemed more sensible than 1 for a strictly formatted string)
Sets desert_region to Las Vegas
Sets TropiCataclysm to the Honduran/Nicaraguan border
Sets DDotD to Edmonton, Alberta
Happily suggest changes to these

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Ideally the game start time would take the dawn of wherever you are into account

Ideally this will be expanded to take into account distance from 0, 0, 0 too but the actual impact of that is fairly negligible with the typical distances travelled

Aftershock Exoplanet probably also wants changing

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Using the wait action `Shift`+`\` -> `w`ait a while and looking at the "wait until daylight" and "wait until night":

8am Spring Day 61 Boston
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/f7110ef5-8e94-4328-b3bf-4c3d12de56e2)

8am Winter Day 61 Boston
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/13346f85-252a-4879-81a4-fdeb98595dda)

8am Spring Day 61 North Pole
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/8003e8e3-3f31-41e4-b2a9-c26b68092e86)

8am Winter Day 61 North Pole (Notably the 8am start time is before dawn)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/0c31958a-071f-454b-9bd8-b3dd3ed91503)

8am Spring Day 61 Quito, Ecuador
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/5db7ac21-d37c-486a-a1ed-d7cf5731f6b5)

8am Winter Day 61 Quito, Ecuador
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/28a4b7f1-a159-438b-8569-6ecd01df12eb)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
