### PR TITLE
Handle nullptr in spawn-monsters-submap

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8810,11 +8810,13 @@ void map::spawn_monsters_submap( const tripoint &gp, bool ignore_sight, bool spa
             }
 
             if( i.mission_id > 0 ) {
-                tmp.mission_ids = { i.mission_id };
                 mission *found_mission = mission::find( i.mission_id );
-                if( found_mission->get_type().goal == MGOAL_KILL_MONSTERS ) {
-                    found_mission->register_kill_needed();
-                }
+                if ( found_mission != nullptr) {
+                    tmp.mission_ids = { i.mission_id };
+                    if( found_mission->get_type().goal == MGOAL_KILL_MONSTERS ) {
+                        found_mission->register_kill_needed();
+                    }
+                } 
             }
             if( i.name != "NONE" ) {
                 tmp.unique_name = i.name;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8816,7 +8816,7 @@ void map::spawn_monsters_submap( const tripoint &gp, bool ignore_sight, bool spa
                     if( found_mission->get_type().goal == MGOAL_KILL_MONSTERS ) {
                         found_mission->register_kill_needed();
                     }
-                } 
+                }
             }
             if( i.name != "NONE" ) {
                 tmp.unique_name = i.name;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8811,7 +8811,7 @@ void map::spawn_monsters_submap( const tripoint &gp, bool ignore_sight, bool spa
 
             if( i.mission_id > 0 ) {
                 mission *found_mission = mission::find( i.mission_id );
-                if ( found_mission != nullptr) {
+                if( found_mission != nullptr) {
                     tmp.mission_ids = { i.mission_id };
                     if( found_mission->get_type().goal == MGOAL_KILL_MONSTERS ) {
                         found_mission->register_kill_needed();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -8811,7 +8811,7 @@ void map::spawn_monsters_submap( const tripoint &gp, bool ignore_sight, bool spa
 
             if( i.mission_id > 0 ) {
                 mission *found_mission = mission::find( i.mission_id );
-                if( found_mission != nullptr) {
+                if( found_mission != nullptr ) {
                     tmp.mission_ids = { i.mission_id };
                     if( found_mission->get_type().goal == MGOAL_KILL_MONSTERS ) {
                         found_mission->register_kill_needed();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Handle nullptr in spawn-monsters-submap"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #70650. 
When checking for missions attached to spawning monsters, the case where mission::find fails and returns a nullptr is not handled, presumably leading to a segmentation fault somewhere down the line. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a check for null pointers before proceeding to operate on the returned mission. The debug message for failing to find the mission with the appropriate mission id has been intentionally left in since whatever is causing the failure would still be considered a (separate) bug, it just shouldn't cause a SIGSEGV now. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Game compiles, no longer segfaults.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
