### PR TITLE
Make saline infusion give effect on the fly, not in the end

### DIFF
--- a/data/json/effects_on_condition/medicine_eocs.json
+++ b/data/json/effects_on_condition/medicine_eocs.json
@@ -23,6 +23,7 @@
     "type": "effect_on_condition",
     "id": "SALINE_INFUSION_eff",
     "//": "4 ml of saline per 1 ml of blood, rate 2L/hour.  1 ml of blood = 10 units of vitamin",
-    "effect": [ { "math": [ "u_vitamin('blood')", "+=", "u_amount_of_saline_infused * ( 10 / 4 )" ] } ]
+    "//2": "because of do_turn_eoc, effect has some precision loss when calculates the amount of blood compensated, in favor of the player",
+    "effect": [ { "math": [ "u_vitamin('blood')", "+=", "(u_amount_of_saline_infused * ( 10 / 4 )) / 3600" ] } ]
   }
 ]

--- a/data/json/player_activities.json
+++ b/data/json/player_activities.json
@@ -1142,6 +1142,6 @@
     "activity_level": "NO_EXERCISE",
     "verb": "infusing saline",
     "based_on": "time",
-    "completion_eoc": "SALINE_INFUSION_eff"
+    "do_turn_eoc": "SALINE_INFUSION_eff"
   }
 ]


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
I don't like you can interrupt saline infusion and got no effect
#### Describe the solution
replace `completion_eoc` with `do_turn_eoc`, tweak the formula accordingly
#### Testing
Runs like clockwork, except some precision loss, but it seems one need to change vitamins to allow doubles to resolve it, since vitamin_eval already uses `double`