### PR TITLE
Add more exception handling so lastworld.json cannot prevent the game from starting

### DIFF
--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -711,7 +711,7 @@ void worldfactory::load_last_world_info()
 {
     cata_path lastworld_path = PATH_INFO::lastworld();
     std::string lwmissing =
-        "lastworld.json or one of its values is empty.  This could be due to data corruption or an unknown error and may be an indicator that your previously played world is damaged.";
+        translate_marker( "lastworld.json or one of its values is empty.  This could be due to data corruption or an unknown error and may be an indicator that your previously played world is damaged." );
 
     try {
         if( !file_exist( lastworld_path ) ) {

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -710,14 +710,30 @@ void worldfactory::remove_world( const std::string &worldname )
 void worldfactory::load_last_world_info()
 {
     cata_path lastworld_path = PATH_INFO::lastworld();
-    if( !file_exist( lastworld_path ) ) {
-        return;
-    }
 
-    JsonValue jsin = json_loader::from_path( lastworld_path );
-    JsonObject data = jsin.get_object();
-    last_world_name = data.get_string( "world_name" );
-    last_character_name = data.get_string( "character_name" );
+    try {
+        if( !file_exist( lastworld_path ) ) {
+            return;
+        }
+
+        std::string json_source_path_string = lastworld_path.generic_u8string();
+        std::optional<std::string> json_file_contents = read_whole_file( lastworld_path );
+
+        if( !json_file_contents.has_value() || json_file_contents->empty() ) {
+            return;
+        }
+        else {
+            JsonValue jsin = json_loader::from_path( lastworld_path );
+            JsonObject data = jsin.get_object();
+            last_world_name = data.get_string( "world_name" );
+            last_character_name = data.get_string( "character_name" );
+        }
+        // JsonError would make more sense here, but it isn't an option because multiple exception types appear before JsonError can throw.
+    } catch( ... )
+    {
+        popup( _( "lastworld.json is empty. This could be due to data corruption or an unknown error and may be an indicator that your previously played world is damaged." ) );
+        debugmsg( "lastworld.json is empty. This could be due to data corruption or an unknown error and may be an indicator that your previously played world is damaged." );
+    }
 }
 
 void worldfactory::save_last_world_info() const

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -730,7 +730,7 @@ void worldfactory::load_last_world_info()
 
             throw JsonError( lwmissing );
         }
-        // JsonError would make more sense here, but it isn't an option because multiple exception types appear before JsonError can throw.
+        // Using non-specific catch because lastworld.json being empty or missing can cause a lot of different types of exceptions. If this is is bad practice, please help correct it if you can.
     } catch( ... ) {
         popup( _( lwmissing ) );
         debugmsg( lwmissing );

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -711,7 +711,7 @@ void worldfactory::load_last_world_info()
 {
     cata_path lastworld_path = PATH_INFO::lastworld();
     std::string lwmissing =
-        "lastworld.json or one of its values is empty. This could be due to data corruption or an unknown error and may be an indicator that your previously played world is damaged.";
+        "lastworld.json or one of its values is empty.  This could be due to data corruption or an unknown error and may be an indicator that your previously played world is damaged.";
 
     try {
         if( !file_exist( lastworld_path ) ) {

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -717,13 +717,12 @@ void worldfactory::load_last_world_info()
         if( !file_exist( lastworld_path ) ) {
             return;
         }
+
+        std::optional<std::string> json_file_contents = read_whole_file( lastworld_path );
         JsonValue jsin = json_loader::from_path( lastworld_path );
         JsonObject data = jsin.get_object();
         last_world_name = data.get_string( "world_name" );
         last_character_name = data.get_string( "character_name" );
-
-        std::string json_source_path_string = lastworld_path.generic_u8string();
-        std::optional<std::string> json_file_contents = read_whole_file( lastworld_path );
 
         if( !json_file_contents.has_value() || json_file_contents->empty() || last_character_name.empty() ||
             last_world_name.empty() ) {

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -729,7 +729,6 @@ void worldfactory::load_last_world_info()
             last_world_name.empty() ) {
 
             throw JsonError( lwmissing );
-
         }
         // JsonError would make more sense here, but it isn't an option because multiple exception types appear before JsonError can throw.
     } catch( ... ) {

--- a/src/worldfactory.cpp
+++ b/src/worldfactory.cpp
@@ -729,7 +729,7 @@ void worldfactory::load_last_world_info()
 
             throw JsonError( lwmissing );
         }
-        // Using non-specific catch because lastworld.json being empty or missing can cause a lot of different types of exceptions. If this is is bad practice, please help correct it if you can.
+        // Using non-specific catch because lastworld.json being empty or missing data can cause a lot of different types of exceptions. If this is is bad practice, please help correct it if you can.
     } catch( ... ) {
         popup( _( lwmissing ) );
         debugmsg( lwmissing );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Add more exception handling so lastworld.json cannot prevent it from starting"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #41632 and removes the need to manually repair or delete lastworld.json in the event of corruption. Also serves as a weak but better-than-nothing intimation that world save data could be damaged and warns the player.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Solution is very straightforward but potentially flawed due to this being my first time messing with this aspect of the project. Adds a try/catch statement specifically to check if lastworld.json or its data is missing or empty

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Deleting my changes and going to bed.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

I tested this pretty thoroughly, but there might be specific cases I missed. When lastworld.json is missing, there are no warnings or errors and the game launches normally. This is intended, because the file not being there is expected if you're on a new installation. If one of the keys or values is deleted, it throws an error. If everything in the file is deleted, it throws an error. In any case, due to how unimportant this file is for core functionality, the errors are always non-fatal now, and the file simply isn't used if there's an issue.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

My code isn't very clean, but it seems acceptable enough to me. If anyone wants to edit it to clean stuff up, I welcome it.

Also, sorry for accidentally making a broken PR earlier. It was only open for a couple of seconds, but it happened because I wasn't paying attention to my head and base repositories.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
