### PR TITLE
Only extract singular enchantment names

### DIFF
--- a/lang/string_extractor/parsers/enchant.py
+++ b/lang/string_extractor/parsers/enchant.py
@@ -6,7 +6,7 @@ def parse_enchant(json, origin):
     if "name" in json:
         name = get_singular_name(json["name"])
         write_text(json["name"], origin,
-                   comment="Name of a enchantment", plural=True)
+                   comment="Name of a enchantment")
 
     if "description" in json:
         write_text(json["description"], origin,


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Unless I missed something the enchantment names are only loaded and used as singular names.

#### Describe the solution
Do not extract the plural.

#### Describe alternatives you've considered

#### Testing

#### Additional context