### PR TITLE
Fix new line in crash log when SDL message box cannot be created

### DIFF
--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -77,7 +77,7 @@ extern "C" {
 #if defined(TILES)
         if( SDL_ShowSimpleMessageBox( SDL_MESSAGEBOX_ERROR, "Error",
                                       log_text.str().c_str(), nullptr ) != 0 ) {
-            log_text << "Error creating SDL message box: " << SDL_GetError() << '\n';
+            log_text << "\nError creating SDL message box: " << SDL_GetError();
         }
 #endif
 #endif


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fix new line in crash log when SDL message box cannot be created

#### Describe the solution
Move the newline to the start of the text, like all other text in the function.

#### Describe alternatives you've considered

#### Testing
Game compiles. I cannot think of a way to make SDL message box not display so I didn't test futher.

#### Additional context
