### PR TITLE
Enable bionic power conversion UPSes to draw from bionic power

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9652,7 +9652,7 @@ units::energy Character::available_ups() const
 
     bool has_bio_powered_ups = false;
     cache_visit_items_with( flag_IS_UPS, [&has_bio_powered_ups]( const item & it ) {
-        if( it.has_flag( flag_USES_BIONIC_POWER ) ) {
+        if( it.has_flag( flag_USES_BIONIC_POWER && !has_bio_powered_ups ) ) {
             has_bio_powered_ups = true;
             break;
         }
@@ -9682,9 +9682,8 @@ units::energy Character::consume_ups( units::energy qty, const int radius )
     // UPS from bionic
     bool has_bio_powered_ups = false;
     cache_visit_items_with( flag_IS_UPS, [&has_bio_powered_ups]( const item & it ) {
-        if( it.has_flag( flag_USES_BIONIC_POWER ) ) {
+        if( it.has_flag( flag_USES_BIONIC_POWER ) && !has_bio_powered_ups ) {
             has_bio_powered_ups = true;
-            break;
         }
     } );
     if( qty != 0_kJ && has_power() && ( has_active_bionic( bio_ups ) || has_bio_powered_ups ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9644,11 +9644,20 @@ bool Character::use_charges_if_avail( const itype_id &it, int quantity )
 units::energy Character::available_ups() const
 {
     units::energy available_charges = 0_kJ;
+
     if( is_mounted() && mounted_creature.get()->has_flag( mon_flag_RIDEABLE_MECH ) ) {
         auto *mons = mounted_creature.get();
         available_charges += units::from_kilojoule( mons->battery_item->ammo_remaining() );
     }
-    if( has_active_bionic( bio_ups ) ) {
+
+    bool has_bio_powered_ups = false;
+    cache_visit_items_with( flag_IS_UPS, [&available_charges]( const item & it ) {
+        if ( it.has_flag( flag_USES_BIONIC_POWER ) ) {
+            has_bio_powered_ups = true;
+            break;
+        }
+    } );
+    if( has_active_bionic( bio_ups ) || has_bio_powered_ups ) {
         available_charges += get_power_level();
     }
 
@@ -9671,7 +9680,14 @@ units::energy Character::consume_ups( units::energy qty, const int radius )
     }
 
     // UPS from bionic
-    if( qty != 0_kJ && has_power() && has_active_bionic( bio_ups ) ) {
+    bool has_bio_powered_ups = false;
+    cache_visit_items_with( flag_IS_UPS, [&available_charges]( const item & it ) {
+        if ( it.has_flag( flag_USES_BIONIC_POWER ) ) {
+            has_bio_powered_ups = true;
+            break;
+        }
+    } );
+    if( qty != 0_kJ && has_power() && ( has_active_bionic( bio_ups ) || has_bio_powered_ups ) ) {
         units::energy bio = std::min( get_power_level(), qty );
         mod_power_level( -bio );
         qty -= std::min( qty, bio );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9652,7 +9652,7 @@ units::energy Character::available_ups() const
 
     bool has_bio_powered_ups = false;
     cache_visit_items_with( flag_IS_UPS, [&has_bio_powered_ups]( const item & it ) {
-        if( it.has_flag( flag_USES_BIONIC_POWER && !has_bio_powered_ups ) ) {
+        if( it.has_flag( flag_USES_BIONIC_POWER ) && !has_bio_powered_ups ) {
             has_bio_powered_ups = true;
             break;
         }

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9654,7 +9654,6 @@ units::energy Character::available_ups() const
     cache_visit_items_with( flag_IS_UPS, [&has_bio_powered_ups]( const item & it ) {
         if( it.has_flag( flag_USES_BIONIC_POWER ) && !has_bio_powered_ups ) {
             has_bio_powered_ups = true;
-            break;
         }
     } );
     if( has_active_bionic( bio_ups ) || has_bio_powered_ups ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9651,7 +9651,7 @@ units::energy Character::available_ups() const
     }
 
     bool has_bio_powered_ups = false;
-    cache_visit_items_with( flag_IS_UPS, [&available_charges]( const item & it ) {
+    cache_visit_items_with( flag_IS_UPS, [&has_bio_powered_ups]( const item & it ) {
         if( it.has_flag( flag_USES_BIONIC_POWER ) ) {
             has_bio_powered_ups = true;
             break;
@@ -9681,7 +9681,7 @@ units::energy Character::consume_ups( units::energy qty, const int radius )
 
     // UPS from bionic
     bool has_bio_powered_ups = false;
-    cache_visit_items_with( flag_IS_UPS, [&available_charges]( const item & it ) {
+    cache_visit_items_with( flag_IS_UPS, [&has_bio_powered_ups]( const item & it ) {
         if( it.has_flag( flag_USES_BIONIC_POWER ) ) {
             has_bio_powered_ups = true;
             break;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -9652,7 +9652,7 @@ units::energy Character::available_ups() const
 
     bool has_bio_powered_ups = false;
     cache_visit_items_with( flag_IS_UPS, [&available_charges]( const item & it ) {
-        if ( it.has_flag( flag_USES_BIONIC_POWER ) ) {
+        if( it.has_flag( flag_USES_BIONIC_POWER ) ) {
             has_bio_powered_ups = true;
             break;
         }
@@ -9682,7 +9682,7 @@ units::energy Character::consume_ups( units::energy qty, const int radius )
     // UPS from bionic
     bool has_bio_powered_ups = false;
     cache_visit_items_with( flag_IS_UPS, [&available_charges]( const item & it ) {
-        if ( it.has_flag( flag_USES_BIONIC_POWER ) ) {
+        if( it.has_flag( flag_USES_BIONIC_POWER ) ) {
             has_bio_powered_ups = true;
             break;
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Enable bionic power conversion UPSes to draw from bionic power"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Resolves #70282. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Allow a UPS modified by the "bionic power conversion mod" to effectively act as a substitute for the Unified Power System CBM. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Forbid modifying UPSes with the aforementioned toolmod to make it clear that it wouldn't work. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Currently testing. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
See the attached issue. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
