### PR TITLE
Studded Gloves Modernization

### DIFF
--- a/data/json/items/melee/unarmed_weapons.json
+++ b/data/json/items/melee/unarmed_weapons.json
@@ -246,7 +246,7 @@
           { "type": "leather", "covered_by_mat": 100, "thickness": 0.5 },
           { "type": "steel", "covered_by_mat": 80, "thickness": 0.25 }
         ],
-        "encumbrance": 5,
+        "encumbrance": 3,
         "coverage": 100,
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_back_l", "hand_back_r" ]
@@ -256,7 +256,7 @@
           { "type": "cotton", "covered_by_mat": 100, "thickness": 0.1 },
           { "type": "leather", "covered_by_mat": 100, "thickness": 0.5 }
         ],
-        "encumbrance": 5,
+        "encumbrance": 0,
         "coverage": 100,
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_wrist_l", "hand_wrist_r", "hand_palm_l", "hand_palm_r" ]
@@ -267,8 +267,8 @@
           { "type": "leather", "covered_by_mat": 100, "thickness": 0.5 },
           { "type": "steel", "covered_by_mat": 50, "thickness": 0.25 }
         ],
-        "encumbrance": 5,
-        "coverage": 50,
+        "encumbrance": 2,
+        "coverage": 100,
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ]
       },

--- a/data/json/items/melee/unarmed_weapons.json
+++ b/data/json/items/melee/unarmed_weapons.json
@@ -271,8 +271,8 @@
         "coverage": 100,
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ]
-      },
-    ]
+      }
+    ],
     "melee_damage": { "bash": 2, "stab": 4 }
   },
   {

--- a/data/json/items/melee/unarmed_weapons.json
+++ b/data/json/items/melee/unarmed_weapons.json
@@ -272,7 +272,7 @@
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ]
       },
-        ],
+    ],
     "melee_damage": { "bash": 2, "stab": 4 }
   },
   {

--- a/data/json/items/melee/unarmed_weapons.json
+++ b/data/json/items/melee/unarmed_weapons.json
@@ -239,7 +239,7 @@
     "warmth": 5,
     "material_thickness": 2,
     "flags": [ "WATER_FRIENDLY", "DURABLE_MELEE", "NONCONDUCTIVE" ],
-        "armor": [
+    "armor": [
       {
         "material": [
           { "type": "cotton", "covered_by_mat": 100, "thickness": 0.1 },

--- a/data/json/items/melee/unarmed_weapons.json
+++ b/data/json/items/melee/unarmed_weapons.json
@@ -272,7 +272,7 @@
         "covers": [ "hand_l", "hand_r" ],
         "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ]
       },
-    ],
+    ]
     "melee_damage": { "bash": 2, "stab": 4 }
   },
   {

--- a/data/json/items/melee/unarmed_weapons.json
+++ b/data/json/items/melee/unarmed_weapons.json
@@ -226,7 +226,7 @@
     "id": "gloves_studded",
     "type": "ARMOR",
     "name": { "str": "pair of studded gloves", "str_pl": "pairs of studded gloves" },
-    "description": "A pair of gloves with studded metal knuckles.",
+    "description": "A pair of gloves with studded metal knuckles and a thin back plating.",
     "weight": "218 g",
     "volume": "250 ml",
     "price": 1100,
@@ -238,8 +238,41 @@
     "color": "light_gray",
     "warmth": 5,
     "material_thickness": 2,
-    "flags": [ "WATER_FRIENDLY", "DURABLE_MELEE" ],
-    "armor": [ { "encumbrance": 5, "coverage": 100, "covers": [ "hand_l", "hand_r" ] } ],
+    "flags": [ "WATER_FRIENDLY", "DURABLE_MELEE", "NONCONDUCTIVE" ],
+        "armor": [
+      {
+        "material": [
+          { "type": "cotton", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 0.5 },
+          { "type": "steel", "covered_by_mat": 80, "thickness": 0.25 }
+        ],
+        "encumbrance": 5,
+        "coverage": 100,
+        "covers": [ "hand_l", "hand_r" ],
+        "specifically_covers": [ "hand_back_l", "hand_back_r" ]
+      },
+      {
+        "material": [
+          { "type": "cotton", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 0.5 }
+        ],
+        "encumbrance": 5,
+        "coverage": 100,
+        "covers": [ "hand_l", "hand_r" ],
+        "specifically_covers": [ "hand_wrist_l", "hand_wrist_r", "hand_palm_l", "hand_palm_r" ]
+      },
+      {
+        "material": [
+          { "type": "cotton", "covered_by_mat": 100, "thickness": 0.1 },
+          { "type": "leather", "covered_by_mat": 100, "thickness": 0.5 },
+          { "type": "steel", "covered_by_mat": 50, "thickness": 0.25 }
+        ],
+        "encumbrance": 5,
+        "coverage": 50,
+        "covers": [ "hand_l", "hand_r" ],
+        "specifically_covers": [ "hand_fingers_l", "hand_fingers_r" ]
+      },
+        ],
     "melee_damage": { "bash": 2, "stab": 4 }
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "added sublimbs and changed protective values for studded gloves"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The studded gloves havent been updated to use the sublimbs system, leaving it to use the automatically assigned protection, making it unreasonably strong. the absence of sublimbs also made the gloves unrealistically armored, having steel plating on the palms.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
added sublimbs and fixed the protection values for the gloves, using 0.1mm of cotton (from the glove liner/light gloves) 0.5mm of leather (from the regular leather and fingerless leather gloves) and 0.25 mm of steel (taken from the armored fingerless gloves). i left half of the fingers, and the entire palm and wrists free from steel.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
loaded onto my current save after i replaced my unarmed_weapons.json, and the studded gloves shown the desired changes
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
follow up to this: #65369
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
