### PR TITLE
Allow u/npc_spawn_monster to pick randomly from a group for count > 1

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
@@ -175,6 +175,7 @@
     "type": "effect_on_condition",
     "id": "creature_hallucinations",
     "//TODO": "ideally checks is the tile visible, and then spawns hallu where player can't see it",
+    "//": "If monsters are nearby, 3/4 chance to spawn some hallucinations of random monsters nearby and run again half the time, 1/4 chance to spawn some of YOUR_FEARS. If not, spawns some of YOUR_FEARS",
     "condition": { "and": [ { "math": [ "rand(3)", "==", "3" ] }, { "not": { "math": [ "u_monsters_nearby()", ">", "1" ] } } ] },
     "effect": { "run_eocs": "creature_hallucinations_fears" },
     "false_effect": [
@@ -184,7 +185,7 @@
         "target_range": 50,
         "lifespan": [ "2 hours", "9 hours" ]
       },
-      { "run_eocs": "creature_hallucinations" }
+      { "weighted_list_eocs": [ [ "creature_hallucinations", 1 ], [ "EOC_NONE", 1 ] ] }
     ]
   },
   {

--- a/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
@@ -175,25 +175,29 @@
     "type": "effect_on_condition",
     "id": "creature_hallucinations",
     "//TODO": "ideally checks is the tile visible, and then spawns hallu where player can't see it",
-    "//": "if monsters are nearby, 3/4 chance to get copy of random monster nearby and run again (with 1/2 prob) and 1/4 chance to spawns one of YOUR_FEARS. If not, spawns one of YOUR_FEARS",
-    "effect": [
+    "condition": { "and": [ { "math": [ "rand(3)", "==", "3" ] }, { "not": { "math": [ "u_monsters_nearby()", ">", "1" ] } } ] },
+    "effect": { "run_eocs": "creature_hallucinations_fears" },
+    "false_effect": [
       {
-        "if": { "and": [ { "math": [ "rand(3)", "==", "3" ] }, { "not": { "math": [ "u_monsters_nearby()", ">", "1" ] } } ] },
-        "then": {
-          "u_spawn_monster": "GROUP_YOUR_FEARS",
-          "group": true,
-          "hallucination_count": { "math": [ "1 + rand(2)" ] },
-          "max_radius": 40,
-          "lifespan": [ "1 hours", "4 hours" ]
-        },
-        "else": {
-          "u_spawn_monster": "",
-          "hallucination_count": { "math": [ "1 + rand(4)" ] },
-          "target_range": 50,
-          "lifespan": [ "2 hours", "9 hours" ]
-        }
-      }
+        "u_spawn_monster": "",
+        "hallucination_count": { "math": [ "1 + rand(4)" ] },
+        "target_range": 50,
+        "lifespan": [ "2 hours", "9 hours" ]
+      },
+      { "run_eocs": "creature_hallucinations" }
     ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "creature_hallucinations_fears",
+    "//TODO": "ideally checks is the tile visible, and then spawns hallu where player can't see it",
+    "effect": {
+      "u_spawn_monster": "GROUP_YOUR_FEARS",
+      "group": true,
+      "hallucination_count": { "math": [ "1 + rand(2)" ] },
+      "max_radius": 40,
+      "lifespan": [ "1 hours", "4 hours" ]
+    }
   },
   {
     "type": "effect_on_condition",

--- a/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
@@ -209,19 +209,11 @@
     "condition": { "math": [ "u_monsters_nearby()", ">", "1" ] },
     "effect": [
       {
-        "if": { "math": [ "u_i", "<", "rng(50, 100)" ] },
-        "then": [
-          {
-            "u_spawn_monster": "",
-            "hallucination_count": 1,
-            "target_range": 50,
-            "max_radius": 50,
-            "lifespan": [ "2 hours", "9 hours" ]
-          },
-          { "math": [ "u_i", "++" ] },
-          { "run_eocs": "hallucination_swarm" }
-        ],
-        "else": { "math": [ "u_i", "=", "0" ] }
+        "u_spawn_monster": "",
+        "hallucination_count": [ 50, 100 ],
+        "target_range": 50,
+        "max_radius": 50,
+        "lifespan": [ "2 hours", "9 hours" ]
       }
     ]
   }

--- a/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/hallucination_eocs.json
@@ -176,9 +176,8 @@
     "id": "creature_hallucinations",
     "//TODO": "ideally checks is the tile visible, and then spawns hallu where player can't see it",
     "//": "If monsters are nearby, 3/4 chance to spawn some hallucinations of random monsters nearby and run again half the time, 1/4 chance to spawn some of YOUR_FEARS. If not, spawns some of YOUR_FEARS",
-    "condition": { "and": [ { "math": [ "rand(3)", "==", "3" ] }, { "not": { "math": [ "u_monsters_nearby()", ">", "1" ] } } ] },
-    "effect": { "run_eocs": "creature_hallucinations_fears" },
-    "false_effect": [
+    "condition": { "and": [ { "math": [ "rand(3)", "<", "3" ] }, { "math": [ "u_monsters_nearby()", ">", "0" ] } ] },
+    "effect": [
       {
         "u_spawn_monster": "",
         "hallucination_count": { "math": [ "1 + rand(4)" ] },
@@ -186,7 +185,8 @@
         "lifespan": [ "2 hours", "9 hours" ]
       },
       { "weighted_list_eocs": [ [ "creature_hallucinations", 1 ], [ "EOC_NONE", 1 ] ] }
-    ]
+    ],
+    "false_effect": { "run_eocs": "creature_hallucinations_fears" }
   },
   {
     "type": "effect_on_condition",

--- a/data/json/effects_on_condition/scenario_specific_eocs.json
+++ b/data/json/effects_on_condition/scenario_specific_eocs.json
@@ -131,30 +131,13 @@
     "type": "effect_on_condition",
     "id": "scenario_surrounded_zombie",
     "eoc_type": "SCENARIO_SPECIFIC",
-    "effect": [
-      { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 1, "min_radius": 12, "max_radius": 20 },
-      { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 1, "min_radius": 12, "max_radius": 20 },
-      { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 1, "min_radius": 15, "max_radius": 22 },
-      { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 1, "min_radius": 15, "max_radius": 22 },
-      { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 1, "min_radius": 18, "max_radius": 30 }
-    ]
+    "effect": [ { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 5, "min_radius": 12, "max_radius": 30 } ]
   },
   {
     "type": "effect_on_condition",
     "id": "scenario_surrounded_zombie_heavy",
     "eoc_type": "SCENARIO_SPECIFIC",
-    "effect": [
-      { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 1, "min_radius": 14, "max_radius": 20 },
-      { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 1, "min_radius": 14, "max_radius": 20 },
-      { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 1, "min_radius": 14, "max_radius": 20 },
-      { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 1, "min_radius": 14, "max_radius": 20 },
-      { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 1, "min_radius": 18, "max_radius": 25 },
-      { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 1, "min_radius": 18, "max_radius": 25 },
-      { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 1, "min_radius": 18, "max_radius": 25 },
-      { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 1, "min_radius": 18, "max_radius": 25 },
-      { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 1, "min_radius": 20, "max_radius": 30 },
-      { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 1, "min_radius": 20, "max_radius": 30 }
-    ]
+    "effect": [ { "u_spawn_monster": "GROUP_ZOMBIE", "group": true, "real_count": 10, "min_radius": 14, "max_radius": 30 } ]
   },
   {
     "type": "effect_on_condition",

--- a/data/json/monsters/zed_lieutenant.json
+++ b/data/json/monsters/zed_lieutenant.json
@@ -165,9 +165,8 @@
       {
         "u_spawn_monster": "GROUP_AMALGAMATIONS_SPAWNED",
         "group": true,
-        "//": "This always spawns 6 of the same type, which is not ideal (6 soldiers is way too deadly). Consider revising the weights if/when talk_effect_fun_t::set_spawn_monster can pick each individual spawn from the group.",
         "real_count": 6,
-        "//2": "The maximum lifespan should not be terribly longer than the cooldown(currently 20 seconds), or else multiple groups can be active at once and make this much harder than desired.",
+        "//": "The maximum lifespan should not be terribly longer than the cooldown(currently 20 seconds), or else multiple groups can be active at once and make this much harder than desired.",
         "lifespan": [ "15 seconds", "30 seconds" ],
         "target_var": { "global_val": "drain_terrain" }
       },
@@ -307,7 +306,7 @@
     "name": "GROUP_AMALGAMATIONS_SPAWNED",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_amalgamation_swarmer", "weight": 20 },
+      { "monster": "mon_amalgamation_swarmer", "weight": 10 },
       { "monster": "mon_amalgamation_corroder", "weight": 4 },
       { "monster": "mon_amalgamation_soldier", "weight": 1 }
     ]

--- a/data/json/monsters/zed_lieutenant.json
+++ b/data/json/monsters/zed_lieutenant.json
@@ -306,7 +306,7 @@
     "name": "GROUP_AMALGAMATIONS_SPAWNED",
     "type": "monstergroup",
     "monsters": [
-      { "monster": "mon_amalgamation_swarmer", "weight": 10 },
+      { "monster": "mon_amalgamation_swarmer", "weight": 20 },
       { "monster": "mon_amalgamation_corroder", "weight": 4 },
       { "monster": "mon_amalgamation_soldier", "weight": 1 }
     ]

--- a/data/mods/Defense_Mode/effects_on_condition/wave_eocs.json
+++ b/data/mods/Defense_Mode/effects_on_condition/wave_eocs.json
@@ -77,7 +77,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -93,7 +93,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_ZOMBIE",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -109,7 +109,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_SPIDER_DM",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -125,7 +125,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_ROBOT_DM",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -141,7 +141,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_TRIFFID_DM",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -157,7 +157,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_NETHER_DM",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -173,7 +173,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_FERAL",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -193,7 +193,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_RATKIN_EVOLVED",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -213,7 +213,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_MIL_HELIPAD",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/effects_on_condition/wave_eocs.json
+++ b/data/mods/Defense_Mode/effects_on_condition/wave_eocs.json
@@ -77,23 +77,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -109,23 +93,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_ZOMBIE",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_ZOMBIE",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_ZOMBIE",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -141,23 +109,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_SPIDER_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_SPIDER_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_SPIDER_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -173,23 +125,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_ROBOT_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_ROBOT_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_ROBOT_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -205,23 +141,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_TRIFFID_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_TRIFFID_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_TRIFFID_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -237,23 +157,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_NETHER_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_NETHER_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_NETHER_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -269,23 +173,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_FERAL",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_FERAL",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_FERAL",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -305,23 +193,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_RATKIN_EVOLVED",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_RATKIN_EVOLVED",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_RATKIN_EVOLVED",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -341,23 +213,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_MIL_HELIPAD",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_MIL_HELIPAD",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_MIL_HELIPAD",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Aftershock/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Aftershock/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "AFS_GROUP_DM",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Aftershock/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Aftershock/eocs.json
@@ -6,23 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "AFS_GROUP_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "AFS_GROUP_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "AFS_GROUP_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/DinoMod/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/DinoMod/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_DINOSAUR_DANGEROUS",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/DinoMod/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/DinoMod/eocs.json
@@ -6,23 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_DINOSAUR_DANGEROUS",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_DINOSAUR_DANGEROUS",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_DINOSAUR_DANGEROUS",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Magiclysm/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Magiclysm/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_LIZARDFOLK_DM",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_GOLEM_DM",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -38,7 +38,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_GOBLIN_STANDARD",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -54,7 +54,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_ORC_DM",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Magiclysm/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Magiclysm/eocs.json
@@ -6,23 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_LIZARDFOLK_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_LIZARDFOLK_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_LIZARDFOLK_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -38,23 +22,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_GOLEM_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_GOLEM_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_GOLEM_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -70,23 +38,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_GOBLIN_STANDARD",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_GOBLIN_STANDARD",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_GOBLIN_STANDARD",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -102,23 +54,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_ORC_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_ORC_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_ORC_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Megafauna/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Megafauna/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_MEGAFAUNA_DM",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Megafauna/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Megafauna/eocs.json
@@ -6,23 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_MEGAFAUNA_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_MEGAFAUNA_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_MEGAFAUNA_DM",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/MindOverMatter/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/MindOverMatter/eocs.json
@@ -14,7 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "2" ], "default": 2 },
+        "real_count": { "math": [ "wave_spawn_number() * 2" ], "default": 2 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/MindOverMatter/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/MindOverMatter/eocs.json
@@ -14,15 +14,7 @@
       },
       {
         "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_VANILLA_ONLY_HUMANS",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "2" ], "default": 2 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/My_Sweet_Cataclysm/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/My_Sweet_Cataclysm/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_SWEET_HORDE",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/My_Sweet_Cataclysm/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/My_Sweet_Cataclysm/eocs.json
@@ -6,23 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_SWEET_HORDE",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_SWEET_HORDE",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_SWEET_HORDE",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Mythos/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Mythos/eocs.json
@@ -6,23 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_MYTHOS_SPAWN",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_MYTHOS_SPAWN",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_MYTHOS_SPAWN",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Mythos/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Mythos/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_MYTHOS_SPAWN",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Xedra_Evolved/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Xedra_Evolved/eocs.json
@@ -6,23 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_EXODII",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_DEFENSE_MODE_EXODII",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_DEFENSE_MODE_EXODII",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -38,23 +22,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_XEDRA",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_DEFENSE_MODE_XEDRA",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
-        "outdoor_only": true,
-        "group": true,
-        "min_radius": 20,
-        "max_radius": 40
-      },
-      {
-        "u_spawn_monster": "GROUP_DEFENSE_MODE_XEDRA",
-        "real_count": { "math": [ "wave_spawn_number()" ], "default": 1 },
+        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/data/mods/Defense_Mode/mod_interactions/Xedra_Evolved/eocs.json
+++ b/data/mods/Defense_Mode/mod_interactions/Xedra_Evolved/eocs.json
@@ -6,7 +6,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_EXODII",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,
@@ -22,7 +22,7 @@
     "effect": [
       {
         "u_spawn_monster": "GROUP_DEFENSE_MODE_XEDRA",
-        "real_count": { "math": [ "wave_spawn_number()", "*", "3" ], "default": 3 },
+        "real_count": { "math": [ "wave_spawn_number() * 3" ], "default": 3 },
         "outdoor_only": true,
         "group": true,
         "min_radius": 20,

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -3688,7 +3688,7 @@ Spawn some monsters around you, NPC or `target_var`
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
-| "u_spawn_monster", "npc_spawn_monster" | **mandatory** | string or [variable object](##variable-object) | monster that would be spawned, set to "" for random nearby monsters |
+| "u_spawn_monster", "npc_spawn_monster" | optional | string or [variable object](##variable-object) | default ""; monster or monstergroup that would be spawned, if ommited defaults to picking from nearby monsters |
 | "real_count" | optional | int, [variable object](##variable-object) or value between two | default 0; amount of monsters, that would be spawned | 
 | "hallucination_count" | optional | int, [variable object](##variable-object) or value between two | default 0; amount of hallucination versions of the monster that would be spawned |
 | "group" | optional | boolean | default false; if true, `_spawn_monster` will spawn a monster from `monstergroup` |

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -3688,10 +3688,11 @@ Spawn some monsters around you, NPC or `target_var`
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
-| "u_spawn_monster", "npc_spawn_monster" | **mandatory** | string or [variable object](##variable-object) | monster that would be spawned |
+| "u_spawn_monster", "npc_spawn_monster" | **mandatory** | string or [variable object](##variable-object) | monster that would be spawned, set to "" for random nearby monsters |
 | "real_count" | optional | int, [variable object](##variable-object) or value between two | default 0; amount of monsters, that would be spawned | 
 | "hallucination_count" | optional | int, [variable object](##variable-object) or value between two | default 0; amount of hallucination versions of the monster that would be spawned |
-| "group" | optional | boolean | default false; if true, `_spawn_monster` would spawn a monster from `monstergroup`; the game pick only one monster from group, so to create mix from different monsters from monstergroup, multiple `u_spawn_monster` should be used | 
+| "group" | optional | boolean | default false; if true, `_spawn_monster` will spawn a monster from `monstergroup` |
+| "single_target" | optional | boolean | default false; if true, `_spawn_monster` the game pick only one monster from the provided `monstergroup` or from nearby monsters | 
 | "min_radius", "max_radius" | optional | int, [variable object](##variable-object) or value between two | default 1 and 10 respectively; range around the target, where the monster would spawn | 
 | "outdoor_only"/ "indoor_only" | optional | boolean | default false; if used, monsters would be able to spawn only outside or only inside buildings | 
 | "open_air_allowed" | optional | boolean | default false; if true, monsters can spawn in the open air | 

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -3688,7 +3688,7 @@ Spawn some monsters around you, NPC or `target_var`
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- | 
-| "u_spawn_monster", "npc_spawn_monster" | optional | string or [variable object](##variable-object) | default ""; monster or monstergroup that would be spawned, if ommited defaults to picking from nearby monsters |
+| "u_spawn_monster", "npc_spawn_monster" | **mandatory** | string or [variable object](##variable-object) | monster or monstergroup that would be spawned, using "" picks randomly from nearby monsters |
 | "real_count" | optional | int, [variable object](##variable-object) or value between two | default 0; amount of monsters, that would be spawned | 
 | "hallucination_count" | optional | int, [variable object](##variable-object) or value between two | default 0; amount of hallucination versions of the monster that would be spawned |
 | "group" | optional | boolean | default false; if true, `_spawn_monster` will spawn a monster from `monstergroup` |

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5659,15 +5659,12 @@ void talk_effect_fun_t::set_spawn_monster( const JsonObject &jo, std::string_vie
 {
     bool group = jo.get_bool( "group", false );
     bool single_target = jo.get_bool( "single_target", false );
-    str_or_var monster_id = get_str_or_var( jo.get_member( member ), member );
+    str_or_var monster_id = get_str_or_var( jo.get_member( member ), member, "" );
     dbl_or_var dov_target_range = get_dbl_or_var( jo, "target_range", false, 0 );
     dbl_or_var dov_hallucination_count = get_dbl_or_var( jo, "hallucination_count", false, 0 );
     dbl_or_var dov_real_count = get_dbl_or_var( jo, "real_count", false, 0 );
     dbl_or_var dov_min_radius = get_dbl_or_var( jo, "min_radius", false, 1 );
     dbl_or_var dov_max_radius = get_dbl_or_var( jo, "max_radius", false, 10 );
-
-    //Default ""?
-    //Don't allow "" + group
 
     const bool outdoor_only = jo.get_bool( "outdoor_only", false );
     const bool indoor_only = jo.get_bool( "indoor_only", false );
@@ -5696,6 +5693,9 @@ void talk_effect_fun_t::set_spawn_monster( const JsonObject &jo, std::string_vie
         bool hallu_group = false;
 
         if( group ) {
+            if( monster_id.evaluate( d ).empty() ) {
+                debugmsg( "Cannot use group without a valid monstergroup.  %s", d.get_callstack() );
+            }
             if( single_target ) {
                 target_monster = monster( MonsterGroupManager::GetRandomMonsterFromGroup( mongroup_id(
                                               monster_id.evaluate( d ) ) ) );
@@ -5740,7 +5740,8 @@ void talk_effect_fun_t::set_spawn_monster( const JsonObject &jo, std::string_vie
             }
         } else {
             if( single_target ) {
-                //error
+                debugmsg( "single_target should not be defined for a singlular monster_id.  %s",
+                          d.get_callstack() );
             }
             target_monster = monster( mtype_id( monster_id.evaluate( d ) ) );
         }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5690,7 +5690,6 @@ void talk_effect_fun_t::set_spawn_monster( const JsonObject &jo, std::string_vie
         monster target_monster;
         std::vector<Creature *> target_monsters;
         mongroup_id target_mongroup;
-        bool hallu_group = false;
 
         if( group ) {
             if( monster_id.evaluate( d ).empty() ) {
@@ -5734,7 +5733,6 @@ void talk_effect_fun_t::set_spawn_monster( const JsonObject &jo, std::string_vie
                     Creature *copy = monsters_in_range[0];
                     target_monster = *copy->as_monster();
                 } else {
-                    hallu_group = true;
                     target_monsters = monsters_in_range;
                 }
             }
@@ -5762,7 +5760,7 @@ void talk_effect_fun_t::set_spawn_monster( const JsonObject &jo, std::string_vie
                 if( group ) {
                     target_monster = monster( MonsterGroupManager::GetRandomMonsterFromGroup( mongroup_id(
                                                   monster_id.evaluate( d ) ) ) );
-                } else if( hallu_group ) {
+                } else {
                     Creature *copy = target_monsters[ rng( 0, target_monsters.size() - 1 ) ];
                     target_monster = *copy->as_monster();
                 }
@@ -5793,7 +5791,7 @@ void talk_effect_fun_t::set_spawn_monster( const JsonObject &jo, std::string_vie
                 if( group ) {
                     target_monster = monster( MonsterGroupManager::GetRandomMonsterFromGroup( mongroup_id(
                                                   monster_id.evaluate( d ) ) ) );
-                } else if( hallu_group ) {
+                } else {
                     Creature *copy = target_monsters[ rng( 0, target_monsters.size() - 1 ) ];
                     target_monster = *copy->as_monster();
                 }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5789,12 +5789,14 @@ void talk_effect_fun_t::set_spawn_monster( const JsonObject &jo, std::string_vie
         }
         for( int i = 0; i < real_count; i++ ) {
             tripoint spawn_point;
-            if( group ) {
-                target_monster = monster( MonsterGroupManager::GetRandomMonsterFromGroup( mongroup_id(
-                                              monster_id.evaluate( d ) ) ) );
-            } else if( hallu_group ) {
-                Creature *copy = target_monsters[ rng( 0, target_monsters.size() - 1 ) ];
-                target_monster = *copy->as_monster();
+            if( !single_target ) {
+                if( group ) {
+                    target_monster = monster( MonsterGroupManager::GetRandomMonsterFromGroup( mongroup_id(
+                                                  monster_id.evaluate( d ) ) ) );
+                } else if( hallu_group ) {
+                    Creature *copy = target_monsters[ rng( 0, target_monsters.size() - 1 ) ];
+                    target_monster = *copy->as_monster();
+                }
             }
             if( g->find_nearby_spawn_point( target_pos, target_monster.type->id, min_radius,
                                             max_radius, spawn_point, outdoor_only, indoor_only, open_air_allowed ) ) {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5659,7 +5659,7 @@ void talk_effect_fun_t::set_spawn_monster( const JsonObject &jo, std::string_vie
 {
     bool group = jo.get_bool( "group", false );
     bool single_target = jo.get_bool( "single_target", false );
-    str_or_var monster_id = get_str_or_var( jo.get_member( member ), member, "" );
+    str_or_var monster_id = get_str_or_var( jo.get_member( member ), member );
     dbl_or_var dov_target_range = get_dbl_or_var( jo, "target_range", false, 0 );
     dbl_or_var dov_hallucination_count = get_dbl_or_var( jo, "hallucination_count", false, 0 );
     dbl_or_var dov_real_count = get_dbl_or_var( jo, "real_count", false, 0 );

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5725,11 +5725,11 @@ void talk_effect_fun_t::set_spawn_monster( const JsonObject &jo, std::string_vie
                     bool valid_target = get_player_character().attitude_to( critter ) == Creature::Attitude::HOSTILE;
                     return not_self && in_range && valid_target;
                 } );
-                if( monsters_in_range.size() == 0 ) {
+                int valid_monsters = monsters_in_range.size();
+                if( valid_monsters == 0 ) {
                     run_eoc_vector( false_eocs, d );
                     return;
-                }
-                if( monsters_in_range.size() == 1 ) {
+                } else if( valid_monsters == 1 ) {
                     Creature *copy = monsters_in_range[0];
                     target_monster = *copy->as_monster();
                 } else {

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5704,7 +5704,7 @@ void talk_effect_fun_t::set_spawn_monster( const JsonObject &jo, std::string_vie
         } else if( monster_id.evaluate( d ).empty() ) {
             int target_range = dov_target_range.evaluate( d );
             if( single_target ) {
-                // Grab a random nearby hostile creature to create a hallucination or copy of
+                // Find a hostile creature in range to be used to create a hallucination or a copy of
                 Creature *copy = g->get_creature_if( [target_range]( const Creature & critter ) -> bool {
                     bool not_self = get_player_character().pos() != critter.pos();
                     bool in_range = std::round( rl_dist_exact( get_player_character().pos(), critter.pos() ) ) <= target_range;
@@ -5717,7 +5717,7 @@ void talk_effect_fun_t::set_spawn_monster( const JsonObject &jo, std::string_vie
                 }
                 target_monster = *copy->as_monster();
             } else {
-                // Grab all hostile creatures to create hallucinations or copies of
+                // Find all hostile creatures in range to be used to create hallucinations or copies of
                 std::vector<Creature *> monsters_in_range = g->get_creatures_if( [target_range](
                 const Creature & critter ) -> bool {
                     bool not_self = get_player_character().pos() != critter.pos();

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -5758,8 +5758,7 @@ void talk_effect_fun_t::set_spawn_monster( const JsonObject &jo, std::string_vie
             tripoint spawn_point;
             if( !single_target ) {
                 if( group ) {
-                    target_monster = monster( MonsterGroupManager::GetRandomMonsterFromGroup( mongroup_id(
-                                                  monster_id.evaluate( d ) ) ) );
+                    target_monster = monster( MonsterGroupManager::GetRandomMonsterFromGroup( target_mongroup ) );
                 } else {
                     Creature *copy = target_monsters[ rng( 0, target_monsters.size() - 1 ) ];
                     target_monster = *copy->as_monster();
@@ -5789,8 +5788,7 @@ void talk_effect_fun_t::set_spawn_monster( const JsonObject &jo, std::string_vie
             tripoint spawn_point;
             if( !single_target ) {
                 if( group ) {
-                    target_monster = monster( MonsterGroupManager::GetRandomMonsterFromGroup( mongroup_id(
-                                                  monster_id.evaluate( d ) ) ) );
+                    target_monster = monster( MonsterGroupManager::GetRandomMonsterFromGroup( target_mongroup ) );
                 } else {
                     Creature *copy = target_monsters[ rng( 0, target_monsters.size() - 1 ) ];
                     target_monster = *copy->as_monster();


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #70812

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds a new field "single_type" that defaults to false but can be defined as true to replicate the old behaviour, I couldn't find any existing EoCs that want appear to want this to occur though (have a couple of ideas how it could be used tho)
Simplifies existing EoCs that were using the workaround of multiple 1 count EoCs
Updates documentation

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested using the below EoCs with expected results
```
  {
    "type": "effect_on_condition",
    "id": "hallucination_swarm_testing",
    "effect": [
      { "u_spawn_monster": "", "hallucination_count": 20, "target_range": 50, "lifespan": [ "2 hours", "9 hours" ] }
    ]
  },
  {
    "type": "effect_on_condition",
    "id": "hallucination_swarm_testing_2",
    "effect": [
      { "u_spawn_monster": "", "hallucination_count": 20, "target_range": 50, "lifespan": [ "2 hours", "9 hours" ], "single_target": true }
    ]
  },
  {
    "type": "effect_on_condition",
    "id": "hallucination_swarm_testing_3",
    "effect": [
      { "u_spawn_monster": "GROUP_PET_DOGS", "real_count": 20, "group": true }
    ]
  },
  {
    "type": "effect_on_condition",
    "id": "hallucination_swarm_testing_4",
    "effect": [
      { "u_spawn_monster": "GROUP_PET_DOGS", "real_count": 20, "group": true, "single_target": true }
    ]
  }
```
If anyone can think of anything else I should test comment below

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
