### PR TITLE
profession/background condition

### DIFF
--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -530,6 +530,27 @@ checks is `victim_type` has `zombie` faction
 { "compare_string": [ "zombie", { "mutator": "mon_faction", "mtype_id": { "context_val": "victim_type" } } ] }
 ```
 
+### `u_profession`
+- type: string or [variable object](##variable-object)
+- Return true if player character has the given profession id or its "hobby" subtype
+
+#### Valid talkers:
+
+| Avatar | Character | NPC | Monster |  Furniture | Item |
+| ------ | --------- | --------- | ---- | ------- | --- | 
+| ✔️ | ✔️ | ❌ | ❌ | ❌ | ❌ |
+
+#### Examples
+True if the character has selected Heist Driver profession at the character creation
+```json
+{ "u_profession": "heist_driver" }
+```
+
+True if the character has selected Fishing background at the character creation
+```json
+{ "u_profession": "fishing" }
+```
+
 ### `u_has_strength`, `npc_has_strength`, `u_has_dexterity`, `npc_has_dexterity`, `u_has_intelligence`, `npc_has_intelligence`, `u_has_perception`, `npc_has_perception`
 - type: int or [variable object](##variable-object)
 - Return true if alpha or beta talker stat is at least the value or higher

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5253,6 +5253,11 @@ const profession *Character::get_profession() const
     return prof;
 }
 
+std::set<const profession *> Character::get_hobbies() const
+{
+    return hobbies;
+}
+
 bool Character::has_mission_item( int mission_id ) const
 {
     return mission_id != -1 && has_item_with( has_mission_item_filter{ mission_id } );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -5248,6 +5248,11 @@ item Character::reduce_charges( item *it, int quantity )
     return result;
 }
 
+const profession *Character::get_profession() const
+{
+    return prof;
+}
+
 bool Character::has_mission_item( int mission_id ) const
 {
     return mission_id != -1 && has_item_with( has_mission_item_filter{ mission_id } );

--- a/src/character.h
+++ b/src/character.h
@@ -755,6 +755,8 @@ class Character : public Creature, public visitable
 
         //returns character's profession
         const profession *get_profession() const;
+        //returns the hobbies
+        std::set<const profession *> get_hobbies() const;
 
         // Has item with mission_id
         bool has_mission_item( int mission_id ) const;

--- a/src/character.h
+++ b/src/character.h
@@ -753,6 +753,9 @@ class Character : public Creature, public visitable
         virtual bool is_ally( const Character &p ) const = 0;
         virtual bool is_obeying( const Character &p ) const = 0;
 
+        //returns character's profession
+        const profession *get_profession() const;
+
         // Has item with mission_id
         bool has_mission_item( int mission_id ) const;
 

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -46,6 +46,7 @@
 #include "overmapbuffer.h"
 #include "point.h"
 #include "popup.h"
+#include "profession.h"
 #include "ranged.h"
 #include "recipe_groups.h"
 #include "talker.h"
@@ -627,6 +628,19 @@ void conditional_t::set_u_safe_mode_trigger( const JsonObject &jo, std::string_v
         const int card_dir = static_cast<int>( io::string_to_enum<cardinal_direction>( dir.evaluate(
                 d ) ) );
         return get_avatar().get_mon_visible().dangerous[card_dir];
+    };
+}
+
+void conditional_t::set_u_profession( const JsonObject& jo, std::string_view member )
+{
+    str_or_var u_profession = get_str_or_var( jo.get_member( member ), member, true );
+    condition = [u_profession]( dialogue const & d ) {
+        const profession *prof = get_player_character().get_profession();
+        if( prof->get_profession_id() == profession_id( u_profession.evaluate( d ) ) ) {
+            return true;
+        } else {
+            return false;
+        }
     };
 }
 
@@ -3462,6 +3476,7 @@ parsers = {
     {"u_has_mission", jarg::string, &conditional_t::set_u_has_mission },
     {"u_monsters_in_direction", jarg::string, &conditional_t::set_u_monsters_in_direction },
     {"u_safe_mode_trigger", jarg::member, &conditional_t::set_u_safe_mode_trigger },
+    {"u_profession", jarg::string, &conditional_t::set_u_profession },
     {"u_has_strength", "npc_has_strength", jarg::member | jarg::array, &conditional_t::set_has_strength },
     {"u_has_dexterity", "npc_has_dexterity", jarg::member | jarg::array, &conditional_t::set_has_dexterity },
     {"u_has_intelligence", "npc_has_intelligence", jarg::member | jarg::array, &conditional_t::set_has_intelligence },

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -636,8 +636,17 @@ void conditional_t::set_u_profession( const JsonObject &jo, std::string_view mem
     str_or_var u_profession = get_str_or_var( jo.get_member( member ), member, true );
     condition = [u_profession]( dialogue const & d ) {
         const profession *prof = get_player_character().get_profession();
+        std::set<const profession *> hobbies = get_player_character().get_hobbies();
         if( prof->get_profession_id() == profession_id( u_profession.evaluate( d ) ) ) {
             return true;
+        } else if( profession_id( u_profession.evaluate( d ) )->is_hobby() ) {
+            for ( const profession *hob : hobbies ) {
+                if( hob->get_profession_id() == profession_id( u_profession.evaluate( d ) ) ) {
+                    return true;
+                }
+                break;
+            }
+            return false;
         } else {
             return false;
         }

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -631,7 +631,7 @@ void conditional_t::set_u_safe_mode_trigger( const JsonObject &jo, std::string_v
     };
 }
 
-void conditional_t::set_u_profession( const JsonObject& jo, std::string_view member )
+void conditional_t::set_u_profession( const JsonObject &jo, std::string_view member )
 {
     str_or_var u_profession = get_str_or_var( jo.get_member( member ), member, true );
     condition = [u_profession]( dialogue const & d ) {

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -640,7 +640,7 @@ void conditional_t::set_u_profession( const JsonObject &jo, std::string_view mem
         if( prof->get_profession_id() == profession_id( u_profession.evaluate( d ) ) ) {
             return true;
         } else if( profession_id( u_profession.evaluate( d ) )->is_hobby() ) {
-            for ( const profession *hob : hobbies ) {
+            for( const profession *hob : hobbies ) {
                 if( hob->get_profession_id() == profession_id( u_profession.evaluate( d ) ) ) {
                     return true;
                 }

--- a/src/condition.h
+++ b/src/condition.h
@@ -103,6 +103,7 @@ struct conditional_t {
         void set_u_has_mission( const JsonObject &jo, std::string_view member );
         void set_u_monsters_in_direction( const JsonObject &jo, std::string_view member );
         void set_u_safe_mode_trigger( const JsonObject &jo, std::string_view member );
+        void set_u_profession( const JsonObject &jo, std::string_view member );
         void set_has_strength( const JsonObject &jo, std::string_view member, bool is_npc = false );
         void set_has_dexterity( const JsonObject &jo, std::string_view member, bool is_npc = false );
         void set_has_intelligence( const JsonObject &jo, std::string_view member, bool is_npc = false );

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -841,6 +841,11 @@ const
     return ret;
 }
 
+profession_id profession::get_profession_id() const
+{
+    return id;
+}
+
 bool profession::is_hobby() const
 {
     return _subtype == "hobby";

--- a/src/profession.h
+++ b/src/profession.h
@@ -135,6 +135,9 @@ class profession
         std::map<spell_id, int> spells() const;
         void learn_spells( avatar &you ) const;
 
+        //returns the profession id
+        profession_id get_profession_id() const;
+
         /**
          * Check if this type of profession has a certain flag set.
          *


### PR DESCRIPTION
#### Summary
Features "add a profession condition for EOCs"

#### Purpose of change
It was weird to me that there was no profession/background condition. I've added this mainly for the npc dialogues, like a troubled character can ask to do a confession if you are a priest, or you can speak with the refugee center EMT about the hard days before cataclysm if you were an EMT. Or speak with someone about a hobby if you have a certain background. Just some roleplaying stuff.

But I think it would be otherwise useful as well. Maybe it can help unhardcode few profession related things, like churl or foodperson dialogue.

#### Describe the solution
Add a "u_profession" condition that reads the player's profession id and returns true if the player has that background or hobby(background). That's it.

#### Describe alternatives you've considered
don't do this ( please do this :( )

#### Testing
For testing purposes smokes at the refuge center will have surprise for career politicians
![Ekran görüntüsü 2024-01-10 082750](https://github.com/CleverRaven/Cataclysm-DDA/assets/30256012/377870b1-4a5b-49e5-b5d4-e949557279a5)
 As you see this person has no extra dialogue because he isn't a career politician now let's try that with a politician:
![Ekran görüntüsü 2024-01-10 083007](https://github.com/CleverRaven/Cataclysm-DDA/assets/30256012/7004be80-271e-4ac1-afd1-70619d205e72)
![Ekran görüntüsü 2024-01-10 083016](https://github.com/CleverRaven/Cataclysm-DDA/assets/30256012/0f1e0caf-b5f8-4113-a17b-fd7dccab39ab)
![Ekran görüntüsü 2024-01-10 083023](https://github.com/CleverRaven/Cataclysm-DDA/assets/30256012/6d5614c9-cd15-448d-a502-03c6aa628c8b)


#### Additional context
Patiently waiting for @nornagon 's #70808 so I can adjust the code accordingly.
