### PR TITLE
Fencing sword sharpening tweaks

### DIFF
--- a/data/json/recipes/weapon/piercing.json
+++ b/data/json/recipes/weapon/piercing.json
@@ -1426,8 +1426,7 @@
     "skill_used": "fabrication",
     "time": "1 h 40 m",
     "autolearn": true,
-    "tools": [ [ [ "rock", -1 ], [ "ceramic_shard", -1 ], [ "sharp_rock", -1 ] ] ],
-    "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "qualities": [ { "id": "FILE", "level": 2 } ],
     "components": [ [ [ "fencing_foil", 1 ] ] ]
   },
   {
@@ -1439,8 +1438,7 @@
     "skill_used": "fabrication",
     "time": "1 h 40 m",
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "tools": [ [ [ "rock", -1 ], [ "ceramic_shard", -1 ], [ "sharp_rock", -1 ] ] ],
+    "qualities": [ { "id": "FILE", "level": 2 } ],
     "components": [ [ [ "fencing_epee", 1 ] ] ]
   },
   {
@@ -1452,8 +1450,7 @@
     "skill_used": "fabrication",
     "time": "1 h 40 m",
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "tools": [ [ [ "rock", -1 ], [ "ceramic_shard", -1 ], [ "sharp_rock", -1 ] ] ],
+    "qualities": [ { "id": "FILE", "level": 2 } ],
     "components": [ [ [ "fencing_sabre", 1 ] ] ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Fencing sword sharpening tweaks"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I found a fencing sword in my most recent playthrough and was surprised by the recipe to craft it. It doesn't make sense to sharpen a sword using only rock and a hammer. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
My solution was to replace the rock and hammer requirements with a level two filing quality requirement. I didn't adjust the sharpening time because I figure the crafter is working carefully to create a consistent edge without reducing the integrity of the blade. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I considered whether grinding would be a more apt tool quality, but I think grinding would destroy the blade by removing too much material, as fencing swords are already rather thin. 
I also considered lowering the requirement to filing one, which would allow sandpaper to sharpen the blade, but making a sharp edge almost always requires a progressive set of finer and finer grades of sharpening tools. Rough sandpaper would make a rather dull edge and fine sandpaper would take ages to sharpen. If someone adds a "sandpaper set", I think that would be a viable way of sharpening the blade, but it would also have filing two. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I loaded my changes as a local mod, and no errors were thrown. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
