### PR TITLE
options: allow type conversion

### DIFF
--- a/data/mods/TEST_DATA/EOC.json
+++ b/data/mods/TEST_DATA/EOC.json
@@ -428,7 +428,7 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_options_test_nested",
-    "condition": { "get_game_option": "AUTOSAVE" },
+    "condition": { "math": [ "game_option('AUTOSAVE')" ] },
     "effect": [ { "math": [ "key3", "=", "1" ] } ]
   },
   {

--- a/doc/NPCs.md
+++ b/doc/NPCs.md
@@ -1011,7 +1011,6 @@ Condition | Type | Description
 --- | --- | ---
 `"mod_is_loaded"` | string or [variable object](#variable-object) | `true` if the mod with the given ID is loaded.
 `"get_condition"` | string or [variable object](#variable-object) | Runs the condition stored in the variable `get_condition` for the current dialogue.
-`"get_game_option"` | string or [variable object](#variable-object) | gets the true or false game option for the provided string.
 
 ---
 

--- a/src/condition.cpp
+++ b/src/condition.cpp
@@ -1734,14 +1734,6 @@ conditional_t::func f_get_condition( const JsonObject &jo, std::string_view memb
     };
 }
 
-conditional_t::func f_get_option( const JsonObject &jo, std::string_view member )
-{
-    str_or_var optionToGet = get_str_or_var( jo.get_member( member ), member, true );
-    return [optionToGet]( dialogue & d ) {
-        return get_option<bool>( optionToGet.evaluate( d ) );
-    };
-}
-
 conditional_t::func f_compare_num( const JsonObject &jo, const std::string_view member )
 {
     JsonArray objects = jo.get_array( member );
@@ -3370,7 +3362,6 @@ parsers = {
     {"math", jarg::member, &conditional_fun::f_math },
     {"compare_string", jarg::member, &conditional_fun::f_compare_string },
     {"get_condition", jarg::member, &conditional_fun::f_get_condition },
-    {"get_game_option", jarg::member, &conditional_fun::f_get_option },
 };
 
 // When updating this, please also update `dynamic_line_string_keys` in

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -81,7 +81,7 @@ std::function<double( dialogue & )> option_eval( char /* scope */,
         std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
 {
     return[option = params[0]]( dialogue const & d ) {
-        return get_option<float>( option.str( d ) );
+        return get_option<float>( option.str( d ), true );
     };
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -770,9 +770,29 @@ std::string options_manager::cOpt::getValue( bool classis_locale ) const
     return "";
 }
 
-template<>
-std::string options_manager::cOpt::value_as<std::string>() const
+template<typename T>
+std::optional<T> options_manager::cOpt::_convert() const
 {
+    if constexpr( std::is_same_v<T, std::string> ) {
+        return getValue( true );
+    } else {
+        if( eType == CVT_BOOL ) {
+            return static_cast<T>( bSet );
+        } else if( eType == CVT_FLOAT ) {
+            return static_cast<T>( fSet );
+        } else if( eType == CVT_INT ) {
+            return static_cast<T>( iSet );
+        }
+    }
+    return std::nullopt;
+}
+
+template<>
+std::string options_manager::cOpt::value_as<std::string>( bool convert ) const
+{
+    if( std::optional<std::string> ret = _convert<std::string>(); convert && ret ) {
+        return *ret;
+    }
     if( eType != CVT_STRING ) {
         debugmsg( "%s tried to get string value from option of type %s", sName, sType );
     }
@@ -780,8 +800,11 @@ std::string options_manager::cOpt::value_as<std::string>() const
 }
 
 template<>
-bool options_manager::cOpt::value_as<bool>() const
+bool options_manager::cOpt::value_as<bool>( bool convert ) const
 {
+    if( std::optional<bool> ret = _convert<bool>(); convert && ret ) {
+        return *ret;
+    }
     if( eType != CVT_BOOL ) {
         debugmsg( "%s tried to get boolean value from option of type %s", sName, sType );
     }
@@ -789,8 +812,11 @@ bool options_manager::cOpt::value_as<bool>() const
 }
 
 template<>
-float options_manager::cOpt::value_as<float>() const
+float options_manager::cOpt::value_as<float>( bool convert ) const
 {
+    if( std::optional<float> ret = _convert<float>(); convert && ret ) {
+        return *ret;
+    }
     if( eType != CVT_FLOAT ) {
         debugmsg( "%s tried to get float value from option of type %s", sName, sType );
     }
@@ -798,8 +824,11 @@ float options_manager::cOpt::value_as<float>() const
 }
 
 template<>
-int options_manager::cOpt::value_as<int>() const
+int options_manager::cOpt::value_as<int>( bool convert ) const
 {
+    if( std::optional<int> ret = _convert<int>(); convert && ret ) {
+        return *ret;
+    }
     if( eType != CVT_INT ) {
         debugmsg( "%s tried to get integer value from option of type %s", sName, sType );
     }

--- a/src/options.h
+++ b/src/options.h
@@ -120,7 +120,7 @@ class options_manager
                 void setValue( int iSetIn );
 
                 template<typename T>
-                T value_as() const;
+                T value_as( bool convert = false ) const;
 
                 bool operator==( const cOpt &rhs ) const;
                 bool operator!=( const cOpt &rhs ) const {
@@ -191,6 +191,9 @@ class options_manager
                 float fMax = 0.0f;
                 float fDefault = 0.0f;
                 float fStep = 0.0f;
+
+                template<typename T>
+                std::optional<T> _convert() const;
         };
 
         using options_container = std::unordered_map<std::string, cOpt>;
@@ -492,9 +495,9 @@ inline bool has_option( const std::string &name )
 }
 
 template<typename T>
-inline T get_option( const std::string &name )
+inline T get_option( const std::string &name, bool convert = false )
 {
-    return get_options().get_option( name ).value_as<T>();
+    return get_options().get_option( name ).value_as<T>( convert );
 }
 
 #endif // CATA_SRC_OPTIONS_H


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
`get_option<type>()` must match the option's internal type. That works fine for code, but not so much for EOCs, specifically `math`'s `game_option()` or the old EOC function `get_game_option`

See https://github.com/CleverRaven/Cataclysm-DDA/pull/70996#issuecomment-1899825377 where it first came up

#### Describe the solution

Allow optional conversion between types.
Use it for `math`'s `game_option()`.
Delete `get_game_option`

#### Describe alternatives you've considered
A broader rework/modernization of options: does not sound very interesting.

#### Testing
Minimal test in updated unit.

#### Additional context
N/A