### PR TITLE
Container variant support for item-groups, items and recipes

### DIFF
--- a/doc/ITEM_SPAWN.md
+++ b/doc/ITEM_SPAWN.md
@@ -37,11 +37,13 @@ The format is this:
 
 `subtype` is optional. It can be `collection` or `distribution`.  If unspecified, it defaults to `old`, which denotes that this item group uses the old format (essentially a distribution).
 
-`container-item` causes all the items of the group to spawn in a container,
-rather than as separate top-level items.  If the items might not all fit in the
-container, you must specify how to deal with the overflow by setting
-`on_overflow` to either `discard` to discard items at random until they fit, or
-`spill` to have the excess items be spawned alongside the container.
+`container-item` causes all the items of the group to spawn in a container, rather than as separate top-level items.  If the items might not all fit in the container, you must specify how
+to deal with the overflow by setting `on_overflow` to either `discard` to discard items at random until they fit, or `spill` to have the excess items be spawned alongside the container.
+`container-item` can also be an object containing an `item` field specifying the container and a `variant` field specifying said container's variant. Eg.
+
+```json
+    "container-item": { "item": "<container-item-id>", "variant": "<container-item-variant-id>" },
+```
 
 There are [some caveats](#ammo-and-magazines) to watch out for when using `ammo` or `magazine`.
 

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -4449,7 +4449,6 @@ The contents of use_action fields can either be a string indicating a built-in f
     "random_ammo_qty": [1, 5],  // If this has values, set remaining ammo of transformed item to one of them chosen at random.
     "ammo_type": "tape",        // If both this and ammo_qty are specified then set transformed item to this specific ammo.
     "container": "jar",  // Container holding the target item.
-    "container_variant": "jar_green",  // Variant of the above container.
     "sealed": true,      // Whether the transformed container is sealed; true by default.
     "menu_text": "Lower visor"      // (Optional) Text displayed in the activation screen, defaults to "Turn on".
     "moves" : 500         // Moves required to transform the item in excess of a normal action.

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -2165,6 +2165,7 @@ Crafting recipes are defined as a JSON object with the following fields:
 ]
 "contained": true, // Boolean value which defines if the resulting item comes in its designated container. Automatically set to true if any container is defined in the recipe. 
 "container": "jar_glass_sealed", //The resulting item will be contained by the item set here, overrides default container.
+"container_variant": "jar_glass_sealed_strawberry_picture", //The container specified above will spawn as the specified variant, overrides the normal weighted behavior.
 "batch_time_factors": [25, 15], // Optional factors for batch crafting time reduction. First number specifies maximum crafting time reduction as percentage, and the second number the minimal batch size to reach that number. In this example given batch size of 20 the last 6 crafts will take only 3750 time units.
 "charges": 2,                // Number of resulting items/charges per craft. Uses default charges if not set. If a container is set, this is the amount that gets put inside it, capped by container capacity.
 "result_mult": 2,            // Multiplier for resulting items. Also multiplies container items.
@@ -4448,6 +4449,7 @@ The contents of use_action fields can either be a string indicating a built-in f
     "random_ammo_qty": [1, 5],  // If this has values, set remaining ammo of transformed item to one of them chosen at random.
     "ammo_type": "tape",        // If both this and ammo_qty are specified then set transformed item to this specific ammo.
     "container": "jar",  // Container holding the target item.
+    "container_variant": "jar_green",  // Variant of the above container.
     "sealed": true,      // Whether the transformed container is sealed; true by default.
     "menu_text": "Lower visor"      // (Optional) Text displayed in the activation screen, defaults to "Turn on".
     "moves" : 500         // Moves required to transform the item in excess of a normal action.

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1221,7 +1221,7 @@ item item::in_its_container( int qty ) const
                          type->default_container_sealed );
 }
 
-item item::in_container( const itype_id &cont, int qty, const bool sealed ) const
+item item::in_container( const itype_id &cont, int qty, const bool sealed, const std::string &variant ) const
 {
     if( cont.is_null() ) {
         return *this;
@@ -1231,6 +1231,9 @@ item item::in_container( const itype_id &cont, int qty, const bool sealed ) cons
         qty = count();
     }
     item container( cont, birthday() );
+    if( variant != "" ) {
+        container.set_itype_variant( variant );
+    }
     if( container.is_container() ) {
         container.fill_with( *this, qty );
         container.invlet = invlet;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1221,7 +1221,8 @@ item item::in_its_container( int qty ) const
                          type->default_container_sealed );
 }
 
-item item::in_container( const itype_id &cont, int qty, bool sealed, const std::string &variant ) const
+item item::in_container( const itype_id &cont, int qty, bool sealed,
+                         const std::string &variant ) const
 {
     if( cont.is_null() ) {
         return *this;

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1232,7 +1232,7 @@ item item::in_container( const itype_id &cont, int qty, bool sealed,
         qty = count();
     }
     item container( cont, birthday() );
-    if( !( variant == "" ) ) {
+    if( !variant.empty() ) {
         container.set_itype_variant( variant );
     }
     if( container.is_container() ) {

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1218,7 +1218,7 @@ bool item::is_worn_by_player() const
 item item::in_its_container( int qty ) const
 {
     return in_container( type->default_container.value_or( itype_null ), qty,
-                         type->default_container_sealed );
+                         type->default_container_sealed, type->default_container_variant.value_or( "" ) );
 }
 
 item item::in_container( const itype_id &cont, int qty, bool sealed,

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1231,8 +1231,8 @@ item item::in_container( const itype_id &cont, int qty, const bool sealed, const
         qty = count();
     }
     item container( cont, birthday() );
-    if( variant != "" ) {
-        container.set_itype_variant( variant );
+    if( container_variant ) {
+        container.set_itype_variant( *container_variant );
     }
     if( container.is_container() ) {
         container.fill_with( *this, qty );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1221,7 +1221,7 @@ item item::in_its_container( int qty ) const
                          type->default_container_sealed );
 }
 
-item item::in_container( const itype_id &cont, int qty, const bool sealed, const std::string &variant ) const
+item item::in_container( const itype_id &cont, int qty, bool sealed, const std::string &variant ) const
 {
     if( cont.is_null() ) {
         return *this;
@@ -1231,8 +1231,8 @@ item item::in_container( const itype_id &cont, int qty, const bool sealed, const
         qty = count();
     }
     item container( cont, birthday() );
-    if( container_variant ) {
-        container.set_itype_variant( *container_variant );
+    if( !( variant == "" ) ) {
+        container.set_itype_variant( variant );
     }
     if( container.is_container() ) {
         container.fill_with( *this, qty );

--- a/src/item.h
+++ b/src/item.h
@@ -949,7 +949,8 @@ class item : public visitable
          * of the container will be ignored.
          */
         item in_its_container( int qty = 0 ) const;
-        item in_container( const itype_id &container_type, int qty = 0, bool sealed = true, const std::string &container_variant = "" ) const;
+        item in_container( const itype_id &container_type, int qty = 0, bool sealed = true,
+                           const std::string &container_variant = "" ) const;
         void add_automatic_whitelist();
         void clear_automatic_whitelist();
 

--- a/src/item.h
+++ b/src/item.h
@@ -949,7 +949,7 @@ class item : public visitable
          * of the container will be ignored.
          */
         item in_its_container( int qty = 0 ) const;
-        item in_container( const itype_id &container_type, const std::optional<std::string> &container_variant, int qty = 0, bool sealed = true ) const;
+        item in_container( const itype_id &container_type, int qty = 0, bool sealed = true, const std::string &container_variant = "" ) const;
         void add_automatic_whitelist();
         void clear_automatic_whitelist();
 

--- a/src/item.h
+++ b/src/item.h
@@ -949,7 +949,7 @@ class item : public visitable
          * of the container will be ignored.
          */
         item in_its_container( int qty = 0 ) const;
-        item in_container( const itype_id &container_type, int qty = 0, bool sealed = true, const std::string &variant = "" ) const;
+        item in_container( const itype_id &container_type, const std::optional<std::string> &container_variant, int qty = 0, bool sealed = true ) const;
         void add_automatic_whitelist();
         void clear_automatic_whitelist();
 

--- a/src/item.h
+++ b/src/item.h
@@ -949,7 +949,7 @@ class item : public visitable
          * of the container will be ignored.
          */
         item in_its_container( int qty = 0 ) const;
-        item in_container( const itype_id &container_type, int qty = 0, bool sealed = true ) const;
+        item in_container( const itype_id &container_type, int qty = 0, bool sealed = true, const std::string &variant = "" ) const;
         void add_automatic_whitelist();
         void clear_automatic_whitelist();
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4920,7 +4920,7 @@ void Item_factory::add_entry( Item_group &ig, const JsonObject &obj, const std::
     use_modifier |= load_min_max( modifier.count, obj, "count" );
     use_modifier |= load_sub_ref( modifier.ammo, obj, "ammo", ig );
     if( obj.has_string( "entry-wrapper" ) ) {
-        sptr->set_container_item( itype_id( obj.get_string( "entry-wrapper" ) ) );
+        sptr->container_item = itype_id( obj.get_string( "entry-wrapper" ) );
     }
     use_modifier |= load_sub_ref( modifier.container, obj, "container", ig );
     use_modifier |= load_sub_ref( modifier.contents, obj, "contents", ig );
@@ -5010,14 +5010,11 @@ void Item_factory::load_item_group( const JsonObject &jsobj, const item_group_id
     }
 
     if( jsobj.has_string( "container-item" ) ) {
-        ig->set_container_item( itype_id( jsobj.get_string( "container-item" ) ) );
+        ig->container_item = itype_id( jsobj.get_string( "container-item" ) );
     } else if( jsobj.has_member( "container-item" ) ) {
         JsonObject jo = jsobj.get_member( "container-item" );
-        itype_id item;
-        std::string variant_id;
-        mandatory( jo, false, "item", item );
-        mandatory( jo, false, "variant", variant_id );
-        ig->set_container_item( item, variant_id );
+        ig->container_item = itype_id( jo.get_string( "item" ) );
+        ig->container_item_variant = jo.get_string( "variant" );
     }
 
     jsobj.read( "on_overflow", ig->on_overflow, false );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -5011,6 +5011,13 @@ void Item_factory::load_item_group( const JsonObject &jsobj, const item_group_id
 
     if( jsobj.has_string( "container-item" ) ) {
         ig->set_container_item( itype_id( jsobj.get_string( "container-item" ) ) );
+    } else if( jsobj.has_member( "container-item" ) ) {
+        JsonObject jo = jsobj.get_member( "container-item" );
+        itype_id item;
+        std::string variant_id;
+        mandatory( jo, false, "item", item );
+        mandatory( jo, false, "variant", variant_id );
+        ig->set_container_item( item, variant_id );
     }
 
     jsobj.read( "on_overflow", ig->on_overflow, false );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4136,6 +4136,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
     optional( jo, false, "variant_type", def.variant_kind, itype_variant_kind::generic );
     optional( jo, false, "variants", def.variants );
     assign( jo, "container", def.default_container );
+    optional( jo, false, "container_variant", def.default_container_variant );
     assign( jo, "sealed", def.default_container_sealed );
     assign( jo, "min_strength", def.min_str );
     assign( jo, "min_dexterity", def.min_dex );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4922,7 +4922,13 @@ void Item_factory::add_entry( Item_group &ig, const JsonObject &obj, const std::
     if( obj.has_string( "entry-wrapper" ) ) {
         sptr->container_item = itype_id( obj.get_string( "entry-wrapper" ) );
     }
-    use_modifier |= load_sub_ref( modifier.container, obj, "container", ig );
+    if( obj.has_object( "container-item" ) ) {
+        JsonObject jo = obj.get_object( "container-item" );
+        sptr->container_item = itype_id( jo.get_string( "item" ) );
+        sptr->container_item_variant = jo.get_string( "variant" );
+    } else {
+        use_modifier |= load_sub_ref( modifier.container, obj, "container", ig );
+    }
     use_modifier |= load_sub_ref( modifier.contents, obj, "contents", ig );
     use_modifier |= load_str_arr( modifier.snippets, obj, "snippets" );
     if( obj.has_member( "sealed" ) ) {

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -122,7 +122,7 @@ static void put_into_container(
     std::shuffle( items.end() - num_items, items.end(), rng_get_engine() );
 
     item ctr( *container_type, birthday );
-    if( !container_variant ) {
+    if( container_variant ) {
         ctr.set_itype_variant ( *container_variant );
     }
     Item_spawn_data::ItemList excess;
@@ -177,7 +177,7 @@ item Single_item_creator::create_single( const time_point &birthday, RecursionLi
 {
     item tmp = create_single_without_container( birthday, rec );
     if( container_item ) {
-            tmp = tmp.in_container( *container_item, tmp.count(), sealed, *container_item_variant );
+            tmp = tmp.in_container( *container_item, *container_item_variant, tmp.count(), sealed );
     }
     return tmp;
 }

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -108,7 +108,7 @@ static pocket_type guess_pocket_for( const item &container, const item &payload 
 
 static void put_into_container(
     Item_spawn_data::ItemList &items, std::size_t num_items,
-    const std::optional<itype_id> &container_type, const bool sealed,
+    const std::optional<itype_id> &container_type, const std::optional<std::string> &container_variant, const bool sealed,
     time_point birthday, Item_spawn_data::overflow_behaviour on_overflow,
     const std::string &context )
 {
@@ -122,8 +122,8 @@ static void put_into_container(
     std::shuffle( items.end() - num_items, items.end(), rng_get_engine() );
 
     item ctr( *container_type, birthday );
-    if( variant != "" ) {
-        ctr.set_itype_variant ( variant );
+    if( !container_variant ) {
+        ctr.set_itype_variant ( *container_variant );
     }
     Item_spawn_data::ItemList excess;
     for( auto it = items.end() - num_items; it != items.end(); ++it ) {
@@ -283,7 +283,7 @@ std::size_t Single_item_creator::create( ItemList &list,
         }
     }
     const std::size_t items_created = list.size() - prev_list_size;
-    put_into_container( list, items_created, container_item, sealed, birthday, on_overflow, context() ); //needs changing?
+    put_into_container( list, items_created, container_item, container_item_variant, sealed, birthday, on_overflow, context() ); //needs changing?
     return list.size() - prev_list_size;
 }
 
@@ -833,7 +833,7 @@ std::size_t Item_group::create( Item_spawn_data::ItemList &list,
         }
     }
     const std::size_t items_created = list.size() - prev_list_size;
-    put_into_container( list, items_created, container_item, sealed, birthday, on_overflow, context() ); //needs changing?
+    put_into_container( list, items_created, container_item, container_item_variant, sealed, birthday, on_overflow, context() ); //needs changing?
 
     return list.size() - prev_list_size;
 }
@@ -869,17 +869,6 @@ void Item_group::check_consistency() const
         elem->check_consistency();
     }
     Item_spawn_data::check_consistency();
-}
-
-void Item_spawn_data::set_container_item( const itype_id &container )
-{
-    container_item = container;
-}
-
-void Item_spawn_data::set_container_item( const itype_id &container, const std::string &variant )
-{
-    container_item = container;
-    container_item_variant = variant;
 }
 
 int Item_spawn_data::get_probability( bool skip_event_check ) const

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -122,6 +122,9 @@ static void put_into_container(
     std::shuffle( items.end() - num_items, items.end(), rng_get_engine() );
 
     item ctr( *container_type, birthday );
+    if( variant != "" ) {
+        ctr.set_itype_variant ( variant );
+    }
     Item_spawn_data::ItemList excess;
     for( auto it = items.end() - num_items; it != items.end(); ++it ) {
         ret_val<void> ret = ctr.can_contain_directly( *it );
@@ -174,7 +177,7 @@ item Single_item_creator::create_single( const time_point &birthday, RecursionLi
 {
     item tmp = create_single_without_container( birthday, rec );
     if( container_item ) {
-        tmp = tmp.in_container( *container_item, tmp.count(), sealed );
+            tmp = tmp.in_container( *container_item, tmp.count(), sealed, *container_item_variant );
     }
     return tmp;
 }
@@ -280,7 +283,7 @@ std::size_t Single_item_creator::create( ItemList &list,
         }
     }
     const std::size_t items_created = list.size() - prev_list_size;
-    put_into_container( list, items_created, container_item, sealed, birthday, on_overflow, context() );
+    put_into_container( list, items_created, container_item, sealed, birthday, on_overflow, context() ); //needs changing?
     return list.size() - prev_list_size;
 }
 
@@ -830,7 +833,7 @@ std::size_t Item_group::create( Item_spawn_data::ItemList &list,
         }
     }
     const std::size_t items_created = list.size() - prev_list_size;
-    put_into_container( list, items_created, container_item, sealed, birthday, on_overflow, context() );
+    put_into_container( list, items_created, container_item, sealed, birthday, on_overflow, context() ); //needs changing?
 
     return list.size() - prev_list_size;
 }
@@ -871,6 +874,12 @@ void Item_group::check_consistency() const
 void Item_spawn_data::set_container_item( const itype_id &container )
 {
     container_item = container;
+}
+
+void Item_spawn_data::set_container_item( const itype_id &container, const std::string &variant )
+{
+    container_item = container;
+    container_item_variant = variant;
 }
 
 int Item_spawn_data::get_probability( bool skip_event_check ) const

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -178,7 +178,8 @@ item Single_item_creator::create_single( const time_point &birthday, RecursionLi
 {
     item tmp = create_single_without_container( birthday, rec );
     if( container_item ) {
-        tmp = tmp.in_container( *container_item, tmp.count(), sealed, container_item_variant.value_or( "" ) );
+        tmp = tmp.in_container( *container_item, tmp.count(), sealed,
+                                container_item_variant.value_or( "" ) );
     }
     return tmp;
 }

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -177,7 +177,7 @@ item Single_item_creator::create_single( const time_point &birthday, RecursionLi
 {
     item tmp = create_single_without_container( birthday, rec );
     if( container_item ) {
-            tmp = tmp.in_container( *container_item, *container_item_variant, tmp.count(), sealed );
+            tmp = tmp.in_container( *container_item, tmp.count(), sealed, *container_item_variant );
     }
     return tmp;
 }

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -511,6 +511,9 @@ void Item_modifier::modify( item &new_item, const std::string &context ) const
             cont = container->create_single( new_item.birthday() );
         } else if( new_item.type->default_container.has_value() ) {
             cont = item( *new_item.type->default_container, new_item.birthday() );
+            if( new_item.type->default_container_variant.has_value() ) {
+                cont.set_itype_variant( *new_item.type->default_container_variant );
+            }
         }
 
         int max_capacity = -1;

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -178,7 +178,7 @@ item Single_item_creator::create_single( const time_point &birthday, RecursionLi
 {
     item tmp = create_single_without_container( birthday, rec );
     if( container_item ) {
-        tmp = tmp.in_container( *container_item, tmp.count(), sealed, *container_item_variant );
+        tmp = tmp.in_container( *container_item, tmp.count(), sealed, container_item_variant.value_or( "" ) );
     }
     return tmp;
 }

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -285,7 +285,7 @@ std::size_t Single_item_creator::create( ItemList &list,
     }
     const std::size_t items_created = list.size() - prev_list_size;
     put_into_container( list, items_created, container_item, container_item_variant, sealed, birthday,
-                        on_overflow, context() ); //needs changing?
+                        on_overflow, context() );
     return list.size() - prev_list_size;
 }
 
@@ -839,7 +839,7 @@ std::size_t Item_group::create( Item_spawn_data::ItemList &list,
     }
     const std::size_t items_created = list.size() - prev_list_size;
     put_into_container( list, items_created, container_item, container_item_variant, sealed, birthday,
-                        on_overflow, context() ); //needs changing?
+                        on_overflow, context() );
 
     return list.size() - prev_list_size;
 }

--- a/src/item_group.cpp
+++ b/src/item_group.cpp
@@ -108,7 +108,8 @@ static pocket_type guess_pocket_for( const item &container, const item &payload 
 
 static void put_into_container(
     Item_spawn_data::ItemList &items, std::size_t num_items,
-    const std::optional<itype_id> &container_type, const std::optional<std::string> &container_variant, const bool sealed,
+    const std::optional<itype_id> &container_type, const std::optional<std::string> &container_variant,
+    const bool sealed,
     time_point birthday, Item_spawn_data::overflow_behaviour on_overflow,
     const std::string &context )
 {
@@ -123,7 +124,7 @@ static void put_into_container(
 
     item ctr( *container_type, birthday );
     if( container_variant ) {
-        ctr.set_itype_variant ( *container_variant );
+        ctr.set_itype_variant( *container_variant );
     }
     Item_spawn_data::ItemList excess;
     for( auto it = items.end() - num_items; it != items.end(); ++it ) {
@@ -177,7 +178,7 @@ item Single_item_creator::create_single( const time_point &birthday, RecursionLi
 {
     item tmp = create_single_without_container( birthday, rec );
     if( container_item ) {
-            tmp = tmp.in_container( *container_item, tmp.count(), sealed, *container_item_variant );
+        tmp = tmp.in_container( *container_item, tmp.count(), sealed, *container_item_variant );
     }
     return tmp;
 }
@@ -283,7 +284,8 @@ std::size_t Single_item_creator::create( ItemList &list,
         }
     }
     const std::size_t items_created = list.size() - prev_list_size;
-    put_into_container( list, items_created, container_item, container_item_variant, sealed, birthday, on_overflow, context() ); //needs changing?
+    put_into_container( list, items_created, container_item, container_item_variant, sealed, birthday,
+                        on_overflow, context() ); //needs changing?
     return list.size() - prev_list_size;
 }
 
@@ -833,7 +835,8 @@ std::size_t Item_group::create( Item_spawn_data::ItemList &list,
         }
     }
     const std::size_t items_created = list.size() - prev_list_size;
-    put_into_container( list, items_created, container_item, container_item_variant, sealed, birthday, on_overflow, context() ); //needs changing?
+    put_into_container( list, items_created, container_item, container_item_variant, sealed, birthday,
+                        on_overflow, context() ); //needs changing?
 
     return list.size() - prev_list_size;
 }

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -175,6 +175,7 @@ class Item_spawn_data
         virtual void replace_items( const std::unordered_map<itype_id, itype_id> &replacements ) = 0;
         virtual bool has_item( const itype_id &itemid ) const = 0;
         void set_container_item( const itype_id &container );
+        void set_container_item( const itype_id &container, const std::string &variant );
 
         virtual std::set<const itype *> every_item() const = 0;
 
@@ -194,6 +195,7 @@ class Item_spawn_data
          * The group spawns contained in this item
          */
         std::optional<itype_id> container_item;
+        std::optional<std::string> container_item_variant;
         overflow_behaviour on_overflow = overflow_behaviour::none;
         bool sealed = true;
 

--- a/src/item_group.h
+++ b/src/item_group.h
@@ -174,8 +174,6 @@ class Item_spawn_data
         virtual bool remove_item( const itype_id &itemid ) = 0;
         virtual void replace_items( const std::unordered_map<itype_id, itype_id> &replacements ) = 0;
         virtual bool has_item( const itype_id &itemid ) const = 0;
-        void set_container_item( const itype_id &container );
-        void set_container_item( const itype_id &container, const std::string &variant );
 
         virtual std::set<const itype *> every_item() const = 0;
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -1257,6 +1257,7 @@ struct itype {
     public:
         // The container it comes in
         std::optional<itype_id> default_container;
+        std::optional<std::string> default_container_variant;
 
         std::set<weapon_category_id> weapon_category;
 

--- a/src/recipe.cpp
+++ b/src/recipe.cpp
@@ -226,6 +226,7 @@ void recipe::load( const JsonObject &jo, const std::string &src )
     // automatically set contained if we specify as container
     assign( jo, "contained", contained, strict );
     contained |= assign( jo, "container", container, strict );
+    optional( jo, false, "container_variant", container_variant );
     assign( jo, "sealed", sealed, strict );
 
     if( jo.has_array( "batch_time_factors" ) ) {
@@ -598,6 +599,9 @@ void recipe::finalize()
 
     if( contained && container.is_null() ) {
         container = item::find_type( result_ )->default_container.value_or( itype_null );
+        if( item::find_type( result_ )->default_container_variant.has_value() ) {
+            container_variant = item::find_type( result_ )->default_container_variant.value();
+        }
     }
 
     std::set<proficiency_id> required;
@@ -751,7 +755,7 @@ std::vector<item> recipe::create_result( bool set_components, bool is_food,
     }
 
     if( contained ) {
-        newit = newit.in_container( container, amount, sealed );
+        newit = newit.in_container( container, amount, sealed, container_variant );
         return { newit };
     } else if( newit.count_by_charges() ) {
         newit.charges = amount;

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -328,7 +328,7 @@ class recipe
 
         /** What does the item spawn contained in? Unset ("null") means default container. */
         itype_id container = itype_id::NULL_ID();
-        
+
         /** What does the item spawn contained in? Unset ("null") means default container. */
         std::string container_variant = "";
 

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -328,6 +328,9 @@ class recipe
 
         /** What does the item spawn contained in? Unset ("null") means default container. */
         itype_id container = itype_id::NULL_ID();
+        
+        /** What does the item spawn contained in? Unset ("null") means default container. */
+        std::string container_variant = "";
 
         /** External requirements (via "using" syntax) where second field is multiplier */
         std::vector<std::pair<requirement_id, int>> reqs_external;

--- a/src/recipe.h
+++ b/src/recipe.h
@@ -320,17 +320,17 @@ class recipe
         /** Does the container spawn sealed? */
         bool sealed = true;
 
+        /** What does the item spawn contained in? Unset ("null") means default container. */
+        itype_id container = itype_id::NULL_ID();
+
+        /** What variant of the above container should be used? Unset ("") means a randomly chosen variant if it has variants. */
+        std::string container_variant;
+
         /** Can recipe be used for disassembly of @ref result via @ref disassembly_requirements */
         bool reversible = false;
 
         /** Time (in moves) to disassemble if different to assembly. Requires `reversible = true` */
         int64_t uncraft_time = 0;
-
-        /** What does the item spawn contained in? Unset ("null") means default container. */
-        itype_id container = itype_id::NULL_ID();
-
-        /** What does the item spawn contained in? Unset ("null") means default container. */
-        std::string container_variant = "";
 
         /** External requirements (via "using" syntax) where second field is multiplier */
         std::vector<std::pair<requirement_id, int>> reqs_external;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #69178

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Item groups `container-item` now accepts an object to pass the `item` and a `variant`, this doesn't work with entry-wrapper rn
Items accept a `container_variant` field to specify their default containers variant
Recipes accept a `container_variant` field to specify their results containers variant

Doesn't touch JSON yet, I'll do a follow-up PR migrating things that could be variants but weren't to get around this

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Making all three accept an single object rather than adding the container_variant fields but that would be more intrusive

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Works with various test groups and altered items including a top level container-item vs an embedded one as well as recipe results

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
