### PR TITLE
DEBUG_ONLY flag for more consistency in "seeing this is a bug"

### DIFF
--- a/data/json/flags.json
+++ b/data/json/flags.json
@@ -1,80 +1,85 @@
 [
   {
+    "id": "DEBUG_ONLY",
+    "type": "json_flag",
+    "info": "This is not intended to be visible during normal gameplay.  <bad>Please file a bug report</bad> unless you are seeing this in the debug menu."
+  },
+  {
     "id": "ABLATIVE_CHAINMAIL_ARMS",
     "type": "json_flag",
-    "info": "You can use this armor <info>with chainmail</info> with out encumbrance penalty",
+    "info": "You can use this armor <info>with chainmail</info> without encumbrance penalty.",
     "restriction": "Item must be a chainmail compatible armor piece"
   },
   {
     "id": "ABLATIVE_CHAINMAIL_ELBOWS",
     "type": "json_flag",
-    "info": "You can use this armor <info>with chainmail</info> with out encumbrance penalty",
+    "info": "You can use this armor <info>with chainmail</info> without encumbrance penalty.",
     "restriction": "Item must be a chainmail compatible armor piece"
   },
   {
     "id": "ABLATIVE_CHAINMAIL_LEGS",
     "type": "json_flag",
-    "info": "You can use this armor <info>with chainmail</info> with out encumbrance penalty",
+    "info": "You can use this armor <info>with chainmail</info> without encumbrance penalty.",
     "restriction": "Item must be a chainmail compatible armor piece"
   },
   {
     "id": "ABLATIVE_CHAINMAIL_KNEES",
     "type": "json_flag",
-    "info": "You can use this armor <info>with chainmail</info> with out encumbrance penalty",
+    "info": "You can use this armor <info>with chainmail</info> without encumbrance penalty.",
     "restriction": "Item must be a chainmail compatible armor piece"
   },
   {
     "id": "ABLATIVE_CHAINMAIL_TORSO",
     "type": "json_flag",
-    "info": "You can use this armor <info>with chainmail</info> with out encumbrance penalty",
+    "info": "You can use this armor <info>with chainmail</info> without encumbrance penalty.",
     "restriction": "Item must be a chainmail compatible armor piece"
   },
   {
     "id": "ABLATIVE_LARGE",
     "type": "json_flag",
-    "info": "This plate will fit in <info>large</info> armor pockets",
+    "info": "This plate will fit in <info>large</info> armor pockets.",
     "restriction": "Item must be a large ablative plate"
   },
   {
     "id": "ABLATIVE_MANTLE",
     "type": "json_flag",
-    "info": "This will hook to a <info>Hub 01 proprietary</info> mantle connector",
+    "info": "This will hook to a <info>Hub 01 proprietary</info> mantle connector.",
     "restriction": "Item must be an armored mantle"
   },
   {
     "id": "STAR_PLATE",
     "type": "json_flag",
-    "info": "This can be supported by the ryūsei battle kit",
+    "info": "This can be supported by the ryūsei battle kit.",
     "restriction": "Item must be resonance plate"
   },
   {
     "id": "STAR_SHOULDER",
     "type": "json_flag",
-    "info": "This can be supported by the ryūsei battle kit",
+    "info": "This can be supported by the ryūsei battle kit.",
     "restriction": "Item must be resonance shoulder"
   },
   {
     "id": "STAR_SKIRT",
     "type": "json_flag",
-    "info": "This can be supported by the ryūsei battle kit",
+    "info": "This can be supported by the ryūsei battle kit.",
     "restriction": "Item must be resonance skirt"
   },
   {
     "id": "ABLATIVE_MEDIUM",
     "type": "json_flag",
-    "info": "This plate will fit in <info>medium</info> armor pockets",
+    "info": "This plate will fit in <info>medium</info> armor pockets.",
     "restriction": "Item must be a medium ablative plate"
   },
   {
     "id": "ABLATIVE_SKIRT",
     "type": "json_flag",
-    "info": "This will hook to a <info>Hub 01 proprietary</info> skirt connector",
+    "info": "This will hook to a <info>Hub 01 proprietary</info> skirt connector.",
     "restriction": "Item must be an armored skirt"
   },
   {
     "id": "ABLATIVE_HELMET",
     "type": "json_flag",
-    "info": "This will hook to a <info>Hub 01 proprietary</info> helmet connector",
+    "info": "This will hook to a <info>Hub 01 proprietary</info> helmet connector.",
     "restriction": "Item must be an armored helmet"
   },
   {
@@ -406,13 +411,13 @@
     "id": "HEAD_STRAP_MOUNT",
     "type": "json_flag",
     "info": "This item is attachable to straps and mountings on some masks and hoods.",
-    "restriction": "Item must be some kind of item that can be attached to straps on masks and hoods."
+    "restriction": "Item must be some kind of item that can be attached to straps on masks and hoods"
   },
   {
     "id": "WRIST_MOUNT_ATTACHMENT",
     "type": "json_flag",
     "info": "This item is attachable to a proprietary wrist mount.",
-    "restriction": "Item must be some kind of item that can be attached to a proprietary wrist mount."
+    "restriction": "Item must be some kind of item that can be attached to a proprietary wrist mount"
   },
   {
     "id": "EXTRA_PLATING",

--- a/data/json/items/fake.json
+++ b/data/json/items/fake.json
@@ -3,13 +3,21 @@
     "abstract": "fake_item",
     "type": "GENERIC",
     "name": { "str": "fake item" },
-    "description": "Dummy item.  If you see this, then something went wrong.",
+    "description": "Dummy item.",
     "//": "Include ZERO_WEIGHT flag to avoid errors when instantiating pseudo items.",
-    "flags": [ "ZERO_WEIGHT" ],
+    "flags": [ "ZERO_WEIGHT", "TRADER_AVOID", "DEBUG_ONLY" ],
     "weight": "1 g",
     "volume": "1 ml",
     "symbol": "@",
     "color": "red"
+  },
+  {
+    "id": "fake_crafting_tool",
+    "copy-from": "fake_item",
+    "type": "TOOL",
+    "name": { "str": "fake crafting tool" },
+    "description": "Used for practice recipes and the like.",
+    "extend": { "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ] }
   },
   {
     "id": "fake_arcfurnace",
@@ -195,7 +203,6 @@
   {
     "abstract": "fake_appliance_tool",
     "name": { "str": "fake appliance tool" },
-    "description": "Dummy item.  If you see this, then something went wrong.",
     "type": "TOOL",
     "copy-from": "fake_item",
     "ammo": [ "battery" ],
@@ -279,82 +286,74 @@
     "id": "pseudo_exercise_machine",
     "type": "TOOL",
     "name": { "str": "exercise machine" },
-    "description": "This is a crafting_pseudo_item if you have it something is wrong.",
+    "copy-from": "fake_crafting_tool",
     "material": [ "steel" ],
     "symbol": "T",
-    "color": "dark_gray",
-    "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ]
+    "color": "dark_gray"
   },
   {
     "id": "pseudo_punching_bag",
     "type": "TOOL",
     "name": { "str": "heavy punching bag" },
-    "description": "This is a crafting_pseudo_item if you have it something is wrong.",
+    "copy-from": "fake_crafting_tool",
     "symbol": "0",
-    "color": "dark_gray",
-    "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ]
+    "color": "dark_gray"
   },
   {
     "id": "pseudo_ergometer_mechanical",
     "type": "TOOL",
     "name": { "str": "mechanical ergometer" },
-    "description": "This is a crafting_pseudo_item if you have it something is wrong.",
+    "copy-from": "fake_crafting_tool",
     "symbol": "5",
-    "color": "dark_gray",
-    "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ]
+    "color": "dark_gray"
   },
   {
     "id": "pseudo_treadmill_mechanical",
     "type": "TOOL",
     "name": { "str": "gravity treadmill" },
-    "description": "This is a crafting_pseudo_item if you have it something is wrong.",
+    "copy-from": "fake_crafting_tool",
     "symbol": "L",
-    "color": "dark_gray",
-    "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ]
+    "color": "dark_gray"
   },
   {
     "id": "pseudo_training_dummy_light",
     "type": "TOOL",
     "name": { "str": "training dummy", "str_pl": "training dummies" },
-    "description": "This is a crafting_pseudo_item if you have it something is wrong.",
+    "copy-from": "fake_crafting_tool",
     "symbol": "@",
-    "color": "brown",
-    "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ]
+    "color": "brown"
   },
   {
     "id": "pseudo_training_dummy_heavy",
     "type": "TOOL",
     "name": { "str": "armored training dummy", "str_pl": "armored training dummies" },
-    "description": "This is a crafting_pseudo_item if you have it something is wrong.",
+    "copy-from": "fake_crafting_tool",
     "symbol": "@",
-    "color": "brown",
-    "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ]
+    "color": "brown"
   },
   {
     "id": "pseudo_archery_target_box",
     "type": "TOOL",
     "name": { "str": "box archery target" },
-    "description": "This is a crafting_pseudo_item if you have it something is wrong.",
+    "copy-from": "fake_crafting_tool",
     "symbol": "@",
-    "color": "brown",
-    "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ]
+    "color": "brown"
   },
   {
     "id": "pseudo_archery_target_bale",
     "type": "TOOL",
     "name": { "str": "bale archery target" },
-    "description": "This is a crafting_pseudo_item if you have it something is wrong.",
+    "copy-from": "fake_crafting_tool",
     "symbol": "@",
-    "color": "yellow",
-    "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ]
+    "color": "yellow"
   },
   {
     "id": "pseudo_magazine",
     "type": "MAGAZINE",
     "category": "spare_parts",
     "name": { "str": "pseudo magazine" },
-    "description": "Pseudo magazine for use in dirty vehicle hacks.  If you see this, then something went wrong",
-    "flags": [ "PSEUDO", "ZERO_WEIGHT", "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD" ],
+    "description": "Pseudo magazine for use in dirty vehicle hacks.",
+    "flags": [ "PSEUDO", "ZERO_WEIGHT", "NO_SALVAGE", "NO_UNLOAD", "NO_RELOAD", "DEBUG_ONLY" ],
     "ammo_type": [ "battery" ],
     "capacity": 1000000,
     "pocket_data": [
@@ -371,53 +370,40 @@
   },
   {
     "id": "fake_lift_light",
-    "copy-from": "fake_item",
+    "copy-from": "fake_crafting_tool",
     "type": "TOOL",
     "name": { "str": "light hoist" },
-    "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ],
     "qualities": [ [ "LIFT", 2 ], [ "ROPE", 2 ], [ "SUSPENDING", 2 ] ]
   },
   {
     "id": "fake_lift_medium",
-    "copy-from": "fake_item",
+    "copy-from": "fake_crafting_tool",
     "type": "TOOL",
     "name": { "str": "sturdy hoist" },
-    "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ],
     "qualities": [ [ "LIFT", 8 ], [ "ROPE", 2 ], [ "SUSPENDING", 2 ] ]
   },
   {
     "id": "fake_lift_heavy",
-    "copy-from": "fake_item",
+    "copy-from": "fake_crafting_tool",
     "type": "TOOL",
     "name": { "str": "heavy-duty hoist" },
-    "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO" ],
     "qualities": [ [ "LIFT", 40 ], [ "ROPE", 2 ], [ "SUSPENDING", 2 ] ]
   },
   {
     "id": "pseudo_app_oxygen_concentrator",
     "type": "TOOL",
+    "name": { "str": "oxygen concentrator" },
+    "copy-from": "fake_crafting_tool",
     "ammo": [ "battery" ],
-    "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO", "ZERO_WEIGHT" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "default_magazine": "pseudo_battery" } ],
-    "description": "Dummy item.  If you see this, then something went wrong.",
-    "weight": "1 g",
-    "volume": "1 ml",
-    "symbol": "@",
-    "color": "red",
-    "name": { "str": "oxygen concentrator" }
+    "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "default_magazine": "pseudo_battery" } ]
   },
   {
     "id": "pseudo_app_hd_compressor_unit",
     "type": "TOOL",
-    "ammo": [ "battery" ],
-    "flags": [ "ALLOWS_REMOTE_USE", "PSEUDO", "ZERO_WEIGHT" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "default_magazine": "pseudo_battery" } ],
-    "description": "Dummy item.  If you see this, then something went wrong.",
-    "weight": "1 g",
-    "volume": "1 ml",
-    "symbol": "@",
-    "color": "red",
     "name": { "str": "high pressure compressor unit" },
+    "copy-from": "fake_crafting_tool",
+    "ammo": [ "battery" ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "default_magazine": "pseudo_battery" } ],
     "charges_per_use": 100,
     "charged_qualities": [ [ "PRESSURIZATION", 10 ] ]
   }

--- a/data/json/items/tool/cooking.json
+++ b/data/json/items/tool/cooking.json
@@ -38,23 +38,6 @@
     "qualities": [ [ "CUT", 2 ], [ "CUT_FINE", 1 ], [ "BUTCHER", 37 ] ]
   },
   {
-    "id": "butter_churn",
-    "type": "TOOL",
-    "name": { "str": "pseudo butter churn" },
-    "description": "This is a crafting_pseudo_item if you have it something is wrong.",
-    "weight": "6464 g",
-    "volume": "9 L",
-    "price": 20000,
-    "price_postapoc": 100,
-    "to_hit": -2,
-    "material": [ "wood" ],
-    "qualities": [ [ "CHURN", 1 ] ],
-    "symbol": "H",
-    "color": "light_cyan",
-    "flags": [ "ALLOWS_REMOTE_USE" ],
-    "melee_damage": { "bash": 9 }
-  },
-  {
     "id": "screw_press",
     "type": "TOOL",
     "name": { "str": "screw press", "str_pl": "screw presses" },

--- a/data/json/items/tool/pseudo.json
+++ b/data/json/items/tool/pseudo.json
@@ -4,71 +4,71 @@
     "type": "TOOL",
     "name": { "str": "butchery tree pseudo item" },
     "description": "This is a pseudo item to represent the support of a tree or butchery rack without a hook.",
-    "weight": "1 g",
-    "volume": "1 ml",
+    "copy-from": "fake_item",
     "symbol": "[",
     "color": "dark_gray",
-    "qualities": [ [ "SUSPENDING", 2 ] ],
-    "flags": [ "TRADER_AVOID", "ZERO_WEIGHT" ]
+    "qualities": [ [ "SUSPENDING", 2 ] ]
   },
   {
     "id": "fake_butcher_rack",
     "type": "TOOL",
     "name": { "str": "fake butcher rack (pseudo item)", "str_pl": "fake butcher racks (pseudo items)" },
     "description": "This is a pseudo item to represent the support of a tree or butchery rack with a hook.",
-    "weight": "1 g",
-    "volume": "1 ml",
+    "copy-from": "fake_item",
     "symbol": "[",
     "color": "dark_gray",
-    "qualities": [ [ "SUSPENDING", 2 ], [ "ROPE", 2 ] ],
-    "flags": [ "TRADER_AVOID", "ZERO_WEIGHT" ]
+    "qualities": [ [ "SUSPENDING", 2 ], [ "ROPE", 2 ] ]
   },
   {
     "id": "medium_surface_pseudo",
     "type": "TOOL",
     "name": { "str": "medium surface pseudo item" },
     "description": "This is a pseudo item to represent a surface large enough to butcher a medium animal on.",
-    "weight": "1 g",
-    "volume": "1 ml",
+    "copy-from": "fake_item",
     "symbol": "[",
     "color": "dark_gray",
-    "qualities": [ [ "SURFACE", 2 ] ],
-    "flags": [ "TRADER_AVOID", "ZERO_WEIGHT" ]
+    "qualities": [ [ "SURFACE", 2 ] ]
   },
   {
     "id": "large_surface_pseudo",
     "type": "TOOL",
     "name": { "str": "large surface pseudo item" },
     "description": "This is a pseudo item to represent a surface large enough to butcher a large animal on.",
-    "weight": "1 g",
-    "volume": "1 ml",
+    "copy-from": "fake_item",
     "symbol": "[",
     "color": "dark_gray",
-    "qualities": [ [ "SURFACE", 3 ] ],
-    "flags": [ "TRADER_AVOID", "ZERO_WEIGHT" ]
+    "qualities": [ [ "SURFACE", 3 ] ]
   },
   {
     "id": "fake_stove",
     "type": "TOOL",
-    "copy-from": "fake_item",
     "name": { "str": "basecamp stove" },
     "description": "A fake stove used for basecamps.",
+    "copy-from": "fake_item",
     "sub": "hotplate",
     "ammo": [ "tinder" ],
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "tinder": 50000 } } ],
-    "charge_factor": 10,
-    "flags": [ "ZERO_WEIGHT" ]
+    "charge_factor": 10
   },
   {
     "id": "brick_oven_pseudo",
     "type": "TOOL",
     "name": { "str": "brick oven" },
-    "description": "This is a pseudo item to represent t_brick_oven.  If you see it, it's a bug.",
-    "weight": "1 g",
-    "volume": "1 ml",
+    "description": "This is a pseudo item to represent t_brick_oven.",
+    "copy-from": "fake_item",
     "symbol": "[",
     "color": "dark_gray",
-    "qualities": [ [ "OVEN", 2 ] ],
-    "flags": [ "TRADER_AVOID", "ZERO_WEIGHT" ]
+    "qualities": [ [ "OVEN", 2 ] ]
+  },
+  {
+    "id": "butter_churn",
+    "type": "TOOL",
+    "name": { "str": "pseudo butter churn" },
+    "copy-from": "fake_item",
+    "material": [ "wood" ],
+    "qualities": [ [ "CHURN", 1 ] ],
+    "symbol": "H",
+    "color": "light_cyan",
+    "extend": { "flags": [ "ALLOWS_REMOTE_USE" ] }
   }
 ]

--- a/data/json/items/tool/pseudo.json
+++ b/data/json/items/tool/pseudo.json
@@ -65,7 +65,6 @@
     "type": "TOOL",
     "name": { "str": "pseudo butter churn" },
     "copy-from": "fake_item",
-    "material": [ "wood" ],
     "qualities": [ [ "CHURN", 1 ] ],
     "symbol": "H",
     "color": "light_cyan",

--- a/data/json/items/toolmod.json
+++ b/data/json/items/toolmod.json
@@ -49,9 +49,9 @@
     "type": "TOOLMOD",
     "category": "spare_parts",
     "name": { "str": "pseudo magazine mod" },
-    "description": "If you see this - you see a bug.",
+    "description": "For containing pseudo magazines, obviously.",
     "color": "light_green",
-    "flags": [ "PSEUDO" ],
+    "flags": [ "PSEUDO", "DEBUG_ONLY" ],
     "pocket_mods": [ { "pocket_type": "MAGAZINE_WELL", "default_magazine": "pseudo_magazine", "item_restriction": [ "pseudo_magazine" ] } ]
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

We have a dozen or more ways of saying "seeing this is a bug" and I find that we duplicate this pointlessly, so this is an effort to have some consistency.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

1. Adds the `DEBUG_ONLY` flag
2. Applies this to `fake_item` and creates `fake_crafting_item` for deduplicating use.
3. `fake_item` now also has `TRADER_AVOID`
4. Removes most duplicated information
5. Moves the fake butter churn to the proper file

Includes: Bonus typo and terminal punctuation (consistency!) fixes in `flags.json`

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

Loads and looks fine. Though I have not tested the recipes yet and I hope the tests will do that for me.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

For the future, add something similar for:
- AI tag effects the player should not have
- Maybe also for mutations?

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
