### PR TITLE
Disable number invlets in inventory selectors when numpad nav is enabled

### DIFF
--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -2331,10 +2331,11 @@ void inventory_selector::prepare_layout( size_t client_width, size_t client_heig
 void inventory_selector::reassign_custom_invlets()
 {
     if( invlet_type_ == SELECTOR_INVLET_DEFAULT || invlet_type_ == SELECTOR_INVLET_NUMERIC ) {
-        int min_invlet = static_cast<uint8_t>( use_invlet ? '0' : '\0' );
+        bool use_num_invlet = uistate.numpad_navigation ? false : use_invlet;
+        int min_invlet = static_cast<uint8_t>( use_num_invlet ? '0' : '\0' );
         for( inventory_column *elem : columns ) {
             elem->prepare_paging();
-            min_invlet = elem->reassign_custom_invlets( u, min_invlet, use_invlet ? '9' : '\0' );
+            min_invlet = elem->reassign_custom_invlets( u, min_invlet, use_num_invlet ? '9' : '\0' );
         }
     } else if( invlet_type_ == SELECTOR_INVLET_ALPHA ) {
         const std::string all_pickup_chars = use_invlet ?
@@ -2945,6 +2946,7 @@ void inventory_selector::on_input( const inventory_input &input )
         toggle_categorize_contained();
     } else if( input.action == "TOGGLE_NUMPAD_NAVIGATION" ) {
         uistate.numpad_navigation = !uistate.numpad_navigation;
+        reassign_custom_invlets();
     } else if( input.action == "EXAMINE_CONTENTS" ) {
         const inventory_entry &selected = get_active_column().get_highlighted();
         if( selected ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Disable number invlets in inventory selectors when numpad nav is enabled"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #67559. Numeric invlet keys interfere with numpad menu navigation, which is very annoying to deal with.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
When numpad navigation is enabled (the `Numpad ON` header), numeric invlets will be disabled. Inventory selectors that use alphabetic invlets will work either way.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I played around with making all inventory selectors default to using Alphabetic invlets, which seemed to work, but I felt like there had to be a reason that's not the default already*, so didn't go through with it.

<details><summary>*</summary>
<p>
Players would already be used to the numeric invlets? Using numeric invlets for map items helps keep them distinctly separate from the inventory? I wouldn't be surprised if there's a discussion about it somewhere.
</p>
</details> 

An alternative solution would be to stop the inventory selector from always using keychar mode, which could be accomplished by removing `, keyboard_mode::keychar` from here:
```
inventory_selector::inventory_selector( Character &u, const inventory_selector_preset &preset )
    : u( u )
    , preset( preset )
    , ctxt( "INVENTORY", keyboard_mode::keychar )
...
```
However, it's not that simple, as this selector is used for most inventory interactions, so they all assume the keychar context - the keycode context doesn't even seem to have default bindings for many actions. So I went with the simple solution.

Long-term, however, I think this would be the far better solution, as it would:
1. Let numpad users keep the number invlets, as they could be made to only respond to the number row keys.
2. Allow removing the whole numpad navigation toggle in favor of tying it entirely to the global keychar/keycode setting. The toggle has caused confusion in the past from players who don't know the significance of `Numpad ON` in the header.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

1. Open a non-pickup inventory selector with items on the ground around me (I used Use Item), see they have number invlets that interfere with the numpad while numpad nav is off.
2. Turn numpad nav on - invlets disappear and the numpad can navigate fine.
3. Turn numpad nav back off - invlets are back, interfere again.
4. Open a pickup-all-around-me inventory selector - alphabetic invlets show up and work no matter the setting.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This issue was the entire reason I even started contributing to the project, way back with #62437. That PR added a setting to toggle it, which is probably why it never got merged since adding extraneous settings is frowned on. This new implementation adds no new settings, simply linking into the numpad toggle that's already in-game, so it's more straightforward. Only took me... uh... more than a year to get around to...
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
