### PR TITLE
Quilts and blankets

### DIFF
--- a/data/json/recipes/armor/other.json
+++ b/data/json/recipes/armor/other.json
@@ -52,6 +52,36 @@
     "byproducts": [ [ "cotton_patchwork", 6 ], [ "scrap_cotton", 2 ] ]
   },
   {
+    "result": "quilt",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_OTHER",
+    "skill_used": "tailor",
+	"skills_required": [ "tailoring", 4 ],
+    "time": "15 h",
+	"//": "Based off of the quickest internet suggestions, which utilize sewing machines."
+    "autolearn": [ "tailoring", 2 ],
+    "qualities": [ { "id": "SEW", "level": 1 }, { "id": "FABRIC_CUT", "level": 1 } ],
+	"components": [ [ "cotton_ball", 150 ], [ "felt_sheet", 33], [ "filament", 200, "LIST" ] ],
+	"//1": "Cotton balls act as the warm filling material for the quilt. 5L / 25mL per cotton ball = 200 cotton balls as an upper limit"
+    "byproducts": [ [ "felt_patch", 6 ], [ "scrap_felt", 2 ] ]
+  },
+  {
+    "result": "quilt_patchwork",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_ARMOR",
+    "subcategory": "CSC_ARMOR_OTHER",
+    "skill_used": "tailor",
+	"skills_required": [ "tailoring", 2 ],
+    "time": "10 h",
+    "autolearn": true,
+	"components": [ [ [ "cotton_ball", 150 ], [ "gambeson_batting", 75 ] ], [ [ "felt_sheet", 33 ], ["patchwork_felt_sheet", 33 ], ["scrap_felt", 264 ] ], [ "filament", 165, "LIST" ] ],
+	"//": "Patchwork quilts are quicker to make because the crafter is primarily concerned about warmth, not beauty. Similar filling calculation as the quilt recipe."
+    "byproducts": [ [ "felt_patch", 6 ], [ "scrap_felt", 2 ] ]
+  },
+  {
     "result": "electric_blanket",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/recipes/armor/other.json
+++ b/data/json/recipes/armor/other.json
@@ -58,13 +58,14 @@
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_OTHER",
     "skill_used": "tailor",
-	"skills_required": [ "tailoring", 4 ],
+    "difficulty": 4,
+    "proficiencies": [ { "proficiency": "prof_quilting", "required": false, "max_experience": "2 h" } ],
     "time": "15 h",
-	"//": "Based off of the quickest internet suggestions, which utilize sewing machines."
-    "autolearn": [ "tailoring", 2 ],
+    "//": "Based off of the quickest internet suggestions, which utilize sewing machines.",
+    "autolearn": [ [ "tailor", 2 ] ],
     "qualities": [ { "id": "SEW", "level": 1 }, { "id": "FABRIC_CUT", "level": 1 } ],
-	"components": [ [ "cotton_ball", 150 ], [ "felt_sheet", 33], [ "filament", 200, "LIST" ] ],
-	"//1": "Cotton balls act as the warm filling material for the quilt. 5L / 25mL per cotton ball = 200 cotton balls as an upper limit"
+    "components": [ [ [ "cotton_ball", 150 ] ], [ [ "sheet_felt", 33 ] ], [ [ "filament", 200, "LIST" ] ] ],
+    "//1": "Cotton balls act as the warm filling material for the quilt. 5L / 25mL per cotton ball = 200 cotton balls as an upper limit",
     "byproducts": [ [ "felt_patch", 6 ], [ "scrap_felt", 2 ] ]
   },
   {
@@ -74,11 +75,17 @@
     "category": "CC_ARMOR",
     "subcategory": "CSC_ARMOR_OTHER",
     "skill_used": "tailor",
-	"skills_required": [ "tailoring", 2 ],
+    "difficulty": 2,
+    "proficiencies": [ { "proficiency": "prof_quilting", "required": false, "max_experience": "2 h" } ],
     "time": "10 h",
     "autolearn": true,
-	"components": [ [ [ "cotton_ball", 150 ], [ "gambeson_batting", 75 ] ], [ [ "felt_sheet", 33 ], ["patchwork_felt_sheet", 33 ], ["scrap_felt", 264 ] ], [ "filament", 165, "LIST" ] ],
-	"//": "Patchwork quilts are quicker to make because the crafter is primarily concerned about warmth, not beauty. Similar filling calculation as the quilt recipe."
+    "qualities": [ { "id": "SEW", "level": 1 }, { "id": "FABRIC_CUT", "level": 1 } ],
+    "components": [
+      [ [ "cotton_ball", 150 ], [ "gambeson_batting", 75 ] ],
+      [ [ "sheet_felt", 33 ], [ "sheet_felt_patchwork", 33 ], [ "scrap_felt", 264 ] ],
+      [ [ "filament", 165, "LIST" ] ]
+    ],
+    "//": "Patchwork quilts are quicker to make because the crafter is primarily concerned about warmth, not beauty. Similar filling calculation as the quilt recipe.",
     "byproducts": [ [ "felt_patch", 6 ], [ "scrap_felt", 2 ] ]
   },
   {

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -698,6 +698,15 @@
     "//": "This recipe somehow manages to lose cotton while creating mass out of thin air. Honestly remarkable, but for me it means I have to look into the weight for thread later on"
   },
   {
+    "result": "fur_blanket",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "10 m",
+    "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "sheet_cotton", 10 ] ], [ [ "sheet_fur_patchwork", 10 ] ], [ [ "thread", 150 ] ] ],
+    "//": "This recipe is based off of the blanket recipe above it, with half of the cotton sheets being replaced by patchwork fur sheets."
+  },
+  {
     "result": "crackpipe",
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -714,6 +714,22 @@
   "//": "This recipe is based off of the blanket recipe above it, with half of the cotton sheets being replaced by patchwork fur sheets."
   },
   {
+    "result": "quilt",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "15 m",
+    "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "sheet_felt", 20 ] ], [ [ "thread", 150 ] ], [ [ "cotton_ball", 100 ] ] ]
+  },
+  {
+    "result": "quilt_patchwork",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "15 m",
+    "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "sheet_felt_patchwork", 20 ] ], [ [ "thread", 100 ] ], [ [ "gambeson_batting", 50 ] ] ]
+  },
+  {
     "result": "crackpipe",
     "type": "uncraft",
     "activity_level": "NO_EXERCISE",

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -698,20 +698,13 @@
     "//": "This recipe somehow manages to lose cotton while creating mass out of thin air. Honestly remarkable, but for me it means I have to look into the weight for thread later on"
   },
   {
-  "result": "fur_blanket",
-  "type": "uncraft",
-  "activity_level": "LIGHT_EXERCISE",
-  "time": "10 m",
-  "qualities": [
-    { "id": "FABRIC_CUT", "level": 1 },
-    { "id": "CUT", "level": 2 }
-  ],
-  "components": [
-    [ [ "sheet_cotton", 10 ] ],
-    [ [ "sheet_fur_patchwork", 10 ] ],
-    [ [ "thread", 150 ] ]
-  ],
-  "//": "This recipe is based off of the blanket recipe above it, with half of the cotton sheets being replaced by patchwork fur sheets."
+    "result": "fur_blanket",
+    "type": "uncraft",
+    "activity_level": "LIGHT_EXERCISE",
+    "time": "10 m",
+    "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
+    "components": [ [ [ "sheet_cotton", 10 ] ], [ [ "sheet_fur_patchwork", 10 ] ], [ [ "thread", 150 ] ] ],
+    "//": "This recipe is based off of the blanket recipe above it, with half of the cotton sheets being replaced by patchwork fur sheets."
   },
   {
     "result": "crackpipe",

--- a/data/json/uncraft/generic.json
+++ b/data/json/uncraft/generic.json
@@ -698,13 +698,20 @@
     "//": "This recipe somehow manages to lose cotton while creating mass out of thin air. Honestly remarkable, but for me it means I have to look into the weight for thread later on"
   },
   {
-    "result": "fur_blanket",
-    "type": "uncraft",
-    "activity_level": "LIGHT_EXERCISE",
-    "time": "10 m",
-    "qualities": [ { "id": "FABRIC_CUT", "level": 1 }, { "id": "CUT", "level": 2 } ],
-    "components": [ [ [ "sheet_cotton", 10 ] ], [ [ "sheet_fur_patchwork", 10 ] ], [ [ "thread", 150 ] ] ],
-    "//": "This recipe is based off of the blanket recipe above it, with half of the cotton sheets being replaced by patchwork fur sheets."
+  "result": "fur_blanket",
+  "type": "uncraft",
+  "activity_level": "LIGHT_EXERCISE",
+  "time": "10 m",
+  "qualities": [
+    { "id": "FABRIC_CUT", "level": 1 },
+    { "id": "CUT", "level": 2 }
+  ],
+  "components": [
+    [ [ "sheet_cotton", 10 ] ],
+    [ [ "sheet_fur_patchwork", 10 ] ],
+    [ [ "thread", 150 ] ]
+  ],
+  "//": "This recipe is based off of the blanket recipe above it, with half of the cotton sheets being replaced by patchwork fur sheets."
   },
   {
     "result": "crackpipe",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Made quilts craftable, added fur blanket disassembly"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
This PR closes #68795. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Fur blankets can now be disassembled. Quilts and patchwork quilts can now be crafted. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Ideally, the quilting recipes should use a sewing machine, but that isn't currently feasible. The fur blanket recipe was based off of the regular blanket recipe, which could use some tweaking of its own. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I did local testing to confirm that the recipes function normally and that the code is free of typos. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This PR took me about 4 hours in total, split between learning the recipe JSON, trying to make quality recipes, and bug fixing. I learned how to edit (and test!) JSON files locally instead of through github.com, and used the JSON linter to make my code look nice and clean. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
