### PR TITLE
Aftershock: OrionBank E-trade network

### DIFF
--- a/data/core/game_balance.json
+++ b/data/core/game_balance.json
@@ -463,6 +463,13 @@
   },
   {
     "type": "EXTERNAL_OPTION",
+    "name": "CAPITALISM",
+    "info": "NPCs will accept your bank balance as payment in trades.",
+    "stype": "bool",
+    "value": false
+  },
+  {
+    "type": "EXTERNAL_OPTION",
     "name": "DESCRIBE_MUSIC_FREQUENCY",
     "info": "Determines frequency (in minutes) of displaying music description in sidebar when listening to MP3-players and the like.",
     "stype": "int",

--- a/data/mods/Aftershock/options.json
+++ b/data/mods/Aftershock/options.json
@@ -16,5 +16,12 @@
     "name": "EMP_DISABLE_ELECTRONICS",
     "stype": "bool",
     "value": false
+  },
+  {
+    "type": "EXTERNAL_OPTION",
+    "name": "CAPITALISM",
+    "info": "NPCs will accept your bank balance as payment in trades.",
+    "stype": "bool",
+    "value": true
   }
 ]

--- a/data/raw/keybindings.json
+++ b/data/raw/keybindings.json
@@ -3685,6 +3685,13 @@
   },
   {
     "type": "keybinding",
+    "id": "BANK_BALANCE",
+    "category": "INVENTORY",
+    "name": "Auto balance trade using bank account",
+    "bindings": [ { "input_method": "keyboard_any", "key": "F2" } ]
+  },
+  {
+    "type": "keybinding",
     "id": "DECREASE_COUNT",
     "category": "INVENTORY",
     "name": "Decrease selected amount for the highlighted item",

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -4337,11 +4337,13 @@ trade_selector::trade_selector( trade_ui *parent, Character &u,
     _ctxt_trade.register_action( ACTION_TRADE_CANCEL );
     _ctxt_trade.register_action( ACTION_TRADE_OK );
     _ctxt_trade.register_action( ACTION_AUTOBALANCE );
+    _ctxt_trade.register_action( ACTION_BANKBALANCE );
     _ctxt_trade.register_action( "ANY_INPUT" );
     // duplicate this action in the parent ctxt so it shows up in the keybindings menu
     // CANCEL and OK are already set in inventory_selector
     ctxt.register_action( ACTION_SWITCH_PANES );
     ctxt.register_action( ACTION_AUTOBALANCE );
+    ctxt.register_action( ACTION_BANKBALANCE );
     resize( size, origin );
     _ui = create_or_get_ui_adaptor();
     set_invlet_type( inventory_selector::SELECTOR_INVLET_ALPHA );
@@ -4375,6 +4377,8 @@ void trade_selector::execute()
             exit = true;
         } else if( action == ACTION_AUTOBALANCE ) {
             _parent->autobalance();
+        } else if( action == ACTION_BANKBALANCE ) {
+            _parent->bank_balance();
         } else {
             input_event const iev = _ctxt_trade.get_raw_input();
             inventory_input const input =

--- a/src/npctrade.cpp
+++ b/src/npctrade.cpp
@@ -327,6 +327,7 @@ bool npc_trading::trade( npc &np, int cost, const std::string &deal )
 
         // NPCs will remember debts, to the limit that they'll extend credit or previous debts
         if( !np.will_exchange_items_freely() ) {
+            player_character.cash -= trade_result.delta_bank;
             update_npc_owed( np, trade_result.balance, trade_result.value_you );
             player_character.practice( skill_speech, trade_result.value_you / 10000 );
         }

--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -15,6 +15,7 @@
 #include "npc.h"
 #include "npctrade.h"
 #include "npctrade_utils.h"
+#include "options.h"
 #include "output.h"
 #include "point.h"
 #include "string_formatter.h"
@@ -146,7 +147,8 @@ trade_ui::trade_ui( party_t &you, npc &trader, currency_t cost, std::string titl
         _cost = trader.op_of_u.owed - cost;
     }
     _balance = _cost;
-
+    _bank = you.cash;
+    _delta_bank = 0;
     _panes[_you]->get_active_column().on_deactivate();
 
     _header_ui.on_screen_resize( [&]( ui_adaptor & ui ) {
@@ -186,13 +188,14 @@ trade_ui::trade_result_t trade_ui::perform_trade()
     if( _traded ) {
         return { _traded,
                  _balance,
+                 _delta_bank,
                  _trade_values[_you],
                  _trade_values[_trader],
                  _panes[_you]->to_trade(),
                  _panes[_trader]->to_trade() };
     }
 
-    return { false, 0, 0, 0, {}, {} };
+    return { false, 0, 0, 0, 0, {}, {} };
 }
 
 void trade_ui::recalc_values_cpane()
@@ -205,7 +208,7 @@ void trade_ui::recalc_values_cpane()
             npc_trading::trading_price( *_parties[-_cpane + 1], *_parties[_cpane], it );
     }
     if( !_parties[_trader]->as_npc()->will_exchange_items_freely() ) {
-        _balance = _cost + _trade_values[_you] - _trade_values[_trader];
+        _balance = _cost + _trade_values[_you] - _trade_values[_trader] + _delta_bank;
     }
     _header_ui.invalidate_ui();
 }
@@ -223,6 +226,22 @@ void trade_ui::autobalance()
         _panes[_cpane]->toggle_entry( entry, entry.chosen_count +
                                       std::min( static_cast<size_t>( extra ), avail ) );
     }
+}
+
+void trade_ui::bank_balance()
+{
+    if (!get_option<bool>( "CAPITALISM" )) {
+            popup( _( "Your promises of digital payment mean nothing here." ) );
+            return;
+    }
+    _bank += _delta_bank;
+    _delta_bank = -( _balance - _delta_bank );
+    if( _delta_bank > 0 ) { // a withdrawal
+        _delta_bank = std::min( _delta_bank, _bank );
+        _delta_bank = std::max( _delta_bank, 0 );
+    }
+    _bank -= _delta_bank;
+    recalc_values_cpane();
 }
 
 void trade_ui::resize()
@@ -308,4 +327,13 @@ void trade_ui::_draw_header()
                                  colorize( _panes[_you]->get_ctxt()->get_desc(
                                          trade_selector::ACTION_AUTOBALANCE ),
                                            c_yellow ) ) );
+    if ( get_option<bool>( "CAPITALISM" ) ) {
+        right_print( _header_w, 2, 1, c_white, string_format( _( "Bank Balance: %s"), format_money(  _bank ) ) );
+        right_print( _header_w, 1, 1, c_white,
+                    string_format( _( "%s to balance trade with bank account balance" ),
+                                    colorize( _panes[_you]->get_ctxt()->get_desc(
+                                            trade_selector::ACTION_BANKBALANCE ),
+                                            c_yellow ) ) );
+    }
+
 }

--- a/src/trade_ui.cpp
+++ b/src/trade_ui.cpp
@@ -230,9 +230,9 @@ void trade_ui::autobalance()
 
 void trade_ui::bank_balance()
 {
-    if (!get_option<bool>( "CAPITALISM" )) {
-            popup( _( "Your promises of digital payment mean nothing here." ) );
-            return;
+    if( !get_option<bool>( "CAPITALISM" ) ) {
+        popup( _( "Your promises of digital payment mean nothing here." ) );
+        return;
     }
     _bank += _delta_bank;
     _delta_bank = -( _balance - _delta_bank );
@@ -327,13 +327,14 @@ void trade_ui::_draw_header()
                                  colorize( _panes[_you]->get_ctxt()->get_desc(
                                          trade_selector::ACTION_AUTOBALANCE ),
                                            c_yellow ) ) );
-    if ( get_option<bool>( "CAPITALISM" ) ) {
-        right_print( _header_w, 2, 1, c_white, string_format( _( "Bank Balance: %s"), format_money(  _bank ) ) );
+    if( get_option<bool>( "CAPITALISM" ) ) {
+        right_print( _header_w, 2, 1, c_white, string_format( _( "Bank Balance: %s" ),
+                     format_money( _bank ) ) );
         right_print( _header_w, 1, 1, c_white,
-                    string_format( _( "%s to balance trade with bank account balance" ),
+                     string_format( _( "%s to balance trade with bank account balance" ),
                                     colorize( _panes[_you]->get_ctxt()->get_desc(
                                             trade_selector::ACTION_BANKBALANCE ),
-                                            c_yellow ) ) );
+                                              c_yellow ) ) );
     }
 
 }

--- a/src/trade_ui.h
+++ b/src/trade_ui.h
@@ -40,6 +40,7 @@ class trade_selector : public inventory_drop_selector
         input_context const *get_ctxt() const;
 
         static constexpr char const *ACTION_AUTOBALANCE = "AUTO_BALANCE";
+        static constexpr char const *ACTION_BANKBALANCE = "BANK_BALANCE";
         static constexpr char const *ACTION_SWITCH_PANES = "SWITCH_LISTS";
         static constexpr char const *ACTION_TRADE_OK = "CONFIRM";
         static constexpr char const *ACTION_TRADE_CANCEL = "QUIT";
@@ -74,6 +75,7 @@ class trade_ui
         struct trade_result_t {
             bool traded = false;
             currency_t balance = 0;
+            currency_t delta_bank = 0;
             currency_t value_you = 0;
             currency_t value_trader = 0;
             select_t items_you;
@@ -89,6 +91,7 @@ class trade_ui
         trade_result_t perform_trade();
         void recalc_values_cpane();
         void autobalance();
+        void bank_balance();
         void resize();
 
         constexpr static int header_size = 5;
@@ -112,6 +115,8 @@ class trade_ui
         bool _traded = false;
         currency_t _cost = 0;
         currency_t _balance = 0;
+        currency_t _bank = 0;
+        currency_t _delta_bank = 0;
         std::string const _title;
         catacurses::window _header_w;
         ui_adaptor _header_ui;


### PR DESCRIPTION
#### Summary
Mods "Aftershock: Can trade with NPCs using your bank account."

#### Purpose of change

Noticed while testing port Augustmoon that the combination of high prices and physical currency items made big purchases rather inconvenient to manage and needed an easier way to complete trades. 

Since Aftershock has a functional economy and society in the lore, I opted to make the old bank account every character has a valid resource for NPC trading, so there's no longer any need to track physical coins.


#### Describe the solution

Adds a new external option "Capitalism" that allows trading using your bank balance and also lets you demand small loans from shopkeepers.

Causes cash cards to become legal-tender again.

#### Testing

Traded with NPCs