### PR TITLE
Show whether keybindings are default or custom

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -396,55 +396,61 @@ void input_manager::save()
                     jsout.member( "is_user_created", is_user_created );
                 }
 
-                jsout.member( "bindings" );
-                jsout.start_array();
-                for( const input_event &event : events ) {
-                    jsout.start_object();
-                    switch( event.type ) {
-                        case input_event_t::keyboard_char:
-                            jsout.member( "input_method", "keyboard_char" );
-                            break;
-                        case input_event_t::keyboard_code:
-                            jsout.member( "input_method", "keyboard_code" );
-                            break;
-                        case input_event_t::gamepad:
-                            jsout.member( "input_method", "gamepad" );
-                            break;
-                        case input_event_t::mouse:
-                            jsout.member( "input_method", "mouse" );
-                            break;
-                        default:
-                            throw std::runtime_error( "unknown input_event_t" );
-                    }
-
-                    jsout.member( "mod" );
+                // optimization: no writing if empty
+                if( !events.empty() ) {
+                    jsout.member( "bindings" );
                     jsout.start_array();
-                    for( const keymod_t mod : event.modifiers ) {
-                        switch( mod ) {
-                            case keymod_t::ctrl:
-                                jsout.write( "ctrl" );
+                    for( const input_event &event : events ) {
+                        jsout.start_object();
+                        switch( event.type ) {
+                            case input_event_t::keyboard_char:
+                                jsout.member( "input_method", "keyboard_char" );
                                 break;
-                            case keymod_t::alt:
-                                jsout.write( "alt" );
+                            case input_event_t::keyboard_code:
+                                jsout.member( "input_method", "keyboard_code" );
                                 break;
-                            case keymod_t::shift:
-                                jsout.write( "shift" );
+                            case input_event_t::gamepad:
+                                jsout.member( "input_method", "gamepad" );
+                                break;
+                            case input_event_t::mouse:
+                                jsout.member( "input_method", "mouse" );
                                 break;
                             default:
-                                throw std::runtime_error( "unknown keymod_t" );
+                                throw std::runtime_error( "unknown input_event_t" );
                         }
-                    }
-                    jsout.end_array();
 
-                    jsout.member( "key" );
-                    jsout.start_array();
-                    for( size_t i = 0; i < event.sequence.size(); i++ ) {
-                        jsout.write( get_keyname( event.sequence[i], event.type, true ) );
+                        // optimization: no writing if empty
+                        if( !event.modifiers.empty() ) {
+                            jsout.member( "mod" );
+                            jsout.start_array();
+                            for( const keymod_t mod : event.modifiers ) {
+                                switch( mod ) {
+                                    case keymod_t::ctrl:
+                                        jsout.write( "ctrl" );
+                                        break;
+                                    case keymod_t::alt:
+                                        jsout.write( "alt" );
+                                        break;
+                                    case keymod_t::shift:
+                                        jsout.write( "shift" );
+                                        break;
+                                    default:
+                                        throw std::runtime_error( "unknown keymod_t" );
+                                }
+                            }
+                            jsout.end_array();
+                        }
+
+                        jsout.member( "key" );
+                        jsout.start_array();
+                        for( size_t i = 0; i < event.sequence.size(); i++ ) {
+                            jsout.write( get_keyname( event.sequence[i], event.type, true ) );
+                        }
+                        jsout.end_array();
+                        jsout.end_object();
                     }
                     jsout.end_array();
-                    jsout.end_object();
                 }
-                jsout.end_array();
 
                 jsout.end_object();
             }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -179,6 +179,8 @@ void input_manager::init()
     } catch( const JsonError &err ) {
         throw std::runtime_error( err.what() );
     }
+    // save non customized keybindings
+    basic_action_contexts = action_contexts;
     try {
         load( PATH_INFO::user_keybindings(), true );
     } catch( const JsonError &err ) {
@@ -769,13 +771,17 @@ int input_manager::get_first_char_for_action( const std::string &action_descript
 const action_attributes &input_manager::get_action_attributes(
     const std::string &action_id,
     const std::string &context,
-    bool *overwrites_default )
+    bool *overwrites_default,
+    bool use_basic_action_contexts )
 {
+    t_action_contexts &action_contexts_ref = use_basic_action_contexts
+            ? basic_action_contexts
+            : action_contexts;
 
     if( context != default_context_id ) {
         // Check if the action exists in the provided context
-        const t_action_contexts::const_iterator action_context = action_contexts.find( context );
-        if( action_context != action_contexts.end() ) {
+        const t_action_contexts::const_iterator action_context = action_contexts_ref.find( context );
+        if( action_context != action_contexts_ref.end() ) {
             const t_actions::const_iterator action = action_context->second.find( action_id );
             if( action != action_context->second.end() ) {
                 if( overwrites_default ) {
@@ -792,7 +798,7 @@ const action_attributes &input_manager::get_action_attributes(
         *overwrites_default = false;
     }
 
-    t_actions &default_action_context = action_contexts[default_context_id];
+    t_actions &default_action_context = action_contexts_ref[default_context_id];
     const t_actions::const_iterator default_action = default_action_context.find( action_id );
     if( default_action == default_action_context.end() ) {
         // A new action is created in the event that the requested action is

--- a/src/input.h
+++ b/src/input.h
@@ -128,9 +128,6 @@ enum : int {
 };
 } // namespace keycode
 
-constexpr int LEGEND_HEIGHT = 8;
-constexpr int BORDER_SPACE = 2;
-
 bool is_mouse_enabled();
 bool is_keycode_mode_supported();
 std::string get_input_string_from_file( const std::string &fname = "input.txt" );

--- a/src/input.h
+++ b/src/input.h
@@ -290,6 +290,11 @@ class input_manager
         using t_actions = std::map<std::string, action_attributes>;
         using t_action_contexts = std::map<std::string, t_actions>;
         t_action_contexts action_contexts;
+        /**
+         * called basic rather than default to not confuse default context
+         * basic means default keybindings (without user changes)
+         */
+        t_action_contexts basic_action_contexts;
 
         using t_key_to_name_map = std::map<int, std::string>;
         t_key_to_name_map keyboard_char_keycode_to_keyname;
@@ -339,11 +344,13 @@ class input_manager
          *                           the found action was not in the default
          *                           context. It will be set to false if the found
          *                           action was in the default context.
+         * @param use_basic_action_contexts If true, use non-customized keybindings.
          */
         const action_attributes &get_action_attributes(
             const std::string &action_id,
             const std::string &context = "default",
-            bool *overwrites_default = nullptr );
+            bool *overwrites_default = nullptr,
+            bool use_basic_action_contexts = false );
 
         /**
          * Get a value to be used as the default name for a newly created action.

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -34,6 +34,9 @@
 
 static const std::string default_context_id( "default" );
 
+static constexpr int LEGEND_HEIGHT = 8;
+static constexpr int BORDER_SPACE = 2;
+
 template <class T1, class T2>
 struct ContainsPredicate {
     const T1 &container;

--- a/src/input_context.cpp
+++ b/src/input_context.cpp
@@ -34,7 +34,7 @@
 
 static const std::string default_context_id( "default" );
 
-static constexpr int LEGEND_HEIGHT = 8;
+static constexpr int LEGEND_HEIGHT = 9;
 static constexpr int BORDER_SPACE = 2;
 
 template <class T1, class T2>
@@ -623,6 +623,7 @@ action_id input_context::display_menu( const bool permit_execute_action )
     legend += colorize( _( "Unbound keys" ), unbound_key ) + "\n";
     legend += colorize( _( "Keybinding active only on this screen" ), local_key ) + "\n";
     legend += colorize( _( "Keybinding active globally" ), global_key ) + "\n";
+    legend += colorize( _( "* User created" ), global_key ) + "\n";
     if( permit_execute_action ) {
         legend += string_format(
                       _( "Press %c to execute action\n" ),
@@ -639,20 +640,20 @@ action_id input_context::display_menu( const bool permit_execute_action )
         draw_border( w_help, BORDER_COLOR, _( "Keybindings" ), c_light_red );
         draw_scrollbar( w_help, scroll_offset, display_height,
                         filtered_registered_actions.size(), point( 0, 7 ), c_white, true );
-        fold_and_print( w_help, point( 2, 1 ), legwidth, c_white, legend );
+        const int legend_lines = 1 + fold_and_print( w_help, point( 2, 1 ), legwidth, c_white, legend );
         const auto item_color = []( const int index_to_draw, int index_highlighted ) {
             return index_highlighted == index_to_draw ? h_light_gray : c_light_gray;
         };
-        right_print( w_help, 4, 2, item_color( static_cast<int>( kb_btn_idx::remove ),
-                                               int( highlighted_btn_index ) ),
+        right_print( w_help, legend_lines, 2,
+                     item_color( static_cast<int>( kb_btn_idx::remove ), int( highlighted_btn_index ) ),
                      string_format( _( "<[<color_yellow>%c</color>] Remove keybinding>" ),
                                     fallback_keys.at( fallback_action::remove ) ) );
-        right_print( w_help, 4, 26, item_color( static_cast<int>( kb_btn_idx::add_local ),
-                                                int( highlighted_btn_index ) ),
+        right_print( w_help, legend_lines, 26,
+                     item_color( static_cast<int>( kb_btn_idx::add_local ), int( highlighted_btn_index ) ),
                      string_format( _( "<[<color_yellow>%c</color>] Add local keybinding>" ),
                                     fallback_keys.at( fallback_action::add_local ) ) );
-        right_print( w_help, 4, 54, item_color( static_cast<int>( kb_btn_idx::add_global ),
-                                                int( highlighted_btn_index ) ),
+        right_print( w_help, legend_lines, 54,
+                     item_color( static_cast<int>( kb_btn_idx::add_global ), int( highlighted_btn_index ) ),
                      string_format( _( "<[<color_yellow>%c</color>] Add global keybinding>" ),
                                     fallback_keys.at( fallback_action::add_global ) ) );
 
@@ -663,6 +664,9 @@ action_id input_context::display_menu( const bool permit_execute_action )
             bool overwrite_default;
             const action_attributes &attributes = inp_mngr.get_action_attributes( action_id, category,
                                                   &overwrite_default );
+            bool basic_overwrite_default;
+            const action_attributes &basic_attributes = inp_mngr.get_action_attributes( action_id, category,
+                    &basic_overwrite_default, true );
 
             char invlet;
             if( i < hotkeys.size() ) {
@@ -689,6 +693,11 @@ action_id input_context::display_menu( const bool permit_execute_action )
                 col = i == size_t( highlight_row_index ) ? h_local_key : local_key;
             } else {
                 col = i == size_t( highlight_row_index ) ? h_global_key : global_key;
+            }
+            if( overwrite_default != basic_overwrite_default
+                || attributes.input_events != basic_attributes.input_events
+              ) {
+                mvwprintz( w_help, point( 3, i + 7 ), col, "*" );
             }
             mvwprintz( w_help, point( 4, i + 7 ), col, "%s:", get_action_name( action_id ) );
             mvwprintz( w_help, point( TERMX >= 100 ? 62 : 52, i + 7 ), col, "%s", get_desc( action_id ) );


### PR DESCRIPTION
#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Resolve #71046

#### Describe the solution
Print `*` before entries in the keybinding menu.
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/13402666/1fa6c830-dca9-4cba-b3d6-66837ad53f9e)

Move `LEGEND_HEIGHT` & `BORDER_SPACE` from `input.h` to `input.cpp`. They are specific to the implementation and shouldn't be accessed from outside. For faster compilation if any of it changes.

Remove some unnecessary empty lists in JSON while at it.

#### Describe alternatives you've considered

#### Testing

KB = keybinding

1. Open `?` menu (in any context you choose)
2. add local KB to something with global KB/s - this overwrites the global KB/s
3. add global KB to something with global KB/s - this adds to the global KB/s
4. add local KB to something with local KB/s - this adds to the local KB/s
5. add local/global KB to something Unbound globally
6. add local KB to something Unbound locally
7. remove KB from something with local KB/s -> Unbound locally
8. remove KB from something with global KB/s -> Unbound globally
9. remove KB from something Unbound locally -> Unbound globally - see separate PR #71968 taking on this issue
10. observe it adds `*` in all those cases

Doesn't work (on my machine) & will not fix:

1. remove last keybinding (example: in AIM remove Examine which has "e or E")
2. add back ("e or E")
3. I would expect to not have `*`
4. It has `*` probably since the data is stored differently, or I don't know

Unnecessary JSON in `config/keybindings.json` (about 12% reduction):

1. look at `config/keybindings.json`
11.  observe there are lots of `"mod": [  ]` and `"bindings": [  ]`
12. load game
13. change any keybinding in the `?` menu (you can change it back, it just needs to be marked dirty)
14. save keybindings
15. observe there are no `"mod": [  ]` and `"bindings": [  ]` in the file
16. game still loads fine and plays fine


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
