### PR TITLE
Only init game if we're running tests that need it

### DIFF
--- a/tests/algo_test.cpp
+++ b/tests/algo_test.cpp
@@ -23,7 +23,7 @@ static void check_cycle_finding( std::unordered_map<int, std::vector<int>> &g,
     CHECK( loops == expected );
 }
 
-TEST_CASE( "find_cycles_small" )
+TEST_CASE( "find_cycles_small", "[nogame]" )
 {
     std::unordered_map<int, std::vector<int>> g = {
         { 0, { 1 } },
@@ -34,7 +34,7 @@ TEST_CASE( "find_cycles_small" )
     };
     check_cycle_finding( g, expected );
 }
-TEST_CASE( "find_cycles" )
+TEST_CASE( "find_cycles", "[nogame]" )
 {
     std::unordered_map<int, std::vector<int>> g = {
         { 0, { 0, 1 } },

--- a/tests/calendar_test.cpp
+++ b/tests/calendar_test.cpp
@@ -4,7 +4,7 @@
 #include "calendar.h"
 #include "cata_catch.h"
 
-TEST_CASE( "time_duration_to_string", "[calendar]" )
+TEST_CASE( "time_duration_to_string", "[calendar][nogame]" )
 {
     calendar::set_season_length( 91 );
     CHECK( to_string( 10_seconds ) == "10 seconds" );
@@ -27,7 +27,7 @@ TEST_CASE( "time_duration_to_string", "[calendar]" )
     CHECK( to_string( 3650_days ) == "10 years and 1 week" );
 }
 
-TEST_CASE( "time_duration_to_string_eternal_season", "[calendar]" )
+TEST_CASE( "time_duration_to_string_eternal_season", "[calendar][nogame]" )
 {
     calendar::set_season_length( 91 );
     calendar::set_eternal_season( true );

--- a/tests/cartesian_product_test.cpp
+++ b/tests/cartesian_product_test.cpp
@@ -2,7 +2,7 @@
 
 #include "cartesian_product.h"
 
-TEST_CASE( "cartesian_product" )
+TEST_CASE( "cartesian_product", "[nogame]" )
 {
     std::vector<int> empty;
     std::vector<int> singleton = { 0 };

--- a/tests/cata_utility_test.cpp
+++ b/tests/cata_utility_test.cpp
@@ -38,7 +38,7 @@ bool test_string_ends_with( const std::string &s1, const char( &s2 )[N] )
     return r1;
 }
 
-TEST_CASE( "string_starts_with", "[utility]" )
+TEST_CASE( "string_starts_with", "[utility][nogame]" )
 {
     CHECK( test_string_starts_with( "", "" ) );
     CHECK( test_string_starts_with( "a", "" ) );
@@ -48,7 +48,7 @@ TEST_CASE( "string_starts_with", "[utility]" )
     CHECK_FALSE( test_string_starts_with( "a", "ab" ) );
 }
 
-TEST_CASE( "string_ends_with", "[utility]" )
+TEST_CASE( "string_ends_with", "[utility][nogame]" )
 {
     CHECK( test_string_ends_with( "", "" ) );
     CHECK( test_string_ends_with( "a", "" ) );
@@ -58,7 +58,7 @@ TEST_CASE( "string_ends_with", "[utility]" )
     CHECK_FALSE( test_string_ends_with( "a", "ba" ) );
 }
 
-TEST_CASE( "string_ends_with_benchmark", "[.][utility][benchmark]" )
+TEST_CASE( "string_ends_with_benchmark", "[.][utility][benchmark][nogame]" )
 {
     const std::string s1 = "long_string_with_suffix";
 
@@ -70,7 +70,7 @@ TEST_CASE( "string_ends_with_benchmark", "[.][utility][benchmark]" )
     };
 }
 
-TEST_CASE( "string_ends_with_season_suffix", "[utility]" )
+TEST_CASE( "string_ends_with_season_suffix", "[utility][nogame]" )
 {
     constexpr size_t suffix_len = 15;
     // NOLINTNEXTLINE(cata-use-mdarray,modernize-avoid-c-arrays)
@@ -84,7 +84,7 @@ TEST_CASE( "string_ends_with_season_suffix", "[utility]" )
     CHECK_FALSE( test_string_ends_with( "t_tile_season_spring1", season_suffix[0] ) );
 }
 
-TEST_CASE( "divide_round_up", "[utility]" )
+TEST_CASE( "divide_round_up", "[utility][nogame]" )
 {
     CHECK( divide_round_up( 0, 5 ) == 0 );
     CHECK( divide_round_up( 1, 5 ) == 1 );
@@ -93,7 +93,7 @@ TEST_CASE( "divide_round_up", "[utility]" )
     CHECK( divide_round_up( 6, 5 ) == 2 );
 }
 
-TEST_CASE( "divide_round_up_units", "[utility]" )
+TEST_CASE( "divide_round_up_units", "[utility][nogame]" )
 {
     CHECK( divide_round_up( 0_ml, 5_ml ) == 0 );
     CHECK( divide_round_up( 1_ml, 5_ml ) == 1 );
@@ -102,7 +102,7 @@ TEST_CASE( "divide_round_up_units", "[utility]" )
     CHECK( divide_round_up( 6_ml, 5_ml ) == 2 );
 }
 
-TEST_CASE( "erase_if", "[utility]" )
+TEST_CASE( "erase_if", "[utility][nogame]" )
 {
     std::set<int> s{1, 2, 3, 4, 5};
     SECTION( "erase none" ) {
@@ -147,7 +147,7 @@ TEST_CASE( "erase_if", "[utility]" )
     }
 }
 
-TEST_CASE( "equal_ignoring_elements", "[utility]" )
+TEST_CASE( "equal_ignoring_elements", "[utility][nogame]" )
 {
     SECTION( "empty sets" ) {
         CHECK( equal_ignoring_elements<std::set<int>>(
@@ -235,7 +235,7 @@ TEST_CASE( "equal_ignoring_elements", "[utility]" )
     }
 }
 
-TEST_CASE( "map_without_keys", "[map][filter]" )
+TEST_CASE( "map_without_keys", "[map][filter][nogame]" )
 {
     std::map<std::string, std::string> map_empty;
     std::map<std::string, std::string> map_name_a = {
@@ -278,7 +278,7 @@ TEST_CASE( "map_without_keys", "[map][filter]" )
     CHECK_FALSE( map_without_keys( map_dirt_2, dirt ) == map_without_keys( map_name_a_dirt_2, dirt ) );
 }
 
-TEST_CASE( "map_equal_ignoring_keys", "[map][filter]" )
+TEST_CASE( "map_equal_ignoring_keys", "[map][filter][nogame]" )
 {
     std::map<std::string, std::string> map_empty;
     std::map<std::string, std::string> map_name_a = {
@@ -348,7 +348,7 @@ TEST_CASE( "map_equal_ignoring_keys", "[map][filter]" )
     CHECK_FALSE( map_equal_ignoring_keys( lagers_are_best, beer_and_stone, rock_and_stone ) );
 }
 
-TEST_CASE( "check_debug_menu_string_methods", "[debug_menu]" )
+TEST_CASE( "check_debug_menu_string_methods", "[debug_menu][nogame]" )
 {
     std::map<std::string, std::vector<std::string>> split_expect = {
         { "", { } },
@@ -380,7 +380,7 @@ TEST_CASE( "check_debug_menu_string_methods", "[debug_menu]" )
     }
 }
 
-TEST_CASE( "lcmatch", "[utility]" )
+TEST_CASE( "lcmatch", "[utility][nogame]" )
 {
     CHECK( lcmatch( "bo", "bo" ) == true );
     CHECK( lcmatch( "Bo", "bo" ) == true );

--- a/tests/cata_variant_test.cpp
+++ b/tests/cata_variant_test.cpp
@@ -19,7 +19,7 @@ static const mtype_id This_is_not_a_valid_id( "This is not a valid id" );
 static const mtype_id mon_zombie( "mon_zombie" );
 static const mtype_id zombie( "zombie" );
 
-TEST_CASE( "variant_construction", "[variant]" )
+TEST_CASE( "variant_construction", "[variant][nogame]" )
 {
     SECTION( "itype_id" ) {
         cata_variant v = cata_variant::make<cata_variant_type::itype_id>( itype_anvil );
@@ -62,7 +62,7 @@ TEST_CASE( "variant_construction", "[variant]" )
     }
 }
 
-TEST_CASE( "variant_copy_move", "[variant]" )
+TEST_CASE( "variant_copy_move", "[variant][nogame]" )
 {
     cata_variant v = cata_variant( zombie );
     cata_variant v2 = v;
@@ -75,7 +75,7 @@ TEST_CASE( "variant_copy_move", "[variant]" )
     CHECK( v5.get<mtype_id>() == zombie );
 }
 
-TEST_CASE( "variant_type_name_round_trip", "[variant]" )
+TEST_CASE( "variant_type_name_round_trip", "[variant][nogame]" )
 {
     int num_types = static_cast<int>( cata_variant_type::num_types );
     for( int i = 0; i < num_types; ++i ) {
@@ -85,14 +85,14 @@ TEST_CASE( "variant_type_name_round_trip", "[variant]" )
     }
 }
 
-TEST_CASE( "variant_default_constructor", "[variant]" )
+TEST_CASE( "variant_default_constructor", "[variant][nogame]" )
 {
     cata_variant v;
     CHECK( v.type() == cata_variant_type::void_ );
     CHECK( v.get_string().empty() );
 }
 
-TEST_CASE( "variant_serialization", "[variant]" )
+TEST_CASE( "variant_serialization", "[variant][nogame]" )
 {
     cata_variant v = cata_variant( zombie );
     std::ostringstream os;
@@ -101,7 +101,7 @@ TEST_CASE( "variant_serialization", "[variant]" )
     CHECK( os.str() == R"(["mtype_id","zombie"])" );
 }
 
-TEST_CASE( "variant_deserialization", "[variant]" )
+TEST_CASE( "variant_deserialization", "[variant][nogame]" )
 {
     JsonValue jsin = json_loader::from_string( R"(["mtype_id","zombie"])" );
     cata_variant v;
@@ -109,13 +109,13 @@ TEST_CASE( "variant_deserialization", "[variant]" )
     CHECK( v == cata_variant( zombie ) );
 }
 
-TEST_CASE( "variant_from_string" )
+TEST_CASE( "variant_from_string", "[nogame]" )
 {
     cata_variant v = cata_variant::from_string( cata_variant_type::mtype_id, "mon_zombie" );
     CHECK( v == cata_variant( mon_zombie ) );
 }
 
-TEST_CASE( "variant_type_for", "[variant]" )
+TEST_CASE( "variant_type_for", "[variant][nogame]" )
 {
     CHECK( cata_variant_type_for<bool>() == cata_variant_type::bool_ );
     CHECK( cata_variant_type_for<int>() == cata_variant_type::int_ );

--- a/tests/catacharset_test.cpp
+++ b/tests/catacharset_test.cpp
@@ -13,7 +13,7 @@
 #include "translations.h"
 #include "unicode.h"
 
-TEST_CASE( "utf8_width", "[catacharset]" )
+TEST_CASE( "utf8_width", "[catacharset][nogame]" )
 {
     CHECK( utf8_width( "Hello, world!", false ) == 13 );
     CHECK( utf8_width( "你好，世界！", false ) == 12 );
@@ -25,7 +25,7 @@ TEST_CASE( "utf8_width", "[catacharset]" )
     CHECK( utf8_width( "à̸̠你⃫", false ) == 3 );
 }
 
-TEST_CASE( "utf8_display_split", "[catacharset]" )
+TEST_CASE( "utf8_display_split", "[catacharset][nogame]" )
 {
     CHECK( utf8_display_split( "你好" ) == std::vector<std::string> { "你", "好" } );
     CHECK( utf8_display_split( "à" ) == std::vector<std::string> { "à" } );
@@ -34,13 +34,13 @@ TEST_CASE( "utf8_display_split", "[catacharset]" )
     CHECK( utf8_display_split( "    " ) == std::vector<std::string> { " ", " ", " ", " " } );
 }
 
-TEST_CASE( "base64", "[catacharset]" )
+TEST_CASE( "base64", "[catacharset][nogame]" )
 {
     CHECK( base64_encode( "hello" ) == "#aGVsbG8=" );
     CHECK( base64_decode( "#aGVsbG8=" ) == "hello" );
 }
 
-TEST_CASE( "utf8_to_wstr", "[catacharset]" )
+TEST_CASE( "utf8_to_wstr", "[catacharset][nogame]" )
 {
     // std::mbstowcs' returning -1 workaround
     char *result = setlocale( LC_ALL, "" );
@@ -52,7 +52,7 @@ TEST_CASE( "utf8_to_wstr", "[catacharset]" )
     REQUIRE( result );
 }
 
-TEST_CASE( "wstr_to_utf8", "[catacharset]" )
+TEST_CASE( "wstr_to_utf8", "[catacharset][nogame]" )
 {
     // std::wcstombs' returning -1 workaround
     char *result = setlocale( LC_ALL, "" );
@@ -64,7 +64,7 @@ TEST_CASE( "wstr_to_utf8", "[catacharset]" )
     REQUIRE( result );
 }
 
-TEST_CASE( "localized_compare", "[catacharset]" )
+TEST_CASE( "localized_compare", "[catacharset][nogame]" )
 {
     try {
         std::locale::global( std::locale( "en_US.UTF-8" ) );
@@ -99,7 +99,7 @@ static void check_in_place_func( const std::function<void( char32_t & )> &func,
     CHECK( ch == expected );
 }
 
-TEST_CASE( "u32_to_lowercase", "[catacharset]" )
+TEST_CASE( "u32_to_lowercase", "[catacharset][nogame]" )
 {
     // Latin
     check_in_place_func( u32_to_lowercase, U'a', U'a' );
@@ -123,7 +123,7 @@ TEST_CASE( "u32_to_lowercase", "[catacharset]" )
     check_in_place_func( u32_to_lowercase, U'😅', U'😅' );
 }
 
-TEST_CASE( "remove_accent", "[catacharset]" )
+TEST_CASE( "remove_accent", "[catacharset][nogame]" )
 {
     // Latin
     check_in_place_func( remove_accent, U'o', U'o' );
@@ -142,7 +142,7 @@ TEST_CASE( "remove_accent", "[catacharset]" )
     check_in_place_func( remove_accent, U'😅', U'😅' );
 }
 
-TEST_CASE( "utf8_view", "[catacharset]" )
+TEST_CASE( "utf8_view", "[catacharset][nogame]" )
 {
     static const std::string str{"Français中文русский"};
     static const std::vector<char32_t> expected_code_points{

--- a/tests/coordinate_test.cpp
+++ b/tests/coordinate_test.cpp
@@ -26,7 +26,7 @@ coords::coord_point<Point, Origin, Scale, InBounds> assert_not_ib( const
     return p;
 }
 
-TEST_CASE( "coordinate_strings", "[point][coords]" )
+TEST_CASE( "coordinate_strings", "[point][coords][nogame]" )
 {
     CHECK( point_abs_omt( point( 3, 4 ) ).to_string() == "(3,4)" );
 
@@ -37,7 +37,7 @@ TEST_CASE( "coordinate_strings", "[point][coords]" )
     }
 }
 
-TEST_CASE( "coordinate_operations", "[point][coords]" )
+TEST_CASE( "coordinate_operations", "[point][coords][nogame]" )
 {
     SECTION( "construct_from_raw_point" ) {
         point p = GENERATE( take( num_trials, random_points() ) );
@@ -193,7 +193,7 @@ TEST_CASE( "coordinate_operations", "[point][coords]" )
     }
 }
 
-TEST_CASE( "coordinate_comparison", "[point][coords]" )
+TEST_CASE( "coordinate_comparison", "[point][coords][nogame]" )
 {
     SECTION( "compare_points" ) {
         point p0 = GENERATE( take( num_trials, random_points() ) );
@@ -224,7 +224,7 @@ TEST_CASE( "coordinate_comparison", "[point][coords]" )
     }
 }
 
-TEST_CASE( "coordinate_hash", "[point][coords]" )
+TEST_CASE( "coordinate_hash", "[point][coords][nogame]" )
 {
     SECTION( "point_hash" ) {
         point p = GENERATE( take( num_trials, random_points() ) );
@@ -239,7 +239,7 @@ TEST_CASE( "coordinate_hash", "[point][coords]" )
     }
 }
 
-TEST_CASE( "coordinate_conversion_consistency", "[point][coords]" )
+TEST_CASE( "coordinate_conversion_consistency", "[point][coords][nogame]" )
 {
     // Verifies that the new coord_point-based conversions yield the same
     // results as the legacy conversion functions.
@@ -384,7 +384,7 @@ TEST_CASE( "coordinate_conversion_consistency", "[point][coords]" )
     }
 }
 
-TEST_CASE( "combine_is_opposite_of_remain", "[point][coords]" )
+TEST_CASE( "combine_is_opposite_of_remain", "[point][coords][nogame]" )
 {
     SECTION( "point_point" ) {
         point p = GENERATE( take( num_trials, random_points() ) );
@@ -438,7 +438,7 @@ TEST_CASE( "combine_is_opposite_of_remain", "[point][coords]" )
     }
 }
 
-TEST_CASE( "coord_point_distances", "[point][coords]" )
+TEST_CASE( "coord_point_distances", "[point][coords][nogame]" )
 {
     point_abs_omt p0;
     point_abs_omt p1( 10, 10 );
@@ -460,7 +460,7 @@ TEST_CASE( "coord_point_distances", "[point][coords]" )
     }
 }
 
-TEST_CASE( "coord_point_midpoint", "[point][coords]" )
+TEST_CASE( "coord_point_midpoint", "[point][coords][nogame]" )
 {
     point_abs_omt p0( 2, 2 );
     point_abs_omt p1( 8, 17 );

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -413,6 +413,8 @@ int main( int argc, const char *argv[] )
 
     if( world_generator == nullptr ) {
         // The session run may not have initialized game state because asked to list tests
+        std::chrono::duration<double> elapsed_seconds = end - start;
+        DebugLog( D_INFO, DC_ALL ) << "Finished in " << elapsed_seconds.count() << " seconds";
         return result;
     }
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -416,22 +416,19 @@ int main( int argc, const char *argv[] )
         return EXIT_FAILURE;
     }
 
-    if( world_generator == nullptr ) {
-        // The session run may not have initialized game state because asked to list tests
-        std::chrono::duration<double> elapsed_seconds = end - start;
-        DebugLog( D_INFO, DC_ALL ) << "Finished in " << elapsed_seconds.count() << " seconds";
-        return result;
-    }
-
-    std::string world_name = world_generator->active_world->world_name;
-    if( result == 0 || dont_save ) {
-        world_generator->delete_world( world_name, true );
-    } else {
-        if( g->save() ) {
-            DebugLog( D_INFO, DC_ALL ) << "Test world " << world_name << " left for inspection.";
-        } else {
-            DebugLog( D_ERROR, DC_ALL ) << "Test world " << world_name << " failed to save.";
-            result = 1;
+    if( world_generator ) {
+        std::string world_name = world_generator->active_world->world_name;
+        if( result == 0 || dont_save ) {
+            world_generator->delete_world( world_name, true );
+        }
+        else {
+            if( g->save() ) {
+                DebugLog( D_INFO, DC_ALL ) << "Test world " << world_name << " left for inspection.";
+            }
+            else {
+                DebugLog( D_ERROR, DC_ALL ) << "Test world " << world_name << " failed to save.";
+                result = 1;
+            }
         }
     }
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -386,13 +386,13 @@ int main( int argc, const char *argv[] )
     // Tests not requiring the global game initialized are tagged with [nogame]
     {
         using namespace Catch;
-        std::vector<TestCase> const& tcs = filterTests(
-            getAllTestCasesSorted( session.config() ),
-            session.config().testSpec(),
-            session.config()
-        );
-        for( auto const& tc : tcs ) {
-            for( auto const& tag : tc.getTestCaseInfo().tags ) {
+        std::vector<TestCase> const &tcs = filterTests(
+                                               getAllTestCasesSorted( session.config() ),
+                                               session.config().testSpec(),
+                                               session.config()
+                                           );
+        for( auto const &tc : tcs ) {
+            for( auto const &tag : tc.getTestCaseInfo().tags ) {
                 needs_game = true;
                 if( tag == "nogame" ) {
                     needs_game = false;

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -402,8 +402,9 @@ int main( int argc, const char *argv[] )
                     break;
                 }
             }
-            if( needs_game )
+            if( needs_game ) {
                 break;
+            }
         }
     }
 
@@ -420,12 +421,10 @@ int main( int argc, const char *argv[] )
         std::string world_name = world_generator->active_world->world_name;
         if( result == 0 || dont_save ) {
             world_generator->delete_world( world_name, true );
-        }
-        else {
+        } else {
             if( g->save() ) {
                 DebugLog( D_INFO, DC_ALL ) << "Test world " << world_name << " left for inspection.";
-            }
-            else {
+            } else {
                 DebugLog( D_ERROR, DC_ALL ) << "Test world " << world_name << " failed to save.";
                 result = 1;
             }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -393,15 +393,17 @@ int main( int argc, const char *argv[] )
                                                config
                                            );
         for( TestCase const &tc : tcs ) {
+            // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
+            needs_game = true;
             for( std::string const &tag : tc.getTestCaseInfo().tags ) {
-                // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
-                needs_game = true;
                 if( tag == "nogame" ) {
                     // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
                     needs_game = false;
                     break;
                 }
             }
+            if( needs_game )
+                break;
         }
     }
 

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -65,7 +65,7 @@ static std::chrono::system_clock::time_point start;
 static std::chrono::system_clock::time_point end;
 static bool error_during_initialization{ false };
 
-static bool needs_game{ true };
+static bool needs_game{ false };
 
 static std::vector<mod_id> extract_mod_selection( const std::string_view mod_string )
 {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -386,15 +386,18 @@ int main( int argc, const char *argv[] )
     // Tests not requiring the global game initialized are tagged with [nogame]
     {
         using namespace Catch;
+        Config const &config = session.config();
         std::vector<TestCase> const &tcs = filterTests(
-                                               getAllTestCasesSorted( session.config() ),
-                                               session.config().testSpec(),
-                                               session.config()
+                                               getAllTestCasesSorted( config ),
+                                               config.testSpec(),
+                                               config
                                            );
-        for( auto const &tc : tcs ) {
-            for( auto const &tag : tc.getTestCaseInfo().tags ) {
+        for( TestCase const &tc : tcs ) {
+            for( std::string const &tag : tc.getTestCaseInfo().tags ) {
+                // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
                 needs_game = true;
                 if( tag == "nogame" ) {
+                    // NOLINTNEXTLINE(cata-tests-must-restore-global-state)
                     needs_game = false;
                     break;
                 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Only init game if we're running tests that need it"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Implement the long-staning `TODO` in `tests/test_main.cpp` with the same name.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The idea is to tag those few `TEST_CASE()`s with the special `[nogame]` tag. This is checked before running the tests by looping over all the selected tests. If all have `[nogame]`, then the global game object is not called.
This speeds up some kind of tests a lot by not initializing the game.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Use a tag `[g]` to do the opposite. But this would have required to review all the 1139 tests.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
- ✅ `[utility]` do not initialized the game object
- ✅ other tags do initialize the game object
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
More tests should be reviewed and tagged as `[nogame]`.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
