### PR TITLE
Remove Mutagen Catalyst

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -1037,7 +1037,7 @@
     "id": "mutagen_alpha",
     "name": [ "Alpha Mutation", "Alpha Transformation", "Alpha Metamorphosis" ],
     "desc": [
-      "You consumed alpha primer.",
+      "You consumed alpha mutagen.",
       "You feel better.  So much better.",
       "The world needs you, surely this won't kill you.  It better not."
     ],
@@ -1067,14 +1067,15 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Alpha Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Alpha Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_batrachian",
     "name": [ "Frog Mutation", "Frog Transformation", "Frog Metamorphosis" ],
     "desc": [
-      "You consumed frog primer.",
+      "You consumed frog mutagen.",
       "Now, to find a quiet pond and settle for the wait…",
       "You feel like you're about to croak… if you don't keel over first."
     ],
@@ -1104,14 +1105,15 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Frog Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Frog Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_beast",
     "name": [ "Beast Mutation", "Beast Transformation", "Beast Metamorphosis" ],
     "desc": [
-      "You consumed beast primer.",
+      "You consumed beast mutagen.",
       "There must be prey around.  Stay alert.",
       "Primal instincts overwhelm your mind, and your saliva has turned to froth."
     ],
@@ -1140,14 +1142,15 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Beast Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Beast Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_bird",
     "name": [ "Bird Mutation", "Bird Transformation", "Bird Metamorphosis" ],
     "desc": [
-      "You consumed bird primer.",
+      "You consumed bird mutagen.",
       "You feel the pull of the skies.",
       "Goosebumps stand across your entire body.  You keep feeling that you're falling."
     ],
@@ -1165,14 +1168,15 @@
     },
     "scaling_mods": { "str_mod": [ -2 ], "per_mod": [ 1.5 ], "speed_mod": [ 3.5 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Bird Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Bird Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_cattle",
     "name": [ "Cattle Mutation", "Cattle Transformation", "Cattle Metamorphosis" ],
     "desc": [
-      "You consumed cattle primer.",
+      "You consumed cattle mutagen.",
       "This pasture will grow barren soon.  Keep moving.",
       "Dull fog clouds your mind, and you feel close to vomiting."
     ],
@@ -1199,14 +1203,15 @@
       "pain_chance": [ -5 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Cattle Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Cattle Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_cephalopod",
     "name": [ "Cephalopod Mutation", "Cephalopod Transformation", "Cephalopod Metamorphosis" ],
     "desc": [
-      "You consumed cephalopod primer.",
+      "You consumed cephalopod mutagen.",
       "Become one with your surroundings.",
       "Your skin crawls and your extremities twitch and jerk."
     ],
@@ -1227,14 +1232,15 @@
     },
     "scaling_mods": { "thirst_tick": [ -400 ], "int_mod": [ 2.5 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Cephalopod Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Cephalopod Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_chimera",
     "name": [ "Chimera Mutation", "Chimera Transformation", "Chimera Metamorphosis" ],
     "desc": [
-      "You consumed chimera primer.  Why?",
+      "You consumed chimera mutagen.",
       "Your flesh is the clay of the new world.  You'll overcome all challenges.",
       "Your body heaving and changing is a rough time, but what doesn't kill you makes you stronger."
     ],
@@ -1255,14 +1261,15 @@
     },
     "scaling_mods": { "hunger_tick": [ -120 ], "str_mod": [ 2.5 ], "int_mod": [ -2 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Chimera Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Chimera Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_elfa",
     "name": [ "Elf-A Mutation", "Elf-A Transformation", "Elf-A Metamorphosis" ],
     "desc": [
-      "You consumed Elf-A primer.",
+      "You consumed Elf-A mutagen.",
       "You must look after this world, if noone else will.",
       "You see stars.  You see so many stars."
     ],
@@ -1280,14 +1287,15 @@
     },
     "scaling_mods": { "per_mod": [ 2.5 ], "int_mod": [ 1 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -15 ] },
     "rating": "bad",
-    "blood_analysis_description": "Elf-A Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Elf-A Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_feline",
     "name": [ "Feline Mutation", "Feline Transformation", "Feline Metamorphosis" ],
     "desc": [
-      "You consumed feline primer.",
+      "You consumed feline mutagen.",
       "Quiet steps and sharp claws.  They'll never see it coming.",
       "If this overdose kills you, you've got a few more lives… right?"
     ],
@@ -1312,14 +1320,15 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Feline Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Feline Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_fish",
     "name": [ "Fish Mutation", "Fish Transformation", "Fish Metamorphosis" ],
     "desc": [
-      "You consumed fish primer.",
+      "You consumed fish mutagen.",
       "The waters call to you.  Leave this exposed wasteland.",
       "You feel clammy yet dry, absolutely parched no matter how much you drink."
     ],
@@ -1340,14 +1349,15 @@
     },
     "scaling_mods": { "thirst_tick": [ -400 ], "per_mod": [ 1 ], "dex_mod": [ 1.5 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Fish Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Fish Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_gastropod",
     "name": [ "Snail Mutation", "Snail Transformation", "Snail Metamorphosis" ],
     "desc": [
-      "You consumed snail primer.",
+      "You consumed snail mutagen.",
       "Slow and steady wins the race.",
       "You itch terribly, and your mouth feels salty and dry."
     ],
@@ -1356,7 +1366,8 @@
     "base_mods": { "hurt_min": [ 1 ], "hurt_max": [ 2 ], "hurt_chance": [ -22 ], "hurt_tick": [ 60 ] },
     "scaling_mods": { "str_mod": [ 1.5 ], "speed_mod": [ -7.5 ], "hurt_chance": [ 21, 0 ] },
     "rating": "bad",
-    "blood_analysis_description": "Snail Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Snail Mutagen"
   },
   {
     "type": "effect_type",
@@ -1372,14 +1383,15 @@
     "base_mods": { "str_mod": [ 0, -2 ], "per_mod": [ 0, -2 ], "dex_mod": [ 0, -2 ], "int_mod": [ 0, -2 ] },
     "scaling_mods": { "str_mod": [ 0, -2.5 ], "per_mod": [ 0, -2.5 ], "dex_mod": [ 0, -2.5 ], "int_mod": [ 0, -2.5 ] },
     "rating": "bad",
-    "blood_analysis_description": "Human Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Human Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_insect",
     "name": [ "Insect Mutation", "Insect Transformation", "Insect Metamorphosis" ],
     "desc": [
-      "You consumed insect primer.",
+      "You consumed insect mutagen.",
       "You can't wait for your change.  It can't be long now.",
       "You can't stop shivering and twitching.  Life is so short."
     ],
@@ -1407,14 +1419,15 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Insect Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Insect Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_lizard",
     "name": [ "Lizard Mutation", "Lizard Transformation", "Lizard Metamorphosis" ],
     "desc": [
-      "You consumed lizard primer.",
+      "You consumed lizard mutagen.",
       "Your skin feels dry and too small.  You'll have to molt soon.",
       "Your limbs slump, almost ready to tear right out of their sockets."
     ],
@@ -1432,14 +1445,15 @@
     },
     "scaling_mods": { "dex_mod": [ 1 ], "int_mod": [ -1.5 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Lizard Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Lizard Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_lupine",
     "name": [ "Lupine Mutation", "Lupine Transformation", "Lupine Metamorphosis" ],
     "desc": [
-      "You consumed lupine primer.",
+      "You consumed lupine mutagen.",
       "Where's your pack?  How will you survive without them?",
       "You pant, unable to stop pacing and full of hunger."
     ],
@@ -1469,15 +1483,16 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Lupine Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Lupine Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_medical",
     "name": [ "Medical Mutation", "Medical Transformation", "Medical Metamorphosis" ],
     "desc": [
-      "You consumed medical primer.",
-      "You consumed medical primer.  You should do that again.",
+      "You consumed medical mutagen.",
+      "You consumed medical mutagen.  You should do that again.",
       "You're tearing yourself apart.  Need to get fixed back up.  Should put some stitches in you."
     ],
     "max_intensity": 3,
@@ -1494,14 +1509,15 @@
     },
     "scaling_mods": { "str_mod": [ 2 ], "dex_mod": [ 2 ], "int_mod": [ -2.5 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -16 ] },
     "rating": "bad",
-    "blood_analysis_description": "Medical Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Medical Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_mouse",
     "name": [ "Mouse Mutation", "Mouse Transformation", "Mouse Metamorphosis" ],
     "desc": [
-      "You consumed mouse primer.",
+      "You consumed mouse mutagen.",
       "Your heart pounds, knowing that predators could approach at any second!",
       "Your heart hammers away with a rapid, irregular beat."
     ],
@@ -1520,14 +1536,15 @@
     },
     "scaling_mods": { "str_mod": [ -1.5 ], "dex_mod": [ 1 ], "speed_mod": [ 6.5 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Mouse Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Mouse Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_plant",
     "name": [ "Plant Mutation", "Plant Transformation", "Plant Metamorphosis" ],
     "desc": [
-      "You consumed plant primer.",
+      "You consumed plant mutagen.",
       "All this running… why don't you just find a nice, fertile spot and bask in the sun?",
       "Your processes are slowing.  You would make great fertilizer."
     ],
@@ -1536,14 +1553,15 @@
     "base_mods": { "hurt_min": [ 1 ], "hurt_max": [ 2 ], "hurt_chance": [ -22 ], "hurt_tick": [ 200 ] },
     "scaling_mods": { "str_mod": [ 1.5 ], "dex_mod": [ 1.5 ], "int_mod": [ -1 ], "speed_mod": [ -7.5 ], "hurt_chance": [ 21, 0 ] },
     "rating": "bad",
-    "blood_analysis_description": "Plant Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Plant Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_raptor",
     "name": [ "Raptor Mutation", "Raptor Transformation", "Raptor Metamorphosis" ],
     "desc": [
-      "You consumed raptor primer.",
+      "You consumed raptor mutagen.",
       "Sharpen your talons and clean your feathers.  Your prey won't give itself easily.",
       "Delusions fill your head… is it true?  Did you die long ago?"
     ],
@@ -1572,14 +1590,15 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Raptor Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Raptor Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_rabbit",
     "name": [ "Rabbit Mutation", "Rabbit Transformation", "Rabbit Metamorphosis" ],
     "desc": [
-      "You consumed rabbit primer.",
+      "You consumed rabbit mutagen.",
       "So much to do!  Better hop to it!",
       "Will you have a future?  Will any new generations be born… your pounding head is full of worry."
     ],
@@ -1604,14 +1623,15 @@
       "pain_chance": [ -15 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Rabbit Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Rabbit Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_rat",
     "name": [ "Rat Mutation", "Rat Transformation", "Rat Metamorphosis" ],
     "desc": [
-      "You consumed rat primer.",
+      "You consumed rat mutagen.",
       "This place is too open.  Hide!",
       "Dull aches fill your stomach, and every smell seems offensive."
     ],
@@ -1629,13 +1649,14 @@
     },
     "scaling_mods": { "dex_mod": [ 1 ], "int_mod": [ -2 ], "speed_mod": [ 3.5 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Rat Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Rat Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_slime",
     "name": [ "Slime Mutation", "Slime Transformation", "Slime Metamorphosis" ],
-    "desc": [ "You consumed slime primer.", "Plop.", "Brain… melting…" ],
+    "desc": [ "You consumed slime mutagen.", "Plop.", "Brain… melting…" ],
     "max_intensity": 3,
     "resist_traits": [ "THRESH_SLIME" ],
     "base_mods": {
@@ -1657,14 +1678,15 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Slime Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Slime Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_spider",
     "name": [ "Spider Mutation", "Spider Transformation", "Spider Metamorphosis" ],
     "desc": [
-      "You consumed spider primer.",
+      "You consumed spider mutagen.",
       "An anchor line there and there, connect with capture threads…",
       "Perhaps you should curl up, just curl up and give in."
     ],
@@ -1682,14 +1704,15 @@
     },
     "scaling_mods": { "dex_mod": [ 1.5 ], "int_mod": [ -1 ], "speed_mod": [ 4 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -25 ] },
     "rating": "bad",
-    "blood_analysis_description": "Spider Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Spider Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_troglobite",
     "name": [ "Troglobite Mutation", "Troglobite Transformation", "Troglobite Metamorphosis" ],
     "desc": [
-      "You consumed troglobite primer.",
+      "You consumed troglobite mutagen.",
       "Down in the dark corners of the new world.  That's where you belong.",
       "Deep and dark, your bones ache and twist."
     ],
@@ -1707,14 +1730,15 @@
     },
     "scaling_mods": { "str_mod": [ 2 ], "per_mod": [ -2.5 ], "dex_mod": [ 1 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Troglobite Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Troglobite Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_ursine",
     "name": [ "Ursine Mutation", "Ursine Transformation", "Ursine Metamorphosis" ],
     "desc": [
-      "You consumed ursine primer.",
+      "You consumed ursine mutagen.",
       "Berries, brood, honey, or meat?  What will today bring?",
       "Sleep sounds good.  Sleep forever, maybe."
     ],
@@ -1742,7 +1766,8 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Ursine Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Ursine Mutagen"
   },
   {
     "type": "effect_type",
@@ -1767,6 +1792,7 @@
     },
     "scaling_mods": { "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
+    "flags": [ "MUTAGEN_EFFECT" ],
     "blood_analysis_description": "Crustacean Mutagen Contamination"
   },
   {

--- a/data/json/items/comestibles/mutagen.json
+++ b/data/json/items/comestibles/mutagen.json
@@ -57,6 +57,7 @@
       "activation_message": "You inject the mutagenic catalyst.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen", 750, 850 ] ]
+       }
    },
   {
     "id": "iv_mutagen_alpha",
@@ -73,7 +74,7 @@
       "activation_message": "You inject the alpha infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_alpha", 450, 550 ] ]
-    }
+      }
   },
   {
     "id": "iv_mutagen_beast",

--- a/data/json/items/comestibles/mutagen.json
+++ b/data/json/items/comestibles/mutagen.json
@@ -29,7 +29,7 @@
     "copy-from": "mutagen_flavor",
     "type": "COMESTIBLE",
     "name": { "str_sp": "abstract iv mutagen flavor" },
-    "description": "A processed mutagenic primer.",
+    "description": "A processed mutagenic infusion.",
     "price": "3000 USD",
     "price_postapoc": "1 USD",
     "weight": "10 g",
@@ -47,8 +47,8 @@
     "id": "iv_mutagen",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "mutagenic catalyst" },
-    "description": "A processed, purified, and condensed dose of mutagenic drugs.  When combined with mutagenic primer, this will cause mutations over time.",
+    "name": { "str_sp": "mutagenic infusion" },
+    "description": "A processed, purified, and condensed dose of mutagenic drugs.  This will cause you to acquire mutations over time.",
     "healthy": -10,
     "stim": -10,
     "addiction_potential": 12,
@@ -57,23 +57,20 @@
       "activation_message": "You inject the mutagenic catalyst.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen", 750, 850 ] ]
-    },
-    "extend": { "flags": [ "MUTAGEN_CATALYST" ] },
-    "delete": { "flags": [ "MUTAGEN_PRIMER" ] }
-  },
+   },
   {
     "id": "iv_mutagen_alpha",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "alpha mutagenic primer" },
-    "description": "A processed mutagenic primer strongly resembling blood.",
+    "name": { "str_sp": "alpha infusion" },
+    "description": "A processed mutagenic infusion strongly resembling blood.",
     "price": "25000 USD",
     "looks_like": "iv_mutagen",
     "color": "red",
     "healthy": -4,
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the alpha mutagenic primer.",
+      "activation_message": "You inject the alpha infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_alpha", 450, 550 ] ]
     }
@@ -82,13 +79,13 @@
     "id": "iv_mutagen_beast",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "beast mutagenic primer" },
-    "description": "A processed mutagenic primer as red as a matador's cape.",
+    "name": { "str_sp": "beast infusion" },
+    "description": "A processed mutagenic infusion as red as a matador's cape.",
     "looks_like": "iv_mutagen",
     "color": "red",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the beast mutagenic primer.",
+      "activation_message": "You inject the beast infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_beast", 450, 550 ] ]
     }
@@ -97,13 +94,13 @@
     "id": "iv_mutagen_bird",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "bird mutagenic primer" },
-    "description": "A processed mutagenic primer the color of the pre-Cataclysmic skies.",
+    "name": { "str_sp": "bird infusion" },
+    "description": "A processed mutagenic infusion the color of the pre-Cataclysmic skies.",
     "looks_like": "iv_mutagen",
     "color": "cyan",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the bird mutagenic primer.",
+      "activation_message": "You inject the bird infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_bird", 450, 550 ] ]
     }
@@ -112,13 +109,13 @@
     "id": "iv_mutagen_cattle",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "cattle mutagenic primer" },
-    "description": "A processed mutagenic primer the color of grass.",
+    "name": { "str_sp": "cattle infusion" },
+    "description": "A processed mutagenic infusion the color of grass.",
     "looks_like": "iv_mutagen",
     "color": "light_green",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the cattle mutagenic primer.",
+      "activation_message": "You inject the cattle infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_cattle", 450, 550 ] ]
     }
@@ -127,13 +124,13 @@
     "id": "iv_mutagen_cephalopod",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "cephalopod mutagenic primer" },
-    "description": "A processed mutagenic primer as black as ink.",
+    "name": { "str_sp": "cephalopod infusion" },
+    "description": "A processed mutagenic infusion as black as ink.",
     "looks_like": "iv_mutagen",
     "color": "dark_gray",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the cephalopod mutagenic primer.",
+      "activation_message": "You inject the cephalopod infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_cephalopod", 450, 550 ] ]
     }
@@ -142,8 +139,8 @@
     "id": "iv_mutagen_chimera",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "chimera mutagenic primer" },
-    "description": "A processed mutagenic primer that churns with iridescence.",
+    "name": { "str_sp": "chimera infusion" },
+    "description": "A processed mutagenic infusion that churns with iridescence.",
     "price": 400000,
     "looks_like": "iv_mutagen",
     "color": "red",
@@ -152,7 +149,7 @@
     "addiction_potential": 4,
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the chimera mutagenic primer.",
+      "activation_message": "You inject the chimera infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_chimera", 450, 550 ] ]
     }
@@ -161,14 +158,14 @@
     "id": "iv_mutagen_elfa",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "Elf-A mutagenic primer" },
-    "description": "A processed mutagenic primer that's a striking sylvan green.",
+    "name": { "str_sp": "Elf-A infusion" },
+    "description": "A processed mutagenic infusion that's a striking sylvan green.",
     "price": 400000,
     "looks_like": "iv_mutagen",
     "color": "light_green",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the Elf-A mutagenic primer.",
+      "activation_message": "You inject the Elf-A infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_elfa", 450, 550 ] ]
     }
@@ -177,13 +174,13 @@
     "id": "iv_mutagen_feline",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "feline mutagenic primer" },
-    "description": "A processed mutagenic primer, yellow and highly reflective.",
+    "name": { "str_sp": "feline infusion" },
+    "description": "A processed mutagenic infusion, yellow and highly reflective.",
     "looks_like": "iv_mutagen",
     "color": "yellow",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the feline mutagenic primer.",
+      "activation_message": "You inject the feline infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_feline", 450, 550 ] ]
     }
@@ -192,13 +189,13 @@
     "id": "iv_mutagen_fish",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "fish mutagenic primer" },
-    "description": "A processed mutagenic primer the color of the ocean, with white foam at the top.",
+    "name": { "str_sp": "fish infusion" },
+    "description": "A processed mutagenic infusion the color of the ocean, with white foam at the top.",
     "looks_like": "iv_mutagen",
     "color": "light_blue",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the fish mutagenic primer.",
+      "activation_message": "You inject the fish infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_fish", 450, 550 ] ]
     }
@@ -207,13 +204,13 @@
     "id": "iv_mutagen_insect",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "insect mutagenic primer" },
-    "description": "A processed mutagenic primer that's a beautiful amber color.",
+    "name": { "str_sp": "insect infusion" },
+    "description": "A processed mutagenic infusion that's a beautiful amber color.",
     "looks_like": "iv_mutagen",
     "color": "yellow",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the insect mutagenic primer.",
+      "activation_message": "You inject the insect infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_insect", 450, 550 ] ]
     }
@@ -222,13 +219,13 @@
     "id": "iv_mutagen_lizard",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "lizard mutagenic primer" },
-    "description": "A processed mutagenic primer that shifts between various shades of green.",
+    "name": { "str_sp": "lizard infusion" },
+    "description": "A processed mutagenic infusion that shifts between various shades of green.",
     "looks_like": "iv_mutagen",
     "color": "light_green",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the lizard mutagenic primer.",
+      "activation_message": "You inject the lizard infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_lizard", 450, 550 ] ]
     }
@@ -237,13 +234,13 @@
     "id": "iv_mutagen_lupine",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "lupine mutagenic primer" },
-    "description": "A processed mutagenic primer as white as a full moon.",
+    "name": { "str_sp": "lupine infusion" },
+    "description": "A processed mutagenic infusion as white as a full moon.",
     "looks_like": "iv_mutagen",
     "color": "white",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the lupine mutagenic primer.",
+      "activation_message": "You inject the lupine infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_lupine", 450, 550 ] ]
     }
@@ -252,15 +249,15 @@
     "id": "iv_mutagen_medical",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "medical mutagenic primer" },
-    "description": "A processed mutagenic primer that looks like a mixture of bodily fluids.",
+    "name": { "str_sp": "medical infusion" },
+    "description": "A processed mutagenic infusion that looks like a mixture of bodily fluids.",
     "price": "3000 USD",
     "looks_like": "iv_mutagen",
     "color": "light_red",
     "healthy": -4,
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the medical mutagenic primer.",
+      "activation_message": "You inject the medical infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_medical", 450, 550 ] ]
     }
@@ -269,13 +266,13 @@
     "id": "iv_mutagen_plant",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "plant mutagenic primer" },
-    "description": "A processed mutagenic primer that looks like pureed spinach.",
+    "name": { "str_sp": "plant infusion" },
+    "description": "A processed mutagenic infusion that looks like pureed spinach.",
     "looks_like": "iv_mutagen",
     "color": "green",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the plant mutagenic primer.",
+      "activation_message": "You inject the plant infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_plant", 450, 550 ] ]
     }
@@ -284,14 +281,14 @@
     "id": "iv_mutagen_raptor",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "raptor mutagenic primer" },
-    "description": "A processed mutagenic primer that seems to shift slightly whenever you look at it.",
+    "name": { "str_sp": "raptor infusion" },
+    "description": "A processed mutagenic infusion that seems to shift slightly whenever you look at it.",
     "price": 400000,
     "looks_like": "iv_mutagen",
     "color": "green",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the raptor mutagenic primer.",
+      "activation_message": "You inject the raptor infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_raptor", 450, 550 ] ]
     }
@@ -300,13 +297,13 @@
     "id": "iv_mutagen_rat",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "rat mutagenic primer" },
-    "description": "A processed mutagenic primer that's a rather unappealing beige.",
+    "name": { "str_sp": "rat infusion" },
+    "description": "A processed mutagenic infusion that's a rather unappealing beige.",
     "looks_like": "iv_mutagen",
     "color": "brown",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the rat mutagenic primer.",
+      "activation_message": "You inject the rat infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_rat", 450, 550 ] ]
     }
@@ -315,13 +312,13 @@
     "id": "iv_mutagen_slime",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "slime mutagenic primer" },
-    "description": "A processed mutagenic primer that looks very much like the black ooze in the zombies' eyes.",
+    "name": { "str_sp": "slime infusion" },
+    "description": "A processed mutagenic infusion that seems to jiggle slightly.",
     "looks_like": "iv_mutagen",
     "color": "dark_gray",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the slime mutagenic primer.",
+      "activation_message": "You inject the slime infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_slime", 450, 550 ] ]
     }
@@ -330,13 +327,13 @@
     "id": "iv_mutagen_spider",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "spider mutagenic primer" },
-    "description": "A processed mutagenic primer with pale filaments suspended in it.",
+    "name": { "str_sp": "spider infusion" },
+    "description": "A processed mutagenic infusion with pale filaments suspended in it.",
     "looks_like": "iv_mutagen",
     "color": "light_gray",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the spider mutagenic primer.",
+      "activation_message": "You inject the spider infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_spider", 450, 550 ] ]
     }
@@ -345,13 +342,13 @@
     "id": "iv_mutagen_snail",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "snail mutagenic primer" },
-    "description": "A processed mutagenic primer with the consistency of snot.",
+    "name": { "str_sp": "snail infusion" },
+    "description": "A processed mutagenic infusion with the consistency of snot.",
     "looks_like": "iv_mutagen",
     "color": "light_gray",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the snail mutagenic primer.",
+      "activation_message": "You inject the snail infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_gastropod", 450, 550 ] ]
     }
@@ -360,13 +357,13 @@
     "id": "iv_mutagen_batrachian",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "batrachian mutagenic primer" },
-    "description": "A processed mutagenic primer that looks like pond water… are the shadows in it moving?",
+    "name": { "str_sp": "batrachian infusion" },
+    "description": "A processed mutagenic infusion that looks like pond water… are the shadows in it moving?",
     "looks_like": "iv_mutagen",
     "color": "light_gray",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the batrachian mutagenic primer.",
+      "activation_message": "You inject the batrachian infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_batrachian", 450, 550 ] ]
     }
@@ -375,13 +372,13 @@
     "id": "iv_mutagen_troglobite",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "troglobite mutagenic primer" },
-    "description": "A processed mutagenic primer that seems to recoil from the light.",
+    "name": { "str_sp": "troglobite infusion" },
+    "description": "A processed mutagenic infusion that seems to recoil from the light.",
     "looks_like": "iv_mutagen",
     "color": "dark_gray",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the troglobite mutagenic primer.",
+      "activation_message": "You inject the troglobite infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_troglobite", 450, 550 ] ]
     }
@@ -390,13 +387,13 @@
     "id": "iv_mutagen_ursine",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "ursine mutagenic primer" },
-    "description": "A processed mutagenic primer that's the color of honey, and is just as thick.",
+    "name": { "str_sp": "ursine infusion" },
+    "description": "A processed mutagenic infusion that's the color of honey, and is just as thick.",
     "looks_like": "iv_mutagen",
     "color": "yellow",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the ursine mutagenic primer.",
+      "activation_message": "You inject the ursine infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_ursine", 450, 550 ] ]
     }
@@ -405,13 +402,13 @@
     "id": "iv_mutagen_mouse",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "mouse mutagenic primer" },
-    "description": "A processed mutagenic primer resembling liquefied metal.",
+    "name": { "str_sp": "mouse infusion" },
+    "description": "A processed mutagenic infusion resembling liquefied metal.",
     "looks_like": "iv_mutagen",
     "color": "light_gray",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the mouse mutagenic primer.",
+      "activation_message": "You inject the mouse infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_mouse", 450, 550 ] ]
     }
@@ -420,12 +417,12 @@
     "id": "iv_mutagen_rabbit",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "rabbit mutagenic primer" },
-    "description": "An orange colored mutagenic primer.",
+    "name": { "str_sp": "rabbit infusion" },
+    "description": "An orange colored mutagenic infusion.",
     "looks_like": "iv_mutagen",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the rabbit mutagenic primer.",
+      "activation_message": "You inject the rabbit infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_rabbit", 450, 550 ] ]
     }
@@ -434,13 +431,13 @@
     "id": "iv_mutagen_crustacean",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "crustacean mutagenic primer" },
-    "description": " A red colored mutagenic primer.",
+    "name": { "str_sp": "crustacean infusion" },
+    "description": " A red colored mutagenic infusion.",
     "color": "red",
     "looks_like": "iv_mutagen",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the crustacean mutagenic primer.",
+      "activation_message": "You inject the crustacean infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_crustacean", 450, 550 ] ]
     }
@@ -450,9 +447,9 @@
     "copy-from": "mutagen_flavor",
     "type": "COMESTIBLE",
     "name": { "str_sp": "mutagen" },
-    "description": "A slurry of organic chemicals and compounds, used as the foundation for making primers and mutagenic catalyst.  In this baseline form, it is highly toxic, and dangerous to consume on its own.",
+    "description": "A syrupy black goop that reeks of noxious chemicals.  Drinking this may cause you to mutate.",
     "addiction_potential": 6,
-    "use_action": { "type": "consume_drug", "activation_message": "You drink the mutagen.", "vitamins": [ [ "mutagenic_slurry", 25 ] ] }
+    "use_action": { "type": "consume_drug", "activation_message": "You drink the mutagen.", "vitamins": [ [ "mutagen", 225 ] ] }
   },
   {
     "id": "mutagen_jabberblood",
@@ -484,7 +481,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the alpha mutagen.",
-      "vitamins": [ [ "mutagen_alpha", 225 ], [ "mutagen", 125 ] ]
+      "vitamins": [ [ "mutagen_alpha", 225 ] ]
     }
   },
   {
@@ -496,7 +493,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the beast mutagen.",
-      "vitamins": [ [ "mutagen_beast", 225 ], [ "mutagen", 125 ] ]
+      "vitamins": [ [ "mutagen_beast", 225 ] ]
     }
   },
   {
@@ -508,7 +505,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the bird mutagen.",
-      "vitamins": [ [ "mutagen_bird", 225 ], [ "mutagen", 125 ] ]
+      "vitamins": [ [ "mutagen_bird", 225 ] ]
     }
   },
   {
@@ -520,7 +517,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the cattle mutagen.",
-      "vitamins": [ [ "mutagen_cattle", 225 ], [ "mutagen", 125 ] ]
+      "vitamins": [ [ "mutagen_cattle", 225 ] ]
     }
   },
   {
@@ -532,7 +529,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the cephalopod mutagen.",
-      "vitamins": [ [ "mutagen_cephalopod", 225 ], [ "mutagen", 125 ] ]
+      "vitamins": [ [ "mutagen_cephalopod", 225 ] ]
     }
   },
   {
@@ -546,7 +543,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the chimera mutagen.",
-      "vitamins": [ [ "mutagen_chimera", 225 ], [ "mutagen", 125 ] ]
+      "vitamins": [ [ "mutagen_chimera", 225 ] ]
     }
   },
   {
@@ -560,7 +557,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the Elf-A mutagen.",
-      "vitamins": [ [ "mutagen_elfa", 225 ], [ "mutagen", 125 ] ]
+      "vitamins": [ [ "mutagen_elfa", 225 ] ]
     }
   },
   {
@@ -655,7 +652,6 @@
     "type": "COMESTIBLE",
     "name": { "str_sp": "raptor mutagen" },
     "description": "An extremely rare mutagen cocktail.",
-    "price": "2000 USD",
     "looks_like": "mutagen",
     "use_action": {
       "type": "consume_drug",

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -190,6 +190,7 @@ const flag_id flag_MOUNTED_GUN( "MOUNTED_GUN" );
 const flag_id flag_MOUSE( "MOUSE" );
 const flag_id flag_MUNDANE( "MUNDANE" );
 const flag_id flag_MUSHY( "MUSHY" );
+const flag_id flag_MUTAGEN_EFFECT( "MUTAGEN_EFFECT" );
 const flag_id flag_MUTE( "MUTE" );
 const flag_id flag_MYCUS_OK( "MYCUS_OK" );
 const flag_id flag_NANOFAB_REPAIR( "NANOFAB_REPAIR" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -200,6 +200,7 @@ extern const flag_id flag_MOUNTED_GUN;
 extern const flag_id flag_MOUSE;
 extern const flag_id flag_MUNDANE;
 extern const flag_id flag_MUSHY;
+extern const flag_id flag_MUTAGEN_EFFECT;
 extern const flag_id flag_MYCUS_OK;
 extern const flag_id flag_NANOFAB_REPAIR;
 extern const flag_id flag_NANOFAB_TEMPLATE;

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1210,18 +1210,12 @@ void suffer::from_other_mutations( Character &you )
 
 void suffer::from_mutagen( Character &you )
 {
-                you.add_msg_if_player( m_warning,
-                                   _( "suffer from mutage" ) );
         bool mutation = true;
         if( one_in( 4 ) ) {
-                            you.add_msg_if_player( m_warning,
-                                   _( "failed accidentally" ) );
             // Random chance to skip mutating.
             mutation = false;
         }
         if( mutation == true ) {
-                            you.add_msg_if_player( m_warning,
-                                   _( "success" ) );
             you.mutate( 0, true );
         }
 }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -204,6 +204,7 @@ static void without_sleep( Character &you, int sleep_deprivation );
 static void from_tourniquet( Character &you );
 static void from_nyctophobia( Character &you );
 static void from_artifact_resonance( Character &you, int amt );
+static void from_mutagen( Character &you );
 } // namespace suffer
 
 static float addiction_scaling( float at_min, float at_max, float add_lvl )
@@ -1207,6 +1208,24 @@ void suffer::from_other_mutations( Character &you )
     }
 }
 
+void suffer::from_mutagen( Character &you )
+{
+                you.add_msg_if_player( m_warning,
+                                   _( "suffer from mutage" ) );
+        bool mutation = true;
+        if( one_in( 4 ) ) {
+                            you.add_msg_if_player( m_warning,
+                                   _( "failed accidentally" ) );
+            // Random chance to skip mutating.
+            mutation = false;
+        }
+        if( mutation == true ) {
+                            you.add_msg_if_player( m_warning,
+                                   _( "success" ) );
+            you.mutate( 0, true );
+        }
+}
+
 void suffer::from_radiation( Character &you )
 {
     map &here = get_map();
@@ -1789,6 +1808,10 @@ void Character::suffer()
 
     if( has_trait( trait_ASTHMA ) ) {
         suffer::from_asthma( *this, current_stim );
+    }
+
+    if( has_effect_with_flag( flag_MUTAGEN_EFFECT ) && calendar::once_every( rng( 1_hours, 6_hours ) ) ) {
+        suffer::from_mutagen( *this );
     }
 
     suffer::in_sunlight( *this, worn );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Remove Mutagen Catalyst"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Fixes #70398 

As detailed in #70398 (please read this issue before commenting), there isn't really a reason for catalyst to exist as a distinct object or vitamin type. It creates massive amounts of confusion, needlessly complicates what is already an inaccessible mechanic, demands a lot of micromanagement, adds useless cruft to what should be high-value loot rewards, deters people from engaging with the system, and allows players to inject themselves with liquid blob for free stat bonuses that last for days and have no risks or downsides.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

THIS IS NOT A REVERSION
- The primary change in this PR is so that players only have to take one drug to mutate instead of two. It still takes the same amount of time, has the same risks and the same chances for things to go the way you want.

CATALYST IS GONE
- We are back to drinking mutagen or injecting serum (now called "infusion" to avoid confusion with I-am-Erk's idea for temporary stat-boosting serums). Mutagen is a low concentration form which is easier to craft. Infusion is more potent and less toxic. This incentivizes making primer, but prevents mutagen from being useless
- Untyped mutagen/infusion are back. They work as they once did, giving mutations from random categories instead of specific ones. Note that this is different from "mutagenic slurry" which was just giving you a small dose of every primer.
- Catalyst in existing saves will become untyped infusion, slurry will become untyped mutagen
- The existing catalyst vitamin is likewise changed to untyped mutagen

PRIMER IS GONE
- If you want to turn into a bird, you drink bird mutagen or inject bird infusion. No faffing around with other chemicals, no waiting for different vitamins to decay. All existing primer will become typed infusion. If you would like to stop mutating, you can take chelator as before
- On the technical side of things, what this change does is obsolete the Catalyst EOC and add suffer::from_mutagen(), which simply checks for the MUTAGEN_EFFECT flag. These flags have been added to the existing primer effects, which have been left in the game relatively unchanged

ITEMGROUP UPDATES
- I will be going over these to ensure that lab loot is reasonable. I don't think I'll actually need to change very much. Mutagen loot is currently very lame, and this will automatically bump it up to be decent,

HELP FILES
- I will go over the help files to make sure they explain how mutagen works.

SUMMARY
The net result is that you pick up bird infusion, inject yourself, then every couple of hours you have a chance to mutate, depending on all the same factors as are present now, except the system is only looking at one vitamin instead of two.

Now you will not be able to take primer without mutating, unless you have all the mutations of that category already, but in that case you don't get any buffs, so there's no more cheesing primer for sick gains. You still get the temporary stat buffs if you aren't post-thresh, but with them will come the risk of mutating. 

Because the process no longer relies on lucking out and finding catalyst, you will be more likely to find something you can use in a lab, and you will have to do less tedious crafting to get mutated. Craft times and requirements are still quite high, so you won't get everything you want without any work, either.

Other than the EOCs in changing_eocs.json, very little of the existing system needs to change. Mutating should take about as long as it did before, with similar chances of success.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
I thought about using a new EOC instead of suffer::, but I can't think of a way to do that as neatly without making duplicate EOCs for every single mutation line, including those in all of our mods. As mutagen is a core concept to our game, I don't think the basic stuff needs to be EOC-ified. Contributors are still able to add or change mutagen types in json.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
ongoing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
https://www.youtube.com/watch?v=jAzgaqC8xCs

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
