### PR TITLE
edit regen in darkness code for readability and correctness

### DIFF
--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3168,7 +3168,7 @@ void monster::process_effects()
         const float light = get_map().ambient_light_at( pos() );
         // Magic number 10000 was chosen so that a floodlight prevents regeneration in a range of 20 tiles
         const float dHP = 50.0 * std::exp( - light * light / 10000 );
-        if( heal( static_cast<int>( dHP ) ) > 0 && one_in( 2 )) {
+        if( heal( static_cast<int>( dHP ) ) > 0 && one_in( 2 ) ) {
             add_msg_if_player_sees( *this, m_warning, _( "The %s uses the darkness to regenerate." ), name() );
         }
     }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -3167,7 +3167,8 @@ void monster::process_effects()
     if( type->regenerates_in_dark ) {
         const float light = get_map().ambient_light_at( pos() );
         // Magic number 10000 was chosen so that a floodlight prevents regeneration in a range of 20 tiles
-        if( heal( static_cast<int>( 50.0 *  std::exp( - light * light / 10000 ) )  > 0 && one_in( 2 ) ) ) {
+        const float dHP = 50.0 * std::exp( - light * light / 10000 );
+        if( heal( static_cast<int>( dHP ) ) > 0 && one_in( 2 )) {
             add_msg_if_player_sees( *this, m_warning, _( "The %s uses the darkness to regenerate." ), name() );
         }
     }


### PR DESCRIPTION
#### Summary
Bugfixes "monsters that regenerate in darkness would only regenerate by a single HP per turn"

#### Describe the solution

The boolean > 0 check was inside the call to heal(), so it ended up passing either 1 or 0 rather than the calculated amount of healing. The clear intent of the check, however, is to only print the message if the monster actually needed to be healed.

I also gave the calculated amount of healing a name (dHP), so that it is clear to future readers what the calculation is for; see the discussion in #67027 for an example of one of the easy ways to misread the old code.

This patch does not change when or by how much the monster regenerates.

#### Describe alternatives you've considered

See also #70774.

#### Testing

I used a debugger to step through the code, observing that the `heal` method was only passed a 1 or a 0 before the patch, and that afterwards it was passed integers between 0 and 50.
