### PR TITLE
Scrapper NPC now calls soldering wire solder.

### DIFF
--- a/data/json/npcs/scrap_trader/scrap_trader_missions.json
+++ b/data/json/npcs/scrap_trader/scrap_trader_missions.json
@@ -53,8 +53,8 @@
   {
     "id": "MISSION_SCRAP_TRADER_GET_100_SOLDER",
     "type": "mission_definition",
-    "name": "Obtain 100 Solder Wire",
-    "description": "Obtain 100 soldering wire in exchange for credit with the scrap merchant.",
+    "name": "Obtain 100 Solder",
+    "description": "Obtain 100 solder in exchange for credit with the scrap merchant.",
     "goal": "MGOAL_FIND_ITEM",
     "item": "solder_wire",
     "count": 100,
@@ -65,7 +65,7 @@
     "has_generic_rewards": true,
     "dialogue": {
       "describe": "I need help…",
-      "offer": "That machine I put together needs some repairs on it, but I'm out of soldering wire.  If you could get me about 100 spools, I'll pay you for it.",
+      "offer": "That machine I put together needs some repairs on it, but I'm out of solder.  If you could get me about 100 spools, I'll pay you for it.",
       "advice": "An electronics store might have some.",
       "accepted": "I'll be here when you get back.  Good luck!",
       "rejected": "Someone's got to do it.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Scrapper NPCs now call soldering wire solder."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #70817. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Change all instances of soldering wire to solder.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Talked to the NPC, they didn't call it soldering wire anymore.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
