### PR TITLE
Fix 2 little bugs in the Evacuee center

### DIFF
--- a/data/json/mapgen/refugee_center/refugee_center.json
+++ b/data/json/mapgen/refugee_center/refugee_center.json
@@ -312,7 +312,7 @@
         { "vehicle": "car_mini", "x": 99, "y": 15, "chance": 75, "rotation": 90 }
       ],
       "place_npcs": [
-        { "class": "scavenger_merc", "x": 49, "y": 3 },
+        { "class": "scavenger_merc", "x": 48, "y": 5 },
         { "class": "guard", "x": 39, "y": 4, "unique_id": "GUARD1" },
         { "class": "guard", "x": 36, "y": 7, "unique_id": "GUARD2" },
         { "class": "arsonist", "x": 38, "y": 19 },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
@@ -385,6 +385,7 @@
         "effect": { "assign_mission": "MISSION_REFUGEE_Jenny_GET_PNEUMATICS" },
         "condition": {
           "and": [
+            { "not": { "u_has_mission": "MISSION_REFUGEE_Jenny_GET_PNEUMATICS" } },
             { "not": { "u_has_var": "Jenny_pneumatics", "value": "mission_complete" } },
             { "not": { "days_since_cataclysm": 60 } }
           ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Fixes #70861
- Fixes #70867

1. Refuge center : Jenny Forcette
Prevent the mission list being filled up with missions from Jenny.
2. Refuge center : Scavenger Mercenary
Fix wrong spawn point : from in the walls to on the chair
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Added the condition : not accepted the mission, as a requirement for showing choices to prevent duplicating that mission.
2. To prevent mercenaries to spawn at obviously the wrong location and get confined to the doctor's room, they spawned on the chair in the next room.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
1. Keep it as a test case that can accept a number of missions that challenge the limits of PC memory usage.
2. Spawn mercenaries in the corridor instead of in the room.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
1. In-game testing was done, confirmed that the choices for which missions are offered do not appears after the mission has been accepted.
2. In-game testing was done, they wait for us on the chair.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I also think it is an odd situation for a fully armed mercenary with a gun to sitting on the chair.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
