### PR TITLE
Initialize the booleans

### DIFF
--- a/src/mattack_actors.h
+++ b/src/mattack_actors.h
@@ -83,9 +83,9 @@ struct grab {
     // Limited to one GRAB-flagged effect per bp
     efftype_id grab_effect;
     // If true will attempt to remove all other GRAB flagged effects from the target and cancel the attack on failure
-    bool exclusive_grab;
+    bool exclusive_grab = false;
     // If true drags/pulls fail when targeting a character in a seat with seatbelts
-    bool respect_seatbelts;
+    bool respect_seatbelts = true;
     // Distance the enemy drags you on successful drag attempt (also enable dragging in the first place)
     int drag_distance;
     // Deviation of each dragging step from a straight line away from the opponent


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

If melee_actor.is_grab is false, grab.exclusive_grab and grab.respect_seatbelts were not initialized. This was causing errors when compiled with -fsanitize=undefined

```C++
src/mattack_actors.h:75:8: runtime error: load of value 190, which is not a valid value for type 'bool'
    #0 0x5a9b6fe in grab::grab(grab const&) src/mattack_actors.h:75
    #1 0x5ab7635 in melee_actor::melee_actor(melee_actor const&) src/mattack_actors.h:106
    #2 0x5ab8412 in std::__detail::_MakeUniq<melee_actor>::__single_object std::make_unique<melee_actor, melee_actor const&>(melee_actor const&) /usr/include/c++/13/bits/unique_ptr.h:1070
    #3 0x5a87e4c in melee_actor::clone() const src/mattack_actors.cpp:962
    #4 0x207632c in cata::clone_ptr<mattack_actor>::clone_ptr(cata::clone_ptr<mattack_actor> const&) src/clone_ptr.h:18
    #5 0x6085941 in mtype_special_attack::mtype_special_attack(mtype_special_attack const&) src/mattack_common.h:47
    #6 0x6085941 in std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack>::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack, true>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&) /usr/include/c++/13/bits/stl_pair.h:559
    #7 0x6085a2b in void std::__new_allocator<std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> > >::construct<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&>(std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack>*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&) /usr/include/c++/13/bits/new_allocator.h:187
    #8 0x6085a2b in void std::allocator_traits<std::allocator<std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> > > >::construct<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&>(std::allocator<std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> > >&, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack>*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&) /usr/include/c++/13/bits/alloc_traits.h:537
    #9 0x6085a2b in void std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> > >::_M_construct_node<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&>(std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> >*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&) /usr/include/c++/13/bits/stl_tree.h:597
    #10 0x6085b06 in std::_Rb_tree_node<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> >* std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> > >::_M_create_node<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&) /usr/include/c++/13/bits/stl_tree.h:614
    #11 0x6085b71 in std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> > >::_Auto_node::_Auto_node<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&>(std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> > >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&) /usr/include/c++/13/bits/stl_tree.h:1637
    #12 0x6085c9d in std::_Rb_tree_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> > std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> > >::_M_emplace_hint_unique<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&>(std::_Rb_tree_const_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&) /usr/include/c++/13/bits/stl_tree.h:2462
    #13 0x608618f in std::_Rb_tree_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> > std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, mtype_special_attack, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> > >::emplace_hint<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&>(std::_Rb_tree_const_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&) /usr/include/c++/13/bits/stl_map.h:640
    #14 0x608618f in std::pair<std::_Rb_tree_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> >, bool> std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, mtype_special_attack, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, mtype_special_attack> > >::emplace<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, mtype_special_attack const&) /usr/include/c++/13/bits/stl_map.h:601
    #15 0x5ff3881 in MonsterGenerator::add_attack(mtype_special_attack const&) src/monstergenerator.cpp:1312
    #16 0x5ffafa5 in MonsterGenerator::load_monster_attack(JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) src/monstergenerator.cpp:1376
    #17 0x4262e91 in operator() src/init.cpp:466
    #18 0x4262e91 in __invoke_impl<void, DynamicDataLoader::initialize()::<lambda(const JsonObject&, const std::string&)>&, const JsonObject&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> /usr/include/c++/13/bits/invoke.h:61
    #19 0x4262e91 in __invoke_r<void, DynamicDataLoader::initialize()::<lambda(const JsonObject&, const std::string&)>&, const JsonObject&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&> /usr/include/c++/13/bits/invoke.h:111
    #20 0x4262e91 in _M_invoke /usr/include/c++/13/bits/std_function.h:290
    #21 0x4290ce9 in std::function<void (JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>::operator()(JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const /usr/include/c++/13/bits/std_function.h:591
    #22 0x42693bf in operator() src/init.cpp:227
    #23 0x42693bf in __invoke_impl<void, DynamicDataLoader::add(const std::string&, const std::function<void(const JsonObject&, const std::__cxx11::basic_string<char>&)>&)::<lambda(const JsonObject&, const std::string&, const cata_path&, const cata_path&)>&, const JsonObject&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, const cata_path&, const cata_path&> /usr/include/c++/13/bits/invoke.h:61
    #24 0x42693bf in __invoke_r<void, DynamicDataLoader::add(const std::string&, const std::function<void(const JsonObject&, const std::__cxx11::basic_string<char>&)>&)::<lambda(const JsonObject&, const std::string&, const cata_path&, const cata_path&)>&, const JsonObject&, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, const cata_path&, const cata_path&> /usr/include/c++/13/bits/invoke.h:111
    #25 0x42693bf in _M_invoke /usr/include/c++/13/bits/std_function.h:290
    #26 0x4290563 in std::function<void (JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, cata_path const&, cata_path const&)>::operator()(JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, cata_path const&, cata_path const&) const /usr/include/c++/13/bits/std_function.h:591
    #27 0x42849b9 in DynamicDataLoader::load_object(JsonObject const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, cata_path const&, cata_path const&) src/init.cpp:137
    #28 0x4285ca2 in DynamicDataLoader::load_all_from_json(JsonValue const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, loading_ui&, cata_path const&, cata_path const&) src/init.cpp:540
    #29 0x42867b4 in DynamicDataLoader::load_data_from_path(cata_path const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, loading_ui&) src/init.cpp:521
    #30 0x3ca266a in game::load_data_from_dir(cata_path const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, loading_ui&) src/game.cpp:571
    #31 0x3d211a0 in game::load_packs(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<string_id<MOD_INFORMATION>, std::allocator<string_id<MOD_INFORMATION> > > const&, loading_ui&) src/game.cpp:3265
    #32 0x3d51925 in game::load_world_modfiles(loading_ui&) src/game.cpp:3235
    #33 0x3e05640 in game::setup() src/game.cpp:756
    #34 0x5111d33 in main_menu::new_character_tab() src/main_menu.cpp:972
    #35 0x5127b5a in main_menu::opening_screen() src/main_menu.cpp:863
    #36 0x50f1ece in main src/main.cpp:792
    #37 0x7fdc43fa9b89 in __libc_start_call_main (/lib64/libc.so.6+0x27b89) (BuildId: f888be5f5e7d58e04cabb8c675c7ab94e77dd68c)
    #38 0x7fdc43fa9c4a in __libc_start_main_alias_2 (/lib64/libc.so.6+0x27c4a) (BuildId: f888be5f5e7d58e04cabb8c675c7ab94e77dd68c)
    #39 0x1bec874 in _start (/home/cdda/git/Cataclysm-DDA/cataclysm-tiles+0x1bec874) (BuildId: be24990d1723c8da00f3e8701793ab983cf64dcc)
```

#### Describe the solution

The solution initialize the booleans to values that match their defaults

#### Testing

-fsanitize=undefined no longer complains about this specific error