### PR TITLE
More verbose main menu versioning

### DIFF
--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -339,7 +339,7 @@ void main_menu::print_menu( const catacurses::window &w_open, int iSel, const po
     }
 
     iLine++;
-    center_print( w_open, iLine, c_light_blue, string_format( _( "Version: %s" ),
+    center_print( w_open, iLine, c_light_blue, string_format( _( "Version: 0.I Experimental, build %s" ),
                   getVersionString() ) );
 
     int menu_length = 0;

--- a/src/main_menu.cpp
+++ b/src/main_menu.cpp
@@ -339,8 +339,9 @@ void main_menu::print_menu( const catacurses::window &w_open, int iSel, const po
     }
 
     iLine++;
-    center_print( w_open, iLine, c_light_blue, string_format( _( "Version: 0.I Experimental, build %s" ),
-                  getVersionString() ) );
+    center_print( w_open, iLine, c_light_blue,
+                  string_format( _( "Version: 0.I Experimental, build %s" ),
+                                 getVersionString() ) );
 
     int menu_length = 0;
     for( size_t i = 0; i < vMenuItems.size(); ++i ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None

#### Purpose of change

In adjusting some of our versioning strings, I noticed that one of the things I hardly ever look at, the version string in the game's main menu, just shows a commit number and nothing about the lettered release and stable/experimental.

This could be made easier, which in turn helps people know what they're playing.

#### Describe the solution

This just adds a small descriptive string. It will have to be manually updated as we move through versions.

#### Describe alternatives you've considered

There are a bunch of ways to automate this but honestly I think it's better to do it simply like this, so that there is less chance of introducing bugs, since the very last commit of a stable release is gonna be changing this bit and we don't want that to unexpectedly break something.

#### Testing

I'm at work, will try to test from home tonight. There's very little chance of this breaking anything, as far as I know.

#### Additional context

This might also help enforce the versioning I've been wanting to standardize, ie the current experiemental we're in is actually 0.I experimental now that we have a 0.H stable cnadidate. Without a visible reminder this is hard to keep track of.