### PR TITLE
Fix segfault when using vehicle tool to hacksaw

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -27,7 +27,6 @@
 #include "units.h"
 #include "units_fwd.h"
 #include "vehicle.h"
-#include "vehicle_selector.h"
 
 #include "activity_actor.h"
 

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -198,8 +198,8 @@ class hacksaw_activity_actor : public activity_actor
     private:
         tripoint target;
         item_location tool;
-        std::optional<tripoint> veh_pos;
         std::optional<itype_id> type;
+        std::optional<tripoint> veh_pos;
         bool can_resume_with_internal( const activity_actor &other,
                                        const Character &/*who*/ ) const override;
 };

--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -27,6 +27,7 @@
 #include "units.h"
 #include "units_fwd.h"
 #include "vehicle.h"
+#include "vehicle_selector.h"
 
 #include "activity_actor.h"
 
@@ -176,7 +177,8 @@ class hacksaw_activity_actor : public activity_actor
     public:
         explicit hacksaw_activity_actor( const tripoint &target,
                                          const item_location &tool ) : target( target ), tool( tool ) {};
-
+        explicit hacksaw_activity_actor( const tripoint &target, const itype_id &type,
+                                         const tripoint &veh_pos ) : target( target ), type( type ), veh_pos( veh_pos ) {};
         activity_id get_type() const override {
             return activity_id( "ACT_HACKSAW" );
         }
@@ -197,7 +199,8 @@ class hacksaw_activity_actor : public activity_actor
     private:
         tripoint target;
         item_location tool;
-
+        std::optional<tripoint> veh_pos;
+        std::optional<itype_id> type;
         bool can_resume_with_internal( const activity_actor &other,
                                        const Character &/*who*/ ) const override;
 };

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -116,7 +116,6 @@
 #include "veh_interact.h"
 #include "veh_type.h"
 #include "vehicle.h"
-#include "vehicle_selector.h"
 #include "viewer.h"
 #include "vitamin.h"
 #include "vpart_position.h"

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -116,6 +116,7 @@
 #include "veh_interact.h"
 #include "veh_type.h"
 #include "vehicle.h"
+#include "vehicle_selector.h"
 #include "viewer.h"
 #include "vitamin.h"
 #include "vpart_position.h"
@@ -4913,7 +4914,7 @@ std::optional<int> iuse::oxytorch( Character *p, item *it, const tripoint & )
     return std::nullopt;
 }
 
-std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint & )
+std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint &it_pnt )
 {
     if( !p ) {
         debugmsg( "%s called action hacksaw that requires character but no character is present",
@@ -4952,8 +4953,11 @@ std::optional<int> iuse::hacksaw( Character *p, item *it, const tripoint & )
         }
         return std::nullopt;
     }
-
-    p->assign_activity( hacksaw_activity_actor( pnt, item_location{*p, it} ) );
+    if( p->pos() == it_pnt ) {
+        p->assign_activity( hacksaw_activity_actor( pnt, item_location{ *p, it } ) );
+    } else {
+        p->assign_activity( hacksaw_activity_actor( pnt, it->typeId(), it_pnt ) );
+    }
 
     return std::nullopt;
 }

--- a/src/iuse.h
+++ b/src/iuse.h
@@ -134,7 +134,7 @@ std::optional<int> granade_act( Character *, item *, const tripoint & );
 std::optional<int> grenade_inc_act( Character *, item *, const tripoint & );
 std::optional<int> gun_repair( Character *, item *, const tripoint & );
 std::optional<int> gunmod_attach( Character *, item *, const tripoint & );
-std::optional<int> hacksaw( Character *, item *, const tripoint & );
+std::optional<int> hacksaw( Character *, item *, const tripoint &it_pnt );
 std::optional<int> hairkit( Character *, item *, const tripoint & );
 std::optional<int> hammer( Character *, item *, const tripoint & );
 std::optional<int> hand_crank( Character *, item *, const tripoint & );

--- a/src/vehicle.h
+++ b/src/vehicle.h
@@ -1774,6 +1774,8 @@ class vehicle
         * @return amount of ammo in the `pseudo_magazine` or 0
         */
         int prepare_tool( item &tool ) const;
+        static bool use_vehicle_tool( vehicle &veh, const tripoint &vp_pos, const itype_id &tool_type,
+                                      bool no_invoke = false );
         /**
         * if \p tool is not an itype with tool != nullptr this returns { itype::NULL_ID(), 0 } pair
         * @param tool the item to examine

--- a/src/vehicle_use.cpp
+++ b/src/vehicle_use.cpp
@@ -1774,7 +1774,8 @@ int vehicle::prepare_tool( item &tool ) const
     return ammo_count;
 }
 
-static bool use_vehicle_tool( vehicle &veh, const tripoint &vp_pos, const itype_id &tool_type )
+bool vehicle::use_vehicle_tool( vehicle &veh, const tripoint &vp_pos, const itype_id &tool_type,
+                                bool no_invoke )
 {
     item tool( tool_type, calendar::turn );
     const auto &[ammo_type_id, avail_ammo_amount] = veh.tool_ammo_available( tool_type );
@@ -1783,7 +1784,9 @@ static bool use_vehicle_tool( vehicle &veh, const tripoint &vp_pos, const itype_
     if( tool.ammo_required() > avail_ammo_amount ) {
         return false;
     }
-    get_player_character().invoke_item( &tool );
+    if( !no_invoke ) {
+        get_player_character().invoke_item( &tool, vp_pos );
+    }
 
     // HACK: Evil hack incoming
     player_activity &act = get_player_character().activity;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #68541
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The hacksaw activity was not set up to use a vehicle tool and was segfaulting when trying to do so.  Added logic to handle using a vehicle tool.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
