### PR TITLE
Don't override RELEASE=0 from matrix.yml

### DIFF
--- a/build-scripts/gha_compile_only.sh
+++ b/build-scripts/gha_compile_only.sh
@@ -62,7 +62,7 @@ then
         ..
     make -j$num_jobs
 else
-    make -j "$num_jobs" RELEASE=1 CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 FRAMEWORK=1 UNIVERSAL_BINARY=1
+    make -j "$num_jobs" CCACHE=1 CROSS="$CROSS_COMPILATION" LINTJSON=0 FRAMEWORK=1 UNIVERSAL_BINARY=1
 
     # For CI on macOS, patch the test binary so it can find SDL2 libraries.
     if [[ ! -z "$OS" && "$OS" = "macos-12" ]]


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

I have noticed that artifacts from a failed "Clang 12, Ubuntu, Tiles, ASan" build are partially stripped (-g1) - they contain enough debug info to generate a backtrace, but not enough to view the contents of the variables in gdb.

It turns out that even though matrix.yml sets RELEASE=0 gha_compile_only.sh was overriding this with RELEASE=1. This also caused the artifacts to be compiled with -Os optimization level making debugging harder

#### Describe the solution

Remove the override. gha_compile_only.sh appears to only be used by matrix.yml, which appears to only be used for testing purposes

#### Testing

Let's wait for "Clang 12, Ubuntu, Tiles, ASan", "GCC 11, Ubuntu, Curses, ASan" and "GCC 12, Ubuntu cross-compile to MinGW-Win64, Tiles, Sound" builds. Other builds should not be affected
