### PR TITLE
[Magiclysm] Require druid to be in natural surroundings to cast Restoration

### DIFF
--- a/data/mods/Magiclysm/Spells/druid.json
+++ b/data/mods/Magiclysm/Spells/druid.json
@@ -631,10 +631,10 @@
     "id": "druid_healing",
     "type": "SPELL",
     "name": "Restoration",
-    "description": "Directed magical energy that slowly heals your body from wounds.",
+    "description": "Slowly heal your wounds by drawing on the power of nature.\n\nYou must be <color_yellow>outdoors and in a natural area</color> away from civilization to cast Restoration.",
     "valid_targets": [ "self" ],
-    "effect": "attack",
-    "effect_str": "flask_regeneration",
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_DRUID_RESTORATION",
     "shape": "blast",
     "flags": [ "CONCENTRATE", "SOMATIC", "VERBAL", "NO_LEGS" ],
     "energy_source": "MANA",
@@ -651,6 +651,33 @@
     "min_duration": 15000,
     "max_duration": 90000,
     "duration_increment": 3000
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_DRUID_RESTORATION",
+    "condition": {
+      "and": [
+        "u_is_outside",
+        { "not": { "u_near_om_location": "road_curved", "range": 1 } },
+        { "not": { "u_near_om_location": "road_four_way", "range": 1 } },
+        { "not": { "u_near_om_location": "road_tee", "range": 1 } },
+        { "not": { "u_near_om_location": "road_straight", "range": 1 } },
+        { "not": { "u_near_om_location": "road_end", "range": 1 } },
+        { "not": { "u_near_om_location": "road_sw", "range": 1 } },
+        { "not": { "u_near_om_location": "road_ne", "range": 1 } },
+        { "not": { "u_near_om_location": "road_ew", "range": 1 } },
+        { "not": { "u_near_om_location": "road_ns", "range": 1 } },
+        { "not": { "u_near_om_location": "road_nesw", "range": 1 } },
+        { "not": { "u_near_om_location": "road", "range": 1 } }
+      ]
+    },
+    "effect": [
+      {
+        "u_add_effect": "flask_regeneration",
+        "duration": { "math": [ "( 15000 + (u_spell_level('druid_healing') * 3000)) " ] }
+      }
+    ],
+    "false_effect": [ { "u_message": "You must be surrounded by nature to use its power to heal.", "type": "bad" } ]
   },
   {
     "id": "druid_healing_herb",

--- a/data/mods/Magiclysm/Spells/druid.json
+++ b/data/mods/Magiclysm/Spells/druid.json
@@ -544,6 +544,13 @@
     "condition": {
       "and": [
         "u_is_outside",
+        {
+          "or": [
+            { "u_is_on_terrain_with_flag": "SHRUB" },
+            { "u_is_on_terrain_with_flag": "DIGGABLE" },
+            { "u_is_on_terrain_with_flag": "YOUNG" }
+          ]
+        },
         { "not": { "u_near_om_location": "road_curved", "range": 1 } },
         { "not": { "u_near_om_location": "road_four_way", "range": 1 } },
         { "not": { "u_near_om_location": "road_tee", "range": 1 } },
@@ -658,6 +665,13 @@
     "condition": {
       "and": [
         "u_is_outside",
+        {
+          "or": [
+            { "u_is_on_terrain_with_flag": "SHRUB" },
+            { "u_is_on_terrain_with_flag": "DIGGABLE" },
+            { "u_is_on_terrain_with_flag": "YOUNG" }
+          ]
+        },
         { "not": { "u_near_om_location": "road_curved", "range": 1 } },
         { "not": { "u_near_om_location": "road_four_way", "range": 1 } },
         { "not": { "u_near_om_location": "road_tee", "range": 1 } },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Require druid to be in natural surroundings to cast Restoration"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

At first, druids had no healing spells except Sacrificial Healing, and everyone said to play Biomancer. Then druids got two healing spells...and one of them is almost never used. Partially because it was bugged for a long time (which took a long time to notice because no one ever used it), and partially because it requires components. 

Well, these are druids we're talking about. They draw on the power of nature and should be stronger in nature, right? So why not make the powerful healing spell require being in nature to cast, and that reflavors the healing spell that requires components as requiring components because the components are a portable version of the power of nature that the druid brings with them. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Change Restoration so it requires the same conditions as Nature's Commune--outdoors and not within 1 overmap tile of a road. Floral Healing remains the same and can be used anywhere. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I have some Biomancer spell ideas I plan to add to help close the healing gap (since Biomancers are supposed to have greater control over their bodies and thus greater self-healing), but in another PR. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
