### PR TITLE
[Sky Islands] Add Butcher's Harness, a harness for preserving and hauling corpses.

### DIFF
--- a/data/mods/Sky_Island/recipes.json
+++ b/data/mods/Sky_Island/recipes.json
@@ -94,6 +94,21 @@
     "flags": [ "BLIND_EASY" ]
   },
   {
+    "result": "warpcorpsebag",
+    "type": "recipe",
+    "activity_level": "NO_EXERCISE",
+    "category": "CC_OTHER",
+    "subcategory": "CSC_OTHER_WARP",
+    "skill_used": "survival",
+    "difficulty": 0,
+    "time": "1 m",
+    "autolearn": true,
+    "reversible": false,
+    "tools": [ [ [ "fakeitem_statue", -1 ] ] ],
+    "components": [ [ [ "warptoken", 5 ] ] ],
+    "flags": [ "BLIND_EASY" ]
+  },
+  {
     "result": "warpmetalbag",
     "type": "recipe",
     "activity_level": "NO_EXERCISE",

--- a/data/mods/Sky_Island/recipes.json
+++ b/data/mods/Sky_Island/recipes.json
@@ -94,7 +94,7 @@
     "flags": [ "BLIND_EASY" ]
   },
   {
-    "result": "warpcorpsebag"
+    "result": "warpcorpsebag",
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "category": "CC_OTHER",

--- a/data/mods/Sky_Island/recipes.json
+++ b/data/mods/Sky_Island/recipes.json
@@ -94,7 +94,7 @@
     "flags": [ "BLIND_EASY" ]
   },
   {
-    "result": "warpcorpsebag",
+    "result": "warpcorpsebag"
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
     "category": "CC_OTHER",

--- a/data/mods/Sky_Island/warpitems.json
+++ b/data/mods/Sky_Island/warpitems.json
@@ -253,7 +253,7 @@
     "id": "warpcorpsebag",
     "name": { "str": "warped butcher's harness", "str_pl": "warped butcher's harnesses" },
     "copy-from": "warpbag_base",
-    "description": "A looped set of shimmering blue-black straps that can be worn over the shoulders like a harness.  They're cold to the touch, and would preserve a corpse indefinitely. It outright refuses to be packed inside of other bags.",
+    "description": "A looped set of shimmering blue-black straps that can be worn over the shoulders like a harness.  They're cold to the touch, and would preserve a corpse indefinitely.  It outright refuses to be packed inside of other bags.",
     "pocket_data": [
       {
         "pocket_type": "CONTAINER",

--- a/data/mods/Sky_Island/warpitems.json
+++ b/data/mods/Sky_Island/warpitems.json
@@ -261,11 +261,11 @@
         "max_contains_weight": "10000 kg",
         "max_item_length": "10 meter",
         "weight_multiplier": 0.001,
-	"spoil_multiplier": 0.001,
+        "spoil_multiplier": 0.001,
         "moves": 2000,
         "rigid": true,
         "holster": true,
-	"flag_restriction": [ "CORPSE" ]
+        "flag_restriction": [ "CORPSE" ]
       }
     ]
   },

--- a/data/mods/Sky_Island/warpitems.json
+++ b/data/mods/Sky_Island/warpitems.json
@@ -249,6 +249,27 @@
     ]
   },
   {
+    "type": "ARMOR",
+    "id": "warpcorpsebag",
+    "name": { "str": "warped butcher's harness", "str_pl": "warped butcher's harnesses" },
+    "copy-from": "warpbag_base",
+    "description": "A looped set of shimmering blue-black straps that can be worn over the shoulders like a harness.  They're cold to the touch, and would preserve a corpse indefinitely. It outright refuses to be packed inside of other bags.",
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "max_contains_volume": "2000 L",
+        "max_contains_weight": "10000 kg",
+        "max_item_length": "10 meter",
+        "weight_multiplier": 0.001,
+	"spoil_multiplier": 0.001,
+        "moves": 2000,
+        "rigid": true,
+        "holster": true,
+	"flag_restriction": [ "CORPSE" ]
+      }
+    ]
+  },
+  {
     "id": "warpextender",
     "type": "COMESTIBLE",
     "comestible_type": "MED",


### PR DESCRIPTION
#### Summary
Mods "Add a Warped Butcher's Harness for preserving and hauling corpses."

#### Purpose of change

Getting meat back to the Sky Island is a bit of a headache; butchery on the ground requires bringing awkward tools and meat doesn't last very long, but corpses don't last very long during a run either. So I decided to make something to make corpses last longer, allowing you to haul them back for butchery at home.

#### Describe the solution

Copied the Warped Hauler's Harness, made a version that can hold a single corpse of any size or weight, reducing spoil speed to zero. Currently requires you to insert the corpse into the item directly if it's too heavy. It uses flag_restriction to only allow it to hold a corpse.

#### Describe alternatives you've considered

Putting up with meat being annoying to get.

#### Testing

Spawned in the harness, spawned in a cow and killed it. Cow corpse fits inside harness. Other items do not fit inside harness.
Checked crafting menu, harness is craftable.

#### Additional context

Right now, the zombification timer does _not_ stop while in the harness. Corpses won't revive in your inventory, but will revive within seconds when dropped. I have no idea how to fix this, or if it's fixable at all; right now the easiest workaround is to skin the corpse on the spot, so it can't revive. I'd like it if there were some way to prevent or delay zombification, but I have no idea how to go about doing that; if anyone has any suggestions, I'm all ears.