### PR TITLE
Autodrive over bridges

### DIFF
--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -22,6 +22,7 @@
 #include "cuboid_rectangle.h"
 #include "debug.h"
 #include "enums.h"
+#include "flood_fill.h"
 #include "hash_utils.h"
 #include "map.h"
 #include "map_iterator.h"
@@ -125,6 +126,15 @@
  * that driving at night should only be possible through familiar terrain with limited
  * lights / night vision or through unfamiliar terrain but with good headlights / excellent
  * night vision.
+ *
+ * In order to keep the memory footprint small and constant, this implementation uses a different
+ * coordinate system for the navigation caches than on the game map. The "nav map" is always
+ * allocated to the size of two OMTs wide and one OMT high. Picture it like having one OMT `a` on
+ * the left and one OMT `b` on the right. The coordinates of the nav map are translated and
+ * rotated so that `a` is always the current OMT and `b` is the next OMT we are trying to reach.
+ * So even if, for example, we are planning a route south, the nav map is still allocated as two
+ * OMTs wide, but its coordinates are instead rotated when we want to deal with actual game map
+ * coordinates.
  */
 
 static constexpr int OMT_SIZE = coords::map_squares_per( coords::omt );
@@ -245,6 +255,21 @@ struct coord_transformation {
     coord_transformation inverse() const;
 };
 
+/*
+ * Collection of points for which there is still some check left to do, and a list of points
+ * that have already been visited. Used for remembering which points are up/down ramps when
+ * evaluating obstacles. Ramps will lead to obstacle-detection on another z-level
+ */
+struct point_queue {
+    std::queue<tripoint_bub_ms> to_check;
+    std::unordered_set<tripoint_bub_ms> visited;
+    void enqueue( const tripoint_bub_ms &p ) {
+        if( visited.find( p ) == visited.end() ) {
+            to_check.push( p );
+        }
+    }
+};
+
 /**
  * Data structure that caches all the data needed in order to navigate from one
  * OMT to the next OMT along the path to destination. Main components:
@@ -283,6 +308,9 @@ struct auto_navigation_data {
     std::array<vehicle_profile, NUM_ORIENTATIONS> profiles;
     // known obstacles on the view map
     cata::mdarray<bool, point, NAV_VIEW_SIZE_X, NAV_VIEW_SIZE_Y> is_obstacle;
+    // z-level of where the ground is per point on the view map
+    // Almost always same as the OMT's z, but might differ per mapsquare if we are driving up or down ramps
+    cata::mdarray<int, point, NAV_VIEW_SIZE_X, NAV_VIEW_SIZE_Y> ground_z;
     // where on the nav map the vehicle pivot may be placed
     std::array<cata::mdarray<bool, point, NAV_VIEW_SIZE_X, NAV_VIEW_SIZE_Y>, NUM_ORIENTATIONS>
     valid_positions;
@@ -313,6 +341,17 @@ struct auto_navigation_data {
     bool valid_position( const node_address &addr ) const {
         return valid_position( addr.facing_dir, point( addr.x, addr.y ) );
     }
+    // transforms a point from map coords into view map coords
+    point to_view( const tripoint_abs_ms &p ) const {
+        return view_to_map.inverse().transform( p.raw().xy() );
+    }
+    // transforms a point from map bub coords into view map coords
+    point to_view( const tripoint_bub_ms &p ) const {
+        return to_view( get_map().getglobal( p ) );
+    }
+    // returns `p` adjusted so that the z-level is placed on the ground
+    template<typename Tripoint>
+    Tripoint adjust_z( const Tripoint &p ) const;
 };
 
 enum class collision_check_result : int {
@@ -343,8 +382,10 @@ class vehicle::autodrive_controller
         auto_navigation_data data;
 
         void compute_coordinates();
-        bool check_drivable( tripoint pt ) const;
+        bool check_drivable( const tripoint_bub_ms &pt ) const;
         void compute_obstacles();
+        void enqueue_if_ramp( point_queue &ramp_points, const map &here, const tripoint_bub_ms &p ) const;
+        void compute_obstacles_from_enqueued_ramp_points( point_queue &ramp_points, const map &here );
         vehicle_profile compute_profile( orientation facing ) const;
         void compute_valid_positions();
         void compute_goal_zone();
@@ -556,6 +597,20 @@ static int signum( int val )
     return ( 0 < val ) - ( val < 0 );
 }
 
+template<typename Tripoint>
+Tripoint auto_navigation_data::adjust_z( const Tripoint &p ) const
+{
+    if( !land_ok ) {
+        return p;
+    }
+    const point pt_view = to_view( p );
+    if( !view_bounds.contains( pt_view ) ) {
+        debugmsg( "Autodrive tried to adjust zlevel on out-of-bounds point p=%s", p.to_string() );
+        return p; // shouldn't happen, but who knows.
+    }
+    return { p.xy(), ground_z[pt_view] };
+}
+
 void vehicle::autodrive_controller::compute_coordinates()
 {
     data.view_bounds = { point_zero, {NAV_VIEW_SIZE_X, NAV_VIEW_SIZE_Y} };
@@ -635,7 +690,7 @@ vehicle_profile vehicle::autodrive_controller::compute_profile( orientation faci
 // Return true if the map tile at the given position (in map coordinates)
 // can be driven on (not an obstacle).
 // The logic should match what is in vehicle::part_collision().
-bool vehicle::autodrive_controller::check_drivable( tripoint pt ) const
+bool vehicle::autodrive_controller::check_drivable( const tripoint_bub_ms &pt ) const
 {
     const map &here = get_map();
 
@@ -683,7 +738,7 @@ bool vehicle::autodrive_controller::check_drivable( tripoint pt ) const
     }
 
     // don't drive over visible traps
-    if( here.can_see_trap_at( pt, driver ) ) {
+    if( here.can_see_trap_at( pt.raw(), driver ) ) {
         return false;
     }
 
@@ -733,13 +788,69 @@ bool vehicle::autodrive_controller::check_drivable( tripoint pt ) const
 void vehicle::autodrive_controller::compute_obstacles()
 {
     const map &here = get_map();
+    const int z = data.current_omt.z();
+    point_queue ramp_points;
     for( int dx = 0; dx < NAV_VIEW_SIZE_X; dx++ ) {
         for( int dy = 0; dy < NAV_VIEW_SIZE_Y; dy++ ) {
-            // TODO: store z-values in the nav map and retrieve here (needed for ramp navigation)
-            const tripoint abs_map_pt = data.view_to_map.transform( point( dx, dy ), data.current_omt.z() );
-            data.is_obstacle[dx][dy] = !check_drivable( here.getlocal( abs_map_pt ) );
+            const tripoint abs_map_pt = data.view_to_map.transform( point( dx, dy ), z );
+            const tripoint_bub_ms p = here.bub_from_abs( abs_map_pt );
+            data.is_obstacle[dx][dy] = !check_drivable( p );
+            data.ground_z[dx][dy] = z;
+            enqueue_if_ramp( ramp_points, here, p );
         }
     }
+    compute_obstacles_from_enqueued_ramp_points( ramp_points, here );
+}
+
+// Checks whether `p` is a drivable ramp up or down,
+// and if so adds the ramp's destination tripoint to `ramp_points`
+void vehicle::autodrive_controller::enqueue_if_ramp( point_queue &ramp_points,
+        const map &here, const tripoint_bub_ms &p ) const
+{
+    if( !data.land_ok ) {
+        return;
+    }
+    ramp_points.visited.emplace( p );
+    if( p.z() < OVERMAP_HEIGHT && here.has_flag( ter_furn_flag::TFLAG_RAMP_UP, p ) ) {
+        ramp_points.enqueue( p + tripoint_above );
+    }
+    if( p.z() > -OVERMAP_DEPTH && here.has_flag( ter_furn_flag::TFLAG_RAMP_DOWN, p ) ) {
+        ramp_points.enqueue( p + tripoint_below );
+    }
+}
+
+// Flood-fills from all enqueued points of up or down ramps. For each connected point, we
+// set `is_obstacle` and `ground_z` again, based on whether they are an obstacle or not on
+// this zlevel.
+void vehicle::autodrive_controller::compute_obstacles_from_enqueued_ramp_points(
+    point_queue &ramp_points, const map &here )
+{
+    auto is_drivable = [this, &here]( const tripoint_bub_ms & p ) {
+        return here.inbounds( p ) && check_drivable( p );
+    };
+    while( !ramp_points.to_check.empty() ) {
+        const tripoint_bub_ms ramp_point = ramp_points.to_check.front();
+        ramp_points.to_check.pop();
+        for( const tripoint_bub_ms &p : ff::point_flood_fill_4_connected( ramp_point, ramp_points.visited,
+                is_drivable ) ) {
+            const point pt_view = data.to_view( p );
+            if( !data.view_bounds.contains( pt_view ) ) {
+                continue;
+            }
+            // We now know that point p is drivable (and not an obstacle) on this zlevel, since
+            // it passed the is_drivable check.
+            if( data.is_obstacle[pt_view] ) {
+                // We have examined this point previously on a different zlevel but conluded
+                // that it was an obstacle at that zlevel. But on this zlevel it is apparently
+                // not an obstacle, so this must be our groundlevel.
+                data.ground_z[pt_view] = p.z();
+            } else {
+                data.ground_z[pt_view] = std::min( data.ground_z[pt_view], p.z() );
+            }
+            data.is_obstacle[pt_view] = false;
+            enqueue_if_ramp( ramp_points, here, p );
+        }
+    };
 }
 
 void vehicle::autodrive_controller::compute_valid_positions()
@@ -769,7 +880,7 @@ void vehicle::autodrive_controller::compute_goal_zone()
 {
     data.goal_zone.clear();
     coord_transformation goal_transform;
-    if( data.next_next_omt != data.next_omt ) {
+    if( data.next_next_omt.xy() != data.next_omt.xy() ) {
         // set the goal at the edge of next_omt and next_next_omt (in next_omt
         // space, pointing towards next_next_omt)
         const point next_omt_middle( OMT_SIZE + OMT_SIZE / 2, OMT_SIZE / 2 );
@@ -977,7 +1088,7 @@ std::optional<std::vector<navigation_step>> vehicle::autodrive_controller::compu
                 const tripoint_abs_ms prev_loc( data.nav_to_map.transform( prev.get_point(),
                                                 data.current_omt.z() ) );
                 ret.emplace_back( navigation_step{
-                    prev_loc,
+                    data.adjust_z( prev_loc ),
                     data.nav_to_map.transform( addr.facing_dir ),
                     node.target_speed_tps
                 } );
@@ -1029,19 +1140,26 @@ void vehicle::autodrive_controller::check_safe_speed()
 
 collision_check_result vehicle::autodrive_controller::check_collision_zone( orientation turn_dir )
 {
-    const tripoint veh_pos = driven_veh.global_pos3();
+    const tripoint_bub_ms veh_pos = driven_veh.pos_bub();
 
     // first check if we have any visibility in front, to prevent blind driving
     tileray face_dir = driven_veh.face;
     face_dir.advance();
     const point forward_offset( face_dir.dx(), face_dir.dy() );
+    bool changed_zlevel = false;
     bool blind = true;
     for( const point &p : data.profile( to_orientation( face_dir.dir() ) ).collision_points ) {
-        if( driver.sees( veh_pos + forward_offset + p ) ) {
+        const tripoint_bub_ms next = data.adjust_z( veh_pos + forward_offset + p );
+        if( driver.sees( next ) ) {
             blind = false;
         }
+        // Known quirk: the player does not always see points above or below when driving
+        // up or down ramps, which makes this check think that we should stop pathfinding.
+        // So here we allow having no visibility in case the path changes zlevel.
+        // Checks further down below in this method will make sure that we instead slow down.
+        changed_zlevel |= ( next.z() != veh_pos.z() );
     }
-    if( blind ) {
+    if( blind && !changed_zlevel ) {
         return collision_check_result::no_visibility;
     }
 
@@ -1062,7 +1180,7 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( orie
         collision_zone.insert( p + offset );
     }
     for( const point &p : collision_zone ) {
-        if( !check_drivable( veh_pos + p ) ) {
+        if( !check_drivable( data.adjust_z( veh_pos + p ) ) ) {
             return collision_check_result::close_obstacle;
         }
     }
@@ -1077,10 +1195,11 @@ collision_check_result vehicle::autodrive_controller::check_collision_zone( orie
         }
     }
     for( const point &p : collision_zone ) {
-        if( !driver.sees( veh_pos + p ) ) {
+        const tripoint_bub_ms next = data.adjust_z( veh_pos + p );
+        if( !driver.sees( next ) ) {
             return collision_check_result::slow_down;
         }
-        if( !check_drivable( veh_pos + p ) ) {
+        if( !check_drivable( next ) ) {
             return collision_check_result::slow_down;
         }
     }
@@ -1234,7 +1353,7 @@ autodrive_result vehicle::do_autodrive( Character &driver )
     const tripoint_abs_ms veh_pos = global_square_location();
     const tripoint_abs_omt veh_omt = project_to<coords::omt>( veh_pos );
     std::vector<tripoint_abs_omt> &omt_path = driver.omt_path;
-    if( !omt_path.empty() && veh_omt == omt_path.back() ) {
+    while( !omt_path.empty() && veh_omt.xy() == omt_path.back().xy() ) {
         omt_path.pop_back();
     }
     if( omt_path.empty() ) {
@@ -1257,7 +1376,7 @@ autodrive_result vehicle::do_autodrive( Character &driver )
         stop_autodriving( false );
         return autodrive_result::abort;
     }
-    if( next_step->pos != veh_pos ) {
+    if( next_step->pos.xy() != veh_pos.xy() ) {
         debugmsg( "compute_next_step returned an invalid result" );
         stop_autodriving();
         return autodrive_result::abort;


### PR DESCRIPTION

<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Autodrive over bridges"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Allows autodrive to find paths when driving up/down ramps and over bridges. Fixes #68788 .

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

This is done by updating `compute_obstacles` so that when we check for whether a point is an obstacle or not, we also remember which points were up or down ramps. Each such ramp point leads to a different zlevel. We then iterate over those points and do a flood-fill starting at those points on the other zlevel. Each point found by the flood-fill is then re-evaluated for whether it is an obstacle also on the other zlevel.

During this process, we also remember which zlevel is the ground. For example, when driving up a ramp, most points will be zlevel=0, but the points on the ramp and bridge will have its ground at zlevel=1. The existing pathfinder collission checks are updated to use this groundlevel z when determining if we are about to hit an obstacle.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* This suggested change uses `tripoint_bub_ms` for remembering ramp points, maybe we could reduce the number of coord translations (to view coords) by using `tripoint_abs_ms` instead?

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Verified the following cases:
* Regular autodrive pathing with a car
* Driving over bridges in a car using autodrive
* Used autodrive to path in a helicopter
* Used autodrive to path a helicopter over a bridge
* Used autodrive to path a helicopter over bridge ramp OMT
* Used autodrive to paddle a canoe under a bridge
* Used autodrive to ride a bicycle in a train tunnel
* Verified that autodrive does not path into known traps

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
