### PR TITLE
Add gun-mounted ammo holders

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -2387,5 +2387,10 @@
     "id": "BLEEDSLOW2",
     "type": "json_flag",
     "info": "The character bleeds even slower than normal, losing blood at 1/3rd the normal rate."
+  },
+  {
+    "id": "NOT_MAGAZINE",
+    "type": "json_flag",
+    "//": "Skips a check in Character::list_ammo that would otherwise prevent items here from being used to reload a gun."
   }
 ]

--- a/data/json/items/gunmod/accessories.json
+++ b/data/json/items/gunmod/accessories.json
@@ -138,8 +138,8 @@
     "type": "GUNMOD",
     "name": { "str": "stock-mounted shell holder" },
     "description": "Designed to be strapped to the side of a shotgun's stock, this polymer shotshell holder can store five 12 gauge shells for easy reloading.",
-    "weight": "16 g",
-    "volume": "60 ml",
+    "weight": "50 g",
+    "volume": "350 ml",
     "price": 2000,
     "price_postapoc": 50,
     "install_time": "30 s",
@@ -149,6 +149,16 @@
     "color": "black",
     "location": "stock accessory",
     "mod_targets": [ "shotgun" ],
+    "pocket_data": [
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": true,
+        "max_contains_volume": "100 ml",
+        "max_contains_weight": "250 g",
+        "ammo_restriction": { "shot": 5 },
+        "moves": 25
+      }
+    ],
     "pocket_mods": [
       {
         "pocket_type": "CONTAINER",

--- a/data/json/items/gunmod/accessories.json
+++ b/data/json/items/gunmod/accessories.json
@@ -132,5 +132,33 @@
     "location": "belt clip",
     "mod_targets": [ "rugerlcp", "kp32", "kp3at", "kpf9", "cop_38", "moss_brownie" ],
     "flags": [ "IS_ARMOR", "SKINTIGHT", "WATER_FRIENDLY" ]
+  },
+  {
+    "id": "12_gauge_shell_holder",
+    "type": "GUNMOD",
+    "name": { "str": "12 gauge shell holder" },
+    "description": "Designed to be affixed to the side of a shotgun's receiver, this polymer shotshell holder can store six 12 gauge shells for easy reloading.",
+    "weight": "16 g",
+    "volume": "60 ml",
+    "price": 2000,
+    "price_postapoc": 50,
+    "install_time": "30 s",
+    "material": [ "plastic" ],
+    "flags": [ "NOT_MAGAZINE" ],
+    "symbol": ":",
+    "color": "black",
+    "location": "loading port",
+    "mod_targets": [ "shotgun" ],
+    "pocket_mods": [
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": true,
+        "max_contains_volume": "120 ml",
+        "max_contains_weight": "300 g",
+        "ammo_restriction": { "shot": 6 },
+        "moves": 25
+      }
+    ],
+    "min_skills": [ [ "weapon", 1 ] ]
   }
 ]

--- a/data/json/items/gunmod/accessories.json
+++ b/data/json/items/gunmod/accessories.json
@@ -134,28 +134,112 @@
     "flags": [ "IS_ARMOR", "SKINTIGHT", "WATER_FRIENDLY" ]
   },
   {
-    "id": "12_gauge_shell_holder",
+    "id": "12ga_shell_holder_stock",
     "type": "GUNMOD",
-    "name": { "str": "12 gauge shell holder" },
-    "description": "Designed to be affixed to the side of a shotgun's receiver, this polymer shotshell holder can store six 12 gauge shells for easy reloading.",
+    "name": { "str": "stock-mounted shell holder" },
+    "description": "Designed to be strapped to the side of a shotgun's stock, this polymer shotshell holder can store five 12 gauge shells for easy reloading.",
     "weight": "16 g",
     "volume": "60 ml",
     "price": 2000,
     "price_postapoc": 50,
     "install_time": "30 s",
     "material": [ "plastic" ],
-    "flags": [ "NOT_MAGAZINE", "TARDIS" ],
+    "flags": [ "NOT_MAGAZINE" ],
     "symbol": ":",
     "color": "black",
-    "location": "loading port",
+    "location": "stock accessory",
     "mod_targets": [ "shotgun" ],
     "pocket_mods": [
       {
         "pocket_type": "CONTAINER",
         "rigid": true,
-        "max_contains_volume": "120 ml",
-        "max_contains_weight": "300 g",
-        "ammo_restriction": { "shot": 6 },
+        "max_contains_volume": "100 ml",
+        "max_contains_weight": "250 g",
+        "ammo_restriction": { "shot": 5 },
+        "moves": 25
+      }
+    ],
+    "min_skills": [ [ "weapon", 1 ] ]
+  },
+  {
+    "id": "12ga_shell_holder_stock_leather",
+    "type": "GUNMOD",
+    "name": { "str": "stock-mounted leather shell holder" },
+    "description": "Designed to be strapped to the side of a shotgun's stock, this leather shotshell holder can store five 12 gauge shells for easy reloading.",
+    "weight": "16 g",
+    "volume": "60 ml",
+    "price": 2000,
+    "price_postapoc": 50,
+    "install_time": "30 s",
+    "material": [ "leather" ],
+    "flags": [ "NOT_MAGAZINE" ],
+    "symbol": ":",
+    "color": "brown",
+    "location": "stock accessory",
+    "mod_targets": [ "shotgun" ],
+    "pocket_mods": [
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": true,
+        "max_contains_volume": "100 ml",
+        "max_contains_weight": "250 g",
+        "ammo_restriction": { "shot": 5 },
+        "moves": 25
+      }
+    ],
+    "min_skills": [ [ "weapon", 1 ] ]
+  },
+  {
+    "id": "rifle_cart_holder_stock",
+    "type": "GUNMOD",
+    "name": { "str": "stock-mounted cartridge holder" },
+    "description": "Designed to be strapped to the side of a rifle's stock, this polymer cartridge holder can store seven rounds for easy reloading.  Fits most larger calibers.",
+    "weight": "16 g",
+    "volume": "60 ml",
+    "price": 2000,
+    "price_postapoc": 50,
+    "install_time": "30 s",
+    "material": [ "plastic" ],
+    "flags": [ "NOT_MAGAZINE" ],
+    "symbol": ":",
+    "color": "black",
+    "location": "stock accessory",
+    "mod_targets": [ "rifle" ],
+    "pocket_mods": [
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": true,
+        "max_contains_volume": "100 ml",
+        "max_contains_weight": "250 g",
+        "ammo_restriction": { "338lapua": 7, "3007": 7, "300": 7, "308": 7, "762R": 7, "77mm_arisaka": 7, "762": 7, "50": 7, "30carbine": 7, "223": 7, "123ln": 7, "303": 7 },
+        "moves": 25
+      }
+    ],
+    "min_skills": [ [ "weapon", 1 ] ]
+  },
+  {
+    "id": "rifle_cart_holder_stock_leather",
+    "type": "GUNMOD",
+    "name": { "str": "stock-mounted leather cartridge holder" },
+    "description": "Designed to be strapped to the side of a rifle's stock, this leather cartridge holder can store seven rounds for easy reloading.  Fits most larger calibers.",
+    "weight": "16 g",
+    "volume": "60 ml",
+    "price": 2000,
+    "price_postapoc": 50,
+    "install_time": "30 s",
+    "material": [ "leather" ],
+    "flags": [ "NOT_MAGAZINE" ],
+    "symbol": ":",
+    "color": "brown",
+    "location": "stock accessory",
+    "mod_targets": [ "rifle" ],
+    "pocket_mods": [
+      {
+        "pocket_type": "CONTAINER",
+        "rigid": true,
+        "max_contains_volume": "100 ml",
+        "max_contains_weight": "250 g",
+        "ammo_restriction": { "338lapua": 7, "3007": 7, "300": 7, "308": 7, "762R": 7, "77mm_arisaka": 7, "762": 7, "50": 7, "30carbine": 7, "223": 7, "123ln": 7, "303": 7 },
         "moves": 25
       }
     ],

--- a/data/json/items/gunmod/accessories.json
+++ b/data/json/items/gunmod/accessories.json
@@ -144,7 +144,7 @@
     "price_postapoc": 50,
     "install_time": "30 s",
     "material": [ "plastic" ],
-    "flags": [ "NOT_MAGAZINE" ],
+    "flags": [ "NOT_MAGAZINE", "TARDIS" ],
     "symbol": ":",
     "color": "black",
     "location": "loading port",

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -636,7 +636,7 @@ void gunmod_remove_activity_actor::finish( player_activity &act, Character &who 
 
 bool gunmod_remove_activity_actor::gunmod_unload( Character &who, item &gunmod )
 {
-    if( gunmod.has_flag( flag_BRASS_CATCHER ) ) {
+    if( gunmod.has_flag( flag_BRASS_CATCHER ) || gunmod.has_flag( flag_NOT_MAGAZINE ) ) {
         // Exclude brass catchers so that removing them wouldn't spill the casings
         return true;
     }

--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -674,19 +674,21 @@ void gunmod_remove_activity_actor::serialize( JsonOut &jsout ) const
     jsout.member( "moves_total", moves_total );
     jsout.member( "gun", gun );
     jsout.member( "gunmod", gunmod_idx );
+    jsout.member( "mod_contents", mod_contents );
 
     jsout.end_object();
 }
 
 std::unique_ptr<activity_actor> gunmod_remove_activity_actor::deserialize( JsonValue &jsin )
 {
-    gunmod_remove_activity_actor actor( 0, item_location(), -1 );
+    gunmod_remove_activity_actor actor( 0, item_location(), -1, {} );
 
     JsonObject data = jsin.get_object();
 
     data.read( "moves_total", actor.moves_total );
     data.read( "gun", actor.gun );
     data.read( "gunmod", actor.gunmod_idx );
+    data.read( "mod_contents", actor.mod_contents );
 
     return actor.clone();
 }

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -144,13 +144,15 @@ class gunmod_remove_activity_actor : public activity_actor
         int moves_total;
         item_location gun;
         int gunmod_idx;
+        std::list<item> mod_contents;
 
     public:
         gunmod_remove_activity_actor(
             int moves_total,
             const item_location &gun,
-            int gunmod_idx
-        ) : moves_total( moves_total ), gun( gun ), gunmod_idx( gunmod_idx ) {}
+            int gunmod_idx,
+            std::list<item> mod_contents
+        ) : moves_total( moves_total ), gun( gun ), gunmod_idx( gunmod_idx ), mod_contents {}
 
         activity_id get_type() const override {
             return activity_id( "ACT_GUNMOD_REMOVE" );

--- a/src/character_ammo.cpp
+++ b/src/character_ammo.cpp
@@ -88,9 +88,6 @@ bool Character::list_ammo( const item_location &base, std::vector<item::reload_o
         if( mod->magazine_current() ) {
             opts.emplace_back( mod_loc, const_cast<item *>( mod->magazine_current() ) );
         }
-        if( mod->has_flag( flag_NOT_MAGAZINE ) ) {
-            opts.emplace_back( mod_loc );
-        }
     }
 
     bool ammo_match_found = false;
@@ -361,10 +358,6 @@ item::reload_option Character::select_ammo( const item_location &base,
 item::reload_option Character::select_ammo( const item_location &base, bool prompt,
         bool empty ) const
 {
-
-    if( has_flag( flag_NOT_MAGAZINE ) ) {
-        return item::reload_option();
-    }
 
     if( !base ) {
         return item::reload_option();

--- a/src/character_ammo.cpp
+++ b/src/character_ammo.cpp
@@ -83,12 +83,12 @@ bool Character::list_ammo( const item_location &base, std::vector<item::reload_o
     }
 
     for( const item *mod : base->gunmods() ) {
-        item_location mod_loc( base, const_cast<item *>( mod ) );
         if( !mod->has_flag( flag_NOT_MAGAZINE ) ) {
+        item_location mod_loc( base, const_cast<item *>( mod ) );
         opts.emplace_back( mod_loc );
-        }
-        if( mod->magazine_current() && !mod->has_flag( flag_NOT_MAGAZINE ) ) {
+        if( mod->magazine_current() ) {
             opts.emplace_back( mod_loc, const_cast<item *>( mod->magazine_current() ) );
+        }
         }
     }
 

--- a/src/character_ammo.cpp
+++ b/src/character_ammo.cpp
@@ -83,12 +83,13 @@ bool Character::list_ammo( const item_location &base, std::vector<item::reload_o
     }
 
     for( const item *mod : base->gunmods() ) {
-        if( !mod->has_flag( flag_NOT_MAGAZINE ) ) {
         item_location mod_loc( base, const_cast<item *>( mod ) );
         opts.emplace_back( mod_loc );
         if( mod->magazine_current() ) {
             opts.emplace_back( mod_loc, const_cast<item *>( mod->magazine_current() ) );
         }
+        if( mod->has_flag( flag_NOT_MAGAZINE ) ) {
+            opts.emplace_back( mod_loc );
         }
     }
 

--- a/src/character_ammo.cpp
+++ b/src/character_ammo.cpp
@@ -97,12 +97,10 @@ bool Character::list_ammo( const item_location &base, std::vector<item::reload_o
             if( p->can_reload_with( *ammo.get_item(), false ) ) {
                 // Record that there's a matching ammo type,
                 // even if something is preventing reloading at the moment.
-                        add_msg_if_player( m_info, _( "ammo found 1." ) );
                 ammo_match_found = true;
             } else if( ( ammo->has_flag( flag_SPEEDLOADER ) || ammo->has_flag( flag_SPEEDLOADER_CLIP ) ) &&
                        p->allows_speedloader( ammo->typeId() ) && ammo->ammo_remaining() > 1 && p->ammo_remaining() < 1 ) {
                 // Again, this is "are they compatible", later check handles "can we do it now".
-                        add_msg_if_player( m_info, _( "ammo found 2." ) );
                 ammo_match_found = p->can_reload_with( *ammo.get_item(), false );
             }
             if( can_reload( *p, ammo.get_item() ) ) {
@@ -112,10 +110,6 @@ bool Character::list_ammo( const item_location &base, std::vector<item::reload_o
     }
     return ammo_match_found;
 }
-
-
-
-
 
 item::reload_option Character::select_ammo( const item_location &base,
         std::vector<item::reload_option> opts, const std::string &name_override ) const

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -17,7 +17,7 @@ void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nes
     src.visit_items( [&src, &nested, &out, &obj, empty]( item * node, item * parent ) {
 
         // This stops containers and magazines counting *themselves* as ammo sources
-        if( node == &obj ) {
+        if( node == &obj && !node->has_flag( flag_NOT_MAGAZINE ) ) {
             return VisitResponse::SKIP;
         }
 
@@ -32,7 +32,7 @@ void find_ammo_helper( T &src, const item &obj, bool empty, Output out, bool nes
         }
 
         // Do not steal ammo from magazines
-        if( parent != nullptr && parent->is_magazine() ) {
+        if( parent != nullptr && parent->is_magazine() && !parent->is_magazine() ) {
             return VisitResponse::SKIP;
         }
 
@@ -252,6 +252,7 @@ bool Character::gunmod_remove( item &gun, item &mod )
             break;
         }
     }
+
     if( gunmod_idx == mods.size() ) {
         debugmsg( "Cannot remove non-existent gunmod" );
         return false;

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -262,18 +262,26 @@ bool Character::gunmod_remove( item &gun, item &mod )
         return false;
     }
 
-    //std::list<item> mod_contents;
-    //for( const item *it : gun.all_items_ptr( pocket_type::CONTAINER ) ) {
-    //    mod_contents.push_back( *it );
-   // }
-    //map &here = get_map();
-    //for( item &content : mod_contents ) {
-    //    here.add_item_or_charges( this->pos(), content );
-   // }
     // Removing gunmod takes only half as much time as installing it
     const int moves = has_trait( trait_DEBUG_HS ) ? 0 : mod.type->gunmod->install_time / 2;
     item_location gun_loc = item_location( *this, &gun );
-    assign_activity( gunmod_remove_activity_actor( moves, gun_loc, static_cast<int>( gunmod_idx ) ) );
+        if( mod.has_flag( flag_NOT_MAGAZINE ) ) {
+            std::list<item> mod_contents;
+            for( const item *it : gun.all_items_ptr( pocket_type::CONTAINER ) ) {
+                mod_contents.push_back( *it );
+            }
+            if( !mod_contents.empty() ) {
+            assign_activity( gunmod_remove_activity_actor( moves, gun_loc, static_cast<int>( gunmod_idx ), mod_contents ) );
+          // make the activity do this stuff
+          //                      map &here = get_map();
+           //     for( item &content : mod_contents ) {
+           //         here.add_item_or_charges( this->pos(), content );
+            //         }
+            return true;
+            }
+    } else {
+    assign_activity( gunmod_remove_activity_actor( moves, gun_loc, static_cast<int>( gunmod_idx ), {} ) );
+    }
     return true;
 }
 

--- a/src/character_guns.cpp
+++ b/src/character_guns.cpp
@@ -262,6 +262,14 @@ bool Character::gunmod_remove( item &gun, item &mod )
         return false;
     }
 
+    //std::list<item> mod_contents;
+    //for( const item *it : gun.all_items_ptr( pocket_type::CONTAINER ) ) {
+    //    mod_contents.push_back( *it );
+   // }
+    //map &here = get_map();
+    //for( item &content : mod_contents ) {
+    //    here.add_item_or_charges( this->pos(), content );
+   // }
     // Removing gunmod takes only half as much time as installing it
     const int moves = has_trait( trait_DEBUG_HS ) ? 0 : mod.type->gunmod->install_time / 2;
     item_location gun_loc = item_location( *this, &gun );

--- a/src/flag.cpp
+++ b/src/flag.cpp
@@ -217,6 +217,7 @@ const flag_id flag_NO_TURRET( "NO_TURRET" );
 const flag_id flag_NO_UNLOAD( "NO_UNLOAD" );
 const flag_id flag_NO_UNWIELD( "NO_UNWIELD" );
 const flag_id flag_NO_WEAR_EFFECT( "NO_WEAR_EFFECT" );
+const flag_id flag_NOT_MAGAZINE( "NOT_MAGAZINE" );
 const flag_id flag_NPC_ACTIVATE( "NPC_ACTIVATE" );
 const flag_id flag_NPC_ALT_ATTACK( "NPC_ALT_ATTACK" );
 const flag_id flag_NPC_SAFE( "NPC_SAFE" );

--- a/src/flag.h
+++ b/src/flag.h
@@ -225,6 +225,7 @@ extern const flag_id flag_NO_TURRET;
 extern const flag_id flag_NO_UNLOAD;
 extern const flag_id flag_NO_UNWIELD;
 extern const flag_id flag_NO_WEAR_EFFECT;
+extern const flag_id flag_NOT_MAGAZINE;
 extern const flag_id flag_NPC_ACTIVATE;
 extern const flag_id flag_NPC_ALT_ATTACK;
 extern const flag_id flag_NPC_SAFE;

--- a/src/item_pocket.cpp
+++ b/src/item_pocket.cpp
@@ -1715,7 +1715,6 @@ bool item_pocket::can_reload_with( const item &ammo, const bool now ) const
             }
 
             return true;
-
         } else if( is_type( pocket_type::MAGAZINE_WELL ) ) {
             // Reloading is refused if there already is full magazine here
             // Reloading with another identical mag with identical contents is also pointless so it is not allowed
@@ -1725,8 +1724,10 @@ bool item_pocket::can_reload_with( const item &ammo, const bool now ) const
                     front().same_contents( ammo ) );
         } else if( is_type( pocket_type::CONTAINER ) ) {
             // Reloading is possible if liquid combines with old liquid
-
             if( front().can_combine( ammo ) ) {
+                return true;
+            }
+            if( !ammo.made_of( phase_id::LIQUID ) ) {
                 return true;
             }
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Adds mods for guns, rifles, and bows that create a pocket for extra ammo"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
IRL there are little doodads you can strap to your gun that hold a few shells or cartridges for quick reloading. There are also bow-mounted quivers. Given that reload speed is a major factor for weapons that reload one round at a time, it would be useful to have these in the game.

closes #69943 

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Adds a few mods with a pocket that hold a the appropriate ammo type and can be fitted to the weapon. These will have a base item retrieval speed of 25 moves, putting them on par with the shell loops on a tac vest.

- Leather and plastic varieties for shotguns and hunting rifle calibers
- A plastic holder that goes to a compound bow
- A leather holder that goes to a primitive bow, handmade only
- recipes for all of the above

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
None yet.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
WIP

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/94415528/978ea9eb-24cb-49f9-801c-18aed1e2d89b)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/94415528/f021c942-e977-480f-aa0a-b6c5859ce635)


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
