### PR TITLE
Extract nested monster attack messages for translation

### DIFF
--- a/lang/string_extractor/parsers/monster.py
+++ b/lang/string_extractor/parsers/monster.py
@@ -1,5 +1,6 @@
 from ..helper import get_singular_name
 from ..write_text import write_text
+from .monster_attack import parse_monster_attack
 
 
 def parse_monster_concrete(json, origin, name):
@@ -14,6 +15,9 @@ def parse_monster_concrete(json, origin, name):
 
     if "special_attacks" in json:
         for attack in json["special_attacks"]:
+            if "type" in attack and attack["type"] == "monster_attack":
+                parse_monster_attack(attack, origin)
+                continue
             if "description" in attack:
                 write_text(attack["description"], origin,
                            comment="Description of special attack of monster "

--- a/lang/string_extractor/parsers/monster_attack.py
+++ b/lang/string_extractor/parsers/monster_attack.py
@@ -2,7 +2,17 @@ from ..write_text import write_text
 
 
 def parse_monster_attack(json, origin):
-    for key in ["hit_dmg_u", "hit_dmg_npc", "miss_msg_u", "miss_msg_npc",
-                "no_dmg_msg_u", "no_dmg_msg_npc"]:
+    for key in [
+        "hit_dmg_u",
+        "hit_dmg_npc",
+        "miss_msg_u",
+        "miss_msg_npc",
+        "no_dmg_msg_u",
+        "no_dmg_msg_npc",
+    ]:
         if key in json:
-            write_text(json[key], origin, comment="Monster attack message")
+            write_text(
+                json[key],
+                origin,
+                comment='Monster attack "{}" message'.format(json["id"]),
+            )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Attack messages in `monster_attack` embedded in the `special_attacks` array of `MONSTER` definitions are not extracted for translation.

A stripped-down example:
```json
  {
    "id": "mon_star_vampire",
    "type": "MONSTER",
    "name": { "str": "star vampire" },
    "special_attacks": [
      {
        "type": "monster_attack",
        "attack_type": "bite",
        "id": "star_vampire_bite",
        "hit_dmg_u": "%1$s bites your %2$s with its fang-filled maw!",
        "hit_dmg_npc": "%1$s bites <npcname>'s %2$s with its fang-filled maw!",
        "miss_msg_u": "%1$s tries to bite you, but you dodge!",
        "miss_msg_npc": "%1$s tries to bite <npcname>, but they dodge!",
        "no_dmg_msg_u": "%1$s tries to bite your %2$s, but can't penetrate your armor.",
        "no_dmg_msg_npc": "%1$s tries to bite <npcname>'s %2$s, but can't penetrate their armor."
      }
  ]
}
```
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Check for `monster_attack` objects in `special_attacks` in `MONSTER`.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
These attack messages now appear in the generated translation template after this patch.
```po
#. ~ Monster attack "star_vampire_bite" message
#: data/json/monsters/nether.json
#, c-format
msgid "%1$s bites your %2$s with its fang-filled maw!"
msgstr ""

#. ~ Monster attack "star_vampire_bite" message
#: data/json/monsters/nether.json
#, c-format
msgid "%1$s bites <npcname>'s %2$s with its fang-filled maw!"
msgstr ""
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
