### PR TITLE
Snippets expand a subset of the tags valid for parse_tags

### DIFF
--- a/data/json/snippets/snippets.json
+++ b/data/json/snippets/snippets.json
@@ -395,6 +395,15 @@
   },
   {
     "type": "snippet",
+    "category": "<punc>",
+    "text": [
+      { "weight": 1, "text": { "str": ".", "ctxt": "punctuation" } },
+      { "weight": 1, "text": { "str": "!", "ctxt": "punctuation" } },
+      { "weight": 1, "text": { "str": "…", "ctxt": "punctuation" } }
+    ]
+  },
+  {
+    "type": "snippet",
     "category": "pyromania_withdrawal",
     "text": [
       "You feel cold.  You need the warmth of a fire.",

--- a/src/npc.h
+++ b/src/npc.h
@@ -86,7 +86,7 @@ void parse_tags( std::string &phrase, const Character &u, const Character &me,
                  const dialogue &d, const itype_id &item_type = itype_id::NULL_ID() );
 
 void parse_tags( std::string &phrase, const talker &u, const talker &me, const dialogue &d,
-                 const itype_id &item_type = itype_id::NULL_ID() );
+                 const itype_id &item_type = itype_id::NULL_ID(), bool expand_snippets = true );
 
 /*
  * Talk:   Trust midlow->high, fear low->mid, need doesn't matter

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -2040,141 +2040,16 @@ void parse_tags( std::string &phrase, const Character &u, const Character &me, c
     parse_tags( phrase, *get_talker_for( u ), *get_talker_for( me ), d, item_type );
 }
 
-static bool parse_static_tags( std::string &phrase, const std::string &tag, size_t fa, size_t fb,
-                               const std::function<void( std::string & )> &recurse )
-{
-    int l = fb - fa + 1;
-
-    if( tag == "<punc>" ) {
-        switch( rng( 0, 2 ) ) {
-            case 0:
-                phrase.replace( fa, l, pgettext( "punctuation", "." ) );
-                break;
-            case 1:
-                phrase.replace( fa, l, pgettext( "punctuation", "…" ) );
-                break;
-            case 2:
-                phrase.replace( fa, l, pgettext( "punctuation", "!" ) );
-                break;
-        }
-    } else if( tag.find( "<global_val:" ) == 0 ) {
-        //adding a global variable to the string
-        std::string var = tag.substr( tag.find( ':' ) + 1 );
-        // remove the trailing >
-        var.pop_back();
-        // resolve nest
-        recurse( var );
-        global_variables &globvars = get_globals();
-        phrase.replace( fa, l, globvars.get_global_value( "npctalk_var_" + var ) );
-    } else if( tag.find( "<item_name:" ) == 0 ) {
-        //embedding an items name in the string
-        std::string var = tag.substr( tag.find( ':' ) + 1 );
-        // remove the trailing >
-        var.pop_back();
-        // resolve nest
-        recurse( var );
-        // Try the variable as an item id
-        phrase.replace( fa, l, itype_id( var )->nname( 1 ) );
-    } else if( tag.find( "<item_description:" ) == 0 ) {
-        //embedding an items name in the string
-        std::string var = tag.substr( tag.find( ':' ) + 1 );
-        // remove the trailing >
-        var.pop_back();
-        // resolve nest
-        recurse( var );
-        // Try the variable as an item id
-        phrase.replace( fa, l, itype_id( var )->description.translated() );
-    } else if( tag.find( "<trait_name:" ) == 0 ) {
-        //embedding an items name in the string
-        std::string var = tag.substr( tag.find( ':' ) + 1 );
-        // remove the trailing >
-        var.pop_back();
-        // resolve nest
-        recurse( var );
-        // Try the variable as a trait id
-        phrase.replace( fa, l, trait_id( var )->name() );
-    } else if( tag.find( "<trait_description:" ) == 0 ) {
-        //embedding an items name in the string
-        std::string var = tag.substr( tag.find( ':' ) + 1 );
-        // remove the trailing >
-        var.pop_back();
-        // resolve nest
-        recurse( var );
-        // Try the variable as a trait id
-        phrase.replace( fa, l, trait_id( var )->desc() );
-    } else if( tag.find( "<spell_name:" ) == 0 ) {
-        //embedding an items name in the string
-        std::string var = tag.substr( tag.find( ':' ) + 1 );
-        // remove the trailing >
-        var.pop_back();
-        // resolve nest
-        recurse( var );
-        // Try the variable as a spell id
-        phrase.replace( fa, l, spell_id( var )->name.translated() );
-    } else if( tag.find( "<spell_description:" ) == 0 ) {
-        //embedding an items name in the string
-        std::string var = tag.substr( tag.find( ':' ) + 1 );
-        // remove the trailing >
-        var.pop_back();
-        // resolve nest
-        recurse( var );
-        // Try the variable as a spell id
-        phrase.replace( fa, l, spell_id( var )->description.translated() );
-    } else if( tag.find( "<city>" ) == 0 ) {
-        std::string cityname = "nowhere";
-        // Gets the closest city to the avatar, who the map is centered around
-        tripoint_abs_sm abs_sub = get_map().get_abs_sub();
-        const city *c = overmap_buffer.closest_city( abs_sub ).city;
-        if( c != nullptr ) {
-            cityname = c->name;
-        }
-        phrase.replace( fa, l, cityname );
-    } else {
-        return false;
-    }
-    return true;
-}
-
-void parse_basic_tags( std::string &phrase )
-{
-    phrase = SNIPPET.expand( remove_color_tags( phrase ), false );
-
-    size_t fa;
-    size_t fb;
-    size_t fa_;
-    std::string tag;
-    do {
-        fa = phrase.find( '<' );
-        fb = phrase.find( '>' );
-        if( fa != std::string::npos ) {
-            size_t nest = 0;
-            fa_ = phrase.find( '<', fa + 1 );
-            while( fa_ < fb && fa_ != std::string::npos ) {
-                nest++;
-                fa_ = phrase.find( '<', fa_ + 1 );
-            }
-            while( nest > 0 && fb != std::string::npos ) {
-                nest--;
-                fb = phrase.find( '>', fb + 1 );
-            }
-        }
-        if( fa != std::string::npos && fb != std::string::npos ) {
-            tag = phrase.substr( fa, fb - fa + 1 );
-        } else {
-            return;
-        }
-
-        if( !parse_static_tags( phrase, tag, fa, fb, parse_basic_tags ) && !tag.empty() ) {
-            debugmsg( "Bad tag.  '%s' (%d - %d)", tag.c_str(), fa, fb );
-            phrase.replace( fa, fb - fa + 1, "????" );
-        }
-    } while( fa != std::string::npos && fb != std::string::npos );
-}
-
 void parse_tags( std::string &phrase, const talker &u, const talker &me, const dialogue &d,
-                 const itype_id &item_type )
+                 const itype_id &item_type, bool expand_snippets )
 {
-    phrase = SNIPPET.expand( remove_color_tags( phrase ), false );
+
+    if( expand_snippets ) {
+        const auto recursive = [&u, &me, &d, &item_type]( std::string & new_phrase ) {
+            parse_tags( new_phrase, u, me, d, item_type, false );
+        };
+        phrase = SNIPPET.expand( remove_color_tags( phrase ), recursive );
+    }
 
     const Character *u_chr = u.get_character();
     const Character *me_chr = me.get_character();
@@ -2203,10 +2078,6 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
         } else {
             return;
         }
-
-        const auto recursive = [&u, &me, &d, &item_type]( std::string & new_phrase ) {
-            parse_tags( new_phrase, u, me, d, item_type );
-        };
 
         const item_location u_weapon = u_chr ? u_chr->get_wielded_item() : item_location();
         const item_location me_weapon = me_chr ? me_chr->get_wielded_item() : item_location();
@@ -2283,7 +2154,16 @@ void parse_tags( std::string &phrase, const talker &u, const talker &me, const d
             // resolve nest
             parse_tags( var, u, me, d, item_type );
             phrase.replace( fa, l, d.get_value( "npctalk_var_" + var ) );
-        } else if( !parse_static_tags( phrase, tag, fa, fb, recursive ) && !tag.empty() ) {
+        } else if( tag.find( "<city>" ) == 0 ) {
+            std::string cityname = "nowhere";
+            // Gets the closest city to the avatar, who the map is centered around
+            tripoint_abs_sm abs_sub = get_map().get_abs_sub();
+            const city *c = overmap_buffer.closest_city( abs_sub ).city;
+            if( c != nullptr ) {
+                cityname = c->name;
+            }
+            phrase.replace( fa, l, cityname );
+        } else if( !tag.empty() ) {
             debugmsg( "Bad tag.  '%s' (%d - %d)", tag.c_str(), fa, fb );
             phrase.replace( fa, fb - fa + 1, "????" );
         }

--- a/src/text_snippets.cpp
+++ b/src/text_snippets.cpp
@@ -232,7 +232,7 @@ bool snippet_library::has_snippet_with_id( const snippet_id &id ) const
     return snippets_by_id.find( id ) != snippets_by_id.end();
 }
 
-std::string snippet_library::expand( const std::string &str ) const
+std::string snippet_library::expand( const std::string &str, bool with_tags ) const
 {
     size_t tag_begin = str.find( '<' );
     if( tag_begin == std::string::npos ) {
@@ -246,6 +246,12 @@ std::string snippet_library::expand( const std::string &str ) const
     std::string symbol = str.substr( tag_begin, tag_end - tag_begin + 1 );
     std::optional<translation> replacement = random_from_category( symbol );
     if( !replacement.has_value() ) {
+        if( with_tags ) {
+            parse_basic_tags( symbol );
+            return str.substr( 0, tag_end + 1 )
+                   + expand( symbol )
+                   + expand( str.substr( tag_end + 1 ) );
+        }
         return str.substr( 0, tag_end + 1 )
                + expand( str.substr( tag_end + 1 ) );
     }

--- a/src/text_snippets.h
+++ b/src/text_snippets.h
@@ -81,7 +81,8 @@ class snippet_library
          * because "<yrwp>" is a special tag that does not have a category defined
          * in the JSON files.
          */
-        std::string expand( const std::string &str, bool with_tags = true ) const;
+        std::string expand( const std::string &str,
+                            std::function<void( std::string & )> unrecognized_callback = do_nothing ) const;
         /**
          * Returns the id of a random snippet out of the given category.
          * Snippets without an id will NOT be returned by this function.
@@ -145,9 +146,11 @@ class snippet_library
         std::unordered_map<std::string, category_snippets> snippets_by_category;
 
         std::optional<std::map<int, snippet_id>> hash_to_id_migration;
-};
 
-void parse_basic_tags( std::string &phrase );
+        std::string parse_tag( std::string &tag,
+                               std::function<void( std::string & )> unrecognized_callback ) const;
+        static void do_nothing( std::string & ) {}
+};
 
 extern snippet_library SNIPPET;
 

--- a/src/text_snippets.h
+++ b/src/text_snippets.h
@@ -81,7 +81,7 @@ class snippet_library
          * because "<yrwp>" is a special tag that does not have a category defined
          * in the JSON files.
          */
-        std::string expand( const std::string &str ) const;
+        std::string expand( const std::string &str, bool with_tags = true ) const;
         /**
          * Returns the id of a random snippet out of the given category.
          * Snippets without an id will NOT be returned by this function.
@@ -146,6 +146,8 @@ class snippet_library
 
         std::optional<std::map<int, snippet_id>> hash_to_id_migration;
 };
+
+void parse_basic_tags( std::string &phrase );
 
 extern snippet_library SNIPPET;
 


### PR DESCRIPTION
#### Summary
Features "Allow snippets to also parse some tags during expansion"

#### Purpose of change
Tag parsing is handy, but is set up for a dialogue. However, a bunch of the tag parsing isn't actually required to be part of a dialogue, and could be used to make our other text expansion mechanism, snippets, more powerful.

@GuardianDll had some use case that made me look at this.

#### Describe the solution
Split `parse_tags` into `parse_static_tags` and `parse_tags`. `parse_tags` parses all the tags that require the elements of a dialogue, then hands it off to `parse_static_tags` to parse tags that do not require the dialogue.

Because tag parsing is recursive, and the static tags should be available to other users, `parse_static_tags` takes as an argument what function it should call to recurse with. This enables `parse_tags` to jump into `parse_static_tags`, but any recursively nested tags will still be parsed as part of the dialogue.
The public interface for `parse_static_tags` is provided through `parse_basic_tags`.

With that in place, `snippet_library::expand` now calls `parse_basic_tags` if a snippet substitution fails, and so snippets can parse (some) tags.
However, as `parse_tags` expands snippets, an optional argument was added to `snippet_library::expand` to skip parsing tags (so that they will be parsed by `parse_tags` when called from `parse_tags`, instead of `parse_basic_tags`).

Additionally: 713164e2189aadcb94a6399f57ec4e5a1415cbf5 makes it so that item descriptions that expand snippets do not save parsed tags, but instead parse tags when they are generated. 

#### Testing
It compiles.
More testing is needed.

#### Additional context
I need to add this to the documentation. To do that, I need to figure out where it needs to be added to the documentation.