### PR TITLE
Standardizes smoothing levels by making brick constructions use level 1 and concrete ones level 2

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -1107,7 +1107,7 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "120 m",
-    "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
+    "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
     "components": [ [ [ "brick", 15 ] ], [ [ "mortar_build", 1 ], [ "mortar_lime", 1 ] ], [ [ "water", 1 ], [ "water_clean", 1 ] ] ],
     "pre_terrain": "t_dirt",
     "post_terrain": "t_brick_wall_halfway"
@@ -1120,7 +1120,7 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "120 m",
-    "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
+    "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
     "components": [ [ [ "brick", 15 ] ], [ [ "mortar_build", 1 ], [ "mortar_lime", 1 ] ], [ [ "water", 1 ], [ "water_clean", 1 ] ] ],
     "pre_terrain": "t_brick_wall_halfway",
     "post_terrain": "t_brick_wall"
@@ -1134,7 +1134,7 @@
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "60 m",
     "tools": [ [ [ "con_mix", 50 ] ] ],
-    "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
+    "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
     "components": [ [ [ "concrete", 2 ] ], [ [ "water", 2 ], [ "water_clean", 2 ] ] ],
     "pre_terrain": "t_pit_shallow",
     "post_terrain": "t_concrete"
@@ -1323,7 +1323,7 @@
     "required_skills": [ [ "fabrication", 4 ] ],
     "time": "180 m",
     "tools": [ [ [ "con_mix", 50 ] ] ],
-    "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
+    "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
     "components": [ [ [ "concrete", 4 ] ], [ [ "2x4", 12 ] ], [ [ "water", 4 ], [ "water_clean", 4 ] ] ],
     "pre_terrain": "t_pit_shallow",
     "post_terrain": "t_sconc_wall_halfway"
@@ -1337,7 +1337,7 @@
     "required_skills": [ [ "fabrication", 4 ] ],
     "time": "180 m",
     "tools": [ [ [ "con_mix", 50 ] ] ],
-    "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
+    "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
     "components": [ [ [ "concrete", 4 ] ], [ [ "2x4", 12 ] ], [ [ "water", 4 ], [ "water_clean", 4 ] ] ],
     "pre_terrain": "t_sconc_wall_halfway",
     "post_terrain": "t_sconc_wall"
@@ -1489,7 +1489,7 @@
     "required_skills": [ [ "fabrication", 5 ] ],
     "time": "120 m",
     "tools": [ [ [ "con_mix", 50 ] ] ],
-    "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
+    "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
     "components": [ [ [ "concrete", 4 ] ], [ [ "water", 4 ], [ "water_clean", 4 ] ] ],
     "pre_terrain": "t_ov_smreb_cage",
     "post_terrain": "t_thconc_floor"
@@ -1914,7 +1914,7 @@
     "category": "CONSTRUCT",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "120 m",
-    "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
+    "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
     "components": [ [ [ "brick", 15 ] ], [ [ "mortar_build", 1 ], [ "mortar_lime", 1 ] ], [ [ "water", 1 ], [ "water_clean", 1 ] ] ],
     "pre_terrain": "t_brick_wall_halfway",
     "post_terrain": "t_embrasure_brick"
@@ -2028,7 +2028,7 @@
     "time": "180 m",
     "//": "The frame is used to keep the shape of the hole until the concrete is solid",
     "tools": [ [ [ "con_mix", 50 ] ], [ [ "frame_wood", -1 ] ] ],
-    "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
+    "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
     "components": [ [ [ "concrete", 4 ] ], [ [ "2x4", 12 ] ], [ [ "water", 4 ], [ "water_clean", 4 ] ] ],
     "pre_terrain": "t_sconc_wall_halfway",
     "post_terrain": "t_embrasure_sconc"
@@ -2522,7 +2522,7 @@
     "category": "FURN",
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "120 m",
-    "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
+    "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
     "components": [ [ [ "brick", 30 ] ], [ [ "mortar_build", 1 ], [ "mortar_lime", 1 ] ], [ [ "water", 1 ], [ "water_clean", 1 ] ] ],
     "pre_special": "check_empty",
     "post_terrain": "f_fireplace"
@@ -5003,7 +5003,7 @@
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "150 m",
     "tools": [ [ [ "con_mix", 125 ] ] ],
-    "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
+    "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
     "components": [ [ [ "concrete", 5 ] ], [ [ "water", 5 ], [ "water_clean", 5 ] ] ],
     "pre_special": "check_ramp_low",
     "post_terrain": "t_ramp_up_low",
@@ -5019,7 +5019,7 @@
     "required_skills": [ [ "fabrication", 3 ] ],
     "time": "150 m",
     "tools": [ [ [ "con_mix", 125 ] ] ],
-    "qualities": [ [ { "id": "SMOOTH", "level": 1 } ] ],
+    "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
     "components": [ [ [ "concrete", 5 ] ], [ [ "water", 5 ], [ "water_clean", 5 ] ] ],
     "pre_special": "check_ramp_high",
     "post_terrain": "t_ramp_up_high",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Made brick constructions need smoothing 1, and concrete ones smoothing 2"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Smoothing level seems to be a completely arbitrary requirement in constructions, randomly jumping up and down from 1 to 2 with no rhyme or reason. This isn't very intuitive or reasonable, which is why I'm making this PR to correct it!

This concern was brought up in #70592, where an user complained they were unable to make a brick fireplace with a trowel. This will close that issue.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adobe and brick constructions need smoothing 1, just a simple, rudimentary smoother.

Concrete constructions are more labor-intensive and complex, so they require smoothing 2 for an industrial-level tool.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Give trowels level 2: Patchwork solution that treats the symptoms only, with construction levels still being arbitrary.
Easily craftable level 2 smoother: Invalidates the metallic smoother and still has the same issue of just dismissing levels wholesale.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned myself in, opened constructions menu, ensured all brick smooth reqs. were 1, and concrete 2.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I don't know shit about smoothing.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
