### PR TITLE
github: build libbacktrace locally and use it for linux/mingw bindist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
             sound: 1
           - name: Windows Tiles x64
             mxe: x86_64
+            libbacktrace: 1
             artifact: windows-tiles-x64
             os: ubuntu-latest
             ext: zip
@@ -73,6 +74,7 @@ jobs:
             sound: 0
           - name: Windows Tiles Sounds x64
             mxe: x86_64
+            libbacktrace: 1
             artifact: windows-tiles-sounds-x64
             os: ubuntu-latest
             ext: zip
@@ -89,6 +91,7 @@ jobs:
             os: ubuntu-20.04
             mxe: none
             android: none
+            libbacktrace: 1
             tiles: 1
             sound: 0
             artifact: linux-tiles-x64
@@ -98,6 +101,7 @@ jobs:
             os: ubuntu-20.04
             mxe: none
             android: none
+            libbacktrace: 1
             tiles: 1
             sound: 1
             artifact: linux-tiles-sounds-x64
@@ -107,6 +111,7 @@ jobs:
             os: ubuntu-20.04
             mxe: none
             android: none
+            libbacktrace: 1
             tiles: 0
             sound: 0
             artifact: linux-curses-x64
@@ -207,9 +212,6 @@ jobs:
           curl -L -o SDL2-devel-2.26.2-mingw.tar.gz https://github.com/libsdl-org/SDL/releases/download/release-2.26.2/SDL2-devel-2.26.2-mingw.tar.gz
           shasum -a 256 -c ./build-scripts/SDL2-devel-2.26.2-mingw.tar.gz.sha256
           sudo tar -xzf SDL2-devel-2.26.2-mingw.tar.gz -C /opt/mxe/usr/${{ matrix.mxe }}-w64-mingw32.static.gcc12 --strip-components=2 SDL2-2.26.2/${{ matrix.mxe }}-w64-mingw32
-          curl -L -o libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz https://github.com/Qrox/libbacktrace/releases/download/2020-01-03/libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz
-          shasum -a 256 -c ./build-scripts/libbacktrace-${{ matrix.mxe }}-w64-mingw32-sha256
-          sudo tar -xzf libbacktrace-${{ matrix.mxe }}-w64-mingw32.tar.gz --exclude=LICENSE -C /opt/mxe/usr/${{ matrix.mxe }}-w64-mingw32.static.gcc12
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none' && !matrix.wasm
         run: |
@@ -246,10 +248,20 @@ jobs:
         shell: bash
         run: |
           lang/compile_mo.sh all
+      - name: Build libbacktrace
+        if: matrix.libbacktrace == 1
+        run: |
+          git clone https://github.com/ianlancetaylor/libbacktrace.git
+          cd libbacktrace
+          git checkout 14818b7783eeb9a56c3f0fca78cefd3143f8c5f6
+          ./configure
+          make -j$((`nproc`+0))
+          cp LICENSE ${{ github.workspace }}/LICENSE-libbacktrace.txt
+          sudo make install
       - name: Build CDDA (linux)
         if: runner.os == 'Linux' && matrix.mxe == 'none' && matrix.android == 'none' && matrix.artifact != 'linux-objectcreator-x64' && !matrix.wasm
         run: |
-          make -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 PCH=0 bindist
+          make -j$((`nproc`+0)) TILES=${{ matrix.tiles }} SOUND=${{ matrix.tiles }} RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} PCH=0 bindist
           mv cataclysmdda-0.I.tar.gz cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.tar.gz
       - name: Build CDDA (WebAssembly)
         if: matrix.wasm
@@ -298,7 +310,7 @@ jobs:
         env:
           PLATFORM: /opt/mxe/usr/bin/${{ matrix.mxe }}-w64-mingw32.static.gcc12-
         run: |
-          make -j$((`nproc`+0)) CROSS="${PLATFORM}" TILES=1 SOUND=1 RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 PCH=0 bindist
+          make -j$((`nproc`+0)) CROSS="${PLATFORM}" TILES=1 SOUND=1 RELEASE=1 LOCALIZE=1 LANGUAGES=all BACKTRACE=1 LIBBACKTRACE=${{ matrix.libbacktrace }} PCH=0 bindist
           mv cataclysmdda-0.I.zip cdda-${{ matrix.artifact }}-${{ needs.release.outputs.timestamp }}.zip
       - name: Build CDDA (windows msvc)
         if: runner.os == 'Windows'

--- a/Makefile
+++ b/Makefile
@@ -876,6 +876,9 @@ ifeq ($(BACKTRACE),1)
   ifeq ($(LIBBACKTRACE),1)
       DEFINES += -DLIBBACKTRACE
       LDFLAGS += -lbacktrace
+      ifneq ("$(wildcard LICENSE-libbacktrace.txt)","")
+        BINDIST_EXTRAS += LICENSE-libbacktrace.txt
+      endif
   endif
 endif
 


### PR DESCRIPTION
#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Improve backtrace performance in linux/mingw builds by using libbacktrace.
* See #70921

#### Describe the solution
Build libbacktrace locally as a github action since it's trivial and fast. Turns out we were already doing it for CI, but not for releases.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
N/A

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The linux and mingw builds from [this release](https://github.com/andrei8l/Cataclysm-DDA/releases/tag/cdda-experimental-2024-01-14-1034)  produce libbacktrace crash logs and contain the license file.

Using the reproducible crash from `https://github.com/CleverRaven/Cataclysm-DDA/issues/70363`
<details>
<summary>crash log from linux binary</summary>

```gdb
The program has crashed.
See the log file for a stack trace.
CRASH LOG FILE: ./config/crash.log
VERSION: 3fa3c4f
TYPE: Signal
MESSAGE: SIGSEGV: Segmentation fault
STACK TRACE:

    0x558.cb6.632.255    src/debug.cpp:952    bt_full
    0x558.cb6.632.255    src/debug.cpp:1.217    debug_write_backtrace(std::ostream&)
    0x558.cb6.60a.a22    src/crash.cpp:85    log_crash
    0x558.cb6.60a.d42    src/crash.cpp:138    signal_handler
    0x7f1.06e.05c.70f    [unknown src]:0    [unknown func]
    0x558.cb6.8ce.961    /usr/include/c++/9/bits/stl_tree.h:2.575    std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >::find(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const
    0x558.cb6.892.91f    src/item.cpp:1.681    item::get_var(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, double) const
    0x558.cb6.326.edb    src/activity_actor.cpp:4.696    reload_activity_actor::finish(player_activity&, Character&)
    0x558.cb6.e89.cc1    src/player_activity.cpp:383    player_activity::do_turn(Character&)
    0x558.cb6.693.ddd    src/do_turn.cpp:495    do_turn()
    0x558.cb6.184.2ee    src/main.cpp:851    main
    0x7f1.06e.045.ccf    [unknown src]:0    [unknown func]
    0x7f1.06e.045.d89    [unknown src]:0    [unknown func]
    0x558.cb6.2dc.d6d    [unknown src]:0    [unknown func]
    0xf.fff.fff.fff.fff.fff    [unknown src]:0    [unknown func]
```


</details>
<details>
<summary>for comparison, crash log from addr2line</summary>

using https://github.com/CleverRaven/Cataclysm-DDA/releases/tag/cdda-experimental-2024-01-14-0816

```gdb
The program has crashed.
See the log file for a stack trace.
CRASH LOG FILE: ./config/crash.log
VERSION: 56dadb6
TYPE: Signal
MESSAGE: SIGSEGV: Segmentation fault
STACK TRACE:

    ./cataclysm-tiles(debug_write_backtrace(std::ostream&)+0x40) [0x5565fbad8f21]
    ./cataclysm-tiles(+0xc0a8f3) [0x5565fbaaf8f3]
    ./cataclysm-tiles(+0xc0ac13) [0x5565fbaafc13]
    /usr/lib/libc.so.6(+0x3e710) [0x7fce42a5c710]
    ./cataclysm-tiles(std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >::find(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const+0x15) [0x5565fbd7f67f]
    ./cataclysm-tiles(item::get_var(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, double) const+0x34) [0x5565fbd4363e]
    ./cataclysm-tiles(reload_activity_actor::finish(player_activity&, Character&)+0x214) [0x5565fb7cbdac]
    ./cataclysm-tiles(player_activity::do_turn(Character&)+0xa70) [0x5565fc33a828]
    ./cataclysm-tiles(do_turn()+0x4f3) [0x5565fbb44afc]
    ./cataclysm-tiles(main+0x1f7d) [0x5565fb6291bf]
    /usr/lib/libc.so.6(+0x27cd0) [0x7fce42a45cd0]
    /usr/lib/libc.so.6(__libc_start_main+0x8a) [0x7fce42a45d8a]
    ./cataclysm-tiles(_start+0x2e) [0x5565fb781c3e]

    Attempting to repeat stack trace using debug symbols…
    debug_write_backtrace(std::ostream&)
    …/src/debug.cpp:1227
    std::__cxx11::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >::str() const
    /usr/include/c++/9/sstream:678
    log_crash
    …/src/crash.cpp:86
    signal_handler
    …/src/crash.cpp:143
    ??
    ??:0
    std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >::find(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const
    /usr/include/c++/9/bits/stl_tree.h:2575
    item::get_var(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, double) const
    …/src/item.cpp:1681
    std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::~basic_string()
    /usr/include/c++/9/bits/basic_string.h:662 (discriminator 2)
    reload_activity_actor::finish(player_activity&, Character&)
    …/src/activity_actor.cpp:4696 (discriminator 2)
    player_activity::do_turn(Character&)
    …/src/player_activity.cpp:383
    do_turn()
    …/src/do_turn.cpp:495
    main
    …/src/main.cpp:851
    ??
    ??:0
    ??
    ??:0
    _start
    ??:?
```

</details>


<details>
<summary>crash log from mingw binary</summary>

```gdb
The program has crashed.
See the log file for a stack trace.
CRASH LOG FILE: ./config/crash.log
VERSION: 3fa3c4f
TYPE: Signal
MESSAGE: SIGSEGV: Segmentation fault
STACK TRACE:

  #0
    (dbghelp: @0x140286ff8[cataclysm-tiles.exe+0x286ff8]), 
    (libbacktrace: debug_write_backtrace(std::ostream&)+0xa8@0x140286ff8),
    0x140286ff8    src/debug.cpp:1125    debug_write_backtrace(std::ostream&)
  #1
    (dbghelp: @0x140266dec[cataclysm-tiles.exe+0x266dec]), 
    (libbacktrace: log_crash+0x1ae@0x140266dec),
    0x140266dec    /opt/mxe/usr/lib/gcc/x86_64-w64-mingw32.static.gcc12/12.2.0/include/c++/sstream:918    std::__cxx11::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >::str() const
    0x140266dec    src/crash.cpp:86    log_crash
  #2
    (dbghelp: @0x1402670c0[cataclysm-tiles.exe+0x2670c0]), 
    (libbacktrace: signal_handler+0x52@0x1402670c0),
    0x1402670c0    src/crash.cpp:143    signal_handler
  #3
    (dbghelp: @0x140cb1452[cataclysm-tiles.exe+0xcb1452]), 
    (libbacktrace: _gnu_exception_handler+0x152@0x140cb1452),
    0x140cb1452    /opt/mxe/tmp-gcc-x86_64-w64-mingw32.static.gcc12/gcc-12.2.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt/crt_handler.c:287    _gnu_exception_handler
  #4
    (dbghelp: __C_specific_handler+0xc8@0x6fffffcb8618[ntdll.dll+0x58618]), 
    (libbacktrace: __C_specific_handler+0xc8@0x170058618),
    0x170058618    ../wine/dlls/ntdll/signal_x86_64.c:1544    __C_specific_handler
  #5
    (dbghelp: @0x6fffffcb5024[ntdll.dll+0x55024]), 
    (libbacktrace: exception_handler_call_wrapper+0x8@0x170055024),
    0x170055024    …/src/wine-64-build/../wine/dlls/ntdll/signal_x86_64.c:0    [unknown func]
  #6
    (dbghelp: call_stack_handlers+0xf4@0x6fffffcb6d84[ntdll.dll+0x56d84]), 
    (libbacktrace: call_stack_handlers+0xf4@0x170056d84),
    0x170056d84    ../wine/dlls/ntdll/signal_x86_64.c:413    call_handler
    0x170056d84    ../wine/dlls/ntdll/signal_x86_64.c:479    call_stack_handlers
  #7
    (dbghelp: dispatch_exception+0xe7@0x6fffffcb7277[ntdll.dll+0x57277]), 
    (libbacktrace: dispatch_exception+0xe7@0x170057277),
    0x170057277    ../wine/dlls/ntdll/signal_x86_64.c:605    dispatch_exception
  #8
    (dbghelp: @0x6fffffcb507e[ntdll.dll+0x5507e]), 
    (libbacktrace: KiUserExceptionDispatcher+0x52@0x17005507e),
    0x17005507e    …/src/wine-64-build/../wine/dlls/ntdll/signal_x86_64.c:0    [unknown func]
  #9
    (dbghelp: @0x1404e58ea[cataclysm-tiles.exe+0x4e58ea]), 
    (libbacktrace: item_contents::get_pockets(std::function<bool (item_pocket const&)> const&)+0xe@0x1404e58ea),
    0x1404e58ea    /opt/mxe/usr/lib/gcc/x86_64-w64-mingw32.static.gcc12/12.2.0/include/c++/bits/stl_list.h:1023    std::__cxx11::list<item_pocket, std::allocator<item_pocket> >::begin()
    0x1404e58ea    src/item_contents.cpp:1995    item_contents::get_pockets(std::function<bool (item_pocket const&)> const&)
  #10
    (dbghelp: @0x1404e59f0[cataclysm-tiles.exe+0x4e59f0]), 
    (libbacktrace: item_contents::get_all_standard_pockets()+0x3a@0x1404e59f0),
    0x1404e59f0    /opt/mxe/usr/lib/gcc/x86_64-w64-mingw32.static.gcc12/12.2.0/include/c++/bits/std_function.h:334    ~function
    0x1404e59f0    /opt/mxe/usr/lib/gcc/x86_64-w64-mingw32.static.gcc12/12.2.0/include/c++/bits/std_function.h:334    std::function<bool (item_pocket const&)>::~function()
    0x1404e59f0    src/item_contents.cpp:2028    item_contents::get_all_standard_pockets()
  #11
    (dbghelp: @0x14047e96d[cataclysm-tiles.exe+0x47e96d]), 
    (libbacktrace: item::get_all_standard_pockets()+0x11@0x14047e96d),
    0x14047e96d    src/item.cpp:9754    item::get_all_standard_pockets()
  #12
    (dbghelp: @0x1412c3194[cataclysm-tiles.exe+0x12c3194]), 
    (libbacktrace: item_location::impl::item_in_container::parent_pocket() const+0x44@0x1412c3194),
    0x1412c3194    /opt/mxe/usr/lib/gcc/x86_64-w64-mingw32.static.gcc12/12.2.0/include/c++/bits/shared_ptr_base.h:1524    ~__shared_ptr
    0x1412c3194    /opt/mxe/usr/lib/gcc/x86_64-w64-mingw32.static.gcc12/12.2.0/include/c++/bits/shared_ptr_base.h:1524    std::__shared_ptr<item_location::impl, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr()
    0x1412c3194    /opt/mxe/usr/lib/gcc/x86_64-w64-mingw32.static.gcc12/12.2.0/include/c++/bits/shared_ptr.h:175    ~shared_ptr
    0x1412c3194    /opt/mxe/usr/lib/gcc/x86_64-w64-mingw32.static.gcc12/12.2.0/include/c++/bits/shared_ptr.h:175    std::shared_ptr<item_location::impl>::~shared_ptr()
    0x1412c3194    src/item_location.h:30    ~item_location
    0x1412c3194    src/item_location.h:30    item_location::~item_location()
    0x1412c3194    src/item_location.cpp:601    item_location::impl::item_in_container::parent_pocket() const
  #13
    (dbghelp: @0x1412c324a[cataclysm-tiles.exe+0x12c324a]), 
    (libbacktrace: item_location::impl::item_in_container::volume_capacity() const+0xa@0x1412c324a),
    0x1412c324a    src/item_location.cpp:739    item_location::impl::item_in_container::volume_capacity() const
  #14
    (dbghelp: @0x1412c329e[cataclysm-tiles.exe+0x12c329e]), 
    (libbacktrace: item_location::impl::item_in_container::check_parent_capacity_recursive() const+0xe@0x1412c329e),
    0x1412c329e    src/item_location.cpp:747    item_location::impl::item_in_container::check_parent_capacity_recursive() const
  #15
    (dbghelp: @0x14003b4b5[cataclysm-tiles.exe+0x3b4b5]), 
    (libbacktrace: reload_activity_actor::finish(player_activity&, Character&)+0x685@0x14003b4b5),
    0x14003b4b5    src/activity_actor.cpp:4718    reload_activity_actor::finish(player_activity&, Character&)
  #16
    (dbghelp: @0x140967153[cataclysm-tiles.exe+0x967153]), 
    (libbacktrace: player_activity::do_turn(Character&)+0x94f@0x140967153),
    0x140967153    src/player_activity.cpp:383    player_activity::do_turn(Character&)
  #17
    (dbghelp: @0x1402dfae3[cataclysm-tiles.exe+0x2dfae3]), 
    (libbacktrace: do_turn()+0x45b@0x1402dfae3),
    0x1402dfae3    src/do_turn.cpp:495    do_turn()
  #18
    (dbghelp: @0x1417822b5[cataclysm-tiles.exe+0x17822b5]), 
    (libbacktrace: main+0x2484@0x1417822b5),
    0x1417822b5    src/main.cpp:851    main
  #19
    (dbghelp: @0x1400013ae[cataclysm-tiles.exe+0x13ae]), 
    (libbacktrace: __tmainCRTStartup+0x22e@0x1400013ae),
    0x1400013ae    /opt/mxe/tmp-gcc-x86_64-w64-mingw32.static.gcc12/gcc-12.2.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt/crtexe.c:323    __tmainCRTStartup
  #20
    (dbghelp: @0x1400014c6[cataclysm-tiles.exe+0x14c6]), 
    (libbacktrace: WinMainCRTStartup+0x16@0x1400014c6),
    0x1400014c6    /opt/mxe/tmp-gcc-x86_64-w64-mingw32.static.gcc12/gcc-12.2.0.build_/mingw-w64-v10.0.0/mingw-w64-crt/crt/crtexe.c:178    WinMainCRTStartup
  #21
    (dbghelp: BaseThreadInitThunk+0x9@0x6fffffac8ae9[kernel32.dll+0x28ae9]), 
    (libbacktrace: BaseThreadInitThunk+0x9@0x178028ae9),
    0x178028ae9    ../wine/dlls/kernel32/thread.c:61    BaseThreadInitThunk
  #22
    (dbghelp: @0x6fffffcb51fb[ntdll.dll+0x551fb]), 
    (libbacktrace: RtlUserThreadStart+0x17@0x1700551fb),
    0x1700551fb    …/src/wine-64-build/../wine/dlls/ntdll/signal_x86_64.c:0    [unknown func]
  #23
    (dbghelp: @0), 
    (unable to get module base address),
  #24
    (dbghelp: @0), 
    (unable to get module base address),
  #25
    (dbghelp: @0), 
    (unable to get module base address),
  #26
    (dbghelp: @0), 
    (unable to get module base address),
```

</details>


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
