### PR TITLE
Plumbing: connects urban_25 to the main sewer system

### DIFF
--- a/data/json/mapgen/city_blocks/urban_25_dense_diner_apt.json
+++ b/data/json/mapgen/city_blocks/urban_25_dense_diner_apt.json
@@ -1,11 +1,46 @@
 [
   {
+    "type": "mapgen",
+    "method": "json",
+    "om_terrain": [ "urban_25_sewer_connector" ],
+    "object": {
+      "fill_ter": "t_thconc_floor",
+      "rows": [
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "                        ",
+        "|||||||||||||||||||     ",
+        "oooooooooooooooooo|     ",
+        "----------|o  o  o|     ",
+        "~~~~~~~~=#|o  o  o|     ",
+        "~~~~~~~~=#|o  o  o|     ",
+        "-#--------|o  o  o|     ",
+        "o=oooooooooooooooo|     ",
+        "|~o||||||||||||||||     ",
+        "|~o|                    ",
+        "|~o|                    ",
+        "|~o|                    ",
+        "|~o|                    ",
+        "|~o|                    ",
+        "|~o|                    ",
+        "|~o|                    ",
+        "|~ooooooooooooooo       "
+      ],
+      "palettes": [ "sewers" ]
+    }
+  },
+  {
     "method": "json",
     "object": {
       "fill_ter": "t_thconc_floor",
       "rows": [
-        "                         :    iiiiiiiiiiiiiiiiii",
-        "                        :::   iZ,,JJJJ6|t|..117i",
+        "                        :!:   iiiiiiiiiiiiiiiiii",
+        "                        :!:   iZ,,JJJJ6|t|..117i",
         "iiiiiiiiiiiiiiiiiiii    :!:   iZ,,,,,,,+,|4..2.i",
         "i......FFUUUgg.....i    :!:   iZ,,,,,,,|S|.4..Ui",
         "i.......z..........i:::::!:   iW,,,,,,,|||&&$&&i",

--- a/data/json/overmap/multitile_city_buildings.json
+++ b/data/json/overmap/multitile_city_buildings.json
@@ -5070,6 +5070,8 @@
     "type": "city_building",
     "id": "urban_25_dense_diner_apt",
     "overmaps": [
+      { "point": [ 1, 1, -1 ], "overmap": "sewer_connector_east" },
+      { "point": [ 0, 1, -1 ], "overmap": "urban_25_sewer_connector_south" },
       { "point": [ 1, 0, -1 ], "overmap": "urban_25_1_south" },
       { "point": [ 0, 0, -1 ], "overmap": "urban_25_2_south" },
       { "point": [ 1, 0, 0 ], "overmap": "urban_25_3_south" },

--- a/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
@@ -1,6 +1,26 @@
 [
   {
     "type": "overmap_terrain",
+    "abstract": "generic_sewer",
+    "name": "sewer",
+    "color": "green",
+    "see_cost": 5,
+    "extras": "sewer"
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "sewer",
+    "copy-from": "generic_sewer",
+    "flags": [ "LINEAR" ]
+  },
+  {
+    "type": "overmap_terrain",
+    "id": "sewer_connector",
+    "copy-from": "generic_sewer",
+    "flags": [ "SHOULD_NOT_SPAWN" ]
+  },
+  {
+    "type": "overmap_terrain",
     "id": [ "sewage_treatment_0_0_0", "sewage_treatment_1_0_0", "sewage_treatment_1_1_0" ],
     "name": "sewage treatment plant",
     "sym": "P",
@@ -87,12 +107,9 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "sewer",
-    "name": "sewer",
-    "color": "green",
-    "see_cost": 5,
-    "extras": "sewer",
-    "flags": [ "LINEAR" ]
+    "id": "urban_25_sewer_connector",
+    "copy-from": "generic_sewer",
+    "sym": "┐"
   },
   {
     "type": "overmap_terrain",
@@ -129,12 +146,6 @@
     "color": "green",
     "see_cost": 999,
     "mondensity": 2
-  },
-  {
-    "type": "overmap_terrain",
-    "id": "sewer_connector",
-    "copy-from": "pump_station_3",
-    "flags": [ "SHOULD_NOT_SPAWN" ]
   },
   {
     "type": "overmap_terrain",

--- a/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
+++ b/data/json/overmap/overmap_terrain/overmap_terrain_waste_junk.json
@@ -15,8 +15,15 @@
   },
   {
     "type": "overmap_terrain",
+    "id": "urban_25_sewer_connector",
+    "copy-from": "generic_sewer",
+    "sym": "┐"
+  },
+  {
+    "type": "overmap_terrain",
     "id": "sewer_connector",
     "copy-from": "generic_sewer",
+    "sym": "X",
     "flags": [ "SHOULD_NOT_SPAWN" ]
   },
   {
@@ -104,12 +111,6 @@
     "color": "pink",
     "see_cost": 5,
     "flags": [ "RISK_HIGH" ]
-  },
-  {
-    "type": "overmap_terrain",
-    "id": "urban_25_sewer_connector",
-    "copy-from": "generic_sewer",
-    "sym": "┐"
   },
   {
     "type": "overmap_terrain",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Connects urban_25 to the main sewer system."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Partially addresses #62747. Yep, still not given up.

There used to be line of sewage tiles underneath dense urban `#25`, which, due to technical limitations, couldn't be linked up with the main sewer line.

Sanitation for the people!

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Connected the sewage line to the main sewage system using fake sewer connectors.
I also added an abstract overmap terrain for future sewer tiles.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

None.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Loaded in a world.

![kép](https://github.com/CleverRaven/Cataclysm-DDA/assets/44979050/d74bd955-21bd-4e90-a949-508c24151aca)
![kép](https://github.com/CleverRaven/Cataclysm-DDA/assets/44979050/b87d6322-458e-4f4c-a215-66f28e9f52fe)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Connecting every building to the sewer system?  I feel like these sewage lines should only represent larger infrastructure and let the smaller ones be filled out by our imagination.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
