### PR TITLE
properly migrate mean_mug and nice_mug

### DIFF
--- a/data/json/obsoletion/migration_items.json
+++ b/data/json/obsoletion/migration_items.json
@@ -42,12 +42,16 @@
   {
     "id": "mean_mug",
     "type": "MIGRATION",
-    "replace": "ceramic_mug"
+    "replace": "ceramic_mug",
+    "variant": "mean_mug",
+    "reset_item_vars": true
   },
   {
     "id": "nice_mug",
     "type": "MIGRATION",
-    "replace": "ceramic_mug"
+    "replace": "ceramic_mug",
+    "variant": "mean_mug2",
+    "reset_item_vars": true
   },
   {
     "id": "ar15",


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Someone found that migrating the item to another item do not reset it's variant, which cause mean mug with variant "fuck_you" search variant "fuck_you" in ceramic_mug, which doesn't have one
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/f9943266-6016-408f-a071-563e8cb63810)
#### Describe the solution
Migrate the variant also
Also reset vars to guarantee no more issues occur
