### PR TITLE
Items warn on exceeding max volume, unify max volume as a game constant

### DIFF
--- a/data/mods/Aftershock/items/inactiverobot.json
+++ b/data/mods/Aftershock/items/inactiverobot.json
@@ -145,7 +145,8 @@
     "price": 1000,
     "material": [ "steel", "plastic" ],
     "weight": "1023850 g",
-    "volume": "1100 L",
+    "//": "Former volume: 1100 L. Adjusted to 1000L so it can actually be placed. TODO(?): Re-add old volume with some sort of flag",
+    "volume": "1000 L",
     "to_hit": -3,
     "flags": [ "TRADER_AVOID", "NO_REPAIR" ],
     "melee_damage": { "bash": 20, "cut": 15 }

--- a/data/mods/Mythos-Creatures/items/corpses/mythos.json
+++ b/data/mods/Mythos-Creatures/items/corpses/mythos.json
@@ -74,7 +74,8 @@
     "name": { "str": "deep one corpse" },
     "description": "The upper half of a dead deep one body, as if torn apart with enormous force.  Some organs are hanging out.",
     "looks_like": "corpse_generic_deep_one",
-    "volume": "46250 L",
+    "//": "Former volume: 46250 L. Adjusted to 1000L so it can actually be placed. TODO(?): Re-add old volume with some sort of flag",
+    "volume": "1000 L",
     "weight": "60 kg",
     "material": [ "flesh" ]
   },

--- a/data/mods/No_Hope/items.json
+++ b/data/mods/No_Hope/items.json
@@ -84,7 +84,8 @@
     "price": 1000,
     "material": [ "steel", "plastic" ],
     "weight": "1023850 g",
-    "volume": "1100 L",
+    "//": "Former volume: 1100 L. Adjusted to 1000L so it can actually be placed. TODO(?): Re-add old volume with some sort of flag",
+    "volume": "1000 L",
     "to_hit": -3,
     "use_action": {
       "type": "place_monster",

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -844,7 +844,7 @@ static std::vector<item> create_charge_items( const itype *drop, int count,
     std::vector<item> objs;
     while( count > 0 ) {
         item obj( drop, calendar::turn, 1 );
-        obj.charges = std::min( count, 1000_liter / obj.volume() );
+        obj.charges = std::min( count, DEFAULT_TILE_VOLUME / obj.volume() );
         count -= obj.charges;
 
         if( obj.has_temperature() ) {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -273,7 +273,7 @@ float Character::workbench_crafting_speed_multiplier( const item &craft,
     }
 
     multiplier *= lerped_multiplier( craft_mass, allowed_mass, 1000_kilogram );
-    multiplier *= lerped_multiplier( craft_volume, allowed_volume, 1000_liter );
+    multiplier *= lerped_multiplier( craft_volume, allowed_volume, DEFAULT_TILE_VOLUME );
 
     return multiplier;
 }

--- a/src/game_constants.h
+++ b/src/game_constants.h
@@ -28,6 +28,9 @@ constexpr int EXPLOSION_MULTIPLIER = 7;
 constexpr int MAX_ITEM_IN_SQUARE = 4096;
 // no reason to differ.
 constexpr int MAX_ITEM_IN_VEHICLE_STORAGE = MAX_ITEM_IN_SQUARE;
+// Sanity checks for volume
+constexpr units::volume DEFAULT_TILE_VOLUME = units::from_liter( 1000 );
+constexpr units::volume MAX_ITEM_VOLUME = DEFAULT_TILE_VOLUME;
 // only can wear a maximum of two of any type of clothing.
 constexpr int MAX_WORN_PER_TYPE = 2;
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7388,6 +7388,10 @@ units::volume item::corpse_volume( const mtype *corpse ) const
     if( has_flag( flag_SKINNED ) ) {
         corpse_volume *= 0.85;
     }
+    if( corpse_volume > MAX_ITEM_VOLUME ) {
+        // Silently set volume so the corpse can still spawn but a mtype can have a volume > MAX_ITEM_VOLUME
+        corpse_volume = MAX_ITEM_VOLUME;
+    }
     if( corpse_volume > 0_ml ) {
         return corpse_volume;
     }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2102,8 +2102,8 @@ void Item_factory::check_definitions() const
         if( type->volume < 0_ml ) {
             msg += "negative volume\n";
         }
-        if( type->volume > 1000_liter ) {
-            msg += "exceeds max volume\n";
+        if( type->volume > MAX_ITEM_VOLUME ) {
+            msg += string_format( "exceeds max volume(%s L)\n", units::to_liter( MAX_ITEM_VOLUME ) );
         }
         if( type->stack_size <= 0 ) {
             if( type->count_by_charges() ) {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2102,6 +2102,9 @@ void Item_factory::check_definitions() const
         if( type->volume < 0_ml ) {
             msg += "negative volume\n";
         }
+        if( type->volume > 1000_liter ) {
+            msg += "exceeds max volume\n";
+        }
         if( type->stack_size <= 0 ) {
             if( type->count_by_charges() ) {
                 msg += string_format( "invalid stack_size %d on type using charges\n", type->stack_size );

--- a/src/item_location.cpp
+++ b/src/item_location.cpp
@@ -932,7 +932,7 @@ ret_val<int> item_location::max_charges_by_parent_recursive( const item &it ) co
     float weight_multiplier = 1.0f;
     float volume_multiplier = 1.0f;
     units::mass max_weight = 1000_kilogram;
-    units::volume max_volume = 1000_liter;
+    units::volume max_volume = MAX_ITEM_VOLUME;
     item_location current_location = *this;
     //item_location class cannot return current pocket so use first pocket for innermost container
     //Only used for weight and volume multipliers

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -31,8 +31,6 @@ static const item_group_id Item_spawn_data_EMPTY_GROUP( "EMPTY_GROUP" );
 namespace
 {
 
-const units::volume DEFAULT_MAX_VOLUME_IN_SQUARE = units::from_liter( 1000 );
-
 generic_factory<ter_t> terrain_data( "terrain" );
 generic_factory<furn_t> furniture_data( "furniture" );
 
@@ -498,7 +496,7 @@ furn_t null_furniture_t()
     new_furniture.transparent = true;
     new_furniture.set_flag( ter_furn_flag::TFLAG_TRANSPARENT );
     new_furniture.examine_func = iexamine_functions_from_string( "none" );
-    new_furniture.max_volume = DEFAULT_MAX_VOLUME_IN_SQUARE;
+    new_furniture.max_volume = DEFAULT_TILE_VOLUME;
     return new_furniture;
 }
 
@@ -520,7 +518,7 @@ ter_t null_terrain_t()
     new_terrain.set_flag( ter_furn_flag::TFLAG_TRANSPARENT );
     new_terrain.set_flag( ter_furn_flag::TFLAG_DIGGABLE );
     new_terrain.examine_func = iexamine_functions_from_string( "none" );
-    new_terrain.max_volume = DEFAULT_MAX_VOLUME_IN_SQUARE;
+    new_terrain.max_volume = DEFAULT_TILE_VOLUME;
     return new_terrain;
 }
 
@@ -1627,7 +1625,7 @@ void furn_t::load( const JsonObject &jo, const std::string &src )
     bonus_fire_warmth_feet = units::from_legacy_bodypart_temp_delta( legacy_bonus_fire_warmth_feet );
     optional( jo, was_loaded, "keg_capacity", keg_capacity, legacy_volume_reader, 0_ml );
     mandatory( jo, was_loaded, "required_str", move_str_req );
-    optional( jo, was_loaded, "max_volume", max_volume, volume_reader(), DEFAULT_MAX_VOLUME_IN_SQUARE );
+    optional( jo, was_loaded, "max_volume", max_volume, volume_reader(), DEFAULT_TILE_VOLUME );
     optional( jo, was_loaded, "crafting_pseudo_item", crafting_pseudo_item, itype_id() );
     optional( jo, was_loaded, "deployed_item", deployed_item );
     load_symbol( jo, "furniture " + id.str() );

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -14,6 +14,7 @@
 #include "clone_ptr.h"
 #include "color.h"
 #include "enum_bitset.h"
+#include "game_constants.h"
 #include "iexamine.h"
 #include "translations.h"
 #include "type_id.h"
@@ -497,7 +498,7 @@ struct map_data_common_t {
         units::temperature_delta floor_bedding_warmth = 0_C_delta;
         int comfort = 0;
         // Maximal volume of items that can be stored in/on this furniture
-        units::volume max_volume = 1000_liter;
+        units::volume max_volume = DEFAULT_TILE_VOLUME;
 
         translation description;
 


### PR DESCRIPTION
#### Summary
Infrastructure "Items warn on exceeding max volume, unify max volume as a game constant"

#### Purpose of change
* Closes #70707

#### Describe the solution
We had an existing 'agreed upon' normal limit of 1000L per in-game tile but this only lived in mapdata.cpp/mapdata.h. Promote that to a game constant, and use the game constant wherever we're checking the volume limit.

The item volume limit inherits from the default tile volume limit - thanks to @ehughsbaird for reminding me of that little bit of syntax.


#### Describe alternatives you've considered
I originally tried implementing this as a check in generic factory, only for it to yell that some furnitures had storages exceeding 1000L. Oops :)
(I realized afterwards that item factory and generic factory are in fact different)

I considered also adding a check to map::_add_item_or_charges to catch cases where singular items exceeded possible available space, but this seemed redundant and somewhat prone to false positives.

#### Testing
Game loads, throws debugmsg for items with volumes exceeding the defined volume limit (1000L).

#### Additional context
~~**Relying on CI to check existing mod items**. Ideally the full test suite should run even if the mapgen tests need to be kicked a few times.~~

Reviewers will probably notice we have a similar limit of 1000kg which also is not warned/enforced. I didn't touch that in this PR as erroneous volume weights shouldn't cause issues of the same scale. It probably should be enforced (and maybe I'll even be the one to do it!) but there only seems to be two places where a 1000kg limit is actually checked.
(Also we have existing items which go past this limit and *should* go past it!)
