### PR TITLE
Add tag to force load the game during unit test

### DIFF
--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -233,7 +233,7 @@ else
         ./build-scripts/get_all_mods.py | \
             while read mods
             do
-                run_test ./tests/cata_test '(all_mods)=> ' '~*' --user-dir=all_modded --mods="${mods}"
+                run_test ./tests/cata_test '(all_mods)=> ' '[force_load_game]' --user-dir=all_modded --mods="${mods}"
             done
     fi
 fi

--- a/build-scripts/gha_test_only.sh
+++ b/build-scripts/gha_test_only.sh
@@ -70,7 +70,7 @@ else
         ./build-scripts/get_all_mods.py | \
             while read mods
             do
-                run_test ./tests/cata_test '(all_mods)=> ' '~*' --user-dir=all_modded --mods="${mods}"
+                run_test ./tests/cata_test '(all_mods)=> ' '[force_load_game]' --user-dir=all_modded --mods="${mods}"
             done
     fi
 fi

--- a/tests/force_load_game_test.cpp
+++ b/tests/force_load_game_test.cpp
@@ -1,0 +1,9 @@
+#include "cata_catch.h"
+
+// A dummy test you can use to force load the game. The game is always loaded if
+// any test without the [nogame] tag is run (including this one), which also
+// means this test should never have the [nogame] tag, and other tests should
+// never have the [force_load_game] tag.
+TEST_CASE( "force_load_game", "[force_load_game]" )
+{
+}


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
https://github.com/CleverRaven/Cataclysm-DDA/pull/70901#issuecomment-1895711870

#### Describe the solution
Add a dummy test that has a `force_load_game` tag which can be used when loading the game is desired when no test without the `nogame` flag is run.

Add the tag to the CI test scripts.

#### Describe alternatives you've considered

#### Testing
Ran the test locally with filters `~*` or `[force_load_game]` and the unit test ran without or with the game loaded.

To be tested in the CI.

#### Additional context
