### PR TITLE
Add a New Random Encounter, the Road Tripper

### DIFF
--- a/data/json/encounters/randec_independent_travelers.json
+++ b/data/json/encounters/randec_independent_travelers.json
@@ -1,0 +1,102 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_RandEnc_Roadstop_camper_add",
+    "recurrence": 1800,
+    "global": true,
+    "effect": [
+      { "set_condition": "random_enc_condition", "condition": { "math": [ "0", "==", "0" ] } },
+      {
+        "run_eoc_with": "EOC_RandEnc",
+        "variables": {
+          "omt": "roadstop_a",
+          "map_update": "nest_RandEnc_campervan_traveler_add",
+          "map_removal": "nest_RandEnc_campervan_traveler_remove",
+          "chance": "10",
+          "days_till_spawn": "7"
+        }
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_traveler_random_destination_direction",
+    "//": "Picks a random direction for the NPC in question to be going in.  Used for dialogue checks.",
+    "condition": { "not": { "u_has_var": "picked_direction", "type": "dialogue", "context": "travel_direction", "value": "yes" } },
+    "effect": [
+      {
+        "//": "Most people aren't going east because of the big cities with lots of zombies, so that response isn't as likely to come up.",
+        "weighted_list_eocs": [
+          [
+            {
+              "id": "going_north",
+              "effect": [
+                { "u_add_var": "going_north", "type": "dialogue", "context": "travel_direction", "value": "yes" },
+                { "u_add_var": "picked_direction", "type": "dialogue", "context": "travel_direction", "value": "yes" }
+              ]
+            },
+            { "const": 1 }
+          ],
+          [
+            {
+              "id": "going_south",
+              "effect": [
+                { "u_add_var": "going_south", "type": "dialogue", "context": "travel_direction", "value": "yes" },
+                { "u_add_var": "picked_direction", "type": "dialogue", "context": "travel_direction", "value": "yes" }
+              ]
+            },
+            { "const": 1 }
+          ],
+          [
+            {
+              "id": "going_east",
+              "effect": [
+                { "u_add_var": "going_east", "type": "dialogue", "context": "travel_direction", "value": "yes" },
+                { "u_add_var": "picked_direction", "type": "dialogue", "context": "travel_direction", "value": "yes" }
+              ]
+            },
+            { "const": 1 }
+          ],
+          [
+            {
+              "id": "going_west",
+              "effect": [
+                { "u_add_var": "going_west", "type": "dialogue", "context": "travel_direction", "value": "yes" },
+                { "u_add_var": "picked_direction", "type": "dialogue", "context": "travel_direction", "value": "yes" }
+              ]
+            },
+            { "const": 1 }
+          ]
+        ]
+      }
+    ]
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "nest_RandEnc_campervan_traveler_add",
+    "object": {
+      "place_vehicles": [
+        {
+          "vehicle": "traveler_van_motorhome",
+          "chance": 100,
+          "fuel": 85,
+          "rotation": 270,
+          "faction": "no_faction",
+          "x": [ 1 ],
+          "y": [ 2 ]
+        }
+      ],
+      "place_npcs": [ { "class": "traveler_camper_van", "x": 1, "y": 2, "unique_id": "TRAVELER" } ]
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "update_mapgen_id": "nest_RandEnc_campervan_traveler_remove",
+    "object": {
+      "remove_npcs": [ { "class": "FM_caravan_merchant_random", "x": [ 0, 23 ], "y": [ 0, 23 ] } ],
+      "remove_vehicles": [ { "vehicles": [ "traveler_van_motorhome" ], "x": [ 0, 23 ], "y": [ 0, 23 ] } ]
+    }
+  }
+]

--- a/data/json/encounters/randec_independent_travelers.json
+++ b/data/json/encounters/randec_independent_travelers.json
@@ -35,7 +35,7 @@
                 { "u_add_var": "picked_direction", "type": "dialogue", "context": "travel_direction", "value": "yes" }
               ]
             },
-            { "const": 1 }
+            1
           ],
           [
             {
@@ -45,7 +45,7 @@
                 { "u_add_var": "picked_direction", "type": "dialogue", "context": "travel_direction", "value": "yes" }
               ]
             },
-            { "const": 1 }
+            1
           ],
           [
             {
@@ -55,7 +55,7 @@
                 { "u_add_var": "picked_direction", "type": "dialogue", "context": "travel_direction", "value": "yes" }
               ]
             },
-            { "const": 1 }
+            1
           ],
           [
             {
@@ -65,7 +65,7 @@
                 { "u_add_var": "picked_direction", "type": "dialogue", "context": "travel_direction", "value": "yes" }
               ]
             },
-            { "const": 1 }
+            1
           ]
         ]
       }

--- a/data/json/encounters/randec_independent_travelers.json
+++ b/data/json/encounters/randec_independent_travelers.json
@@ -25,13 +25,12 @@
     "condition": { "not": { "u_has_var": "picked_direction", "type": "dialogue", "context": "travel_direction", "value": "yes" } },
     "effect": [
       {
-        "//": "Most people aren't going east because of the big cities with lots of zombies, so that response isn't as likely to come up.",
         "weighted_list_eocs": [
           [
             {
               "id": "going_north",
               "effect": [
-                { "u_add_var": "going_north", "type": "dialogue", "context": "travel_direction", "value": "yes" },
+                { "u_add_var": "travel_direction", "type": "dialogue", "context": "travel_direction", "value": "north" },
                 { "u_add_var": "picked_direction", "type": "dialogue", "context": "travel_direction", "value": "yes" }
               ]
             },
@@ -41,7 +40,7 @@
             {
               "id": "going_south",
               "effect": [
-                { "u_add_var": "going_south", "type": "dialogue", "context": "travel_direction", "value": "yes" },
+                { "u_add_var": "travel_direction", "type": "dialogue", "context": "travel_direction", "value": "south" },
                 { "u_add_var": "picked_direction", "type": "dialogue", "context": "travel_direction", "value": "yes" }
               ]
             },
@@ -51,7 +50,7 @@
             {
               "id": "going_east",
               "effect": [
-                { "u_add_var": "going_east", "type": "dialogue", "context": "travel_direction", "value": "yes" },
+                { "u_add_var": "travel_direction", "type": "dialogue", "context": "travel_direction", "value": "east" },
                 { "u_add_var": "picked_direction", "type": "dialogue", "context": "travel_direction", "value": "yes" }
               ]
             },
@@ -61,7 +60,7 @@
             {
               "id": "going_west",
               "effect": [
-                { "u_add_var": "going_west", "type": "dialogue", "context": "travel_direction", "value": "yes" },
+                { "u_add_var": "travel_direction", "type": "dialogue", "context": "travel_direction", "value": "west" },
                 { "u_add_var": "picked_direction", "type": "dialogue", "context": "travel_direction", "value": "yes" }
               ]
             },

--- a/data/json/npcs/random_encounters/camper_van_traveler.json
+++ b/data/json/npcs/random_encounters/camper_van_traveler.json
@@ -63,9 +63,7 @@
           ]
         },
         "effect": [
-          {
-            "arithmetic": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "rand": 4 } ]
-          },
+          { "math": [ "npc_randomize_dialogue_direction", "=", "rand(4)" ] },
           { "npc_add_var": "gave_directions", "type": "dialogue", "context": "camper_van_traveler", "value": "yes" }
         ],
         "switch": true
@@ -173,19 +171,19 @@
     "type": "talk_topic",
     "id": "TALK_NPC_CAMPER_VAN_TRAVELER_INTERESTING_THINGS",
     "dynamic_line": {
-      "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 0 } ],
+      "math": [ "npc_randomize_dialogue_direction", "==", "0" ],
       "yes": "I haven't found anything out of the ordinary, just a bunch of <zombies> and the ruins of our old lives.",
       "no": {
-        "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ],
+        "math": [ "npc_randomize_dialogue_direction", "==", "1" ],
         "yes": "Actually, I came across a group of farmers on my way here.  They were a little suspicious, but turned out to be pretty nice.  Good place to buy some food, if they're still around.",
         "no": {
-          "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 2 } ],
+          "math": [ "npc_randomize_dialogue_direction", "==", "2" ],
           "yes": "I found a small cabin out in the woods, someone was living there and had some serious chemistry equipment.  I managed to get good medical supplies from there.  They even had some oddball things too, like <swear> napalm and black powder.",
           "no": {
-            "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 3 } ],
+            "math": [ "npc_randomize_dialogue_direction", "==", "3" ],
             "yes": "I ran in to someone living in an old barn, didn't want anything to do with the world.  The odd thing is, they looked like one of those old, Wild West cowboys.",
             "no": {
-              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 4 } ],
+              "math": [ "npc_randomize_dialogue_direction", "==", "4" ],
               "yes": "I came across an abandoned house, half of it was collapsed in, looked like it was from way before <the_cataclysm>.  I was poking around to see what was there, and I found a whole bunker underneath the place.  I don't know what the heck was up with that, but I wouldn't want to find out.",
               "no": "ERROR: out of bounds on randomize_directions."
             }
@@ -199,9 +197,7 @@
         "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS_2",
         "condition": {
           "and": [
-            {
-              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ]
-            },
+            { "math": [ "npc_randomize_dialogue_direction", "==", "1" ] },
             {
               "not": { "npc_has_var": "directions", "type": "camper_van_traveler", "context": "mission", "value": "isherwood" }
             }
@@ -218,9 +214,7 @@
         "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS_2",
         "condition": {
           "and": [
-            {
-              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 2 } ]
-            },
+            { "math": [ "npc_randomize_dialogue_direction", "==", "2" ] },
             {
               "not": { "npc_has_var": "directions", "type": "camper_van_traveler", "context": "mission", "value": "chem_chabin" }
             }
@@ -237,9 +231,7 @@
         "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS_2",
         "condition": {
           "and": [
-            {
-              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 3 } ]
-            },
+            { "math": [ "npc_randomize_dialogue_direction", "==", "3" ] },
             {
               "not": { "npc_has_var": "directions", "type": "camper_van_traveler", "context": "mission", "value": "cowboy" }
             }
@@ -256,9 +248,7 @@
         "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS_2",
         "condition": {
           "and": [
-            {
-              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 4 } ]
-            },
+            { "math": [ "npc_randomize_dialogue_direction", "==", "4" ] },
             {
               "not": { "npc_has_var": "directions", "type": "camper_van_traveler", "context": "mission", "value": "bunker_shop" }
             }

--- a/data/json/npcs/random_encounters/camper_van_traveler.json
+++ b/data/json/npcs/random_encounters/camper_van_traveler.json
@@ -121,28 +121,28 @@
     "type": "talk_topic",
     "id": "TALK_NPC_CAMPER_VAN_TRAVELER_DESTINATION",
     "dynamic_line": {
-      "npc_has_var": "going_north",
+      "npc_has_var": "travel_direction",
       "type": "dialogue",
       "context": "travel_direction",
-      "value": "yes",
+      "value": "north",
       "yes": "I'm going north, up towards the border and the big wide wilderness.  I heard that there's some sort of safe spot up there, where people didn't go crazy and try to kill each other.  I don't know whether or not that's true, but at the very least, the colder climate might help keep the <zombies> down.",
       "no": {
-        "npc_has_var": "going_south",
+        "npc_has_var": "travel_direction",
         "type": "dialogue",
         "context": "travel_direction",
-        "value": "yes",
+        "value": "south",
         "yes": "I'm going south.  Hopefully somebody down there fared better than the people I knew up here.  Besides, I won't have to worry about freezing my <swear> butt off when winter comes.",
         "no": {
-          "npc_has_var": "going_east",
+          "npc_has_var": "travel_direction",
           "type": "dialogue",
           "context": "travel_direction",
-          "value": "yes",
+          "value": "east",
           "yes": "I'm going east, towards the coastline.  I heard some rumors that Rhode Island was still holding itself together, so I'm going to go and check that out.  Heck, I might just go out to sea myself, live on an old oil rig or something like that.",
           "no": {
-            "npc_has_var": "going_west",
+            "npc_has_var": "travel_direction",
             "type": "dialogue",
             "context": "travel_direction",
-            "value": "yes",
+            "value": "west",
             "yes": "I'm going west, see how things are out there in tumbleweed territory.  You see, the Midwest didn't have a whole lot of people in it compared the the East Coast, so there logically shouldn't be as many <zombies> as there are here.  I just hope that everything hasn't <swear> collapsed, that someone's still holding on.",
             "no": "ERROR: DIRECTION PARAMETERS EITHER NOT PICKED OR OUT OF BOUNDS"
           }

--- a/data/json/npcs/random_encounters/camper_van_traveler.json
+++ b/data/json/npcs/random_encounters/camper_van_traveler.json
@@ -1,0 +1,381 @@
+[
+  {
+    "type": "npc",
+    "id": "traveler_camper_van",
+    "class": "NC_SCAVENGER",
+    "attitude": 0,
+    "mission": 3,
+    "chat": "TALK_NPC_CAMPER_VAN_TRAVELER",
+    "faction": "no_faction"
+  },
+  {
+    "type": "npc_class",
+    "id": "NC_CAMPER_VAN_TRAVELER",
+    "name": { "str": "Scavenger" },
+    "job_description": "I'm just trying to survive.",
+    "traits": [ { "group": "BG_survival_story_EVACUEE" }, { "group": "NPC_starting_traits" }, { "group": "Appearance_demographics" } ],
+    "shopkeeper_price_rules": [
+      { "category": "food", "premium": 2.5 },
+      { "item": "gasoline", "premium": 2.5 },
+      { "item": "water_clean", "premium": 2.5 }
+    ],
+    "skills": [
+      { "skill": "ALL", "level": { "sum": [ { "dice": [ 3, 2 ] }, { "constant": -3 } ] } },
+      { "skill": "gun", "bonus": { "rng": [ 2, 4 ] } },
+      { "skill": "pistol", "bonus": { "rng": [ 2, 5 ] } },
+      { "skill": "rifle", "bonus": { "rng": [ 0, 3 ] } },
+      { "skill": "archery", "bonus": { "rng": [ 0, 3 ] } }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": [
+      "TALK_NPC_CAMPER_VAN_TRAVELER",
+      "TALK_NPC_CAMPER_VAN_TRAVELER_DESTINATION",
+      "TALK_NPC_CAMPER_VAN_TRAVELER_BACKSTORY",
+      "TALK_NPC_CAMPER_VAN_TRAVELER_LEAVING_WHEN"
+    ],
+    "responses": [
+      {
+        "text": "Do you have anything that you'd like to sell?",
+        "topic": "TALK_NPC_CAMPER_VAN_TRAVELER_TRADE",
+        "condition": { "npc_has_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" }
+      },
+      {
+        "text": "Where did you say you were going again?",
+        "topic": "TALK_NPC_CAMPER_VAN_TRAVELER_DESTINATION",
+        "condition": { "npc_has_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" }
+      },
+      {
+        "text": "What did you do before <the_cataclysm>?",
+        "topic": "TALK_NPC_CAMPER_VAN_TRAVELER_BACKSTORY",
+        "condition": { "npc_has_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" }
+      },
+      {
+        "text": "Have you found anything out of the ordinary out in the wastes?",
+        "topic": "TALK_NPC_CAMPER_VAN_TRAVELER_INTERESTING_THINGS",
+        "condition": {
+          "and": [
+            { "npc_has_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" },
+            {
+              "not": { "npc_has_var": "gave_directions", "type": "dialogue", "context": "camper_van_traveler", "value": "yes" }
+            }
+          ]
+        },
+        "effect": [
+          {
+            "arithmetic": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "rand": 4 } ]
+          },
+          { "npc_add_var": "gave_directions", "type": "dialogue", "context": "camper_van_traveler", "value": "yes" }
+        ],
+        "switch": true
+      },
+      {
+        "text": "Have you found anything out of the ordinary out in the wastes?",
+        "topic": "TALK_NPC_CAMPER_VAN_TRAVELER_INTERESTING_THINGS",
+        "condition": {
+          "and": [
+            { "npc_has_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" },
+            { "npc_has_var": "gave_directions", "type": "dialogue", "context": "camper_van_traveler", "value": "yes" }
+          ]
+        },
+        "switch": true,
+        "default": true
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_NPC_CAMPER_VAN_TRAVELER",
+    "dynamic_line": {
+      "npc_has_var": "knows_u",
+      "type": "dialogue",
+      "context": "first_meeting",
+      "value": "yes",
+      "yes": "<greet>",
+      "no": "I didn't think anyone was around here.  Pleased to meet you, I'm <npc_name>."
+    },
+    "speaker_effect": {
+      "effect": [
+        { "npc_add_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" },
+        { "u_run_npc_eocs": [ "EOC_traveler_random_destination_direction" ], "unique_ids": [ "TRAVELER" ] }
+      ]
+    },
+    "responses": [
+      {
+        "text": "What's in that RV of yours?  Couldn't be anything you need, so hand over your stuff.",
+        "trial": { "type": "INTIMIDATE", "difficulty": 30 },
+        "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": -4, "fear": 3 } },
+        "failure": { "topic": "TALK_DONE", "effect": "hostile" },
+        "condition": { "not": { "npc_has_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" } }
+      },
+      {
+        "text": "Good to meet you too.  What are you doing out here?",
+        "topic": "TALK_NPC_CAMPER_VAN_TRAVELER_DESTINATION",
+        "condition": { "not": { "npc_has_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" } }
+      },
+      { "text": "<end_talking>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_NPC_CAMPER_VAN_TRAVELER_DESTINATION",
+    "dynamic_line": {
+      "npc_has_var": "going_north",
+      "type": "dialogue",
+      "context": "travel_direction",
+      "value": "yes",
+      "yes": "I'm going north, up towards the border and the big wide wilderness.  I heard that there's some sort of safe spot up there, where people didn't go crazy and try to kill each other.  I don't know whether or not that's true, but at the very least, the colder climate might help keep the <zombies> down.",
+      "no": {
+        "npc_has_var": "going_south",
+        "type": "dialogue",
+        "context": "travel_direction",
+        "value": "yes",
+        "yes": "I'm going south.  Hopefully somebody down there fared better than the people I knew up here.  Besides, I won't have to worry about freezing my <swear> butt off when winter comes.",
+        "no": {
+          "npc_has_var": "going_east",
+          "type": "dialogue",
+          "context": "travel_direction",
+          "value": "yes",
+          "yes": "I'm going east, towards the coastline.  I heard some rumors that Rhode Island was still holding itself together, so I'm going to go and check that out.  Heck, I might just go out to sea myself, live on an old oil rig or something like that.",
+          "no": {
+            "npc_has_var": "going_west",
+            "type": "dialogue",
+            "context": "travel_direction",
+            "value": "yes",
+            "yes": "I'm going west, see how things are out there in tumbleweed territory.  You see, the Midwest didn't have a whole lot of people in it compared the the East Coast, so there logically shouldn't be as many <zombies> as there are here.  I just hope that everything hasn't <swear> collapsed, that someone's still holding on.",
+            "no": "ERROR: DIRECTION PARAMETERS EITHER NOT PICKED OR OUT OF BOUNDS"
+          }
+        }
+      }
+    },
+    "responses": [
+      { "text": "When will you be leaving?", "topic": "TALK_NPC_CAMPER_VAN_TRAVELER_LEAVING_WHEN" },
+      { "text": "<end_talking>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_NPC_CAMPER_VAN_TRAVELER_LEAVING_WHEN",
+    "dynamic_line": "I'll be gone here in a day or two, just stopping long enough to get some supplies and fix anything wrong with the camper.",
+    "responses": [ { "text": "<end_talking>", "topic": "TALK_DONE" } ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_NPC_CAMPER_VAN_TRAVELER_TRADE",
+    "dynamic_line": "I don't have a whole lot, but I've got a few things that I could stand to be rid of, too much weight tanks the gas milage.  I could always use more fuel, food, and clean water if you have any to spare.  Entertainment is also appreciated, it's pretty <swear> boring looking at nothing but road for 10 hours a day.",
+    "responses": [
+      { "text": "Let's take a look.", "topic": "TALK_NPC_CAMPER_VAN_TRAVELER", "effect": "start_trade" },
+      { "text": "<end_talking>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_NPC_CAMPER_VAN_TRAVELER_INTERESTING_THINGS",
+    "dynamic_line": {
+      "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 0 } ],
+      "yes": "I haven't found anything out of the ordinary, just a bunch of <zombies> and the ruins of our old lives.",
+      "no": {
+        "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ],
+        "yes": "Actually, I came across a group of farmers on my way here.  They were a little suspicious, but turned out to be pretty nice.  Good place to buy some food, if they're still around.",
+        "no": {
+          "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 2 } ],
+          "yes": "I found a small cabin out in the woods, someone was living there and had some serious chemistry equipment.  I managed to get good medical supplies from there.  They even had some oddball things too, like <swear> napalm and black powder.",
+          "no": {
+            "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 3 } ],
+            "yes": "I ran in to someone living in an old barn, didn't want anything to do with the world.  The odd thing is, they looked like one of those old, Wild West cowboys.",
+            "no": {
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 4 } ],
+              "yes": "I came across an abandoned house, half of it was collapsed in, looked like it was from way before <the_cataclysm>.  I was poking around to see what was there, and I found a whole bunker underneth the place.  I don't know what the heck was up with that, but I wouldn't want to find out.",
+              "no": "ERROR: out of bounds on randomize_directions."
+            }
+          }
+        }
+      }
+    },
+    "responses": [
+      {
+        "text": "How do I get to that farm?",
+        "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS_2",
+        "condition": {
+          "and": [
+            {
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 1 } ]
+            },
+            {
+              "not": { "npc_has_var": "directions", "type": "camper_van_traveler", "context": "mission", "value": "isherwood" }
+            }
+          ]
+        },
+        "effect": [
+          { "npc_add_var": "directions", "type": "camper_van_traveler", "context": "mission", "value": "isherwood" },
+          { "assign_mission": "directions_isherwood_traveler" }
+        ],
+        "switch": true
+      },
+      {
+        "text": "How do I get to that cabin?",
+        "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS_2",
+        "condition": {
+          "and": [
+            {
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 2 } ]
+            },
+            {
+              "not": { "npc_has_var": "directions", "type": "camper_van_traveler", "context": "mission", "value": "chem_chabin" }
+            }
+          ]
+        },
+        "effect": [
+          { "npc_add_var": "directions", "type": "camper_van_traveler", "context": "mission", "value": "chem_chabin" },
+          { "assign_mission": "directions_cabin" }
+        ],
+        "switch": true
+      },
+      {
+        "text": "Where were they at?",
+        "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS_2",
+        "condition": {
+          "and": [
+            {
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 3 } ]
+            },
+            {
+              "not": { "npc_has_var": "directions", "type": "camper_van_traveler", "context": "mission", "value": "cowboy" }
+            }
+          ]
+        },
+        "effect": [
+          { "npc_add_var": "directions", "type": "camper_van_traveler", "context": "mission", "value": "cowboy" },
+          { "assign_mission": "directions_cowboy" }
+        ],
+        "switch": true
+      },
+      {
+        "text": "Where was the bunker at?",
+        "topic": "TALK_FREE_MERCHANT_TEAMSTER_DIRECTIONS_2",
+        "condition": {
+          "and": [
+            {
+              "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 4 } ]
+            },
+            {
+              "not": { "npc_has_var": "directions", "type": "camper_van_traveler", "context": "mission", "value": "bunker_shop" }
+            }
+          ]
+        },
+        "effect": [
+          { "npc_add_var": "directions", "type": "camper_van_traveler", "context": "mission", "value": "bunker_shop" },
+          { "assign_mission": "directions_bunker_shop" }
+        ],
+        "switch": true
+      },
+      {
+        "text": "Ah, that's nothing new to me.  Thanks anyway though.",
+        "topic": "TALK_NPC_CAMPER_VAN_TRAVELER",
+        "switch": true,
+        "default": true
+      },
+      { "text": "<end_talking>", "topic": "TALK_DONE" }
+    ]
+  },
+  {
+    "type": "talk_topic",
+    "id": "TALK_NPC_CAMPER_VAN_TRAVELER_BACKSTORY",
+    "//": "This should also be included as part of a randomly selected list of backgrounds in the future.",
+    "dynamic_line": "I used to travel a lot before <the_cataclysm>, and I've had this camper with me for a while now.  I was at home when the riots started, so I grabbed everything I could from my house and hopped in the camper.  I nearly wrecked on my way out of town when some crazy people tried to smash my van, but I made it out.  I've been on the move ever since.",
+    "responses": [ { "text": "<end_talking>", "topic": "TALK_DONE" } ]
+  },
+  {
+    "id": "directions_isherwood_traveler",
+    "type": "mission_definition",
+    "name": { "str": "Check out that farm" },
+    "goal": "MGOAL_GO_TO",
+    "difficulty": 2,
+    "value": 0,
+    "start": {
+      "assign_mission_target": { "om_special": "Isherwood Farms", "om_terrain": "farm_isherwood_1", "reveal_radius": 5, "search_range": 400 }
+    },
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "dialogue": {
+      "describe": ".",
+      "offer": ".",
+      "accepted": ".",
+      "rejected": ".",
+      "advice": "Be careful.  Seems like a rough place to me.",
+      "inquire": "How is the search going?",
+      "success": "Sweet.",
+      "success_lie": "Sweet.",
+      "failure": "That's unfortunate."
+    }
+  },
+  {
+    "id": "directions_cabin",
+    "type": "mission_definition",
+    "name": { "str": "Check out that cabin" },
+    "goal": "MGOAL_GO_TO",
+    "difficulty": 2,
+    "value": 0,
+    "start": {
+      "assign_mission_target": { "om_terrain": "chemical_lab_ocu", "om_special": "Occupied Chem Lab", "reveal_radius": 5, "search_range": 400 }
+    },
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "dialogue": {
+      "describe": ".",
+      "offer": ".",
+      "accepted": ".",
+      "rejected": ".",
+      "advice": "Be careful.  Seems like a rough place to me.",
+      "inquire": "How is the search going?",
+      "success": "Sweet.",
+      "success_lie": "Sweet.",
+      "failure": "That's unfortunate."
+    }
+  },
+  {
+    "id": "directions_cowboy",
+    "type": "mission_definition",
+    "name": { "str": "Check out that desolate barn" },
+    "goal": "MGOAL_GO_TO",
+    "difficulty": 2,
+    "value": 0,
+    "start": {
+      "assign_mission_target": { "om_terrain": "desolatebarn", "om_special": "desolate barn", "reveal_radius": 5, "search_range": 400 }
+    },
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "dialogue": {
+      "describe": ".",
+      "offer": ".",
+      "accepted": ".",
+      "rejected": ".",
+      "advice": "Be careful.  Seems like a rough place to me.",
+      "inquire": "How is the search going?",
+      "success": "Sweet.",
+      "success_lie": "Sweet.",
+      "failure": "That's unfortunate."
+    }
+  },
+  {
+    "id": "directions_bunker_shop",
+    "type": "mission_definition",
+    "name": { "str": "Check out that collapsed house" },
+    "goal": "MGOAL_GO_TO",
+    "difficulty": 2,
+    "value": 0,
+    "start": {
+      "assign_mission_target": { "om_terrain": "bunker_shop_g", "om_special": "bunker shop", "reveal_radius": 5, "search_range": 400 }
+    },
+    "origins": [ "ORIGIN_SECONDARY" ],
+    "dialogue": {
+      "describe": ".",
+      "offer": ".",
+      "accepted": ".",
+      "rejected": ".",
+      "advice": "Be careful.  Seems like a rough place to me.",
+      "inquire": "How is the search going?",
+      "success": "Sweet.",
+      "success_lie": "Sweet.",
+      "failure": "That's unfortunate."
+    }
+  }
+]

--- a/data/json/npcs/random_encounters/camper_van_traveler.json
+++ b/data/json/npcs/random_encounters/camper_van_traveler.json
@@ -163,7 +163,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_NPC_CAMPER_VAN_TRAVELER_TRADE",
-    "dynamic_line": "I don't have a whole lot, but I've got a few things that I could stand to be rid of, too much weight tanks the gas milage.  I could always use more fuel, food, and clean water if you have any to spare.  Entertainment is also appreciated, it's pretty <swear> boring looking at nothing but road for 10 hours a day.",
+    "dynamic_line": "I don't have a whole lot, but I've got a few things that I could stand to be rid of, too much weight tanks the gas mileage.  I could always use more fuel, food, and clean water if you have any to spare.  Entertainment is also appreciated, it's pretty <swear> boring looking at nothing but road for 10 hours a day.",
     "responses": [
       { "text": "Let's take a look.", "topic": "TALK_NPC_CAMPER_VAN_TRAVELER", "effect": "start_trade" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }
@@ -186,7 +186,7 @@
             "yes": "I ran in to someone living in an old barn, didn't want anything to do with the world.  The odd thing is, they looked like one of those old, Wild West cowboys.",
             "no": {
               "compare_num": [ { "npc_val": "var", "var_name": "direction", "type": "randomize", "context": "dialogue" }, "=", { "const": 4 } ],
-              "yes": "I came across an abandoned house, half of it was collapsed in, looked like it was from way before <the_cataclysm>.  I was poking around to see what was there, and I found a whole bunker underneth the place.  I don't know what the heck was up with that, but I wouldn't want to find out.",
+              "yes": "I came across an abandoned house, half of it was collapsed in, looked like it was from way before <the_cataclysm>.  I was poking around to see what was there, and I found a whole bunker underneath the place.  I don't know what the heck was up with that, but I wouldn't want to find out.",
               "no": "ERROR: out of bounds on randomize_directions."
             }
           }

--- a/data/json/vehicles/factional.json
+++ b/data/json/vehicles/factional.json
@@ -69,5 +69,81 @@
       { "type": "LOOT_AMMO", "x": -3, "y": 0 },
       { "type": "LOOT_GUNS", "x": -3, "y": 1 }
     ]
+  },
+  {
+    "id": "traveler_van_motorhome",
+    "//": "Just a normal mini RV with a few different items included.  Later versions could inlcude things like makeshift armor, a trailer, or a ram.",
+    "type": "vehicle",
+    "name": "Mini RV",
+    "blueprint": [
+      [ "-o--+o-" ],
+      [ "+=&&#'|" ],
+      [ "+=#=#'|" ],
+      [ "-o+-+o-" ]
+    ],
+    "parts": [
+      {
+        "x": 0,
+        "y": 0,
+        "parts": [
+          "frame#cross",
+          "reclining_seat#windshield_front",
+          "seatbelt",
+          "controls",
+          "integrated_heater_small",
+          "integrated_cooler"
+        ]
+      },
+      { "x": 0, "y": 0, "parts": [ "stereo", "dashboard", "vehicle_alarm" ] },
+      { "x": 0, "y": 0, "parts": [ "horn_car", "roof" ] },
+      { "x": 0, "y": -1, "parts": [ "frame#vertical_left", "door#nw", "v_curtain" ] },
+      { "x": 0, "y": 1, "parts": [ "frame#cross", "reclining_seat#windshield_front", "seatbelt", "roof" ] },
+      { "x": 0, "y": 2, "parts": [ "frame#vertical_right", "door#ne", "v_curtain" ] },
+      { "x": 1, "y": -1, "parts": [ "frame#vertical_T_left", "windshield#wheel_left", "v_curtain" ] },
+      { "x": 1, "y": -1, "parts": [ "wheel_mount_medium_steerable", "wheel_wide" ] },
+      { "x": 1, "y": 0, "parts": [ "frame#horizontal_2", "windshield#cover_left", "v_curtain" ] },
+      { "x": 1, "y": 1, "parts": [ "frame#horizontal_2", "windshield#cover_right", "v_curtain" ] },
+      { "x": 1, "y": 2, "parts": [ "frame#vertical_T_right", "windshield#wheel_right", "v_curtain" ] },
+      { "x": 1, "y": 2, "parts": [ "wheel_mount_medium_steerable", "wheel_wide" ] },
+      { "x": 2, "y": -1, "parts": [ "frame#nw", "halfboard#nw", "headlight" ] },
+      { "x": 2, "y": 0, "parts": [ "frame#horizontal_front", "halfboard#cover_left", "engine_v6", "alternator_car" ] },
+      { "x": 2, "y": 1, "parts": [ "frame#horizontal_front", "halfboard#cover_right", "battery_car" ] },
+      { "x": 2, "y": 2, "parts": [ "frame#ne", "halfboard#ne", "headlight" ] },
+      { "x": -1, "y": -1, "parts": [ "frame#vertical_left", "board#nw_edge" ] },
+      { "x": -1, "y": 0, "parts": [ "frame#cross", "roof" ] },
+      { "x": -1, "y": 0, "parts": [ { "part": "veh_tools_kitchen", "tools": [ "hotplate", "pan", "pot" ] } ] },
+      { "x": -1, "y": 0, "parts": [ { "part": "tank", "fuel": "water_clean" } ] },
+      { "x": -1, "y": 1, "parts": [ "frame#cross", "aisle", "aisle_lights", "roof" ] },
+      { "x": -1, "y": 2, "parts": [ "frame#vertical_right", "board#ne_edge" ] },
+      { "x": -2, "y": -1, "parts": [ "frame#vertical_left", "board#vertical_left" ] },
+      { "x": -2, "y": -1, "parts": [ { "part": "tank", "fuel": "gasoline" } ] },
+      { "x": -2, "y": 0, "parts": [ "frame#cross", "minifridge", "roof", "solar_panel" ] },
+      { "x": -2, "y": 1, "parts": [ "frame#cross", "bed", "roof", "solar_panel" ] },
+      { "x": -2, "y": 2, "parts": [ "frame#vertical_right", "door_opaque#full_right", "door_motor" ] },
+      { "x": -2, "y": 2, "parts": [ "large_storage_battery" ] },
+      { "x": -3, "y": -1, "parts": [ "frame#vertical_left", "board#wheel_left", "wheel_mount_medium", "wheel_wide" ] },
+      { "x": -3, "y": 0, "parts": [ "frame#cross", "cargo_space", "roof", "solar_panel" ] },
+      { "x": -3, "y": 1, "parts": [ "frame#cross", "cargo_space", "roof", "solar_panel" ] },
+      {
+        "x": -3,
+        "y": 2,
+        "parts": [ "frame#vertical_right", "board#wheel_right", "wheel_mount_medium", "wheel_wide" ]
+      },
+      { "x": -4, "y": -1, "parts": [ "frame#sw", "board#sw" ] },
+      { "x": -4, "y": 0, "parts": [ "frame#horizontal_rear", "door_opaque#rear", "door_motor", "muffler" ] },
+      { "x": -4, "y": 1, "parts": [ "frame#horizontal_rear", "door_opaque#rear", "door_motor" ] },
+      { "x": -4, "y": 2, "parts": [ "frame#se", "board#se" ] }
+    ],
+    "items": [
+      { "x": 0, "y": 0, "chance": 10, "items": [ "roadmap" ] },
+      { "x": -3, "y": 0, "chance": 100, "item_groups": [ "spare_tire_kit_wide_wheel" ] },
+      { "x": -3, "y": 0, "chance": 100, "item_groups": [ "traveler" ] },
+      { "x": -3, "y": 0, "chance": 100, "item_groups": [ "swat_gear" ] },
+      { "x": -3, "y": 0, "chance": 100, "item_groups": [ "preserved_food" ] },
+      { "x": -3, "y": 1, "chance": 100, "item_groups": [ "tools_common_small" ] },
+      { "x": -3, "y": 1, "chance": 100, "item_groups": [ "tools_mechanic" ] },
+      { "x": -3, "y": 1, "chance": 100, "item_groups": [ "fuel_gasoline" ] }
+    ],
+    "zones": [ { "type": "LOOT_UNSORTED", "x": -3, "y": 0 }, { "type": "LOOT_UNSORTED", "x": -3, "y": 1 } ]
   }
 ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Add a new random encounter, the road tripper."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
As part of a project requested by @I-am-Erk, I have created a new random encounter. This should also add some more variety to the world.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add a new random encounter that occurs at public washrooms. Players can find a traveling NPC in a camper van, going in a randomly selected cardinal direction for assorted reasons. This NPC will trade some items within the back of their camper in exchange for clean water, food, and gasoline at a premium, and can also point players to some points of interest if asked. Otherwise, most of the dialogue is small talk and minor lore. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested everything numerous times over the course of development, everything works like it should.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
This feature also suffers from a problem experienced by the Free Merchant caravans regarding item ownership, that's outlined in #71025. I don't know how to fix that, but any fixes made for that can be ported to this.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
