### PR TITLE
Remove the by-product steel blocks from the tin recipes

### DIFF
--- a/data/json/recipes/other/materials.json
+++ b/data/json/recipes/other/materials.json
@@ -924,7 +924,6 @@
     "result": "tin",
     "type": "recipe",
     "activity_level": "NO_EXERCISE",
-    "byproducts": [ [ "steel_chunk" ] ],
     "category": "CC_OTHER",
     "subcategory": "CSC_OTHER_MATERIALS",
     "skill_used": "chemistry",


### PR DESCRIPTION
#### Summary

Bugfixes "Remove the by-product steel blocks from the tin recipes"

#### Purpose of change

The recipe for producing tin will produce steel blocks as by-products, which is not reasonable

#### Describe the solution

Remove the by-product steel blocks from the tin recipes

#### Describe alternatives you've considered

None

#### Testing

Enter the game, check the recipe, everything is normal

#### Additional context

None
