### PR TITLE
fix glock 22 nest uses wrong ammo

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/nested_guns.json
@@ -72,8 +72,8 @@
     "ammo": 100,
     "entries": [
       { "item": "glock_22", "charges-min": 0, "ammo-item": "40sw", "charges-max": 15 },
-      { "item": "glock40mag" },
-      { "item": "glock40mag", "prob": 50 },
+      { "item": "glock40mag", "charges-min": 0, "ammo-item": "40sw", "charges-max": 15 },
+      { "item": "glock40mag", "charges-min": 0, "ammo-item": "40sw", "charges-max": 15, "prob": 50 },
       { "group": "on_hand_40" }
     ]
   },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Fix #70689
#### Describe the solution
Specify the ammo type in nested itemgroup
#### Testing
Before:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/4c3b85cf-816c-4ca8-97be-d5de145c6dbf)

After:

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/a049f7a5-3440-41a1-a79f-76076fc459f9)