### PR TITLE
eoc: add function to trigger events manually

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/portal_storm_effect_on_condition.json
@@ -235,7 +235,11 @@
       { "remove_active_mission": "MISSION_INVESTIGATE_PORTAL_STORM_CENTER" },
       { "alter_timed_events": "portal_dungeon_entrance" },
       { "math": [ "u_counter_portal_storm_counter", "++" ] },
-      { "math": [ "talked_to_storm", "=", "0" ] }
+      { "math": [ "talked_to_storm", "=", "0" ] },
+      {
+        "trigger_event": "u_var_changed",
+        "args": [ "portal_storm_counter", { "u_val": "counter_portal_storm_counter" } ]
+      }
     ]
   },
   {

--- a/src/dialogue_helpers.h
+++ b/src/dialogue_helpers.h
@@ -161,6 +161,7 @@ struct talk_effect_fun_t {
         void set_activate( const JsonObject &jo, std::string_view member, bool is_npc );
         void set_map_run_item_eocs( const JsonObject &jo, std::string_view member, bool is_npc );
         void set_set_talker( const JsonObject &jo, std::string_view member, bool is_npc );
+        void set_trigger_event( const JsonObject &jo, std::string_view member );
         void operator()( dialogue &d ) const {
             if( !function ) {
                 return;

--- a/src/event.h
+++ b/src/event.h
@@ -14,6 +14,7 @@
 #include "calendar.h"
 #include "cata_variant.h"
 #include "debug.h"
+#include "enum_conversions.h"
 
 template <typename E> struct enum_traits;
 
@@ -901,6 +902,7 @@ class event
             , time_( time )
             , data_( std::move( data ) )
         {}
+        event() : type_( event_type::num_event_types ) {}
 
         // Call this to construct an event in a type-safe manner.  It will
         // verify that the types you pass match the expected types for the
@@ -919,6 +921,10 @@ class event
                    Type, std::make_index_sequence<sizeof...( Args )>
                    > ()( calendar::turn, std::forward<Args>( args )... );
         }
+
+        // Call this to construct an event from a runtime-defined type and string arguments.
+        // All arguments will be converted to the respective types with the same index in the event spec
+        static event make_dyn( event_type type, std::vector<std::string> &args );
 
         using fields_type = std::unordered_map<std::string, cata_variant_type>;
         static fields_type get_fields( event_type );

--- a/src/event_bus.cpp
+++ b/src/event_bus.cpp
@@ -63,6 +63,12 @@ void event_bus::unsubscribe( event_subscriber *s )
 
 void event_bus::send( const cata::event &e ) const
 {
+    // don't accept malformed events (ex: wrong number of arguments)
+    // from event::make_dyn()
+    if( e.type() == event_type::num_event_types ) {
+        debugmsg( "Null event sent to bus.  REJECTED!" );
+        return;
+    }
     for( event_subscriber *s : subscribers ) {
         s->notify( e );
     }
@@ -83,3 +89,70 @@ void event_bus::send_with_talker( Creature *alpha, item_location *beta,
         s->notify( e, get_talker_for( alpha ), get_talker_for( beta ) );
     }
 }
+namespace
+{
+template<event_type Type, typename IndexSequence>
+struct make_dyn_helper;
+template<event_type Type, size_t... I>
+struct make_dyn_helper<Type, std::index_sequence<I...>> {
+    using Spec = cata::event_detail::event_spec<Type>;
+
+    cata::event operator()( time_point time, std::vector<std::string> &args ) {
+        return cata::event(
+                   Type,
+                   time,
+        std::map<std::string, cata_variant> { {
+                Spec::fields[I].first,
+                cata_variant::from_string( Spec::fields[I].second, std::move( args[I] ) )
+            } ...
+        } );
+    }
+};
+
+template<event_type Type>
+cata::event _make_dyn( std::vector<std::string> &args )
+{
+    using Spec = cata::event_detail::event_spec<Type>;
+    static_assert( std::is_empty_v<Spec>,
+                   "spec for this event type must be defined and empty" );
+
+    if( Spec::fields.size() != args.size() ) {
+        debugmsg(
+            R"(Wrong number of arguments passed to event type "%s".  Expected %d, got %d)",
+            io::enum_to_string( Type ), Spec::fields.size(), args.size() );
+        return {}; // event_bus::send() can reject a null event
+    }
+
+    return make_dyn_helper <
+           Type, std::make_index_sequence<Spec::fields.size()>
+           > ()( calendar::turn, std::forward<std::vector<std::string> &>( args ) );
+}
+
+template<size_t I>
+cata::event _make_dyn_impl( std::vector<std::string> &s )
+{
+    constexpr event_type T = static_cast<event_type>( I );
+    return _make_dyn<T>( s );
+}
+
+using make_dyn_ptr_t = cata::event( * )( std::vector<std::string> & );
+
+template<size_t... I>
+constexpr make_dyn_ptr_t _make_dyn_impl_2( event_type type,
+        std::index_sequence<I...>  /* IS */ )
+{
+    constexpr size_t num_types = static_cast<size_t>( event_type::num_event_types );
+    constexpr std::array<make_dyn_ptr_t, num_types> _make_dyn_ptrs = {{
+            _make_dyn_impl<I>...
+        }
+    };
+    return _make_dyn_ptrs[static_cast<size_t>( type )];
+}
+} // namespace
+
+cata::event cata::event::make_dyn( event_type type, std::vector<std::string> &args )
+{
+    constexpr size_t num_types = static_cast<size_t>( event_type::num_event_types );
+    return _make_dyn_impl_2( type, std::make_index_sequence<num_types> {} )( args );
+}
+

--- a/tests/stats_tracker_test.cpp
+++ b/tests/stats_tracker_test.cpp
@@ -932,8 +932,15 @@ TEST_CASE( "achievements_tracker_in_game", "[stats]" )
     const character_id u_id = get_player_character().getID();
     send_game_start( get_event_bus(), u_id );
 
+    std::vector<std::string> args{ std::to_string( u_id.get_value() ), mon_zombie.c_str(), "0" };
+
+    bool dynamic_event = GENERATE( false, true );
+    CAPTURE( dynamic_event );
+
     const cata::event avatar_zombie_kill =
-        cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie, 0 );
+        dynamic_event
+        ? cata::event::make_dyn( event_type::character_kills_monster, args )
+        : cata::event::make<event_type::character_kills_monster>( u_id, mon_zombie, 0 );
     get_event_bus().send( avatar_zombie_kill );
 
     achievement_id c_pacifist( "conduct_zero_kills" );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The `Reality is falling apart` achievement stopped working when portal storm EOCs were ported to math.


#### Describe the solution
<details>
<summary>Add an EOC function that can trigger events.</summary>
It looks like this

```JSON
      {
        "trigger_event": "u_var_changed",
        "args": [ "portal_storm_counter", { "u_val": "counter_portal_storm_counter" } ]
      }
```

</details>

Use it to trigger the event that completes `Reality is falling apart`

#### Describe alternatives you've considered
* #71032 - fixing the event and triggering it from `math`. As I've said in that PR, I don't think `u_var_changed` is a good event because it has poor scoping. There might be some performance consideration too.

#### Testing
<details>
<summary>Before - no achievement for surviving portal storm</summary>

![0 - before](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/e6d9309f-e11c-4ca3-87c8-02e8b58dbc04)


</details>

<details>
<summary>After - achievement triggers</summary>

![after](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/7a8859e2-98c6-4219-8f5c-1e75d032d918)


</details>

#### Additional context
jbytheway can you take a look please and let me know if this is too objectionable. ~~I really hate the gigantic switch~~
