### PR TITLE
Correct mistake for the stone tepoztopili recipe

### DIFF
--- a/data/json/recipes/weapon/bashing.json
+++ b/data/json/recipes/weapon/bashing.json
@@ -516,7 +516,7 @@
   {
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",
-    "result": "aztec_spear_glass",
+    "result": "aztec_spear_stone",
     "category": "CC_WEAPON",
     "subcategory": "CSC_WEAPON_CUTTING",
     "skill_used": "fabrication",


### PR DESCRIPTION
#### Summary
Bugfixes "The stone bladed tepoztopili did not have a recipe, it does now"

#### Purpose of change
There was a little oversight in #70855 that gave the glass bladed tepoztopili 2 recipes, and the stone one none, so this had to be fixed.

#### Describe the solution
Puts the correct result for the stone recipe.

#### Describe alternatives you've considered

#### Testing

#### Additional context
