### PR TITLE
Update first pass component selection to avoid poison

### DIFF
--- a/src/activity_item_handling.cpp
+++ b/src/activity_item_handling.cpp
@@ -1777,7 +1777,7 @@ static bool construction_activity( Character &you, const zone_data * /*zone*/,
             comp_selection<item_comp> sel;
             sel.use_from = usage_from::both;
             sel.comp = comp;
-            std::list<item> empty_consumed = you.consume_items( sel, 1, is_empty_crafting_component );
+            std::list<item> empty_consumed = you.consume_items( sel, 1, is_preferred_crafting_component );
 
             int left_to_consume = 0;
 

--- a/src/basecamp.cpp
+++ b/src/basecamp.cpp
@@ -913,7 +913,7 @@ void basecamp_action_components::consume_components()
     }
     for( const comp_selection<item_comp> &sel : item_selections_ ) {
         std::list<item> empty_consumed = player_character.consume_items( target_map, sel, batch_size_,
-                                         is_empty_crafting_component, src );
+                                         is_preferred_crafting_component, src );
         int left_to_consume = 0;
 
         if( !empty_consumed.empty() && empty_consumed.front().count_by_charges() ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1030,7 +1030,7 @@ void place_construction( std::vector<construction_group_str_id> const &groups )
                 sel.use_from = usage_from::both;
                 sel.comp = comp;
                 std::list<item> empty_consumed = player_character.consume_items( sel, 1,
-                                                 is_empty_crafting_component );
+                                                 is_preferred_crafting_component );
 
                 int left_to_consume = 0;
 

--- a/src/craft_command.cpp
+++ b/src/craft_command.cpp
@@ -342,8 +342,8 @@ bool craft_command::continue_prompt_liquids( const std::function<bool( const ite
 static std::list<item> sane_consume_items( const comp_selection<item_comp> &it, Character *crafter,
         int batch, const std::function<bool( const item & )> &filter )
 {
-    std::function<bool( const item & )> empty_container_filter = [&filter]( const item & it ) {
-        return it.is_container_empty() && filter( it );
+    std::function<bool( const item & )> preferred_component_filter = [&filter]( const item & it ) {
+        return is_preferred_component( it ) && filter( it );
     };
     map &m = get_map();
     const std::vector<pocket_data> it_pkt = it.comp.type->pockets;
@@ -351,7 +351,7 @@ static std::list<item> sane_consume_items( const comp_selection<item_comp> &it, 
     !std::any_of( it_pkt.begin(), it_pkt.end(), []( const pocket_data & p ) {
     return p.type == pocket_type::CONTAINER && p.watertight;
 } ) ) {
-        std::list<item> empty_consumed = crafter->consume_items( it, batch, empty_container_filter );
+        std::list<item> empty_consumed = crafter->consume_items( it, batch, preferred_component_filter );
         int left_to_consume = 0;
 
         if( !empty_consumed.empty() && empty_consumed.front().count_by_charges() ) {

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1163,7 +1163,8 @@ bool inventory::must_use_hallu_poison( const itype_id &id, int to_use ) const
     int bad = 0;
     for( std::list<item> item_list : items ) {
         for( item it : item_list ) {
-            if( it.typeId() == id && it.has_flag( flag_HIDDEN_POISON ) || it.has_flag( flag_HIDDEN_HALLU ) ) {
+            if( it.typeId() == id && ( it.has_flag( flag_HIDDEN_POISON ) ||
+                                       it.has_flag( flag_HIDDEN_HALLU ) ) ) {
                 if( it.count_by_charges() ) {
                     bad += it.charges;
                 } else {

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1157,6 +1157,24 @@ bool inventory::must_use_liq_container( const itype_id &id, int to_use ) const
     return leftover < 0 && leftover * -1 <= total - iter->second;
 }
 
+bool inventory::must_use_hallu_poison( const itype_id &id, int to_use ) const
+{
+    const int total = count_item( id );
+    int bad = 0;
+    for( std::list<item> item_list : items ) {
+        for( item it : item_list ) {
+            if( it.typeId() == id && it.has_flag( flag_HIDDEN_POISON ) || it.has_flag( flag_HIDDEN_HALLU ) ) {
+                if( it.count_by_charges() ) {
+                    bad += it.charges;
+                } else {
+                    bad += it.count();
+                }
+            }
+        }
+    }
+    return total - bad < to_use;
+}
+
 void inventory::replace_liq_container_count( const std::map<itype_id, int> &newmap, bool use_max )
 {
     for( const auto &it : newmap ) {

--- a/src/inventory.cpp
+++ b/src/inventory.cpp
@@ -1161,8 +1161,8 @@ bool inventory::must_use_hallu_poison( const itype_id &id, int to_use ) const
 {
     const int total = count_item( id );
     int bad = 0;
-    for( std::list<item> item_list : items ) {
-        for( item it : item_list ) {
+    for( const std::list<item> &item_list : items ) {
+        for( const item &it : item_list ) {
             if( it.typeId() == id && ( it.has_flag( flag_HIDDEN_POISON ) ||
                                        it.has_flag( flag_HIDDEN_HALLU ) ) ) {
                 if( it.count_by_charges() ) {

--- a/src/inventory.h
+++ b/src/inventory.h
@@ -269,6 +269,7 @@ class inventory : public visitable
 
         // specifically used to for displaying non-empty liquid container color in crafting screen
         bool must_use_liq_container( const itype_id &id, int to_use ) const;
+        bool must_use_hallu_poison( const itype_id &id, int to_use ) const;
         void update_liq_container_count( const itype_id &id, int count );
         void replace_liq_container_count( const std::map<itype_id, int> &newmap, bool use_max = false );
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -15115,9 +15115,8 @@ void item::combine( const item_contents &read_input, bool convert )
 
 bool is_preferred_component( const item &component )
 {
-    return component.is_container_empty() && ( !component.has_flag( flag_FORAGE_POISON ) ||
-            component.has_flag( flag_HIDDEN_POISON ) ) && ( !component.has_flag( flag_FORAGE_HALLU ) ||
-                    component.has_flag( flag_HIDDEN_HALLU ) );
+    return component.is_container_empty() && !component.has_flag( flag_HIDDEN_POISON ) &&
+           !component.has_flag( flag_HIDDEN_HALLU );
 }
 
 bool is_preferred_crafting_component( const item &component )

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -15112,3 +15112,15 @@ void item::combine( const item_contents &read_input, bool convert )
 {
     contents.combine( read_input, convert );
 }
+
+bool is_preferred_component( const item &component )
+{
+    return component.is_container_empty() && ( !component.has_flag( flag_FORAGE_POISON ) ||
+            component.has_flag( flag_HIDDEN_POISON ) ) && ( !component.has_flag( flag_FORAGE_HALLU ) ||
+                    component.has_flag( flag_HIDDEN_HALLU ) );
+}
+
+bool is_preferred_crafting_component( const item &component )
+{
+    return is_preferred_component( component ) && is_crafting_component( component );
+}

--- a/src/item.h
+++ b/src/item.h
@@ -3230,11 +3230,13 @@ inline bool is_crafting_component( const item &component )
 }
 
 /**
+ * Filter for crafting components first pass searches excluding undesirable properties.
+ */
+bool is_preferred_component( const item &component );
+
+/**
  * Filter for empty crafting components first pass searches
  */
-inline bool is_empty_crafting_component( const item &component )
-{
-    return component.is_container_empty() && is_crafting_component( component );
-}
+bool is_preferred_crafting_component( const item &component );
 
 #endif // CATA_SRC_ITEM_H

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -750,7 +750,7 @@ std::vector<std::string> requirement_data::get_folded_components_list( int width
 }
 
 template<typename T>
-std::vector<std::string> requirement_data::w( int width,
+std::vector<std::string> requirement_data::get_folded_list( int width,
         const read_only_visitable &crafting_inv, const std::function<bool( const item & )> &filter,
         const std::vector< std::vector<T> > &objs, int batch, const std::string_view hilite,
         requirement_display_flags flags ) const

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -750,7 +750,7 @@ std::vector<std::string> requirement_data::get_folded_components_list( int width
 }
 
 template<typename T>
-std::vector<std::string> requirement_data::get_folded_list( int width,
+std::vector<std::string> requirement_data::w( int width,
         const read_only_visitable &crafting_inv, const std::function<bool( const item & )> &filter,
         const std::vector< std::vector<T> > &objs, int batch, const std::string_view hilite,
         requirement_display_flags flags ) const
@@ -993,6 +993,9 @@ nc_color item_comp::get_color( bool has_one, const read_only_visitable &crafting
         if( std::any_of( type->pockets.begin(), type->pockets.end(), []( const pocket_data & d ) {
         return d.type == pocket_type::CONTAINER && d.watertight;
     } ) && inv != nullptr && inv->must_use_liq_container( type, count * batch ) ) {
+            return c_magenta;
+        }
+        if( inv != nullptr && inv->must_use_hallu_poison( type, count * batch ) ) {
             return c_magenta;
         }
         // Will use favorited component


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary

None

<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #70796, i.e. select non poisonous/hallucinogenic food in preference of poisonous/hallucinogenic one where the same item exists in both variants, as well as indicate the need to use such undesirable items when there aren't enough of them by coloring the item line in magenta (same logic that's used for used water tight containers).

Note: This PR's purpose has been expanded from its first incarnation. The various edit notes have been removed and only the "final" content remains. This note is made to explain why things have changed, if anyone has looked at the PR previously.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Extend the restriction for first pass item selection to exclude known poisonous and hallucinogenic items in addition to the previous exclusion of containers containing items.

As a side effect the odd case where a separate filter was used (because it was used together with a supplied filter) had its first pass filter use a common operation to remove code duplication.

The code ended up no longer being inlined as the addition relied on flags that weren't in the set of files copied into the header (and the compiler complained about mismatching definitions elsewhere when it was done).

Changed the logic for component coloring to use the same kind of two pass process the component selection used, as that logic also had the side effect of determining whether components should be consumed from the personal inventory, environment inventory, or both. The changed process also made use of the same filter as the consumption used, rather than local defined ones. This added the effect handling poisonous/hallucinogenic food items.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

- Try to figure out how to detect if the crafter is unaware of the poison. My current belief is that this information is not stored, but calculated on the fly for display only purposes when a poisonous/hallucinogenic item is found.
- Change the consumption logic for used containers to a three pass process, where the first pass would look for any kind of empty containers, the second one add containers using non liquid contents, and the third one going for all containers. Considered out of scope, as well as not obvious it would be desired.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

- Debug spawned two normal and two poisonous mushrooms.
- Dropped one of each on the tile to the south of the PC.
- Crafted cooked mushrooms (the recipe uses two mushrooms).
- Verified I ended up with normal (not poisonous) cooked mushrooms.
- Spawned two normal mushrooms and dropped one on the tile beneath the PC's feet together with the poisonous one in the inventory.
- Crafted cooked mushrooms and verified the result was non poisonous and that the poisonous mushrooms remained where they were dropped.
- Spawned a normal mushroom.
- Crafted cooked mushrooms, verifying the shroom entry was magenta and that the result was poisonous.
- Spawned the components for two charcoal kilns and dropped one tank on the tile beneath the PC and the other on the tile to the east (had moved to a different crafting spot as I had most materials available there).
- Spawned two more tanks and "refilled" them with fluid. Dropped one tank on the tile beneath the PC and the other on the tile to the east.
- Crafted two charcoal kilns and verified the used tanks remained on the floor (this test is a regression test).
- Verified the charcoal kiln recipe entry showed the tank component in magenta (as no empty tanks were available). Again, this is a regression test.

In addition to the "formal" ones above, a lot of tests were made during the development of this PR, including ones using hallucinogenic mushrooms.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

As noted, I'm unable to test for usage of undetected poisonous shrooms, but I doubt there actually is such a thing beside the message shown when the shrooms are discovered. There's some Survival based code for whether to detect if shrooms are poisonous/hallucinogenic, but I failed to see any code to keep track of that on the item itself.

During the development and testing of this PR, #70846 was encountered. It was verified that bug existed prior to the start of the work on this PR.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
