### PR TITLE
Include unistd.h for getpid on MSYS2

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,7 +55,7 @@
 #include "translations.h"
 #include "type_id.h"
 #include "ui_manager.h"
-#if defined(MACOSX)
+#if defined(MACOSX) || defined(__CYGWIN__)
 #   include <unistd.h> // getpid()
 #endif
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
MSYS2 uses CYGWIN which has `getpid` declared in `unistd.h`.

#### Describe the solution
Include `unistd.h` on CYGWIN.

#### Describe alternatives you've considered

#### Testing
Game compiles now.

#### Additional context
