### PR TITLE
Remove Mutagen Catalyst (again)

### DIFF
--- a/data/json/effects.json
+++ b/data/json/effects.json
@@ -1037,7 +1037,7 @@
     "id": "mutagen_alpha",
     "name": [ "Alpha Mutation", "Alpha Transformation", "Alpha Metamorphosis" ],
     "desc": [
-      "You consumed alpha primer.",
+      "You consumed alpha mutagen.",
       "You feel better.  So much better.",
       "The world needs you, surely this won't kill you.  It better not."
     ],
@@ -1067,14 +1067,15 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Alpha Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Alpha Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_batrachian",
     "name": [ "Frog Mutation", "Frog Transformation", "Frog Metamorphosis" ],
     "desc": [
-      "You consumed frog primer.",
+      "You consumed frog mutagen.",
       "Now, to find a quiet pond and settle for the wait…",
       "You feel like you're about to croak… if you don't keel over first."
     ],
@@ -1104,14 +1105,15 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Frog Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Frog Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_beast",
     "name": [ "Beast Mutation", "Beast Transformation", "Beast Metamorphosis" ],
     "desc": [
-      "You consumed beast primer.",
+      "You consumed beast mutagen.",
       "There must be prey around.  Stay alert.",
       "Primal instincts overwhelm your mind, and your saliva has turned to froth."
     ],
@@ -1140,14 +1142,15 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Beast Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Beast Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_bird",
     "name": [ "Bird Mutation", "Bird Transformation", "Bird Metamorphosis" ],
     "desc": [
-      "You consumed bird primer.",
+      "You consumed bird mutagen.",
       "You feel the pull of the skies.",
       "Goosebumps stand across your entire body.  You keep feeling that you're falling."
     ],
@@ -1165,14 +1168,15 @@
     },
     "scaling_mods": { "str_mod": [ -2 ], "per_mod": [ 1.5 ], "speed_mod": [ 3.5 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Bird Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Bird Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_cattle",
     "name": [ "Cattle Mutation", "Cattle Transformation", "Cattle Metamorphosis" ],
     "desc": [
-      "You consumed cattle primer.",
+      "You consumed cattle mutagen.",
       "This pasture will grow barren soon.  Keep moving.",
       "Dull fog clouds your mind, and you feel close to vomiting."
     ],
@@ -1199,14 +1203,15 @@
       "pain_chance": [ -5 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Cattle Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Cattle Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_cephalopod",
     "name": [ "Cephalopod Mutation", "Cephalopod Transformation", "Cephalopod Metamorphosis" ],
     "desc": [
-      "You consumed cephalopod primer.",
+      "You consumed cephalopod mutagen.",
       "Become one with your surroundings.",
       "Your skin crawls and your extremities twitch and jerk."
     ],
@@ -1227,14 +1232,15 @@
     },
     "scaling_mods": { "thirst_tick": [ -400 ], "int_mod": [ 2.5 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Cephalopod Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Cephalopod Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_chimera",
     "name": [ "Chimera Mutation", "Chimera Transformation", "Chimera Metamorphosis" ],
     "desc": [
-      "You consumed chimera primer.  Why?",
+      "You consumed chimera mutagen.",
       "Your flesh is the clay of the new world.  You'll overcome all challenges.",
       "Your body heaving and changing is a rough time, but what doesn't kill you makes you stronger."
     ],
@@ -1255,14 +1261,15 @@
     },
     "scaling_mods": { "hunger_tick": [ -120 ], "str_mod": [ 2.5 ], "int_mod": [ -2 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Chimera Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Chimera Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_elfa",
     "name": [ "Elf-A Mutation", "Elf-A Transformation", "Elf-A Metamorphosis" ],
     "desc": [
-      "You consumed Elf-A primer.",
+      "You consumed Elf-A mutagen.",
       "You must look after this world, if noone else will.",
       "You see stars.  You see so many stars."
     ],
@@ -1280,14 +1287,15 @@
     },
     "scaling_mods": { "per_mod": [ 2.5 ], "int_mod": [ 1 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -15 ] },
     "rating": "bad",
-    "blood_analysis_description": "Elf-A Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Elf-A Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_feline",
     "name": [ "Feline Mutation", "Feline Transformation", "Feline Metamorphosis" ],
     "desc": [
-      "You consumed feline primer.",
+      "You consumed feline mutagen.",
       "Quiet steps and sharp claws.  They'll never see it coming.",
       "If this overdose kills you, you've got a few more lives… right?"
     ],
@@ -1312,14 +1320,15 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Feline Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Feline Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_fish",
     "name": [ "Fish Mutation", "Fish Transformation", "Fish Metamorphosis" ],
     "desc": [
-      "You consumed fish primer.",
+      "You consumed fish mutagen.",
       "The waters call to you.  Leave this exposed wasteland.",
       "You feel clammy yet dry, absolutely parched no matter how much you drink."
     ],
@@ -1340,14 +1349,15 @@
     },
     "scaling_mods": { "thirst_tick": [ -400 ], "per_mod": [ 1 ], "dex_mod": [ 1.5 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Fish Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Fish Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_gastropod",
     "name": [ "Snail Mutation", "Snail Transformation", "Snail Metamorphosis" ],
     "desc": [
-      "You consumed snail primer.",
+      "You consumed snail mutagen.",
       "Slow and steady wins the race.",
       "You itch terribly, and your mouth feels salty and dry."
     ],
@@ -1356,7 +1366,8 @@
     "base_mods": { "hurt_min": [ 1 ], "hurt_max": [ 2 ], "hurt_chance": [ -22 ], "hurt_tick": [ 60 ] },
     "scaling_mods": { "str_mod": [ 1.5 ], "speed_mod": [ -7.5 ], "hurt_chance": [ 21, 0 ] },
     "rating": "bad",
-    "blood_analysis_description": "Snail Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Snail Mutagen"
   },
   {
     "type": "effect_type",
@@ -1372,14 +1383,15 @@
     "base_mods": { "str_mod": [ 0, -2 ], "per_mod": [ 0, -2 ], "dex_mod": [ 0, -2 ], "int_mod": [ 0, -2 ] },
     "scaling_mods": { "str_mod": [ 0, -2.5 ], "per_mod": [ 0, -2.5 ], "dex_mod": [ 0, -2.5 ], "int_mod": [ 0, -2.5 ] },
     "rating": "bad",
-    "blood_analysis_description": "Human Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Human Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_insect",
     "name": [ "Insect Mutation", "Insect Transformation", "Insect Metamorphosis" ],
     "desc": [
-      "You consumed insect primer.",
+      "You consumed insect mutagen.",
       "You can't wait for your change.  It can't be long now.",
       "You can't stop shivering and twitching.  Life is so short."
     ],
@@ -1407,14 +1419,15 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Insect Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Insect Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_lizard",
     "name": [ "Lizard Mutation", "Lizard Transformation", "Lizard Metamorphosis" ],
     "desc": [
-      "You consumed lizard primer.",
+      "You consumed lizard mutagen.",
       "Your skin feels dry and too small.  You'll have to molt soon.",
       "Your limbs slump, almost ready to tear right out of their sockets."
     ],
@@ -1432,14 +1445,15 @@
     },
     "scaling_mods": { "dex_mod": [ 1 ], "int_mod": [ -1.5 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Lizard Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Lizard Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_lupine",
     "name": [ "Lupine Mutation", "Lupine Transformation", "Lupine Metamorphosis" ],
     "desc": [
-      "You consumed lupine primer.",
+      "You consumed lupine mutagen.",
       "Where's your pack?  How will you survive without them?",
       "You pant, unable to stop pacing and full of hunger."
     ],
@@ -1469,15 +1483,16 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Lupine Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Lupine Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_medical",
     "name": [ "Medical Mutation", "Medical Transformation", "Medical Metamorphosis" ],
     "desc": [
-      "You consumed medical primer.",
-      "You consumed medical primer.  You should do that again.",
+      "You consumed medical mutagen.",
+      "You consumed medical mutagen.  You should do that again.",
       "You're tearing yourself apart.  Need to get fixed back up.  Should put some stitches in you."
     ],
     "max_intensity": 3,
@@ -1494,14 +1509,15 @@
     },
     "scaling_mods": { "str_mod": [ 2 ], "dex_mod": [ 2 ], "int_mod": [ -2.5 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -16 ] },
     "rating": "bad",
-    "blood_analysis_description": "Medical Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Medical Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_mouse",
     "name": [ "Mouse Mutation", "Mouse Transformation", "Mouse Metamorphosis" ],
     "desc": [
-      "You consumed mouse primer.",
+      "You consumed mouse mutagen.",
       "Your heart pounds, knowing that predators could approach at any second!",
       "Your heart hammers away with a rapid, irregular beat."
     ],
@@ -1520,14 +1536,15 @@
     },
     "scaling_mods": { "str_mod": [ -1.5 ], "dex_mod": [ 1 ], "speed_mod": [ 6.5 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Mouse Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Mouse Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_plant",
     "name": [ "Plant Mutation", "Plant Transformation", "Plant Metamorphosis" ],
     "desc": [
-      "You consumed plant primer.",
+      "You consumed plant mutagen.",
       "All this running… why don't you just find a nice, fertile spot and bask in the sun?",
       "Your processes are slowing.  You would make great fertilizer."
     ],
@@ -1536,14 +1553,15 @@
     "base_mods": { "hurt_min": [ 1 ], "hurt_max": [ 2 ], "hurt_chance": [ -22 ], "hurt_tick": [ 200 ] },
     "scaling_mods": { "str_mod": [ 1.5 ], "dex_mod": [ 1.5 ], "int_mod": [ -1 ], "speed_mod": [ -7.5 ], "hurt_chance": [ 21, 0 ] },
     "rating": "bad",
-    "blood_analysis_description": "Plant Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Plant Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_raptor",
     "name": [ "Raptor Mutation", "Raptor Transformation", "Raptor Metamorphosis" ],
     "desc": [
-      "You consumed raptor primer.",
+      "You consumed raptor mutagen.",
       "Sharpen your talons and clean your feathers.  Your prey won't give itself easily.",
       "Delusions fill your head… is it true?  Did you die long ago?"
     ],
@@ -1572,14 +1590,15 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Raptor Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Raptor Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_rabbit",
     "name": [ "Rabbit Mutation", "Rabbit Transformation", "Rabbit Metamorphosis" ],
     "desc": [
-      "You consumed rabbit primer.",
+      "You consumed rabbit mutagen.",
       "So much to do!  Better hop to it!",
       "Will you have a future?  Will any new generations be born… your pounding head is full of worry."
     ],
@@ -1604,14 +1623,15 @@
       "pain_chance": [ -15 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Rabbit Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Rabbit Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_rat",
     "name": [ "Rat Mutation", "Rat Transformation", "Rat Metamorphosis" ],
     "desc": [
-      "You consumed rat primer.",
+      "You consumed rat mutagen.",
       "This place is too open.  Hide!",
       "Dull aches fill your stomach, and every smell seems offensive."
     ],
@@ -1629,13 +1649,14 @@
     },
     "scaling_mods": { "dex_mod": [ 1 ], "int_mod": [ -2 ], "speed_mod": [ 3.5 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Rat Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Rat Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_slime",
     "name": [ "Slime Mutation", "Slime Transformation", "Slime Metamorphosis" ],
-    "desc": [ "You consumed slime primer.", "Plop.", "Brain… melting…" ],
+    "desc": [ "You consumed slime mutagen.", "Plop.", "Brain… melting…" ],
     "max_intensity": 3,
     "resist_traits": [ "THRESH_SLIME" ],
     "base_mods": {
@@ -1657,14 +1678,15 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Slime Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Slime Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_spider",
     "name": [ "Spider Mutation", "Spider Transformation", "Spider Metamorphosis" ],
     "desc": [
-      "You consumed spider primer.",
+      "You consumed spider mutagen.",
       "An anchor line there and there, connect with capture threads…",
       "Perhaps you should curl up, just curl up and give in."
     ],
@@ -1682,14 +1704,15 @@
     },
     "scaling_mods": { "dex_mod": [ 1.5 ], "int_mod": [ -1 ], "speed_mod": [ 4 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -25 ] },
     "rating": "bad",
-    "blood_analysis_description": "Spider Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Spider Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_troglobite",
     "name": [ "Troglobite Mutation", "Troglobite Transformation", "Troglobite Metamorphosis" ],
     "desc": [
-      "You consumed troglobite primer.",
+      "You consumed troglobite mutagen.",
       "Down in the dark corners of the new world.  That's where you belong.",
       "Deep and dark, your bones ache and twist."
     ],
@@ -1707,14 +1730,15 @@
     },
     "scaling_mods": { "str_mod": [ 2 ], "per_mod": [ -2.5 ], "dex_mod": [ 1 ], "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
-    "blood_analysis_description": "Troglobite Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Troglobite Mutagen"
   },
   {
     "type": "effect_type",
     "id": "mutagen_ursine",
     "name": [ "Ursine Mutation", "Ursine Transformation", "Ursine Metamorphosis" ],
     "desc": [
-      "You consumed ursine primer.",
+      "You consumed ursine mutagen.",
       "Berries, brood, honey, or meat?  What will today bring?",
       "Sleep sounds good.  Sleep forever, maybe."
     ],
@@ -1742,7 +1766,8 @@
       "pain_chance": [ -30 ]
     },
     "rating": "bad",
-    "blood_analysis_description": "Ursine Primer Contamination"
+    "flags": [ "MUTAGEN_EFFECT" ],
+    "blood_analysis_description": "Ursine Mutagen"
   },
   {
     "type": "effect_type",
@@ -1767,6 +1792,7 @@
     },
     "scaling_mods": { "hurt_chance": [ 21, 0 ], "pain_chance": [ -30 ] },
     "rating": "bad",
+    "flags": [ "MUTAGEN_EFFECT" ],
     "blood_analysis_description": "Crustacean Mutagen Contamination"
   },
   {

--- a/data/json/items/comestibles/mutagen.json
+++ b/data/json/items/comestibles/mutagen.json
@@ -57,6 +57,7 @@
       "activation_message": "You inject the mutagenic catalyst.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen", 750, 850 ] ]
+       }
    },
   {
     "id": "iv_mutagen_alpha",
@@ -73,7 +74,7 @@
       "activation_message": "You inject the alpha infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_alpha", 450, 550 ] ]
-    }
+      }
   },
   {
     "id": "iv_mutagen_beast",

--- a/data/json/items/comestibles/mutagen.json
+++ b/data/json/items/comestibles/mutagen.json
@@ -29,7 +29,7 @@
     "copy-from": "mutagen_flavor",
     "type": "COMESTIBLE",
     "name": { "str_sp": "abstract iv mutagen flavor" },
-    "description": "A processed mutagenic primer.",
+    "description": "A processed mutagenic infusion.",
     "price": "3000 USD",
     "price_postapoc": "1 USD",
     "weight": "10 g",
@@ -47,8 +47,8 @@
     "id": "iv_mutagen",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "mutagenic catalyst" },
-    "description": "A processed, purified, and condensed dose of mutagenic drugs.  When combined with mutagenic primer, this will cause mutations over time.",
+    "name": { "str_sp": "mutagenic infusion" },
+    "description": "A processed, purified, and condensed dose of mutagenic drugs.  This will cause you to acquire mutations over time.",
     "healthy": -10,
     "stim": -10,
     "addiction_potential": 12,
@@ -57,23 +57,20 @@
       "activation_message": "You inject the mutagenic catalyst.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen", 750, 850 ] ]
-    },
-    "extend": { "flags": [ "MUTAGEN_CATALYST" ] },
-    "delete": { "flags": [ "MUTAGEN_PRIMER" ] }
-  },
+   },
   {
     "id": "iv_mutagen_alpha",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "alpha mutagenic primer" },
-    "description": "A processed mutagenic primer strongly resembling blood.",
+    "name": { "str_sp": "alpha infusion" },
+    "description": "A processed mutagenic infusion strongly resembling blood.",
     "price": "25000 USD",
     "looks_like": "iv_mutagen",
     "color": "red",
     "healthy": -4,
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the alpha mutagenic primer.",
+      "activation_message": "You inject the alpha infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_alpha", 450, 550 ] ]
     }
@@ -82,13 +79,13 @@
     "id": "iv_mutagen_beast",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "beast mutagenic primer" },
-    "description": "A processed mutagenic primer as red as a matador's cape.",
+    "name": { "str_sp": "beast infusion" },
+    "description": "A processed mutagenic infusion as red as a matador's cape.",
     "looks_like": "iv_mutagen",
     "color": "red",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the beast mutagenic primer.",
+      "activation_message": "You inject the beast infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_beast", 450, 550 ] ]
     }
@@ -97,13 +94,13 @@
     "id": "iv_mutagen_bird",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "bird mutagenic primer" },
-    "description": "A processed mutagenic primer the color of the pre-Cataclysmic skies.",
+    "name": { "str_sp": "bird infusion" },
+    "description": "A processed mutagenic infusion the color of the pre-Cataclysmic skies.",
     "looks_like": "iv_mutagen",
     "color": "cyan",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the bird mutagenic primer.",
+      "activation_message": "You inject the bird infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_bird", 450, 550 ] ]
     }
@@ -112,13 +109,13 @@
     "id": "iv_mutagen_cattle",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "cattle mutagenic primer" },
-    "description": "A processed mutagenic primer the color of grass.",
+    "name": { "str_sp": "cattle infusion" },
+    "description": "A processed mutagenic infusion the color of grass.",
     "looks_like": "iv_mutagen",
     "color": "light_green",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the cattle mutagenic primer.",
+      "activation_message": "You inject the cattle infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_cattle", 450, 550 ] ]
     }
@@ -127,13 +124,13 @@
     "id": "iv_mutagen_cephalopod",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "cephalopod mutagenic primer" },
-    "description": "A processed mutagenic primer as black as ink.",
+    "name": { "str_sp": "cephalopod infusion" },
+    "description": "A processed mutagenic infusion as black as ink.",
     "looks_like": "iv_mutagen",
     "color": "dark_gray",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the cephalopod mutagenic primer.",
+      "activation_message": "You inject the cephalopod infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_cephalopod", 450, 550 ] ]
     }
@@ -142,8 +139,8 @@
     "id": "iv_mutagen_chimera",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "chimera mutagenic primer" },
-    "description": "A processed mutagenic primer that churns with iridescence.",
+    "name": { "str_sp": "chimera infusion" },
+    "description": "A processed mutagenic infusion that churns with iridescence.",
     "price": 400000,
     "looks_like": "iv_mutagen",
     "color": "red",
@@ -152,7 +149,7 @@
     "addiction_potential": 4,
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the chimera mutagenic primer.",
+      "activation_message": "You inject the chimera infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_chimera", 450, 550 ] ]
     }
@@ -161,14 +158,14 @@
     "id": "iv_mutagen_elfa",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "Elf-A mutagenic primer" },
-    "description": "A processed mutagenic primer that's a striking sylvan green.",
+    "name": { "str_sp": "Elf-A infusion" },
+    "description": "A processed mutagenic infusion that's a striking sylvan green.",
     "price": 400000,
     "looks_like": "iv_mutagen",
     "color": "light_green",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the Elf-A mutagenic primer.",
+      "activation_message": "You inject the Elf-A infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_elfa", 450, 550 ] ]
     }
@@ -177,13 +174,13 @@
     "id": "iv_mutagen_feline",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "feline mutagenic primer" },
-    "description": "A processed mutagenic primer, yellow and highly reflective.",
+    "name": { "str_sp": "feline infusion" },
+    "description": "A processed mutagenic infusion, yellow and highly reflective.",
     "looks_like": "iv_mutagen",
     "color": "yellow",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the feline mutagenic primer.",
+      "activation_message": "You inject the feline infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_feline", 450, 550 ] ]
     }
@@ -192,13 +189,13 @@
     "id": "iv_mutagen_fish",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "fish mutagenic primer" },
-    "description": "A processed mutagenic primer the color of the ocean, with white foam at the top.",
+    "name": { "str_sp": "fish infusion" },
+    "description": "A processed mutagenic infusion the color of the ocean, with white foam at the top.",
     "looks_like": "iv_mutagen",
     "color": "light_blue",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the fish mutagenic primer.",
+      "activation_message": "You inject the fish infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_fish", 450, 550 ] ]
     }
@@ -207,13 +204,13 @@
     "id": "iv_mutagen_insect",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "insect mutagenic primer" },
-    "description": "A processed mutagenic primer that's a beautiful amber color.",
+    "name": { "str_sp": "insect infusion" },
+    "description": "A processed mutagenic infusion that's a beautiful amber color.",
     "looks_like": "iv_mutagen",
     "color": "yellow",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the insect mutagenic primer.",
+      "activation_message": "You inject the insect infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_insect", 450, 550 ] ]
     }
@@ -222,13 +219,13 @@
     "id": "iv_mutagen_lizard",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "lizard mutagenic primer" },
-    "description": "A processed mutagenic primer that shifts between various shades of green.",
+    "name": { "str_sp": "lizard infusion" },
+    "description": "A processed mutagenic infusion that shifts between various shades of green.",
     "looks_like": "iv_mutagen",
     "color": "light_green",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the lizard mutagenic primer.",
+      "activation_message": "You inject the lizard infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_lizard", 450, 550 ] ]
     }
@@ -237,13 +234,13 @@
     "id": "iv_mutagen_lupine",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "lupine mutagenic primer" },
-    "description": "A processed mutagenic primer as white as a full moon.",
+    "name": { "str_sp": "lupine infusion" },
+    "description": "A processed mutagenic infusion as white as a full moon.",
     "looks_like": "iv_mutagen",
     "color": "white",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the lupine mutagenic primer.",
+      "activation_message": "You inject the lupine infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_lupine", 450, 550 ] ]
     }
@@ -252,15 +249,15 @@
     "id": "iv_mutagen_medical",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "medical mutagenic primer" },
-    "description": "A processed mutagenic primer that looks like a mixture of bodily fluids.",
+    "name": { "str_sp": "medical infusion" },
+    "description": "A processed mutagenic infusion that looks like a mixture of bodily fluids.",
     "price": "3000 USD",
     "looks_like": "iv_mutagen",
     "color": "light_red",
     "healthy": -4,
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the medical mutagenic primer.",
+      "activation_message": "You inject the medical infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_medical", 450, 550 ] ]
     }
@@ -269,13 +266,13 @@
     "id": "iv_mutagen_plant",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "plant mutagenic primer" },
-    "description": "A processed mutagenic primer that looks like pureed spinach.",
+    "name": { "str_sp": "plant infusion" },
+    "description": "A processed mutagenic infusion that looks like pureed spinach.",
     "looks_like": "iv_mutagen",
     "color": "green",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the plant mutagenic primer.",
+      "activation_message": "You inject the plant infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_plant", 450, 550 ] ]
     }
@@ -284,14 +281,14 @@
     "id": "iv_mutagen_raptor",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "raptor mutagenic primer" },
-    "description": "A processed mutagenic primer that seems to shift slightly whenever you look at it.",
+    "name": { "str_sp": "raptor infusion" },
+    "description": "A processed mutagenic infusion that seems to shift slightly whenever you look at it.",
     "price": 400000,
     "looks_like": "iv_mutagen",
     "color": "green",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the raptor mutagenic primer.",
+      "activation_message": "You inject the raptor infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_raptor", 450, 550 ] ]
     }
@@ -300,13 +297,13 @@
     "id": "iv_mutagen_rat",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "rat mutagenic primer" },
-    "description": "A processed mutagenic primer that's a rather unappealing beige.",
+    "name": { "str_sp": "rat infusion" },
+    "description": "A processed mutagenic infusion that's a rather unappealing beige.",
     "looks_like": "iv_mutagen",
     "color": "brown",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the rat mutagenic primer.",
+      "activation_message": "You inject the rat infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_rat", 450, 550 ] ]
     }
@@ -315,13 +312,13 @@
     "id": "iv_mutagen_slime",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "slime mutagenic primer" },
-    "description": "A processed mutagenic primer that looks very much like the black ooze in the zombies' eyes.",
+    "name": { "str_sp": "slime infusion" },
+    "description": "A processed mutagenic infusion that seems to jiggle slightly.",
     "looks_like": "iv_mutagen",
     "color": "dark_gray",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the slime mutagenic primer.",
+      "activation_message": "You inject the slime infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_slime", 450, 550 ] ]
     }
@@ -330,13 +327,13 @@
     "id": "iv_mutagen_spider",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "spider mutagenic primer" },
-    "description": "A processed mutagenic primer with pale filaments suspended in it.",
+    "name": { "str_sp": "spider infusion" },
+    "description": "A processed mutagenic infusion with pale filaments suspended in it.",
     "looks_like": "iv_mutagen",
     "color": "light_gray",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the spider mutagenic primer.",
+      "activation_message": "You inject the spider infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_spider", 450, 550 ] ]
     }
@@ -345,13 +342,13 @@
     "id": "iv_mutagen_snail",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "snail mutagenic primer" },
-    "description": "A processed mutagenic primer with the consistency of snot.",
+    "name": { "str_sp": "snail infusion" },
+    "description": "A processed mutagenic infusion with the consistency of snot.",
     "looks_like": "iv_mutagen",
     "color": "light_gray",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the snail mutagenic primer.",
+      "activation_message": "You inject the snail infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_gastropod", 450, 550 ] ]
     }
@@ -360,13 +357,13 @@
     "id": "iv_mutagen_batrachian",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "batrachian mutagenic primer" },
-    "description": "A processed mutagenic primer that looks like pond water… are the shadows in it moving?",
+    "name": { "str_sp": "batrachian infusion" },
+    "description": "A processed mutagenic infusion that looks like pond water… are the shadows in it moving?",
     "looks_like": "iv_mutagen",
     "color": "light_gray",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the batrachian mutagenic primer.",
+      "activation_message": "You inject the batrachian infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_batrachian", 450, 550 ] ]
     }
@@ -375,13 +372,13 @@
     "id": "iv_mutagen_troglobite",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "troglobite mutagenic primer" },
-    "description": "A processed mutagenic primer that seems to recoil from the light.",
+    "name": { "str_sp": "troglobite infusion" },
+    "description": "A processed mutagenic infusion that seems to recoil from the light.",
     "looks_like": "iv_mutagen",
     "color": "dark_gray",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the troglobite mutagenic primer.",
+      "activation_message": "You inject the troglobite infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_troglobite", 450, 550 ] ]
     }
@@ -390,13 +387,13 @@
     "id": "iv_mutagen_ursine",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "ursine mutagenic primer" },
-    "description": "A processed mutagenic primer that's the color of honey, and is just as thick.",
+    "name": { "str_sp": "ursine infusion" },
+    "description": "A processed mutagenic infusion that's the color of honey, and is just as thick.",
     "looks_like": "iv_mutagen",
     "color": "yellow",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the ursine mutagenic primer.",
+      "activation_message": "You inject the ursine infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_ursine", 450, 550 ] ]
     }
@@ -405,13 +402,13 @@
     "id": "iv_mutagen_mouse",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "mouse mutagenic primer" },
-    "description": "A processed mutagenic primer resembling liquefied metal.",
+    "name": { "str_sp": "mouse infusion" },
+    "description": "A processed mutagenic infusion resembling liquefied metal.",
     "looks_like": "iv_mutagen",
     "color": "light_gray",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the mouse mutagenic primer.",
+      "activation_message": "You inject the mouse infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_mouse", 450, 550 ] ]
     }
@@ -420,12 +417,12 @@
     "id": "iv_mutagen_rabbit",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "rabbit mutagenic primer" },
-    "description": "An orange colored mutagenic primer.",
+    "name": { "str_sp": "rabbit infusion" },
+    "description": "An orange colored mutagenic infusion.",
     "looks_like": "iv_mutagen",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the rabbit mutagenic primer.",
+      "activation_message": "You inject the rabbit infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_rabbit", 450, 550 ] ]
     }
@@ -434,13 +431,13 @@
     "id": "iv_mutagen_crustacean",
     "copy-from": "iv_mutagen_flavor",
     "type": "COMESTIBLE",
-    "name": { "str_sp": "crustacean mutagenic primer" },
-    "description": " A red colored mutagenic primer.",
+    "name": { "str_sp": "crustacean infusion" },
+    "description": " A red colored mutagenic infusion.",
     "color": "red",
     "looks_like": "iv_mutagen",
     "use_action": {
       "type": "consume_drug",
-      "activation_message": "You inject the crustacean mutagenic primer.",
+      "activation_message": "You inject the crustacean infusion.",
       "tools_needed": { "syringe": -1 },
       "vitamins": [ [ "mutagen_crustacean", 450, 550 ] ]
     }
@@ -450,9 +447,9 @@
     "copy-from": "mutagen_flavor",
     "type": "COMESTIBLE",
     "name": { "str_sp": "mutagen" },
-    "description": "A slurry of organic chemicals and compounds, used as the foundation for making primers and mutagenic catalyst.  In this baseline form, it is highly toxic, and dangerous to consume on its own.",
+    "description": "A syrupy black goop that reeks of noxious chemicals.  Drinking this may cause you to mutate.",
     "addiction_potential": 6,
-    "use_action": { "type": "consume_drug", "activation_message": "You drink the mutagen.", "vitamins": [ [ "mutagenic_slurry", 25 ] ] }
+    "use_action": { "type": "consume_drug", "activation_message": "You drink the mutagen.", "vitamins": [ [ "mutagen", 225 ] ] }
   },
   {
     "id": "mutagen_jabberblood",
@@ -484,7 +481,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the alpha mutagen.",
-      "vitamins": [ [ "mutagen_alpha", 225 ], [ "mutagen", 125 ] ]
+      "vitamins": [ [ "mutagen_alpha", 225 ] ]
     }
   },
   {
@@ -496,7 +493,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the beast mutagen.",
-      "vitamins": [ [ "mutagen_beast", 225 ], [ "mutagen", 125 ] ]
+      "vitamins": [ [ "mutagen_beast", 225 ] ]
     }
   },
   {
@@ -508,7 +505,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the bird mutagen.",
-      "vitamins": [ [ "mutagen_bird", 225 ], [ "mutagen", 125 ] ]
+      "vitamins": [ [ "mutagen_bird", 225 ] ]
     }
   },
   {
@@ -520,7 +517,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the cattle mutagen.",
-      "vitamins": [ [ "mutagen_cattle", 225 ], [ "mutagen", 125 ] ]
+      "vitamins": [ [ "mutagen_cattle", 225 ] ]
     }
   },
   {
@@ -532,7 +529,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the cephalopod mutagen.",
-      "vitamins": [ [ "mutagen_cephalopod", 225 ], [ "mutagen", 125 ] ]
+      "vitamins": [ [ "mutagen_cephalopod", 225 ] ]
     }
   },
   {
@@ -546,7 +543,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the chimera mutagen.",
-      "vitamins": [ [ "mutagen_chimera", 225 ], [ "mutagen", 125 ] ]
+      "vitamins": [ [ "mutagen_chimera", 225 ] ]
     }
   },
   {
@@ -560,7 +557,7 @@
     "use_action": {
       "type": "consume_drug",
       "activation_message": "You drink the Elf-A mutagen.",
-      "vitamins": [ [ "mutagen_elfa", 225 ], [ "mutagen", 125 ] ]
+      "vitamins": [ [ "mutagen_elfa", 225 ] ]
     }
   },
   {
@@ -655,7 +652,6 @@
     "type": "COMESTIBLE",
     "name": { "str_sp": "raptor mutagen" },
     "description": "An extremely rare mutagen cocktail.",
-    "price": "2000 USD",
     "looks_like": "mutagen",
     "use_action": {
       "type": "consume_drug",

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -190,6 +190,7 @@ const flag_id flag_MOUNTED_GUN( "MOUNTED_GUN" );
 const flag_id flag_MOUSE( "MOUSE" );
 const flag_id flag_MUNDANE( "MUNDANE" );
 const flag_id flag_MUSHY( "MUSHY" );
+const flag_id flag_MUTAGEN_EFFECT( "MUTAGEN_EFFECT" );
 const flag_id flag_MUTE( "MUTE" );
 const flag_id flag_MYCUS_OK( "MYCUS_OK" );
 const flag_id flag_NANOFAB_REPAIR( "NANOFAB_REPAIR" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -200,6 +200,7 @@ extern const flag_id flag_MOUNTED_GUN;
 extern const flag_id flag_MOUSE;
 extern const flag_id flag_MUNDANE;
 extern const flag_id flag_MUSHY;
+extern const flag_id flag_MUTAGEN_EFFECT;
 extern const flag_id flag_MYCUS_OK;
 extern const flag_id flag_NANOFAB_REPAIR;
 extern const flag_id flag_NANOFAB_TEMPLATE;

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -1210,18 +1210,12 @@ void suffer::from_other_mutations( Character &you )
 
 void suffer::from_mutagen( Character &you )
 {
-                you.add_msg_if_player( m_warning,
-                                   _( "suffer from mutage" ) );
         bool mutation = true;
         if( one_in( 4 ) ) {
-                            you.add_msg_if_player( m_warning,
-                                   _( "failed accidentally" ) );
             // Random chance to skip mutating.
             mutation = false;
         }
         if( mutation == true ) {
-                            you.add_msg_if_player( m_warning,
-                                   _( "success" ) );
             you.mutate( 0, true );
         }
 }

--- a/src/suffer.cpp
+++ b/src/suffer.cpp
@@ -204,6 +204,7 @@ static void without_sleep( Character &you, int sleep_deprivation );
 static void from_tourniquet( Character &you );
 static void from_nyctophobia( Character &you );
 static void from_artifact_resonance( Character &you, int amt );
+static void from_mutagen( Character &you );
 } // namespace suffer
 
 static float addiction_scaling( float at_min, float at_max, float add_lvl )
@@ -1207,6 +1208,24 @@ void suffer::from_other_mutations( Character &you )
     }
 }
 
+void suffer::from_mutagen( Character &you )
+{
+                you.add_msg_if_player( m_warning,
+                                   _( "suffer from mutage" ) );
+        bool mutation = true;
+        if( one_in( 4 ) ) {
+                            you.add_msg_if_player( m_warning,
+                                   _( "failed accidentally" ) );
+            // Random chance to skip mutating.
+            mutation = false;
+        }
+        if( mutation == true ) {
+                            you.add_msg_if_player( m_warning,
+                                   _( "success" ) );
+            you.mutate( 0, true );
+        }
+}
+
 void suffer::from_radiation( Character &you )
 {
     map &here = get_map();
@@ -1789,6 +1808,10 @@ void Character::suffer()
 
     if( has_trait( trait_ASTHMA ) ) {
         suffer::from_asthma( *this, current_stim );
+    }
+
+    if( has_effect_with_flag( flag_MUTAGEN_EFFECT ) && calendar::once_every( rng( 1_hours, 6_hours ) ) ) {
+        suffer::from_mutagen( *this );
     }
 
     suffer::in_sunlight( *this, worn );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Removes mutagen catalyst, carries its function over to primer"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
Continued from #70699 - @kevingranade mentioned that I hadn't adequately explained my reasoning for this proposal. @I-am-Erk convinced me to open a second PR, as the first had most of its justification buried in comments to attempt to do so.

A quick clarification before I get started: When I say 'catalyst' I am referring to the vitamin which is currently called 'mutagen'. When I say 'primer', I am referring to the vitamin which is currently called (type) primer. These are different from the item which is called (type) mutagen.

So here goes:

Mutate() currently works by checking for two vitamins, catalyst and primer. Primer doesn't do anything but give you buffs. Catalyst also doesn't do anything. Every 45 minutes to 6 hours or something like that, the game spends 100 catalyst to roll to see if you get a mutation. If you do, it then picks a primer vitamin you have, and if you have enough, it deducts some from that and gives you your mutation.

- There is an irreconcilable issue with our system needing two vitamins to work. The vitamins have an asymmetrical decay/expenditure rate, and without removing one of the vitamins, this can't be fixed without dumping most of our existing mutation code, as it relies on a lot of randomness so that results aren't deterministic. Specifically, the system is always spending catalyst at a random and highly variable rate, but only spends primer when you actually mutate. As @actually-a-cat pointed out, this results in a situation where you are always running out of catalyst. As @Terrorforge points out, crafting primer is a trap option because of these lopsided requirements. The result is that you are forced to wait for weeks while nothing interesting happens just so your primer can decay.
- Primer, a substance made of concentrated blob matter, gives you free long-term buffs without mutating or in most cases even harming you. This is off-theme and runs counter to what we want out of mutations, which is life-altering body horror, not temporary super doggo juice. These long-term risk-free buffs were the stated reason for catalyst being a thing at all. If we remove the buffs, it serves zero purpose.
- Mutating is confusing in an out-of-character way that discourages people from engaging with the system. Rather than encouraging experimentation and exploration, it is mostly just alienating for players and is driving many away from using the system. See additional context for evidence and testimonials.
- As @Zireael07 pointed out, 'catalyst' and 'primer' don't translate well conceptually to other languages. I don't think they're good terms in English either, as they're neither medical terms nor familiar fictional ones like "mutagen". What players are expecting when they go to a mutagen lab and inject a vial labeled BIRD is that they will enter a state of possibly gaining some bird traits. They are understandably confused when instead, nothing happens, especially when there's a good chance that the chemical that actually turns them into a bird doesn't even spawn in the same facility. Having nothing happen will be their experience taking 3 and possibly 4 of our current types of mutagen drugs!
- There are 3 vitamins and 5 items named "mutagen". One of the reasons this PR is so verbose is because it's difficult to even discuss the system because you constantly have to clarify what you're even talking about.
- Worse, typed mutagen contains both primer and catalyst, but with a much higher amount of primer, so you can't use it to top off your catalyst because overdosing on primer is deadly. You might assume that regular mutagen (the item) would work for that purpose, but that's actually a completely different thing that contains a small amount of every primer in it. So "mutagen" = all primers, "(type) mutagen" = mutagen+1 primer, "catalyst" = mutagen, "primer" = 1 primer. Madness!
- Players can't see how much of either vitamin they have. Their only guidepost is in the effects panel, which shows a chunk of prose that is only meaningful if you already know the system. I always have to go look it up, myself. The effect intensity names are all just synonyms for the same thing - changing, metamorphosing, warping, mutating, transmogrifying - it doesn't matter what you write, it's largely subjective, especially once we translate it into another language. Even if it showed the numbers plainly, you'd still need to consult a guide to understand what your target numbers were even supposed to be.
- Your excess primer that you can't get rid of can in some cases damage you over time and eventually kill you, and there's not a lot you can do about it. Chelator can address this, but it's rare and uncraftable. Of course overdosing on mutagens should be dangerous, but you have no way of knowing if you're a dead man walking for quite some time after your fate is sealed.
- The above issue incentivizes largely avoiding the system until you have a huge stockpile of primer and catalyst so that you can deal with any life threatening oopsies, rather than mutating gradually over the course of your adventure.
- Getting rid of one of the vitamins and just having primer do everything will maintain all the benefits of the current system, and the only things that will be lost are the confusing black box micromanagement, the free long-term buffs with no downsides, and weeks of waiting with nothing happening.


#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Mutate() will work by checking for any primer in your system. Every 45 minutes to 6 hours or something like that, the game picks a primer vitamin that you have and spends 100 of it to roll to see if you get a mutation. If you do, it then picks a primer vitamin you have, and if you have enough, it then deducts some from that and gives you your mutation.

- Catalyst (the vitamin currently known as mutagen) is removed.
- All of Catalyst's former functions are simply ported over to primer, so that one vitamin does both jobs. This is currently accomplished by replacing Catalyst's EOC with a few lines of C++ that accomplish the same thing, checking for effect flags instead of a specific effect. If it's absolutely critical that not one new line of C++ be added to the mutation system, I can probably figure out a way for EOCs to pass the effect's mutation category as an argument to mutate(), though I don't understand why we'd want this specifically in an EOC. I also suspect a new EOC would need to be made for every single mutation category, including all those added by mods. They would not differ in any way from each other, because that difference is handled in the existing primer jsons.
- Truly random untyped mutagens are re-introduced for players who enjoy playing Russian roulette, or who just want to dip their toes in and see what happens. This also means that if a new player is exploring a lab, finds a mutagen, and says "I wonder what this does", the answer isn't "nothing, actually."
- Player-side, nothing changes from the current system, except that they inject a primer instead of a primer and a catalyst. All of the probabilities, risks, messaging, time to mutate, and everything else is kept as it was.
- This also keeps the current weighted selection of mutation categories, and has no effect on the risk involved in trying to mutate multiple categories at once.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
- Renaming the chemicals and vitamins without deleting any: This is addressing a symptom, not a cause. It might reduce some confusion, but it won't alleviate it because we're still dealing with 3 vitamins and 5 chemicals that have opaque and lopsided interactions.
- Signpost it better with messaging: The messaging is already painfully clear, the player is told far more than their character could possibly know in mostly out of character terms. It literally tells you to go inject more primer if you're out. People still aren't understanding why it isn't working. The problem is not a lack of explanation, it's that the task is artificially complex in a way that is not always able to be intuited even by attentive players.
- Signpost it better with effect descriptions: Again, these are just prose, we don't (and shouldn't) show numbers. Players are forced to guess whether metamorphosis is better or worse than transformation or mutation. This also runs into the translation problem.
- Signpost it better with snippets players can find in labs: We already do this.
- Help files: This should be done in any case, but we all know that only a small percentage of players will ever consult the help files, especially with HHG and a very outdated wiki sitting right there. Most people assume the helpfiles aren't maintained, or if they're like me, they don't want to do a bunch of math homework in order to play a video game.
- Adjust spawns: Again, this would help, but not fix the core problem with the system.
- Adjust decay rates: This won't work because what's happening is that you are being taxed an amount of catalyst every time mutate() runs (which itself happens at random intervals) regardless of whether you mutate or not, and that's in addition to the natural decay rate. So your catalyst rapidly ticks down at an unpredictable rate while your primer just sits there.
- Increase the decay rate of primer: If this was done at a sufficient rate to keep up with Catalyst's decay and expenditure, you'd usually run out too quickly to mutate.
- Remove or reduce primer buffs: Yes, absolutely, but it won't fix the core problem.
- Make chelator craftable: This is the worst kind of fix. It's just handing the player even more busy work to fix a problem that does not need to exist, and it further convolutes a convoluted process.

The burden of justification is on the contributor, and I think I've done that, but I should also ask: What exactly is the benefit of not doing this? The proposed system is exactly as random, exactly as risky, has the exact same chance of not working even if you do it correctly, and takes exactly as long to mutate you. All that is lost is the guesswork trying to balance two randomly changing integers you can't see with chemicals that take days or weeks to acquire.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Ongoing

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
The first four quotes are random people on my discord. They're obviously going to be biased toward me, but the collection of reddit posts is just what I immediately got searching 'primer' on the subreddit. I keep up with people over there and these complaints are as frequent as they look.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/94415528/1256c2e1-837a-416b-995a-cb13551d60c4)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/94415528/e14f41ce-ae78-4325-8861-bbc2fd5b2b23)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/94415528/f87b2e1f-7f8f-464e-960e-edb6b4995596)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/94415528/cd60c6bb-5e3d-46e7-b28b-31aef45deaaf)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/94415528/f168840b-180f-4441-8562-61bf3eec0885)

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
