### PR TITLE
math_parser: trigger event u_var_changed

### DIFF
--- a/data/json/statistics.json
+++ b/data/json/statistics.json
@@ -2455,7 +2455,7 @@
     "id": "portal_storm_happened",
     "type": "event_transformation",
     "event_type": "u_var_changed",
-    "value_constraints": { "var": { "equals": [ "string", "portal_storm_counter" ] } }
+    "value_constraints": { "scope": { "equals": [ "string", "u" ] }, "var": { "equals": [ "string", "counter_portal_storm_counter" ] } }
   },
   {
     "id": "witnessed_portal_storm",

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -152,17 +152,6 @@ std::string get_talk_varname( const JsonObject &jo, std::string_view member,
             + var_context ) + "_" + var_basename;
 }
 
-std::string get_talk_var_basename( const JsonObject &jo, std::string_view member,
-                                   bool check_value )
-{
-    if( check_value && !( jo.has_string( "value" ) || jo.has_member( "time" ) ||
-                          jo.has_array( "possible_values" ) ) ) {
-        jo.throw_error( "invalid " + std::string( member ) + " condition in " + jo.str() );
-    }
-    const std::string &var_basename = jo.get_string( std::string( member ) );
-    return var_basename;
-}
-
 dbl_or_var_part get_dbl_or_var_part( const JsonValue &jv, std::string_view member, bool required,
                                      double default_val )
 {

--- a/src/condition.h
+++ b/src/condition.h
@@ -54,8 +54,6 @@ void write_var_value( var_type type, const std::string &name, talker *talk, dial
                       double value );
 std::string get_talk_varname( const JsonObject &jo, std::string_view member,
                               bool check_value, dbl_or_var &default_val );
-std::string get_talk_var_basename( const JsonObject &jo, std::string_view member,
-                                   bool check_value );
 // the truly awful declaration for the conditional_t loading helper_function
 void read_condition( const JsonObject &jo, const std::string &member_name,
                      std::function<bool( dialogue & )> &condition, bool default_val );

--- a/src/event.h
+++ b/src/event.h
@@ -861,7 +861,8 @@ struct event_spec<event_type::uses_debug_menu> {
 
 template<>
 struct event_spec<event_type::u_var_changed> {
-    static constexpr std::array<std::pair<const char *, cata_variant_type>, 2> fields = { {
+    static constexpr std::array<std::pair<const char *, cata_variant_type>, 3> fields = { {
+            { "scope", cata_variant_type::string },
             { "var", cata_variant_type::string },
             { "value", cata_variant_type::string },
         }

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -34,6 +34,7 @@
 #include "creature_tracker.h"
 #include "debug.h"
 #include "effect_on_condition.h"
+#include "enum_conversions.h"
 #include "enums.h"
 #include "event_bus.h"
 #include "faction.h"
@@ -2925,7 +2926,7 @@ void talk_effect_fun_t::set_add_var( const JsonObject &jo, std::string_view memb
 {
     dbl_or_var empty;
     const std::string var_name = get_talk_varname( jo, member, false, empty );
-    const std::string var_base_name = get_talk_var_basename( jo, member, false );
+    const std::string var_base_name = var_name.substr( 12 );
     const bool time_check = jo.has_member( "time" ) && jo.get_bool( "time" );
     std::vector<std::string> possible_values = jo.get_string_array( "possible_values" );
     if( possible_values.empty() ) {
@@ -2939,7 +2940,7 @@ void talk_effect_fun_t::set_add_var( const JsonObject &jo, std::string_view memb
         } else {
             int index = rng( 0, possible_values.size() - 1 );
             actor->set_value( var_name, possible_values[index] );
-            get_event_bus().send<event_type::u_var_changed>( var_base_name, possible_values[index] );
+            get_event_bus().send<event_type::u_var_changed>( "u", var_name, possible_values[index] );
         }
     };
 }
@@ -2959,7 +2960,7 @@ void talk_effect_fun_t::set_adjust_var( const JsonObject &jo, std::string_view m
 {
     dbl_or_var empty;
     const std::string var_name = get_talk_varname( jo, member, false, empty );
-    const std::string var_base_name = get_talk_var_basename( jo, member, false );
+    const std::string var_base_name = var_name.substr( 12 );
     dbl_or_var dov = get_dbl_or_var( jo, "adjustment" );
     function = [is_npc, var_base_name, var_name, dov]( dialogue & d ) {
         int adjusted_value = dov.evaluate( d );
@@ -2970,7 +2971,8 @@ void talk_effect_fun_t::set_adjust_var( const JsonObject &jo, std::string_view m
         }
 
         d.actor( is_npc )->set_value( var_name, std::to_string( adjusted_value ) );
-        get_event_bus().send<event_type::u_var_changed>( var_base_name, std::to_string( adjusted_value ) );
+        get_event_bus().send<event_type::u_var_changed>( "u", var_name,
+                std::to_string( adjusted_value ) );
     };
 }
 


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The old EOC functions `u_add_var` and `u_adjust_var` trigger the event `u_var_changed` and `math` doesn't

* See: #71027

#### Describe the solution
1. Fix the event. It was discarding MOST of the var data, including extended name and scope. For example `eoc_sample_item_transporter_set_coordinates` was passed to the event bus as `set_coordinates` only, in addition to losing scope.
2. Add the equivalent event bus call to math

#### Describe alternatives you've considered
I don't think this is a good event, so I thought about removing it. Even if we're scoping it to alpha/beta/global, it can't know if alpha is avatar or an item or a blorg, for example. That can be worked around by using very specific variable names, but that throws away some of the advantage of scoping.

#### Testing
Portal storm was already ported to math so `Reality is falling apart` is currently unobtainable
<details>
<summary>Before - no achievement for surviving portal storm</summary>

![0 - before](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/e6d9309f-e11c-4ca3-87c8-02e8b58dbc04)


</details>

<details>
<summary>After - achievement triggers</summary>

![1 - after](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/02d68020-a6a1-41ed-a02b-5dc9a09d30c1)


</details>

#### Additional context
N/A
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
