### PR TITLE
Variants properly pluralize with quantity

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -14471,7 +14471,7 @@ std::string item::type_name( unsigned int quantity ) const
     } else if( iter != item_vars.end() ) {
         return iter->second;
     } else if( has_itype_variant() ) {
-        ret_name = itype_variant().alt_name.translated();
+        ret_name = itype_variant().alt_name.translated( quantity );
     } else {
         ret_name = type->nname( quantity );
     }


### PR DESCRIPTION
#### Summary
SUMMARY: None

#### Purpose of change
Variants didn't pluralize properly.

#### Describe the solution
Someone forgot to pass in the quantity argument when fetching variant names.

#### Testing
Spawn in 4 of `Angkor Wat jigsaw puzzle`. They now show as `4 Angkor Wat jigsaw puzzles` instead of `4 Angkor Wat jigsaw puzzle`.