### PR TITLE
Add missing paints to paint requirement

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -8035,7 +8035,7 @@
     "category": "CONSTRUCT",
     "time": "1 m",
     "difficulty": 0,
-    "using": [ [ "marking_soft", 1, "LIST" ] ]
+    "using": [ [ "marking_soft", 1, "LIST" ] ],
     "pre_terrain": "f_hay",
     "post_terrain": "f_archery_target_bale"
   },

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -8035,7 +8035,7 @@
     "category": "CONSTRUCT",
     "time": "1 m",
     "difficulty": 0,
-    "using": [ [ "marking_soft", 10, "LIST" ] ],
+    "using": [ [ "marking_soft", 1, "LIST" ] ],
     "pre_terrain": "f_hay",
     "post_terrain": "f_archery_target_bale"
   },

--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -8035,7 +8035,7 @@
     "category": "CONSTRUCT",
     "time": "1 m",
     "difficulty": 0,
-    "using": [ [ "marking_soft", 1, "LIST" ] ],
+    "using": [ [ "marking_soft", 1, "LIST" ] ]
     "pre_terrain": "f_hay",
     "post_terrain": "f_archery_target_bale"
   },

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -3133,11 +3133,11 @@
     "autolearn": true,
     "proficiencies": [ { "proficiency": "prof_carpentry_basic" } ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 2 } ],
+    "using": [ [ "marking_hard", 25, "LIST" ] ],
     "components": [
       [ [ "wood_panel", 1 ] ],
       [ [ "2x4", 2 ] ],
       [ [ "nail", 30 ], [ "bronze_nail", 30 ] ],
-      [ [ "duct_tape", 25 ], [ "medical_tape", 50 ], [ "paint", 1, "LIST" ] ],
       [ [ "2x4", 4 ], [ "log", 1 ], [ "wood_beam", 1 ] ]
     ]
   },

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -3133,7 +3133,7 @@
     "autolearn": true,
     "proficiencies": [ { "proficiency": "prof_carpentry_basic" } ],
     "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_W", "level": 2 } ],
-    "using": [ [ "marking_hard", 25, "LIST" ] ],
+    "using": [ [ "marking_hard", 1, "LIST" ] ],
     "components": [
       [ [ "wood_panel", 1 ] ],
       [ [ "2x4", 2 ] ],
@@ -3267,7 +3267,7 @@
     "skill_used": "fabrication",
     "time": "8 m",
     "autolearn": true,
-    "using": [ [ "fabric_standard", 200 ], [ "marking_hard", 10, "LIST" ] ],
+    "using": [ [ "fabric_standard", 200 ], [ "marking_hard", 1, "LIST" ] ],
     "components": [ [ [ "box_medium", 1 ] ] ]
   },
   {

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -449,11 +449,17 @@
     "components": [
       [
         [ "paint_red", 1 ],
-        [ "paint_blue", 1 ],
-        [ "paint_white", 1 ],
+        [ "paint_orange", 1 ],
+        [ "paint_yellow", 1 ],
         [ "paint_green", 1 ],
+        [ "paint_cyan", 1 ],
+        [ "paint_blue", 1 ],
+        [ "paint_pink", 1 ],
         [ "paint_purple", 1 ],
-        [ "paint_yellow", 1 ]
+        [ "paint_white", 1 ],
+        [ "paint_gray", 1 ],
+        [ "paint_black", 1 ],
+        [ "paint_brown", 1 ]
       ]
     ]
   },

--- a/data/json/requirements/materials.json
+++ b/data/json/requirements/materials.json
@@ -446,7 +446,7 @@
     "id": "paint",
     "type": "requirement",
     "//": "Materials used for painting something of any color",
-    "components": [
+    "tools": [
       [
         [ "paint_red", 1 ],
         [ "paint_orange", 1 ],

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -390,7 +390,7 @@
   {
     "id": "marking_hard",
     "type": "requirement",
-    "//": "Tools to mark a hard surface. Uses individual paint colors as using the paint requirement didn't work",
+    "//": "Tools to mark a hard surface.",
     "tools": [
       [
         [ "ink_standard", 2, "LIST" ],
@@ -398,41 +398,19 @@
         [ "duct_tape", 1 ],
         [ "permanent_marker", 1 ],
         [ "survival_marker", -1 ],
-        [ "paint_red", 1 ],
-        [ "paint_blue", 1 ],
-        [ "paint_white", 1 ],
-        [ "paint_green", 1 ],
-        [ "paint_purple", 1 ],
-        [ "paint_yellow", 1 ],
-        [ "paint_black", 1 ],
-        [ "paint_gray", 1 ],
-        [ "paint_brown", 1 ],
-        [ "paint_cyan", 1 ],
-        [ "paint_pink", 1 ],
-        [ "paint_orange", 1 ]
+        [ "paint", 1, "LIST" ]
       ]
     ]
   },
   {
     "id": "marking_soft",
     "type": "requirement",
-    "//": "Tools to mark a soft, rough surface. Uses individual paint colors as using the paint requirement didn't work",
+    "//": "Tools to mark a soft, rough surface.",
     "tools": [
       [
         [ "duct_tape", 1 ],
         [ "survival_marker", -1 ],
-        [ "paint_red", 1 ],
-        [ "paint_blue", 1 ],
-        [ "paint_white", 1 ],
-        [ "paint_green", 1 ],
-        [ "paint_purple", 1 ],
-        [ "paint_yellow", 1 ],
-        [ "paint_black", 1 ],
-        [ "paint_gray", 1 ],
-        [ "paint_brown", 1 ],
-        [ "paint_cyan", 1 ],
-        [ "paint_pink", 1 ],
-        [ "paint_orange", 1 ]
+        [ "paint", 1, "LIST" ]
       ]
     ]
   },

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -393,10 +393,10 @@
     "//": "Tools to mark a hard surface.",
     "tools": [
       [
-        [ "ink_standard", 2, "LIST" ],
-        [ "medical_tape", 1 ],
-        [ "duct_tape", 1 ],
-        [ "permanent_marker", 1 ],
+        [ "ink_standard", 50, "LIST" ],
+        [ "medical_tape", 25 ],
+        [ "duct_tape", 25 ],
+        [ "permanent_marker", 25 ],
         [ "survival_marker", -1 ],
         [ "paint", 1, "LIST" ]
       ]
@@ -406,7 +406,7 @@
     "id": "marking_soft",
     "type": "requirement",
     "//": "Tools to mark a soft, rough surface.",
-    "tools": [ [ [ "duct_tape", 1 ], [ "survival_marker", -1 ], [ "paint", 1, "LIST" ] ] ]
+    "tools": [ [ [ "duct_tape", 25 ], [ "survival_marker", -1 ], [ "paint", 1, "LIST" ] ] ]
   },
   {
     "id": "ppe_gloves",

--- a/data/json/requirements/toolsets.json
+++ b/data/json/requirements/toolsets.json
@@ -406,13 +406,7 @@
     "id": "marking_soft",
     "type": "requirement",
     "//": "Tools to mark a soft, rough surface.",
-    "tools": [
-      [
-        [ "duct_tape", 1 ],
-        [ "survival_marker", -1 ],
-        [ "paint", 1, "LIST" ]
-      ]
-    ]
+    "tools": [ [ [ "duct_tape", 1 ], [ "survival_marker", -1 ], [ "paint", 1, "LIST" ] ] ]
   },
   {
     "id": "ppe_gloves",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds paints missing from the "paint" requirement
Removes paints from the other two requirements that manually list the paints and replaces them with the altered requirement
Changes training_dummy_light to use the marking_hard requirement

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked the 2 recipes and 1 construction ( :c ) actually using these work
Checked it still consumes paint

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
