### PR TITLE
tgz_archiver: skip symlink check

### DIFF
--- a/src/tgz_archiver.cpp
+++ b/src/tgz_archiver.cpp
@@ -24,7 +24,7 @@ std::string tgz_archiver::_gen_tar_header( fs::path const &file_name, fs::path c
     unsigned const type = fs::is_directory( real_path ) ? 5 : 0;
     unsigned const perms = fs::is_directory( real_path ) ? 0775 : 0664;
     // https://stackoverflow.com/a/61067330
-    std::time_t const mtime = !fs::is_symlink( real_path ) || fs::exists( real_path )
+    std::time_t const mtime = fs::exists( real_path )
                               ? std::chrono::system_clock::to_time_t(
                                   std::chrono::time_point_cast<std::chrono::system_clock::duration>(
                                       fs::last_write_time( real_path ) - _fsnow + _sysnow ) ) : std::time_t{};


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
`std::filesystem::is_symlink()` is broken for one of our target compilers.

See https://github.com/CleverRaven/Cataclysm-DDA/issues/70731#issuecomment-1879903333 for an encounter in the wild

#### Describe the solution
Skip the symlink check. It's redundant anyway

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I can't recreate the scenario, but I don't expect any problems.

Folders with broken symlinks still don't crash the game when archived

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
https://developercommunity.visualstudio.com/t/std::filesystem::is_symlink-is-broken-on/1638272
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
