### PR TITLE
#68633 Avoid duplicates in speed adjustments

### DIFF
--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -956,7 +956,7 @@ static std::vector<speedlist_entry> get_speedlist_entries( const Character &you,
     }
 
     for( const speed_bonus_effect &effect : you.get_speed_bonus_effects() ) {
-        if( effect.bonus != 0 && speed_effects.end() == speed_effects.find(effect.description) ) {
+        if( effect.bonus != 0 && speed_effects.end() == speed_effects.find( effect.description ) ) {
             const speedlist_entry entry { true, effect.description, effect.bonus, false };
             entries.push_back( entry );
         }

--- a/src/player_display.cpp
+++ b/src/player_display.cpp
@@ -948,20 +948,20 @@ static std::vector<speedlist_entry> get_speedlist_entries( const Character &you,
 {
     std::vector<speedlist_entry> entries;
 
-    for( const speed_bonus_effect &effect : you.get_speed_bonus_effects() ) {
-        if( effect.bonus != 0 ) {
-            const speedlist_entry entry { true, effect.description, effect.bonus, false };
-            entries.push_back( entry );
-        }
-    }
-
-    //FIXME I think these are already included above. Need more testing.
     for( const std::pair<const std::string, int> &speed_effect : speed_effects ) {
         if( speed_effect.second != 0 ) {
             const speedlist_entry entry { true, speed_effect.first, speed_effect.second, false };
             entries.push_back( entry );
         }
     }
+
+    for( const speed_bonus_effect &effect : you.get_speed_bonus_effects() ) {
+        if( effect.bonus != 0 && speed_effects.end() == speed_effects.find(effect.description) ) {
+            const speedlist_entry entry { true, effect.description, effect.bonus, false };
+            entries.push_back( entry );
+        }
+    }
+
 
     float movecost = 100;
     for( const run_cost_effect &effect : you.run_cost_effects( movecost ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Avoid duplicates in speed adjustments"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
`Creature::effects` can be altered by the debug menu, but `Character::mod_speed_bonus` is altered during a turn, so in the future. This is probably what created confusion, as by the note comment in previous code.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
I inverted the two loops so that I first fill the `std::vector` with the `std::map`.
Then I append `speed_bonus_effects` but using the `std::map` to avoid duplicates.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Only on Windows 10 SDL, under VS debugger. Using Debug menu to add frenzy effect, step through code and observe.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
