### PR TITLE
String extraction script fixes

### DIFF
--- a/lang/string_extractor/parsers/talk_topic.py
+++ b/lang/string_extractor/parsers/talk_topic.py
@@ -70,6 +70,10 @@ def parse_response(json, origin):
         write_text(json["truefalsetext"]["false"], origin, c_format=False,
                    comment="Negative response to NPC dialogue")
 
+    if "failure_explanation" in json:
+        write_text(json["failure_explanation"], origin, c_format=False,
+                   comment="Failure explanation for NPC dialogue response")
+
     if "success" in json:
         parse_response(json["success"], origin)
 

--- a/lang/string_extractor/parsers/ter_furn_transform.py
+++ b/lang/string_extractor/parsers/ter_furn_transform.py
@@ -10,12 +10,13 @@ def transform_result(result):
     if type(result) is str:
         return result
     elif type(result) is list:
-        results = set()
+        # Using a list to reserve order and ensure stability across runs
+        results = []
         for r in result:
-            if type(r) is str:
-                results.add(r)
-            elif type(r) is list:
-                results.add(r[0])
+            if type(r) is str and r not in results:
+                results.append(r)
+            elif type(r) is list and r[0] not in results:
+                results.append(r[0])
         return ", ".join(results)
 
 

--- a/src/mattack_actors.cpp
+++ b/src/mattack_actors.cpp
@@ -723,7 +723,7 @@ bool melee_actor::call( monster &z ) const
         sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos() ),
                                  sfx::get_heard_angle( z.pos() ) );
         target->add_msg_player_or_npc( msg_type, miss_msg_u,
-                                       get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? miss_msg_npc : to_translation( "" ),
+                                       get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? miss_msg_npc : translation(),
                                        z.name(), body_part_name_accusative( bp_id ) );
         return true;
     }
@@ -733,7 +733,7 @@ bool melee_actor::call( monster &z ) const
             sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos() ),
                                      sfx::get_heard_angle( z.pos() ) );
             target->add_msg_player_or_npc( msg_type, miss_msg_u,
-                                           get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? miss_msg_npc : to_translation( "" ),
+                                           get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? miss_msg_npc : translation(),
                                            mon_name, body_part_name_accusative( bp_id ) );
             return true;
         }
@@ -867,7 +867,7 @@ bool melee_actor::call( monster &z ) const
         sfx::play_variant_sound( "mon_bite", "bite_miss", sfx::get_heard_volume( z.pos() ),
                                  sfx::get_heard_angle( z.pos() ) );
         target->add_msg_player_or_npc( msg_type, no_dmg_msg_u,
-                                       get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? no_dmg_msg_npc : to_translation( "" ),
+                                       get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? no_dmg_msg_npc : translation(),
                                        mon_name, body_part_name_accusative( grabbed_bp_id.value_or( bp_id ) ) );
         if( !effects_require_dmg ) {
             for( const mon_effect_data &eff : effects ) {
@@ -884,7 +884,7 @@ bool melee_actor::call( monster &z ) const
         if( g->fling_creature( target, coord_to_angle( z.pos(), target->pos() ),
                                throw_strength ) ) {
             target->add_msg_player_or_npc( msg_type, throw_msg_u,
-                                           get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? throw_msg_npc : to_translation( "" ),
+                                           get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? throw_msg_npc : translation(),
                                            mon_name );
 
             // Items strapped to you may fall off as you hit the ground
@@ -930,7 +930,7 @@ void melee_actor::on_damage( monster &z, Creature &target, dealt_damage_instance
     const std::string mon_name = get_player_character().sees( z.pos() ) ?
                                  z.disp_name( false, true ) : _( "Something" );
     target.add_msg_player_or_npc( msg_type, hit_dmg_u,
-                                  get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? hit_dmg_npc : to_translation( "" ),
+                                  get_option<bool>( "LOG_MONSTER_ATTACK_MONSTER" ) ? hit_dmg_npc : translation(),
                                   mon_name, body_part_name_accusative( bp ) );
 
     for( const mon_effect_data &eff : effects ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -3915,7 +3915,7 @@ void talk_effect_fun_t::set_u_buy_monster( const JsonObject &jo, std::string_vie
     function = [monster_type_id, cost, count, pacified, name, true_eocs,
                      false_eocs]( dialogue & d ) {
         const mtype_id mtype( monster_type_id.evaluate( d ) );
-        translation translated_name = to_translation( _( name.evaluate( d ) ) );
+        translation translated_name = to_translation( name.evaluate( d ) );
         if( d.actor( false )->buy_monster( *d.actor( true ), mtype, cost.evaluate( d ), count.evaluate( d ),
                                            pacified, translated_name ) ) {
             run_eoc_vector( true_eocs, d );
@@ -6494,8 +6494,9 @@ bool json_talk_response::gen_responses( dialogue &d, bool switch_done ) const
         } else if( !failure_explanation.empty() || !failure_topic.empty() ) {
             // build additional talk responses for failed options with an explanation if details are given
             talk_response tr = talk_response();
-            tr.truetext = to_translation( string_format( "*%s: %s", failure_explanation.translated(),
-                                          actual_response.truetext.translated() ) );
+            tr.truetext = no_translation(
+                              string_format( pgettext( "failure_explanation: actual_response", "*%s: %s" ),
+                                             failure_explanation.translated(), actual_response.truetext.translated() ) );
             if( !failure_topic.empty() ) {
                 // Default is TALK_NONE otherwise go to the failure topic provided
                 tr.success.next_topic = talk_topic( failure_topic );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
1. Make the generated comments on terrain/furniture transform strings stable across runs of the string extraction script.
2. Fix empty string warnings from gettext.
3. Extract responce failure explanation strings and update the c++ code to avoid some double translation in `npctalk.cpp`.

#### Describe the solution

#### Describe alternatives you've considered

#### Testing
1. Run the string extraction script twice and the generated comments do not change anymore.
2. Gettext no longer emits the warnings.
3. Run the string extraction script and the strings are extracted. Tested in game and the strings are correctly displayed.

#### Additional context