### PR TITLE
Allow toggling brand names of drugs

### DIFF
--- a/data/json/items/comestibles/med.json
+++ b/data/json/items/comestibles/med.json
@@ -34,12 +34,20 @@
     "symbol": "!",
     "color": "light_red",
     "container": "bottle_plastic_pill_prescription",
+    "variant_type": "drug",
+    "variants": [
+      {
+        "id": "adderall",
+        "name": { "str_sp": "Adderall" },
+        "description": "Medical-grade amphetamine salts mixed with dextroamphetamine salts, commonly prescribed to treat hyperactive attention deficits.  It suppresses the appetite, and is quite addictive."
+      }
+    ],
     "stim": 24,
     "fun": 10,
     "addiction_potential": 10,
     "addiction_type": "amphetamine",
     "flags": [ "NPC_SAFE", "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "EDIBLE_FROZEN" ],
-    "use_action": { "type": "consume_drug", "activation_message": "You take some stimulants." }
+    "use_action": { "type": "consume_drug", "activation_message": "You take some %s." }
   },
   {
     "id": "adrenaline_injector",
@@ -568,6 +576,14 @@
     "symbol": "!",
     "color": "white",
     "container": "bottle_plastic_pill_prescription",
+    "variant_type": "drug",
+    "variants": [
+      {
+        "id": "diazepam",
+        "name": { "str_sp": "diazepam" },
+        "description": "A strong benzodiazepine drug used to treat muscle spasms, anxiety, seizures, and panic attacks."
+      }
+    ],
     "stim": -8,
     "healthy": -1,
     "fun": 8,
@@ -1079,6 +1095,15 @@
     "symbol": "!",
     "color": "light_red",
     "container": "bottle_plastic_pill_prescription",
+    "variant_type": "drug",
+    "variants": [
+      {
+        "id": "ambien",
+        "name": { "str_sp": "Ambien" },
+        "append": true,
+        "description": "Its generic name is zolpidem tartarate."
+      }
+    ],
     "stim": -8,
     "fun": 5,
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "EDIBLE_FROZEN" ],
@@ -1193,6 +1218,8 @@
     "symbol": "!",
     "color": "light_green",
     "container": "bottle_plastic_pill_prescription",
+    "variant_type": "drug",
+    "variants": [ { "id": "prozac", "name": { "str_sp": "Prozac" }, "append": true, "description": "Its generic name is fluoxetine." } ],
     "stim": -5,
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "EDIBLE_FROZEN" ],
     "addiction_potential": 5,
@@ -1270,6 +1297,15 @@
     "symbol": "!",
     "color": "light_red",
     "container": "bottle_plastic_pill_prescription",
+    "variant_type": "drug",
+    "variants": [
+      {
+        "id": "thorazine",
+        "name": { "str_sp": "Thorazine" },
+        "append": true,
+        "description": "Its generic name is chlorpromazine."
+      }
+    ],
     "stim": -30,
     "flags": [ "IRREPLACEABLE_CONSUMABLE", "WATER_DISSOLVE", "EDIBLE_FROZEN" ],
     "use_action": [ "THORAZINE" ]
@@ -1545,6 +1581,15 @@
     "symbol": "!",
     "color": "cyan",
     "container": "bottle_plastic_pill_prescription",
+    "variant_type": "drug",
+    "variants": [
+      {
+        "id": "xanax",
+        "name": { "str_sp": "Xanax" },
+        "append": true,
+        "description": "An anti-anxiety agent with a powerful sedative effect.  May cause dissociation and loss of memory.  It is dangerously addictive, and withdrawal from regular use should be gradual."
+      }
+    ],
     "stim": -4,
     "healthy": -2,
     "fun": 20,

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9237,6 +9237,8 @@ bool item::has_itype_variant( bool check_option ) const
     switch( type->variant_kind ) {
         case itype_variant_kind::gun:
             return get_option<bool>( "SHOW_GUN_VARIANTS" );
+        case itype_variant_kind::drug:
+            return get_option<bool>( "SHOW_DRUG_VARIANTS" );
         default:
             return true;
     }

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -60,6 +60,8 @@ std::string enum_to_string<itype_variant_kind>( itype_variant_kind data )
             return "gun";
         case itype_variant_kind::generic:
             return "generic";
+        case itype_variant_kind::drug:
+            return "drug";
         case itype_variant_kind::last:
             debugmsg( "Invalid variant type!" );
             return "";

--- a/src/itype.h
+++ b/src/itype.h
@@ -650,6 +650,7 @@ struct islot_wheel {
 enum class itype_variant_kind : int {
     gun,
     generic,
+    drug,
     last
 };
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1811,6 +1811,9 @@ void options_manager::add_options_interface()
     add_option_group( "interface", Group( "naming_opts", to_translation( "Naming Options" ),
                                           to_translation( "Options regarding the naming of items." ) ),
     [&]( const std::string & page_id ) {
+        add( "SHOW_DRUG_VARIANTS", page_id, to_translation( "Show drug brand names" ),
+             to_translation( "If true, show brand names for drugs, instead of generic functional names - 'Adderall', instead of 'prescription stimulant'." ),
+             false );
         add( "SHOW_GUN_VARIANTS", page_id, to_translation( "Show gun brand names" ),
              to_translation( "If true, show brand names for guns, instead of generic functional names - 'm4a1' or 'h&k416a5' instead of 'NATO assault rifle'." ),
              false );

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -1146,6 +1146,7 @@ fluidly
 flummox
 flummoxing
 flump
+fluoxetine
 flusteration
 flyable
 flyin
@@ -3053,6 +3054,7 @@ tangrams
 tankbot
 tannin
 tarket
+tartarate
 tassed
 tassin
 tastemakers
@@ -3534,8 +3536,7 @@ zentai
 zeriatric
 zincite
 zischt
-zorc
-zorcs
+zolpidem
 zombaby
 zombear
 zombeaver
@@ -3549,6 +3550,8 @@ zombull
 zombullfrog
 zoomorphic
 zoonotic
+zorc
+zorcs
 zowlbear
 zowlbears
 zpzzzzpzz


### PR DESCRIPTION
#### Summary
Interface "Allow toggling on drug brand names"

#### Purpose of change
Fixes https://github.com/CleverRaven/Cataclysm-DDA/issues/51689

In #45308, the names of various pharmaceutical items were changed from brand names to generic names describing their active ingredients.

In #46814, the names of various guns were changed from specific brand names to generic versions, and many guns were collapsed into the generic versions. However, variants were added, allowing a toggle to bring back all those names.

We can follow that same approach for drugs, using variants to allow toggling between the generic names and brand names.

#### Describe the solution
To do this, simply add a new variant type, a new option, and then change whether that type is shown based on the value of that option. Then, add the variants for brand names.

#### Testing
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/e3fdbdbe-d01d-4471-942f-ab39ff4a3e20)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/d5504b2f-e0b3-47e1-b02e-e9b9ff1af5f0)
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/44244083/36413c1b-eca7-4354-b97c-8f2ae773088f)


#### Additional context
I didn't add back the non-generic names for the antibiotics because
1. Only strong/weak antibiotics had them
2. They didn't seem to be real names
