### PR TITLE
Fix: Stable vehicle speeds with autotravel

### DIFF
--- a/src/vehicle_autodrive.cpp
+++ b/src/vehicle_autodrive.cpp
@@ -1222,8 +1222,10 @@ std::optional<navigation_step> vehicle::autodrive_controller::compute_next_step(
                                         navigation_step();
     bool maintain_speed = false;
     // If vehicle did not move as far as planned and direction is the same
-    // then it is still accelerating.
-    if( two_steps && square_dist( first_step.pos.xy().raw(), second_step.pos.xy().raw() ) >
+    // then it is still accelerating. If the vehicle moved more than expected
+    // then we likely underestimated the acceleration when planning the path.
+    // If either of these happen, we should maintain speed but compute a new path.
+    if( two_steps && square_dist( first_step.pos.xy().raw(), second_step.pos.xy().raw() ) !=
         square_dist( first_step.pos.xy().raw(), veh_pos.xy().raw() ) &&
         first_step.steering_dir == second_step.steering_dir ) {
         data.path.pop_back();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Stable vehicle speeds with autotravel"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Prevents autotravel speeds from jerking back and forth between minimum and cruising speeds, but instead tries to maintain the autotravel planned speed.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Before, what could happen was:
1. the autotravel planner chose a path based on an estimated vehicle acceleration and speed
2. but sometimes the vehicle happens to travel further than what was planned
3. if this happened, then the `if` statement changed by this commit was not satisfied: https://github.com/CleverRaven/Cataclysm-DDA/blob/eec670dc1553ddb223c22f07412e240808928911/src/vehicle_autodrive.cpp#L1226-L1228
4. Instead, we end up on the `while( !data.path.empty`-part.
5. that loop removes path steps until we reach the vehicle's current position: https://github.com/CleverRaven/Cataclysm-DDA/blob/eec670dc1553ddb223c22f07412e240808928911/src/vehicle_autodrive.cpp#L1233-L1235 
7. but because of 2, the vehicle's position `veh_pos` is never **exactly** equal to the planned position
8. the loop at step 4 will therefore remove all path steps, and instead of maintaining speed, it will look like we have just started to plan a new path.

This commit instead changes step 3 so that "maintain speed but calculate a new path" happens also if the vehicle traveled further than planned (and not only if it traveled shorter like before).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

* If the vehicle traveled further than planned, we might be able to reuse the planned path somehow but recalculate the remaining steps, instead of planning a new path. There are some nice ideas in #62956 about how that could work also with enabling higher speeds. We could possibly make an even better algorithm specialized for traveling in a straight line.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

* Played the game for a bit
* Drove around with autodrive through a town with lots of wrecks. Collision prevention still works as before.
* Drove with autotravel on a bike through an area with many zombies. Amazingly, I did not get hit.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

* There was some talk in https://github.com/CleverRaven/Cataclysm-DDA/issues/53832 related to what this issue attempts to resolve.
* https://github.com/CleverRaven/Cataclysm-DDA/pull/57642 had another suggested way of resolving cruising speeds.
* About the oscillating speed, [xkcd 612](https://xkcd.com/612/) comes to mind:
![xkcd 612](https://imgs.xkcd.com/comics/estimation.png)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
