### PR TITLE
Update first pass component selection to avoid poison

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1777,7 +1777,7 @@ static bool construction_activity( Character &you, const zone_data * /*zone*/,
             comp_selection<item_comp> sel;
             sel.use_from = usage_from::both;
             sel.comp = comp;
-            std::list<item> empty_consumed = you.consume_items( sel, 1, is_empty_crafting_component );
+            std::list<item> empty_consumed = you.consume_items( sel, 1, is_preferred_crafting_component );
 
             int left_to_consume = 0;
 

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -913,7 +913,7 @@ void basecamp_action_components::consume_components()
     }
     for( const comp_selection<item_comp> &sel : item_selections_ ) {
         std::list<item> empty_consumed = player_character.consume_items( target_map, sel, batch_size_,
-                                         is_empty_crafting_component, src );
+                                         is_preferred_crafting_component, src );
         int left_to_consume = 0;
 
         if( !empty_consumed.empty() && empty_consumed.front().count_by_charges() ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1030,7 +1030,7 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
                 sel.use_from = usage_from::both;
                 sel.comp = comp;
                 std::list<item> empty_consumed = player_character.consume_items( sel, 1,
-                                                 is_empty_crafting_component );
+                                                 is_preferred_crafting_component );
 
                 int left_to_consume = 0;
 

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -342,8 +342,8 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
 static std::list<item> sane_consume_items( const comp_selection<item_comp> &it, Character *crafter,
         int batch, const std::function<bool( const item & )> &filter )
 {
-    std::function<bool( const item & )> empty_container_filter = [&filter]( const item & it ) {
-        return it.is_container_empty() && filter( it );
+    std::function<bool( const item & )> preferred_component_filter = [&filter]( const item & it ) {
+        return is_preferred_component( it ) && filter( it );
     };
     map &m = get_map();
     const std::vector<pocket_data> it_pkt = it.comp.type->pockets;
@@ -351,7 +351,7 @@ static std::list<item> sane_consume_items( const comp_selection<item_comp> &it, 
     !std::any_of( it_pkt.begin(), it_pkt.end(), []( const pocket_data & p ) {
     return p.type == pocket_type::CONTAINER && p.watertight;
 } ) ) {
-        std::list<item> empty_consumed = crafter->consume_items( it, batch, empty_container_filter );
+        std::list<item> empty_consumed = crafter->consume_items( it, batch, preferred_component_filter );
         int left_to_consume = 0;
 
         if( !empty_consumed.empty() && empty_consumed.front().count_by_charges() ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -15112,3 +15112,15 @@ void item::combine( const item_contents &read_input, bool convert )
 {
     contents.combine( read_input, convert );
 }
+
+bool is_preferred_component( const item &component )
+{
+    return component.is_container_empty() && ( !component.has_flag( flag_FORAGE_POISON ) ||
+            component.has_flag( flag_HIDDEN_POISON ) ) && ( !component.has_flag( flag_FORAGE_HALLU ) ||
+                    component.has_flag( flag_HIDDEN_HALLU ) );
+}
+
+bool is_preferred_crafting_component( const item &component )
+{
+    return is_preferred_component( component ) && is_crafting_component( component );
+}

--- a/src/item.h
+++ b/src/item.h
@@ -3230,11 +3230,13 @@ inline bool is_crafting_component( const item &component )
 }
 
 /**
+ * Filter for crafting components first pass searches excluding undesirable properties.
+ */
+bool is_preferred_component( const item &component );
+
+/**
  * Filter for empty crafting components first pass searches
  */
-inline bool is_empty_crafting_component( const item &component )
-{
-    return component.is_container_empty() && is_crafting_component( component );
-}
+bool is_preferred_crafting_component( const item &component );
 
 #endif // CATA_SRC_ITEM_H


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Address the component selection half of #70796 (but not the UI display part for component selection).

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Extend the restriction for first pass item selection to exclude known poisonous and hallucinogenic items in addition to the previous exclusion of containers containing items.

As a side effect the odd case where a separate filter was used (because it was used together with a supplied filter) had its first pass filter use a common operation to remove code duplication.

The code ended up no longer being inlined as the addition relied on flags that weren't in the set of files copied into the header (and the compiler complained about mismatching definitions elsewhere when it was done).

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

- Try to figure out how to deal with the component selection display side of the report.
- Try harder to figure out how to test the solution.
 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Not Tested Should Work...

I was unable to figure out how to (if possible) spawn mushrooms (or any other item that comes in random poisonous and/or hallucinogenic variants) the were affected. Manipulating flags only seems to do that, i.e. allow the removal of flags, but not actually set that it was poisonous. Adding the hidden flag would not help testing even if it would work, as the test shouldn't exclude poison you don't know about.

Ended up with a simple regression test of ordering the base camp expansion construction of two stoves where two tanks were placed one each of the two storage zone tiles, with one being empty and one containing a liquid, and verifying the two liquid containing tanks remained and the empty ones were consumed.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

As it's not tested, it would be appreciated if the logic was double checked.

I'd appreciate if someone could explain how to (and if) you can spawn poisonous and hallucinogenic shrooms, as well as ones that are but that fact is hidden to the player for testing purposes.

I realize foraging enough should eventually result in known shrooms and/or may apples of the two known categories, but that's a fair bit of work that still wouldn't cover the hidden poison/hallucinogen case.

Spawning shrooms one at a time 20 times resulted in 20 shrooms in a stack when dropped, indicating none of them would be poisonous or hallucinogenic (and the "examine" description didn't say they were). The normal foraging code seems to give poison a 1 in 10 chance of appearing, so that sample ought to have cause some poisonous or hallucinogenic case if debug spawning used the same logic.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
