### PR TITLE
item: aggregate contents

### DIFF
--- a/data/mods/TEST_DATA/items.json
+++ b/data/mods/TEST_DATA/items.json
@@ -84,7 +84,17 @@
     "to_hit": -2,
     "effects": [ "NEVER_MISFIRES", "NON_FOULING", "RECOVER_80" ],
     "qualities": [ [ "HAMMER", 1 ] ],
-    "melee_damage": { "bash": 7 }
+    "melee_damage": { "bash": 7 },
+    "variant_type": "generic",
+    "variants": [
+      { "id": "test_rock_blue", "name": { "str": "blue test_rock" }, "description": "It's a blue test rock", "append": true },
+      {
+        "id": "test_rock_green",
+        "name": { "str": "green test_rock" },
+        "description": "It's a green test rock",
+        "append": true
+      }
+    ]
   },
   {
     "type": "TOOL_ARMOR",

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7949,8 +7949,9 @@ std::string Character::weapname_simple() const
     if( weapon.is_gun() ) {
         gun_mode current_mode = weapon.gun_current_mode();
         const bool no_mode = !current_mode.target;
-        std::string gun_name = no_mode ? weapon.display_name() : current_mode->tname( 1, true, 0, true,
-                               false );
+        tname::segment_bitset segs( tname::default_tname );
+        segs.set( tname::segments::TAGS, false );
+        std::string gun_name = no_mode ? weapon.display_name() : current_mode->tname( 1, segs );
         return gun_name;
 
     } else if( !is_armed() ) {

--- a/src/character_attire.cpp
+++ b/src/character_attire.cpp
@@ -2565,11 +2565,11 @@ const item &outfit::i_at( int position ) const
     }
 }
 
-std::string outfit::get_armor_display( bodypart_id bp, unsigned int truncate ) const
+std::string outfit::get_armor_display( bodypart_id bp ) const
 {
     for( auto it = worn.rbegin(); it != worn.rend(); ++it ) {
         if( it->covers( bp ) ) {
-            return it->tname( 1, true, truncate );
+            return it->tname( 1 );
         }
     }
     return "-";

--- a/src/character_attire.h
+++ b/src/character_attire.h
@@ -214,7 +214,7 @@ class outfit
         void set_fitted();
         std::vector<item> available_pockets() const;
         void write_text_memorial( std::ostream &file, const std::string &indent, const char *eol ) const;
-        std::string get_armor_display( bodypart_id bp, unsigned int truncate = 0 ) const;
+        std::string get_armor_display( bodypart_id bp ) const;
         void activate_combat_items( npc &guy );
         void deactivate_combat_items( npc &guy );
 

--- a/src/enum_bitset.h
+++ b/src/enum_bitset.h
@@ -21,6 +21,7 @@ class enum_bitset
         enum_bitset() = default;
         enum_bitset( const enum_bitset & ) = default;
         enum_bitset &operator=( const enum_bitset & ) = default;
+        explicit constexpr enum_bitset( unsigned long long val ) noexcept : bits( val ) {}
 
         bool operator==( const enum_bitset &rhs ) const noexcept {
             return bits == rhs.bits;
@@ -61,6 +62,18 @@ class enum_bitset
 
         bool test( E e ) const {
             return bits.test( get_pos( e ) );
+        }
+
+        bool any() const noexcept {
+            return bits.any();
+        }
+
+        bool all() const noexcept {
+            return bits.all();
+        }
+
+        bool none() const noexcept {
+            return bits.none();
         }
 
         static constexpr size_t size() noexcept {

--- a/src/enum_bitset.h
+++ b/src/enum_bitset.h
@@ -50,6 +50,11 @@ class enum_bitset
             return *this;
         }
 
+        enum_bitset &set() noexcept {
+            bits.set();
+            return *this;
+        }
+
         enum_bitset &reset( E e ) {
             bits.reset( get_pos( e ) );
             return *this;

--- a/src/enum_bitset.h
+++ b/src/enum_bitset.h
@@ -100,4 +100,20 @@ class enum_bitset
         std::bitset<enum_bitset<E>::size()> bits;
 };
 
+template <typename E>
+enum_bitset<E> operator&( const enum_bitset<E> &lhs, const enum_bitset<E> &rhs ) noexcept
+{
+    enum_bitset<E> ret( lhs );
+    ret &= rhs;
+    return ret;
+}
+
+template <typename E>
+enum_bitset<E> operator|( const enum_bitset<E> &lhs, const enum_bitset<E> &rhs ) noexcept
+{
+    enum_bitset<E> ret( lhs );
+    ret |= rhs;
+    return ret;
+}
+
 #endif // CATA_SRC_ENUM_BITSET_H

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -20,6 +20,7 @@
 #include "item_pocket.h"
 #include "item_search.h"
 #include "item_stack.h"
+#include "item_tname.h"
 #include "iteminfo_query.h"
 #include "line.h"
 #include "make_static.h"
@@ -88,8 +89,8 @@ item_name_t &get_cached_name( item const *it )
     auto iter = item_name_cache.find( it );
     if( iter == item_name_cache.end() ) {
         return item_name_cache
-               .emplace( it, item_name_t{ remove_color_tags( it->tname( 1, false, 0, true, false ) ),
-                                          remove_color_tags( it->tname( 1, true, 0, true, false ) ) } )
+               .emplace( it, item_name_t{ remove_color_tags( it->tname( 1, false ) ),
+                                          remove_color_tags( it->tname( 1, true ) ) } )
                .first->second;
     }
 
@@ -1969,8 +1970,10 @@ bool inventory_selector::drag_drop_item( item *sourceItem, item *destItem )
         }
     }
     if( !any_containable ) {
+        tname::segment_bitset segs( tname::unprefixed_tname );
+        segs.set( tname::segments::CONTENTS, false );
         popup( string_format( _( "%s contains no pockets that can contain item." ),
-                              destItem->tname( 1, false, 0, false, false, false ) ) );
+                              destItem->tname( 1, segs ) ) );
         return false;
     }
     action_menu.query();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -12207,18 +12207,8 @@ const item_category &item::get_category_shallow() const
 const item_category &item::get_category_of_contents() const
 {
     if( type->category_force == item_category_container ) {
-        const std::list<const item *> items = contents.all_items_top( pocket_type::CONTAINER );
-        if( !items.empty() ) {
-            const item_category &category_of_first_item = items.front()->get_category_of_contents();
-            if( items.size() == 1 ) {
-                return category_of_first_item;
-            }
-            const auto has_same_category = [&category_of_first_item]( const item * i ) {
-                return i->get_category_of_contents() == category_of_first_item;
-            };
-            if( std::all_of( ++items.begin(), items.end(), has_same_category ) ) {
-                return category_of_first_item;
-            }
+        if( item::aggregate_t const aggi = aggregated_contents(); aggi ) {
+            return aggi.header->get_category_of_contents();
         }
     }
     return this->get_category_shallow();

--- a/src/item.h
+++ b/src/item.h
@@ -188,6 +188,14 @@ iteminfo weight_to_info( const std::string &type, const std::string &left,
 
 inline bool is_crafting_component( const item &component );
 
+struct stacking_info {
+    tname::segment_bitset bits;
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    operator bool() const {
+        return bits.all();
+    }
+};
+
 class item : public visitable
 {
     public:
@@ -613,8 +621,9 @@ class item : public visitable
          * stacks like "3 items-count-by-charge (5)".
          */
         bool display_stacked_with( const item &rhs, bool check_components = false ) const;
-        bool stacks_with( const item &rhs, bool check_components = false,
-                          bool combine_liquid = false, int depth = 0, int maxdepth = 2 ) const;
+        stacking_info stacks_with( const item &rhs, bool check_components = false,
+                                   bool combine_liquid = false, bool check_cat = false,
+                                   int depth = 0, int maxdepth = 2, bool precise = false ) const;
 
         /**
          * Whether the two items have same contents.
@@ -1325,7 +1334,7 @@ class item : public visitable
         void rand_degradation();
 
         // @see itype::damage_level()
-        int damage_level() const;
+        int damage_level( bool precise = false ) const;
 
         // modifies melee weapon damage to account for item's damage
         float damage_adjusted_melee_weapon_damage( float value ) const;
@@ -1611,6 +1620,7 @@ class item : public visitable
         bool is_transformable() const;
         bool is_relic() const;
         bool is_same_relic( item const &rhs ) const;
+        bool is_same_temperature( item const &rhs ) const;
         bool is_bucket_nonempty() const;
 
         bool is_brewable() const;

--- a/src/item.h
+++ b/src/item.h
@@ -549,7 +549,7 @@ class item : public visitable
         const item_category &get_category_shallow() const;
         // Returns the dominant category of items inside this one.
         // "can of meat" would be food, instead of container.
-        const item_category &get_category_of_contents() const;
+        const item_category &get_category_of_contents( int depth = 0, int maxdepth = 2 ) const;
 
         class reload_option
         {
@@ -2935,7 +2935,7 @@ class item : public visitable
                 return header != nullptr;
             }
         };
-        aggregate_t aggregated_contents() const;
+        aggregate_t aggregated_contents( int depth = 0, int maxdepth = 2 ) const;
 
         /**
          * returns a list of pointers to all items inside recursively
@@ -3187,6 +3187,12 @@ class item : public visitable
         light_emission light = nolight;
         mutable std::optional<float> cached_relative_encumbrance;
         mutable cata::value_ptr<link_data> link_;
+
+        struct cat_cache {
+            item_category_id id;
+            time_point timestamp = calendar::turn_max;
+        };
+        mutable cat_cache cached_category;
 
         // additional encumbrance this specific item has
         units::volume additional_encumbrance = 0_ml;

--- a/src/item.h
+++ b/src/item.h
@@ -2921,6 +2921,22 @@ class item : public visitable
 
         item const *this_or_single_content() const;
         bool contents_only_one_type() const;
+        struct aggregate_t {
+            stacking_info info;
+            item const *header{};
+            unsigned int count{};
+
+            aggregate_t() = default;
+            explicit aggregate_t( item const *i )
+                : header( i ), count( 1 ) {
+                info.bits.set();
+            };
+
+            explicit operator bool() const noexcept {
+                return header != nullptr;
+            }
+        };
+        aggregate_t aggregated_contents() const;
 
         /**
          * returns a list of pointers to all items inside recursively

--- a/src/item.h
+++ b/src/item.h
@@ -547,9 +547,8 @@ class item : public visitable
 
         // Returns the category of this item, regardless of contents.
         const item_category &get_category_shallow() const;
-        // Returns the category of item inside this item.
+        // Returns the dominant category of items inside this one.
         // "can of meat" would be food, instead of container.
-        // If there are multiple items/stacks or none then it defaults to category of this item.
         const item_category &get_category_of_contents() const;
 
         class reload_option

--- a/src/item.h
+++ b/src/item.h
@@ -620,6 +620,12 @@ class item : public visitable
          * stacks like "3 items-count-by-charge (5)".
          */
         bool display_stacked_with( const item &rhs, bool check_components = false ) const;
+        /**
+         * Check wether each element of tname::segments stacks, ie. wether the respective
+         * pieces of information are considered equal for display purposes
+         *
+         * stacking_info is implicitly convertible to bool and will be true only if ALL segments stack
+         */
         stacking_info stacks_with( const item &rhs, bool check_components = false,
                                    bool combine_liquid = false, bool check_cat = false,
                                    int depth = 0, int maxdepth = 2, bool precise = false ) const;

--- a/src/item.h
+++ b/src/item.h
@@ -26,6 +26,7 @@
 #include "item_components.h"
 #include "item_contents.h"
 #include "item_location.h"
+#include "item_tname.h"
 #include "material.h"
 #include "requirements.h"
 #include "safe_reference.h"
@@ -404,15 +405,11 @@ class item : public visitable
          * Return the (translated) item name.
          * @param quantity used for translation to the proper plural form of the name, e.g.
          * returns "rock" for quantity 1 and "rocks" for quantity > 0.
-         * @param with_prefix determines whether to include more item properties, such as
-         * the extent of damage and burning (was created to sort by name without prefix
-         * in additional inventory)
-         * @param with_contents determines whether to add a suffix with the full name of the contents
-         * of this item (if with_contents = false and item is not empty, "n items" will be added)
+         * @param segments determines which tname elements are included
          */
-        std::string tname( unsigned int quantity = 1, bool with_prefix = true,
-                           unsigned int truncate = 0, bool with_contents_full = true,
-                           bool with_collapsed = true, bool with_contents_abbrev = true ) const;
+        std::string tname( unsigned int quantity = 1,
+                           tname::segment_bitset const &segments = tname::default_tname ) const;
+        std::string tname( unsigned int quantity, bool with_prefix ) const;
         std::string display_money( unsigned int quantity, unsigned int total,
                                    const std::optional<unsigned int> &selected = std::nullopt ) const;
         /**
@@ -1847,7 +1844,8 @@ class item : public visitable
          * Or "The jacket is too small", when it applies to all jackets, not just the one the
          * character tried to wear).
          */
-        std::string type_name( unsigned int quantity = 1 ) const;
+        std::string type_name( unsigned int quantity = 1, bool use_variant = true,
+                               bool use_cond_name = true, bool use_corpse = true ) const;
 
         /**
          * Number of (charges of) this item that fit into the given volume.
@@ -2759,7 +2757,8 @@ class item : public visitable
         /**
         * Returns label from "item_label" itemvar and quantity
         */
-        std::string label( unsigned int quantity = 0 ) const;
+        std::string label( unsigned int quantity = 0, bool use_variant = true,
+                           bool use_cond_name = true, bool use_corpse = true ) const;
 
         bool has_infinite_charges() const;
 

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -443,7 +443,7 @@ bool item_pocket::stacks_with( const item_pocket &rhs, int depth, int maxdepth )
             rhs.contents.begin(), rhs.contents.end(),
     [depth, maxdepth]( const item & a, const item & b ) {
         return depth < maxdepth && a.charges == b.charges &&
-               a.stacks_with( b, false, false, depth + 1, maxdepth );
+               a.stacks_with( b, false, false, false, depth + 1, maxdepth );
     } );
 }
 

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -2624,7 +2624,9 @@ bool item_pocket::favorite_settings::accepts_item( const item &it ) const
         return false;
     }
     const itype_id &id = it.typeId();
-    const item_category_id &cat = it.get_category_of_contents().id;
+    const item_category_id &cat = category_blacklist.empty() && category_whitelist.empty()
+                                  ? item_category_id{} :
+                                  it.get_category_of_contents().id;
 
     // if the item is explicitly listed in either of the lists, then it's clear what to do with it
     if( item_blacklist.count( id ) ) {

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -1,0 +1,519 @@
+#include "item_tname.h"
+
+#include <set>
+#include <string>
+#include <vector>
+
+#include "avatar.h"
+#include "cata_utility.h"
+#include "color.h"
+#include "coordinate_conversions.h"
+#include "coordinates.h"
+#include "debug.h"
+#include "enums.h"
+#include "fault.h"
+#include "flag.h"
+#include "flat_set.h"
+#include "item.h"
+#include "item_category.h"
+#include "item_contents.h"
+#include "item_pocket.h"
+#include "itype.h"
+#include "map.h"
+#include "options.h"
+#include "point.h"
+#include "recipe.h"
+#include "relic.h"
+#include "string_formatter.h"
+#include "translations.h"
+#include "type_id.h"
+#include "units.h"
+
+
+static const itype_id itype_barrel_small( "barrel_small" );
+static const itype_id itype_disassembly( "disassembly" );
+
+static const skill_id skill_survival( "survival" );
+
+std::string tname::faults( item const &it, unsigned int /* quantity */,
+                           segment_bitset const &/* segments */ )
+{
+    std::string damtext;
+    // add first prefix if item has a fault that defines a prefix (prioritize?)
+    for( const fault_id &f : it.faults ) {
+        const std::string prefix = f->item_prefix();
+        if( !prefix.empty() ) {
+            damtext = prefix + " ";
+            break;
+        }
+    }
+
+    return damtext;
+}
+
+std::string tname::dirt_symbol( item const &it, unsigned int /* quantity */,
+                                segment_bitset const &/* segments */ )
+{
+    return it.dirt_symbol();
+}
+
+std::string tname::overheat_symbol( item const &it, unsigned int /* quantity */,
+                                    segment_bitset const &/* segments */ )
+{
+    return it.overheat_symbol();
+}
+
+std::string tname::pre_asterisk( item const &it, unsigned int /* quantity */,
+                                 segment_bitset const &/* segments */ )
+{
+    if( it.is_favorite && get_option<std::string>( "ASTERISK_POSITION" ) == "prefix" ) {
+        return _( "* " ); // Display asterisk for favorite items, before item's name
+    }
+    return {};
+}
+
+std::string tname::durability( item const &it, unsigned int /* quantity */,
+                               segment_bitset const &/* segments */ )
+{
+    const std::string item_health_option = get_option<std::string>( "ITEM_HEALTH" );
+    const bool show_bars = item_health_option == "both" || item_health_option == "bars";
+    if( !it.is_null() &&
+        ( it.damage() != 0 || ( it.degradation() > 0 && it.degradation() >= it.max_damage() / 5 ) ||
+          ( show_bars && it.is_armor() ) ) ) {
+        return it.durability_indicator();
+    }
+    return {};
+}
+
+std::string tname::engine_displacement( item const &it, unsigned int /* quantity */,
+                                        segment_bitset const &/* segments */ )
+{
+    if( it.is_engine() && it.engine_displacement() > 0 ) {
+        return string_format( pgettext( "vehicle adjective", "%gL " ),
+                              it.engine_displacement() / 100.0f );
+    }
+    return {};
+}
+
+std::string tname::wheel_diameter( item const &it, unsigned int /* quantity */,
+                                   segment_bitset const &/* segments */ )
+{
+    if( it.is_wheel() && it.type->wheel->diameter > 0 ) {
+        return string_format( pgettext( "vehicle adjective", "%d\" " ), it.type->wheel->diameter );
+    }
+    return {};
+}
+
+std::string tname::burn( item const &it, unsigned int /* quantity */,
+                         segment_bitset const &/* segments */ )
+{
+    if( !it.made_of_from_type( phase_id::LIQUID ) ) {
+        if( it.volume() >= 1_liter && it.burnt * 125_ml >= it.volume() ) {
+            return pgettext( "burnt adjective", "badly burnt " );
+        }
+        if( it.burnt > 0 ) {
+            return pgettext( "burnt adjective", "burnt " );
+        }
+    }
+    return {};
+}
+
+std::string tname::label( item const &it, unsigned int quantity, segment_bitset const &segments )
+{
+    if( !it.is_craft() ) {
+        return it.label( quantity, segments[tname::segments::VARIANT],
+                         ( segments & tname_conditional ) == tname_conditional,
+                         segments[tname::segments::CORPSE] );
+    }
+    return {};
+}
+
+std::string tname::mods( item const &it, unsigned int /* quantity */,
+                         segment_bitset const &/* segments */ )
+{
+    int amt = 0;
+    if( it.is_armor() && it.has_clothing_mod() ) {
+        amt++;
+    }
+    if( ( ( it.is_gun() || it.is_tool() || it.is_magazine() ) && !it.is_power_armor() ) ||
+        it.get_contents().has_additional_pockets() ) {
+
+        for( const item *mod : it.is_gun() ? it.gunmods() : it.toolmods() ) {
+            if( !it.type->gun || !it.type->gun->built_in_mods.count( mod->typeId() ) ||
+                !it.type->gun->default_mods.count( mod->typeId() ) ) {
+                amt++;
+            }
+        }
+        amt += it.get_contents().get_added_pockets().size();
+    }
+    if( amt > 0 ) {
+        return string_format( "+%d", amt );
+    }
+    return {};
+}
+
+std::string tname::craft( item const &it, unsigned int /* quantity */,
+                          segment_bitset const &/* segments */ )
+{
+    if( it.is_craft() ) {
+        std::string maintext;
+        if( it.typeId() == itype_disassembly ) {
+            maintext = string_format( _( "in progress disassembly of %s" ),
+                                      it.get_making().result_name() );
+        } else {
+            maintext = string_format( _( "in progress %s" ), it.get_making().result_name() );
+        }
+        if( it.charges > 1 ) {
+            maintext += string_format( " (%d)", it.charges );
+        }
+        const int percent_progress = it.item_counter / 100000;
+        return string_format( "%s (%d%%)", maintext, percent_progress );
+    }
+    return {};
+}
+
+std::string tname::wbl_mark( item const &it, unsigned int /* quantity */,
+                             segment_bitset const &/* segments */ )
+{
+    std::vector<const item_pocket *> pkts = it.get_all_contained_pockets();
+    bool wl = false;
+    bool bl = false;
+    bool player_wbl = false;
+    for( item_pocket const *pkt : pkts ) {
+        bool const wl_ = !pkt->settings.get_item_whitelist().empty() ||
+                         !pkt->settings.get_category_whitelist().empty();
+        bool const bl_ = !pkt->settings.get_item_blacklist().empty() ||
+                         !pkt->settings.get_category_blacklist().empty();
+        player_wbl |= ( wl_ || bl_ ) && pkt->settings.was_edited();
+        wl |= wl_;
+        bl |= bl_;
+    }
+    return
+        wl || bl ? colorize( "⁺", player_wbl ? c_light_gray : c_dark_gray ) : std::string();
+}
+
+std::string tname::contents( item const &it, unsigned int /* quantity */,
+                             segment_bitset const &segments )
+{
+    item_contents const &contents = it.get_contents();
+    if( segments[tname::segments::CONTENTS_FULL] && !it.get_contents().empty() &&
+        it.contents_only_one_type() ) {
+        const item &contents_item = contents.first_item();
+        const unsigned contents_count =
+            ( ( contents_item.made_of( phase_id::LIQUID ) ||
+                contents_item.is_food() || contents_item.count_by_charges() ) &&
+              contents_item.charges > 1 )
+            ? contents_item.charges
+            : contents.num_item_stacks();
+
+        if( !contents_item.is_null() ) {
+            std::string contents_suffix_text;
+            // with_contents=false for nested items to prevent excessively long names
+            segment_bitset abrev( default_tname );
+            abrev.set( tname::segments::CONTENTS_FULL, false );
+            abrev.set( tname::segments::CONTENTS_ABREV, contents_count == 1 );
+            const std::string contents_tname = contents_item.tname( contents_count, abrev );
+            std::string const ctnc = colorize( contents_tname, contents_item.color_in_inventory() );
+            if( contents_count == 1 || !it.ammo_types().empty() ) {
+                // Don't append an item count for single items, or items that are ammo-exclusive
+                // (eg: quivers), as they format their own counts.
+                contents_suffix_text = string_format( pgettext( "item name",
+                                                      //~ [container item name] " > [inner item name]
+                                                      " > %1$s" ), ctnc );
+            } else if( contents_count != 0 ) {
+                // Otherwise, add a contents count!
+                contents_suffix_text = string_format( pgettext( "item name",
+                                                      //~ [container item name] " > [inner item name] (qty)
+                                                      " > %1$s (%2$zd)" ), ctnc, contents_count );
+            }
+            if( it.is_collapsed() ) {
+                contents_suffix_text += string_format( " %s", _( "hidden" ) );
+            }
+            return contents_suffix_text;
+        }
+    } else if( segments[tname::segments::CONTENTS_ABREV] && !contents.empty_container() &&
+               contents.num_item_stacks() != 0 ) {
+        std::string const suffix =
+            npgettext( "item name",
+                       //~ [container item name] " > [count] item"
+                       " > %1$zd%2$s item", " > %1$zd%2$s items", contents.num_item_stacks() );
+        std::string const hidden =
+            it.is_collapsed() ? string_format( " %s", _( "hidden" ) ) : std::string();
+        return string_format( suffix, contents.num_item_stacks(), hidden );
+    }
+    return {};
+}
+
+std::string tname::food_traits( item const &it, unsigned int /* quantity */,
+                                segment_bitset const &/* segments */ )
+{
+    if( it.is_food() ) {
+        if( it.has_flag( flag_HIDDEN_POISON ) &&
+            get_avatar().get_greater_skill_or_knowledge_level( skill_survival ) >= 3 ) {
+            return _( " (poisonous)" );
+        } else if( it.has_flag( flag_HIDDEN_HALLU ) &&
+                   get_avatar().get_greater_skill_or_knowledge_level( skill_survival ) >= 5 ) {
+            return _( " (hallucinogenic)" );
+        }
+    }
+    return {};
+}
+
+std::string tname::location_hint( item const &it, unsigned int /* quantity */,
+                                  segment_bitset const &/* segments */ )
+{
+    if( it.has_var( "spawn_location_omt" ) ) {
+        tripoint_abs_omt loc( it.get_var( "spawn_location_omt", tripoint_zero ) );
+        tripoint_abs_omt player_loc( ms_to_omt_copy( get_map().getabs( get_avatar().pos() ) ) );
+        int dist = rl_dist( player_loc, loc );
+        if( dist < 1 ) {
+            return _( " (from here)" );
+        } else if( dist < 6 ) {
+            return _( " (from nearby)" );
+        } else if( dist < 30 ) {
+            return _( " (from this area)" );
+        }
+        return _( " (from far away)" );
+    }
+    return {};
+}
+
+std::string tname::ethereal( item const &it, unsigned int /* quantity */,
+                             segment_bitset const &/* segments */ )
+{
+    if( it.ethereal ) {
+        return string_format( _( " (%s turns)" ), it.get_var( "ethereal" ) );
+    }
+    return {};
+}
+
+std::string tname::food_status( item const &it, unsigned int /* quantity */,
+                                segment_bitset const &/* segments */ )
+{
+    std::string tagtext;
+    if( it.goes_bad() || it.is_food() ) {
+        if( it.has_own_flag( flag_DIRTY ) ) {
+            tagtext += _( " (dirty)" );
+        } else if( it.rotten() ) {
+            tagtext += _( " (rotten)" );
+        } else if( it.has_flag( flag_MUSHY ) ) {
+            tagtext += _( " (mushy)" );
+        } else if( it.is_going_bad() ) {
+            tagtext += _( " (old)" );
+        } else if( it.is_fresh() ) {
+            tagtext += _( " (fresh)" );
+        }
+    }
+    return tagtext;
+}
+
+std::string tname::food_irradiated( item const &it, unsigned int /* quantity */,
+                                    segment_bitset const &/* segments */ )
+{
+    if( it.goes_bad() ) {
+        if( it.has_own_flag( flag_IRRADIATED ) ) {
+            return _( " (irradiated)" );
+        }
+    }
+    return {};
+}
+
+std::string tname::temperature( item const &it, unsigned int /* quantity */,
+                                segment_bitset const &/* segments */ )
+{
+    std::string ret;
+    if( it.has_temperature() ) {
+        if( it.has_flag( flag_HOT ) ) {
+            ret = _( " (hot)" );
+        }
+        if( it.has_flag( flag_COLD ) ) {
+            ret = _( " (cold)" );
+        }
+        if( it.has_flag( flag_FROZEN ) ) {
+            ret += _( " (frozen)" );
+        } else if( it.has_flag( flag_MELTS ) ) {
+            ret += _( " (melted)" ); // he melted
+        }
+    }
+    return ret;
+}
+
+std::string tname::clothing_size( item const &it, unsigned int /* quantity */,
+                                  segment_bitset const &/* segments */ )
+{
+    const item::sizing sizing_level = it.get_sizing( get_avatar() );
+
+    if( sizing_level == item::sizing::human_sized_small_char ) {
+        return _( " (too big)" );
+    } else if( sizing_level == item::sizing::big_sized_small_char ) {
+        return _( " (huge!)" );
+    } else if( sizing_level == item::sizing::human_sized_big_char ||
+               sizing_level == item::sizing::small_sized_human_char ) {
+        return _( " (too small)" );
+    } else if( sizing_level == item::sizing::small_sized_big_char ) {
+        return _( " (tiny!)" );
+    } else if( !it.has_flag( flag_FIT ) && it.has_flag( flag_VARSIZE ) ) {
+        return _( " (poor fit)" );
+    }
+    return {};
+}
+
+std::string tname::filthy( item const &it, unsigned int /* quantity */,
+                           segment_bitset const &/* segments */ )
+{
+    if( it.is_filthy() ) {
+        return _( " (filthy)" );
+    }
+    return {};
+}
+
+std::string tname::tags( item const &it, unsigned int /* quantity */,
+                         segment_bitset const &/* segments */ )
+{
+    std::string ret;
+    if( it.is_gun() && ( it.has_flag( flag_COLLAPSED_STOCK ) || it.has_flag( flag_FOLDED_STOCK ) ) ) {
+        ret += _( " (folded)" );
+    }
+    if( it.has_flag( flag_RADIO_MOD ) ) {
+        ret += _( " (radio:" );
+        if( it.has_flag( flag_RADIOSIGNAL_1 ) ) {
+            ret += pgettext( "The radio mod is associated with the [R]ed button.", "R)" );
+        } else if( it.has_flag( flag_RADIOSIGNAL_2 ) ) {
+            ret += pgettext( "The radio mod is associated with the [B]lue button.", "B)" );
+        } else if( it.has_flag( flag_RADIOSIGNAL_3 ) ) {
+            ret += pgettext( "The radio mod is associated with the [G]reen button.", "G)" );
+        } else {
+            debugmsg( "Why is the radio neither red, blue, nor green?" );
+            ret += "?)";
+        }
+    }
+    if( it.active && ( it.has_flag( flag_WATER_EXTINGUISH ) || it.has_flag( flag_LITCIG ) ) ) {
+        ret += _( " (lit)" );
+    }
+    return ret;
+}
+
+std::string tname::vars( item const &it, unsigned int /* quantity */,
+                         segment_bitset const &/* segments */ )
+{
+    std::string ret;
+    if( it.has_var( "NANOFAB_ITEM_ID" ) ) {
+        if( it.has_flag( flag_NANOFAB_TEMPLATE_SINGLE_USE ) ) {
+            //~ Single-use descriptor for nanofab templates. %s = name of resulting item. The leading space is intentional.
+            ret += string_format( _( " (SINGLE USE %s)" ),
+                                  item::nname( itype_id( it.get_var( "NANOFAB_ITEM_ID" ) ) ) );
+        }
+        ret += string_format( " (%s)", item::nname( itype_id( it.get_var( "NANOFAB_ITEM_ID" ) ) ) );
+    }
+    if( it.already_used_by_player( get_avatar() ) ) {
+        ret += _( " (used)" );
+    }
+    if( it.has_flag( flag_IS_UPS ) && it.get_var( "cable" ) == "plugged_in" ) {
+        ret += _( " (plugged in)" );
+    }
+    return ret;
+}
+
+std::string tname::broken( item const &it, unsigned int /* quantity */,
+                           segment_bitset const &/* segments */ )
+{
+    if( it.is_broken() ) {
+        return _( " (broken)" );
+    }
+    return {};
+}
+
+std::string tname::cbm_status( item const &it, unsigned int /* quantity */,
+                               segment_bitset const &/* segments */ )
+{
+    if( it.is_bionic() && !it.has_flag( flag_NO_PACKED ) ) {
+        if( !it.has_flag( flag_NO_STERILE ) ) {
+            return _( " (sterile)" );
+        }
+        return _( " (packed)" );
+    }
+    return {};
+}
+
+std::string tname::ups( item const &it, unsigned int /* quantity */,
+                        segment_bitset const &/* segments */ )
+{
+    if( it.is_tool() && it.has_flag( flag_USE_UPS ) ) {
+        return _( " (UPS)" );
+    }
+    return {};
+}
+
+std::string tname::wetness( item const &it, unsigned int /* quantity */,
+                            segment_bitset const &/* segments */ )
+{
+    if( ( it.wetness > 0 ) || it.has_flag( flag_WET ) ) {
+        return _( " (wet)" );
+    }
+    return {};
+}
+
+std::string tname::active( item const &it, unsigned int /* quantity */,
+                           segment_bitset const &/* segments */ )
+{
+    if( it.active && !it.has_temperature() && !string_ends_with( it.typeId().str(), "_on" ) ) {
+        // Usually the items whose ids end in "_on" have the "active" or "on" string already contained
+        // in their name, also food is active while it rots.
+        return _( " (active)" );
+    }
+    return {};
+}
+
+std::string tname::sealed( item const &it, unsigned int /* quantity */,
+                           segment_bitset const &/* segments */ )
+{
+    if( it.all_pockets_sealed() ) {
+        return _( " (sealed)" );
+    } else if( it.any_pockets_sealed() ) {
+        return _( " (part sealed)" );
+    }
+    return {};
+}
+
+std::string tname::post_asterisk( item const &it, unsigned int /* quantity */,
+                                  segment_bitset const &/* segments */ )
+{
+    if( it.is_favorite && get_option<std::string>( "ASTERISK_POSITION" ) == "suffix" ) {
+        return _( " *" );
+    }
+    return {};
+}
+
+std::string tname::weapon_mods( item const &it, unsigned int /* quantity */,
+                                segment_bitset const &/* segments */ )
+{
+    std::string modtext;
+    if( it.gunmod_find( itype_barrel_small ) != nullptr ) {
+        modtext += _( "sawn-off " );
+    }
+    if( it.is_gun() && it.has_flag( flag_REMOVED_STOCK ) ) {
+        modtext += _( "pistol " );
+    }
+    if( it.has_flag( flag_DIAMOND ) ) {
+        modtext += std::string( pgettext( "Adjective, as in diamond katana", "diamond" ) ) + " ";
+    }
+    return modtext;
+}
+
+std::string tname::relic_charges( item const &it, unsigned int /* quantity */,
+                                  segment_bitset const &/* segments */ )
+{
+    if( it.is_relic() && it.relic_data->max_charges() > 0 && it.relic_data->charges_per_use() > 0 ) {
+        return string_format( " (%d/%d)", it.relic_data->charges(), it.relic_data->max_charges() );
+    }
+    return {};
+}
+
+std::string tname::category( item const &it, unsigned int /* quantity */,
+                             segment_bitset const &segments )
+{
+    nc_color const &color = segments[tname::segments::FOOD_PERISHABLE] && it.is_food()
+                            ? it.color_in_inventory( &get_avatar() )
+                            : c_magenta;
+    return colorize( it.get_category_of_contents().name(), color );
+}

--- a/src/item_tname.h
+++ b/src/item_tname.h
@@ -1,0 +1,188 @@
+#pragma once
+#ifndef CATA_SRC_ITEM_TNAME_H
+#define CATA_SRC_ITEM_TNAME_H
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+
+#include "enum_bitset.h"
+#include "enum_traits.h"
+
+class item;
+
+namespace tname
+{
+enum class segments : std::size_t {
+    FAULTS = 0,
+    DIRT,
+    OVERHEAT,
+    FAVORITE_PRE,
+    DURABILITY,
+    ENGINE_DISPLACEMENT,
+    WHEEL_DIAMETER,
+    BURN,
+    WEAPON_MODS,
+    TYPE,
+    CATEGORY,
+    MODS,
+    CRAFT,
+    WHITEBLACKLIST,
+    CHARGES,
+    FOOD_TRAITS,
+    FOOD_STATUS,
+    FOOD_IRRADIATED,
+    TEMPERATURE,
+    LOCATION_HINT,
+    CLOTHING_SIZE,
+    ETHEREAL,
+    FILTHY,
+    BROKEN,
+    CBM_STATUS,
+    UPS,
+    TAGS,
+    VARS,
+    WETNESS,
+    ACTIVE,
+    SEALED,
+    FAVORITE_POST,
+    RELIC,
+    LINK,
+    TECHNIQUES,
+    CONTENTS,
+
+    last_segment,
+
+    // separate flags for TYPE
+    VARIANT,
+    COMPONENTS,
+    CORPSE,
+
+    // separate flags for CONTENTS
+    CONTENTS_FULL,
+    CONTENTS_ABREV,
+
+    // separate flags for CATEGORY
+    FOOD_PERISHABLE,
+
+    last,
+};
+
+using segment_bitset = enum_bitset<tname::segments>;
+
+#ifndef CATA_IN_TOOL
+using decl_fsegment = std::string( item const &it, unsigned int quantity,
+                                   segment_bitset const &segments );
+decl_fsegment faults;
+decl_fsegment dirt_symbol;
+decl_fsegment overheat_symbol;
+decl_fsegment pre_asterisk;
+decl_fsegment durability;
+decl_fsegment engine_displacement;
+decl_fsegment wheel_diameter;
+decl_fsegment burn;
+decl_fsegment label;
+decl_fsegment category;
+decl_fsegment mods;
+decl_fsegment craft;
+decl_fsegment wbl_mark;
+decl_fsegment contents;
+decl_fsegment contents_abrev;
+decl_fsegment food_traits;
+decl_fsegment location_hint;
+decl_fsegment ethereal;
+decl_fsegment food_status;
+decl_fsegment food_irradiated;
+decl_fsegment temperature;
+decl_fsegment clothing_size;
+decl_fsegment filthy;
+decl_fsegment broken;
+decl_fsegment cbm_status;
+decl_fsegment ups;
+decl_fsegment wetness;
+decl_fsegment active;
+decl_fsegment sealed;
+decl_fsegment post_asterisk;
+decl_fsegment weapon_mods;
+decl_fsegment relic_charges;
+decl_fsegment tags;
+decl_fsegment vars;
+
+inline std::string noop( item const & /* it */, unsigned int /* quantity */,
+                         segment_bitset const & /* segments */ )
+{
+    return {};
+}
+
+inline std::unordered_map<segments, decl_fsegment *> const segment_map = {
+    { segments::FAULTS, faults },
+    { segments::DIRT, dirt_symbol },
+    { segments::OVERHEAT, overheat_symbol },
+    { segments::FAVORITE_PRE, pre_asterisk },
+    { segments::DURABILITY, durability },
+    { segments::ENGINE_DISPLACEMENT, engine_displacement },
+    { segments::WHEEL_DIAMETER, wheel_diameter },
+    { segments::BURN, burn },
+    { segments::TYPE, label },
+    { segments::CATEGORY, category },
+    { segments::MODS, mods },
+    { segments::CRAFT, craft },
+    { segments::WHITEBLACKLIST, wbl_mark },
+    { segments::CHARGES, noop },
+    { segments::CONTENTS, contents },
+    { segments::FOOD_TRAITS, food_traits },
+    { segments::LOCATION_HINT, location_hint },
+    { segments::ETHEREAL, ethereal },
+    { segments::FOOD_STATUS, food_status },
+    { segments::FOOD_IRRADIATED, food_irradiated },
+    { segments::TEMPERATURE, temperature },
+    { segments::CLOTHING_SIZE, clothing_size },
+    { segments::FILTHY, filthy },
+    { segments::BROKEN, broken },
+    { segments::CBM_STATUS, cbm_status },
+    { segments::UPS, ups },
+    { segments::WETNESS, wetness },
+    { segments::ACTIVE, active },
+    { segments::SEALED, sealed },
+    { segments::FAVORITE_POST, post_asterisk },
+    { segments::WEAPON_MODS, weapon_mods },
+    { segments::RELIC, relic_charges },
+    { segments::LINK, noop },
+    { segments::VARS, vars },
+    { segments::TECHNIQUES, noop },
+    { segments::TAGS, tags },
+};
+
+#endif // CATA_IN_TOOL
+} // namespace tname
+
+template<>
+struct enum_traits<tname::segments> {
+    static constexpr tname::segments last = tname::segments::last;
+};
+
+namespace tname
+{
+constexpr unsigned long long default_tname_bits =
+    std::numeric_limits<unsigned long long>::max() &
+    ~( 1ULL << static_cast<size_t>( tname::segments::CATEGORY ) );
+constexpr unsigned long long tname_prefix_bits =
+    1ULL << static_cast<size_t>( tname::segments::FAVORITE_PRE ) |
+    1ULL << static_cast<size_t>( tname::segments::DURABILITY ) |
+    1ULL << static_cast<size_t>( tname::segments::BURN );
+constexpr unsigned long long tname_contents_bits =
+    1ULL << static_cast<size_t>( tname::segments::CONTENTS ) |
+    1ULL << static_cast<size_t>( tname::segments::CONTENTS_FULL ) |
+    1ULL << static_cast<size_t>( tname::segments::CONTENTS_ABREV );
+constexpr unsigned long long tname_conditional_bits =    // TODO: fine grain?
+    1ULL << static_cast<size_t>( tname::segments::COMPONENTS ) |
+    1ULL << static_cast<size_t>( tname::segments::TAGS ) |
+    1ULL << static_cast<size_t>( tname::segments::VARS );
+constexpr segment_bitset default_tname( default_tname_bits );
+constexpr segment_bitset unprefixed_tname( default_tname_bits & ~tname_prefix_bits );
+constexpr segment_bitset tname_contents( tname_contents_bits );
+constexpr segment_bitset tname_conditional( tname_conditional_bits );
+
+} // namespace tname
+
+#endif // CATA_SRC_ITEM_TNAME_H

--- a/src/item_tname.h
+++ b/src/item_tname.h
@@ -13,6 +13,9 @@ class item;
 
 namespace tname
 {
+// segments for item::tname()
+// Each element corresponds to a piece of information about an item and is displayed in the item's name
+// Each element is checked individually for stacking in item::stacks_with(), and all elements much stack for any 2 items to stack
 enum class segments : std::size_t {
     FAULTS = 0,
     DIRT,
@@ -71,42 +74,43 @@ enum class segments : std::size_t {
 using segment_bitset = enum_bitset<tname::segments>;
 
 #ifndef CATA_IN_TOOL
-using decl_fsegment = std::string( item const &it, unsigned int quantity,
-                                   segment_bitset const &segments );
-decl_fsegment faults;
-decl_fsegment dirt_symbol;
-decl_fsegment overheat_symbol;
-decl_fsegment pre_asterisk;
-decl_fsegment durability;
-decl_fsegment engine_displacement;
-decl_fsegment wheel_diameter;
-decl_fsegment burn;
-decl_fsegment label;
-decl_fsegment category;
-decl_fsegment mods;
-decl_fsegment craft;
-decl_fsegment wbl_mark;
-decl_fsegment contents;
-decl_fsegment contents_abrev;
-decl_fsegment food_traits;
-decl_fsegment location_hint;
-decl_fsegment ethereal;
-decl_fsegment food_status;
-decl_fsegment food_irradiated;
-decl_fsegment temperature;
-decl_fsegment clothing_size;
-decl_fsegment filthy;
-decl_fsegment broken;
-decl_fsegment cbm_status;
-decl_fsegment ups;
-decl_fsegment wetness;
-decl_fsegment active;
-decl_fsegment sealed;
-decl_fsegment post_asterisk;
-decl_fsegment weapon_mods;
-decl_fsegment relic_charges;
-decl_fsegment tags;
-decl_fsegment vars;
+// function type that prints an element of tname::segments
+using decl_f_print_segment = std::string( item const &it, unsigned int quantity,
+                             segment_bitset const &segments );
+decl_f_print_segment faults;
+decl_f_print_segment dirt_symbol;
+decl_f_print_segment overheat_symbol;
+decl_f_print_segment pre_asterisk;
+decl_f_print_segment durability;
+decl_f_print_segment engine_displacement;
+decl_f_print_segment wheel_diameter;
+decl_f_print_segment burn;
+decl_f_print_segment label;
+decl_f_print_segment category;
+decl_f_print_segment mods;
+decl_f_print_segment craft;
+decl_f_print_segment wbl_mark;
+decl_f_print_segment contents;
+decl_f_print_segment contents_abrev;
+decl_f_print_segment food_traits;
+decl_f_print_segment location_hint;
+decl_f_print_segment ethereal;
+decl_f_print_segment food_status;
+decl_f_print_segment food_irradiated;
+decl_f_print_segment temperature;
+decl_f_print_segment clothing_size;
+decl_f_print_segment filthy;
+decl_f_print_segment broken;
+decl_f_print_segment cbm_status;
+decl_f_print_segment ups;
+decl_f_print_segment wetness;
+decl_f_print_segment active;
+decl_f_print_segment sealed;
+decl_f_print_segment post_asterisk;
+decl_f_print_segment weapon_mods;
+decl_f_print_segment relic_charges;
+decl_f_print_segment tags;
+decl_f_print_segment vars;
 
 inline std::string noop( item const & /* it */, unsigned int /* quantity */,
                          segment_bitset const & /* segments */ )
@@ -114,7 +118,7 @@ inline std::string noop( item const & /* it */, unsigned int /* quantity */,
     return {};
 }
 
-inline std::unordered_map<segments, decl_fsegment *> const segment_map = {
+inline std::unordered_map<segments, decl_f_print_segment *> const segment_map = {
     { segments::FAULTS, faults },
     { segments::DIRT, dirt_symbol },
     { segments::OVERHEAT, overheat_symbol },
@@ -163,18 +167,18 @@ struct enum_traits<tname::segments> {
 
 namespace tname
 {
-constexpr unsigned long long default_tname_bits =
-    std::numeric_limits<unsigned long long>::max() &
+constexpr uint64_t default_tname_bits =
+    std::numeric_limits<uint64_t>::max() &
     ~( 1ULL << static_cast<size_t>( tname::segments::CATEGORY ) );
-constexpr unsigned long long tname_prefix_bits =
+constexpr uint64_t tname_prefix_bits =
     1ULL << static_cast<size_t>( tname::segments::FAVORITE_PRE ) |
     1ULL << static_cast<size_t>( tname::segments::DURABILITY ) |
     1ULL << static_cast<size_t>( tname::segments::BURN );
-constexpr unsigned long long tname_contents_bits =
+constexpr uint64_t tname_contents_bits =
     1ULL << static_cast<size_t>( tname::segments::CONTENTS ) |
     1ULL << static_cast<size_t>( tname::segments::CONTENTS_FULL ) |
     1ULL << static_cast<size_t>( tname::segments::CONTENTS_ABREV );
-constexpr unsigned long long tname_conditional_bits =    // TODO: fine grain?
+constexpr uint64_t tname_conditional_bits =    // TODO: fine grain?
     1ULL << static_cast<size_t>( tname::segments::COMPONENTS ) |
     1ULL << static_cast<size_t>( tname::segments::TAGS ) |
     1ULL << static_cast<size_t>( tname::segments::VARS );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2169,7 +2169,9 @@ void make_gun_sound_effect( const Character &p, bool burst, item *weapon )
         sounds::sound( p.pos(), data.volume, sounds::sound_t::combat,
                        data.sound.empty() ? _( "Bang!" ) : data.sound );
     }
-    p.add_msg_if_player( _( "You shoot your %1$s.  %2$s" ), weapon->tname( 1, false, 0, false ),
+    tname::segment_bitset segs( tname::unprefixed_tname );
+    segs.set( tname::segments::CONTENTS, false );
+    p.add_msg_if_player( _( "You shoot your %1$s.  %2$s" ), weapon->tname( 1, segs ),
                          uppercase_first_letter( data.sound ) );
 }
 

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -1,13 +1,16 @@
-#include <iosfwd>
 #include <memory>
-#include <set>
 #include <string>
 
+#include "avatar.h"
 #include "calendar.h"
 #include "cata_catch.h"
 #include "character.h"
+#include "color.h"
 #include "flag.h"
 #include "item.h"
+#include "item_category.h"
+#include "item_pocket.h"
+#include "item_tname.h"
 #include "itype.h"
 #include "options_helpers.h"
 #include "pocket_type.h"
@@ -20,6 +23,9 @@ static const fault_id fault_gun_dirt( "fault_gun_dirt" );
 static const item_category_id item_category_veh_parts( "veh_parts" );
 
 static const itype_id itype_backpack_hiking( "backpack_hiking" );
+static const itype_id itype_bag_garbage( "bag_garbage" );
+static const itype_id itype_bag_plastic( "bag_plastic" );
+static const itype_id itype_hammer( "hammer" );
 static const itype_id itype_purse( "purse" );
 static const itype_id itype_rock( "rock" );
 static const itype_id itype_test_rock( "test_rock" );
@@ -663,6 +669,10 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
     item backpack_hiking( itype_backpack_hiking );
     item purse( itype_purse );
     item rock( itype_test_rock );
+    item bag( itype_bag_plastic );
+    item bag_garbage( itype_bag_garbage );
+    item hammer( itype_hammer );
+    rock.clear_itype_variant();
     item rock2( itype_rock );
     const std::string color_pref =
         "<color_c_green>++</color>\u00A0";
@@ -674,6 +684,7 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
         backpack_hiking.put_in( rock, pocket_type::CONTAINER );
 
         std::string const rock_nested_tname = colorize( rock.tname(), rock.color_in_inventory() );
+        std::string const hammers_nested_tname = colorize( hammer.tname( 2 ), rock.color_in_inventory() );
         std::string const rocks_nested_tname = colorize( rock.tname( 2 ), rock.color_in_inventory() );
         REQUIRE( rock_nested_tname == "<color_c_light_gray>TEST rock</color>" );
         SECTION( "single rock" ) {
@@ -683,12 +694,51 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
         SECTION( "several rocks" ) {
             backpack_hiking.put_in( rock, pocket_type::CONTAINER );
             CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym +
-                   " " + rocks_nested_tname + " (2)" );
+                   " 2 " + rocks_nested_tname );
         }
         SECTION( "several stacks" ) {
+            REQUIRE( rock.get_category_shallow().id != purse.get_category_shallow().id );
+            backpack_hiking.put_in( rock, pocket_type::CONTAINER );
+            backpack_hiking.put_in( purse, pocket_type::CONTAINER );
+            CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym + " 2 items" );
+        }
+        SECTION( "several stacks of same category" ) {
+            REQUIRE( rock.get_category_shallow().id == rock2.get_category_shallow().id );
             backpack_hiking.put_in( rock, pocket_type::CONTAINER );
             backpack_hiking.put_in( rock2, pocket_type::CONTAINER );
-            CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym + " 2 items" );
+            CHECK( backpack_hiking.tname( 1 ) ==
+                   color_pref + "hiking backpack " + nesting_sym + " 2 " +
+                   colorize( rock.get_category_shallow().name(), c_magenta ) );
+        }
+        SECTION( "several stacks of variants" ) {
+            item rock_blue( itype_test_rock );
+            item rock_green( itype_test_rock );
+            rock_blue.set_itype_variant( "test_rock_blue" );
+            rock_green.set_itype_variant( "test_rock_green" );
+            backpack_hiking.put_in( rock_blue, pocket_type::CONTAINER );
+            backpack_hiking.put_in( rock_green, pocket_type::CONTAINER );
+            CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym +
+                   " 3 " + rocks_nested_tname );
+        }
+        SECTION( "dominant type" ) {
+            backpack_hiking.clear_items();
+            REQUIRE( backpack_hiking.put_in( hammer, pocket_type::CONTAINER ).success() );
+            REQUIRE( backpack_hiking.put_in( hammer, pocket_type::CONTAINER ).success() );
+            REQUIRE( backpack_hiking.put_in( bag, pocket_type::CONTAINER ).success() );
+            CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym + " 2 " +
+                   hammers_nested_tname + " / 3 items" );
+        }
+        SECTION( "dominant category" ) {
+            backpack_hiking.clear_items();
+            REQUIRE( rock.get_category_shallow().id == rock2.get_category_shallow().id );
+            REQUIRE( backpack_hiking.put_in( rock, pocket_type::CONTAINER ).success() );
+            REQUIRE( backpack_hiking.put_in( rock2, pocket_type::CONTAINER ).success() );
+            REQUIRE( rock.get_category_of_contents().id == rock2.get_category_of_contents().id );
+            REQUIRE( rock.get_category_of_contents().id != purse.get_category_of_contents().id );
+            REQUIRE( backpack_hiking.put_in( purse, pocket_type::CONTAINER ).success() );
+            CHECK( backpack_hiking.tname( 1 ) ==
+                   color_pref + "hiking backpack " + nesting_sym + " 2 " +
+                   colorize( rock.get_category_shallow().name(), c_magenta ) + " / 3 items" );
         }
         SECTION( "container has whitelist" ) {
             std::string const wlmark = "⁺";
@@ -738,7 +788,22 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
             backpack_hiking.put_in( purse, pocket_type::CONTAINER );
 
             CHECK( backpack_hiking.tname( 1 ) == color_pref + "hiking backpack " + nesting_sym +
-                   " " + purse_color + color_pref + "purses" + color_end_tag + " (2)" );
+                   " 2 " + purse_color + color_pref + "purses" + color_end_tag );
+        }
+        SECTION( "dominant nested category" ) {
+            REQUIRE( bag.put_in( rock, pocket_type::CONTAINER ).success() );
+            REQUIRE( bag_garbage.put_in( rock, pocket_type::CONTAINER ).success() );
+            REQUIRE( bag.get_category_of_contents().id == rock.get_category_of_contents().id );
+            REQUIRE( bag_garbage.get_category_of_contents().id == rock.get_category_of_contents().id );
+            REQUIRE( backpack_hiking.put_in( bag_garbage, pocket_type::CONTAINER ).success() );
+            REQUIRE( backpack_hiking.put_in( bag, pocket_type::CONTAINER ).success() );
+            item bag2( itype_bag_plastic );
+            REQUIRE( bag2.put_in( hammer, pocket_type::CONTAINER ).success() );
+            REQUIRE( bag.get_category_of_contents().id != bag2.get_category_of_contents().id );
+            REQUIRE( backpack_hiking.put_in( bag2, pocket_type::CONTAINER ).success() );
+            CHECK( backpack_hiking.tname( 1 ) ==
+                   color_pref + "hiking backpack " + nesting_sym + " 2 " +
+                   colorize( rock.get_category_shallow().name(), c_magenta ) + " / 3 items" );
         }
     }
 
@@ -752,5 +817,148 @@ TEST_CASE( "nested_items_tname", "[item][tname]" )
         REQUIRE( medisoft_nested_tname == "<color_c_light_gray>MediSoft</color>" );
         usb_drive.put_in( medisoft, pocket_type::SOFTWARE );
         CHECK( usb_drive.tname( 1 ) == "USB drive " + nesting_sym + " " + medisoft_nested_tname );
+    }
+
+    tname::segment_bitset type_only;
+    type_only.set( tname::segments::TYPE );
+    SECTION( "aggregated food stats" ) {
+        avatar &u = get_avatar();
+        item salt( "salt" );
+        std::string const cat_food_str = salt.get_category_shallow().name();
+        item pepper( "pepper" );
+        item juniper( "juniper" );
+        item ration( "protein_bar_evac" );
+        item carrot( "carrot" );
+        item sauerkraut( "sauerkraut" );
+        item bag( itype_bag_plastic );
+        std::string const carrots_tname = carrot.tname( 2, type_only );
+
+        SECTION( "inedible" ) {
+            REQUIRE( ( salt.is_food() && pepper.is_food() && juniper.is_food() && ration.is_food() &&
+                       carrot.is_food() && sauerkraut.is_food() ) );
+
+            REQUIRE( ( u.will_eat( salt ).value() == edible_rating::INEDIBLE &&
+                       u.will_eat( pepper ).value() == edible_rating::INEDIBLE ) );
+            REQUIRE( bag.put_in( salt, pocket_type::CONTAINER ).success() );
+            REQUIRE( bag.put_in( pepper, pocket_type::CONTAINER ).success() );
+            CHECK( bag.tname( 1 ) == "plastic bag > 2 " + colorize( cat_food_str, c_dark_gray ) );
+        }
+
+        SECTION( "non-perishable" ) {
+            REQUIRE( ( !juniper.goes_bad() && !ration.goes_bad() ) );
+            REQUIRE( ( u.will_eat( juniper ).value() == edible_rating::EDIBLE &&
+                       u.will_eat( ration ).value() == edible_rating::EDIBLE ) );
+            REQUIRE( bag.put_in( juniper, pocket_type::CONTAINER ).success() );
+            REQUIRE( bag.put_in( ration, pocket_type::CONTAINER ).success() );
+            CHECK( bag.tname( 1 ) == "plastic bag > 2 " + colorize( cat_food_str, c_cyan ) );
+        }
+
+        SECTION( "perishable" ) {
+            bool same_item = GENERATE( true, false );
+            bool rotten = GENERATE( true, false );
+            bool both_rotten = rotten ? GENERATE( true, false ) : false;
+            bool frozen = GENERATE( true, false );
+            bool both_frozen = frozen ? GENERATE( true, false ) : false;
+            bool mushy = !rotten ? GENERATE( true, false ) : false;
+            bool both_mushy = mushy ? GENERATE( true, false ) : false;
+            CAPTURE( same_item, rotten, both_rotten, mushy, both_mushy, frozen, both_frozen );
+
+            nc_color color = c_light_cyan;
+            item second_food( same_item ? carrot : sauerkraut );
+
+            std::string fresh_str( " (fresh)" );
+            std::string frozen_str;
+
+            REQUIRE( ( carrot.goes_bad() && second_food.goes_bad() ) );
+            REQUIRE( ( u.will_eat( carrot ).value() == edible_rating::EDIBLE &&
+                       u.will_eat( second_food ).value() == edible_rating::EDIBLE ) );
+            REQUIRE( ( carrot.is_fresh() && second_food.is_fresh() ) );
+
+            if( rotten ) {
+                carrot.set_relative_rot( 99 );
+                REQUIRE_FALSE( carrot.is_fresh() );
+                fresh_str = std::string{};
+                if( both_rotten ) {
+                    second_food.set_relative_rot( 99 );
+                    fresh_str = " (rotten)";
+                    color = c_brown;
+                }
+            } else if( mushy ) {
+                carrot.set_flag( flag_MUSHY );
+                fresh_str = std::string{};
+                if( both_mushy ) {
+                    second_food.set_flag( flag_MUSHY );
+                    fresh_str = " (mushy)";
+                }
+            }
+            if( frozen ) {
+                carrot.set_flag( flag_FROZEN );
+                if( both_frozen ) {
+                    second_food.set_flag( flag_FROZEN );
+                    frozen_str = " (frozen)";
+                    color = c_dark_gray;
+                }
+            }
+            REQUIRE( bag.put_in( carrot, pocket_type::CONTAINER ).success() );
+            REQUIRE( bag.put_in( second_food, pocket_type::CONTAINER ).success() );
+            if( same_item ) {
+                CHECK( bag.tname( 1 ) ==
+                       "plastic bag > 2 " +
+                       colorize( carrots_tname + fresh_str + frozen_str, color ) );
+            } else {
+                CHECK( bag.tname( 1 ) == "plastic bag > 2 " +
+                       colorize( cat_food_str, color ) + fresh_str +
+                       frozen_str );
+            }
+        }
+    }
+
+    SECTION( "aggregated clothing stats" ) {
+        item pants( "pants" );
+        pants.clear_itype_variant();
+        pants.set_flag( flag_FIT );
+        bool same_item = GENERATE( true, false );
+        item second_item( same_item ? "pants" : "jeans" );
+        second_item.clear_itype_variant();
+        second_item.set_flag( flag_FIT );
+        REQUIRE( ( pants.has_flag( flag_VARSIZE ) && second_item.has_flag( flag_VARSIZE ) ) );
+
+        bool damaged = GENERATE( true, false );
+        bool both_damaged = damaged ? GENERATE( true, false ) : false;
+        bool unfit = GENERATE( true, false );
+        bool both_unfit = unfit ? GENERATE( true, false ) : false;
+        CAPTURE( same_item, damaged, both_damaged, unfit, both_unfit );
+
+        std::string const cat_cl_str = pants.get_category_shallow().name();
+        std::string const pants_tname = pants.tname( 2, type_only );
+        std::string dura_str = pants.durability_indicator();
+        std::string fit_str;
+
+        if( damaged ) {
+            pants.inc_damage();
+            dura_str = std::string{};
+            if( both_damaged ) {
+                second_item.inc_damage();
+                dura_str = pants.durability_indicator();
+            }
+        }
+        if( unfit ) {
+            pants.unset_flag( flag_FIT );
+            if( both_unfit ) {
+                second_item.unset_flag( flag_FIT );
+                fit_str = " (poor fit)";
+            }
+        }
+
+        REQUIRE( bag.put_in( pants, pocket_type::CONTAINER ).success() );
+        REQUIRE( bag.put_in( second_item, pocket_type::CONTAINER ).success() );
+
+        if( same_item ) {
+            CHECK( bag.tname( 1 ) == "plastic bag > 2 " +
+                   colorize( dura_str + pants_tname + fit_str, c_light_gray ) );
+        } else {
+            CHECK( bag.tname( 1 ) == "plastic bag > 2 " + dura_str +
+                   colorize( cat_cl_str, c_magenta ) + fit_str );
+        }
     }
 }

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -258,18 +258,6 @@ TEST_CASE( "diamond_item", "[item][tname][diamond]" )
     CHECK( katana.tname() == "diamond katana" );
 }
 
-TEST_CASE( "truncated_item_name", "[item][tname][truncate]" )
-{
-    SECTION( "plain item name can be truncated" ) {
-        item katana( "katana" );
-
-        CHECK( katana.tname() == "katana" );
-        CHECK( katana.tname( 1, false, 5 ) == "katan" );
-    }
-
-    // TODO: color-coded or otherwise embellished item name can be truncated
-}
-
 TEST_CASE( "engine_displacement_volume", "[item][tname][engine]" )
 {
     item vtwin = item( "v2_combustion" );

--- a/tests/itemname_test.cpp
+++ b/tests/itemname_test.cpp
@@ -181,13 +181,13 @@ TEST_CASE( "display_name_rotten_food", "[item][display_name][contents]" )
 
     REQUIRE( wrapper.put_in( butter_rot1, pocket_type::CONTAINER ).success() );
     CHECK( wrapper.display_name() ==
-           "paper wrapper > " + butter_rot_tname + " hidden" );
+           "paper wrapper > " + butter_rot_tname );
 
     REQUIRE( wrapper.put_in( butter_rot2, pocket_type::CONTAINER ).success() );
     CHECK( wrapper.display_name() ==
-           "paper wrapper > " + butter_rot_tname + " (2) hidden" );
+           "paper wrapper > 2 " + butter_rot_tname );
 
     REQUIRE( wrapper.put_in( butter_std, pocket_type::CONTAINER ).success() );
     CHECK( wrapper.display_name() ==
-           "paper wrapper > 3 hidden items" );
+           "paper wrapper > 3 " + butter_std_tname );
 }


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Too many restrictive checks are performed when expanding contents name so a lot of containers that should reasonably be named `container > contents_name (X)` are instead shown as `container > X items`. And we can do even better by showing more common stats when most contents are of some particular type.


* Fixes: #67603
* Fixes: #69959
* Fixes: #68341
* Fixes: #70332 (incidentally)
Also fixes items with varying whitelists stacking when they shouldn't (incidentally).

#### Describe the solution
1. Break `item::tname()` into segments
2. Break `item::stacks_with()` into bits corresponding to tname segments
3. When determining item contents, aggregate all the stacking bits by type and category (ie. determine the common bits for each type and category)
4. Display all the common segments for the dominant item or category. An item/category is dominant if it covers more than half of the contents

I'm also getting rid of the `hidden` marker because the chevron already conveys that information. I wanted to remove it back in #56630 but the chevrons were too new back then.

<details>
<summary>Some examples with pictures:</summary>

<details>
<summary>A bag of salt in a bag of salt (#69959)</summary>

![0 - bag of salt in a bag of salt](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/a2299498-a911-489b-a6c4-e99051e2b9b0)


</details>

<details>
<summary>Some pepper has snuck into this bag but the salt still dominates</summary>

![1 - bag of salt in bos + pepper](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/a065562a-c43b-48db-8b35-563c121bb899)


</details>

<details>
<summary>A lot of pepper has snuck into this bag and the salt doesn't dominate anymore. But the dominant category is FOOD</summary>

![2 - bag of salt in a bos + lotsa pepper](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/67217726-337a-4177-a495-4a6a9cea630f)

</details>

<details>
<summary>This bag holds several variants of the same item. Note that the common durability and poor fit are also mentioned</summary>

![b0 - variants + poor fit + durability](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/9d94da50-e0df-4140-a283-3c5bc846717d)


</details>

<details>
<summary>One of the masks got damaged and the dominant type doesn't have common durability anymore</summary>

![b1 - variants + poor fit - durability](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/a9869f33-7693-4111-9f3d-fa02ad1be316)

</details>

<details>
<summary>Another clothing example - the common filthy state is also mentioned</summary>

![3 - filthy clothing](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/f1655685-09ee-4a7c-851a-725d06897aff)

</details>

<details>
<summary>Nested food of various type</summary>

![4 - nested food of various type](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/71d2607e-62b0-4b13-990d-3470a06d51c9)

</details>

<details>
<summary>Another FOOD example, showing aggregated perishability and freshness</summary>

![5 - food cat color + aggregated fresh](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/d713ef59-b779-44a0-8cc9-c5ef1d215ad9)

</details>


<details>
<summary>Bag with various sawn-off guns, showing aggregated barrel mod</summary>

![Screenshot from 2024-01-14 08-09-44](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/776d702f-9434-4bd5-ad41-91837a071af2)

</details>

</details>
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

TODO:
- [x] Write more tests
- [x] Investigate performance impact. Caching `item::get_category_of_contents()` covered most of it. This definitely reverts #70685 and I haven't been able to restore it.

#### Describe alternatives you've considered
Step 1 isn't strictly necessary but `item::tname()` was a monolithic monster. #67954 was the original attempt that didn't split `tname` and I didn't think was tenable. Similar for splitting `item::stacks_with()`

If there were some guarantee that insertion/removal/transformation had backlinks (ex: by using an `item_location`), there wouldn't be any need for a timestamp in the category cache.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Updated test units that cover the examples above. I don't expect to correctly cover all the cases in this PR, but I will address errors as they are discovered in gameplay.

There is a moderate performance impact. Timing for opening the `pickup all` in [City of the Dalles.zip](https://github.com/CleverRaven/Cataclysm-DDA/files/13927482/City.of.the.Dalles.zip) with a standard (`-Os`) release build

Before:
![0 - before](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/99920ab3-d2b5-4d9d-b520-4d48fae193eb)

After:
![1 - after](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/6707a9da-85a2-49c3-a6a4-b49e0efa522d)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
While this is a large PR, a big chunk of it is just moving code around (step 1 - fe3abb60c8353ce99e3609cf2deec631504f638c). The second biggest chunk is mostly just not'ing boolean expressions and moving them to separate functions (step 2 - ec53b3e83d4232ef617ba3da89a421e9cc4ea725). The third biggest chunk is test code (3ba12135af552d8f12b962696b74a69e0d71f2bc).

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
