### PR TITLE
2 unicorn plushies, some typo fixes

### DIFF
--- a/data/json/items/toy.json
+++ b/data/json/items/toy.json
@@ -463,7 +463,7 @@
       },
       {
         "id": "toy_plush_rooster",
-        "name": { "str": " plushie" },
+        "name": { "str": "rooster plushie" },
         "description": "A fun and colorful rooster plushie with soft, vibrant fauxfeathers made of cotton, a long rooster tail, and a bold expression.",
         "weight": 1
       },

--- a/data/json/items/toy.json
+++ b/data/json/items/toy.json
@@ -709,12 +709,12 @@
       {
         "id": "toy_plush_wunicorn",
         "name": { "str": "white unicorn plushie" },
-        "description": "This majestic unicorn plushie features a soft white body and horn, with tufts of white hair on its neck and tail. Its black eyes are adorably large and round.",
+        "description": "This majestic unicorn plushie features a soft white body and horn, with tufts of white hair on its neck and tail. Its black eyes are adorably large and round."
       },
       {
         "id": "toy_plush_municorn",
         "name": { "str": "white unicorn plushie" },
-        "description": "This majestic unicorn plushie features a soft white body and horn, with tufts of white hair on its neck and tail. Its black eyes are adorably large and round. For some odd reason, this one is wielding a plush knife with its forehooves.",
+        "description": "This majestic unicorn plushie features a soft white body and horn, with tufts of white hair on its neck and tail. Its black eyes are adorably large and round. For some odd reason, this one is wielding a plush knife with its forehooves."
       }
     ]
   },

--- a/data/json/items/toy.json
+++ b/data/json/items/toy.json
@@ -626,7 +626,7 @@
       {
         "id": "toy_plush_crab",
         "name": { "str": "crab plushie" },
-        "description": "A amazing crab plushie with soft, textured blue and red bumpy shell and big, curious eyes.",
+        "description": "An amazing crab plushie with soft, textured blue and red bumpy shell and big, curious eyes.",
         "weight": 1
       },
       {
@@ -698,13 +698,23 @@
       {
         "id": "toy_plush_boar",
         "name": { "str": "wild boar plushie" },
-        "description": "This big wild boar plushie features a soft tuft of coarse, dark fur along its spine, with a soft and plushy body.  It also have a pair of soft tusks protruding from its snout and has a fierce expression.",
+        "description": "This big wild boar plushie features a soft tuft of coarse, dark fur along its spine, with a soft and plushy body.  It also has a pair of soft tusks protruding from its snout and has a fierce expression.",
         "weight": 1
       },
       {
         "id": "toy_plush_pig",
         "name": { "str": "pig plushie" },
         "description": "This loving, precious pig plushie has a soft pink fur, with endearing floppy ears and bright eyes.  It also has a plush snout with brown fur on its legs and paws.  Its nose is somewhat long and black, and its eyes are large and expressive."
+      },
+      {
+        "id": "toy_plush_wunicorn",
+        "name": { "str": "white unicorn plushie" },
+        "description": "This majestic unicorn plushie features a soft white body and horn, with tufts of white hair on its neck and tail. Its black eyes are adorably large and round.",
+      },
+      {
+        "id": "toy_plush_municorn",
+        "name": { "str": "white unicorn plushie" },
+        "description": "This majestic unicorn plushie features a soft white body and horn, with tufts of white hair on its neck and tail. Its black eyes are adorably large and round. For some odd reason, this one is wielding a plush knife with its forehooves.",
       }
     ]
   },

--- a/data/json/items/toy.json
+++ b/data/json/items/toy.json
@@ -709,12 +709,12 @@
       {
         "id": "toy_plush_wunicorn",
         "name": { "str": "white unicorn plushie" },
-        "description": "This majestic unicorn plushie features a soft white body and horn, with tufts of white hair on its neck and tail. Its black eyes are adorably large and round."
+        "description": "This majestic unicorn plushie features a soft white body and horn, with tufts of white hair on its neck and tail.  Its black eyes are adorably large and round."
       },
       {
         "id": "toy_plush_municorn",
         "name": { "str": "white unicorn plushie" },
-        "description": "This majestic unicorn plushie features a soft white body and horn, with tufts of white hair on its neck and tail. Its black eyes are adorably large and round. For some odd reason, this one is wielding a plush knife with its forehooves."
+        "description": "This majestic unicorn plushie features a soft white body and horn, with tufts of white hair on its neck and tail.  Its black eyes are adorably large and round.  For some odd reason, this one is wielding a plush knife with its forehooves."
       }
     ]
   },

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -1159,6 +1159,8 @@ footrest
 forager
 foregrip
 foregrips
+forehoof
+forehooves
 foreleg
 forelegs
 forestalling


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "2 unicorn variants for plush toy item"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
A certain someone responded with righteous fury upon discovering that, despite the numerous plushie variants now in existence, not even one of them is a unicorn. This is obviously an extremely serious issue that must be addressed immediately.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Added 2 unicorn variants. Both of them are a majestic white.
Updated dictionary.txt. "Forehooves" is a real word!
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I could've added a ton of different-colored unicorn variants, but then I'd be here all week and the people that translate all this stuff would probably be mad at me.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Put the new toy.json into the game and made sure everything loaded without errors. Searched for the new variants in the spawn-item debug menu to see they were there.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
