### PR TITLE
Initialize reset_item_vars

### DIFF
--- a/src/item_factory.h
+++ b/src/item_factory.h
@@ -50,7 +50,7 @@ class migration
         int charges = 0;
 
         // if set to true then reset item_vars std::map to the value of itype's item_variables
-        bool reset_item_vars;
+        bool reset_item_vars = false;
 
         class content
         {


### PR DESCRIPTION
#### Summary

None

#### Purpose of change

If the migration did not explicitly set reset_item_vars to true or to false, the value remained uninitialized.

I found this via -fsanitize=undefined

reset_item_vars was introduced in 646fa4d5a2f5894828f94a1dba5a1fbb537bae39. Based on the fact @irwiss decided to add this boolean switch and set it to true for several migrations I assume the intended default value is false.

#### Describe the solution

Always initialize reset_item_vars to false

#### Testing

-fsanitize=undefined no longer reports the error
