### PR TITLE
add hallucinations for kaluptic psychosis trait

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
@@ -44,7 +44,7 @@
   {
     "type": "effect_on_condition",
     "id": "bad_hallucinations",
-    "effect": [ { "weighted_list_eocs": [ [ "creature_hallucinations", 20 ], [ "visuals", 10 ] ] } ]
+    "effect": [ { "weighted_list_eocs": [ [ "creature_hallucinations", 20 ], [ "visuals", 10 ], [ "hallucination_swarm", 4 ] ] } ]
   },
   {
     "type": "effect_on_condition",
@@ -98,19 +98,19 @@
           {
             "id": "injured_talk",
             "condition": { "math": [ "n_hp('ALL')", "<", "n_hp_max('bp_null')" ] },
-            "effect": { "u_message": "Your weapon says \"<schizo_weapon_talk_damaged>\"" },
+            "effect": { "u_message": "Your <npc_name> says \"<schizo_weapon_talk_damaged>\"" },
             "false_effect": {
               "run_eocs": {
                 "id": "you_injured_talk",
                 "//": "Weapon will be concerned for you if you're significantly injured.",
                 "condition": { "math": [ "(u_hp('ALL') * 1.4)", "<", "u_hp_max('bp_null')" ] },
-                "effect": { "u_message": "Your weapon says \"<schizo_weapon_talk_bleeding>\"" },
+                "effect": { "u_message": "Your <npc_name> says \"<schizo_weapon_talk_bleeding>\"" },
                 "false_effect": {
                   "run_eocs": {
                     "id": "monsters_nearby_talk",
                     "condition": { "and": [ "u_can_see", { "math": [ "u_monsters_nearby('radius': 10)", ">=", "1" ] } ] },
-                    "effect": { "u_message": "Your weapon says \"<schizo_weapon_talk_monster>\"" },
-                    "false_effect": { "run_eocs": { "id": "normal_talk", "effect": { "u_message": "Your weapon says \"<schizo_weapon_talk_misc>\"" } } }
+                    "effect": { "u_message": "Your <npc_name> says \"<schizo_weapon_talk_monster>\"" },
+                    "false_effect": { "run_eocs": { "id": "normal_talk", "effect": { "u_message": "Your <npc_name> says \"<schizo_weapon_talk_misc>\"" } } }
                   }
                 }
               }
@@ -174,9 +174,25 @@
   {
     "type": "effect_on_condition",
     "id": "creature_hallucinations",
+    "//TODO": "ideally checks is the tile visible, and then spawns hallu where player can't see it",
+    "//": "if monsters are nearby, 3/4 chance to get copy of random monster nearby and run again (with 1/2 prob) and 1/4 chance to spawns one of YOUR_FEARS. If not, spawns one of YOUR_FEARS",
     "effect": [
-      { "u_message": "You can't trust everything you see…", "type": "bad" },
-      { "u_add_effect": "hallu", "duration": [ "1 hour", "3 hours" ] }
+      {
+        "if": { "and": [ { "math": [ "rand(3)", "==", "3" ] }, { "not": { "math": [ "u_monsters_nearby()", ">", "1" ] } } ] },
+        "then": {
+          "u_spawn_monster": "GROUP_YOUR_FEARS",
+          "group": true,
+          "hallucination_count": { "math": [ "1 + rand(2)" ] },
+          "max_radius": 40,
+          "lifespan": [ "1 hours", "4 hours" ]
+        },
+        "else": {
+          "u_spawn_monster": "",
+          "hallucination_count": { "math": [ "1 + rand(4)" ] },
+          "target_range": 50,
+          "lifespan": [ "2 hours", "9 hours" ]
+        }
+      }
     ]
   },
   {
@@ -185,6 +201,28 @@
     "effect": [
       { "u_message": "Your vision becomes very distorted…", "type": "bad" },
       { "u_add_effect": "visuals", "duration": [ 15, 60 ] }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "hallucination_swarm",
+    "condition": { "math": [ "u_monsters_nearby()", ">", "1" ] },
+    "effect": [
+      {
+        "if": { "math": [ "u_i", "<", "rng(50, 100)" ] },
+        "then": [
+          {
+            "u_spawn_monster": "",
+            "hallucination_count": 1,
+            "target_range": 50,
+            "max_radius": 50,
+            "lifespan": [ "2 hours", "9 hours" ]
+          },
+          { "math": [ "u_i", "++" ] },
+          { "run_eocs": "hallucination_swarm" }
+        ],
+        "else": { "math": [ "u_i", "=", "0" ] }
+      }
     ]
   }
 ]


### PR DESCRIPTION
#### Summary
Features "Did you know we didn't have any hallucinations for a while? now they're back, baby!"
#### Purpose of change
Apparently #69919, that jsonified all hallucinations, missed to add the very important part of them - hallucinated monsters, and limited itself to giving effect `hallu` - one that it unhardcoded
#### Describe the solution
Changed `creature_hallucinations` to actually spawn hallucination - not the effect that was before, where giant army attacks you all the time, but more granular approach - they spawn very rarely, since it is `bad_hallucinations`, and usually spawns a copy of a monster rather than some random foe (tho it does spawn random creature from YOUR_FEARS group if there is no another monsters nearby)
Added `hallucination_swarm` effect, that checks is there monsters nearby, and if yes, flood the entire map with said monsters. Because of #70812, it currently just duplicate the same monster all over again, which looks silly, but i hope it would be resolved one day
Added `<npc_name>` to the `weapon_talk_hallucination`, peeked in #70791
#### Testing

<details>
  <summary> creature_hallucinations </summary>

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/6e0e7b49-a73b-4252-ad77-d53170b3292e) 

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/7026b51a-1255-48af-a9f6-5ccabd2d4159)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/53e1b755-4aa8-492f-abf4-b8d4e66dde67)

</details>

<details>
  <summary> hallucination_swarm </summary>

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/714cee56-23fc-4cd6-b38f-6c110a04dc2d) 

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/2ad60de6-63c6-4466-8006-222c538fe939) 

</details>

<details>
  <summary> weapon_talk_hallucination </summary>

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/5ec19ad5-0dd0-4c9e-8a8f-54bebab3a927)

</details>