### PR TITLE
Significantly adjusts mutagen mutagen spawn rates.

### DIFF
--- a/data/json/itemgroups/science_and_tech.json
+++ b/data/json/itemgroups/science_and_tech.json
@@ -263,8 +263,8 @@
       [ "recipe_animal", 4 ],
       [ "recipe_maiar", 4 ],
       [ "recipe_labchem", 6 ],
-      [ "mutagen", 8 ],
-      [ "iv_mutagen", 6 ],
+      [ "mutagen", 16 ],
+      [ "iv_mutagen", 20 ],
       [ "iv_mutagen_elfa", 2 ],
       [ "iv_mutagen_alpha", 2 ],
       [ "iv_mutagen_raptor", 2 ],
@@ -310,7 +310,7 @@
     "id": "mutagens",
     "//": "If we ever get themed labs defined by what types of mutagens they worked on this itemgroup may need to be re-evaluated.",
     "items": [
-      [ "mutagen", 8 ],
+      [ "mutagen", 12 ],
       [ "mutagen_elfa", 2 ],
       [ "mutagen_alpha", 2 ],
       [ "mutagen_raptor", 2 ],
@@ -335,7 +335,7 @@
       [ "mutagen_lupine", 2 ],
       [ "mutagen_rabbit", 2 ],
       [ "mutagen_crustacean", 2 ],
-      [ "iv_mutagen", 6 ],
+      [ "iv_mutagen", 16 ],
       [ "iv_mutagen_elfa", 2 ],
       [ "iv_mutagen_alpha", 2 ],
       [ "iv_mutagen_raptor", 2 ],
@@ -371,7 +371,7 @@
     "id": "mut_iv",
     "//": "If we ever get themed labs defined by what types of mutagens they worked on this itemgroup may need to be re-evaluated.",
     "items": [
-      [ "iv_mutagen", 10 ],
+      [ "iv_mutagen", 20 ],
       [ "iv_mutagen_elfa", 2 ],
       [ "iv_mutagen_alpha", 2 ],
       [ "iv_mutagen_raptor", 2 ],
@@ -397,7 +397,7 @@
       [ "iv_mutagen_mouse", 2 ],
       [ "iv_mutagen_rabbit", 2 ],
       [ "iv_mutagen_crustacean", 2 ],
-      [ "iv_purifier", 20 ],
+      [ "iv_purifier", 10 ],
       [ "syringe", 10 ]
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Significantly adjusts mutagen mutagen spawn rates to be more common."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Mutagenic catalyst and normal mutagen were far, far too rare in their respective loot pools for no good reason.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

I've vastly increased the amount of mutagen mutagen (including catalyst) found in the loot pools. Presumably what happened is that more and more primers got added and the catalyst became less and less common until now where you're more likely to find 10 primers than a single catalyst when going lab diving. Primers are completely worthless without a hefty amount of catalyst so this way you can actually, you know, use them before setting up a mutagen syntesizing lab?

Additionally, I've reduced the amount of purifier. Why was it so common? Nobody's coming to the labs hoping for a mutation reversion.. not in these quantities.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Removing catalyst and merging it into primer. The obvious solution that solves every issue, but I guess that's not an option.

Making primers give enough mutagen mutagen for at least one mutation. Basically just the first alternative with extra steps.

Somehow making mutagen drastically easier to create, leaving primer to be the thing needing scavenge runs. This wouldn't even be that unreasonable honestly.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned self into various labs to ensure the ratios were appropiate to my design.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Is this an Audit? That makes it sound fancy and smart and professonal, so I guess it is.
Mutagen mutagen has no good global name.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
