### PR TITLE
NPC condition style consistency and typo fixes

### DIFF
--- a/data/json/npcs/civilians/civilians.json
+++ b/data/json/npcs/civilians/civilians.json
@@ -31,7 +31,7 @@
     "type": "talk_topic",
     "id": "TALK_CIVILIAN_FIGHTER_EVAC",
     "dynamic_line": [ "Like hell I will!", "Fuck that, I'm not going out like a coward!" ],
-    "responses": [ { "text": "[Leave them to their futile fight]", "topic": "TALK_DONE" } ]
+    "responses": [ { "text": "[Leave them to their futile fight.]", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",

--- a/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
@@ -32,8 +32,8 @@
     "type": "talk_topic",
     "dynamic_line": "This character was previously put into a suspension state due to an AI bug.  If you have reason to believe the problem was fixed, you can wake them up.  Do you want to do that now?",
     "responses": [
-      { "text": "yes, wake up!", "topic": "TALK_NONE", "effect": "wake_up" },
-      { "text": "no, go back to sleep.", "topic": "TALK_DONE" }
+      { "text": "Yes, wake up!", "topic": "TALK_NONE", "effect": "wake_up" },
+      { "text": "No, go back to sleep.", "topic": "TALK_DONE" }
     ]
   },
   {
@@ -55,7 +55,7 @@
       { "text": "I just wanted to talk for a bit.", "topic": "TALK_ALLY_SOCIAL" },
       { "text": "Can you help me understand something?  (HELP/TUTORIAL)", "topic": "TALK_ALLY_TUTORIAL" },
       {
-        "text": "[HAS DEBUG MIND CONTROL] Now listen closely… (DEBUG FUNCTIONS)",
+        "text": "[DEBUG MIND CONTROL] Now listen closely… (DEBUG FUNCTIONS)",
         "condition": { "u_has_trait": "DEBUG_MIND_CONTROL" },
         "topic": "TALK_ALLY_DEBUG"
       },
@@ -1090,7 +1090,7 @@
   {
     "id": [ "TALK_ALLY_DEBUG" ],
     "type": "talk_topic",
-    "dynamic_line": { "is_by_radio": " *tshk* Not sure it works when i am that far.", "no": "Yes?" },
+    "dynamic_line": { "is_by_radio": " *tshk* Not sure it works when I am that far.", "no": "Yes?" },
     "responses": [
       {
         "text": "Trust me (+10 trust).",

--- a/data/json/npcs/exodii/exodii_Luliya.json
+++ b/data/json/npcs/exodii/exodii_Luliya.json
@@ -58,16 +58,16 @@
       "context": "meeting",
       "value": "yes",
       "yes": [ "Inikwani dehina metahi tegwazhi." ],
-      "no": "[You see a tall golden figure with female features.  Strapped to the back of the head with copper wire is a glass cylinder containing long frizzy black hair.  The body stands still and emits an unpleasant beeping sound.  On the back there is a large red button with strange markings.  There is a golden harp of some kind.]"
+      "no": "&You see a tall golden figure with female features.  Strapped to the back of the head with copper wire is a glass cylinder containing long frizzy black hair.  The body stands still and emits an unpleasant beeping sound.  On the back there is a large red button with strange markings.  There is a golden harp of some kind in their hand."
     },
     "responses": [
       {
-        "text": "[PUSH THE BIG RED BUTTON]",
+        "text": "[Push the big red button.]",
         "condition": { "not": { "u_has_var": "u_met_luliya", "type": "general", "context": "meeting", "value": "yes" } },
         "topic": "TALK_LULIYA_BUTTON"
       },
       {
-        "text": "[HAS STETHOSCOPE] Is this alive?  [CHECK FOR A PULSE]",
+        "text": "[Use Stethoscope] Is this alive?",
         "condition": {
           "and": [
             { "not": { "u_has_var": "u_met_luliya", "type": "general", "context": "meeting", "value": "yes" } },
@@ -77,7 +77,7 @@
         "topic": "TALK_LULIYA_PULSE"
       },
       {
-        "text": "[DO NOTHING]",
+        "text": "[Do nothing.]",
         "condition": { "not": { "u_has_var": "u_met_luliya", "type": "general", "context": "meeting", "value": "yes" } },
         "topic": "TALK_DONE"
       },
@@ -104,7 +104,7 @@
         }
       },
       {
-        "text": "I heard you playing that.  [You point at the golden harp she holds]  La la la.  Do you like music Luliya?",
+        "text": "I heard you playing that.  [You point at the golden harp she holds]  La la la.  Do you like music, Luliya?",
         "condition": {
           "and": [
             { "u_has_var": "u_luliya_name", "type": "general", "context": "name", "value": "yes" },
@@ -129,7 +129,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_LULIYA_BUTTON",
-    "dynamic_line": "[You hear a loud static discharge, a rough mechanical chugging sound, and then high-pitched shrieking with strange distortions and modulations in the sound.  The golden figure shudders, arms flailing] ቆዳዬ! ቆዳዬ በእሳት ላይ ነው! እየሞትኩ ነው!",
+    "dynamic_line": "&You hear a loud static discharge, a rough mechanical chugging sound, and then high-pitched shrieking with strange distortions and modulations in the sound.  The golden figure shudders, arms flailing. \"ቆዳዬ! ቆዳዬ በእሳት ላይ ነው! እየሞትኩ ነው!\"",
     "speaker_effect": {
       "effect": [
         { "u_add_var": "u_met_luliya", "type": "general", "context": "meeting", "value": "yes" },
@@ -155,7 +155,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_LULIYA_PULSE",
-    "dynamic_line": "[You press your stethoscope to the chest of the figure and hear a clear strong heartbeat and a strange whirring sound like clockwork].",
+    "dynamic_line": "&You press your stethoscope to the chest of the figure and hear a clear, strong heartbeat and a strange whirring sound that sounds like clockwork.",
     "responses": [
       { "text": "So she's alive then.", "topic": "TALK_LULIYA" },
       { "text": "Probably fine then.  Anyway, I need to move along.", "topic": "TALK_DONE" }
@@ -164,7 +164,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_LULIYA_ENGLISH",
-    "dynamic_line": "[A long pause, then she shakes her head]  Inigilizinya yelemi.  No.",
+    "dynamic_line": "&A long pause, then she shakes her head  \"Inigilizinya yelemi.  No.\"",
     "speaker_effect": { "effect": { "u_add_var": "u_not_english_luliya", "type": "general", "context": "language", "value": "yes" } },
     "responses": [
       { "text": "All right then.  You seem to understand what I mean.  And the word no.", "topic": "TALK_LULIYA" },
@@ -174,14 +174,14 @@
   {
     "type": "talk_topic",
     "id": "TALK_LULIYA_NAME",
-    "dynamic_line": "[A long pause.  You can't see her eyes but it seems like she is studying your face.]  Sime Luliya ibalalehu.  [She points to her own chest.]  Luliya.  [She points to your chest.]  <u_name>.  Siletewawekini desi bilonyali, <u_name>.  [She strums a pleasant melody on her krar.]",
+    "dynamic_line": "&A long pause.  You can't see her eyes but it seems like she is studying your face.  \"Sime Luliya ibalalehu.\"  [She points to her own chest.]  \"Luliya.\"  [She points to your chest.]  \"<u_name>.  Siletewawekini desi bilonyali, <u_name>.\"  [She strums a pleasant melody on her krar.]",
     "speaker_effect": { "effect": { "u_add_var": "u_luliya_name", "type": "general", "context": "name", "value": "yes" } },
     "responses": [ { "text": "We're getting somewhere.  Pleased to meet you Luliya.", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_LULIYA_ARABIC",
-    "dynamic_line": "[A long pause, then she shakes her head]  Ayi arebinya alinagerimi.",
+    "dynamic_line": "&A long pause, then she shakes her head.  \"Ayi arebinya alinagerimi.\"",
     "speaker_effect": { "effect": { "u_add_var": "u_not_arabic_luliya", "type": "general", "context": "language", "value": "yes" } },
     "responses": [
       { "text": "All right then.  It seems like you do kind of understand it though.", "topic": "TALK_LULIYA" },
@@ -191,35 +191,35 @@
   {
     "type": "talk_topic",
     "id": "TALK_LULIYA_MUSIC",
-    "dynamic_line": "[She nods enthusiastically and strums a few notes on her krar.] Awo muzika iwedalehu.",
+    "dynamic_line": "&She nods enthusiastically and strums a few notes on her krar. \"Awo muzika iwedalehu.\"",
     "responses": [
       {
-        "text": "[HAS GUITAR] I happen to have a nice guitar, want to play with me?",
+        "text": "[Use Guitar] I happen to have a nice guitar, want to play with me?",
         "topic": "TALK_LULIYA_MUSIC2",
         "condition": { "u_has_item": "acoustic_guitar" }
       },
       {
-        "text": "[HAS TRUMPET] I happen to have a nice trumpet, want to play with me?",
+        "text": "[Use Trumpet] I happen to have a nice trumpet, want to play with me?",
         "topic": "TALK_LULIYA_MUSIC2",
         "condition": { "u_has_item": "trumpet" }
       },
       {
-        "text": "[HAS SAXOPHONE] I happen to have a nice saxophone, want to play with me?",
+        "text": "[Use Saxophone] I happen to have a nice saxophone, want to play with me?",
         "topic": "TALK_LULIYA_MUSIC2",
         "condition": { "u_has_item": "saxophone" }
       },
       {
-        "text": "[HAS VIOLIN] I happen to have a nice violin, want to play with me?",
+        "text": "[Use Violin] I happen to have a nice violin, want to play with me?",
         "topic": "TALK_LULIYA_MUSIC2",
         "condition": { "u_has_item": "violin" }
       },
       {
-        "text": "[HAS HARMONICA] I happen to have a nice harmonica, want to play with me?",
+        "text": "[Use Harmonica] I happen to have a nice harmonica, want to play with me?",
         "topic": "TALK_LULIYA_MUSIC2",
         "condition": { "u_has_item": "harmonica_holder" }
       },
       {
-        "text": "[HAS COWBELL] I happen to have a nice cowbell, want to play with me?",
+        "text": "[Use Cowbell] I happen to have a nice cowbell, want to play with me?",
         "topic": "TALK_LULIYA_MUSIC2",
         "condition": { "u_has_item": "cow_bell" }
       },
@@ -232,7 +232,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_LULIYA_MUSIC2",
-    "dynamic_line": "[You perform on your musical instrument with everything you have, giving a strong performance.  Luliya sways and begins to play her instrument and sing along.  The music and her voice are beautiful, she sounds like she has had some formal musical training.]",
+    "dynamic_line": "&You perform on your musical instrument with everything you have, giving a strong performance.  Luliya sways and begins to play her instrument and sing along.  The music and her voice are beautiful, she sounds like she has had some formal musical training.",
     "speaker_effect": {
       "effect": [
         { "u_add_var": "u_jammed_luliya", "type": "general", "context": "music", "value": "yes" },
@@ -241,7 +241,7 @@
       ]
     },
     "responses": [
-      { "text": "Fun, thank you for playing with me Luliya.", "topic": "TALK_LULIYA" },
+      { "text": "Fun, thank you for playing with me, Luliya.", "topic": "TALK_LULIYA" },
       { "text": "Fun, thank you.  Anyway I have to go.", "topic": "TALK_DONE" }
     ]
   }

--- a/data/json/npcs/exodii/exodii_Luliya.json
+++ b/data/json/npcs/exodii/exodii_Luliya.json
@@ -129,7 +129,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_LULIYA_BUTTON",
-    "dynamic_line": "&You hear a loud static discharge, a rough mechanical chugging sound, and then high-pitched shrieking with strange distortions and modulations in the sound.  The golden figure shudders, arms flailing. \"ቆዳዬ! ቆዳዬ በእሳት ላይ ነው! እየሞትኩ ነው!\"",
+    "dynamic_line": "&You hear a loud static discharge, a rough mechanical chugging sound, and then high-pitched shrieking with strange distortions and modulations in the sound.  The golden figure shudders, arms flailing.  \"ቆዳዬ! ቆዳዬ በእሳት ላይ ነው! እየሞትኩ ነው!\"",
     "speaker_effect": {
       "effect": [
         { "u_add_var": "u_met_luliya", "type": "general", "context": "meeting", "value": "yes" },
@@ -191,7 +191,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_LULIYA_MUSIC",
-    "dynamic_line": "&She nods enthusiastically and strums a few notes on her krar. \"Awo muzika iwedalehu.\"",
+    "dynamic_line": "&She nods enthusiastically and strums a few notes on her krar.  \"Awo muzika iwedalehu.\"",
     "responses": [
       {
         "text": "[Use Guitar] I happen to have a nice guitar, want to play with me?",

--- a/data/json/npcs/holdouts/NC_GLOOSCAP.json
+++ b/data/json/npcs/holdouts/NC_GLOOSCAP.json
@@ -103,22 +103,22 @@
     "dynamic_line": "And stuff sure.  How can I help you stranger?  They say I'm the nice one.  See this smile?  Nice smile right?",
     "responses": [
       {
-        "text": "[HAS BEER] I am extremely into your smile yes.  I have some drinks with me, want to have some?",
+        "text": "[Offer Beer] I am extremely into your smile yes.  I have some drinks with me, want to have some?",
         "topic": "TALK_GLOOSCAP_SOCIAL",
         "condition": { "u_has_item": "beer" }
       },
       {
-        "text": "[HAS IPA] I am extremely into your smile yes.  I have some drinks with me, want to have some?",
+        "text": "[Offer India Pale Ale] I am extremely into your smile yes.  I have some drinks with me, want to have some?",
         "topic": "TALK_GLOOSCAP_SOCIAL",
         "condition": { "u_has_item": "india_pale_ale" }
       },
       {
-        "text": "[HAS CIGARETTES] I am extremely into your smile yes.  I have some cigarettes, want one with me?",
+        "text": "[Offer Cigarettes] I am extremely into your smile yes.  I have some cigarettes, want one with me?",
         "topic": "TALK_GLOOSCAP_SOCIAL",
         "condition": { "u_has_item": "cig" }
       },
       {
-        "text": "[HAS JOINT] I am extremely into your smile yes.  I have something to smoke, want to have some with me?",
+        "text": "[Offer Joint] I am extremely into your smile yes.  I have something to smoke, want to have some with me?",
         "topic": "TALK_GLOOSCAP_SOCIAL",
         "condition": { "u_has_item": "joint" }
       },
@@ -134,7 +134,7 @@
       {
         "text": "[GLORIOUS] Worship my beauty.",
         "topic": "TALK_GLOOSCAP_WORSHIP",
-        "condition": { "u_has_trait": "GLORIUS" }
+        "condition": { "u_has_trait": "BEAUTIFUL3" }
       },
       {
         "text": "[TERRIFYING] Fear me!  I am disgusting!",
@@ -313,22 +313,22 @@
     "dynamic_line": "Among other things, sure.  I have some extra I might be willing to trade, but I only trade with my friends and I don't have a lot of those left.",
     "responses": [
       {
-        "text": "[HAS BEER] I don't know about friends, but I have some drinks with me, want to have some?",
+        "text": "[Offer Beer] I don't know about friends, but I have some drinks with me, want to have some?",
         "topic": "TALK_GLOOSCAP_SOCIAL",
         "condition": { "u_has_item": "beer" }
       },
       {
-        "text": "[HAS IPA] I don't know about friends, but I have some drinks with me, want to have some?",
+        "text": "[Offer India Pale Ale] I don't know about friends, but I have some drinks with me, want to have some?",
         "topic": "TALK_GLOOSCAP_SOCIAL",
         "condition": { "u_has_item": "india_pale_ale" }
       },
       {
-        "text": "[HAS CIGARETTES] I don't know about friends, but I have some cigarettes, want one with me?",
+        "text": "[Offer Cigarettes] I don't know about friends, but I have some cigarettes, want one with me?",
         "topic": "TALK_GLOOSCAP_SOCIAL",
         "condition": { "u_has_item": "cig" }
       },
       {
-        "text": "[HAS JOINT] I don't know about friends, but I have something to smoke, want to have some with me?",
+        "text": "[Offer Joint] I don't know about friends, but I have something to smoke, want to have some with me?",
         "topic": "TALK_GLOOSCAP_SOCIAL",
         "condition": { "u_has_item": "joint" }
       },
@@ -344,7 +344,7 @@
       {
         "text": "[GLORIOUS] Worship my beauty.",
         "topic": "TALK_GLOOSCAP_WORSHIP",
-        "condition": { "u_has_trait": "GLORIUS" }
+        "condition": { "u_has_trait": "BEAUTIFUL3" }
       },
       {
         "text": "[TERRIFYING] Fear me!  I am disgusting!",

--- a/data/json/npcs/island_prison/prisoners.json
+++ b/data/json/npcs/island_prison/prisoners.json
@@ -312,7 +312,7 @@
         }
       },
       {
-        "text": "[Cannibal] It's hard to die of hunger when there's so many tasty corpses lying around.",
+        "text": "[CANNIBAL] It's hard to die of hunger when there's so many tasty corpses lying around.",
         "topic": "TALK_PRISONER_LEADER_LEARNED_ABOUT_CANNIBAL",
         "condition": {
           "and": [
@@ -477,7 +477,7 @@
     },
     "responses": [
       {
-        "text": "[Show the military id card] You mean this stuff?",
+        "text": "[Show the military ID card] You mean this stuff?",
         "topic": "TALK_PRISONER_LEADER_SHOW_MILITARY_ID",
         "condition": {
           "and": [

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
@@ -95,7 +95,7 @@
       },
       { "text": "You seem a little forward…", "topic": "TALK_REFUGEE_Alonso_Forward" },
       {
-        "text": "[PERCEPTION 10] What is up with you?  What's with the fake accent, and speaking in the third person?",
+        "text": "[PER 10] What is up with you?  What's with the fake accent, and speaking in the third person?",
         "topic": "TALK_REFUGEE_Alonso_CalledOut1",
         "condition": {
           "and": [

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Draco_Dune.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Draco_Dune.json
@@ -471,7 +471,7 @@
         "switch": true
       },
       {
-        "text": "[Perform an masterful dance]",
+        "text": "[Perform a masterful dance]",
         "topic": "TALK_REFUGEE_Draco_Dance_5",
         "condition": { "math": [ "u_val('dodge')", "<", "20" ] },
         "switch": true

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -181,7 +181,7 @@
     "dynamic_line": "No, unfortunately.  They're folks that wanted to join us, but we're too full and we don't have enough to share.  Most people leave and look for their own place when we turn them down, but these ones… didn't.  We've been trying to find them a safe place, but there's a shortage of those these days, for reasons I'm sure you can guess.  Until then, we're letting them crash here as long as they don't mess the place up.",
     "responses": [
       {
-        "text": "[SOCIAL 1+] If I could look into clearing them out of here, would you be able to pay me back?",
+        "text": "[Social 1] If I could look into clearing them out of here, would you be able to pay me back?",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_Beggars_Reward",
         "condition": { "math": [ "u_skill('speech')", ">=", "1" ] },
         "effect": { "npc_add_var": "beggars_reward_agreed", "type": "general", "context": "recruit", "value": "yes" }

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk_fluff.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk_fluff.json
@@ -79,7 +79,7 @@
     "dynamic_line": "*rolls his eyes.  \"Tell me about it.  My actual name is Gavin, which I think I told you.  I used to be a firefighter, and people started recognizing me because of the helmet.  Someone called me 'smokes' because of it, and it stuck.  I hate it.  I've never even touched a cigarette.\"",
     "responses": [
       {
-        "text": "[PER 8+] If you hate it, then why are you smiling?",
+        "text": "[PER 8] If you hate it, then why are you smiling?",
         "topic": "TALK_FREE_MERCHANTS_MERCHANT_AboutMe_Smokes2",
         "condition": { "u_has_perception": 8 }
       },

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -400,7 +400,7 @@
     "dynamic_line": "&The intercom's tray slides shut.\n\n\"This is the case; thank you.  Transferring the stipulated amount now.\"  The tray slides back open with your payment.  \"As an additional form of payment, you have been given clearance to receive a map of the area around this site, to assist in your work.  The standing price is 1 HGC; please inform us if you'd like to follow up on that offer going forward.",
     "responses": [
       {
-        "text": "[PER 8+] The original markings on that case had been scratched out.  Who did it really belong to?",
+        "text": "[PER 8] The original markings on that case had been scratched out.  Who did it really belong to?",
         "condition": { "u_has_perception": 8 },
         "topic": "MISSION_ROBOFAC_INTERCOM_2_COMPLETE_Hardcase"
       },

--- a/doc/MANUAL_OF_STYLE.md
+++ b/doc/MANUAL_OF_STYLE.md
@@ -19,3 +19,11 @@ Follow these conventions when adding or editing in-game text. Theses conventions
 10. Brand names do not need to be avoided as we are covered under fair use.  However, as CDDA-Earth is a parallel universe, nonexistent brands are also allowed.
 11. Don't avoid using Unicode letters, which includes proper names and alphabets when needed, or symbols as ® or ™.
 12. Always make sure that all descriptions follow a sentence case, i.e. they start with a big letter and end with a full stop, even if they are just for testing purposes (they can still appear by mistake and can be seen in debug menus).
+
+For writing NPC dialogues with mentioned conditional checks:
+
+1. When specifying stats, use the abbreviated form, e.g `[PER 10] I can see something weird.`. Avoid: `[PER 10+]` or `[PERCEPTION 10]`.
+2. When specifying skills, use regular sentence case, e.g `[Tailoring 2] I can patch it up for you!`
+3. When specifying traits, write it in all uppercase, e.g `[SWEET TOOTH] Do you have something more sugary than fruit?`
+4. When specifying that an item will be used (not used up), use e.g `[Use Stethoscope] Let's see if this one is still alive.`
+5. When specifying an action without any dialogue, use e.g `[Push the button.]`.


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

I originally wanted to work on Luliya and got sidetracked cleaning up style and wondering whether or not we have style guidelines on how to format skill checks and other stuff in `[]`.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

Made up some rules on how to format displayed conditions:

1. When specifying stats, use the abbreviated form: `[PER 10] I can see something weird.`. Avoid: `[PER 10+]` or `[PERCEPTION 10]`.
2. When specifying skills, use regular sentence case: `[Tailoring 2] I can patch it up for you!`
3. When specifying traits, write it in all uppercase: `[SWEET TOOTH] Do you have something more sugary than fruit?`
4. When specifying that an item will be used (not used up), use `[Use Stethoscope] Let's see if this one is still alive.`
5. When specifying an action without any dialogue, use `[Push the button.]`.

I found most of the stuff with `grep -rF '"text": "['` in the npc dir.

Bonus bug fix: Glooscap checked for a misspelled trait.
Also some misc other typo/grammar fixes.

I am unsure where to document this. `MANUAL_OF_STYLE.md` was my first instinct but who even looks there when trying to make a NPC? `NPCs.md` has no suitable place to insert it though where it would not get lost.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Loads fine. Also briefly looked through Luliyas dialogue.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
