### PR TITLE
Add gendered_line to dialogues

### DIFF
--- a/data/json/npcs/Backgrounds/OtherSurvivorStories/NC_Farmer_background.json
+++ b/data/json/npcs/Backgrounds/OtherSurvivorStories/NC_Farmer_background.json
@@ -2,7 +2,10 @@
   {
     "id": "BOSS_NC_FARMER_Story1",
     "type": "talk_topic",
-    "dynamic_line": "Actually, I ran into another survivor once - survivalist, total nutcase.  He was headed for a military bunker to try and loot it, guessing that didn't go well.  Anyway, he mentioned a pack of survivors who camped out at a farm around here, some of them actually knew about farming.  There's a chance they're still out there, could be worth looking for.",
+    "dynamic_line": {
+      "gendered_line": "Actually, I ran into another survivor once - survivalist, total nutcase.  He was headed for a military bunker to try and loot it, guessing that didn't go well.  Anyway, he mentioned a pack of survivors who camped out at a farm around here, some of them actually knew about farming.  There's a chance they're still out there, could be worth looking for.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "Let's see how to get there and go check on them.",

--- a/data/json/npcs/Backgrounds/OtherSurvivorStories/NC_SURVIVOR_CHEF_background.json
+++ b/data/json/npcs/Backgrounds/OtherSurvivorStories/NC_SURVIVOR_CHEF_background.json
@@ -2,7 +2,10 @@
   {
     "id": "BOSS_NC_SURVIVOR_CHEF_Story1",
     "type": "talk_topic",
-    "dynamic_line": "I found a cell phone a while ago and it started ringing.  I picked it up and just listened.  It was this cook, and they just kept talking on and on about some restaurant and all the good food there and asking to be rescued.  Maybe they were just dialing random numbers?  I don't know.  But they might still be out there, and I wouldn't mind a good meal.",
+    "dynamic_line": {
+      "gendered_line": "I found a cell phone a while ago and it started ringing.  I picked it up and just listened.  It was this cook, and they just kept talking on and on about some restaurant and all the good food there and asking to be rescued.  Maybe they were just dialing random numbers?  I don't know.  But they might still be out there, and I wouldn't mind a good meal.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "Let's see how to get there and go check on them.",

--- a/data/json/npcs/Backgrounds/OtherSurvivorStories/No_Others_01.json
+++ b/data/json/npcs/Backgrounds/OtherSurvivorStories/No_Others_01.json
@@ -2,7 +2,10 @@
   {
     "id": "BOSS_No_Others_01_Story1",
     "type": "talk_topic",
-    "dynamic_line": "Sorry, but until I met you, I thought I might be the only one left.",
+    "dynamic_line": {
+      "gendered_line": "Sorry, but until I met you, I thought I might be the only one left.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Oh well.  Let's hope we find others.", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/bg_pizzaiolo.json
+++ b/data/json/npcs/Backgrounds/bg_pizzaiolo.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_pizzaiolo_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I was just a regular pizzaiolo.  My father was a pizzaiolo, my grandfather was a pizzaiolo and I also became a pizzaiolo.  I was making pizza my whole life, until some american <name_b>s ruined my business!  I couldn't do anything about this, but now, with <the_cataclysm> and <zombies> around, I have a chance to get my revenge!  And I got my revenge, thanks to a special someone.",
+    "dynamic_line": {
+      "gendered_line": "I was just a regular pizzaiolo.  My father was a pizzaiolo, my grandfather was a pizzaiolo and I also became a pizzaiolo.  I was making pizza my whole life, until some american <name_b>s ruined my business!  I couldn't do anything about this, but now, with <the_cataclysm> and <zombies> around, I have a chance to get my revenge!  And I got my revenge, thanks to a special someone.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "He-he, that was a fun ride, <name_g>.", "topic": "BGSS_pizzaiolo_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND" },
@@ -12,7 +15,10 @@
   {
     "id": "BGSS_pizzaiolo_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Are you kidding?  That was the best!  When I imagine the face of that arrogant cook… mmm, sweet, sweet picture.  Oh, and how we beat up that <dumb> <swear> food-<name_b>, I dreamed about it for so long… and my restaurant, we beat the shit out of those <name_b>s.  Too bad it was trashed as hell… anyway, let's hit the dirt.",
+    "dynamic_line": {
+      "gendered_line": "Are you kidding?  That was the best!  When I imagine the face of that arrogant cook… mmm, sweet, sweet picture.  Oh, and how we beat up that <dumb> <swear> food-<name_b>, I dreamed about it for so long… and my restaurant, we beat the shit out of those <name_b>s.  Too bad it was trashed as hell… anyway, let's hit the dirt.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "<done_conversation_section>", "topic": "TALK_FRIEND" }, { "text": "<end_talking>", "topic": "TALK_DONE" } ]
   }
 ]

--- a/data/json/npcs/Backgrounds/burger_flipper_1.json
+++ b/data/json/npcs/Backgrounds/burger_flipper_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_BURGER_FLIPPER_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Before this started, I had a crappy job flipping burgers at Sambal's Grille.  Losing that isn't a big deal.  Losing my mom and dad hurts a lot more.  Last time I saw them alive, I just came home from school, grabbed a snack and went to work.  I don't think I even told my mom I loved her, and I was pissed at my dad for some <dumb> shit that really doesn't matter.  Didn't matter then, really doesn't now.  Things started going crazy while I was at work… the military rolled into town, and the evacuation alert sounded.",
+    "dynamic_line": {
+      "gendered_line": "Before this started, I had a crappy job flipping burgers at Sambal's Grille.  Losing that isn't a big deal.  Losing my mom and dad hurts a lot more.  Last time I saw them alive, I just came home from school, grabbed a snack and went to work.  I don't think I even told my mom I loved her, and I was pissed at my dad for some <dumb> shit that really doesn't matter.  Didn't matter then, really doesn't now.  Things started going crazy while I was at work… the military rolled into town, and the evacuation alert sounded.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "So, did you evacuate?", "topic": "BGSS_BURGER_FLIPPER_1_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -12,7 +15,10 @@
   {
     "id": "BGSS_BURGER_FLIPPER_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "I didn't evacuate.  I went home… saw some freaky shit on the way, but at the time I just thought it was riots or drugs.  By the time I got there, my parents were gone.  No sign of them.  There was a big mess, stuff scattered everywhere like there'd been a struggle, and a little blood on the floor.",
+    "dynamic_line": {
+      "gendered_line": "I didn't evacuate.  I went home… saw some freaky shit on the way, but at the time I just thought it was riots or drugs.  By the time I got there, my parents were gone.  No sign of them.  There was a big mess, stuff scattered everywhere like there'd been a struggle, and a little blood on the floor.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "So, did you evacuate then?", "topic": "BGSS_BURGER_FLIPPER_1_STORY3" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -22,7 +28,10 @@
   {
     "id": "BGSS_BURGER_FLIPPER_1_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "I haven't found them yet.  Whenever I see a <zombie>, a little part of me is afraid it's going to be one of them.  But then, maybe not.  Maybe they were evacuated, maybe they fought and tried to wait for me but the military took them anyway?  I've heard that sort of thing happened.  I don't know if I'll ever know.",
+    "dynamic_line": {
+      "gendered_line": "I haven't found them yet.  Whenever I see a <zombie>, a little part of me is afraid it's going to be one of them.  But then, maybe not.  Maybe they were evacuated, maybe they fought and tried to wait for me but the military took them anyway?  I've heard that sort of thing happened.  I don't know if I'll ever know.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/codger.json
+++ b/data/json/npcs/Backgrounds/codger.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_CODGER_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Well now, that's a hell of a story, so settle in.  It all goes back to about five years ago, after I retired from my job at the mill.  Times was tough, but we got by.",
+    "dynamic_line": {
+      "gendered_line": "Well now, that's a hell of a story, so settle in.  It all goes back to about five years ago, after I retired from my job at the mill.  Times was tough, but we got by.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Okay, please continue.", "topic": "BGSS_CODGER_STORY2" },
       { "text": "On second thought, let's talk about something else.", "topic": "BGSS_CODGER_STORY2" }
@@ -71,7 +74,10 @@
   {
     "id": "BGSS_CODGER_STORY6",
     "type": "talk_topic",
-    "dynamic_line": "Anyway, long story short, I were headin' back up to Mount Greenwood to check on th'old ranger station again when I heard them bombs fallin and choppers flyin.  Decided to camp out there to see it all through, but it didn't ever end, now, did it?  So here I am.",
+    "dynamic_line": {
+      "gendered_line": "Anyway, long story short, I were headin' back up to Mount Greenwood to check on th'old ranger station again when I heard them bombs fallin and choppers flyin.  Decided to camp out there to see it all through, but it didn't ever end, now, did it?  So here I am.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Thanks for the story!", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "…", "topic": "TALK_FRIEND_CONVERSATION" },

--- a/data/json/npcs/Backgrounds/cop_1.json
+++ b/data/json/npcs/Backgrounds/cop_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_COP_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I was a cop.  Small town sheriff.  We got orders without even really knowing what they meant.  At some point one of the g-men on the phone told me it was a Chinese attack, something in the water supply… I don't know if I believe it now, but at the time it was the best explanation.  At first it was weird, a few people - <zombies> - fighting like rabid animals.  Then it got worse.  I tried to control things, but it was just me and my deputies against a town in riot.  Then things really got fucked up.",
+    "dynamic_line": {
+      "gendered_line": "I was a cop.  Small town sheriff.  We got orders without even really knowing what they meant.  At some point one of the g-men on the phone told me it was a Chinese attack, something in the water supply… I don't know if I believe it now, but at the time it was the best explanation.  At first it was weird, a few people - <zombies> - fighting like rabid animals.  Then it got worse.  I tried to control things, but it was just me and my deputies against a town in riot.  Then things really got fucked up.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What happened?", "topic": "BGSS_COP_1_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -12,7 +15,10 @@
   {
     "id": "BGSS_COP_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "A big-ass hole opened up right in the middle of town, and a <monster> crawled out, right in front of the church.  We unloaded into it, but bullets just bounced off.  Got some civilians in the crossfire.  It started just devouring people like potato chips into a gullet that looked like a rotting asshole with teeth, and… well, I lost my nerve.  I ran.  I think I might have been the only person to escape.  I haven't been able to even look at my badge since then.",
+    "dynamic_line": {
+      "gendered_line": "A big-ass hole opened up right in the middle of town, and a <monster> crawled out, right in front of the church.  We unloaded into it, but bullets just bounced off.  Got some civilians in the crossfire.  It started just devouring people like potato chips into a gullet that looked like a rotting asshole with teeth, and… well, I lost my nerve.  I ran.  I think I might have been the only person to escape.  I haven't been able to even look at my badge since then.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/cop_2.json
+++ b/data/json/npcs/Backgrounds/cop_2.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_COP_2_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I was SWAT.  By all rights I should be dead.  We were called to control \"riots\", which we all know were the first <zombie> hordes.  Fat lot of good we were.  Pretty sure we killed more civilians.  Even among my crew, morale was piss poor and we were shooting wild.  Then something hit us, something big.  Might have been a bomb, I really don't remember.  I woke up pinned underneath the SWAT van.  I couldn't see anything… but I could hear it, <swear!>.  I could hear everything.  I spent hours, maybe days under that van, not even trying to get out.",
+    "dynamic_line": {
+      "gendered_line": "I was SWAT.  By all rights I should be dead.  We were called to control \"riots\", which we all know were the first <zombie> hordes.  Fat lot of good we were.  Pretty sure we killed more civilians.  Even among my crew, morale was piss poor and we were shooting wild.  Then something hit us, something big.  Might have been a bomb, I really don't remember.  I woke up pinned underneath the SWAT van.  I couldn't see anything… but I could hear it, <swear!>.  I could hear everything.  I spent hours, maybe days under that van, not even trying to get out.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "But you did get out.", "topic": "BGSS_COP_2_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" }
@@ -11,7 +14,10 @@
   {
     "id": "BGSS_COP_2_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Eventually yes.  It had been quiet for hours.  I was parched, injured, and terrified.  My training was maybe the only thing that kept me from freaking out.  I decided to try to pull myself out and see how bad my injuries were.  It was <very> easy.  The side of the van was torn open, and it turned out I was basically just lying under a little debris, with the ruins of the van tented around me.  I wasn't even too badly hurt.  I grabbed as much gear as I could, and I slipped out.  It was night.  I could hear fighting farther away in the city, so I went the other way.  I made it a few blocks before I ran into any <zombies>… I ran from them.  I ran, and I ran, and I ran some more.  And here I am.",
+    "dynamic_line": {
+      "gendered_line": "Eventually yes.  It had been quiet for hours.  I was parched, injured, and terrified.  My training was maybe the only thing that kept me from freaking out.  I decided to try to pull myself out and see how bad my injuries were.  It was <very> easy.  The side of the van was torn open, and it turned out I was basically just lying under a little debris, with the ruins of the van tented around me.  I wasn't even too badly hurt.  I grabbed as much gear as I could, and I slipped out.  It was night.  I could hear fighting farther away in the city, so I went the other way.  I made it a few blocks before I ran into any <zombies>… I ran from them.  I ran, and I ran, and I ran some more.  And here I am.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/cop_3.json
+++ b/data/json/npcs/Backgrounds/cop_3.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_COP_3_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Before <the_cataclysm>, I was a cop.  I got shot just a couple days before everything went down… I made a bad call in a drug bust and a scumbag got me right in the gut, it was barely stopped by my vest.  I took some pretty bad internal bruising.  I never thought getting shot would save my life, but I was off duty recuperating when the worst of it hit.",
+    "dynamic_line": {
+      "gendered_line": "Before <the_cataclysm>, I was a cop.  I got shot just a couple days before everything went down… I made a bad call in a drug bust and a scumbag got me right in the gut, it was barely stopped by my vest.  I took some pretty bad internal bruising.  I never thought getting shot would save my life, but I was off duty recuperating when the worst of it hit.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "What did you do when you found out about the Cataclysm?",
@@ -28,7 +31,10 @@
   {
     "id": "BGSS_COP_3_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "At first I wanted to help.  The riots, fighting in the streets, it was too much for me to just sit in my house and hear about it on the news.  Then a buddy of mine called me from just off the front lines.  He'd been hurt and he wasn't making much sense, but what he told me… well, you can imagine the kind of stuff he told me.  Everything the worst of the internet was making up, and more.  Instead of packing up to try to volunteer back onto active duty, I took his advice and packed up to leave.  My house was on the edge of town and the riots hadn't reached it yet, but from what I'd heard it was smarter to get out than to hold tight.  I slipped out that night, took my quad out, and camped a few days in the woods, waiting for it to blow over.  It never did.",
+    "dynamic_line": {
+      "gendered_line": "At first I wanted to help.  The riots, fighting in the streets, it was too much for me to just sit in my house and hear about it on the news.  Then a buddy of mine called me from just off the front lines.  He'd been hurt and he wasn't making much sense, but what he told me… well, you can imagine the kind of stuff he told me.  Everything the worst of the internet was making up, and more.  Instead of packing up to try to volunteer back onto active duty, I took his advice and packed up to leave.  My house was on the edge of town and the riots hadn't reached it yet, but from what I'd heard it was smarter to get out than to hold tight.  I slipped out that night, took my quad out, and camped a few days in the woods, waiting for it to blow over.  It never did.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "What was it like, surviving out there with an injury?",
@@ -42,7 +48,10 @@
   {
     "id": "BGSS_COP_3_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "Honestly, probably better than it sounds.  I had a good bug-out bag, a nice tent, a lot of good stuff.  I hadn't suffered any internal organ damage, my stomach muscles were just really badly bruised, and I'd already had some good time to recover.  I think it kept me from doing anything too stupid, and believe me there was a high chance of that.  For a long time I had these Rambo visions of rushing into town and saving everyone, but I was still too immobile.  By the time I had my strength back, it wasn't an option… we were well into the rushing into town for supplies phase.  The closest I got to saving any old friends was putting down the monsters wearing their faces.",
+    "dynamic_line": {
+      "gendered_line": "Honestly, probably better than it sounds.  I had a good bug-out bag, a nice tent, a lot of good stuff.  I hadn't suffered any internal organ damage, my stomach muscles were just really badly bruised, and I'd already had some good time to recover.  I think it kept me from doing anything too stupid, and believe me there was a high chance of that.  For a long time I had these Rambo visions of rushing into town and saving everyone, but I was still too immobile.  By the time I had my strength back, it wasn't an option… we were well into the rushing into town for supplies phase.  The closest I got to saving any old friends was putting down the monsters wearing their faces.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/criminal_1.json
+++ b/data/json/npcs/Backgrounds/criminal_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_CRIMINAL_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I was just sittin' in lockup.  They took me in the night before, for a bullshit parole violation.  Assholes.  I was stuck in my cell when the cops all started yelling about an emergency, geared up, and left me in there havin' a <swear> staring contest with a security cam that probably wasn't even on.  I was stuck in there for two god-damn days, with no food and only a little water.  Then this big-ass zombie busted in.  I didn't know what the fuck to think, but if my cam wasn't working, the one in the hall sure was.  Tripped a motion sensor or some shit, alarm started going, and the big dumb fuck turned around to get at it while its arms were still stuck in the cell bars.  Ripped the whole door out.",
+    "dynamic_line": {
+      "gendered_line": "I was just sittin' in lockup.  They took me in the night before, for a bullshit parole violation.  Assholes.  I was stuck in my cell when the cops all started yelling about an emergency, geared up, and left me in there havin' a <swear> staring contest with a security cam that probably wasn't even on.  I was stuck in there for two god-damn days, with no food and only a little water.  Then this big-ass zombie busted in.  I didn't know what the fuck to think, but if my cam wasn't working, the one in the hall sure was.  Tripped a motion sensor or some shit, alarm started going, and the big dumb fuck turned around to get at it while its arms were still stuck in the cell bars.  Ripped the whole door out.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Lucky you.  How did you get away?", "topic": "BGSS_CRIMINAL_1_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -23,7 +26,10 @@
   {
     "id": "BGSS_CRIMINAL_1_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "'cuz I know how cops think.  If you can call it that.  Early days, they were still going after alarms in case it meant, I dunno, survivors.  You smack some fucker's sports car, it starts wailing, the cops come to take a look and you can walk right behind 'em.  That's the thing about cops; they follow orders, right?  Even when the world's comin' apart.  I kept my head down until I got past the worst of it, but then, lucky me, I got sergeant brainiac.  Figured out why someone would trip an alarm on purpose, had them case all up and down the streets for me.  I wound up on the edge of town layin' low under an abandoned RV for a few hours.  By then… well, they had some other big problems to deal with.  For a little bit.  Might've survived if they hadn't blown their wads chasing me around the block.",
+    "dynamic_line": {
+      "gendered_line": "'cuz I know how cops think.  If you can call it that.  Early days, they were still going after alarms in case it meant, I dunno, survivors.  You smack some fucker's sports car, it starts wailing, the cops come to take a look and you can walk right behind 'em.  That's the thing about cops; they follow orders, right?  Even when the world's comin' apart.  I kept my head down until I got past the worst of it, but then, lucky me, I got sergeant brainiac.  Figured out why someone would trip an alarm on purpose, had them case all up and down the streets for me.  I wound up on the edge of town layin' low under an abandoned RV for a few hours.  By then… well, they had some other big problems to deal with.  For a little bit.  Might've survived if they hadn't blown their wads chasing me around the block.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What were you in for in the first place?", "topic": "BGSS_CRIMINAL_1_PAROLE" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -33,7 +39,10 @@
   {
     "id": "BGSS_CRIMINAL_1_PAROLE",
     "type": "talk_topic",
-    "dynamic_line": "Bullshit, that's what.  The assholes busted me on possession, wasn't even my fuckin' stash.  I don't do crack, man, that shit's nasty, I was just carryin' it for my buddy Johnny.  Y'know, this might be a <swear> hellhole now, but if I've seen the last power-trippin' asshole cop, it might all be worth it.",
+    "dynamic_line": {
+      "gendered_line": "Bullshit, that's what.  The assholes busted me on possession, wasn't even my fuckin' stash.  I don't do crack, man, that shit's nasty, I was just carryin' it for my buddy Johnny.  Y'know, this might be a <swear> hellhole now, but if I've seen the last power-trippin' asshole cop, it might all be worth it.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What were you saying before?", "topic": "TALK_NONE" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },

--- a/data/json/npcs/Backgrounds/criminal_2.json
+++ b/data/json/npcs/Backgrounds/criminal_2.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_CRIMINAL_2_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I was <very> lucky for <the_cataclysm>.  I was squatting in a warehouse out on the edge of town.  I was in a real <shitty> place, and my crew had mostly just been arrested in a big drug bust, but I had skipped out.  I was scared they were gonna think I ratted 'em out and come get me, but hey, no worries about that now.",
+    "dynamic_line": {
+      "gendered_line": "I was <very> lucky for <the_cataclysm>.  I was squatting in a warehouse out on the edge of town.  I was in a real <shitty> place, and my crew had mostly just been arrested in a big drug bust, but I had skipped out.  I was scared they were gonna think I ratted 'em out and come get me, but hey, no worries about that now.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Woah, lucky for you.  How did you find out about <the_cataclysm>?", "topic": "BGSS_CRIMINAL_2_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_NONE" },
@@ -12,7 +15,10 @@
   {
     "id": "BGSS_CRIMINAL_2_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "I was just in a warehouse, not in Zambonia.  I had the internet.  Watched those crazy videos on YouTube in real time, scared the shit out of me.  I had it pretty good though, I'd lifted a bunch of canned food and shit, and I had a pretty sweet little squat in that warehouse.  I'd been planning on spending a long time there after all, while I figured out how to get in good with my crew.",
+    "dynamic_line": {
+      "gendered_line": "I was just in a warehouse, not in Zambonia.  I had the internet.  Watched those crazy videos on YouTube in real time, scared the shit out of me.  I had it pretty good though, I'd lifted a bunch of canned food and shit, and I had a pretty sweet little squat in that warehouse.  I'd been planning on spending a long time there after all, while I figured out how to get in good with my crew.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Something must have driven you out of there.", "topic": "BGSS_CRIMINAL_2_STORY3" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -22,7 +28,10 @@
   {
     "id": "BGSS_CRIMINAL_2_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "Yeah.  <zombies>.  A bunch of them, led by this big creepy-ass jet-black bastard with glowing red eyes, I shit you not.  I dunno what brought them way out my way but they saw me takin' a piss outside and that was that.  I took a few shots at them but that creepy-ass motherfucker waves his hands and brings 'em back up, so I ran.  Once I got my shit together again I realized it wasn't so bad, I was running out of stuff anyway.  Been livin' on what I can loot ever since, until I fell in with you.",
+    "dynamic_line": {
+      "gendered_line": "Yeah.  <zombies>.  A bunch of them, led by this big creepy-ass jet-black bastard with glowing red eyes, I shit you not.  I dunno what brought them way out my way but they saw me takin' a piss outside and that was that.  I took a few shots at them but that creepy-ass motherfucker waves his hands and brings 'em back up, so I ran.  Once I got my shit together again I realized it wasn't so bad, I was running out of stuff anyway.  Been livin' on what I can loot ever since, until I fell in with you.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Got any tips about the boss zombie?", "topic": "BGSS_CRIMINAL_2_NECROMANCER" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -32,7 +41,10 @@
   {
     "id": "BGSS_CRIMINAL_2_NECROMANCER",
     "type": "talk_topic",
-    "dynamic_line": "Well, I mean, if he's surrounded by buddies like that and he can just bring 'em back, I think he's a scary bastard.  If I got him on his own I think maybe I could have taken him.  Also when I was running I managed to get a zombie on its own, and I smashed it to shit with a stick before the rest showed up.  He tried to raise that one and it didn't get back up.",
+    "dynamic_line": {
+      "gendered_line": "Well, I mean, if he's surrounded by buddies like that and he can just bring 'em back, I think he's a scary bastard.  If I got him on his own I think maybe I could have taken him.  Also when I was running I managed to get a zombie on its own, and I smashed it to shit with a stick before the rest showed up.  He tried to raise that one and it didn't get back up.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/dreamer.json
+++ b/data/json/npcs/Backgrounds/dreamer.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_DREAMER_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "OK, this is gonna sound crazy but I, like, I knew this was going to happen.  Like, before it did.  You can even ask my psychic except, like, I think she's dead now.  I told her about my dreams a week before the world ended.  Serious!",
+    "dynamic_line": {
+      "gendered_line": "OK, this is gonna sound crazy but I, like, I knew this was going to happen.  Like, before it did.  You can even ask my psychic except, like, I think she's dead now.  I told her about my dreams a week before the world ended.  Serious!",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What were your dreams?", "topic": "BGSS_DREAMER_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_NONE" },
@@ -53,7 +56,10 @@
   {
     "id": "BGSS_DREAMER_STORY5",
     "type": "talk_topic",
-    "dynamic_line": "OK, so, sometimes I dream that I am a zombie.  I just don't realize it.  And I just act normal to myself and I see zombies as normal people and normal people as zombies.  When I wake up I know it's fake though because if it were real, there would be way more normal people.  Because they'd actually be zombies.  And everyone is a zombie now.",
+    "dynamic_line": {
+      "gendered_line": "OK, so, sometimes I dream that I am a zombie.  I just don't realize it.  And I just act normal to myself and I see zombies as normal people and normal people as zombies.  When I wake up I know it's fake though because if it were real, there would be way more normal people.  Because they'd actually be zombies.  And everyone is a zombie now.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "I think we all have dreams like that now.", "topic": "BGSS_DREAMER_STORY6" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -72,7 +78,10 @@
   {
     "id": "CWH_DREAMER_IDEAS1",
     "type": "talk_topic",
-    "dynamic_line": "So, like, there were some really bad riots, okay?  Everyone got really violent and nasty, and to be honest, I was on a bit of a spirit journey for a lot of it and I don't really remember too well.  But the weirdest part is, nobody even *cared* about each other.  It's like all our caring got sucked away.  I think it was some kind of negative energy thing.  And also that made the dead, like, come back to life and stuff.  Plus, like, there were some monsters?  I'm not really sure how they fit in.",
+    "dynamic_line": {
+      "gendered_line": "So, like, there were some really bad riots, okay?  Everyone got really violent and nasty, and to be honest, I was on a bit of a spirit journey for a lot of it and I don't really remember too well.  But the weirdest part is, nobody even *cared* about each other.  It's like all our caring got sucked away.  I think it was some kind of negative energy thing.  And also that made the dead, like, come back to life and stuff.  Plus, like, there were some monsters?  I'm not really sure how they fit in.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "You seem to know a lot, what do you think caused it all?", "topic": "CWH_DREAMER_IDEAS2" },
       { "text": "<done_conversation_section>", "topic": "TALK_NONE" },

--- a/data/json/npcs/Backgrounds/evacuee_1.json
+++ b/data/json/npcs/Backgrounds/evacuee_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_EVACUEE_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I made it to one of those <swear> evac shelters, but it was almost worse than what I left behind.  Escaped from there, been on the run since.",
+    "dynamic_line": {
+      "gendered_line": "I made it to one of those <swear> evac shelters, but it was almost worse than what I left behind.  Escaped from there, been on the run since.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "How did you survive on the run?",
@@ -28,7 +31,10 @@
   {
     "id": "BGSS_EVACUEE_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "I spent a lot of time rummaging for rhubarb and bits of vegetables in the forest before I found the courage to start picking off some of those dead monsters.  I guess I was getting desperate.",
+    "dynamic_line": {
+      "gendered_line": "I spent a lot of time rummaging for rhubarb and bits of vegetables in the forest before I found the courage to start picking off some of those dead monsters.  I guess I was getting desperate.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "And that's it?  You spent months just living off the land?",
@@ -42,7 +48,10 @@
   {
     "id": "BGSS_EVACUEE_1_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "Not exactly.  After a while, I got brave.  I started venturing towards the outskirts of town, picking off zombies here and there.  I learned about traveling in at night to avoid all but those <swear> shadow-zombies, and that got me pretty far.  Eventually I cleared out a cozy little nook for myself and started really feeling comfortable.  I guess I got a bit complacent.",
+    "dynamic_line": {
+      "gendered_line": "Not exactly.  After a while, I got brave.  I started venturing towards the outskirts of town, picking off zombies here and there.  I learned about traveling in at night to avoid all but those <swear> shadow-zombies, and that got me pretty far.  Eventually I cleared out a cozy little nook for myself and started really feeling comfortable.  I guess I got a bit complacent.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Complacent?", "topic": "BGSS_EVACUEE_1_STORY4" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -52,7 +61,10 @@
   {
     "id": "BGSS_EVACUEE_1_STORY4",
     "type": "talk_topic",
-    "dynamic_line": "I thought I had those damned <zombies> figured out.  I got braver, started heading out by day more and more.  One of those screamer zombies spotted me and called in a horde, with a giant <swear> beastie at the head of it, the size of a volkswagen and all covered in bone plates.  I know when I'm outclassed.  The big guy was held back by his own horde of buddies, and I managed to book it back to my place.  I closed the windows, locked it down, but it was too late.  The giant followed me and just started hammering right through the walls.  I grabbed what I could and made for the horizon.  Last I saw of my squat, it was collapsing on the bastard.  For all I know, it died in the crash, but I am not going back to find out.",
+    "dynamic_line": {
+      "gendered_line": "I thought I had those damned <zombies> figured out.  I got braver, started heading out by day more and more.  One of those screamer zombies spotted me and called in a horde, with a giant <swear> beastie at the head of it, the size of a volkswagen and all covered in bone plates.  I know when I'm outclassed.  The big guy was held back by his own horde of buddies, and I managed to book it back to my place.  I closed the windows, locked it down, but it was too late.  The giant followed me and just started hammering right through the walls.  I grabbed what I could and made for the horizon.  Last I saw of my squat, it was collapsing on the bastard.  For all I know, it died in the crash, but I am not going back to find out.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }
@@ -61,7 +73,10 @@
   {
     "id": "CWH_EVACUEE_1_IDEAS1",
     "type": "talk_topic",
-    "dynamic_line": "What happened?  I'm not really sure.  You must know about the riots and all that, that the government and the police totally failed to contain.  I don't have a good guess what caused that.  I thought it was the usual stuff at first, and I gotta admit, I was sort of excited and scared it was the start of a revolution.  Not excited enough to join in though, and I guess anyone who was is probably dead now.  I tried to wait it out at home, packed a little bug-out bag, but then the internet started showing videos of rioters getting back up and fighting with crazy injuries.  I don't know how many people really believed it at first, but I took that as my sign and ditched town for the evac shelter.  I don't know exactly what happened after that.  The center I was in was heavily vandalized and empty, and I never saw anyone else.  The cell phone grid was locked up, except for one emergency message that came through around a day later saying the government had fallen.  Power went out a few days later.",
+    "dynamic_line": {
+      "gendered_line": "What happened?  I'm not really sure.  You must know about the riots and all that, that the government and the police totally failed to contain.  I don't have a good guess what caused that.  I thought it was the usual stuff at first, and I gotta admit, I was sort of excited and scared it was the start of a revolution.  Not excited enough to join in though, and I guess anyone who was is probably dead now.  I tried to wait it out at home, packed a little bug-out bag, but then the internet started showing videos of rioters getting back up and fighting with crazy injuries.  I don't know how many people really believed it at first, but I took that as my sign and ditched town for the evac shelter.  I don't know exactly what happened after that.  The center I was in was heavily vandalized and empty, and I never saw anyone else.  The cell phone grid was locked up, except for one emergency message that came through around a day later saying the government had fallen.  Power went out a few days later.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/evacuee_2.json
+++ b/data/json/npcs/Backgrounds/evacuee_2.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_EVACUEE_2_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Same as most people who didn't get killed straight up during the riots.  I went to one of those <dumb> <swear> evacuation death traps.  I actually lived there for a while with three others.  One guy who I guess had watched a lot of movies kinda ran the show, because he seemed to really know what was going on.  Spoiler alert: he <swear> didn't.",
+    "dynamic_line": {
+      "gendered_line": "Same as most people who didn't get killed straight up during the riots.  I went to one of those <dumb> <swear> evacuation death traps.  I actually lived there for a while with three others.  One guy who I guess had watched a lot of movies kinda ran the show, because he seemed to really know what was going on.  Spoiler alert: he <swear> didn't.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "What happened to your original crew?",
@@ -18,7 +21,10 @@
   {
     "id": "BGSS_EVACUEE_2_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Things went south when our fearless leader decided we had to put down one of the other survivors that had been bitten.  Her husband felt a bit strongly against that, and I wasn't too keen on it either; by this point, he'd already been wrong about a lot.  Well, he took matters into his own hands and killed her.  Then her husband decided one good turn deserves another, and killed the idiot.  And then she got back up and I killed her again, and pulped our former leader.  Unfortunately she'd given her husband a hell of a nip during the struggle, when he couldn't get his shit together enough to fight back.  Not that I fucking blame him.  We made it out of there together, but it was too much for him, he clearly wasn't in it anymore… the bite got infected, but it was another <zombie> that finally killed him.  And then I was alone.",
+    "dynamic_line": {
+      "gendered_line": "Things went south when our fearless leader decided we had to put down one of the other survivors that had been bitten.  Her husband felt a bit strongly against that, and I wasn't too keen on it either; by this point, he'd already been wrong about a lot.  Well, he took matters into his own hands and killed her.  Then her husband decided one good turn deserves another, and killed the idiot.  And then she got back up and I killed her again, and pulped our former leader.  Unfortunately she'd given her husband a hell of a nip during the struggle, when he couldn't get his shit together enough to fight back.  Not that I fucking blame him.  We made it out of there together, but it was too much for him, he clearly wasn't in it anymore… the bite got infected, but it was another <zombie> that finally killed him.  And then I was alone.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }
@@ -37,7 +43,10 @@
   {
     "id": "CWH_EVACUEE_2_IDEAS1",
     "type": "talk_topic",
-    "dynamic_line": "Well, I assume you know about the riots and the military and police and the freakin' nightmare monsters walking the earth beside zombies, right?  If you're asking what I think caused it all, well, I dunno.  My best guess it was some huge government overreach, maybe some kind of experimental bioweapon that got away.  They tried to lie so much at the start about everything that was going on, I don't think the whole 'Chinese attack' shit measures up.  They were trying to cover something up.  As for the real end times, maybe the rest of the world tried to contain it.  I heard there were honest-to-god nukes going off here on American soil.  To me that seems like somewhere else, maybe Europe, trying to get whatever is going on here contained.  Maybe it even worked.  It's bad now but it's not like it was.",
+    "dynamic_line": {
+      "gendered_line": "Well, I assume you know about the riots and the military and police and the freakin' nightmare monsters walking the earth beside zombies, right?  If you're asking what I think caused it all, well, I dunno.  My best guess it was some huge government overreach, maybe some kind of experimental bioweapon that got away.  They tried to lie so much at the start about everything that was going on, I don't think the whole 'Chinese attack' shit measures up.  They were trying to cover something up.  As for the real end times, maybe the rest of the world tried to contain it.  I heard there were honest-to-god nukes going off here on American soil.  To me that seems like somewhere else, maybe Europe, trying to get whatever is going on here contained.  Maybe it even worked.  It's bad now but it's not like it was.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "<done_conversation_section>", "topic": "TALK_NONE" }, { "text": "<end_talking>", "topic": "TALK_DONE" } ]
   }
 ]

--- a/data/json/npcs/Backgrounds/evacuee_3.json
+++ b/data/json/npcs/Backgrounds/evacuee_3.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_EVACUEE_3_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "There's nothing too special about me, I'm not sure why I survived.  I got evacuated with a handful of others, but we were too late to make the second trip to a FEMA center.  We got attacked by the dead… I was the only one to make it out.  I never looked back.",
+    "dynamic_line": {
+      "gendered_line": "There's nothing too special about me, I'm not sure why I survived.  I got evacuated with a handful of others, but we were too late to make the second trip to a FEMA center.  We got attacked by the dead… I was the only one to make it out.  I never looked back.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "How did you survive after that?",
@@ -28,7 +31,10 @@
   {
     "id": "BGSS_EVACUEE_3_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Sheer luck I guess.  I went the absolute wrong way, into town, and wound up stuck in the subway system.  I spent a few days living off vending machine food.  Not the best eating, but I pulled through.  At least there weren't so many zombies down there.",
+    "dynamic_line": {
+      "gendered_line": "Sheer luck I guess.  I went the absolute wrong way, into town, and wound up stuck in the subway system.  I spent a few days living off vending machine food.  Not the best eating, but I pulled through.  At least there weren't so many zombies down there.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "What got you out of the subway?",
@@ -47,7 +53,10 @@
   {
     "id": "BGSS_EVACUEE_3_STORY3_EARLY",
     "type": "talk_topic",
-    "dynamic_line": "Straight up hunger.  I didn't have any great light source down there, and I didn't have much food.  I was slipping up and down to the station to buy from the vending machines, but once I ran out of cash I had to make a break for it.  I waited until dark and then skipped out.",
+    "dynamic_line": {
+      "gendered_line": "Straight up hunger.  I didn't have any great light source down there, and I didn't have much food.  I was slipping up and down to the station to buy from the vending machines, but once I ran out of cash I had to make a break for it.  I waited until dark and then skipped out.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }
@@ -56,7 +65,10 @@
   {
     "id": "BGSS_EVACUEE_3_STORY3_LATE",
     "type": "talk_topic",
-    "dynamic_line": "Straight up hunger.  I didn't have any great light source down there, and I didn't have much food.  I was slipping up and down to the station to buy from the vending machines, but once I ran out of cash I had to think of something else.  I started raiding the surrounding area by night, and built a decent little base under there.",
+    "dynamic_line": {
+      "gendered_line": "Straight up hunger.  I didn't have any great light source down there, and I didn't have much food.  I was slipping up and down to the station to buy from the vending machines, but once I ran out of cash I had to think of something else.  I started raiding the surrounding area by night, and built a decent little base under there.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "I didn't meet you in the subway though.  You left.", "topic": "BGSS_EVACUEE_3_STORY4" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -66,7 +78,10 @@
   {
     "id": "BGSS_EVACUEE_3_STORY4",
     "type": "talk_topic",
-    "dynamic_line": "Yeah.  I had it pretty good there, but eventually I just started going a bit nuts.  Always dark, a bit cold, living off scavenged junk food… a soul can only live like that for so long.  When the weather above ground got warmer and the daylight hours got longer I decided to get a bit braver.  I'd learned enough about the <zombies> that I was able to live pretty well after that.  I've camped a few places, scavenged berries and whatnot, lived a pretty good life compared to those first few months.",
+    "dynamic_line": {
+      "gendered_line": "Yeah.  I had it pretty good there, but eventually I just started going a bit nuts.  Always dark, a bit cold, living off scavenged junk food… a soul can only live like that for so long.  When the weather above ground got warmer and the daylight hours got longer I decided to get a bit braver.  I'd learned enough about the <zombies> that I was able to live pretty well after that.  I've camped a few places, scavenged berries and whatnot, lived a pretty good life compared to those first few months.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }
@@ -75,7 +90,10 @@
   {
     "id": "CWH_EVACUEE_3_IDEAS1",
     "type": "talk_topic",
-    "dynamic_line": "Woah, <name_g>, I don't even know where to start.  The riots?  I think it was going on sooner than that.  There were bad murmurs going on a few weeks before that happened.  Lots of really scary crimes, not your usual stuff but like cannibalism and some real unspeakable shit, you know?  When the riots started, I think I was already primed to think of it as something different from a normal equality riot or anything like that.  I think that's part of how I got out safer, I had had some time to get some stuff and get going, and didn't try to make shopping trips.  People were abso-fuckin-lutely crazy in those days.  It was a lot like the pandemic a few years back, except the police were out in the streets in force, gunning people down like it was going out of style.",
+    "dynamic_line": {
+      "gendered_line": "Woah, <name_g>, I don't even know where to start.  The riots?  I think it was going on sooner than that.  There were bad murmurs going on a few weeks before that happened.  Lots of really scary crimes, not your usual stuff but like cannibalism and some real unspeakable shit, you know?  When the riots started, I think I was already primed to think of it as something different from a normal equality riot or anything like that.  I think that's part of how I got out safer, I had had some time to get some stuff and get going, and didn't try to make shopping trips.  People were abso-fuckin-lutely crazy in those days.  It was a lot like the pandemic a few years back, except the police were out in the streets in force, gunning people down like it was going out of style.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Do you have any idea what the actual cause was?", "topic": "CWH_EVACUEE_3_IDEAS2" },
       { "text": "<done_conversation_section>", "topic": "TALK_NONE" },

--- a/data/json/npcs/Backgrounds/evacuee_4.json
+++ b/data/json/npcs/Backgrounds/evacuee_4.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_EVACUEE_4_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "They were shipping me with a bunch of evacuees over to a refugee center, when the bus got smashed in by the biggest zombie you ever saw.  It was busy with the other passengers, so I did what anyone would do and fucked right out of there.",
+    "dynamic_line": {
+      "gendered_line": "They were shipping me with a bunch of evacuees over to a refugee center, when the bus got smashed in by the biggest zombie you ever saw.  It was busy with the other passengers, so I did what anyone would do and fucked right out of there.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Don't leave me hanging, what happened next?", "topic": "BGSS_EVACUEE_4_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_NONE" },
@@ -12,7 +15,10 @@
   {
     "id": "BGSS_EVACUEE_4_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "I ran until I felt like my lungs were going to jump right out of my mouth.  I holed up in the forest for the night, under a fir tree.  In the morning I heard someone talking, so I went to see.  I was playing it pretty careful though, there were still a lot of psychos and rioters around.  I snuck up on some kind of thing, some monster worse than any zombie.  Some huge bug thing, saying random phrases like some kind of broken tape recorder.  It was dragging a few human bodies behind it, I couldn't tell if they were dead or unconscious.  Honestly I didn't wait to find out, I ducked into the bushes and tried not to breath until I couldn't hear it anymore.",
+    "dynamic_line": {
+      "gendered_line": "I ran until I felt like my lungs were going to jump right out of my mouth.  I holed up in the forest for the night, under a fir tree.  In the morning I heard someone talking, so I went to see.  I was playing it pretty careful though, there were still a lot of psychos and rioters around.  I snuck up on some kind of thing, some monster worse than any zombie.  Some huge bug thing, saying random phrases like some kind of broken tape recorder.  It was dragging a few human bodies behind it, I couldn't tell if they were dead or unconscious.  Honestly I didn't wait to find out, I ducked into the bushes and tried not to breath until I couldn't hear it anymore.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Where did you go from there?", "topic": "BGSS_EVACUEE_4_STORY3" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -22,7 +28,10 @@
   {
     "id": "BGSS_EVACUEE_4_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "Once I was okay leaving the bushes, I made my way to an old shed I could see a ways off.  It was falling in but it kept the rain and wind off and gave me a place out of sight.  I stayed there until I ran out of those ass-tasting ration bars I'd filled my backpack with.  Then I took on the wanderin' life until we met.",
+    "dynamic_line": {
+      "gendered_line": "Once I was okay leaving the bushes, I made my way to an old shed I could see a ways off.  It was falling in but it kept the rain and wind off and gave me a place out of sight.  I stayed there until I ran out of those ass-tasting ration bars I'd filled my backpack with.  Then I took on the wanderin' life until we met.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/evacuee_5.json
+++ b/data/json/npcs/Backgrounds/evacuee_5.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_EVACUEE_5_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "My evac shelter got swarmed by some of those bees, the ones the size of dogs.  I took out a few with a plank, but pretty quick I realized it was either head for the hills or get stuck like a pig.  The rest is history.",
+    "dynamic_line": {
+      "gendered_line": "My evac shelter got swarmed by some of those bees, the ones the size of dogs.  I took out a few with a plank, but pretty quick I realized it was either head for the hills or get stuck like a pig.  The rest is history.",
+      "relevant_genders": [ "npc" ]
+    },
     "//": "TK: In a future iteration, this evacuee might give you directions to a hive.",
     "responses": [
       { "text": "Giant bees?  Tell me more.", "topic": "BGSS_EVACUEE_5_BEES" },
@@ -18,7 +21,10 @@
   {
     "id": "BGSS_EVACUEE_5_BEES",
     "type": "talk_topic",
-    "dynamic_line": "Yeah, I'm sure you've seen them, they're everywhere.  Like something out of an old sci-fi movie.  Some of the others in the evac shelter got stung, it was no joke.  I didn't stick around to see what the lasting effect was though.  I'm not ashamed to admit I ran like a <swear> chicken.",
+    "dynamic_line": {
+      "gendered_line": "Yeah, I'm sure you've seen them, they're everywhere.  Like something out of an old sci-fi movie.  Some of the others in the evac shelter got stung, it was no joke.  I didn't stick around to see what the lasting effect was though.  I'm not ashamed to admit I ran like a <swear> chicken.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "But bees aren't usually aggressive… do you mean wasps?",

--- a/data/json/npcs/Backgrounds/evacuee_6.json
+++ b/data/json/npcs/Backgrounds/evacuee_6.json
@@ -2,13 +2,19 @@
   {
     "id": "BGSS_EVACUEE_6_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Well, I was at home when the cell phone alert went off and told me to get to an evac shelter.  So I went to an evac shelter.  And then the shelter got too crowded, and people were waiting to get taken to the refugee center, but the buses never came.  You must already know about all that.  It turned into panic, and then fighting.  I didn't stick around to see what happened next; I headed into the woods with what tools I could snatch from the lockers.  I went back a few days later, but the place was totally abandoned.  No idea what happened to all those people.",
+    "dynamic_line": {
+      "gendered_line": "Well, I was at home when the cell phone alert went off and told me to get to an evac shelter.  So I went to an evac shelter.  And then the shelter got too crowded, and people were waiting to get taken to the refugee center, but the buses never came.  You must already know about all that.  It turned into panic, and then fighting.  I didn't stick around to see what happened next; I headed into the woods with what tools I could snatch from the lockers.  I went back a few days later, but the place was totally abandoned.  No idea what happened to all those people.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "<done_conversation_section>", "topic": "TALK_NONE" }, { "text": "<end_talking>", "topic": "TALK_DONE" } ]
   },
   {
     "id": "CWH_EVACUEE_6_IDEAS1",
     "type": "talk_topic",
-    "dynamic_line": "I gotta be honest with you, I heard a lot of stories back at the shelter, and only one of them really stuck.  This is some kind of science experiment gone wrong.  I don't know what caused the riots and the undead in the first place, but there's no way it's this out of control everywhere.  Yeah, I got the same 'the government has fallen' text as everyone, but it doesn't make *sense* that it could be so widespread so fast.  I think we're in some sort of exclusion zone, where they're letting whatever is going on run its course to see how it works so they can fight it better next time.  Somewhere out there, outside the zone, it's more or less business as usual.",
+    "dynamic_line": {
+      "gendered_line": "I gotta be honest with you, I heard a lot of stories back at the shelter, and only one of them really stuck.  This is some kind of science experiment gone wrong.  I don't know what caused the riots and the undead in the first place, but there's no way it's this out of control everywhere.  Yeah, I got the same 'the government has fallen' text as everyone, but it doesn't make *sense* that it could be so widespread so fast.  I think we're in some sort of exclusion zone, where they're letting whatever is going on run its course to see how it works so they can fight it better next time.  Somewhere out there, outside the zone, it's more or less business as usual.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "<done_conversation_section>", "topic": "TALK_NONE" }, { "text": "<end_talking>", "topic": "TALK_DONE" } ]
   }
 ]

--- a/data/json/npcs/Backgrounds/fema_evacuee_1.json
+++ b/data/json/npcs/Backgrounds/fema_evacuee_1.json
@@ -52,7 +52,10 @@
   {
     "id": "BGSS_FEMA_EVACUEE_1_ESCAPE1",
     "type": "talk_topic",
-    "dynamic_line": "That place was chaos.  I only stayed a few hours.  They had a big backhoe running, digging a huge pit in a cordoned section they wouldn't let us near.  Well, I managed to sneak over that way, and saw them dumping load after load of the dead in the pit, pouring dirt back over them even as they revived and tried to climb out.  Even with all the shit I've seen since, it haunts me.  I knew then I had to get out.  Luckily for me, we were attacked the next morning by some giant horror, a kind I haven't really seen since then.  While the guards were busy with that, I grabbed some supplies I'd stocked up over the night and I fucked right out of there.  A few others tried to fuck out with me, but as far as I know I was the only lucky one.",
+    "dynamic_line": {
+      "gendered_line": "That place was chaos.  I only stayed a few hours.  They had a big backhoe running, digging a huge pit in a cordoned section they wouldn't let us near.  Well, I managed to sneak over that way, and saw them dumping load after load of the dead in the pit, pouring dirt back over them even as they revived and tried to climb out.  Even with all the shit I've seen since, it haunts me.  I knew then I had to get out.  Luckily for me, we were attacked the next morning by some giant horror, a kind I haven't really seen since then.  While the guards were busy with that, I grabbed some supplies I'd stocked up over the night and I fucked right out of there.  A few others tried to fuck out with me, but as far as I know I was the only lucky one.",
+      "relevant_genders": [ "npc" ]
+    },
     "//": "TK: In a future version this character will give you directions to the FEMA camp.",
     "responses": [
       { "text": "Tell me more about that FEMA camp.", "topic": "BGSS_FEMA_EVACUEE_1_STORY2" },
@@ -85,7 +88,10 @@
   {
     "id": "CWH_FEMA_EVACUEE_1_IDEAS1",
     "type": "talk_topic",
-    "dynamic_line": "Woof, you ready for a real hot take?  The <swear> government did this to us.  Intentionally, or at least sort-of intentionally.",
+    "dynamic_line": {
+      "gendered_line": "Woof, you ready for a real hot take?  The <swear> government did this to us.  Intentionally, or at least sort-of intentionally.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "Oh?", "topic": "CWH_FEMA_EVACUEE_1_IDEAS2" },
       { "text": "<done_conversation_section>", "topic": "TALK_NONE" },

--- a/data/json/npcs/Backgrounds/grad_student_1.json
+++ b/data/json/npcs/Backgrounds/grad_student_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_GRAD_STUDENT_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I'm not from around here… You can probably tell from the accent, I'm from the UK.  I was here doing my PhD at Dartmouth.  I was halfway to MIT for a conference when <the_cataclysm> stopped me.  I was staying at a flea-ridden little motel on the side of the road.  When I got up for whatever was going to pass for breakfast, the fat bloody proprietor was sitting at his desk, wearing the same grubby clothes from the night before.  I thought he had just slept there, but when he looked at me… well, you know what those Zed-eyes look like.  He lunged, and I reacted without thinking.  Smacked him on the head with my tablet, again and again, until he stopped coming for me.  I never thought I had anything like that in me.",
+    "dynamic_line": {
+      "gendered_line": "I'm not from around here… You can probably tell from the accent, I'm from the UK.  I was here doing my PhD at Dartmouth.  I was halfway to MIT for a conference when <the_cataclysm> stopped me.  I was staying at a flea-ridden little motel on the side of the road.  When I got up for whatever was going to pass for breakfast, the fat bloody proprietor was sitting at his desk, wearing the same grubby clothes from the night before.  I thought he had just slept there, but when he looked at me… well, you know what those Zed-eyes look like.  He lunged, and I reacted without thinking.  Smacked him on the head with my tablet, again and again, until he stopped coming for me.  I never thought I had anything like that in me.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What did you do next?", "topic": "BGSS_GRAD_STUDENT_1_STORY2" },
       { "text": "What were you studying?", "topic": "BGSS_GRAD_STUDENT_1_FIELD" },
@@ -13,7 +16,10 @@
   {
     "id": "BGSS_GRAD_STUDENT_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "I wandered for a little while around the grounds, letting the adrenaline fade, hoping for some kind of idea what to do.  I was out in the middle of nowhere, and I didn't know the area at all.  I wasn't certain if I should head back to Hanover, and try to get my belongings, or stay out where I was.  Finally, I decided to rest a while until I knew what was going on.  The internet told me most of what I needed; I'm sure you saw Twitter in those days.  Even if I'd thought it wise to go back all the way to New Hampshire, I was far too scared.",
+    "dynamic_line": {
+      "gendered_line": "I wandered for a little while around the grounds, letting the adrenaline fade, hoping for some kind of idea what to do.  I was out in the middle of nowhere, and I didn't know the area at all.  I wasn't certain if I should head back to Hanover, and try to get my belongings, or stay out where I was.  Finally, I decided to rest a while until I knew what was going on.  The internet told me most of what I needed; I'm sure you saw Twitter in those days.  Even if I'd thought it wise to go back all the way to New Hampshire, I was far too scared.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Something must have driven you out of the motel.", "topic": "BGSS_GRAD_STUDENT_1_STORY3" },
       { "text": "What were you studying?", "topic": "BGSS_GRAD_STUDENT_1_FIELD" },
@@ -24,7 +30,10 @@
   {
     "id": "BGSS_GRAD_STUDENT_1_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "Yes.  Simple hunger.  The vending machines sold only peanuts and biscuits.  I wasn't about to rely on that for survival.  I stayed long enough to realize no one was going to come for me, then packed up what I could and drove off.  Eventually my car was caught in a downpour of acid rain that stripped the tires and left me to carry on on foot, living the life of a hunter gatherer.  Honestly, I think I eat better this way than I did as a grad student.",
+    "dynamic_line": {
+      "gendered_line": "Yes.  Simple hunger.  The vending machines sold only peanuts and biscuits.  I wasn't about to rely on that for survival.  I stayed long enough to realize no one was going to come for me, then packed up what I could and drove off.  Eventually my car was caught in a downpour of acid rain that stripped the tires and left me to carry on on foot, living the life of a hunter gatherer.  Honestly, I think I eat better this way than I did as a grad student.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What were you studying?", "topic": "BGSS_GRAD_STUDENT_1_FIELD" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -34,7 +43,10 @@
   {
     "id": "BGSS_GRAD_STUDENT_1_FIELD",
     "type": "talk_topic",
-    "dynamic_line": "I was in biochemistry.  Specifically, if you're interested, I was studying the folding of non-standard nucleic acids into enzyme-like structures.  It sounds more interesting than it was; most of my time was spent cursing at computer screens and wishing we had more information on threose chains at unusual temperatures and pressures for modeling.",
+    "dynamic_line": {
+      "gendered_line": "I was in biochemistry.  Specifically, if you're interested, I was studying the folding of non-standard nucleic acids into enzyme-like structures.  It sounds more interesting than it was; most of my time was spent cursing at computer screens and wishing we had more information on threose chains at unusual temperatures and pressures for modeling.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What were you saying before?", "topic": "TALK_NONE" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },

--- a/data/json/npcs/Backgrounds/gung_ho_1.json
+++ b/data/json/npcs/Backgrounds/gung_ho_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_GUNG_HO_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Nothin' special before <the_cataclysm>.  When the dead started walking, I geared up and started puttin' them back down.",
+    "dynamic_line": {
+      "gendered_line": "Nothin' special before <the_cataclysm>.  When the dead started walking, I geared up and started puttin' them back down.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "How did that go?", "topic": "BGSS_GUNG_HO_1_STORY2" },
       { "text": "Cool.  <done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -12,7 +15,10 @@
   {
     "id": "BGSS_GUNG_HO_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Almost got killed.  One <zombie> is easy pickins, but ten is a lot, and a hundred is a death trap.  I got myself in too deep, an' barely slipped out with my guts still inside me.  Holed up in an old motel for a while lickin' my wounds and thinkin' about what I wanted to do next.  That's when I figured it out.",
+    "dynamic_line": {
+      "gendered_line": "Almost got killed.  One <zombie> is easy pickins, but ten is a lot, and a hundred is a death trap.  I got myself in too deep, an' barely slipped out with my guts still inside me.  Holed up in an old motel for a while lickin' my wounds and thinkin' about what I wanted to do next.  That's when I figured it out.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Figured what out?", "topic": "BGSS_GUNG_HO_1_STORY3" },
       { "text": "Never mind.  <done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -22,7 +28,10 @@
   {
     "id": "BGSS_GUNG_HO_1_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "This is it.  This is what I was made for.  There in the street, smashin' monster heads and prayin' I'd make it out?  I've never felt like that.  Alive.  Important.  So after I got myself all stuck back together, I nutted up and went back to it.  Probly killed a thousand Z since then, and I'm still not tired of it.",
+    "dynamic_line": {
+      "gendered_line": "This is it.  This is what I was made for.  There in the street, smashin' monster heads and prayin' I'd make it out?  I've never felt like that.  Alive.  Important.  So after I got myself all stuck back together, I nutted up and went back to it.  Probly killed a thousand Z since then, and I'm still not tired of it.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "It's good you found your calling.  <done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "It's good you found your calling.  <end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/gung_ho_2.json
+++ b/data/json/npcs/Backgrounds/gung_ho_2.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_GUNG_HO_2_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Oh, you know.  Blah blah blah, had a job and a life, everyone died.  Boo hoo.  I gotta be straight with you though: I honestly think I like this better.  Fighting for survival every day?  I've never felt so alive.  I've killed hundreds of those bastards.  Sooner or later one of them will take me out, but I'll go down knowing I did something actually important.",
+    "dynamic_line": {
+      "gendered_line": "Oh, you know.  Blah blah blah, had a job and a life, everyone died.  Boo hoo.  I gotta be straight with you though: I honestly think I like this better.  Fighting for survival every day?  I've never felt so alive.  I've killed hundreds of those bastards.  Sooner or later one of them will take me out, but I'll go down knowing I did something actually important.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "It's good you found your calling.  <done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "It's good you found your calling.  <end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/gung_ho_3.json
+++ b/data/json/npcs/Backgrounds/gung_ho_3.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_GUNG_HO_3_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Well y'see, I'm not from these parts at all.  I was driving up from the South to visit my son when it all happened.  I was staying at a motel when a military convoy passed through and told us to evacuate to a FEMA shelter.",
+    "dynamic_line": {
+      "gendered_line": "Well y'see, I'm not from these parts at all.  I was driving up from the South to visit my son when it all happened.  I was staying at a motel when a military convoy passed through and told us to evacuate to a FEMA shelter.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Tell me about your son.", "topic": "BGSS_GUNG_HO_3_SON1" },
       { "text": "So, you went to one of the FEMA camps?", "topic": "BGSS_GUNG_HO_3_FEMA1" },
@@ -13,7 +16,10 @@
   {
     "id": "BGSS_GUNG_HO_3_SON1",
     "type": "talk_topic",
-    "dynamic_line": "He lives up in Northern Canada, way in the middle of nowhere, with his crazy wife and my three grandkids.  He's an environmental engineer for some oil and gas company out there.  She's a bit of a hippy-dippy headcase.  I love em both though, and as far as I'm concerned they all made it out of this fucked up mess safe, out there in the boondocks.  I guess they think I'm dead, so they'll steer clear of this hellhole, and that's the best as could be.",
+    "dynamic_line": {
+      "gendered_line": "He lives up in Northern Canada, way in the middle of nowhere, with his crazy wife and my three grandkids.  He's an environmental engineer for some oil and gas company out there.  She's a bit of a hippy-dippy headcase.  I love em both though, and as far as I'm concerned they all made it out of this fucked up mess safe, out there in the boondocks.  I guess they think I'm dead, so they'll steer clear of this hellhole, and that's the best as could be.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What was it you said before?", "topic": "BGSS_GUNG_HO_3_STORY1" },
       { "text": "So, you went to one of the FEMA camps?", "topic": "BGSS_GUNG_HO_3_FEMA1" },
@@ -24,7 +30,10 @@
   {
     "id": "BGSS_GUNG_HO_3_FEMA1",
     "type": "talk_topic",
-    "dynamic_line": "Lord no.  I'll be fucked if I let a kid in a too-big uniform tell me what the hell to do.  I had my Hummer loaded out and ready to go offroading, I had a ton of gas, and I even had as many rifles as the border was gonna let me bring over.  I didn't know what I was supposed to be running from, but I sure as shit didn't run.",
+    "dynamic_line": {
+      "gendered_line": "Lord no.  I'll be fucked if I let a kid in a too-big uniform tell me what the hell to do.  I had my Hummer loaded out and ready to go offroading, I had a ton of gas, and I even had as many rifles as the border was gonna let me bring over.  I didn't know what I was supposed to be running from, but I sure as shit didn't run.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Where did you go then?", "topic": "BGSS_GUNG_HO_3_STORY2" },
       { "text": "Tell me about your son.", "topic": "BGSS_GUNG_HO_3_SON1" },
@@ -36,7 +45,10 @@
   {
     "id": "BGSS_GUNG_HO_3_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "At first, I just kept going North, but I ran into a huge military blockade.  They even had those giant walking robots like on TV.  I started going up to check it out, and before I knew it they were opening fire!  I coulda died, but I still have pretty good reactions.  I turned tail and rolled out of there.  My Hummer had taken some bad hits though, and I found out the hard way I was leaking gas all down the freeway.  Made it a few miles before I wound up stuck in the ass-end of nowhere.  I settled in to wander.  I guess I'm still kinda heading North, just by a pretty round-about way, you know?",
+    "dynamic_line": {
+      "gendered_line": "At first, I just kept going North, but I ran into a huge military blockade.  They even had those giant walking robots like on TV.  I started going up to check it out, and before I knew it they were opening fire!  I coulda died, but I still have pretty good reactions.  I turned tail and rolled out of there.  My Hummer had taken some bad hits though, and I found out the hard way I was leaking gas all down the freeway.  Made it a few miles before I wound up stuck in the ass-end of nowhere.  I settled in to wander.  I guess I'm still kinda heading North, just by a pretty round-about way, you know?",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Tell me about your son.", "topic": "BGSS_GUNG_HO_3_SON1" },
       { "text": "What was it you said before?", "topic": "BGSS_GUNG_HO_3_STORY1" },
@@ -47,7 +59,10 @@
   {
     "id": "CWH_GUNG_HO_3_IDEAS1",
     "type": "talk_topic",
-    "dynamic_line": "We're all thinking the same thing, aren't we?  Not much this could be but some kind of secret military bullshit.  At first, I thought it was our own government, but after all that went down, it's just too much.  It must've been the Chinese.  I wonder if those sons of bitches are sitting back home, right as rain, watching us struggling down here and waiting for things to die down.",
+    "dynamic_line": {
+      "gendered_line": "We're all thinking the same thing, aren't we?  Not much this could be but some kind of secret military bullshit.  At first, I thought it was our own government, but after all that went down, it's just too much.  It must've been the Chinese.  I wonder if those sons of bitches are sitting back home, right as rain, watching us struggling down here and waiting for things to die down.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "How could that have caused everything that went down?", "topic": "BGSS_GUNG_HO_3_IDEAS2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -57,7 +72,10 @@
   {
     "id": "CWH_GUNG_HO_3_IDEAS2",
     "type": "talk_topic",
-    "dynamic_line": "I dunno, I'm no expert.  You might not remember, but there was that big news a couple years back that supposedly China had some kind of super fusion reactor.  I read a news article, apparently that was all a front for some other kind of secret weapon they were working on.  Made so much energy, there was no way to hide it, so they made it a story about fusion power instead.  That'd explain why we never saw fusion power Stateside, don't you think?  And if they were that much more advanced that they could make fusion power, who knows what else they could make.",
+    "dynamic_line": {
+      "gendered_line": "I dunno, I'm no expert.  You might not remember, but there was that big news a couple years back that supposedly China had some kind of super fusion reactor.  I read a news article, apparently that was all a front for some other kind of secret weapon they were working on.  Made so much energy, there was no way to hide it, so they made it a story about fusion power instead.  That'd explain why we never saw fusion power Stateside, don't you think?  And if they were that much more advanced that they could make fusion power, who knows what else they could make.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Huh.  Interesting stuff.  <done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "Huh.  Interesting stuff.  <end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/high_school_1.json
+++ b/data/json/npcs/Backgrounds/high_school_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_HIGH_SCHOOL_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I was at school.  I'm a senior.  We'd heard about riots… it started with a kid showing videos of one of the big riots in Providence.  You've probably seen it, the one where the woman turns to the camera and you can see her whole lower lip has been ripped off, and is just flapping there?  It got so bad, they went over the PA system to tell us about Chinese drugs in the water supply.  Right… does anyone buy that explanation?",
+    "dynamic_line": {
+      "gendered_line": "I was at school.  I'm a senior.  We'd heard about riots… it started with a kid showing videos of one of the big riots in Providence.  You've probably seen it, the one where the woman turns to the camera and you can see her whole lower lip has been ripped off, and is just flapping there?  It got so bad, they went over the PA system to tell us about Chinese drugs in the water supply.  Right… does anyone buy that explanation?",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Where did things go from there?", "topic": "BGSS_HIGH_SCHOOL_1_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -12,7 +15,10 @@
   {
     "id": "BGSS_HIGH_SCHOOL_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "I guess it got worse, because the faculty decided to put us in lockdown.  For hours.  And then the school buses showed up to evacuate us.  Eventually, they ran out of buses.  I was one of the lucky few who didn't have a bus to get on.  The soldiers weren't much older than me… they didn't look like they knew what was going on.  I lived just a few blocks away.  I snuck off.",
+    "dynamic_line": {
+      "gendered_line": "I guess it got worse, because the faculty decided to put us in lockdown.  For hours.  And then the school buses showed up to evacuate us.  Eventually, they ran out of buses.  I was one of the lucky few who didn't have a bus to get on.  The soldiers weren't much older than me… they didn't look like they knew what was going on.  I lived just a few blocks away.  I snuck off.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Did you get home?", "topic": "BGSS_HIGH_SCHOOL_1_STORY3" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -22,7 +28,10 @@
   {
     "id": "BGSS_HIGH_SCHOOL_1_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "Yeah.  On the way there, I met some <zombies> for real.  They chased me, but I did pretty well in track.  I lost them… but I couldn't get home, there were just too many.  I wound up running more.  Stole a bike and ran more again.  I'm a bit better at killing those things now, but I haven't made it home yet.  I guess I'm afraid of what I'll find.",
+    "dynamic_line": {
+      "gendered_line": "Yeah.  On the way there, I met some <zombies> for real.  They chased me, but I did pretty well in track.  I lost them… but I couldn't get home, there were just too many.  I wound up running more.  Stole a bike and ran more again.  I'm a bit better at killing those things now, but I haven't made it home yet.  I guess I'm afraid of what I'll find.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/hospital_1.json
+++ b/data/json/npcs/Backgrounds/hospital_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_HOSPITAL_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I saw it all pretty early, before it all really started.  I worked at the hospital.  It started with a jump in the number of code whites - that's an aggressive patient.  Wasn't my training so I didn't hear about it until later… but rumors started flying about hyperaggressive delirious patients that coded and seemed to die, then started attacking staff, and wouldn't respond to anything we hit them with.  Then a friend of mine was killed by one of them, and I realized it wasn't just a few weird reports.  I called in sick the next day.",
+    "dynamic_line": {
+      "gendered_line": "I saw it all pretty early, before it all really started.  I worked at the hospital.  It started with a jump in the number of code whites - that's an aggressive patient.  Wasn't my training so I didn't hear about it until later… but rumors started flying about hyperaggressive delirious patients that coded and seemed to die, then started attacking staff, and wouldn't respond to anything we hit them with.  Then a friend of mine was killed by one of them, and I realized it wasn't just a few weird reports.  I called in sick the next day.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What happened on your sick day?", "topic": "BGSS_HOSPITAL_1_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -12,7 +15,10 @@
   {
     "id": "BGSS_HOSPITAL_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Well, <the_cataclysm>.  I lived a fair distance out of town, and I already knew something was seriously wrong, but I hadn't admitted to myself what I was really seeing quite yet.  When I saw the military convoys pouring into the city, I put the pieces together.  At first I thought it was just my hospital.  Still, I packed up my bags, locked the doors and windows, and waited for the evacuation call.",
+    "dynamic_line": {
+      "gendered_line": "Well, <the_cataclysm>.  I lived a fair distance out of town, and I already knew something was seriously wrong, but I hadn't admitted to myself what I was really seeing quite yet.  When I saw the military convoys pouring into the city, I put the pieces together.  At first I thought it was just my hospital.  Still, I packed up my bags, locked the doors and windows, and waited for the evacuation call.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Did you get evacuated?", "topic": "BGSS_HOSPITAL_1_STORY3" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -22,7 +28,10 @@
   {
     "id": "BGSS_HOSPITAL_1_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "No.  The call came too late.  I'd already seen the clouds on the horizon.  Mushroom clouds, and also those insane hell-clouds.  I've heard that horrible things came out of them.  I decided it was safer in my locked up house.",
+    "dynamic_line": {
+      "gendered_line": "No.  The call came too late.  I'd already seen the clouds on the horizon.  Mushroom clouds, and also those insane hell-clouds.  I've heard that horrible things came out of them.  I decided it was safer in my locked up house.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Something must have happened to drive you out?", "topic": "BGSS_HOSPITAL_1_STORY4" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -32,7 +41,10 @@
   {
     "id": "BGSS_HOSPITAL_1_STORY4",
     "type": "talk_topic",
-    "dynamic_line": "The military happened.  They showed up and commandeered my land for some kind of forward base, demanding I evacuate to a FEMA camp.  I didn't even try to argue… I had my dad's old hunting rifle, they had high tech weapons.  I heard one of them joking about the FEMA camp being Auschwitz, though.  I gave their evac driver the slip and decided to make for my sister's place up north.  In theory I guess I'm still going that way, although honestly I'm just busy not dying.",
+    "dynamic_line": {
+      "gendered_line": "The military happened.  They showed up and commandeered my land for some kind of forward base, demanding I evacuate to a FEMA camp.  I didn't even try to argue… I had my dad's old hunting rifle, they had high tech weapons.  I heard one of them joking about the FEMA camp being Auschwitz, though.  I gave their evac driver the slip and decided to make for my sister's place up north.  In theory I guess I'm still going that way, although honestly I'm just busy not dying.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/hospital_2.json
+++ b/data/json/npcs/Backgrounds/hospital_2.json
@@ -7,8 +7,14 @@
       "yes": "I just can't talk about that right now.  I can't.",
       "no": {
         "npc_has_effect": "player_BGSS_SAIDYES",
-        "yes": "I was at work at the hospital, when it all went down.  It's a bit of a blur.  For a while there were weird reports, stuff that sounded unbelievable about patients getting back up after dying, but mostly things were business as usual.  Then, towards the end, stuff just skyrocketed.  We thought it was a Chinese attack, and that's what we were being told.  People coming in crazed, covered in wounds from bullets and bites.  About halfway through my shift I… well, I broke.",
-        "no": "I was at work at the hospital, when it all went down.  It's a bit of a blur.  For a while there were weird reports, stuff that sounded unbelievable about patients getting back up after dying, but mostly things were business as usual.  Then, towards the end, stuff just skyrocketed.  We thought it was a Chinese attack, and that's what we were being told.  People coming in crazed, covered in wounds from bullets and bites.  About halfway through my shift I… well, I broke.  I'd seen such horrible injuries, and then I… <swear!>, I can't even talk about it."
+        "yes": {
+          "gendered_line": "I was at work at the hospital, when it all went down.  It's a bit of a blur.  For a while there were weird reports, stuff that sounded unbelievable about patients getting back up after dying, but mostly things were business as usual.  Then, towards the end, stuff just skyrocketed.  We thought it was a Chinese attack, and that's what we were being told.  People coming in crazed, covered in wounds from bullets and bites.  About halfway through my shift I… well, I broke.",
+          "relevant_genders": [ "npc" ]
+        },
+        "no": {
+          "gendered_line": "I was at work at the hospital, when it all went down.  It's a bit of a blur.  For a while there were weird reports, stuff that sounded unbelievable about patients getting back up after dying, but mostly things were business as usual.  Then, towards the end, stuff just skyrocketed.  We thought it was a Chinese attack, and that's what we were being told.  People coming in crazed, covered in wounds from bullets and bites.  About halfway through my shift I… well, I broke.  I'd seen such horrible injuries, and then I… <swear!>, I can't even talk about it.",
+          "relevant_genders": [ "npc" ]
+        }
       }
     },
     "responses": [
@@ -54,7 +60,10 @@
   {
     "id": "BGSS_HOSPITAL_2_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "A young mother.  I know she was a mother, because I delivered her baby.  Sweet girl, she… she had a good sense of humor.  She came in, spitting that black goo, fighting the orderlies, dead from a bullet wound through the chest.  That's when I… I don't know if I woke up, finally, or if I finally went crazy.  Either way, I broke.  I broke a lot earlier than my colleagues, and that's the only reason I lived.  I skipped out, went to a dead corner of the hospital I used to hide in when I was a resident.  An old stairwell leading to a closed-off unit the maintenance staff were using to store old equipment.  I hid there for hours, while I listened to the world crumbling outside and inside.",
+    "dynamic_line": {
+      "gendered_line": "A young mother.  I know she was a mother, because I delivered her baby.  Sweet girl, she… she had a good sense of humor.  She came in, spitting that black goo, fighting the orderlies, dead from a bullet wound through the chest.  That's when I… I don't know if I woke up, finally, or if I finally went crazy.  Either way, I broke.  I broke a lot earlier than my colleagues, and that's the only reason I lived.  I skipped out, went to a dead corner of the hospital I used to hide in when I was a resident.  An old stairwell leading to a closed-off unit the maintenance staff were using to store old equipment.  I hid there for hours, while I listened to the world crumbling outside and inside.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "How did you get out of there?",
@@ -76,7 +85,10 @@
   {
     "id": "BGSS_HOSPITAL_2_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "Somehow, I don't know how, I managed to fall asleep in there.  I think it might have started with me hyperventilating and passing out.  When I woke up it was night, I was starving and parched, and… and the screaming had died down.  At first I tried to go out the way I came in, but I peaked out the window and saw one of the nurses stumbling around, spitting that black shit up.  Her name was Becky.  She wasn't Becky anymore.  So, I went back up and somehow made it into the storage area.  From there, the roof.  I drank water from some nasty old puddle and I camped out there for a while, watching the city around me burn.",
+    "dynamic_line": {
+      "gendered_line": "Somehow, I don't know how, I managed to fall asleep in there.  I think it might have started with me hyperventilating and passing out.  When I woke up it was night, I was starving and parched, and… and the screaming had died down.  At first I tried to go out the way I came in, but I peaked out the window and saw one of the nurses stumbling around, spitting that black shit up.  Her name was Becky.  She wasn't Becky anymore.  So, I went back up and somehow made it into the storage area.  From there, the roof.  I drank water from some nasty old puddle and I camped out there for a while, watching the city around me burn.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What finally brought you down?", "topic": "BGSS_HOSPITAL_2_STORY4" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -91,8 +103,14 @@
       "type": "mission",
       "context": "BGSS",
       "value": "yes",
-      "no": "Well, I still didn't have any food.  Eventually I had to climb down the side of the building… so I did, as quietly as I could.  It was night, and I have pretty good nightvision.  Apparently the zombies don't, because I was able to slip right past them and steal a bicycle that was just laying on the side of the road.  I'd kind of scouted out my route from above… I'm not from a big city, the hospital was the tallest building around.  I avoided the major military blockades, and headed out of town towards a friend's old cabin.  I had to fight off a couple of the <zombies>, but I managed to avoid any big fuss, by some miracle.  I never made it to the cabin, but that's not important now.",
-      "yes": "Well, I still didn't have any food.  Eventually I had to climb down the side of the building… so I did, as quietly as I could.  It was night, and I have pretty good nightvision.  Apparently the zombies don't, because I was able to slip right past them and steal a bicycle that was just laying on the side of the road.  I'd kind of scouted out my route from above… I'm not from a big city, the hospital was the tallest building around.  I avoided the major military blockades, and headed out of town towards a friend's old cabin.  I had to fight off a couple of the <zombies>, but I managed to avoid any big fuss, by some miracle."
+      "no": {
+        "gendered_line": "Well, I still didn't have any food.  Eventually I had to climb down the side of the building… so I did, as quietly as I could.  It was night, and I have pretty good nightvision.  Apparently the zombies don't, because I was able to slip right past them and steal a bicycle that was just laying on the side of the road.  I'd kind of scouted out my route from above… I'm not from a big city, the hospital was the tallest building around.  I avoided the major military blockades, and headed out of town towards a friend's old cabin.  I had to fight off a couple of the <zombies>, but I managed to avoid any big fuss, by some miracle.  I never made it to the cabin, but that's not important now.",
+        "relevant_genders": [ "npc" ]
+      },
+      "yes": {
+        "gendered_line": "Well, I still didn't have any food.  Eventually I had to climb down the side of the building… so I did, as quietly as I could.  It was night, and I have pretty good nightvision.  Apparently the zombies don't, because I was able to slip right past them and steal a bicycle that was just laying on the side of the road.  I'd kind of scouted out my route from above… I'm not from a big city, the hospital was the tallest building around.  I avoided the major military blockades, and headed out of town towards a friend's old cabin.  I had to fight off a couple of the <zombies>, but I managed to avoid any big fuss, by some miracle.",
+        "relevant_genders": [ "npc" ]
+      }
     },
     "responses": [
       { "text": "What did you see, up there on the roof?", "topic": "BGSS_HOSPITAL_2_ROOF" },
@@ -135,7 +153,10 @@
   {
     "id": "BGSS_HOSPITAL_2_ROOF",
     "type": "talk_topic",
-    "dynamic_line": "My hospital was the tallest building in town, so I saw quite a bit.  The military set up blockades on the roads coming in and out of the town, and there was quite a lightshow going on out there when I started up.  I think it was mostly automated turrets and robots, I didn't hear much shouting.  I saw a few cars and trucks try to run the barricade and get blown to high hell.  There were swarms of <zombies> in the streets, traveling in packs towards sounds and noises.  I watched them rip a few running cars to shreds, including the people inside who were trying to get away.  You know.  The usual stuff.  I was pretty numb by that point.",
+    "dynamic_line": {
+      "gendered_line": "My hospital was the tallest building in town, so I saw quite a bit.  The military set up blockades on the roads coming in and out of the town, and there was quite a lightshow going on out there when I started up.  I think it was mostly automated turrets and robots, I didn't hear much shouting.  I saw a few cars and trucks try to run the barricade and get blown to high hell.  There were swarms of <zombies> in the streets, traveling in packs towards sounds and noises.  I watched them rip a few running cars to shreds, including the people inside who were trying to get away.  You know.  The usual stuff.  I was pretty numb by that point.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "How did you get down?", "topic": "BGSS_HOSPITAL_2_STORY4" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },

--- a/data/json/npcs/Backgrounds/hospital_3.json
+++ b/data/json/npcs/Backgrounds/hospital_3.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_HOSPITAL_3_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I was called in to work at the hospital.  I don't usually work there, I'm a community doctor.  I don't really love emergency medicine at the best of times, and when your patient keeps trying to rip your face off, well, it takes the last bit of fun out of it.  You might think I'm a coward, but I slipped out early on, and I've got no regrets.  There was nothing I could have done except die like everyone else.  I couldn't get out of the building, the military had blockaded us in… so I went to the most secure, quiet damned place in the building.",
+    "dynamic_line": {
+      "gendered_line": "I was called in to work at the hospital.  I don't usually work there, I'm a community doctor.  I don't really love emergency medicine at the best of times, and when your patient keeps trying to rip your face off, well, it takes the last bit of fun out of it.  You might think I'm a coward, but I slipped out early on, and I've got no regrets.  There was nothing I could have done except die like everyone else.  I couldn't get out of the building, the military had blockaded us in… so I went to the most secure, quiet damned place in the building.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Where was that?", "topic": "BGSS_HOSPITAL_3_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" }
@@ -11,7 +14,10 @@
   {
     "id": "BGSS_HOSPITAL_3_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "The morgue.  Seems like a dumb place to go at the start of a zombie apocalypse, right?  Thing is, nobody had made it to the morgue in quite a while, the bodies were reanimating too quickly and the staff were just too busy.  I was shaking and puking and I could see the world was ending… I bundled myself up, grabbed a few snacks from the pathologist's desk, and crawled into one of those drawers to contemplate the end of the world.  After breaking the handle to make sure it couldn't lock behind me, of course.  It was <very> safe and quiet in there.  Not just my cubby, the whole morgue.  At first it was because nobody was <dumb> enough to come down there except me.  Later, it was because nobody was left.",
+    "dynamic_line": {
+      "gendered_line": "The morgue.  Seems like a dumb place to go at the start of a zombie apocalypse, right?  Thing is, nobody had made it to the morgue in quite a while, the bodies were reanimating too quickly and the staff were just too busy.  I was shaking and puking and I could see the world was ending… I bundled myself up, grabbed a few snacks from the pathologist's desk, and crawled into one of those drawers to contemplate the end of the world.  After breaking the handle to make sure it couldn't lock behind me, of course.  It was <very> safe and quiet in there.  Not just my cubby, the whole morgue.  At first it was because nobody was <dumb> enough to come down there except me.  Later, it was because nobody was left.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Clearly you escaped at some point.", "topic": "BGSS_HOSPITAL_3_STORY3" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -21,7 +27,10 @@
   {
     "id": "BGSS_HOSPITAL_3_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "The door was good heavy steel with no window, and there was a staff room with a fully stocked fridge, so when it became clear that nothing was going to get any better on its own, I set up shop.  I stayed down there for a couple days.  I could hear explosions and screaming for the first while, then just guns and explosions, and then it got <really> quiet.  Eventually, I ran out of snacks, so I worked up the nerve to climb out a window and check out the city by night.  I used that place as a base for a little while, but the area around the hospital was too hot to keep it up, so I made my way out to greener pastures.  And here I am.",
+    "dynamic_line": {
+      "gendered_line": "The door was good heavy steel with no window, and there was a staff room with a fully stocked fridge, so when it became clear that nothing was going to get any better on its own, I set up shop.  I stayed down there for a couple days.  I could hear explosions and screaming for the first while, then just guns and explosions, and then it got <really> quiet.  Eventually, I ran out of snacks, so I worked up the nerve to climb out a window and check out the city by night.  I used that place as a base for a little while, but the area around the hospital was too hot to keep it up, so I made my way out to greener pastures.  And here I am.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Thanks for telling me that.  <done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/hunter_1.json
+++ b/data/json/npcs/Backgrounds/hunter_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_HUNTER_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I live way out of town.  I hear the small towns lasted a bit longer than the big cities.  Doesn't matter to me, I was out on my end-of-winter hunting trip, I'd been out of town for a week already.  First clue I had things were going wrong was when I saw a mushroom cloud out near an old abandoned military base, way out in the middle of nowhere.  I didn't think much about that.  Then I was attacked by a demon.",
+    "dynamic_line": {
+      "gendered_line": "I live way out of town.  I hear the small towns lasted a bit longer than the big cities.  Doesn't matter to me, I was out on my end-of-winter hunting trip, I'd been out of town for a week already.  First clue I had things were going wrong was when I saw a mushroom cloud out near an old abandoned military base, way out in the middle of nowhere.  I didn't think much about that.  Then I was attacked by a demon.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "A demon?", "topic": "BGSS_HUNTER_1_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -12,7 +15,10 @@
   {
     "id": "BGSS_HUNTER_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Yeah, it was like a… like a soft shelled crab, with tentacle mouths, and it kept talking in different voices.  I saw it before it saw me, and I capped it with my Remington.  That just pissed it off, but I got another couple shots off while it charged me.  Third or fourth shot took it down.  I figured out shit had hit the fan, somehow.  Headed to my cabin and camped out there for a while, but I had to skip out when a bunch of <zombies> showed up and trashed the place.  I ran into you not much later.",
+    "dynamic_line": {
+      "gendered_line": "Yeah, it was like a… like a soft shelled crab, with tentacle mouths, and it kept talking in different voices.  I saw it before it saw me, and I capped it with my Remington.  That just pissed it off, but I got another couple shots off while it charged me.  Third or fourth shot took it down.  I figured out shit had hit the fan, somehow.  Headed to my cabin and camped out there for a while, but I had to skip out when a bunch of <zombies> showed up and trashed the place.  I ran into you not much later.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" } ]
   }
 ]

--- a/data/json/npcs/Backgrounds/hunter_2.json
+++ b/data/json/npcs/Backgrounds/hunter_2.json
@@ -21,7 +21,10 @@
   {
     "id": "BGSS_HUNTER_2_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "Yeah… the… the accident got him, but when I came to he was already coming back.  Thank god for seatbelts, right?  He was screeching and flapping around, hanging upside down.  I thought he was just hurt at first, but he just kept coming at me while I tried to talk to him.  His arm was badly hurt already and instead of unbuckling himself he started… he was ripping it right off pulling against the seatbelt.  That, and the crazy shit with the chopper, was when I realized just how fucked up things had got.  I grabbed my hunting knife and ran, but my brother got out and started crawling after me.",
+    "dynamic_line": {
+      "gendered_line": "Yeah… the… the accident got him, but when I came to he was already coming back.  Thank god for seatbelts, right?  He was screeching and flapping around, hanging upside down.  I thought he was just hurt at first, but he just kept coming at me while I tried to talk to him.  His arm was badly hurt already and instead of unbuckling himself he started… he was ripping it right off pulling against the seatbelt.  That, and the crazy shit with the chopper, was when I realized just how fucked up things had got.  I grabbed my hunting knife and ran, but my brother got out and started crawling after me.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Did you keep running?", "topic": "BGSS_HUNTER_2_STORY4" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -31,7 +34,10 @@
   {
     "id": "BGSS_HUNTER_2_STORY4",
     "type": "talk_topic",
-    "dynamic_line": "I ran for a little bit, but then I saw soldier zombies crawling out of that chopper.  They had the same look about them as my brother did, and it was them on one side and him on the other.  I'm no genius but I've seen a few movies: I figured out what was happening.  I didn't want to take on Kevlar armor with my knife, so I turned back and faced the other zombie.  I couldn't let my brother stay… like that.  So I did what I had to, and I guess I'll live with that forever.",
+    "dynamic_line": {
+      "gendered_line": "I ran for a little bit, but then I saw soldier zombies crawling out of that chopper.  They had the same look about them as my brother did, and it was them on one side and him on the other.  I'm no genius but I've seen a few movies: I figured out what was happening.  I didn't want to take on Kevlar armor with my knife, so I turned back and faced the other zombie.  I couldn't let my brother stay… like that.  So I did what I had to, and I guess I'll live with that forever.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Thanks for telling me your story.  <done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/lab_1.json
+++ b/data/json/npcs/Backgrounds/lab_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_LAB_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "For me, this started a couple days before <the_cataclysm>.  I'm a biochemist.  I did my postdoc work with a brilliant colleague, Pat Dionne.  I hadn't talked to Pat in ages… word has it, the government got wind of our thesis, found out Pat did most of the heavy lifting, and that was the last we talked for years.  So, I was a bit surprised to see an e-mail from Pat.Dionne@FreeMailNow.co.ru… even more surprised when it was a series of nostalgic references to a D&D game we played years earlier.",
+    "dynamic_line": {
+      "gendered_line": "For me, this started a couple days before <the_cataclysm>.  I'm a biochemist.  I did my postdoc work with a brilliant colleague, Pat Dionne.  I hadn't talked to Pat in ages… word has it, the government got wind of our thesis, found out Pat did most of the heavy lifting, and that was the last we talked for years.  So, I was a bit surprised to see an e-mail from Pat.Dionne@FreeMailNow.co.ru… even more surprised when it was a series of nostalgic references to a D&D game we played years earlier.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "I don't see where this is going.", "topic": "BGSS_LAB_1_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -12,7 +15,10 @@
   {
     "id": "BGSS_LAB_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Well, the references weren't quite right.  Pat referred to things that we'd never played.  The situations were close, but not right, and when I put it all together, it told a story.  A story about a scholar whose kids were being held captive by a corrupt government, forced to research dark magic for them.  And there was a clincher: A warning that the magic had escaped, a warning that all heroes had to leave the kingdom before it fell.",
+    "dynamic_line": {
+      "gendered_line": "Well, the references weren't quite right.  Pat referred to things that we'd never played.  The situations were close, but not right, and when I put it all together, it told a story.  A story about a scholar whose kids were being held captive by a corrupt government, forced to research dark magic for them.  And there was a clincher: A warning that the magic had escaped, a warning that all heroes had to leave the kingdom before it fell.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Okay…", "topic": "BGSS_LAB_1_STORY3" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -22,7 +28,10 @@
   {
     "id": "BGSS_LAB_1_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "Listen, I know it's incredibly cheesy.  That's D&D for you.  Anyway, something about the tone really got to me.  I knew it was important.  I wasted a little time waffling, then decided to use my outstanding vacation time and skip town for a while.  I packed for the end of the world.  Turns out, I packed the right stuff.",
+    "dynamic_line": {
+      "gendered_line": "Listen, I know it's incredibly cheesy.  That's D&D for you.  Anyway, something about the tone really got to me.  I knew it was important.  I wasted a little time waffling, then decided to use my outstanding vacation time and skip town for a while.  I packed for the end of the world.  Turns out, I packed the right stuff.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Was there anything else of use in that email?", "topic": "BGSS_LAB_1_DIONNE1" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -32,7 +41,10 @@
   {
     "id": "BGSS_LAB_1_DIONNE1",
     "type": "talk_topic",
-    "dynamic_line": "There was, yeah, but it was cryptic.  If I had a copy of Pat's notes, I could probably decipher it, but I'm sure those burned up in <the_cataclysm>.  They bombed those labs, you know.",
+    "dynamic_line": {
+      "gendered_line": "There was, yeah, but it was cryptic.  If I had a copy of Pat's notes, I could probably decipher it, but I'm sure those burned up in <the_cataclysm>.  They bombed those labs, you know.",
+      "relevant_genders": [ "npc" ]
+    },
     "//": "TK, give player the option to give this guy a copy of the Dionne report, in return for some special info about XE037… probably gated over time, giving the NPC a few days to read further.",
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },

--- a/data/json/npcs/Backgrounds/left_for_dead_1.json
+++ b/data/json/npcs/Backgrounds/left_for_dead_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_LEFT_FOR_DEAD_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I was late to evacuate when the shit hit the fan.  Got stuck in town for a few days, survived by hiding in basements eating girl scout cookies and drinking warm root beer.  Eventually I managed to weasel my way out without getting caught by the <zombies>.  I spent a few days holed up in an abandoned mall, but I needed food so I headed out to fend for myself in the woods.  I wasn't doing a great job of it, so I'm kinda glad you showed up.",
+    "dynamic_line": {
+      "gendered_line": "I was late to evacuate when the shit hit the fan.  Got stuck in town for a few days, survived by hiding in basements eating girl scout cookies and drinking warm root beer.  Eventually I managed to weasel my way out without getting caught by the <zombies>.  I spent a few days holed up in an abandoned mall, but I needed food so I headed out to fend for myself in the woods.  I wasn't doing a great job of it, so I'm kinda glad you showed up.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "<done_conversation_section>", "topic": "TALK_NONE" }, { "text": "<end_talking>", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/Backgrounds/left_for_dead_2.json
+++ b/data/json/npcs/Backgrounds/left_for_dead_2.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_LEFT_FOR_DEAD_2_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I was home with the flu when the world went to shit, and when I recovered enough to make a run to the store for groceries… well, I've been running ever since.",
+    "dynamic_line": {
+      "gendered_line": "I was home with the flu when the world went to shit, and when I recovered enough to make a run to the store for groceries… well, I've been running ever since.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Come on, don't leave me hanging.", "topic": "BGSS_LEFT_FOR_DEAD_2_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -12,7 +15,10 @@
   {
     "id": "BGSS_LEFT_FOR_DEAD_2_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Okay, well, I was kinda out of it those first few days.  I knew there were storms, but I was having crazy fever dreams and stuff.  Honestly I probably should have gone to the hospital, except then I guess I'd be dead now.  I don't know what was a dream and what was the world ending.  I remember heading to the fridge for a drink and noticing the light was out and the water was warm, I think that was a bit before my fever broke.  I was still pretty groggy when I ran out of chicken soup, so it took me a while to really process how dark and dead my building was when I headed out.",
+    "dynamic_line": {
+      "gendered_line": "Okay, well, I was kinda out of it those first few days.  I knew there were storms, but I was having crazy fever dreams and stuff.  Honestly I probably should have gone to the hospital, except then I guess I'd be dead now.  I don't know what was a dream and what was the world ending.  I remember heading to the fridge for a drink and noticing the light was out and the water was warm, I think that was a bit before my fever broke.  I was still pretty groggy when I ran out of chicken soup, so it took me a while to really process how dark and dead my building was when I headed out.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What happened when you went out?", "topic": "BGSS_LEFT_FOR_DEAD_2_STORY3" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -22,7 +28,10 @@
   {
     "id": "BGSS_LEFT_FOR_DEAD_2_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "You probably remember what the cities were like.  I think it was about day four.  Once I stepped outside I realized what was going on, or realized I didn't know what was going on at least.  I saw a bunch of rioters smashing a car, and then I noticed one of them was bashing a woman's head in.  I canceled my grocery trip, ran back to my apartment before they saw me, and holed up there for as long as I could.  Things got comparatively quiet as the dead started to outnumber the living, so I started looting what I could from my neighbors, re-killing them when I had to.  Eventually the <zombies> overran my building and I had to climb out and head for the hills on an old bike.",
+    "dynamic_line": {
+      "gendered_line": "You probably remember what the cities were like.  I think it was about day four.  Once I stepped outside I realized what was going on, or realized I didn't know what was going on at least.  I saw a bunch of rioters smashing a car, and then I noticed one of them was bashing a woman's head in.  I canceled my grocery trip, ran back to my apartment before they saw me, and holed up there for as long as I could.  Things got comparatively quiet as the dead started to outnumber the living, so I started looting what I could from my neighbors, re-killing them when I had to.  Eventually the <zombies> overran my building and I had to climb out and head for the hills on an old bike.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Thanks for telling me all that.  <done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "Thanks for telling me all that.  <end_talking>", "topic": "TALK_DONE" }
@@ -31,7 +40,10 @@
   {
     "id": "CWH_LEFT_FOR_DEAD_2_IDEAS1",
     "type": "talk_topic",
-    "dynamic_line": "You mean what caused the riots and all that?  Well, they told us it was a Chinese bioweapon but I have troubles believing anyone could engineer a bioweapon that could do all this.  The only answer I can come up with, silly though it sounds, is aliens.",
+    "dynamic_line": {
+      "gendered_line": "You mean what caused the riots and all that?  Well, they told us it was a Chinese bioweapon but I have troubles believing anyone could engineer a bioweapon that could do all this.  The only answer I can come up with, silly though it sounds, is aliens.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "You think this is an invasion?", "topic": "CWH_LEFT_FOR_DEAD_2_IDEAS2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -41,7 +53,10 @@
   {
     "id": "CWH_LEFT_FOR_DEAD_2_IDEAS2",
     "type": "talk_topic",
-    "dynamic_line": "Well, maybe, but I'd guess it's too disorganized to be a proper invasion.  If I had to guess, I'd say there was something locked in the polar ice.  Like, remember a few years back there was that big thing online about an alien body found in the ice?  I don't know if you remember but it was all over the news for a while until it turned out to be a hoax.  Only, since then, I've seen some aliens walking around that look a *lot* like that ice body.  Maybe it wasn't a hoax, maybe that was a cover-up.  So, maybe those aliens had some kind of virus.  It went around the world and infected everything silently until, somehow, it activated and caused the violence and monsters and mutations.",
+    "dynamic_line": {
+      "gendered_line": "Well, maybe, but I'd guess it's too disorganized to be a proper invasion.  If I had to guess, I'd say there was something locked in the polar ice.  Like, remember a few years back there was that big thing online about an alien body found in the ice?  I don't know if you remember but it was all over the news for a while until it turned out to be a hoax.  Only, since then, I've seen some aliens walking around that look a *lot* like that ice body.  Maybe it wasn't a hoax, maybe that was a cover-up.  So, maybe those aliens had some kind of virus.  It went around the world and infected everything silently until, somehow, it activated and caused the violence and monsters and mutations.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "<done_conversation_section>", "topic": "TALK_NONE" }, { "text": "<end_talking>", "topic": "TALK_DONE" } ]
   }
 ]

--- a/data/json/npcs/Backgrounds/left_for_dead_3.json
+++ b/data/json/npcs/Backgrounds/left_for_dead_3.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_LEFT_FOR_DEAD_3_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Let's not dance around it: I joined the riots, at first.  I don't really remember what I was thinking.  I'd protested stuff like police brutality before, but this was different.  I didn't make a sign and go down there expecting to chant and march, I grabbed a bat and went outside planning to fuck shit up.  I've never felt so angry before.  The riots had already been going on a while at that point, and to me, it just looked like the government trying to squash the people again.",
+    "dynamic_line": {
+      "gendered_line": "Let's not dance around it: I joined the riots, at first.  I don't really remember what I was thinking.  I'd protested stuff like police brutality before, but this was different.  I didn't make a sign and go down there expecting to chant and march, I grabbed a bat and went outside planning to fuck shit up.  I've never felt so angry before.  The riots had already been going on a while at that point, and to me, it just looked like the government trying to squash the people again.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Those rioters had a reputation for being absolutely psycho.", "topic": "BGSS_LEFT_FOR_DEAD_3_STORY2" },
       { "text": "Not many people made it out of the riots alive.", "topic": "BGSS_LEFT_FOR_DEAD_3_STORY3" },
@@ -13,7 +16,10 @@
   {
     "id": "BGSS_LEFT_FOR_DEAD_3_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Yeah, you're telling me.  The rioters… they weren't even like humans, let alone protesters.  Nothing like any protest I'd ever been in before.  That didn't stop me.  I joined them, and I was as bad as a bunch of them.  Smashed windows, beat up bystanders, burnt cars.  I remember ripping riot gear off a cop and… nevermind.  I don't want to remember that.",
+    "dynamic_line": {
+      "gendered_line": "Yeah, you're telling me.  The rioters… they weren't even like humans, let alone protesters.  Nothing like any protest I'd ever been in before.  That didn't stop me.  I joined them, and I was as bad as a bunch of them.  Smashed windows, beat up bystanders, burnt cars.  I remember ripping riot gear off a cop and… nevermind.  I don't want to remember that.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "How did you survive?", "topic": "BGSS_LEFT_FOR_DEAD_3_STORY3" },
       { "text": "What made you come back?", "topic": "BGSS_LEFT_FOR_DEAD_3_STORY4" },
@@ -24,7 +30,10 @@
   {
     "id": "BGSS_LEFT_FOR_DEAD_3_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "At some point, I felt like I was waking up.  It was around the time they were busting out those Humvees with riot control turrets on top.  Says something about my frame of mind that I don't even remember if I'd seen them before that point.  Anyway I heard the gunfire going off and just kinda realized I was on the edges of a mob charging a heavily armed military emplacement.  That's when I started seeing the mob for what it was, seeing the wild-eyed animals, even the zombies.  I turned and ran.",
+    "dynamic_line": {
+      "gendered_line": "At some point, I felt like I was waking up.  It was around the time they were busting out those Humvees with riot control turrets on top.  Says something about my frame of mind that I don't even remember if I'd seen them before that point.  Anyway I heard the gunfire going off and just kinda realized I was on the edges of a mob charging a heavily armed military emplacement.  That's when I started seeing the mob for what it was, seeing the wild-eyed animals, even the zombies.  I turned and ran.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What made you come back?", "topic": "BGSS_LEFT_FOR_DEAD_3_STORY4" },
       { "text": "Where did you go from there?", "topic": "BGSS_LEFT_FOR_DEAD_3_STORY5" },
@@ -35,7 +44,10 @@
   {
     "id": "BGSS_LEFT_FOR_DEAD_3_STORY4",
     "type": "talk_topic",
-    "dynamic_line": "I honestly don't know.  I wonder if some of the others would have come back to their senses, given time.  I don't think I'm anything special.  Maybe a lot of them did, and just weren't on the edge of the crowd at the time.  I'll tell you, almost as soon as I came back to myself, I could see some of the rioters looking at me like I was prey.  I didn't stick around to see what would happen.",
+    "dynamic_line": {
+      "gendered_line": "I honestly don't know.  I wonder if some of the others would have come back to their senses, given time.  I don't think I'm anything special.  Maybe a lot of them did, and just weren't on the edge of the crowd at the time.  I'll tell you, almost as soon as I came back to myself, I could see some of the rioters looking at me like I was prey.  I didn't stick around to see what would happen.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Where did you go from there?", "topic": "BGSS_LEFT_FOR_DEAD_3_STORY5" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -45,7 +57,10 @@
   {
     "id": "BGSS_LEFT_FOR_DEAD_3_STORY5",
     "type": "talk_topic",
-    "dynamic_line": "I knew the city pretty well.  I went for an abandoned building I knew about, headed through a broken window, and holed up in there for a few days.  I had a fair bit of stolen food and I just kept to myself.  When things started to quiet down, I headed out, and here I am.",
+    "dynamic_line": {
+      "gendered_line": "I knew the city pretty well.  I went for an abandoned building I knew about, headed through a broken window, and holed up in there for a few days.  I had a fair bit of stolen food and I just kept to myself.  When things started to quiet down, I headed out, and here I am.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Thanks for telling me all that.  <done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "Thanks for telling me all that.  <end_talking>", "topic": "TALK_DONE" }
@@ -54,7 +69,10 @@
   {
     "id": "CWH_LEFT_FOR_DEAD_3_IDEAS1",
     "type": "talk_topic",
-    "dynamic_line": "So, I remember the time leading up to the riots, same as anyone.  Things were bad, there were some really awful crimes being reported in the news, and there was a lot of racial tension as usual from the way the cops were handling it.  Then people started rioting, which isn't unusual, but it was weird the kind of places that the riots were starting in.  Like, upper middle class neighborhoods, midwestern small towns, things like that.  Anyway, I joined the riots and I don't remember a lot of clear stuff after that.",
+    "dynamic_line": {
+      "gendered_line": "So, I remember the time leading up to the riots, same as anyone.  Things were bad, there were some really awful crimes being reported in the news, and there was a lot of racial tension as usual from the way the cops were handling it.  Then people started rioting, which isn't unusual, but it was weird the kind of places that the riots were starting in.  Like, upper middle class neighborhoods, midwestern small towns, things like that.  Anyway, I joined the riots and I don't remember a lot of clear stuff after that.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "You joined the riots?", "topic": "BGSS_LEFT_FOR_DEAD_3_STORY1" },
       {
@@ -68,7 +86,10 @@
   {
     "id": "CWH_LEFT_FOR_DEAD_3_IDEAS2",
     "type": "talk_topic",
-    "dynamic_line": "Kinda, I guess.  I heard people blaming the riots on some kind of mind control drug, and frankly I'm not sure that's far off base.  That's kinda what it felt like, although the whole time I really felt like myself.  It wasn't until I snapped out of it that I realized how weird it was.  That doesn't explain anything else though: the zombies, the monsters, all this stuff is way off base.  Anything I've tried to guess just sounds like bad science fiction, like demonic curses or alien weapons kinda stuff.",
+    "dynamic_line": {
+      "gendered_line": "Kinda, I guess.  I heard people blaming the riots on some kind of mind control drug, and frankly I'm not sure that's far off base.  That's kinda what it felt like, although the whole time I really felt like myself.  It wasn't until I snapped out of it that I realized how weird it was.  That doesn't explain anything else though: the zombies, the monsters, all this stuff is way off base.  Anything I've tried to guess just sounds like bad science fiction, like demonic curses or alien weapons kinda stuff.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "<done_conversation_section>", "topic": "TALK_NONE" }, { "text": "<end_talking>", "topic": "TALK_DONE" } ]
   }
 ]

--- a/data/json/npcs/Backgrounds/lost_partner_1.json
+++ b/data/json/npcs/Backgrounds/lost_partner_1.json
@@ -19,7 +19,10 @@
   {
     "id": "BGSS_LOST_PARTNER_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "That's how it goes, you know?  These are the end times.  I don't really want to talk about it more than that.  And honestly, I never really felt like I belonged, in the old world.  In a weird way, I actually feel like I have a purpose now.  Do you ever get that?",
+    "dynamic_line": {
+      "gendered_line": "That's how it goes, you know?  These are the end times.  I don't really want to talk about it more than that.  And honestly, I never really felt like I belonged, in the old world.  In a weird way, I actually feel like I have a purpose now.  Do you ever get that?",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "No, that's messed up.", "topic": "BGSS_LOST_PARTNER_1_NOWAY" },
       {
@@ -54,7 +57,10 @@
   {
     "id": "BGSS_LOST_PARTNER_1_TRIFFIDS",
     "type": "talk_topic",
-    "dynamic_line": "Yeah, have you seen them yet?  They're these <shitty> walking flowers with a big <swear> stinger in the middle.  They travel in packs.  They hate the zombies, and we were using them for cover to clear a horde of the dead.  Unfortunately, turns out the plants are better trackers than the <zombies>.  They almost seemed intelligent… I barely made it out, only because they were, uh, distracted.",
+    "dynamic_line": {
+      "gendered_line": "Yeah, have you seen them yet?  They're these <shitty> walking flowers with a big <swear> stinger in the middle.  They travel in packs.  They hate the zombies, and we were using them for cover to clear a horde of the dead.  Unfortunately, turns out the plants are better trackers than the <zombies>.  They almost seemed intelligent… I barely made it out, only because they were, uh, distracted.",
+      "relevant_genders": [ "npc" ]
+    },
     "//": "In a future version this NPC might give you directions to a triffid grove.",
     "responses": [
       { "text": "I'm sorry you lost someone.", "topic": "BGSS_LOST_PARTNER_1_STORY2" },

--- a/data/json/npcs/Backgrounds/lost_partner_2.json
+++ b/data/json/npcs/Backgrounds/lost_partner_2.json
@@ -4,10 +4,16 @@
     "type": "talk_topic",
     "dynamic_line": {
       "npc_has_effect": "player_BGSS_SAIDNO",
-      "yes": "I said, I don't wanna talk about it.  How are you not understanding this?",
+      "yes": {
+        "gendered_line": "I said, I don't wanna talk about it.  How are you not understanding this?",
+        "relevant_genders": [ "npc" ]
+      },
       "no": {
         "npc_has_effect": "player_BGSS_SAIDYES",
-        "yes": "Like I said, it's a <shitty> story, but I guess it won't kill me to tell it one more time.",
+        "yes": {
+          "gendered_line": "Like I said, it's a <shitty> story, but I guess it won't kill me to tell it one more time.",
+          "relevant_genders": [ "npc" ]
+        },
         "no": "Just another <shitty> tale of love and loss.  Not one I like to tell."
       }
     },
@@ -109,7 +115,10 @@
   {
     "id": "BGSS_LOST_PARTNER_2_SOMESHIT",
     "type": "talk_topic",
-    "dynamic_line": "Yeah.  I really did.  It took me two days to make it across the city on foot, camping out in dumpsters and places like that.  I started moving more by night, and I learned right away to avoid the military.  They were a magnet for the <zombies>, and they were usually stationed where the monsters were coming.  Some parts of the city were pretty tame at first.  There were a few chunks where people had been evacuated or cleared out, and the <zombies> didn't really go there.  Later on, others like me started moving into those neighborhoods, so I switched and started running through the blasted out downtown.  I had to anyway, to get home.  By the time I made the switch though, the fighting was starting to die off, and I was mostly just avoiding attention from zombies and other things.",
+    "dynamic_line": {
+      "gendered_line": "Yeah.  I really did.  It took me two days to make it across the city on foot, camping out in dumpsters and places like that.  I started moving more by night, and I learned right away to avoid the military.  They were a magnet for the <zombies>, and they were usually stationed where the monsters were coming.  Some parts of the city were pretty tame at first.  There were a few chunks where people had been evacuated or cleared out, and the <zombies> didn't really go there.  Later on, others like me started moving into those neighborhoods, so I switched and started running through the blasted out downtown.  I had to anyway, to get home.  By the time I made the switch though, the fighting was starting to die off, and I was mostly just avoiding attention from zombies and other things.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "I take it home was bad.", "topic": "BGSS_LOST_PARTNER_2_HOME1" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -119,7 +128,10 @@
   {
     "id": "BGSS_LOST_PARTNER_2_HOME1",
     "type": "talk_topic",
-    "dynamic_line": "The first warning was that I had to move from the preserved parts of the city to the burnt out ones to get home.  It only got worse.  There was a police barricade right outside my house, with a totally useless pair of automated turrets sitting in front just idly watching the zombies lurch by.  That was before someone switched them to kill everybody, back when it only killed trespassing humans.  Good times, you can always trust bureaucracy to fuck things up in the most spectacular way possible.  Anyway, the house itself was half collapsed, a SWAT van had plowed into it.  I think I knew what I was going to see in there, but I had made it that far and I wasn't going to turn back.",
+    "dynamic_line": {
+      "gendered_line": "The first warning was that I had to move from the preserved parts of the city to the burnt out ones to get home.  It only got worse.  There was a police barricade right outside my house, with a totally useless pair of automated turrets sitting in front just idly watching the zombies lurch by.  That was before someone switched them to kill everybody, back when it only killed trespassing humans.  Good times, you can always trust bureaucracy to fuck things up in the most spectacular way possible.  Anyway, the house itself was half collapsed, a SWAT van had plowed into it.  I think I knew what I was going to see in there, but I had made it that far and I wasn't going to turn back.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "You must have seen some shit on the way there.", "topic": "BGSS_LOST_PARTNER_2_SOMESHIT" },
       { "text": "Did you make it into the house?", "topic": "BGSS_LOST_PARTNER_2_HOME2" },

--- a/data/json/npcs/Backgrounds/meteorologist.json
+++ b/data/json/npcs/Backgrounds/meteorologist.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_METEOROLOGIST_1",
     "type": "talk_topic",
-    "dynamic_line": "Before <the_cataclysm>, I was just a regular meteorologist.  I worked for the local weather station doing data analysis and stuff.  In general, ordinary boredom.  In my free time I was studying electronics and radio engineering, a bit for work but mostly just as a hobby.  When the riots got serious, my neighborhood was looking pretty sketchy.  I gathered all my things that I managed to carry with me and settled in a radio station that seemed abandoned.  I lived there for a while, doing all sorts of nonsense, until I met you.  I guess you know the rest.",
+    "dynamic_line": {
+      "gendered_line": "Before <the_cataclysm>, I was just a regular meteorologist.  I worked for the local weather station doing data analysis and stuff.  In general, ordinary boredom.  In my free time I was studying electronics and radio engineering, a bit for work but mostly just as a hobby.  When the riots got serious, my neighborhood was looking pretty sketchy.  I gathered all my things that I managed to carry with me and settled in a radio station that seemed abandoned.  I lived there for a while, doing all sorts of nonsense, until I met you.  I guess you know the rest.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/nerd_1.json
+++ b/data/json/npcs/Backgrounds/nerd_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_NERD_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I was at school for <the_cataclysm>.  Funny thing, actually: I was gearing up to run a zombie survival RPG with my friends on the weekend.  Ha, I didn't think it'd turn into a LARP!  Okay….  No, that wasn't funny.",
+    "dynamic_line": {
+      "gendered_line": "I was at school for <the_cataclysm>.  Funny thing, actually: I was gearing up to run a zombie survival RPG with my friends on the weekend.  Ha, I didn't think it'd turn into a LARP!  Okay….  No, that wasn't funny.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "How did you survive school?", "topic": "BGSS_NERD_1_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -12,7 +15,10 @@
   {
     "id": "BGSS_NERD_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Well, I may be a huge <swear> nerd, but I'm not an idiot.  Plus I'm genre savvy.  We'd already heard about people coming back from the dead, actually that's why I was doing the RPG.  When the cops came to put the school on lockdown I managed to slip out the back.  I live a long way out of town, but there was no way I was going to take a bus home, so I walked.  Two hours.  Heard a lot of sirens, and I even saw jets overhead.  It was getting late when I got back, but my mom and dad weren't back from work yet.  I stayed there, hoping they'd come.  I sent texts but got no reply.  After a few days, well… the news got worse and worse, then it stopped completely.",
+    "dynamic_line": {
+      "gendered_line": "Well, I may be a huge <swear> nerd, but I'm not an idiot.  Plus I'm genre savvy.  We'd already heard about people coming back from the dead, actually that's why I was doing the RPG.  When the cops came to put the school on lockdown I managed to slip out the back.  I live a long way out of town, but there was no way I was going to take a bus home, so I walked.  Two hours.  Heard a lot of sirens, and I even saw jets overhead.  It was getting late when I got back, but my mom and dad weren't back from work yet.  I stayed there, hoping they'd come.  I sent texts but got no reply.  After a few days, well… the news got worse and worse, then it stopped completely.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What about your parents?", "topic": "BGSS_NERD_1_PARENTS" },
       { "text": "What got you out of there?", "topic": "BGSS_NERD_1_STORY3" },
@@ -23,7 +29,10 @@
   {
     "id": "BGSS_NERD_1_PARENTS",
     "type": "talk_topic",
-    "dynamic_line": "I'm not stupid.  I know they're gone.  Who knows where… maybe in an evac shelter, maybe in a FEMA camp.  Most of everyone is dead.",
+    "dynamic_line": {
+      "gendered_line": "I'm not stupid.  I know they're gone.  Who knows where… maybe in an evac shelter, maybe in a FEMA camp.  Most of everyone is dead.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What got you out of the house?", "topic": "BGSS_NERD_1_STORY3" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -33,7 +42,10 @@
   {
     "id": "BGSS_NERD_1_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "Eventually the zombies came.  I figured they would.  Before the net cut out, there were plenty of videos online making it clear enough what was going on.  I'd picked out some good gear and loaded my bag up with supplies….  When they started knocking at the door, I slipped out the back and took to the street.  And here I am.",
+    "dynamic_line": {
+      "gendered_line": "Eventually the zombies came.  I figured they would.  Before the net cut out, there were plenty of videos online making it clear enough what was going on.  I'd picked out some good gear and loaded my bag up with supplies….  When they started knocking at the door, I slipped out the back and took to the street.  And here I am.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What about your parents?", "topic": "BGSS_NERD_1_PARENTS" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },

--- a/data/json/npcs/Backgrounds/no_past_3.json
+++ b/data/json/npcs/Backgrounds/no_past_3.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_NO_PAST_3_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "This is gonna sound crazy, but I woke up in the forest in the middle of nowhere, freezing cold, about a week before I met you.  I had my clothes, a splitting headache, and absolutely no memory of anything.  Like, I know stuff.  I can talk, I have skills and understanding… but I don't remember where any of it comes from.  I had a driver's license in my pocket and that's the only way I even know my name.",
+    "dynamic_line": {
+      "gendered_line": "This is gonna sound crazy, but I woke up in the forest in the middle of nowhere, freezing cold, about a week before I met you.  I had my clothes, a splitting headache, and absolutely no memory of anything.  Like, I know stuff.  I can talk, I have skills and understanding… but I don't remember where any of it comes from.  I had a driver's license in my pocket and that's the only way I even know my name.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What do you think happened?", "topic": "BGSS_NO_PAST_3_STORY2" },
       { "text": "That does sound a little crazy…", "topic": "BGSS_NO_PAST_3_CRAZY" },
@@ -24,7 +27,10 @@
   {
     "id": "BGSS_NO_PAST_3_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "Well, not having a memory is weird as heck, but I'll be honest: I think it might be better?  With what's going on, I bet you my memories weren't happy ones.  Besides my driver's license, there were pictures of kids in my wallet… not that that sparked any reaction from me.  I didn't see any kids around.  Maybe losing my mind is a mercy.  Hell, maybe it's some kind of psychotic break and my brain did this to itself.  To be honest with you I think I'd rather focus on surviving, and not worry about it.",
+    "dynamic_line": {
+      "gendered_line": "Well, not having a memory is weird as heck, but I'll be honest: I think it might be better?  With what's going on, I bet you my memories weren't happy ones.  Besides my driver's license, there were pictures of kids in my wallet… not that that sparked any reaction from me.  I didn't see any kids around.  Maybe losing my mind is a mercy.  Hell, maybe it's some kind of psychotic break and my brain did this to itself.  To be honest with you I think I'd rather focus on surviving, and not worry about it.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "That does sound a little crazy…", "topic": "BGSS_NO_PAST_3_CRAZY" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -34,7 +40,10 @@
   {
     "id": "BGSS_NO_PAST_3_CRAZY",
     "type": "talk_topic",
-    "dynamic_line": "I know it's nuts.  It sounds like fake amnesia from a Bugs Bunny cartoon.  See?  How can I know that, but not remember how I know it?  Like, I remember Bugs Bunny but I don't remember any time I sat down and watched a Bugs Bunny show.",
+    "dynamic_line": {
+      "gendered_line": "I know it's nuts.  It sounds like fake amnesia from a Bugs Bunny cartoon.  See?  How can I know that, but not remember how I know it?  Like, I remember Bugs Bunny but I don't remember any time I sat down and watched a Bugs Bunny show.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "What were you saying before?", "topic": "TALK_NONE" }, { "text": "<end_talking>", "topic": "TALK_DONE" } ]
   }
 ]

--- a/data/json/npcs/Backgrounds/no_past_4.json
+++ b/data/json/npcs/Backgrounds/no_past_4.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_NO_PAST_4_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Who I was is gone.  All that stuff burned away in <the_cataclysm>.  Got it?  Who I am now started two days into it.  I was on the run from a big-ass hell zombie, running like I'd always been doing, when I found a steel baseball bat just laying on the ground.  I took it as a sign and beat that gooey bastard to a pulp… and that's when I became me.  I still run, because who doesn't, but I stand my ground now.",
+    "dynamic_line": {
+      "gendered_line": "Who I was is gone.  All that stuff burned away in <the_cataclysm>.  Got it?  Who I am now started two days into it.  I was on the run from a big-ass hell zombie, running like I'd always been doing, when I found a steel baseball bat just laying on the ground.  I took it as a sign and beat that gooey bastard to a pulp… and that's when I became me.  I still run, because who doesn't, but I stand my ground now.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What happened to you after that?", "topic": "BGSS_NO_PAST_4_STORY2" },
       {
@@ -17,7 +20,10 @@
   {
     "id": "BGSS_NO_PAST_4_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "I went on, running when I had to and fighting when I could, like the rest of us.  Started learning who I am now.  Lost the bat in a fight against some crazy electric lightning shooting zombie.  It was arcing electricity through my bat so I dropped it and used a nearby plank, but I wound up having to run and leave the ol' slugger behind.  I nearly died that day.",
+    "dynamic_line": {
+      "gendered_line": "I went on, running when I had to and fighting when I could, like the rest of us.  Started learning who I am now.  Lost the bat in a fight against some crazy electric lightning shooting zombie.  It was arcing electricity through my bat so I dropped it and used a nearby plank, but I wound up having to run and leave the ol' slugger behind.  I nearly died that day.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "It can't be healthy to abandon your past like that…",

--- a/data/json/npcs/Backgrounds/no_past_5.json
+++ b/data/json/npcs/Backgrounds/no_past_5.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_NO_PAST_5_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Let's not talk about it, ok?  It just hurts to think about.  I've lost so many people… and I'm sure you have too.  Let's focus on the here and now.",
+    "dynamic_line": {
+      "gendered_line": "Let's not talk about it, ok?  It just hurts to think about.  I've lost so many people… and I'm sure you have too.  Let's focus on the here and now.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "I can respect that.  <done_conversation_section>", "topic": "TALK_NONE" },
       { "text": "Fair enough.  <end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/out_of_town_1.json
+++ b/data/json/npcs/Backgrounds/out_of_town_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_OUT_OF_TOWN_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I didn't even know about <the_cataclysm> right away.  I was way out, away from the worst of it.  My car broke down out on the highway, and I was waiting for a tow for hours.  I finally wound up camping in the bushes off the side of the road; good thing, too, because a semi truck whipped by - dead driver, you know - and turned my car into a skid mark.  I feel bad for the bastards that were in the cities when it hit.",
+    "dynamic_line": {
+      "gendered_line": "I didn't even know about <the_cataclysm> right away.  I was way out, away from the worst of it.  My car broke down out on the highway, and I was waiting for a tow for hours.  I finally wound up camping in the bushes off the side of the road; good thing, too, because a semi truck whipped by - dead driver, you know - and turned my car into a skid mark.  I feel bad for the bastards that were in the cities when it hit.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "How did you survive outside?", "topic": "BGSS_OUT_OF_TOWN_1_STORY2" },
       { "text": "What did you see in those first few days?", "topic": "BGSS_OUT_OF_TOWN_1_STORY3" },
@@ -13,7 +16,10 @@
   {
     "id": "BGSS_OUT_OF_TOWN_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Ha, I don't fully understand it myself.  Those first few days were a tough time to be outside, that's for sure.  I got caught in one of those hellish rainstorms, it started to burn my skin right off.  I managed to take shelter under a car, lying on top of my tent.  Wrecked the damn thing, but better it than me.  From what I hear, though, I got lucky.  That was pretty much the worst I saw.  I didn't run into any of those demon-monsters that I hear attacked the cities, so I guess I got off lucky.",
+    "dynamic_line": {
+      "gendered_line": "Ha, I don't fully understand it myself.  Those first few days were a tough time to be outside, that's for sure.  I got caught in one of those hellish rainstorms, it started to burn my skin right off.  I managed to take shelter under a car, lying on top of my tent.  Wrecked the damn thing, but better it than me.  From what I hear, though, I got lucky.  That was pretty much the worst I saw.  I didn't run into any of those demon-monsters that I hear attacked the cities, so I guess I got off lucky.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What did you see in those first few days?", "topic": "BGSS_OUT_OF_TOWN_1_STORY3" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -23,7 +29,10 @@
   {
     "id": "BGSS_OUT_OF_TOWN_1_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "Besides the acid rain, I mostly saw people fleeing the cities.  I tried to stay away from the roads, but I didn't want to get lost in the woods either, so I stuck to the deep margins.  I saw cars, buses, trucks loaded down with evacuees.  Plenty went right on, but a lot stalled out of gas and other stuff.  Some were so full of gear and people there were folks hanging off them.  Stalling out was a death sentence, because the dead were coming along the roads picking off the survivors.",
+    "dynamic_line": {
+      "gendered_line": "Besides the acid rain, I mostly saw people fleeing the cities.  I tried to stay away from the roads, but I didn't want to get lost in the woods either, so I stuck to the deep margins.  I saw cars, buses, trucks loaded down with evacuees.  Plenty went right on, but a lot stalled out of gas and other stuff.  Some were so full of gear and people there were folks hanging off them.  Stalling out was a death sentence, because the dead were coming along the roads picking off the survivors.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "How did you survive outside?", "topic": "BGSS_OUT_OF_TOWN_1_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },

--- a/data/json/npcs/Backgrounds/out_of_town_2.json
+++ b/data/json/npcs/Backgrounds/out_of_town_2.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_OUT_OF_TOWN_2_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I was out on a fishing trip with my friend when it happened.  I don't know exactly how the days line up… our first clue that Armageddon had come was when we got blasted by some kind of poison wind, with a sort of acid mist in it that burnt our eyes and skin.  We weren't sure what to make of it so we went inside to rest up, and while we were in there a weird dust settled over everything.",
+    "dynamic_line": {
+      "gendered_line": "I was out on a fishing trip with my friend when it happened.  I don't know exactly how the days line up… our first clue that Armageddon had come was when we got blasted by some kind of poison wind, with a sort of acid mist in it that burnt our eyes and skin.  We weren't sure what to make of it so we went inside to rest up, and while we were in there a weird dust settled over everything.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What happened after the acid mist?", "topic": "BGSS_OUT_OF_TOWN_2_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -22,7 +25,10 @@
   {
     "id": "BGSS_OUT_OF_TOWN_2_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "She took sick a few hours after we left the lake.  Puking, complaining about her joints hurting.  I took us to a little shop I knew about on the riverside, hoping they might have something to help or at least know what was going on.",
+    "dynamic_line": {
+      "gendered_line": "She took sick a few hours after we left the lake.  Puking, complaining about her joints hurting.  I took us to a little shop I knew about on the riverside, hoping they might have something to help or at least know what was going on.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "I guess they didn't know.", "topic": "BGSS_OUT_OF_TOWN_2_STORY4" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -32,7 +38,10 @@
   {
     "id": "BGSS_OUT_OF_TOWN_2_STORY4",
     "type": "talk_topic",
-    "dynamic_line": "The shop was empty, actually.  She was desperate though, so I broke in.  I found out more about the chaos in towns from the store radio.  Got my friend some painkillers and gravol, but when I came out to the boat, well… it was too late for her.",
+    "dynamic_line": {
+      "gendered_line": "The shop was empty, actually.  She was desperate though, so I broke in.  I found out more about the chaos in towns from the store radio.  Got my friend some painkillers and gravol, but when I came out to the boat, well… it was too late for her.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "She was dead?", "topic": "BGSS_OUT_OF_TOWN_2_STORY5" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -42,7 +51,10 @@
   {
     "id": "BGSS_OUT_OF_TOWN_2_STORY5",
     "type": "talk_topic",
-    "dynamic_line": "I wish.  That would have been a mercy.  She was letting out an awful, choking scream, and her body was shredding itself apart.  Mushrooms were busting out of every part of her.  I… I ran.  Now I wish that I'd put her out of her misery, but going back there now would be suicide.",
+    "dynamic_line": {
+      "gendered_line": "I wish.  That would have been a mercy.  She was letting out an awful, choking scream, and her body was shredding itself apart.  Mushrooms were busting out of every part of her.  I… I ran.  Now I wish that I'd put her out of her misery, but going back there now would be suicide.",
+      "relevant_genders": [ "npc" ]
+    },
     "//": "In the future this NPC might give you the coordinates of his friend where you can go take down a fungal grove of some kind.",
     "responses": [
       { "text": "That's awful.  <done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },

--- a/data/json/npcs/Backgrounds/prepper_1.json
+++ b/data/json/npcs/Backgrounds/prepper_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_PREPPER_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Ooooh, boy.  I was ready for this.  The winds were blowing this way for years.  I had a full last man on earth shelter set up just out of town.  So, of course, just my luck: I was miles out of town for a work conference when China attacked and the world ended.",
+    "dynamic_line": {
+      "gendered_line": "Ooooh, boy.  I was ready for this.  The winds were blowing this way for years.  I had a full last man on earth shelter set up just out of town.  So, of course, just my luck: I was miles out of town for a work conference when China attacked and the world ended.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What happened to you?", "topic": "BGSS_PREPPER_1_STORY2" },
       { "text": "What about your shelter?", "topic": "BGSS_PREPPER_1_LMOE" },
@@ -37,7 +40,10 @@
   {
     "id": "BGSS_PREPPER_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Our conference was at a retreat by a lake.  We all got the emergency broadcast on our cells, but I was the only one to read between the lines and see it for what it was: large scale bio-terrorism.  I wasn't about to stay and find out who of my coworkers was a sleeper agent.  Although I'd bet fifty bucks it was Lee.  Anyway, I stole the coordinator's pickup and headed straight for my shelter.",
+    "dynamic_line": {
+      "gendered_line": "Our conference was at a retreat by a lake.  We all got the emergency broadcast on our cells, but I was the only one to read between the lines and see it for what it was: large scale bio-terrorism.  I wasn't about to stay and find out who of my coworkers was a sleeper agent.  Although I'd bet fifty bucks it was Lee.  Anyway, I stole the coordinator's pickup and headed straight for my shelter.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Did you get there?", "topic": "BGSS_PREPPER_1_STORY3" },
       { "text": "What about your shelter?", "topic": "BGSS_PREPPER_1_LMOE" },
@@ -48,7 +54,10 @@
   {
     "id": "BGSS_PREPPER_1_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "No, I barely got two miles.  I crashed into some kind of hell-spawn chink bio-weapon, a crazy screeching <monster> made of arms and legs and heads from all sorts of creatures, humans too.  I think I killed it, but I know for sure I killed the truck.  Grabbed my duffel bag and ran, after putting a couple bullets into it for good measure.  I hope I never see something like that again.",
+    "dynamic_line": {
+      "gendered_line": "No, I barely got two miles.  I crashed into some kind of hell-spawn chink bio-weapon, a crazy screeching <monster> made of arms and legs and heads from all sorts of creatures, humans too.  I think I killed it, but I know for sure I killed the truck.  Grabbed my duffel bag and ran, after putting a couple bullets into it for good measure.  I hope I never see something like that again.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What about your shelter?", "topic": "BGSS_PREPPER_1_LMOE" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -63,7 +72,10 @@
       "type": "mission",
       "context": "BGSS",
       "value": "yes",
-      "no": "I never made it there and can't imagine I ever will.  Every time I've tried I've been headed off by the <zombies>.",
+      "no": {
+        "gendered_line": "I never made it there and can't imagine I ever will.  Every time I've tried I've been headed off by the <zombies>.",
+        "relevant_genders": [ "npc" ]
+      },
       "yes": "The shelter's in your hands, at this point."
     },
     "responses": [
@@ -134,7 +146,10 @@
   {
     "id": "BGSS_PREPPER_1_LMOE2",
     "type": "talk_topic",
-    "dynamic_line": "The shelter?  Bought the land pretty cheap.  I hired a contractor to build the thing but did the door myself.  Metal pin in the door frame.  Can't open unless you remove it.  There's a little pulley inside you have to pull up to reset.  They made dozens of these in the area, and I couldn't sleep knowing just any <name_b> at that company could waltz in as soon as shit hit the fan.  They'd know exactly where to go and what to do!  Nah… how do you think I've made it this long?  Always keep a trick up your sleeve.",
+    "dynamic_line": {
+      "gendered_line": "The shelter?  Bought the land pretty cheap.  I hired a contractor to build the thing but did the door myself.  Metal pin in the door frame.  Can't open unless you remove it.  There's a little pulley inside you have to pull up to reset.  They made dozens of these in the area, and I couldn't sleep knowing just any <name_b> at that company could waltz in as soon as shit hit the fan.  They'd know exactly where to go and what to do!  Nah… how do you think I've made it this long?  Always keep a trick up your sleeve.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "A contractor?  How much does something like a survivalist shelter cost?", "topic": "BGSS_PREPPER_1_LMOE4" },
       {
@@ -169,13 +184,19 @@
   {
     "id": "BGSS_PREPPER_1_LMOE3",
     "type": "talk_topic",
-    "dynamic_line": "Nope, that's it.  Got the idea for the door from a book on medieval castles, in case you were wondering.  But instead of a counterweight holding a drawbridge up, I just ram a hex key in a hole.",
+    "dynamic_line": {
+      "gendered_line": "Nope, that's it.  Got the idea for the door from a book on medieval castles, in case you were wondering.  But instead of a counterweight holding a drawbridge up, I just ram a hex key in a hole.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "Interesting…", "topic": "TALK_NONE" } ]
   },
   {
     "id": "BGSS_PREPPER_1_LMOE4",
     "type": "talk_topic",
-    "dynamic_line": "Almost as much as my house, in the end.  I think they realized they could make a lot of money as things got worse and worse.  But it's nicer than my house, too.  They said the ventilation system was built to withstand a month of anything: nuclear fallout, biological attack, you name it.  Concrete and soil above me to absorb radiation, appliances and supplies…  I even brought some old books I've never read.  I always knew it would come to this.",
+    "dynamic_line": {
+      "gendered_line": "Almost as much as my house, in the end.  I think they realized they could make a lot of money as things got worse and worse.  But it's nicer than my house, too.  They said the ventilation system was built to withstand a month of anything: nuclear fallout, biological attack, you name it.  Concrete and soil above me to absorb radiation, appliances and supplies…  I even brought some old books I've never read.  I always knew it would come to this.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "How many of these places did the company build?", "topic": "BGSS_PREPPER_1_LMOE5" } ]
   },
   {
@@ -250,7 +271,10 @@
   {
     "id": "BGSS_PREPPER_1_SHARELOOTFAILURE4",
     "type": "talk_topic",
-    "dynamic_line": "I knew it…  This whole time.  It was all part of the plan.  The riots, the storms…  You always had control…",
+    "dynamic_line": {
+      "gendered_line": "I knew it…  This whole time.  It was all part of the plan.  The riots, the storms…  You always had control…",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "Prepare to meet your end, <npc_name>.  *Attack <npc_name>.*",
@@ -287,7 +311,10 @@
   {
     "id": "BGSS_PREPPER_1_SHELTERFAILURE",
     "type": "talk_topic",
-    "dynamic_line": "I'd have to be absolutely <dumb> to give up the location of my stash to someone I barely know.  For all I know you'd just kill me and take it all for yourself!  Better luck next time, pal.",
+    "dynamic_line": {
+      "gendered_line": "I'd have to be absolutely <dumb> to give up the location of my stash to someone I barely know.  For all I know you'd just kill me and take it all for yourself!  Better luck next time, pal.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "Okay, calm down…", "topic": "TALK_NONE" } ]
   },
   {
@@ -319,8 +346,14 @@
     "dynamic_line": [
       {
         "math": [ "time_since('cataclysm', 'unit':'days') >= 14" ],
-        "no": "That's pretty presumptive of you, considering it hasn't been that long since shit went down.  What made you assume I was dead?",
-        "yes": "The door was open?  Was there anyone inside?  Why would you assume I was dead?"
+        "no": {
+          "gendered_line": "That's pretty presumptive of you, considering it hasn't been that long since shit went down.  What made you assume I was dead?",
+          "relevant_genders": [ "npc", "u" ]
+        },
+        "yes": {
+          "gendered_line": "The door was open?  Was there anyone inside?  Why would you assume I was dead?",
+          "relevant_genders": [ "npc", "u" ]
+        }
       }
     ],
     "responses": [
@@ -348,8 +381,14 @@
     "dynamic_line": [
       {
         "math": [ "time_since('cataclysm', 'unit':'days') >= 14" ],
-        "no": "Well, that's one way to say 'fuck you'!  How…  Why…  I was still trying to get back there, surviving and struggling just like you!  How would you feel if I came and stole all YOUR stuff right when you needed it most?!",
-        "yes": "Well, that's one way to say 'fuck you'!  I know it's been a while since shit went down, but I didn't lock that door and put up that sign for no reason!  How would you feel if I came and stole all the stuff that YOU locked away for safe keeping?!"
+        "no": {
+          "gendered_line": "Well, that's one way to say 'fuck you'!  How…  Why…  I was still trying to get back there, surviving and struggling just like you!  How would you feel if I came and stole all YOUR stuff right when you needed it most?!",
+          "relevant_genders": [ "npc" ]
+        },
+        "yes": {
+          "gendered_line": "Well, that's one way to say 'fuck you'!  I know it's been a while since shit went down, but I didn't lock that door and put up that sign for no reason!  How would you feel if I came and stole all the stuff that YOU locked away for safe keeping?!",
+          "relevant_genders": [ "npc" ]
+        }
       }
     ],
     "responses": [
@@ -380,7 +419,10 @@
   {
     "id": "BGSS_PREPPER_1_FOUND_LMOE3_BENICE",
     "type": "talk_topic",
-    "dynamic_line": "I suppose that's true.  Still not a very nice way to break the news to someone you accidentally robbed…",
+    "dynamic_line": {
+      "gendered_line": "I suppose that's true.  Still not a very nice way to break the news to someone you accidentally robbed…",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "You're right, sorry.", "topic": "TALK_FRIEND_CONVERSATION" },
       {
@@ -398,7 +440,10 @@
   {
     "id": "BGSS_PREPPER_1_FOUND_LMOE4_BEHONEST",
     "type": "talk_topic",
-    "dynamic_line": "I guess I can't judge.  I've made some fucked up decisions, too.  Taken some things that aren't mine.",
+    "dynamic_line": {
+      "gendered_line": "I guess I can't judge.  I've made some fucked up decisions, too.  Taken some things that aren't mine.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "I'm sorry.  I'm sure we can find lots of stuff to replace whatever I took.",
@@ -409,7 +454,10 @@
   {
     "id": "BGSS_PREPPER_1_FOUND_LMOE4_FAILLIE",
     "type": "talk_topic",
-    "dynamic_line": "You're not really a good liar.  I built that thing like a fortress.  No one would just break into it.",
+    "dynamic_line": {
+      "gendered_line": "You're not really a good liar.  I built that thing like a fortress.  No one would just break into it.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "Well…  I did.  And that's just how it goes.  It wasn't even that difficult.",
@@ -425,7 +473,10 @@
   {
     "id": "BGSS_PREPPER_1_FOUND_LMOE4_FAILLIE2",
     "type": "talk_topic",
-    "dynamic_line": "Just don't lie about it.  I understand your life was probably in danger.  I can see past that.  Trust me, I've been in sticky situations before.  Tell the truth next time.",
+    "dynamic_line": {
+      "gendered_line": "Just don't lie about it.  I understand your life was probably in danger.  I can see past that.  Trust me, I've been in sticky situations before.  Tell the truth next time.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "…", "topic": "TALK_DONE" } ]
   },
   {
@@ -468,7 +519,10 @@
       {
         "math": [ "time_since('cataclysm', 'unit':'days') >= 21" ],
         "no": "&<npc_name> sighs and pauses for a moment.\n\n\"Listen…  I know what you think I am, but the threats are real.  The dead are walking, strange hellspawn crawling out of…  well, I can't even talk about it.  Whatever demonic, technological abomination, bio-weapon the communists unleashed on the world is definitely out of their control.  Look around you!  Isn't it obvious something bigger is going on?\"",
-        "yes": "&<npc_name> sighs and pauses for a moment.\n\n\"It's been so long now.  I barely even remember what I was doing.  There was so much confusion and violence in those last days.  My family didn't understand the threat, even though I tried to tell them.  I know what you think I am, but look what's happened!  The dead are walking, the sky is cracking open, and…  well, I can't even talk about it.  Isn't it obvious something bigger is going on?\""
+        "yes": {
+          "gendered_line": "&<npc_name> sighs and pauses for a moment.\n\n\"It's been so long now.  I barely even remember what I was doing.  There was so much confusion and violence in those last days.  My family didn't understand the threat, even though I tried to tell them.  I know what you think I am, but look what's happened!  The dead are walking, the sky is cracking open, and…  well, I can't even talk about it.  Isn't it obvious something bigger is going on?\"",
+          "relevant_genders": [ "npc" ]
+        }
       }
     ],
     "responses": [
@@ -486,7 +540,10 @@
         "math": [ "time_since('cataclysm', 'unit':'days') >= 21" ],
         "//": "Before the Cataclysm, the prepper was pretty sure it was a Chinese plot for American destabilization and control, maybe aided by elites across the world.  If you meet them early, they still sort of think this. American propaganda about 'Chinese mind control' also influenced them. Later, once the portal storms ramp up, they decide it might be something more cosmic, possibly religious. The conversation from this point should allow the player to bounce ideas about what happened off of the prepper.",
         "no": "It's an invasion.  Or, at least, I think that's what they were trying to do at first.  Sudden bouts of violence, sending agitators to riots, doing false flags with covert and overt agents alike…  When they couldn't get what they wanted, they went full 'scorched earth'.  They decided to destroy everything instead.",
-        "yes": "I thought I knew at one point.  There were so many signs of manipulation and control.  I thought maybe they were trying to discredit the protests, but when the violence broke out it seemed to be everywhere.  There was footage on the news of people fighting, destroying property, eating animals and… each other in the street.  I thought at some point they were going to sweep in and seize control, but it just never happened."
+        "yes": {
+          "gendered_line": "I thought I knew at one point.  There were so many signs of manipulation and control.  I thought maybe they were trying to discredit the protests, but when the violence broke out it seemed to be everywhere.  There was footage on the news of people fighting, destroying property, eating animals and… each other in the street.  I thought at some point they were going to sweep in and seize control, but it just never happened.",
+          "relevant_genders": [ "npc" ]
+        }
       }
     ],
     "responses": [ { "text": "What do you mean?  Who is 'they'?", "topic": "BGSS_PREPPER_1_FOUND_LMOE8" } ]
@@ -497,7 +554,10 @@
     "dynamic_line": [
       {
         "math": [ "time_since('cataclysm', 'unit':'days') >= 21" ],
-        "no": "You know, the elites.  The ones who have always had control will continue having control, no matter what it costs.  If it means destroying everything to be king of the ashes, they'll do it.  I used to think it was China, for sure, but I'm not so sure anymore.  I figured they would probably be here by now, putting on their crown.  Maybe they're still waiting to make their move…",
+        "no": {
+          "gendered_line": "You know, the elites.  The ones who have always had control will continue having control, no matter what it costs.  If it means destroying everything to be king of the ashes, they'll do it.  I used to think it was China, for sure, but I'm not so sure anymore.  I figured they would probably be here by now, putting on their crown.  Maybe they're still waiting to make their move…",
+          "relevant_genders": [ "npc" ]
+        },
         "yes": "The government.  Whoever was left, really.  I don't know…  I'm starting to think that maybe some of those folks were right…  Maybe this is some kind of punishment for humanity.  Maybe some god decided they'd had enough of us.  Or maybe there's no answer.  I can't explain some of the things I've seen."
       }
     ],
@@ -545,7 +605,10 @@
   {
     "id": "BGSS_PREPPER_1_FOUND_LMOE9_GOVERNMENT",
     "type": "talk_topic",
-    "dynamic_line": "That's what I'm saying!  Everything that's going on wouldn't be possible without massive fuck-ups by people in power.  China has fusion reactors?  Well, I've never seen it!  America sinks trillions and trillions of dollars into secret military budgets with no explanation.  If you gave me a trillion dollars and the brain of a bureaucrat, I bet I could completely fuck up reality, too.",
+    "dynamic_line": {
+      "gendered_line": "That's what I'm saying!  Everything that's going on wouldn't be possible without massive fuck-ups by people in power.  China has fusion reactors?  Well, I've never seen it!  America sinks trillions and trillions of dollars into secret military budgets with no explanation.  If you gave me a trillion dollars and the brain of a bureaucrat, I bet I could completely fuck up reality, too.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "Well, let's get going.  I'm trying to stick it to 'The Man' while we've still got a chance.",
@@ -556,7 +619,10 @@
   {
     "id": "BGSS_PREPPER_1_FOUND_LMOE9_GOD",
     "type": "talk_topic",
-    "dynamic_line": "I've been trying not to think about it, but you could be right.  The more that I see, the less I can explain.  I grew up around a lot of people who always talked about the Rapture.  Hell itself opening up and everything.  It was like they KNEW it would happen.  Before the internet stopped working, I saw people saying that sinners were becoming zombies.  'As above, so below' someone said, or something like that…",
+    "dynamic_line": {
+      "gendered_line": "I've been trying not to think about it, but you could be right.  The more that I see, the less I can explain.  I grew up around a lot of people who always talked about the Rapture.  Hell itself opening up and everything.  It was like they KNEW it would happen.  Before the internet stopped working, I saw people saying that sinners were becoming zombies.  'As above, so below' someone said, or something like that…",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "We should keep moving…  No sense dwelling on fate.  If those people are right, then this is all we've got: survival.",
@@ -604,7 +670,10 @@
   {
     "id": "BGSS_PREPPER_1_FOUND_LMOE9_BONE_SEER",
     "type": "talk_topic",
-    "dynamic_line": "She said it was… energy in bones?  Listen, I've heard a lot of crazy bullshit in my time and that's up there, for sure.  And I don't see how something like that explains all the crazy shit I've seen either.  But collecting bones to… save the world?  Fuck it, give it a shot.  Maybe that's something just YOU do, though.  I'm happy believing a lie if that's the truth, I'll be honest.",
+    "dynamic_line": {
+      "gendered_line": "She said it was… energy in bones?  Listen, I've heard a lot of crazy bullshit in my time and that's up there, for sure.  And I don't see how something like that explains all the crazy shit I've seen either.  But collecting bones to… save the world?  Fuck it, give it a shot.  Maybe that's something just YOU do, though.  I'm happy believing a lie if that's the truth, I'll be honest.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "I didn't say it was a SOLID theory, but maybe she's onto something.  This is evil on a cosmic scale; I don't know how else to explain it.  Maybe she's right.  Maybe the bones really are 'singing'.",
@@ -615,7 +684,10 @@
   {
     "id": "BGSS_PREPPER_1_FOUND_LMOE9_ALIENS",
     "type": "talk_topic",
-    "dynamic_line": "I've been trying not to think about it, but you could be right.  The more that I see, the less I can explain.  I don't know why humans would want this, but if you're a brain-sucking alien, this is the place to be.",
+    "dynamic_line": {
+      "gendered_line": "I've been trying not to think about it, but you could be right.  The more that I see, the less I can explain.  I don't know why humans would want this, but if you're a brain-sucking alien, this is the place to be.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "So… are you down to kick some alien ass with me?", "topic": "BGSS_PREPPER_1_FOUND_LMOE10_ALIENS" },
       { "text": "Let's not dwell on it.  I'm ready to get a move on…", "topic": "TALK_DONE" }
@@ -639,13 +711,19 @@
   {
     "id": "BGSS_PREPPER_1_FOUND_LMOE10_SKEPTIC",
     "type": "talk_topic",
-    "dynamic_line": "You're right, but I still think there's something bigger out there.  Something evil.  It doesn't matter whether science can explain it because we damn sure don't seem capable of defeating it.",
+    "dynamic_line": {
+      "gendered_line": "You're right, but I still think there's something bigger out there.  Something evil.  It doesn't matter whether science can explain it because we damn sure don't seem capable of defeating it.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [ { "text": "Yeah, it does seem a little grim…  Let's keep moving for now.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "BGSS_PREPPER_1_FOUND_LMOE10_TAKE_BAIT",
     "type": "talk_topic",
-    "dynamic_line": "I'm sorry, 'officer'.  I didn't write the book of cop jokes, you know.",
+    "dynamic_line": {
+      "gendered_line": "I'm sorry, 'officer'.  I didn't write the book of cop jokes, you know.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "Let's just keep moving.  We don't have time for this nonsense…", "topic": "TALK_DONE" } ]
   },
   {
@@ -659,7 +737,10 @@
   {
     "id": "BGSS_PREPPER_1_FOUND_LMOE10_HUB01",
     "type": "talk_topic",
-    "dynamic_line": "Scared?  Yeah, that's fair.  I wouldn't say it's a friendly world out here.  Still, it's best to be friends.  Anyone that prepared for the apocalypse is probably armed to the teeth anyway.",
+    "dynamic_line": {
+      "gendered_line": "Scared?  Yeah, that's fair.  I wouldn't say it's a friendly world out here.  Still, it's best to be friends.  Anyone that prepared for the apocalypse is probably armed to the teeth anyway.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "Let's get moving.  I feel like it's useless worrying who they are when they're some of the only friends we've got…",

--- a/data/json/npcs/Backgrounds/prepper_2.json
+++ b/data/json/npcs/Backgrounds/prepper_2.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_PREPPER_2_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Oh, man.  I thought I was ready.  I had it all planned out.  Bug out bags.  Loaded guns.  Maps of escape routes.  Bunker in the back yard.",
+    "dynamic_line": {
+      "gendered_line": "Oh, man.  I thought I was ready.  I had it all planned out.  Bug out bags.  Loaded guns.  Maps of escape routes.  Bunker in the back yard.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Sounds like it didn't work out.", "topic": "BGSS_PREPPER_2_STORY2" },
       {
@@ -17,7 +20,10 @@
   {
     "id": "BGSS_PREPPER_2_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Depends on your definition.  I'm alive, aren't I?  When Hell itself came down from the skies and monsters started attacking the cities, I grabbed my stuff and crammed into the bunker.  My surface cameras stayed online for days; I could see everything happening up there.  I watched those things stride past.  I still have nightmares about the way their bodies moved, like they broke the world just to be here.  I had nothing better to do.  I watched them rip up the cops and the military, watched the dead rise back up and start fighting the living.  I watched the nice old lady down the street rip the head off my neighbor's dog.  I saw a soldier's body twitch and grow into some kind of electrified hulk beast.  I watched it all happen.",
+    "dynamic_line": {
+      "gendered_line": "Depends on your definition.  I'm alive, aren't I?  When Hell itself came down from the skies and monsters started attacking the cities, I grabbed my stuff and crammed into the bunker.  My surface cameras stayed online for days; I could see everything happening up there.  I watched those things stride past.  I still have nightmares about the way their bodies moved, like they broke the world just to be here.  I had nothing better to do.  I watched them rip up the cops and the military, watched the dead rise back up and start fighting the living.  I watched the nice old lady down the street rip the head off my neighbor's dog.  I saw a soldier's body twitch and grow into some kind of electrified hulk beast.  I watched it all happen.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Why did you leave your bunker?", "topic": "BGSS_PREPPER_2_STORY3" },
       {
@@ -32,7 +38,10 @@
   {
     "id": "BGSS_PREPPER_2_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "Honestly?  I was planning to die.  After what I'd seen, I went a little crazy.  I thought it was over for sure, I figured there was no point in fighting it.  I thought I wouldn't last a minute out here, but I couldn't bring myself to end it down there.  I headed out, planning to let the <zombies> finish me off, but what can I say?  Survival instinct is a funny thing, and I killed the ones outside the bunker.  I guess the adrenaline was what I needed.  It's kept me going since then.",
+    "dynamic_line": {
+      "gendered_line": "Honestly?  I was planning to die.  After what I'd seen, I went a little crazy.  I thought it was over for sure, I figured there was no point in fighting it.  I thought I wouldn't last a minute out here, but I couldn't bring myself to end it down there.  I headed out, planning to let the <zombies> finish me off, but what can I say?  Survival instinct is a funny thing, and I killed the ones outside the bunker.  I guess the adrenaline was what I needed.  It's kept me going since then.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "Hey, I'd really be interested in seeing those maps.",

--- a/data/json/npcs/Backgrounds/prisoner_1.json
+++ b/data/json/npcs/Backgrounds/prisoner_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_PRISONER_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I was in jail for <the_cataclysm>, but I escaped.  Hell of a story.",
+    "dynamic_line": {
+      "gendered_line": "I was in jail for <the_cataclysm>, but I escaped.  Hell of a story.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "So tell me this 'hell of a story'", "topic": "BGSS_PRISONER_1_STORY2" },
       {
@@ -184,13 +187,19 @@
   {
     "id": "BGSS_PRISONER_1_IN_FOR_BIOWEAPON",
     "type": "talk_topic",
-    "dynamic_line": "It's a bit of a… it's a thing.  It started out as a dare.  I wound up making a bioweapon.  It didn't get used or anything, but, well, it got out of hand.",
+    "dynamic_line": {
+      "gendered_line": "It's a bit of a… it's a thing.  It started out as a dare.  I wound up making a bioweapon.  It didn't get used or anything, but, well, it got out of hand.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "<done_conversation_section>", "topic": "TALK_NONE" }, { "text": "<end_talking>", "topic": "TALK_DONE" } ]
   },
   {
     "id": "BGSS_PRISONER_1_IN_FOR_TAXEVASION",
     "type": "talk_topic",
-    "dynamic_line": "Tax evasion.  I was an accountant, and I helped my boss move a hell of a lot of money in some very clever ways.  Not clever enough, it turns out…",
+    "dynamic_line": {
+      "gendered_line": "Tax evasion.  I was an accountant, and I helped my boss move a hell of a lot of money in some very clever ways.  Not clever enough, it turns out…",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "<done_conversation_section>", "topic": "TALK_NONE" }, { "text": "<end_talking>", "topic": "TALK_DONE" } ]
   },
   {
@@ -208,7 +217,10 @@
   {
     "id": "BGSS_PRISONER_1_IN_FOR_METH",
     "type": "talk_topic",
-    "dynamic_line": "Multiple counts of possession.  I used to be really hung up on meth.",
+    "dynamic_line": {
+      "gendered_line": "Multiple counts of possession.  I used to be really hung up on meth.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "<done_conversation_section>", "topic": "TALK_NONE" }, { "text": "<end_talking>", "topic": "TALK_DONE" } ]
   },
   {
@@ -226,7 +238,10 @@
   {
     "id": "BGSS_PRISONER_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Okay, well, I was in the wrong place at the wrong time.  There was a big fight, I didn't stay clear of it, and me and a bunch of others got tossed in solitary while a few more landed in the infirmary.  Some looked pretty bad, now I kinda wonder if any of them were our first <zombies>.",
+    "dynamic_line": {
+      "gendered_line": "Okay, well, I was in the wrong place at the wrong time.  There was a big fight, I didn't stay clear of it, and me and a bunch of others got tossed in solitary while a few more landed in the infirmary.  Some looked pretty bad, now I kinda wonder if any of them were our first <zombies>.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "How did you get out of lockup?", "topic": "BGSS_PRISONER_1_STORY3" },
       { "text": "<done_conversation_section>", "topic": "TALK_NONE" },
@@ -236,7 +251,10 @@
   {
     "id": "BGSS_PRISONER_1_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "I heard gunshots, even from down in lockup.  Didn't hear much screaming or anything.  That was my first clue something was up.  Food stopped showing up, next.  Then, the lights went out.  I was down there for maybe hours, maybe days, when finally a flashlight in the bars blinded me.  It was a guard.  He let me out, filled me in on what was going on.  I wanted to think he was crazy, but something in his eyes… I believed him.",
+    "dynamic_line": {
+      "gendered_line": "I heard gunshots, even from down in lockup.  Didn't hear much screaming or anything.  That was my first clue something was up.  Food stopped showing up, next.  Then, the lights went out.  I was down there for maybe hours, maybe days, when finally a flashlight in the bars blinded me.  It was a guard.  He let me out, filled me in on what was going on.  I wanted to think he was crazy, but something in his eyes… I believed him.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What did you do from there?", "topic": "BGSS_PRISONER_1_STORY4" },
       { "text": "<done_conversation_section>", "topic": "TALK_NONE" },
@@ -266,7 +284,10 @@
   {
     "id": "BGSS_PRISONER_1_STORY6",
     "type": "talk_topic",
-    "dynamic_line": "The guard took off on his own.  Didn't trust us, and I don't blame him.  The other two wanted to set up a bandit gig.  Didn't sit right with me, so I split on pretty good terms.  I ran into the guard a couple more times.  Thought of seeing if he'd travel with me, but I dunno.  I don't think he'd take the offer, I'll always be a con to him.  If you want to try, I can tell you where I saw him last.  Wasn't long before I met you, and he had a good thing going, might still be there.",
+    "dynamic_line": {
+      "gendered_line": "The guard took off on his own.  Didn't trust us, and I don't blame him.  The other two wanted to set up a bandit gig.  Didn't sit right with me, so I split on pretty good terms.  I ran into the guard a couple more times.  Thought of seeing if he'd travel with me, but I dunno.  I don't think he'd take the offer, I'll always be a con to him.  If you want to try, I can tell you where I saw him last.  Wasn't long before I met you, and he had a good thing going, might still be there.",
+      "relevant_genders": [ "npc" ]
+    },
     "//": "TK: Add two mission options, to go find the guard survivor and the bandits",
     "responses": [ { "text": "<done_conversation_section>", "topic": "TALK_NONE" }, { "text": "<end_talking>", "topic": "TALK_DONE" } ]
   }

--- a/data/json/npcs/Backgrounds/professor_1.json
+++ b/data/json/npcs/Backgrounds/professor_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_PROFESSOR_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I'm actually a chemistry professor at Harvard.  I'd been on sabbatical for the last six months.  I can't imagine the university was a good place to be, given what I've heard about Boston… I'm not sure anyone made it out.  I was out at my cabin near Chatham, ostensibly working on the finishing touches for a paper, but mostly just sipping whisky and thanking my lucky stars for tenure.  Those were good days.  Then came <the_cataclysm>, the military convoys, the <zombies>.  My cabin was crushed by a <monster>, just collateral damage after it got blasted off Orleans by a tank.  I was already busy running frantically by then.",
+    "dynamic_line": {
+      "gendered_line": "I'm actually a chemistry professor at Harvard.  I'd been on sabbatical for the last six months.  I can't imagine the university was a good place to be, given what I've heard about Boston… I'm not sure anyone made it out.  I was out at my cabin near Chatham, ostensibly working on the finishing touches for a paper, but mostly just sipping whisky and thanking my lucky stars for tenure.  Those were good days.  Then came <the_cataclysm>, the military convoys, the <zombies>.  My cabin was crushed by a <monster>, just collateral damage after it got blasted off Orleans by a tank.  I was already busy running frantically by then.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "Do you think there's some way your knowledge could help us understand all this?",

--- a/data/json/npcs/Backgrounds/religious_2.json
+++ b/data/json/npcs/Backgrounds/religious_2.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_RELIGIOUS_2_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Same as anyone.  I turned away from God, and now I'm paying the price.  The Rapture has come, and I was left behind.  So now, I guess I wander through Hell on Earth.  I wish I'd paid more attention in Sunday School.",
+    "dynamic_line": {
+      "gendered_line": "Same as anyone.  I turned away from God, and now I'm paying the price.  The Rapture has come, and I was left behind.  So now, I guess I wander through Hell on Earth.  I wish I'd paid more attention in Sunday School.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }
@@ -11,7 +14,10 @@
   {
     "id": "CWH_RELIGIOUS_2_IDEAS1",
     "type": "talk_topic",
-    "dynamic_line": "Well, I guess that was the Rapture.  It didn't play out how I thought it would.  They made me think it was gonna be a flash of light and then *poof*, everyone's gone.  Instead it was messy and dirty.  Riots in the streets, the military and police serving the Antichrist to gun down the people like - what was it my dad used to say - like wheat before the chaff?  Then when we'd really showed our Sin, God came in with the real plagues.  The dead started walking, getting up with machine gun holes in them to fight the military, and the military started turning on each other too.  After that, the legions of Hell itself came out.  Huge monsters, worse than anything I'd ever imagined, just tore through the cities ripping everything to shreds.  Then they started dying off as quick as they'd arrived, and we were left trying to run and hide from the undead.  A day or two later the power started going out.",
+    "dynamic_line": {
+      "gendered_line": "Well, I guess that was the Rapture.  It didn't play out how I thought it would.  They made me think it was gonna be a flash of light and then *poof*, everyone's gone.  Instead it was messy and dirty.  Riots in the streets, the military and police serving the Antichrist to gun down the people like - what was it my dad used to say - like wheat before the chaff?  Then when we'd really showed our Sin, God came in with the real plagues.  The dead started walking, getting up with machine gun holes in them to fight the military, and the military started turning on each other too.  After that, the legions of Hell itself came out.  Huge monsters, worse than anything I'd ever imagined, just tore through the cities ripping everything to shreds.  Then they started dying off as quick as they'd arrived, and we were left trying to run and hide from the undead.  A day or two later the power started going out.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/rural_1.json
+++ b/data/json/npcs/Backgrounds/rural_1.json
@@ -18,7 +18,10 @@
   {
     "id": "BGSS_RURAL_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Well, it built up a bit.  There was that acid rain, it burnt up one of my tractors.  Not that I'd been working the fields since… well, it'd been a <shitty> year and I hadn't done much worth doing.  There were explosions and things, and choppers overhead.  I was scared, kept the curtains drawn, kept changing the channels.  Then, one day, there were no channels to change to.  Just the emergency broadcast, over and over.",
+    "dynamic_line": {
+      "gendered_line": "Well, it built up a bit.  There was that acid rain, it burnt up one of my tractors.  Not that I'd been working the fields since… well, it'd been a <shitty> year and I hadn't done much worth doing.  There were explosions and things, and choppers overhead.  I was scared, kept the curtains drawn, kept changing the channels.  Then, one day, there were no channels to change to.  Just the emergency broadcast, over and over.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What happened next?", "topic": "BGSS_RURAL_1_STORY3" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -33,8 +36,14 @@
       "type": "mission",
       "context": "BGSS",
       "value": "yes",
-      "no": "That was the first thing to really shake me out of it.  I didn't really have any very close friends, but there were people back in town I cared about a bit.  I had sent some texts, but I hadn't really twigged that they hadn't replied for days.  I got in my truck and tried to get back to town.  Didn't get far before I hit a <zombie> infested pileup blocking the highway, and that's when I started to put it all together.  Never did get to town.  Unfortunately I led the <zombies> back to my farm, and had to bug out of there.  Might go back and clear it out, someday.",
-      "yes": "That was the first thing to really shake me out of it.  I didn't really have any very close friends, but there were people back in town I cared about a bit.  I had sent some texts, but I hadn't really twigged that they hadn't replied for days.  I got in my truck and tried to get back to town.  Didn't get far before I hit a <zombie> infested pileup blocking the highway, and that's when I started to put it all together.  Never did get to town.  Unfortunately I led the <zombies> back to my farm, and had to bug out of there.  And now I'm here with you."
+      "no": {
+        "gendered_line": "That was the first thing to really shake me out of it.  I didn't really have any very close friends, but there were people back in town I cared about a bit.  I had sent some texts, but I hadn't really twigged that they hadn't replied for days.  I got in my truck and tried to get back to town.  Didn't get far before I hit a <zombie> infested pileup blocking the highway, and that's when I started to put it all together.  Never did get to town.  Unfortunately I led the <zombies> back to my farm, and had to bug out of there.  Might go back and clear it out, someday.",
+        "relevant_genders": [ "npc" ]
+      },
+      "yes": {
+        "gendered_line": "That was the first thing to really shake me out of it.  I didn't really have any very close friends, but there were people back in town I cared about a bit.  I had sent some texts, but I hadn't really twigged that they hadn't replied for days.  I got in my truck and tried to get back to town.  Didn't get far before I hit a <zombie> infested pileup blocking the highway, and that's when I started to put it all together.  Never did get to town.  Unfortunately I led the <zombies> back to my farm, and had to bug out of there.  And now I'm here with you.",
+        "relevant_genders": [ "npc" ]
+      }
     },
     "responses": [
       {

--- a/data/json/npcs/Backgrounds/rural_2.json
+++ b/data/json/npcs/Backgrounds/rural_2.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_RURAL_2_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Well, I lived on the edge of a small town.  Corner store and a gas station and not much else.  We heard about the shit goin' down in the city, but we didn't see much of it until the military came blazing through and tried to set up a camp there.  They wanted to bottle us all up in town, and I wasn't having with that, so my dog Buck and I, we headed out while they were all sniffin' their own farts.",
+    "dynamic_line": {
+      "gendered_line": "Well, I lived on the edge of a small town.  Corner store and a gas station and not much else.  We heard about the shit goin' down in the city, but we didn't see much of it until the military came blazing through and tried to set up a camp there.  They wanted to bottle us all up in town, and I wasn't having with that, so my dog Buck and I, we headed out while they were all sniffin' their own farts.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What happened next?", "topic": "BGSS_RURAL_2_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -12,7 +15,10 @@
   {
     "id": "BGSS_RURAL_2_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Buck and I slipped out and went East, headin' for my friend's ranch.  Cute little dope thought we were just goin' for a real long walk.  I couldn't take the truck without the army boys catchin' wind of it.  We made it out to the forest, camped out in a lean to.  Packed up and kept heading out.  At first we walked along the highway a little, but saw too many army trucks and buses full of evacuees, and that's when we found out about the <zombies>.",
+    "dynamic_line": {
+      "gendered_line": "Buck and I slipped out and went East, headin' for my friend's ranch.  Cute little dope thought we were just goin' for a real long walk.  I couldn't take the truck without the army boys catchin' wind of it.  We made it out to the forest, camped out in a lean to.  Packed up and kept heading out.  At first we walked along the highway a little, but saw too many army trucks and buses full of evacuees, and that's when we found out about the <zombies>.",
+      "relevant_genders": [ "npc" ]
+    },
     "//": "TK: In a future version this NPC might give you directions to the ranch.",
     "responses": [
       { "text": "Where's Buck now?", "topic": "BGSS_RURAL_2_STORY3" },
@@ -23,7 +29,10 @@
   {
     "id": "BGSS_RURAL_2_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "We got to my buddy's ranch, but the <swear> g-men had been there first.  It was all boarded up and there was a police barricade out front.  One of those <swear> turrets… <swear> shot Buck.  Almost got me too.  I managed to get my pup… get him outta there, that… it wasn't easy, had to use a police car door as a shield, had to kill a cop-zombie first.  And then, well, while I was still cryin', Buck came back.  I had to… <swear!>.  I… I can't say it.  You know.",
+    "dynamic_line": {
+      "gendered_line": "We got to my buddy's ranch, but the <swear> g-men had been there first.  It was all boarded up and there was a police barricade out front.  One of those <swear> turrets… <swear> shot Buck.  Almost got me too.  I managed to get my pup… get him outta there, that… it wasn't easy, had to use a police car door as a shield, had to kill a cop-zombie first.  And then, well, while I was still cryin', Buck came back.  I had to… <swear!>.  I… I can't say it.  You know.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "I'm sorry about Buck.  <done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "I'm sorry about Buck.  <end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/scavenger_merc_1.json
+++ b/data/json/npcs/Backgrounds/scavenger_merc_1.json
@@ -4,7 +4,10 @@
     "type": "talk_topic",
     "dynamic_line": {
       "npc_has_effect": "player_BGSS_SAIDYES",
-      "yes": "Like I said, you want me to tell you a story, you gotta pony up the whisky.  A full bottle, mind you.",
+      "yes": {
+        "gendered_line": "Like I said, you want me to tell you a story, you gotta pony up the whisky.  A full bottle, mind you.",
+        "relevant_genders": [ "npc" ]
+      },
       "no": "Listen.  I'm gonna cut this off short.  I work for you, okay?  I'm not interested in getting attached.  You didn't pay me to be your friend."
     },
     "responses": [
@@ -36,7 +39,10 @@
   {
     "id": "BGSS_SCAVENGER_MERC_1_FUCKOFF",
     "type": "talk_topic",
-    "dynamic_line": "No dice.  You asked me to come along.  This is what you get.  If you don't like it, I'll take my fee and go back to the center.  Ain't hard to find contracts.",
+    "dynamic_line": {
+      "gendered_line": "No dice.  You asked me to come along.  This is what you get.  If you don't like it, I'll take my fee and go back to the center.  Ain't hard to find contracts.",
+      "relevant_genders": [ "u" ]
+    },
     "speaker_effect": { "opinion": { "fear": -1 } },
     "responses": [
       {
@@ -118,7 +124,10 @@
   {
     "id": "BGSS_SCAVENGER_MERC_1_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "Mostly I just wanted to get some scotch out of you.  There really ain't much of a story.  I was in the marines, years ago.  After that, did security contract work.  I was out guarding some dump of a warehouse when the apocalypse rolled through town.  I was out on the edge of town, armed, and know when to not pick a fight, so I didn't get killed.  Wound up recruited by the Free Merchants early on, and then the Old Guard for a bit, but I was getting itchy feet when you came by with an offer.  Here I am.",
+    "dynamic_line": {
+      "gendered_line": "Mostly I just wanted to get some scotch out of you.  There really ain't much of a story.  I was in the marines, years ago.  After that, did security contract work.  I was out guarding some dump of a warehouse when the apocalypse rolled through town.  I was out on the edge of town, armed, and know when to not pick a fight, so I didn't get killed.  Wound up recruited by the Free Merchants early on, and then the Old Guard for a bit, but I was getting itchy feet when you came by with an offer.  Here I am.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "Why was a guy with your skillset guarding a warehouse?  Must've been some warehouse.",
@@ -134,7 +143,10 @@
   {
     "id": "BGSS_SCAVENGER_MERC_1_STORY4",
     "type": "talk_topic",
-    "dynamic_line": "Huh.  Hadn't thought about it in ages, but now that you mention it, that was a weird job.  It was just a boarded up warehouse in the middle of nowhere, and I was not a cheap contractor in those days.  Coulda got any fat rent-a-cop to watch it.  I had only just started working there when the shit hit the fan, and I kinda forgot about that to be honest.",
+    "dynamic_line": {
+      "gendered_line": "Huh.  Hadn't thought about it in ages, but now that you mention it, that was a weird job.  It was just a boarded up warehouse in the middle of nowhere, and I was not a cheap contractor in those days.  Coulda got any fat rent-a-cop to watch it.  I had only just started working there when the shit hit the fan, and I kinda forgot about that to be honest.",
+      "relevant_genders": [ "npc" ]
+    },
     "//": "UPCOMING: this merc will offer a mission for you to explore the warehouse in question.",
     "responses": [
       { "text": "What were you saying before?", "topic": "TALK_NONE" },
@@ -160,7 +172,10 @@
   {
     "id": "BGSS_SCAVENGER_MERC_1_OLD_GUARD",
     "type": "talk_topic",
-    "dynamic_line": "Good work, and some fun stuff, but risky.  Without a few hands at my side that I trust, I wouldn't take more of their work.  If I had a solid team, though, I'd happily work for Uncle Sam again.",
+    "dynamic_line": {
+      "gendered_line": "Good work, and some fun stuff, but risky.  Without a few hands at my side that I trust, I wouldn't take more of their work.  If I had a solid team, though, I'd happily work for Uncle Sam again.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "Why was a guy with your skillset guarding a warehouse?  Must've been some warehouse.",

--- a/data/json/npcs/Backgrounds/scientist_1.json
+++ b/data/json/npcs/Backgrounds/scientist_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_SCIENTIST_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Before <the_cataclysm> I worked in a lab.  Don't look at me like that, it had nothing to do with this stuff… I was studying protein-protein interactions in smooth muscle in mice, using NMR.  Nothing even vaguely related to zombies.  Anyway, I was at last year's Experimental Biology conference in San Francisco, and an old friend of mine was talking about some really weird shit she'd heard of coming out of government labs.  Really hush hush stuff.  Normally I wouldn't put much cred into that sort of thing, but from her, it actually had me worried.  I packed a bug-out bag just in case.",
+    "dynamic_line": {
+      "gendered_line": "Before <the_cataclysm> I worked in a lab.  Don't look at me like that, it had nothing to do with this stuff… I was studying protein-protein interactions in smooth muscle in mice, using NMR.  Nothing even vaguely related to zombies.  Anyway, I was at last year's Experimental Biology conference in San Francisco, and an old friend of mine was talking about some really weird shit she'd heard of coming out of government labs.  Really hush hush stuff.  Normally I wouldn't put much cred into that sort of thing, but from her, it actually had me worried.  I packed a bug-out bag just in case.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What came of it?", "topic": "BGSS_SCIENTIST_1_STORY2" },
       {
@@ -16,7 +19,10 @@
   {
     "id": "BGSS_SCIENTIST_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "The evacuation order sounded, so I evacuated, comparatively quickly.  That got me out before the worst part.  Our evacuation center was useless… me, a couple other evacuees, a few tins of food, and a few emergency blankets.  Not even close to enough to go around.  The evacuees split down the middle into a few camps, and infighting started.  I ran into the woods nearby with a few others.  We got away, had a little camp going.  They tried to make me their leader, thought I knew more about things than I did because I'd come so prepared.  Like I said, I'm not that kind of scientist, but they didn't seem to understand.  I… I did my best.",
+    "dynamic_line": {
+      "gendered_line": "The evacuation order sounded, so I evacuated, comparatively quickly.  That got me out before the worst part.  Our evacuation center was useless… me, a couple other evacuees, a few tins of food, and a few emergency blankets.  Not even close to enough to go around.  The evacuees split down the middle into a few camps, and infighting started.  I ran into the woods nearby with a few others.  We got away, had a little camp going.  They tried to make me their leader, thought I knew more about things than I did because I'd come so prepared.  Like I said, I'm not that kind of scientist, but they didn't seem to understand.  I… I did my best.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What happened with your leadership run?", "topic": "BGSS_SCIENTIST_1_STORY3" },
       {
@@ -30,7 +36,10 @@
   {
     "id": "BGSS_SCIENTIST_1_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "I thought that us leaving, letting the others have the evac center to themselves, would be enough, but it wasn't.  They tracked us down in the night, a few days later.  They… well… I made it out, along with one other survivor.  The attackers, they were like animals.  We tried to travel together for a while.  I blamed myself, for what had happened, and couldn't really get past it.  We parted ways on good terms not long before I met you.  I just couldn't face the reminder of what had happened.",
+    "dynamic_line": {
+      "gendered_line": "I thought that us leaving, letting the others have the evac center to themselves, would be enough, but it wasn't.  They tracked us down in the night, a few days later.  They… well… I made it out, along with one other survivor.  The attackers, they were like animals.  We tried to travel together for a while.  I blamed myself, for what had happened, and couldn't really get past it.  We parted ways on good terms not long before I met you.  I just couldn't face the reminder of what had happened.",
+      "relevant_genders": [ "npc" ]
+    },
     "//": "TK, this survivor could give a quest to locate the other survivor.",
     "responses": [
       {

--- a/data/json/npcs/Backgrounds/scientist_2.json
+++ b/data/json/npcs/Backgrounds/scientist_2.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_SCIENTIST_2_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I've got a memory blank for about three days before and after <the_cataclysm> actually.  I worked at a lab - nothing to do with any of this; physics stuff.  I think I was working there when things happened.  My first clear memory is running through the underbrush a few miles from town.  I was bandaged up, I had a messenger bag loaded with gear, and I'd taken a hard hit to the side of my head.  I have no idea what happened to me, but clearly I had already been on the run for a bit.",
+    "dynamic_line": {
+      "gendered_line": "I've got a memory blank for about three days before and after <the_cataclysm> actually.  I worked at a lab - nothing to do with any of this; physics stuff.  I think I was working there when things happened.  My first clear memory is running through the underbrush a few miles from town.  I was bandaged up, I had a messenger bag loaded with gear, and I'd taken a hard hit to the side of my head.  I have no idea what happened to me, but clearly I had already been on the run for a bit.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "Do you think there's some way your knowledge could help us understand all this?",

--- a/data/json/npcs/Backgrounds/soldier_1.json
+++ b/data/json/npcs/Backgrounds/soldier_1.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_SOLDIER_1_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "Listen, I don't want to get too into it.  I was in the reserves, OK?  I didn't sign on for some glory loaded shit about protecting my nation, I wanted to get some exercise, make some friends, and it looks good on my resume.  I never thought I'd get called to active duty to fight <swear> zombies.  Maybe I'm a deserter, or a chickenshit, but I can tell you one other thing I am that the other grunts ain't: alive.  You can figure the rest out.",
+    "dynamic_line": {
+      "gendered_line": "Listen, I don't want to get too into it.  I was in the reserves, OK?  I didn't sign on for some glory loaded shit about protecting my nation, I wanted to get some exercise, make some friends, and it looks good on my resume.  I never thought I'd get called to active duty to fight <swear> zombies.  Maybe I'm a deserter, or a chickenshit, but I can tell you one other thing I am that the other grunts ain't: alive.  You can figure the rest out.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Fair enough, thanks.  <done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/soldier_2.json
+++ b/data/json/npcs/Backgrounds/soldier_2.json
@@ -2,7 +2,10 @@
   {
     "id": "BGSS_SOLDIER_2_STORY1",
     "type": "talk_topic",
-    "dynamic_line": "I was in the army.  Just a new recruit.  I wasn't even done basic training, they actually called me out of boot camp to serve once the shit hit the fan.  I barely knew which end of the gun the bullets came out of, and they jammed me into a truck and drove me to Newport to 'assist in the evacuation efforts'.  Our orders barely made sense, our officers were as confused as we were.",
+    "dynamic_line": {
+      "gendered_line": "I was in the army.  Just a new recruit.  I wasn't even done basic training, they actually called me out of boot camp to serve once the shit hit the fan.  I barely knew which end of the gun the bullets came out of, and they jammed me into a truck and drove me to Newport to 'assist in the evacuation efforts'.  Our orders barely made sense, our officers were as confused as we were.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What happened in Newport?", "topic": "BGSS_SOLDIER_2_STORY2" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -12,7 +15,10 @@
   {
     "id": "BGSS_SOLDIER_2_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "We never even made it to Newport.  The truck got stomped by something gigantic.  I didn't even see it, just saw this huge black-and-green spiny leg jam through the ceiling, through the el-tee.  Heard the tires grinding, felt the truck lift up.  We were kicked off the leg like dog shit off a sneaker.  I don't know how I survived.  The thing rolled over, killed most of us right there.  I musta blacked out for a bit.  Came to, and while I was getting myself out, the others started getting back up.  Long story short, I lived, they didn't, and I ran.",
+    "dynamic_line": {
+      "gendered_line": "We never even made it to Newport.  The truck got stomped by something gigantic.  I didn't even see it, just saw this huge black-and-green spiny leg jam through the ceiling, through the el-tee.  Heard the tires grinding, felt the truck lift up.  We were kicked off the leg like dog shit off a sneaker.  I don't know how I survived.  The thing rolled over, killed most of us right there.  I musta blacked out for a bit.  Came to, and while I was getting myself out, the others started getting back up.  Long story short, I lived, they didn't, and I ran.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Thanks for telling me all that.  <done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
       { "text": "<end_talking>", "topic": "TALK_DONE" }

--- a/data/json/npcs/Backgrounds/wedding_1.json
+++ b/data/json/npcs/Backgrounds/wedding_1.json
@@ -12,7 +12,10 @@
   {
     "id": "BGSS_WEDDING_1_STORY2",
     "type": "talk_topic",
-    "dynamic_line": "Yeah, in hindsight it maybe wasn't the best choice of dates, huh?  I admit I had cold feet though.  Anyway we were getting hitched at the church.  Lucky for me I was late to the ceremony… I guess some of the fresher corpses in the graveyard had gotten up and started harassing the party.",
+    "dynamic_line": {
+      "gendered_line": "Yeah, in hindsight it maybe wasn't the best choice of dates, huh?  I admit I had cold feet though.  Anyway we were getting hitched at the church.  Lucky for me I was late to the ceremony… I guess some of the fresher corpses in the graveyard had gotten up and started harassing the party.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What did you do next?", "topic": "BGSS_WEDDING_1_STORY3" },
       { "text": "You seem surprisingly calm about all this.", "topic": "BGSS_WEDDING_1_CALM" },
@@ -23,7 +26,10 @@
   {
     "id": "BGSS_WEDDING_1_STORY3",
     "type": "talk_topic",
-    "dynamic_line": "After I saw what was going on, I turned around and headed out in the opposite direction.  I've seen zombie movies before.  I picked up some stuff from home and I managed to get out of town before things went really bad.  At the time I thought I was being a coward, but now I know if I'd stayed to help, I'd just be another dripping corpse.",
+    "dynamic_line": {
+      "gendered_line": "After I saw what was going on, I turned around and headed out in the opposite direction.  I've seen zombie movies before.  I picked up some stuff from home and I managed to get out of town before things went really bad.  At the time I thought I was being a coward, but now I know if I'd stayed to help, I'd just be another dripping corpse.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "You seem surprisingly calm about all this.", "topic": "BGSS_WEDDING_1_CALM" },
       { "text": "<done_conversation_section>", "topic": "TALK_FRIEND_CONVERSATION" },
@@ -47,7 +53,10 @@
   {
     "id": "CWH_WEDDING_1_IDEAS1",
     "type": "talk_topic",
-    "dynamic_line": "I'll be honest with you, I was paying more attention to wedding planning than current events leading up to things.  I knew there were riots going on, but they were out of town.  Even when they got closer to home, I tried to ignore them so we could have our big day.  After the zombies started coming, though, well that's when stuff got really weird.  When I was running from the wedding I swear I saw the sky rip open and monsters fly out of the hole, like something out of Independence Day.  I don't know what it all was, it looked like black magic or something.",
+    "dynamic_line": {
+      "gendered_line": "I'll be honest with you, I was paying more attention to wedding planning than current events leading up to things.  I knew there were riots going on, but they were out of town.  Even when they got closer to home, I tried to ignore them so we could have our big day.  After the zombies started coming, though, well that's when stuff got really weird.  When I was running from the wedding I swear I saw the sky rip open and monsters fly out of the hole, like something out of Independence Day.  I don't know what it all was, it looked like black magic or something.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "<done_conversation_section>", "topic": "TALK_NONE" }, { "text": "<end_talking>", "topic": "TALK_DONE" } ]
   }
 ]

--- a/data/json/npcs/EOC_talkers/portal_storm.json
+++ b/data/json/npcs/EOC_talkers/portal_storm.json
@@ -25,7 +25,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_PORTAL_STORM_DO_FOR_ME",
-    "dynamic_line": "You are limited.  Here outside there are no limits.  I could free you from your bonds.  Or bring you halfway here to get a taste.",
+    "dynamic_line": {
+      "gendered_line": "You are limited.  Here outside there are no limits.  I could free you from your bonds.  Or bring you halfway here to get a taste.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "Free me, would such a thing even be me?", "topic": "TALK_PORTAL_STORM_BE_ME" },
       { "text": "What is halfway between us?", "topic": "TALK_PORTAL_STORM_HALFWAY" },
@@ -58,7 +61,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_PORTAL_STORM_GROW_INTO",
-    "dynamic_line": "Language is too weak to describe it.  You are too limited to understand freedom yet.  What is mortality when time is a choice?  What is weakness when limits are an illusion?  What is up when there is no down, wrong when there is no right?",
+    "dynamic_line": {
+      "gendered_line": "Language is too weak to describe it.  You are too limited to understand freedom yet.  What is mortality when time is a choice?  What is weakness when limits are an illusion?  What is up when there is no down, wrong when there is no right?",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "Would such a thing even be me?", "topic": "TALK_PORTAL_STORM_BE_ME" },
       { "text": "Leave me alone.", "topic": "TALK_PORTAL_STORM_IGNORE" }

--- a/data/json/npcs/Kindred/NPC_Brigitte_LaCroix.json
+++ b/data/json/npcs/Kindred/NPC_Brigitte_LaCroix.json
@@ -109,10 +109,10 @@
         "type": "dialogue",
         "context": "song",
         "value": "yes",
-        "no": "You're back.  Have you come to listen to the song?",
+        "no": { "gendered_line": "You're back.  Have you come to listen to the song?", "relevant_genders": [ "u" ] },
         "yes": {
           "u_has_trait": "seer_mark",
-          "no": "Traveller.",
+          "no": { "gendered_line": "Traveller.", "relevant_genders": [ "u" ] },
           "yes": { "u_female": true, "yes": "Greetings, sister.", "no": "Greetings, brother." }
         }
       }
@@ -281,7 +281,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_BONE_SEER_POSITIVE",
-    "dynamic_line": "Your mind is open.  More than most.  Perhaps one day, you too will feel the power of the song and become Kindred.  For now, traveller, listen, listen and feel the song.",
+    "dynamic_line": {
+      "gendered_line": "Your mind is open.  More than most.  Perhaps one day, you too will feel the power of the song and become Kindred.  For now, traveller, listen, listen and feel the song.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [ { "text": "I… thank you.", "topic": "TALK_BONE_SEER" } ]
   },
   {
@@ -479,7 +482,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_BONE_SEER_METCOOPER",
-    "dynamic_line": "I see.  And you live still.  Does that mean you managed to stop him?",
+    "dynamic_line": { "gendered_line": "I see.  And you live still.  Does that mean you managed to stop him?", "relevant_genders": [ "u" ] },
     "responses": [
       {
         "text": "I've confronted him.  He ended up attacking me.",
@@ -506,7 +509,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_BONE_SEER_COOPERFIGHT",
-    "dynamic_line": "It saddens me to see a talented Kindred lose his way so greatly, but I take solace in the fact that you are unscathed.",
+    "dynamic_line": {
+      "gendered_line": "It saddens me to see a talented Kindred lose his way so greatly, but I take solace in the fact that you are unscathed.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [ { "text": "Best not to dwell on it.  Let's move on.", "topic": "TALK_BONE_SEER" } ]
   },
   {

--- a/data/json/npcs/Kindred/NPC_Darren_Cooper.json
+++ b/data/json/npcs/Kindred/NPC_Darren_Cooper.json
@@ -99,7 +99,10 @@
       "value": "yes",
       "no": {
         "u_has_trait": "seer_mark",
-        "yes": "How do you do.  Name's Cooper.  What's your- wait… that's the Mark of the Seer on your hand.  You're Kindred.  So I guess you know who I am, then.",
+        "yes": {
+          "gendered_line": "How do you do.  Name's Cooper.  What's your- wait… that's the Mark of the Seer on your hand.  You're Kindred.  So I guess you know who I am, then.",
+          "relevant_genders": [ "u" ]
+        },
         "no": "How do you do.  Name's Cooper.  And you are?"
       },
       "yes": {
@@ -428,7 +431,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_COOPER_MONSTER",
-    "dynamic_line": "And how many people have you killed?  Maybe it was in self defense, maybe because you wanted their gear.  It's all the same.  I give their death meaning.  I hate that I have to do it, I truly do, but you really must understand, there is no other way.  The sooner I finish my mission, the sooner all this madness can end.",
+    "dynamic_line": {
+      "gendered_line": "And how many people have you killed?  Maybe it was in self defense, maybe because you wanted their gear.  It's all the same.  I give their death meaning.  I hate that I have to do it, I truly do, but you really must understand, there is no other way.  The sooner I finish my mission, the sooner all this madness can end.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "I suppose you're right.", "topic": "TALK_COOPER_AGREE" },
       { "text": "You're mad.  You have to be stopped.", "topic": "TALK_COOPER_FIGHT" },
@@ -457,7 +463,10 @@
     "id": "TALK_COOPER_AGREE",
     "dynamic_line": {
       "u_has_trait": "seer_mark",
-      "yes": "You're like me then, Kindred.  I'm glad I'm not the only one who realizes what's necessary.  Perhaps one day, we'll be able to work together, but what I do now, I must do alone.",
+      "yes": {
+        "gendered_line": "You're like me then, Kindred.  I'm glad I'm not the only one who realizes what's necessary.  Perhaps one day, we'll be able to work together, but what I do now, I must do alone.",
+        "relevant_genders": [ "u" ]
+      },
       "no": "I'm glad you realize the necessity of the burden I bear.  Maybe someday we'll even join our forces, but for now, I have to do this alone."
     },
     "speaker_effect": { "effect": { "u_add_var": "cooper_friendly", "type": "dialogue", "context": "cooper", "value": "yes" } },
@@ -475,7 +484,10 @@
     "id": "TALK_COOPER_WORK",
     "dynamic_line": {
       "u_has_trait": "seer_mark",
-      "yes": "You're Kindred, and yet you question the power the bones hold, the Song itself?  This hypocrisy is why I set off on my own.  Stop wasting my time and get out of my way.",
+      "yes": {
+        "gendered_line": "You're Kindred, and yet you question the power the bones hold, the Song itself?  This hypocrisy is why I set off on my own.  Stop wasting my time and get out of my way.",
+        "relevant_genders": [ "u" ]
+      },
       "no": "I know it's hard to comprehend when you can't hear the song.  The bones hold power, you just don't hear it yet.  But you will, eventually."
     },
     "responses": [

--- a/data/json/npcs/Lighthouse_Family/NPC_lighthouse_man.json
+++ b/data/json/npcs/Lighthouse_Family/NPC_lighthouse_man.json
@@ -226,7 +226,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_lighthouse_man_family",
-    "dynamic_line": "Did you find them, <name_g>?",
+    "dynamic_line": { "gendered_line": "Did you find them, <name_g>?", "relevant_genders": [ "u" ] },
     "responses": [
       {
         "text": "We did it.  All safe.",

--- a/data/json/npcs/Lighthouse_Family/TALK_fix_lighthouse.json
+++ b/data/json/npcs/Lighthouse_Family/TALK_fix_lighthouse.json
@@ -55,10 +55,16 @@
       "math": [ "time_since(n_time_lighthouse_wait)", ">", "time('2 d')" ],
       "yes": {
         "npc_has_trait": "Exp_Eng_Electrical1Fake2",
-        "yes": "Boss, here's the thing… just don't be mad, please.  I lied that I'm good at this… I thought I could figure it out, but it's far beyond my comprehension.  I'm sorry.",
+        "yes": {
+          "gendered_line": "Boss, here's the thing… just don't be mad, please.  I lied that I'm good at this… I thought I could figure it out, but it's far beyond my comprehension.  I'm sorry.",
+          "relevant_genders": [ "npc" ]
+        },
         "no": {
           "npc_has_trait": "Exp_Eng_Electrical0Fake2",
-          "yes": "Boss, here's the thing… just don't be mad, please.  I lied that I know something about this… I thought I could figure it out, but it's far beyond my comprehension.  I'm sorry.",
+          "yes": {
+            "gendered_line": "Boss, here's the thing… just don't be mad, please.  I lied that I know something about this… I thought I could figure it out, but it's far beyond my comprehension.  I'm sorry.",
+            "relevant_genders": [ "npc" ]
+          },
           "no": "All done, boss.  Tell that fisherman to try it in action."
         }
       },

--- a/data/json/npcs/Lighthouse_Family/npc_survivor.json
+++ b/data/json/npcs/Lighthouse_Family/npc_survivor.json
@@ -22,13 +22,28 @@
     "dynamic_line": {
       "concatenate": [
         [
-          "During one of my night searches of food and supplies, I noticed a bright glow that came from somewhere far away.  I thought that one of the survivors had lit it to indicate their location.  As you can see, I was right.  I managed to find a boat near the nearest shore, on which I set sail.",
-          "I have been sailing on my little boat from coast to coast for a long time.  In truth, the boat was not entirely mine, but it doesn't matter.  That way of life provided me with sufficient safety from the <zombies>, and I managed to get around the sea creatures deftly.  When I saw a distant light, at first, I could not believe my eyes.  Then, I decided to find out what it is."
+          {
+            "gendered_line": "During one of my night searches of food and supplies, I noticed a bright glow that came from somewhere far away.  I thought that one of the survivors had lit it to indicate their location.  As you can see, I was right.  I managed to find a boat near the nearest shore, on which I set sail.",
+            "relevant_genders": [ "npc" ]
+          },
+          {
+            "gendered_line": "I have been sailing on my little boat from coast to coast for a long time.  In truth, the boat was not entirely mine, but it doesn't matter.  That way of life provided me with sufficient safety from the <zombies>, and I managed to get around the sea creatures deftly.  When I saw a distant light, at first, I could not believe my eyes.  Then, I decided to find out what it is.",
+            "relevant_genders": [ "npc" ]
+          }
         ],
         [
-          "  Unfortunately, during my 'voyage' to this lighthouse, luck turned away from me.  I was attacked by some <monster> from the underwater depths.  I couldn't fight off him and he dragged my ship to the bottom.  The waves brought me straight to the shore of this little island.  I still don't understand by what miracle I managed to survive, <name_g>.",
-          "  Unfortunately, when I arrived here, I forgot to tie my boat, and during yesterday's storm it was carried off somewhere.  Well, you don't always have to be lucky, right?",
-          "  I sailed here a few days ago.  Mikhail and his family are very hospitable.  Unfortunately, during our joint fishing, we were attacked by a swarm of underwater <monster>'s, and my boat was smashed to pieces.  It was <very> scary, we could barely sail away on Mikhail's ship."
+          {
+            "gendered_line": "  Unfortunately, during my 'voyage' to this lighthouse, luck turned away from me.  I was attacked by some <monster> from the underwater depths.  I couldn't fight off him and he dragged my ship to the bottom.  The waves brought me straight to the shore of this little island.  I still don't understand by what miracle I managed to survive, <name_g>.",
+            "relevant_genders": [ "npc" ]
+          },
+          {
+            "gendered_line": "  Unfortunately, when I arrived here, I forgot to tie my boat, and during yesterday's storm it was carried off somewhere.  Well, you don't always have to be lucky, right?",
+            "relevant_genders": [ "npc" ]
+          },
+          {
+            "gendered_line": "  I sailed here a few days ago.  Mikhail and his family are very hospitable.  Unfortunately, during our joint fishing, we were attacked by a swarm of underwater <monster>'s, and my boat was smashed to pieces.  It was <very> scary, we could barely sail away on Mikhail's ship.",
+            "relevant_genders": [ "npc" ]
+          }
         ]
       ]
     },

--- a/data/json/npcs/TALK_CITY_COP.json
+++ b/data/json/npcs/TALK_CITY_COP.json
@@ -7,7 +7,10 @@
       "type": "dialogue",
       "context": "survivor_cop",
       "value": "yes",
-      "no": "STOP, Put your hands in the air!  Ha, startled you didn't I… there is no law anymore…",
+      "no": {
+        "gendered_line": "STOP, Put your hands in the air!  Ha, startled you didn't I… there is no law anymore…",
+        "relevant_genders": [ "npc" ]
+      },
       "yes": "Hi there, <name_g>."
     },
     "responses": [
@@ -25,7 +28,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_CITY_COP_INTRO",
-    "dynamic_line": "I was watching the station when things went sideways.  None of the other officers returned from the last call, well not as humans anyway…",
+    "dynamic_line": {
+      "gendered_line": "I was watching the station when things went sideways.  None of the other officers returned from the last call, well not as humans anyway…",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Why don't you go somewhere else?", "topic": "TALK_CITY_COP_LEAVE" },
       { "text": "Let's trade then.", "effect": "start_trade", "topic": "TALK_CITY_COP" },
@@ -35,7 +41,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_CITY_COP_LEAVE",
-    "dynamic_line": "This is a nice, secure building.  I'd be a fool to leave.  Been living off the vending machines, but I found the code for the evidence lockup so I've been doing some trading with other survivors.",
+    "dynamic_line": {
+      "gendered_line": "This is a nice, secure building.  I'd be a fool to leave.  Been living off the vending machines, but I found the code for the evidence lockup so I've been doing some trading with other survivors.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What kind of stuff was in the evidence lockup?", "topic": "TALK_CITY_COP_EVIDENCE" },
       { "text": "You've seen other survivors?", "topic": "TALK_CITY_COP_NEWS" },

--- a/data/json/npcs/TALK_CYBORG_1.json
+++ b/data/json/npcs/TALK_CYBORG_1.json
@@ -7,7 +7,10 @@
       "type": "dialogue",
       "context": "cyborg",
       "value": "yes",
-      "no": "I… I'm free.  *Zzzt* I'm actually free!  *bzzz* Look, you're the first person I've seen in a long time.",
+      "no": {
+        "gendered_line": "I… I'm free.  *Zzzt* I'm actually free!  *bzzz* Look, you're the first person I've seen in a long time.",
+        "relevant_genders": [ "npc" ]
+      },
       "yes": "Hey again.  *kzzz*"
     },
     "speaker_effect": { "effect": { "npc_add_var": "cyborg_has_talked", "type": "dialogue", "context": "cyborg", "value": "yes" } },

--- a/data/json/npcs/TALK_MARLOSS_VOICE.json
+++ b/data/json/npcs/TALK_MARLOSS_VOICE.json
@@ -51,7 +51,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_MARLOSS_VOICE_A_PRIEST",
-    "dynamic_line": "I'm a priest or guide of a sort.  I sing the hymns along my companions so that we may learn to live in unity, both with each other and with our ailing world.",
+    "dynamic_line": {
+      "gendered_line": "I'm a priest or guide of a sort.  I sing the hymns along my companions so that we may learn to live in unity, both with each other and with our ailing world.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Alright.", "topic": "TALK_MARLOSS_VOICE" },
       { "text": "Can I join you?", "topic": "TALK_MARLOSS_VOICE_WITH_US", "condition": { "u_has_flag": "mycus" } },

--- a/data/json/npcs/TALK_NC_FARMER.json
+++ b/data/json/npcs/TALK_NC_FARMER.json
@@ -2,7 +2,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_NC_FARMER",
-    "dynamic_line": "Are you one of them?",
+    "dynamic_line": { "gendered_line": "Are you one of them?", "relevant_genders": [ "u" ] },
     "responses": [
       { "text": "One of who?", "topic": "TALK_NC_FARMER_INTRO" },
       {
@@ -16,7 +16,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NC_FARMER_INTRO",
-    "dynamic_line": "Hey, you're alive!  Me too.  Been a long while since I've had a conversation.  Uh, with someone else.  Um.",
+    "dynamic_line": {
+      "gendered_line": "Hey, you're alive!  Me too.  Been a long while since I've had a conversation.  Uh, with someone else.  Um.",
+      "relevant_genders": [ "npc", "u" ]
+    },
     "responses": [
       { "text": "It's not safe here anymore, you need to move on.", "topic": "TALK_NC_FARMER_LEAVE" },
       { "text": "How did you make it?", "topic": "TALK_NC_FARMER_STORY1" },
@@ -28,7 +31,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NC_FARMER_LEAVE",
-    "dynamic_line": "I heard it's bad in the cities, back when the radio was still working.  Some of those things came through here.  I want to stay out in the country if I can stay safe.",
+    "dynamic_line": {
+      "gendered_line": "I heard it's bad in the cities, back when the radio was still working.  Some of those things came through here.  I want to stay out in the country if I can stay safe.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What did you do before the Cataclysm?", "topic": "TALK_NC_FARMER_EXPERTISE" },
       { "text": "Wanna get outta here?", "topic": "TALK_SUGGEST_FOLLOW" },
@@ -72,7 +78,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NC_FARMER_STORY4",
-    "dynamic_line": "I'm a lot better now, I've been hunkering down here.  Something came by in the night screaming and crying, sounded just like that woman.  Maybe a ghost, I don't know.  It's good to have company again.  You're not a ghost, right?  On second thought, don't tell me if you are, I probably don't want to know.",
+    "dynamic_line": {
+      "gendered_line": "I'm a lot better now, I've been hunkering down here.  Something came by in the night screaming and crying, sounded just like that woman.  Maybe a ghost, I don't know.  It's good to have company again.  You're not a ghost, right?  On second thought, don't tell me if you are, I probably don't want to know.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What did you do before the Cataclysm?", "topic": "TALK_NC_FARMER_EXPERTISE" },
       { "text": "Let's trade items.", "topic": "TALK_NONE", "effect": "start_trade" },
@@ -82,7 +91,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NC_FARMER_EXPERTISE",
-    "dynamic_line": "I grew up on the farm, I don't know much about ghosts and goblins, but I've spent a lot of time growing food and I work hard.  It's better in the country, cleaner.  Not as dangerous.  I hope.",
+    "dynamic_line": {
+      "gendered_line": "I grew up on the farm, I don't know much about ghosts and goblins, but I've spent a lot of time growing food and I work hard.  It's better in the country, cleaner.  Not as dangerous.  I hope.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Why don't you go somewhere else?", "topic": "TALK_NC_FARMER_LEAVE" },
       { "text": "Wanna get outta here?", "topic": "TALK_SUGGEST_FOLLOW" },

--- a/data/json/npcs/TALK_SURVIVOR_CHEF.json
+++ b/data/json/npcs/TALK_SURVIVOR_CHEF.json
@@ -2,7 +2,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NC_SURVIVOR_CHEF",
-    "dynamic_line": "Hey, I didn't expect to live long enough to see another living human!",
+    "dynamic_line": {
+      "gendered_line": "Hey, I didn't expect to live long enough to see another living human!",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What are you doing here?", "topic": "TALK_NC_SURVIVOR_CHEF_INTRO" },
       { "text": "Wanna get outta here?", "topic": "TALK_SUGGEST_FOLLOW" },
@@ -13,7 +16,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_NC_SURVIVOR_CHEF_INTRO",
-    "dynamic_line": "I've been here since shit went down.  Just my luck I had to work.",
+    "dynamic_line": { "gendered_line": "I've been here since shit went down.  Just my luck I had to work.", "relevant_genders": [ "npc" ] },
     "responses": [
       { "text": "Why don't you go somewhere else?", "topic": "TALK_NC_SURVIVOR_CHEF_LEAVE" },
       { "text": "How are you alive?", "topic": "TALK_NC_SURVIVOR_CHEF_STORY1" },
@@ -25,7 +28,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NC_SURVIVOR_CHEF_LEAVE",
-    "dynamic_line": "Well, the dishwasher made a break for it three days after things got weird.  He was ripped to shreds before he made it to the street.  I figure this place has gotta be safer than my apartment, and at least I've got all this food here.",
+    "dynamic_line": {
+      "gendered_line": "Well, the dishwasher made a break for it three days after things got weird.  He was ripped to shreds before he made it to the street.  I figure this place has gotta be safer than my apartment, and at least I've got all this food here.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What did you do before the Cataclysm?", "topic": "TALK_NC_SURVIVOR_CHEF_EXPERTISE" },
       { "text": "Wanna get outta here?", "topic": "TALK_SUGGEST_FOLLOW" },
@@ -36,7 +42,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NC_SURVIVOR_CHEF_STORY1",
-    "dynamic_line": "I… um… hid.  I was in the kitchen, preparing another masterpiece when I heard glass shattering followed by screaming.  I ran over to the serving window to see what happened, assuming a guest had fallen and broke something.  What I witnessed was the most awful thing I've ever seen.  I'm not even sure I could go over it again.",
+    "dynamic_line": {
+      "gendered_line": "I… um… hid.  I was in the kitchen, preparing another masterpiece when I heard glass shattering followed by screaming.  I ran over to the serving window to see what happened, assuming a guest had fallen and broke something.  What I witnessed was the most awful thing I've ever seen.  I'm not even sure I could go over it again.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What happened next?", "topic": "TALK_NC_SURVIVOR_CHEF_STORY2" },
       { "text": "What did you do before the Cataclysm?", "topic": "TALK_NC_SURVIVOR_CHEF_EXPERTISE" },
@@ -47,7 +56,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NC_SURVIVOR_CHEF_STORY2",
-    "dynamic_line": "Some lunatic covered in a film of goo, black as oil, had fallen through one of the large glass windows.  There were glass shards stuck in its head and neck.  I thought the poor guy, girl-thing-whatever was dead.  People began to crowd around it, some were taking pictures.",
+    "dynamic_line": {
+      "gendered_line": "Some lunatic covered in a film of goo, black as oil, had fallen through one of the large glass windows.  There were glass shards stuck in its head and neck.  I thought the poor guy, girl-thing-whatever was dead.  People began to crowd around it, some were taking pictures.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Horrible.  Did you get any pictures yourself?", "topic": "TALK_NC_SURVIVOR_CHEF_STORY3" },
       { "text": "What did you do before the Cataclysm?", "topic": "TALK_NC_SURVIVOR_CHEF_EXPERTISE" },
@@ -58,7 +70,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NC_SURVIVOR_CHEF_STORY3",
-    "dynamic_line": "No!  I figured the thing dead until it started writhing and spazzing out for a moment.  Everyone jumped back, a few screamed, and one curious stranger stepped in closer, kneeling a little… it attacked him!",
+    "dynamic_line": {
+      "gendered_line": "No!  I figured the thing dead until it started writhing and spazzing out for a moment.  Everyone jumped back, a few screamed, and one curious stranger stepped in closer, kneeling a little… it attacked him!",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What'd you do?", "topic": "TALK_NC_SURVIVOR_CHEF_STORY4" },
       { "text": "What did you do before the Cataclysm?", "topic": "TALK_NC_SURVIVOR_CHEF_EXPERTISE" },
@@ -69,7 +84,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NC_SURVIVOR_CHEF_STORY4",
-    "dynamic_line": "I ran to the back of the kitchen and hid as best I could.  People outside were screaming and I could hear them running.  Suddenly I heard more glass shatter and something skitter out of the restaurant.  I waited a moment and then went and checked the dining area.  Both the stranger and the thing were gone.  People were running in the streets, some even had guns so I locked all the doors and blocked the windows with what I could and barricaded myself in here.",
+    "dynamic_line": {
+      "gendered_line": "I ran to the back of the kitchen and hid as best I could.  People outside were screaming and I could hear them running.  Suddenly I heard more glass shatter and something skitter out of the restaurant.  I waited a moment and then went and checked the dining area.  Both the stranger and the thing were gone.  People were running in the streets, some even had guns so I locked all the doors and blocked the windows with what I could and barricaded myself in here.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Crazy, so you have been here ever since?", "topic": "TALK_NC_SURVIVOR_CHEF_STORY5" },
       { "text": "What did you do before the Cataclysm?", "topic": "TALK_NC_SURVIVOR_CHEF_EXPERTISE" },
@@ -80,7 +98,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NC_SURVIVOR_CHEF_STORY5",
-    "dynamic_line": "Yeah, it was awhile before it was quiet again.  I heard all kinds of sounds: explosions, jets flying by, helicopters, screaming, and rapid gunfire.  I swear I even heard what sounded like a freaking tank drive by at one time!  I've been hiding here since.",
+    "dynamic_line": {
+      "gendered_line": "Yeah, it was awhile before it was quiet again.  I heard all kinds of sounds: explosions, jets flying by, helicopters, screaming, and rapid gunfire.  I swear I even heard what sounded like a freaking tank drive by at one time!  I've been hiding here since.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What did you do before the Cataclysm?", "topic": "TALK_NC_SURVIVOR_CHEF_EXPERTISE" },
       { "text": "Let's trade items.", "topic": "TALK_NONE", "effect": "start_trade" },
@@ -90,7 +111,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NC_SURVIVOR_CHEF_EXPERTISE",
-    "dynamic_line": "I've been a cook since forever, this wasn't the best joint, but management was cool.",
+    "dynamic_line": {
+      "gendered_line": "I've been a cook since forever, this wasn't the best joint, but management was cool.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Why don't you go somewhere else?", "topic": "TALK_NC_SURVIVOR_CHEF_LEAVE" },
       { "text": "Wanna get outta here?", "topic": "TALK_SUGGEST_FOLLOW" },

--- a/data/json/npcs/TALK_TRUE_FOODPERSON.json
+++ b/data/json/npcs/TALK_TRUE_FOODPERSON.json
@@ -15,7 +15,7 @@
           "type": "dialogue",
           "context": "foodperson",
           "value": "yes",
-          "no": "So you're back… explain yourself!",
+          "no": { "gendered_line": "So you're back… explain yourself!", "relevant_genders": [ "u" ] },
           "yes": "Greetings friend, it's nice to see you."
         }
       },
@@ -140,7 +140,7 @@
   {
     "id": "TALK_FOODPERSON_INTRODUCTION",
     "type": "talk_topic",
-    "dynamic_line": "Indeed it is I!  The one and only FOODPERSON!",
+    "dynamic_line": { "gendered_line": "Indeed it is I!  The one and only FOODPERSON!", "relevant_genders": [ "npc" ] },
     "responses": [
       {
         "text": "Wow!  Such an honor to meet you in person!",
@@ -407,7 +407,7 @@
   {
     "id": "TALK_FOODPERSON_NOTRAINING",
     "type": "talk_topic",
-    "dynamic_line": "You're not ready for this.",
+    "dynamic_line": { "gendered_line": "You're not ready for this.", "relevant_genders": [ "u" ] },
     "speaker_effect": { "effect": { "npc_add_var": "npc_failed_training", "type": "dialogue", "context": "foodperson", "value": "yes" } },
     "responses": [ { "text": "But I am worthy!", "topic": "TALK_NONE" } ]
   },
@@ -442,7 +442,7 @@
   {
     "id": "TALK_FOODPERSON_SIDEKICK",
     "type": "talk_topic",
-    "dynamic_line": "What about: you prove your worth and join me as my sidekick?",
+    "dynamic_line": { "gendered_line": "What about: you prove your worth and join me as my sidekick?", "relevant_genders": [ "u" ] },
     "speaker_effect": { "effect": { "npc_add_var": "npc_sidekick_offer", "type": "dialogue", "context": "foodperson", "value": "yes" } },
     "responses": [
       { "condition": { "not": "has_assigned_mission" }, "text": "That sounds great!", "topic": "TALK_MISSION_LIST" },

--- a/data/json/npcs/bunker_shop/TALK_BUNKER_MERCHANT.json
+++ b/data/json/npcs/bunker_shop/TALK_BUNKER_MERCHANT.json
@@ -16,13 +16,19 @@
   {
     "type": "talk_topic",
     "id": "TALK_BUNKER_MERCHANT_HERE",
-    "dynamic_line": "No, no… well, maybe a little.  It was just as wrecked down here as it is up top when I found it, wasn't too hard to fix up.  You're welcome to stay in the spare room awhile, just don't hog it.  You're not the only scav out there.",
+    "dynamic_line": {
+      "gendered_line": "No, no… well, maybe a little.  It was just as wrecked down here as it is up top when I found it, wasn't too hard to fix up.  You're welcome to stay in the spare room awhile, just don't hog it.  You're not the only scav out there.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "Interesting…", "topic": "TALK_BUNKER_MERCHANT" } ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_BUNKER_MERCHANT_WHO",
-    "dynamic_line": "Just a scav who got lucky.  Now I'm content to sit around here on my pile of treasure.  I'm more than willing to trade if you've got the cash.",
+    "dynamic_line": {
+      "gendered_line": "Just a scav who got lucky.  Now I'm content to sit around here on my pile of treasure.  I'm more than willing to trade if you've got the cash.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "I see…", "topic": "TALK_BUNKER_MERCHANT" } ]
   },
   {

--- a/data/json/npcs/cabin_chemist/chemist_npc.json
+++ b/data/json/npcs/cabin_chemist/chemist_npc.json
@@ -85,13 +85,19 @@
   {
     "type": "talk_topic",
     "id": "TALK_NPC_CABIN_CHEMIST_STORY",
-    "dynamic_line": "I used to be a chemist.  Well, I am a chemist.  I've been living out here in the wilderness for a little while now since <the_cataclysm>.  Lucky enough, I even found some good equipment out here, though unfortunately missing some of the more sensitive and expensive stuff.  I found a couple useful things here in the cupboards, but other than that, entirely empty.  So, I moved in.",
+    "dynamic_line": {
+      "gendered_line": "I used to be a chemist.  Well, I am a chemist.  I've been living out here in the wilderness for a little while now since <the_cataclysm>.  Lucky enough, I even found some good equipment out here, though unfortunately missing some of the more sensitive and expensive stuff.  I found a couple useful things here in the cupboards, but other than that, entirely empty.  So, I moved in.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "Hmm.", "topic": "TALK_NONE" } ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_NPC_CABIN_CHEMIST_HOME",
-    "dynamic_line": "Not my place, just somewhere I ended up.  Some old shack, maybe a hunting cabin or something more… criminal, at least judging by some of what I found on the shelves.  You certainly wouldn't attract much attention synthesizing illegal substances all the way out here, that's all I'm saying.  I found it while I was trying to escape all the <zombies> in the city, and I decided to stay.",
+    "dynamic_line": {
+      "gendered_line": "Not my place, just somewhere I ended up.  Some old shack, maybe a hunting cabin or something more… criminal, at least judging by some of what I found on the shelves.  You certainly wouldn't attract much attention synthesizing illegal substances all the way out here, that's all I'm saying.  I found it while I was trying to escape all the <zombies> in the city, and I decided to stay.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "Hmm.", "topic": "TALK_NONE" } ]
   },
   {

--- a/data/json/npcs/campus/NPC_campus_guard_generic.json
+++ b/data/json/npcs/campus/NPC_campus_guard_generic.json
@@ -30,8 +30,14 @@
     "id": "TALK_GUARD_CAMP_BACKGROUND",
     "dynamic_line": [
       "Everybody left has to take a turn.  I guess it's fair but not everyone is really suited for beating up zombies or whatever.",
-      "I'm not even supposed to be here today, I just lost a bet and had to take this shift.",
-      "I should be resting right now, this is my third straight shift.  Too many people sick or hurt right now.",
+      {
+        "gendered_line": "I'm not even supposed to be here today, I just lost a bet and had to take this shift.",
+        "relevant_genders": [ "npc" ]
+      },
+      {
+        "gendered_line": "I should be resting right now, this is my third straight shift.  Too many people sick or hurt right now.",
+        "relevant_genders": [ "npc" ]
+      },
       "I live for this stuff.  I'm not really big on books, so this is probably what I'm best at here."
     ],
     "responses": [ { "text": "Well, bye.", "topic": "TALK_DONE" } ]

--- a/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_ALLY.json
@@ -1081,7 +1081,7 @@
   {
     "id": "TALK_ABANDON",
     "type": "talk_topic",
-    "dynamic_line": "Are you sure?",
+    "dynamic_line": { "gendered_line": "Are you sure?", "relevant_genders": [ "u" ] },
     "responses": [
       { "text": "Yes, I'm sure.", "topic": "TALK_DONE", "effect": "abandon_camp" },
       { "text": "Actually, never mind.", "topic": "TALK_NONE" }

--- a/data/json/npcs/common_chat/TALK_COMMON_GREET.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_GREET.json
@@ -180,7 +180,7 @@
   {
     "id": "TALK_DEMAND_LEAVE",
     "type": "talk_topic",
-    "dynamic_line": "Now get out of here, before I kill you.",
+    "dynamic_line": { "gendered_line": "Now get out of here, before I kill you.", "relevant_genders": [ "npc" ] },
     "responses": [ { "text": "Okay, I'm going.", "topic": "TALK_DONE", "effect": "player_leaving", "opinion": { "fear": -1 } } ]
   }
 ]

--- a/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
+++ b/data/json/npcs/common_chat/TALK_COMMON_OTHER.json
@@ -63,7 +63,7 @@
                 "no": "I have some reason for not telling you.",
                 "yes": "Nothing comes to my mind now.  Ask me later perhaps?"
               },
-              "yes": "I'm too tired, let me rest first."
+              "yes": { "gendered_line": "I'm too tired, let me rest first.", "relevant_genders": [ "npc" ] }
             },
             "yes": "I'm too hungry, give me something to eat."
           },
@@ -81,7 +81,7 @@
       "no": {
         "npc_has_effect": "asked_to_follow",
         "no": "Why should I travel with you?",
-        "yes": "You asked me recently; ask again later."
+        "yes": { "gendered_line": "You asked me recently; ask again later.", "relevant_genders": [ "u" ] }
       },
       "yes": "Not until I get some antibiotics…"
     },
@@ -313,7 +313,7 @@
                 "no": "I have some reason for denying you training.",
                 "yes": "Give it some time, I'll show you something new later…"
               },
-              "yes": "I'm too tired, let me rest first."
+              "yes": { "gendered_line": "I'm too tired, let me rest first.", "relevant_genders": [ "npc" ] }
             },
             "yes": "I'm too hungry, give me something to eat."
           },
@@ -344,7 +344,7 @@
                 "no": "I have some reason to refuse hosting a training seminar.",
                 "yes": "Give it some time, we'll talk about a training seminar later…"
               },
-              "yes": "I'm too tired, let me rest first."
+              "yes": { "gendered_line": "I'm too tired, let me rest first.", "relevant_genders": [ "npc" ] }
             },
             "yes": "I'm too hungry, give me something to eat."
           },
@@ -404,7 +404,7 @@
     "type": "talk_topic",
     "dynamic_line": {
       "npc_has_effect": "asked_for_item",
-      "yes": "You just asked me for stuff; ask later.",
+      "yes": { "gendered_line": "You just asked me for stuff; ask later.", "relevant_genders": [ "u" ] },
       "no": "Why should I share my equipment with you?"
     },
     "responses": [

--- a/data/json/npcs/common_chat/TALK_FRIEND_CONVERSATION.json
+++ b/data/json/npcs/common_chat/TALK_FRIEND_CONVERSATION.json
@@ -2,7 +2,10 @@
   {
     "id": "TALK_CONVERSATION_DANGER",
     "type": "talk_topic",
-    "dynamic_line": "Are you sure?  This doesn't seem like a particularly safe place for small talk…",
+    "dynamic_line": {
+      "gendered_line": "Are you sure?  This doesn't seem like a particularly safe place for small talk…",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       {
         "text": "It's fine, we've got a moment.",

--- a/data/json/npcs/exodii/exodii_merchant_talk.json
+++ b/data/json/npcs/exodii/exodii_merchant_talk.json
@@ -125,7 +125,11 @@
     "type": "talk_topic",
     "dynamic_line": {
       "u_has_effect": "u_exodii_interaction_timer_short",
-      "yes": [ "Back in a blink and a whiff, eh?", "Forgot sommat?", "Ah, a returnin', an I'm ken." ],
+      "yes": [
+        "Back in a blink and a whiff, eh?",
+        { "gendered_line": "Forgot sommat?", "relevant_genders": [ "u" ] },
+        "Ah, a returnin', an I'm ken."
+      ],
       "no": {
         "u_has_var": "u_met_Rubik",
         "type": "general",

--- a/data/json/npcs/godco/members/NPC_Arturo_Maldonado.json
+++ b/data/json/npcs/godco/members/NPC_Arturo_Maldonado.json
@@ -70,7 +70,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Arturo_Firstmeet",
-    "dynamic_line": "Yeah, just that I sometimes see things.  I wanna be sure you're real.",
+    "dynamic_line": {
+      "gendered_line": "Yeah, just that I sometimes see things.  I wanna be sure you're real.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "It's alright, just take your time.", "topic": "TALK_DONE" },
       { "text": "Sorry, I gotta go.", "topic": "TALK_DONE" }
@@ -133,7 +136,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Arturo_U_Mutant",
-    "dynamic_line": "I see things sometimes, and there's no way anyone could look like you!  I know you're not real, and if you are, stay away you ugly <name_b>!",
+    "dynamic_line": {
+      "gendered_line": "I see things sometimes, and there's no way anyone could look like you!  I know you're not real, and if you are, stay away you ugly <name_b>!",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [ { "text": "Chill out man, I'm leaving.", "topic": "TALK_DONE" } ]
   }
 ]

--- a/data/json/npcs/godco/members/NPC_Chloe_Taylor_King.json
+++ b/data/json/npcs/godco/members/NPC_Chloe_Taylor_King.json
@@ -43,7 +43,7 @@
   {
     "id": "TALK_GODCO_chloe_idle_chat",
     "type": "talk_topic",
-    "dynamic_line": [ "Shoot." ],
+    "dynamic_line": "Shoot.",
     "responses": [
       {
         "text": "Really, what's your story?",
@@ -70,15 +70,13 @@
   {
     "id": "TALK_GODCO_chloe_2",
     "type": "talk_topic",
-    "dynamic_line": [ "Things suck right now, but you know that anyway.  I don't even know why you bother asking these stupid questions." ],
+    "dynamic_line": "Things suck right now, but you know that anyway.  I don't even know why you bother asking these stupid questions.",
     "responses": [ { "text": "What's your story?", "topic": "TALK_GODCO_chloe_past" }, { "text": "I gotta go.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_GODCO_chloe_help",
     "type": "talk_topic",
-    "dynamic_line": [
-      "I'm not a baby you know, I don't need a babysitter.  Sonia looks out for me though.  She's not so weird, I guess.  She promised to give me guitar lessons and she even signed me an autograph.  I know she's only nice to me because I saved her, but that's okay; we're equal now."
-    ],
+    "dynamic_line": "I'm not a baby you know, I don't need a babysitter.  Sonia looks out for me though.  She's not so weird, I guess.  She promised to give me guitar lessons and she even signed me an autograph.  I know she's only nice to me because I saved her, but that's okay; we're equal now.",
     "responses": [
       { "text": "How'd you and Sonia come to meet?", "topic": "TALK_GODCO_chloe_sonia" },
       { "text": "Yeah, that's enough for me.", "topic": "TALK_DONE" }
@@ -87,9 +85,10 @@
   {
     "id": "TALK_GODCO_chloe_past",
     "type": "talk_topic",
-    "dynamic_line": [
-      "You're creepy.  I'm sorry for your lack of friends but, like, I'm literally a kid.  Everyone on Earth turned into a zombie, we're running out of toilet paper and everything, and my parents are gone.  I know they're still alive and they're looking for me.  I miss them.  Is that enough personal stuff for you?"
-    ],
+    "dynamic_line": {
+      "gendered_line": "You're creepy.  I'm sorry for your lack of friends but, like, I'm literally a kid.  Everyone on Earth turned into a zombie, we're running out of toilet paper and everything, and my parents are gone.  I know they're still alive and they're looking for me.  I miss them.  Is that enough personal stuff for you?",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "I'm sorry for your loss.  Mabey we should talk about something else.", "topic": "TALK_GODCO_chloe" },
       { "text": "Yeah, that's enough for me.", "topic": "TALK_DONE" }
@@ -98,9 +97,7 @@
   {
     "id": "TALK_GODCO_chloe_past_2",
     "type": "talk_topic",
-    "dynamic_line": [
-      "Well, I grew up in the city.  My parents were always out of town on some business meeting or another, so I had plenty of time to myself.  They're great people; mom's a wonderful cook, she makes an amazing fish casserole.  Dad's a hot shot for military contracts, he handled business deals for DARPA and whatnot.  He's an ex-marine, and taught me how to defend myself with a knife."
-    ],
+    "dynamic_line": "Well, I grew up in the city.  My parents were always out of town on some business meeting or another, so I had plenty of time to myself.  They're great people; mom's a wonderful cook, she makes an amazing fish casserole.  Dad's a hot shot for military contracts, he handled business deals for DARPA and whatnot.  He's an ex-marine, and taught me how to defend myself with a knife.",
     "responses": [
       {
         "text": "Where do you think your parents are now?",
@@ -112,9 +109,7 @@
   {
     "id": "TALK_GODCO_chloe_sonia",
     "type": "talk_topic",
-    "dynamic_line": [
-      "I was home alone during the ongoing riots.  My parents chose the worst possible time to reconnect, which sucks, but I'm also kinda happy for them.  Anyway, they were part of the NECC people, so they knew about this place and their plans and all.  Thing is, it was, like, really far away.  I kinda didn't want to go alone but I also didn't want the rioters to eat me, so I asked Sonia - my neighbor - to evacuate with me, I guess.  So that was fun; escaping my hometown, walking down the country road, waiting for a horror to ambush us.  Spoiler alert: we were attacked.  So this zombie shambles in front of us and Sonia whacks it real hard with her guitar!  Its brain splatters all over the pavement, I threw up 'cause it was so disgusting.  We got here soon after that.  My parents weren't here, obviously.  Oh man, they must worry about me so much…"
-    ],
+    "dynamic_line": "I was home alone during the ongoing riots.  My parents chose the worst possible time to reconnect, which sucks, but I'm also kinda happy for them.  Anyway, they were part of the NECC people, so they knew about this place and their plans and all.  Thing is, it was, like, really far away.  I kinda didn't want to go alone but I also didn't want the rioters to eat me, so I asked Sonia - my neighbor - to evacuate with me, I guess.  So that was fun; escaping my hometown, walking down the country road, waiting for a horror to ambush us.  Spoiler alert: we were attacked.  So this zombie shambles in front of us and Sonia whacks it real hard with her guitar!  Its brain splatters all over the pavement, I threw up 'cause it was so disgusting.  We got here soon after that.  My parents weren't here, obviously.  Oh man, they must worry about me so much…",
     "responses": [
       {
         "text": "Aren't you a bit young to be carrying a knife?",
@@ -136,9 +131,7 @@
   {
     "id": "TALK_GODCO_chloe_parents_where",
     "type": "talk_topic",
-    "dynamic_line": [
-      "I don't know.  They were going to a contract deal before the riots broke out, at one of military bases I think.  I don't know what happened to them from there."
-    ],
+    "dynamic_line": "I don't know.  They were going to a contract deal before the riots broke out, at one of military bases I think.  I don't know what happened to them from there.",
     "responses": [
       { "text": "I'll let you know if anything turns up.", "topic": "TALK_GODCO_chloe_idle_chat" },
       { "text": "I'll let you know if anything turns up.  See you around.", "topic": "TALK_DONE" }
@@ -147,21 +140,19 @@
   {
     "id": "TALK_GODCO_chloe_knife",
     "type": "talk_topic",
-    "dynamic_line": [
-      "Aren't you a bit too old not to realize how dangerous the world is for a kid like me?  I know how to handle one without hurting myself!  My dad taught me everything, he's a real pro."
-    ],
+    "dynamic_line": "Aren't you a bit too old not to realize how dangerous the world is for a kid like me?  I know how to handle one without hurting myself!  My dad taught me everything, he's a real pro.",
     "responses": [ { "text": "That makes sense.", "topic": "TALK_GODCO_chloe_idle_chat" } ]
   },
   {
     "id": "TALK_GODCO_chloe_loss",
     "type": "talk_topic",
-    "dynamic_line": [ "They're not dead." ],
+    "dynamic_line": "They're not dead.",
     "responses": [ { "text": "…", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_GODCO_chloe_nochat",
     "type": "talk_topic",
-    "dynamic_line": [ "I don't wanna talk about it right now." ],
+    "dynamic_line": "I don't wanna talk about it right now.",
     "responses": [ { "text": "Alright, let's change the subject.", "topic": "TALK_GODCO_chloe_idle_chat" } ]
   }
 ]

--- a/data/json/npcs/godco/members/NPC_Darryl_Johnstone.json
+++ b/data/json/npcs/godco/members/NPC_Darryl_Johnstone.json
@@ -36,14 +36,21 @@
       "type": "dialogue",
       "context": "godco",
       "value": "yes",
-      "yes": "What the <swear> are you, sinner?  Get away from me.",
+      "yes": { "gendered_line": "What the <swear> are you, sinner?  Get away from me.", "relevant_genders": [ "u" ] },
       "no": {
         "npc_has_var": "u_met_godco_darryl",
         "type": "general",
         "context": "meeting",
         "value": "yes",
-        "yes": [ "Praise the Lord.", "Welcome back.", "Nice to see you again, survivor." ],
-        "no": "Well I'll be damned, a fellow survivor!  I'm Darryl, nice to meet you."
+        "yes": [
+          "Praise the Lord.",
+          "Welcome back.",
+          { "gendered_line": "Nice to see you again, survivor.", "relevant_genders": [ "u" ] }
+        ],
+        "no": {
+          "gendered_line": "Well I'll be damned, a fellow survivor!  I'm Darryl, nice to meet you.",
+          "relevant_genders": [ "u" ]
+        }
       }
     },
     "responses": [
@@ -261,7 +268,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Darryl_BarterSuccess",
-    "dynamic_line": "Well, you got me there.  I sure ain't one to block a fellow farmer's right to reclaim this God-given earth.",
+    "dynamic_line": {
+      "gendered_line": "Well, you got me there.  I sure ain't one to block a fellow farmer's right to reclaim this God-given earth.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [ { "text": "Thank you.  See you around, Darryl.", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/godco/members/NPC_Gemma_Johnstone.json
+++ b/data/json/npcs/godco/members/NPC_Gemma_Johnstone.json
@@ -40,7 +40,10 @@
       "type": "dialogue",
       "context": "godco",
       "value": "yes",
-      "yes": "The Lord isn't with you, and that's obvious.  Get out of my sight, sinner.",
+      "yes": {
+        "gendered_line": "The Lord isn't with you, and that's obvious.  Get out of my sight, sinner.",
+        "relevant_genders": [ "u" ]
+      },
       "no": {
         "npc_has_var": "u_met_godco_gemma",
         "type": "general",
@@ -111,7 +114,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Gemma_Firstmeet",
-    "dynamic_line": "It's nice to meet you too, survivor.  It's a tragedy what's become of the New England Church Community, perhaps it'll flourish again someday.",
+    "dynamic_line": {
+      "gendered_line": "It's nice to meet you too, survivor.  It's a tragedy what's become of the New England Church Community, perhaps it'll flourish again someday.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [ { "text": "I'd better get going.  Nice meeting you.", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/godco/members/NPC_Helena_Misinter.json
+++ b/data/json/npcs/godco/members/NPC_Helena_Misinter.json
@@ -37,7 +37,7 @@
       "type": "dialogue",
       "context": "godco",
       "value": "yes",
-      "yes": "Get away from here, sinner, we don't want your kind here.",
+      "yes": { "gendered_line": "Get away from here, sinner, we don't want your kind here.", "relevant_genders": [ "u" ] },
       "no": {
         "npc_has_var": "u_met_godco_helena",
         "type": "general",
@@ -107,7 +107,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Helena_Joinee",
-    "dynamic_line": "I'm glad you could make it here.  May the Lord have mercy on you.",
+    "dynamic_line": { "gendered_line": "I'm glad you could make it here.  May the Lord have mercy on you.", "relevant_genders": [ "u" ] },
     "responses": [
       { "text": "Thank you, I hope he shares that sentiment.", "topic": "TALK_GODCO_Helena_2" },
       { "text": "Thank you.  I'll see you around.", "topic": "TALK_DONE" }

--- a/data/json/npcs/godco/members/NPC_Jane_Schulz.json
+++ b/data/json/npcs/godco/members/NPC_Jane_Schulz.json
@@ -63,7 +63,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Jane_Firstmeet",
-    "dynamic_line": "Always nice to meet a fellow outsider.  How can I help you?",
+    "dynamic_line": { "gendered_line": "Always nice to meet a fellow outsider.  How can I help you?", "relevant_genders": [ "u" ] },
     "responses": [ { "text": "Actually I'm just heading out.", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/godco/members/NPC_Jeremiah_Weaver.json
+++ b/data/json/npcs/godco/members/NPC_Jeremiah_Weaver.json
@@ -70,9 +70,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Jeremiah_2",
-    "dynamic_line": [
-      "I thought asking about each other's emotions went out of style after <the_cataclysm>.  Uhm, okay then.  I'm fine, I guess."
-    ],
+    "dynamic_line": "I thought asking about each other's emotions went out of style after <the_cataclysm>.  Uhm, okay then.  I'm fine, I guess.",
     "responses": [
       { "text": "I noticed you're holding a D&D handbook.  Do you play much?", "topic": "TALK_GODCO_Jeremiah_Dnd" },
       {

--- a/data/json/npcs/godco/members/NPC_Julian_Ray.json
+++ b/data/json/npcs/godco/members/NPC_Julian_Ray.json
@@ -128,7 +128,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Julian_Leave",
-    "dynamic_line": "You sure?  I mean, you've been traveling for a long time, haven't you?  Alright, it's your decision.  Let me know when you changed your mind.",
+    "dynamic_line": {
+      "gendered_line": "You sure?  I mean, you've been traveling for a long time, haven't you?  Alright, it's your decision.  Let me know when you changed your mind.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [ { "text": "I'd better get going.  Nice meeting you.", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/godco/members/NPC_Katherine_Weaver.json
+++ b/data/json/npcs/godco/members/NPC_Katherine_Weaver.json
@@ -57,14 +57,14 @@
       "type": "dialogue",
       "context": "godco",
       "value": "yes",
-      "yes": "Oh well, yet another sinner.  Don't talk to me.",
+      "yes": { "gendered_line": "Oh well, yet another sinner.  Don't talk to me.", "relevant_genders": [ "u" ] },
       "no": {
         "npc_has_var": "u_met_godco_katherine",
         "type": "general",
         "context": "meeting",
         "value": "yes",
         "yes": [ "Praise the Lord.", "<u_name>, bless you." ],
-        "no": "Oh well, yet another survivor.  Welcome to our group, I'm Katherine."
+        "no": { "gendered_line": "Oh well, yet another survivor.  Welcome to our group, I'm Katherine.", "relevant_genders": [ "u" ] }
       }
     },
     "responses": [
@@ -113,7 +113,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Katherine_2a",
-    "dynamic_line": [ "We have many things to pray for, I'm afraid." ],
+    "dynamic_line": "We have many things to pray for, I'm afraid.",
     "responses": [ { "text": "Well, it's been nice talking to you, but I need to head out.", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
+++ b/data/json/npcs/godco/members/NPC_Kostas_Walsman.json
@@ -54,7 +54,10 @@
         "context": "meeting",
         "value": "yes",
         "yes": [ "Praise the Lord.", "<u_name>, how can I help you?" ],
-        "no": "You must be new here, nice to meet you.  They call me Kostas, I'm the local herbalist."
+        "no": {
+          "gendered_line": "You must be new here, nice to meet you.  They call me Kostas, I'm the local herbalist.",
+          "relevant_genders": [ "u" ]
+        }
       }
     },
     "responses": [
@@ -245,7 +248,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_GODCO_Kostas_Jeremiah_Persuade",
-    "dynamic_line": "Alright, you've convinced me.  I'll take Jeremiah on and show him the ropes.",
+    "dynamic_line": {
+      "gendered_line": "Alright, you've convinced me.  I'll take Jeremiah on and show him the ropes.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       {
         "text": "Thank you.  See you around, Kostas.",

--- a/data/json/npcs/godco/members/NPC_Sonia_Greene.json
+++ b/data/json/npcs/godco/members/NPC_Sonia_Greene.json
@@ -35,7 +35,10 @@
       "type": "general",
       "context": "meeting",
       "value": "yes",
-      "yes": [ "Well now, good to see you again, friend.", "Nice of you to come around <u_name>." ],
+      "yes": [
+        { "gendered_line": "Well now, good to see you again, friend.", "relevant_genders": [ "u" ] },
+        "Nice of you to come around <u_name>."
+      ],
       "no": "Good to see people like you in the world.  I'm Sonia, Sonia Greene.  I entertain the people."
     },
     "responses": [

--- a/data/json/npcs/godco/members/NPC_Tom_Powell.json
+++ b/data/json/npcs/godco/members/NPC_Tom_Powell.json
@@ -39,7 +39,10 @@
         "context": "meeting",
         "value": "yes",
         "yes": "Hey, it's you again <u_name>!  Any news from the outside world?",
-        "no": "Ah, another survivor!  I hope you come in peace.  I'm Tom, nice to meet you."
+        "no": {
+          "gendered_line": "Ah, another survivor!  I hope you come in peace.  I'm Tom, nice to meet you.",
+          "relevant_genders": [ "u" ]
+        }
       }
     },
     "responses": [

--- a/data/json/npcs/godco/members/NPC_Zachary_Montes.json
+++ b/data/json/npcs/godco/members/NPC_Zachary_Montes.json
@@ -21,7 +21,7 @@
   {
     "id": "TALK_GODCO_Zachary",
     "type": "talk_topic",
-    "dynamic_line": "I got my rights to be here, chum.  Squatter's rights!",
+    "dynamic_line": { "gendered_line": "I got my rights to be here, chum.  Squatter's rights!", "relevant_genders": [ "u" ] },
     "responses": [
       {
         "text": "Don't worry, I'm not going to hurt you.",
@@ -77,7 +77,10 @@
   {
     "id": "TALK_GODCO_Zachary_Story0",
     "type": "talk_topic",
-    "dynamic_line": "That ain't the point here, chum.  Don'tcha get it?  This was MY territory, but they took it away from me.  Now they think of us as nothin' but a <swear> nuisance.",
+    "dynamic_line": {
+      "gendered_line": "That ain't the point here, chum.  Don'tcha get it?  This was MY territory, but they took it away from me.  Now they think of us as nothin' but a <swear> nuisance.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "What did you do before <the_cataclysm>?", "topic": "TALK_GODCO_Zachary_Background" },
       { "text": "What were you saying before?", "topic": "TALK_NONE" },
@@ -123,7 +126,10 @@
   {
     "id": "TALK_GODCO_Zachary_Result_rewardIcon",
     "type": "talk_topic",
-    "dynamic_line": "Ha ha ha!  Think before you speak, chum.  Eight icons for an honest day's work, I say the system's broken!",
+    "dynamic_line": {
+      "gendered_line": "Ha ha ha!  Think before you speak, chum.  Eight icons for an honest day's work, I say the system's broken!",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "Sorry to hear that.  What were you saying before?", "topic": "TALK_NONE" },
       { "text": "No rest for the weary…", "topic": "TALK_DONE" }
@@ -132,7 +138,10 @@
   {
     "id": "TALK_GODCO_Zachary_Nightmare",
     "type": "talk_topic",
-    "dynamic_line": "Ain't you heard it?  It's been screeching out in the forest during the night for a while now, keeps me up sometimes.  I'm too scared to go out and see what that thing is.  If you'd kill it, I'd be in your debt forever.",
+    "dynamic_line": {
+      "gendered_line": "Ain't you heard it?  It's been screeching out in the forest during the night for a while now, keeps me up sometimes.  I'm too scared to go out and see what that thing is.  If you'd kill it, I'd be in your debt forever.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       {
         "text": "I'll see what I can do.",
@@ -150,7 +159,10 @@
       "type": "mission",
       "context": "meeting",
       "value": "yes",
-      "yes": "After what you did for me, I'll follow you to the ends of the Earth!  No one around here's stood up for me like that, I owe ya one.",
+      "yes": {
+        "gendered_line": "After what you did for me, I'll follow you to the ends of the Earth!  No one around here's stood up for me like that, I owe ya one.",
+        "relevant_genders": [ "u" ]
+      },
       "no": "No chance!  Its not you, its the world out there I'm worried about.  All those <swear> monsters really give me the creeps, and as far as I know this church is the last bastion of humanity in the <the_cataclysm>."
     },
     "responses": [

--- a/data/json/npcs/godco/members/cook.json
+++ b/data/json/npcs/godco/members/cook.json
@@ -18,7 +18,10 @@
         "context": "meeting",
         "value": "yes",
         "yes": [ "Welcome back.", "Hello again.  What do you need?", "*waves you over.  \"Hey <u_name>.  How's it going for you?\"" ],
-        "no": "Hello stranger, I don't think we've met before.  Its nice to meet you, name's Simon."
+        "no": {
+          "gendered_line": "Hello stranger, I don't think we've met before.  Its nice to meet you, name's Simon.",
+          "relevant_genders": [ "u" ]
+        }
       }
     },
     "responses": [
@@ -117,9 +120,7 @@
   {
     "id": "TALK_GODCO_chef_intro",
     "type": "talk_topic",
-    "dynamic_line": [
-      "This is the New England Community Church, I should say it's one of their old retreats.  I'm Simon, the head chef around here."
-    ],
+    "dynamic_line": "This is the New England Community Church, I should say it's one of their old retreats.  I'm Simon, the head chef around here.",
     "responses": [
       { "text": "What's your story?", "topic": "TALK_GODCO_chef_past" },
       { "text": "Thanks for the info.", "topic": "TALK_DONE" }
@@ -128,9 +129,7 @@
   {
     "id": "TALK_GODCO_chef_past",
     "type": "talk_topic",
-    "dynamic_line": [
-      "I used to volunteer as a cook in a homeless shelter.  I met the church through that job; their missionaries would come by every so often and hand out essentials to people living there, then give a sermon in one of the back rooms.  Katherine and I wound up going to one of their sermons, and we've stayed connected since.  Working in that shelter taught me to cook on a shoestring budget; that's really useful these days, ya know."
-    ],
+    "dynamic_line": "I used to volunteer as a cook in a homeless shelter.  I met the church through that job; their missionaries would come by every so often and hand out essentials to people living there, then give a sermon in one of the back rooms.  Katherine and I wound up going to one of their sermons, and we've stayed connected since.  Working in that shelter taught me to cook on a shoestring budget; that's really useful these days, ya know.",
     "responses": [
       { "text": "Where's your family now?", "topic": "TALK_GODCO_chef_family" },
       { "text": "Thanks, <name_g>.  See you around.", "topic": "TALK_DONE" }
@@ -139,7 +138,7 @@
   {
     "id": "TALK_GODCO_chef_family",
     "type": "talk_topic",
-    "dynamic_line": [ "Katherine's probably in the bunks right now, and Jeremiah's next door.  Feel free to say hello sometime." ],
+    "dynamic_line": "Katherine's probably in the bunks right now, and Jeremiah's next door.  Feel free to say hello sometime.",
     "speaker_effect": { "effect": { "npc_add_var": "u_know_about_family", "type": "general", "context": "meeting", "value": "yes" } },
     "responses": [
       { "text": "Who's Katherine?", "topic": "TALK_GODCO_chef_katherine" },
@@ -151,7 +150,7 @@
   {
     "id": "TALK_GODCO_chef_get_food",
     "type": "talk_topic",
-    "dynamic_line": [ "It's been a while since anyone gave out meals.  We're low on supplies around here, I can't spare any.  I'm sorry." ],
+    "dynamic_line": "It's been a while since anyone gave out meals.  We're low on supplies around here, I can't spare any.  I'm sorry.",
     "responses": [
       { "text": "Would you accept any money for it?", "topic": "TALK_GODCO_chef_get_food_bribe" },
       { "text": "Please?  I need it for my family.", "topic": "TALK_GODCO_chef_get_food_family" },
@@ -161,7 +160,7 @@
   {
     "id": "TALK_GODCO_chef_get_food_joinee",
     "type": "talk_topic",
-    "dynamic_line": [ "They can, but we're limited on the portions for now.  Hope you enjoy it, and come back tomorrow for another." ],
+    "dynamic_line": "They can, but we're limited on the portions for now.  Hope you enjoy it, and come back tomorrow for another.",
     "speaker_effect": {
       "effect": [
         { "u_spawn_item": "macaroni_helper", "container": "can_food" },
@@ -174,7 +173,7 @@
   {
     "id": "TALK_GODCO_chef_get_food_bribe",
     "type": "talk_topic",
-    "dynamic_line": [ "No, I wouldn't.  Like I said, we don't have any to spare." ],
+    "dynamic_line": "No, I wouldn't.  Like I said, we don't have any to spare.",
     "responses": [
       { "text": "Is there any way I could join the community?", "topic": "TALK_GODCO_chef_join" },
       { "text": "It was worth a shot, I guess.", "topic": "TALK_DONE" }
@@ -183,9 +182,7 @@
   {
     "id": "TALK_GODCO_chef_katherine",
     "type": "talk_topic",
-    "dynamic_line": [
-      "She's my wife, worked for the Church before <the_cataclysm>.  She used to organized charities for the needy, now we're the ones in need of charity.  She has a bit of a high horse these days, but a nice lady once you get to know her.  We've been married for 28 years, and I couldn't ask for a better wife."
-    ],
+    "dynamic_line": "She's my wife, worked for the Church before <the_cataclysm>.  She used to organized charities for the needy, now we're the ones in need of charity.  She has a bit of a high horse these days, but a nice lady once you get to know her.  We've been married for 28 years, and I couldn't ask for a better wife.",
     "responses": [
       { "text": "Who's Jeremiah?", "topic": "TALK_GODCO_chef_jeremiah" },
       {
@@ -198,9 +195,7 @@
   {
     "id": "TALK_GODCO_chef_jeremiah",
     "type": "talk_topic",
-    "dynamic_line": [
-      "Jeremiah is my son, he's a sweet boy and all grown up now.  We taught him everything he knows, and we all had high hopes for how he could make it in the world, before <the_cataclysm> took it away.  He doesn't like his mother, Katherine, very much, and I've tried to help the two, but they can't seem to properly get along."
-    ],
+    "dynamic_line": "Jeremiah is my son, he's a sweet boy and all grown up now.  We taught him everything he knows, and we all had high hopes for how he could make it in the world, before <the_cataclysm> took it away.  He doesn't like his mother, Katherine, very much, and I've tried to help the two, but they can't seem to properly get along.",
     "responses": [
       { "text": "Who's Katherine?", "topic": "TALK_GODCO_chef_katherine" },
       { "text": "Why would they have an issue with each other?", "topic": "TALK_GODCO_chef_k&j_conflict" },
@@ -211,9 +206,7 @@
   {
     "id": "TALK_GODCO_chef_k&j_conflict",
     "type": "talk_topic",
-    "dynamic_line": [
-      "Katherine is a bit overprotective of him, and ever since <the_cataclysm>, she's become extremely worried for his safety.  He wants more independence, seein' as how he's grown now, but she won't leave him be.  She tells me that someone needs to keep an eye on him, so she took it upon herself to do so.  I think she has the best intentions at heart, I know she loves him dearly, but the boy needs to figure out some things on his own."
-    ],
+    "dynamic_line": "Katherine is a bit overprotective of him, and ever since <the_cataclysm>, she's become extremely worried for his safety.  He wants more independence, seein' as how he's grown now, but she won't leave him be.  She tells me that someone needs to keep an eye on him, so she took it upon herself to do so.  I think she has the best intentions at heart, I know she loves him dearly, but the boy needs to figure out some things on his own.",
     "responses": [
       { "text": "Could you tell me more about Katherine?", "topic": "TALK_GODCO_chef_katherine" },
       { "text": "Could you tell me more about Jeremiah?", "topic": "TALK_GODCO_chef_jeremiah" },
@@ -224,21 +217,19 @@
   {
     "id": "TALK_GODCO_chef_get_food_family",
     "type": "talk_topic",
-    "dynamic_line": [ "Look, I have a family too.  I know how hard it is for you, but I've already told you, rules are rules." ],
+    "dynamic_line": "Look, I have a family too.  I know how hard it is for you, but I've already told you, rules are rules.",
     "responses": [ { "text": "I guess I'll starve.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_GODCO_chef_mood",
     "type": "talk_topic",
-    "dynamic_line": [
-      "Could be better, could be worse, but I'm not complaining.  I have everything I need here; my family, a nice job, and roof over my head.  I only wish God was as forgiving to others as to me."
-    ],
+    "dynamic_line": "Could be better, could be worse, but I'm not complaining.  I have everything I need here; my family, a nice job, and roof over my head.  I only wish God was as forgiving to others as to me.",
     "responses": [ { "text": "Good to hear that.", "topic": "TALK_NONE" } ]
   },
   {
     "id": "TALK_GODCO_chef_join",
     "type": "talk_topic",
-    "dynamic_line": [ "You'd have to talk to Gemma or Julian about that.  I'm sure there's a way, though." ],
+    "dynamic_line": "You'd have to talk to Gemma or Julian about that.  I'm sure there's a way, though.",
     "responses": [ { "text": "Thanks for the info.", "topic": "TALK_DONE" } ]
   }
 ]

--- a/data/json/npcs/godco/visitors/TALK_CARAVAN_GUARD_PREDATORY.json
+++ b/data/json/npcs/godco/visitors/TALK_CARAVAN_GUARD_PREDATORY.json
@@ -64,7 +64,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_GUARD_PREDATORY_PICKUP",
-    "dynamic_line": "Really, I haven't heard anything about it.  What's it you need?",
+    "dynamic_line": { "gendered_line": "Really, I haven't heard anything about it.  What's it you need?", "relevant_genders": [ "npc" ] },
     "responses": [
       { "text": "The boss wants your accounting papers, I need them.", "topic": "TALK_CARAVAN_GUARD_PREDATORY_ACCRECORDS" },
       { "text": "Oh nothing, I must have the wrong person.", "topic": "TALK_DONE" }
@@ -93,7 +93,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_GUARD_PREDATORY_RECORDS_NOW",
-    "dynamic_line": "I told you already, I'm not finished with them, come back later.",
+    "dynamic_line": { "gendered_line": "I told you already, I'm not finished with them, come back later.", "relevant_genders": [ "npc" ] },
     "responses": [
       {
         "text": "We both know that's a lie.  Hand them over, or else.",
@@ -218,7 +218,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_GUARD_PREDATORY_RECORDS_FIFTY_WIN",
-    "dynamic_line": "Ah, a rich man I see.  I think you have yourself a deal.",
+    "dynamic_line": { "gendered_line": "Ah, a rich man I see.  I think you have yourself a deal.", "relevant_genders": [ "u" ] },
     "responses": [
       {
         "text": "Sounds great to me.",

--- a/data/json/npcs/godco/visitors/TALK_CARAVAN_MERCHANT_PREDATORY.json
+++ b/data/json/npcs/godco/visitors/TALK_CARAVAN_MERCHANT_PREDATORY.json
@@ -34,7 +34,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_MERCHANT_PREDATORY_Job",
-    "dynamic_line": "I'm a businessman, and business is my game.  I came out here to help these poor, poor people who are doing without in such a bad time.",
+    "dynamic_line": {
+      "gendered_line": "I'm a businessman, and business is my game.  I came out here to help these poor, poor people who are doing without in such a bad time.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Sure, let's trade.", "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_Trade", "effect": "start_trade" },
       { "text": "That's it?  What's your story?", "topic": "TALK_CARAVAN_MERCHANT_PREDATORY_Story" },
@@ -44,7 +47,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_MERCHANT_PREDATORY_Story",
-    "dynamic_line": "I'm just a man looking to help some poor folks out, caught word of this place from one of those old FEMA bunkers, a group's holed up there.  I figured I'd come out here and help these people out.",
+    "dynamic_line": {
+      "gendered_line": "I'm just a man looking to help some poor folks out, caught word of this place from one of those old FEMA bunkers, a group's holed up there.  I figured I'd come out here and help these people out.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "That's interesting.  Well, let's trade.",
@@ -96,7 +102,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_MERCHANT_PREDATORY_Price",
-    "dynamic_line": "Like I said, I'm a businessman and business is my job.  Those other yahoos you've been talkin' to don't know what they're doing.",
+    "dynamic_line": {
+      "gendered_line": "Like I said, I'm a businessman and business is my job.  Those other yahoos you've been talkin' to don't know what they're doing.",
+      "relevant_genders": [ "npc" ]
+    },
     "speaker_effect": { "effect": { "u_add_var": "u_think_suspicious_price", "type": "general", "context": "trade", "value": "yes" } },
     "responses": [
       {

--- a/data/json/npcs/holdouts/NC_GLOOSCAP.json
+++ b/data/json/npcs/holdouts/NC_GLOOSCAP.json
@@ -20,9 +20,18 @@
       "value": "yes",
       "yes": [
         "Good to see you again, how can I help you?",
-        "They say I turned a man into a cedar tree once.  That's a terrible thing to say.",
-        "You like maple syrup?  That was me.  Not the syrup, that was the trees, but I figured out how to make it much harder to concentrate it, used to be way too easy.  Pretty nice right?",
-        "Did I tell you the one about the beavers?  Used to be way too big.  Like giant beavers, it was a mess.  I fixed that.  Of course there seem to be a bunch of new giant things out here now.  I'll have to think about that.",
+        {
+          "gendered_line": "They say I turned a man into a cedar tree once.  That's a terrible thing to say.",
+          "relevant_genders": [ "npc" ]
+        },
+        {
+          "gendered_line": "You like maple syrup?  That was me.  Not the syrup, that was the trees, but I figured out how to make it much harder to concentrate it, used to be way too easy.  Pretty nice right?",
+          "relevant_genders": [ "npc" ]
+        },
+        {
+          "gendered_line": "Did I tell you the one about the beavers?  Used to be way too big.  Like giant beavers, it was a mess.  I fixed that.  Of course there seem to be a bunch of new giant things out here now.  I'll have to think about that.",
+          "relevant_genders": [ "npc" ]
+        },
         "You know storms?  Used to be more.  Took me a lot of work, but there aren't as many now.  That was me, I did that.  Fewer storms, pretty good.  There's a big eagle, it's a long story really.  I'm good with rope though."
       ],
       "no": "It's decided then.  I will be Glooscap.  Who will you be?"
@@ -70,7 +79,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_GLOOSCAP_WHERE",
-    "dynamic_line": "I'm used to it.  No, Glooscap has been a name here for a very long time.  Is your name foreign?",
+    "dynamic_line": {
+      "gendered_line": "I'm used to it.  No, Glooscap has been a name here for a very long time.  Is your name foreign?",
+      "relevant_genders": [ "npc" ]
+    },
     "speaker_effect": { "effect": { "u_add_var": "u_met_glooscap", "type": "general", "context": "meeting", "value": "yes" } },
     "responses": [
       { "text": "No, my name has been a name here for a very long time too.", "topic": "TALK_GLOOSCAP" },
@@ -100,7 +112,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_GLOOSCAP_MYTH_FAIL",
-    "dynamic_line": "And stuff sure.  How can I help you stranger?  They say I'm the nice one.  See this smile?  Nice smile right?",
+    "dynamic_line": {
+      "gendered_line": "And stuff sure.  How can I help you stranger?  They say I'm the nice one.  See this smile?  Nice smile right?",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "[Offer Beer] I am extremely into your smile yes.  I have some drinks with me, want to have some?",
@@ -157,7 +172,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_GLOOSCAP_MYTH_SUCCESS",
-    "dynamic_line": "I do have a twin.  Malsumis is probably around here somewhere, very tricky.  You know I turned Malsumis to stone once?  I'm supposed to be the nice one, but you know how much it hurts turning yourself back from stone?  It takes days.",
+    "dynamic_line": {
+      "gendered_line": "I do have a twin.  Malsumis is probably around here somewhere, very tricky.  You know I turned Malsumis to stone once?  I'm supposed to be the nice one, but you know how much it hurts turning yourself back from stone?  It takes days.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "[INT 14] I'll look out then, thanks.  Of course if you were Malsumis you probably wouldn't admit it because no one likes Malsumis.  Who would your twin say you are?",
@@ -196,7 +214,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_GLOOSCAP_MYTH_ACCUSE",
-    "dynamic_line": "If I were Malsumis you would be in terrible danger my friend.  But Glooscap would stop me.",
+    "dynamic_line": {
+      "gendered_line": "If I were Malsumis you would be in terrible danger my friend.  But Glooscap would stop me.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Fight me Malsumis!", "effect": "insult_combat", "topic": "TALK_DONE" },
       {

--- a/data/json/npcs/holdouts/Rural-Cowboy_Friendly.json
+++ b/data/json/npcs/holdouts/Rural-Cowboy_Friendly.json
@@ -53,13 +53,19 @@
   {
     "type": "talk_topic",
     "id": "TALK_COWBOYFR_BACKGROUND",
-    "dynamic_line": "I worked on a ranch not too fah from here 'fore it all went down.  I'd love ta get back ta what I did - taking care of horses, cows, all sorts of animals, makin' sure the fields stay safe an' all that.  But now?  I dunno, man.  Just tryin' ta survive, I suppose.  Hopefully, tha world will get back togetha' one day and I can put mah skills ta use doin' what I like.",
+    "dynamic_line": {
+      "gendered_line": "I worked on a ranch not too fah from here 'fore it all went down.  I'd love ta get back ta what I did - taking care of horses, cows, all sorts of animals, makin' sure the fields stay safe an' all that.  But now?  I dunno, man.  Just tryin' ta survive, I suppose.  Hopefully, tha world will get back togetha' one day and I can put mah skills ta use doin' what I like.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "Let's hope it will.", "topic": "TALK_NONE" } ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_COWBOYFR_INTRODUCTION",
-    "dynamic_line": "I was just sort of wanderin' around, hoping ta maybe find some bettah gear.  Decided ta rest up, 'eard someone walkin', and, well, here we are.",
+    "dynamic_line": {
+      "gendered_line": "I was just sort of wanderin' around, hoping ta maybe find some bettah gear.  Decided ta rest up, 'eard someone walkin', and, well, here we are.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "I see.", "topic": "TALK_NONE" } ]
   },
   {

--- a/data/json/npcs/holdouts/Rural-Cowboy_Nihilist.json
+++ b/data/json/npcs/holdouts/Rural-Cowboy_Nihilist.json
@@ -70,8 +70,11 @@
       "type": "dialogue",
       "context": "cowboyn",
       "value": "yes",
-      "no": "Lived in a nearby town.  Normal life.  9 to 5 job.  When it all happened, we ran away to find some safety.  But there's no safety anymore, is there?",
-      "yes": "I already told you.  Don't want to go through it again."
+      "no": {
+        "gendered_line": "Lived in a nearby town.  Normal life.  9 to 5 job.  When it all happened, we ran away to find some safety.  But there's no safety anymore, is there?",
+        "relevant_genders": [ "npc" ]
+      },
+      "yes": { "gendered_line": "I already told you.  Don't want to go through it again.", "relevant_genders": [ "npc" ] }
     },
     "responses": [
       {
@@ -99,7 +102,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_COWBOYN_PARTNER",
-    "dynamic_line": "I didn't leave the town alone.  I arrived here alone.",
+    "dynamic_line": { "gendered_line": "I didn't leave the town alone.  I arrived here alone.", "relevant_genders": [ "npc" ] },
     "responses": [
       {
         "text": "I'm sorry for your loss.  But you still can't give up.  You have a lot to live for!",
@@ -170,7 +173,7 @@
       "context": "cowboyn",
       "value": "yes",
       "yes": "I dunno.  Maybe.  Might give me something to do while I think about all this.",
-      "no": "I told you to just leave me alone."
+      "no": { "gendered_line": "I told you to just leave me alone.", "relevant_genders": [ "npc" ] }
     },
     "responses": [
       {

--- a/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Barry_Isherwood.json
@@ -64,7 +64,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_ISHERWOOD_BARRY_TOWER",
-    "dynamic_line": [ "Yeah, I think we need to talk about it, but I'm not ready yet.  Let me reclaim my life for a while." ],
+    "dynamic_line": "Yeah, I think we need to talk about it, but I'm not ready yet.  Let me reclaim my life for a while.",
     "responses": [ { "text": "Sounds good, Barry.", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Claire_Isherwood.json
@@ -113,7 +113,7 @@
     "dynamic_line": {
       "u_is_wearing": "badge_marshal",
       "yes": "Is that a U.S. Marshal's badge you're wearing?",
-      "no": { "u_male": true, "yes": "Hello, what brings you here?", "no": "Hi, what brings you here?" }
+      "no": "Hi, what brings you here?"
     },
     "responses": [
       {

--- a/data/json/npcs/isherwood_farm/NPC_Jack_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Jack_Isherwood.json
@@ -149,7 +149,7 @@
     "dynamic_line": {
       "u_is_wearing": "badge_marshal",
       "yes": "Is that a U.S. Marshal's badge you're wearing?",
-      "no": { "u_male": true, "yes": "Hello traveler, what brings you here?", "no": "Hello traveler, what brings you here?" }
+      "no": { "gendered_line": "Hello traveler, what brings you here?", "relevant_genders": [ "u" ] }
     },
     "responses": [
       {

--- a/data/json/npcs/isherwood_farm/NPC_Jesse_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Jesse_Isherwood.json
@@ -46,11 +46,7 @@
     "dynamic_line": {
       "u_is_wearing": "badge_marshal",
       "yes": "Leave our property, Marshal.",
-      "no": {
-        "u_male": true,
-        "yes": "Hello.  We don't see many people these days.",
-        "no": "Hello.  We don't see many people these days."
-      }
+      "no": "Hello.  We don't see many people these days."
     },
     "responses": [
       {

--- a/data/json/npcs/isherwood_farm/NPC_Lisa_Isherwood.json
+++ b/data/json/npcs/isherwood_farm/NPC_Lisa_Isherwood.json
@@ -44,7 +44,7 @@
     "dynamic_line": {
       "u_is_wearing": "badge_marshal",
       "yes": "I see that badge, I think you need to keep on walking, straight off this property.",
-      "no": { "u_male": true, "yes": "Hello, what brings you here?", "no": "Hi, what brings you here?" }
+      "no": "Hi, what brings you here?"
     },
     "responses": [
       {

--- a/data/json/npcs/island_prison/prisoners.json
+++ b/data/json/npcs/island_prison/prisoners.json
@@ -134,7 +134,10 @@
       "type": "dialogue",
       "context": "first_meeting",
       "value": "yes",
-      "no": "Hey, who the fuck are you?  I haven't seen you 'round.  Ah, fuck it, it doesn't matter.\nHere's the rules.  The first and most important one: ALWAYS CLOSE THE FUCKING ENTRY DOOR BEHIND YOUR ASS!  If you're okay with that, the following rules are: don't fuck with us, don't steal from us, don't start a fight without a reason with someone from us.  Got it, punk?  Now get lost.",
+      "no": {
+        "gendered_line": "Hey, who the fuck are you?  I haven't seen you 'round.  Ah, fuck it, it doesn't matter.\nHere's the rules.  The first and most important one: ALWAYS CLOSE THE FUCKING ENTRY DOOR BEHIND YOUR ASS!  If you're okay with that, the following rules are: don't fuck with us, don't steal from us, don't start a fight without a reason with someone from us.  Got it, punk?  Now get lost.",
+        "relevant_genders": [ "u" ]
+      },
       "yes": "<get_lost>"
     },
     "speaker_effect": { "effect": { "u_add_var": "first_meeting", "type": "dialogue", "context": "first_meeting", "value": "yes" } },
@@ -212,7 +215,10 @@
       "context": "annoyed_greeter",
       "value": "yes",
       "no": "<get_lost>",
-      "yes": "Are you deaf or stupid?  I said I don't give a fuck for you and your <swear> problems.  Bother me one more time, and you'll regret that.  <get_lost>"
+      "yes": {
+        "gendered_line": "Are you deaf or stupid?  I said I don't give a fuck for you and your <swear> problems.  Bother me one more time, and you'll regret that.  <get_lost>",
+        "relevant_genders": [ "u" ]
+      }
     },
     "speaker_effect": { "effect": { "u_add_var": "talked_to_greeter", "type": "dialogue", "context": "angry_greeter", "value": "yes" } },
     "responses": [
@@ -227,7 +233,7 @@
   {
     "id": "TALK_PRISONER_READY_TO_MUG",
     "type": "talk_topic",
-    "dynamic_line": "You think you're immortal, huh, <name_b>?",
+    "dynamic_line": { "gendered_line": "You think you're immortal, huh, <name_b>?", "relevant_genders": [ "u" ] },
     "responses": [
       { "text": "Gee, what's the matter with you?  Okay, okay, I'm leaving.", "topic": "TALK_PRISONER_MUG" },
       {
@@ -240,7 +246,7 @@
   {
     "id": "TALK_PRISONER_MUG",
     "type": "talk_topic",
-    "dynamic_line": [ "Not so fast, I think you need to pay for breaking your promise and bothering me.  Give me your shit, now!" ],
+    "dynamic_line": "Not so fast, I think you need to pay for breaking your promise and bothering me.  Give me your shit, now!",
     "responses": [
       { "text": "Please don't hurt me!  Take all that you want.", "topic": "TALK_MUG" },
       { "text": "What, <no>!", "topic": "TALK_DONE", "effect": "hostile" }
@@ -266,7 +272,10 @@
           "type": "mission",
           "context": "completed",
           "value": "yes",
-          "yes": "I don't know if you know, but there are sewers underneath the prison.  I was planning an escape long before <the_cataclysm>, and while I was working on cleaning the sewers, I noticed a damaged wall section.  There was a flow of fresh air coming out of it, so I think it's leading to the surface.  It could be your way to freedom.  Feel free to use it.",
+          "yes": {
+            "gendered_line": "I don't know if you know, but there are sewers underneath the prison.  I was planning an escape long before <the_cataclysm>, and while I was working on cleaning the sewers, I noticed a damaged wall section.  There was a flow of fresh air coming out of it, so I think it's leading to the surface.  It could be your way to freedom.  Feel free to use it.",
+            "relevant_genders": [ "npc" ]
+          },
           "no": {
             "u_has_var": "talked_to_leader",
             "type": "dialogue",
@@ -402,18 +411,14 @@
   {
     "id": "TALK_PRISONER_LEADER_LEARNED_ABOUT_CANNIBAL",
     "type": "talk_topic",
-    "dynamic_line": [
-      "Huh, even so?  I'm not saying I approve your… tastes, but I definitely respect people who use all possibilities life has to offer."
-    ],
+    "dynamic_line": "Huh, even so?  I'm not saying I approve your… tastes, but I definitely respect people who use all possibilities life has to offer.",
     "speaker_effect": { "effect": { "u_add_var": "talked_to_leader", "type": "dialogue", "context": "cannibal", "value": "yes" } },
     "responses": [ { "text": "Yeah, we share the same opinions on this matter.", "topic": "TALK_NONE" } ]
   },
   {
     "id": "TALK_PRISONER_LEADER_INQUIRY",
     "type": "talk_topic",
-    "dynamic_line": [
-      "Well, that's a boastful statement.  Not that I don't believe it, it's just….  Ah, nevermind.  Let's get to the point.  What do you want?"
-    ],
+    "dynamic_line": "Well, that's a boastful statement.  Not that I don't believe it, it's just….  Ah, nevermind.  Let's get to the point.  What do you want?",
     "responses": [
       {
         "text": "I want to get out of this <swear> prison.  I hoped you could help me with that.",
@@ -424,7 +429,7 @@
   {
     "id": "TALK_PRISONER_LEADER_FROWN",
     "type": "talk_topic",
-    "dynamic_line": [ "Hold the horses, pal.  Nobody allowed you to stay here - yet." ],
+    "dynamic_line": "Hold the horses, pal.  Nobody allowed you to stay here - yet.",
     "responses": [
       {
         "text": "Please!  I don't want to go back there!  I'm tired and hungry!  I just need time to rest!",
@@ -436,9 +441,7 @@
   {
     "id": "TALK_PRISONER_LEADER_ANNOYED",
     "type": "talk_topic",
-    "dynamic_line": [
-      "We don't have much space, and there's not much food.  Besides, I don't know you at all, and something tells me you won't survive another day."
-    ],
+    "dynamic_line": "We don't have much space, and there's not much food.  Besides, I don't know you at all, and something tells me you won't survive another day.",
     "responses": [
       {
         "text": "[STR 11] I'm tougher than it seems!",
@@ -456,9 +459,7 @@
   {
     "id": "TALK_PRISONER_LEADER_NO",
     "type": "talk_topic",
-    "dynamic_line": [
-      "The answer is still no.  In fact it might be better for us to kill you right away - you know, the less mouths to feed, the better.  But I'm in a good mood today, so I've decided to help you get out of this island."
-    ],
+    "dynamic_line": "The answer is still no.  In fact it might be better for us to kill you right away - you know, the less mouths to feed, the better.  But I'm in a good mood today, so I've decided to help you get out of this island.",
     "responses": [
       { "text": "Ok, I'm listening.", "topic": "TALK_PRISONER_LEADER_GIVES_WORK" },
       { "text": "You know, I think I'll manage without your help.  Bye.", "topic": "TALK_DONE" }
@@ -544,9 +545,7 @@
   {
     "id": "TALK_PRISONER_LEADER_ASKED_ABOUT_SAFE_CONTENTS",
     "type": "talk_topic",
-    "dynamic_line": [
-      "As I said, that's the thing I need.  You don't need to know what's that exactly.  Just grab all things you find in the safe, and call it a day."
-    ],
+    "dynamic_line": "As I said, that's the thing I need.  You don't need to know what's that exactly.  Just grab all things you find in the safe, and call it a day.",
     "responses": [
       { "text": "That's weird.", "topic": "TALK_NONE" },
       { "text": "I have a bad feeling about this.  Sorry, I'll pass.", "topic": "TALK_DONE" }
@@ -555,7 +554,7 @@
   {
     "id": "TALK_PRISONER_LEADER_ASKED_ABOUT_WHAT_FOR_DO_YOU_NEED_IT",
     "type": "talk_topic",
-    "dynamic_line": [ "Let's say that's none of your <swear> business.  Other questions?" ],
+    "dynamic_line": "Let's say that's none of your <swear> business.  Other questions?",
     "responses": [
       { "text": "That's weird.", "topic": "TALK_NONE" },
       { "text": "I have a bad feeling about this.  Sorry, I'll pass.", "topic": "TALK_DONE" }
@@ -565,7 +564,7 @@
     "id": "TALK_PRISONER_LEADER_SHOW_MILITARY_ID",
     "type": "talk_topic",
     "speaker_effect": { "effect": { "u_add_var": "prisoner_leader_mission", "type": "mission", "context": "military_id", "value": "yes" } },
-    "dynamic_line": [ "Hey, where did you get it?  Nevermind, just give it to me.  Just <swear> now." ],
+    "dynamic_line": "Hey, where did you get it?  Nevermind, just give it to me.  Just <swear> now.",
     "responses": [
       {
         "text": "Hey, no need to be hostile.  Here you go, I don't need it anyway.",
@@ -590,16 +589,14 @@
   {
     "id": "TALK_PRISONER_LEADER_TRIAL_SUCCESS",
     "type": "talk_topic",
-    "dynamic_line": [
-      "Okay.  It was convincing.  I'll still get what I want, one way or another.  You better watch your back from now on."
-    ],
+    "dynamic_line": "Okay.  It was convincing.  I'll still get what I want, one way or another.  You better watch your back from now on.",
     "responses": [ { "text": "Noted.  Bye.", "topic": "TALK_DONE" } ]
   },
   {
     "id": "TALK_PRISONER_LEADER_DEMANDED_SUBSTANTIAL_REWARD",
     "type": "talk_topic",
     "speaker_effect": { "effect": { "u_add_var": "prisoner_leader_mission", "type": "mission", "context": "military_id", "value": "yes" } },
-    "dynamic_line": [ "I'm afraid you're not in the position to demand anything from me, <name_b>.  <get_lost>" ],
+    "dynamic_line": "I'm afraid you're not in the position to demand anything from me, <name_b>.  <get_lost>",
     "responses": [
       { "text": "Hey, <fuck_you>!  You'll regret that!", "topic": "TALK_DONE", "effect": "hostile" },
       { "text": "Okay, fine.  Cheapskate!", "topic": "TALK_DONE" }

--- a/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_dialogue.json
@@ -5,7 +5,7 @@
     "dynamic_line": [
       "Hiya darlin', welcome to the shop.",
       "Hey, killer!  How's it going?",
-      "You look like you haven't eaten in days.",
+      { "gendered_line": "You look like you haven't eaten in days.", "relevant_genders": [ "u" ] },
       "Still the apocalypse out there, huh?",
       "See anything you like?"
     ],

--- a/data/json/npcs/isolated_road/isolated_road_cody_fabricate.json
+++ b/data/json/npcs/isolated_road/isolated_road_cody_fabricate.json
@@ -12,9 +12,10 @@
     "id": "TALK_BLACKSMITH_FABRICATE",
     "//": "this is all the dialogue related to working on armor with Cody",
     "type": "talk_topic",
-    "dynamic_line": [
-      "Sure.  After what you did for me, I'd equip an army for you.  I'll need some money to negotiate with the caravans and scavengers that come by.  What level of protection are you thinking?  I can do 2mm, 4mm, and 6mm suits depending on how much you want to resemble a tank, or I can make you a suit of chainmail instead if you want a little more flexibility.  Materials costs are 300 merch to pay for the food I need to do the labor plus 100 merch per 2mm or 50 merch for the chainmail.  Whatever I save in non-scaling bits like the chain and leather, I get gouged in looking for so much bulk metal."
-    ],
+    "dynamic_line": {
+      "gendered_line": "Sure.  After what you did for me, I'd equip an army for you.  I'll need some money to negotiate with the caravans and scavengers that come by.  What level of protection are you thinking?  I can do 2mm, 4mm, and 6mm suits depending on how much you want to resemble a tank, or I can make you a suit of chainmail instead if you want a little more flexibility.  Materials costs are 300 merch to pay for the food I need to do the labor plus 100 merch per 2mm or 50 merch for the chainmail.  Whatever I save in non-scaling bits like the chain and leather, I get gouged in looking for so much bulk metal.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "Forget it.", "topic": "TALK_BLACKSMITH_SERVICES" },
       {
@@ -376,9 +377,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_BLACKSMITH_PROTOTYPE_EXODII_ITEMS",
-    "dynamic_line": [
-      "Yeah; the designs you showed me call for 'em.  Not sure what they are myself, but the pictures are real descriptive about how to use them.  To make anything, I'll need one of each of those wire kits.  Got any?"
-    ],
+    "dynamic_line": {
+      "gendered_line": "Yeah; the designs you showed me call for 'em.  Not sure what they are myself, but the pictures are real descriptive about how to use them.  To make anything, I'll need one of each of those wire kits.  Got any?",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       {
         "text": "Here you go.  [Hand over a CBM interface wire kit and an external climate control kit.]",
@@ -396,6 +398,9 @@
   {
     "type": "talk_topic",
     "id": "TALK_BLACKSMITH_PROTOTYPE_EXODII_ITEMS_READY",
-    "dynamic_line": [ "Thanks, sugar!  If you ever have me make some armor, just let me know if you want me to use these in it." ]
+    "dynamic_line": {
+      "gendered_line": "Thanks, sugar!  If you ever have me make some armor, just let me know if you want me to use these in it.",
+      "relevant_genders": [ "u" ]
+    }
   }
 ]

--- a/data/json/npcs/lumbermill_employees/TALK_lumbermill_fabricate.json
+++ b/data/json/npcs/lumbermill_employees/TALK_lumbermill_fabricate.json
@@ -87,7 +87,7 @@
     "id": "TALK_LUMBERMILL_FABRICATE_END",
     "//": "This is all the dialogue related to buying bulk wood. TO-DO - Use variables to refine shop system. See SCRIPT_EFFECTS.md and isolated road fabriation system.",
     "type": "talk_topic",
-    "dynamic_line": [ "Is there anything else you want?" ],
+    "dynamic_line": "Is there anything else you want?",
     "responses": [
       { "text": "No, that's all.", "topic": "TALK_DONE" },
       {

--- a/data/json/npcs/lumbermill_employees/TALK_lumbermill_logger.json
+++ b/data/json/npcs/lumbermill_employees/TALK_lumbermill_logger.json
@@ -71,17 +71,29 @@
     "id": "TALK_NPC_LUMBERMILL_LOGGER_STORY",
     "dynamic_line": {
       "npc_has_trait": "BGSS_No_Past_2",
-      "yes": "I'll be honest, I don't remember a whole lot about what I was doing here.  I know that I cut trees, but not much else.  Good thing I have friends here, they've helped me out a lot.",
+      "yes": {
+        "gendered_line": "I'll be honest, I don't remember a whole lot about what I was doing here.  I know that I cut trees, but not much else.  Good thing I have friends here, they've helped me out a lot.",
+        "relevant_genders": [ "npc" ]
+      },
       "no": {
         "npc_has_trait": "BGSS_No_Past_3",
-        "yes": "I'll be honest, I don't remember a whole lot about what I was doing here.  I know that I cut trees, but not much else.  Good thing I have friends here, they've helped me out a lot.",
+        "yes": {
+          "gendered_line": "I'll be honest, I don't remember a whole lot about what I was doing here.  I know that I cut trees, but not much else.  Good thing I have friends here, they've helped me out a lot.",
+          "relevant_genders": [ "npc" ]
+        },
         "no": [
-          "Not much to it.  I worked here as a logger before <the_cataclysm> began.  When all went to hell, I was on the job and had to hole up here with my coworkers.  Good news is we all came out fine, and the boss decided to keep the mill running.  I don't know how much longer we can last, though; not unless we make some contact with other people.  Customers, I guess you might call 'em.",
+          {
+            "gendered_line": "Not much to it.  I worked here as a logger before <the_cataclysm> began.  When all went to hell, I was on the job and had to hole up here with my coworkers.  Good news is we all came out fine, and the boss decided to keep the mill running.  I don't know how much longer we can last, though; not unless we make some contact with other people.  Customers, I guess you might call 'em.",
+            "relevant_genders": [ "npc" ]
+          },
           "Well, I'm a logger here.  Seasonal work but good pay… or it was, at least.  Before that first <zombie> showed up and made it clear how bad things were really getting.",
           "I'm a lumberjack out here.  Things were quiet for a long time.  We're pretty far out in the woods so it was kind of a shock to find out just how bad it'd gotten in civilization.  We had a couple close run-ins ourselves.  My friend over there almost got eaten!  But we still have resources that I'm sure people can use.",
           "My comrades and I were lucky to be in the right place at the right time, I suppose.  We keep really busy out here, so we didn't expect <the_cataclysm> to land right in our lap like that.  Luckily these axes can chop more than wood.  They'll take a good chunk out of anything nasty that threatens our mill.",
           "Well, I work here.  Welcome to the mill.  Used to be trucks in and out of here all the time but you're the first face we've seen in a while.",
-          "New to the job… or, well, whatever's happening now.  I still cut trees and run logs through the saw from time to time, so I guess you'd call me a logger.  Things have only gotten weirder after those fucking <zombies> nearly killed us.  I'm not sure how much longer we'll last…"
+          {
+            "gendered_line": "New to the job… or, well, whatever's happening now.  I still cut trees and run logs through the saw from time to time, so I guess you'd call me a logger.  Things have only gotten weirder after those fucking <zombies> nearly killed us.  I'm not sure how much longer we'll last…",
+            "relevant_genders": [ "npc" ]
+          }
         ]
       }
     },

--- a/data/json/npcs/other/NPC_pizzaiolo.json
+++ b/data/json/npcs/other/NPC_pizzaiolo.json
@@ -58,7 +58,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_pizzaiolo_celebrate",
-    "dynamic_line": "Ah, home sweet home.  It feels like I haven't been here for ages.  <swear>, it looks so horrible now.  I guess it's because of <the_cataclysm>.  Thank you for bringing me here, <name_g>.  Let's eat the cake.",
+    "dynamic_line": {
+      "gendered_line": "Ah, home sweet home.  It feels like I haven't been here for ages.  <swear>, it looks so horrible now.  I guess it's because of <the_cataclysm>.  Thank you for bringing me here, <name_g>.  Let's eat the cake.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "[*NOM-NOM*]", "topic": "TALK_pizzaiolo_celebrate1" } ]
   },
   {
@@ -81,7 +84,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_pizzaiolo_Background",
-    "dynamic_line": "I'm just a regular pizzaiolo.  My father was a pizzaiolo, my grandfather was a pizzaiolo and I also became a pizzaiolo.  I was making pizza my whole life, until some american <name_b>s ruined my business!  I couldn't do anything about this, but now, with <the_cataclysm> and <zombies> around, I have a chance to get my revenge!"
+    "dynamic_line": {
+      "gendered_line": "I'm just a regular pizzaiolo.  My father was a pizzaiolo, my grandfather was a pizzaiolo and I also became a pizzaiolo.  I was making pizza my whole life, until some american <name_b>s ruined my business!  I couldn't do anything about this, but now, with <the_cataclysm> and <zombies> around, I have a chance to get my revenge!",
+      "relevant_genders": [ "npc" ]
+    }
   },
   {
     "id": "MISSION_pizzaiolo_1",

--- a/data/json/npcs/other/TALK_ANIMAL_SHELTER_SURVIVOR.json
+++ b/data/json/npcs/other/TALK_ANIMAL_SHELTER_SURVIVOR.json
@@ -69,7 +69,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NPC_ANIMAL_SHELTER_SURVIVOR_WHO",
-    "dynamic_line": "I worked here before <the_cataclysm> dumped everything in the <swear> bin.  I took care of all the animals here, and when the <zombies> started roaming the streets, I gathered every pet or stray I could.  I still take care of them, just gotta worry about the <zombies> now on top of disease, cleanliness, etc.",
+    "dynamic_line": {
+      "gendered_line": "I worked here before <the_cataclysm> dumped everything in the <swear> bin.  I took care of all the animals here, and when the <zombies> started roaming the streets, I gathered every pet or stray I could.  I still take care of them, just gotta worry about the <zombies> now on top of disease, cleanliness, etc.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "That's quite noble of you, but how do you take care of so many animals?",

--- a/data/json/npcs/other/TALK_GUN_STORE_SURVIVOR.json
+++ b/data/json/npcs/other/TALK_GUN_STORE_SURVIVOR.json
@@ -8,7 +8,7 @@
       "context": "first_meeting",
       "value": "yes",
       "yes": "<greet>",
-      "no": "Hey stranger.  How's life treatin' ya these days?"
+      "no": { "gendered_line": "Hey stranger.  How's life treatin' ya these days?", "relevant_genders": [ "u" ] }
     },
     "speaker_effect": { "effect": { "npc_add_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" } },
     "responses": [
@@ -71,7 +71,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NPC_GUN_STORE_SURVIVOR_WHO",
-    "dynamic_line": "I'm just an average person, really.  When a horde of those <swear> <zombies> came knockin' on my door, I ran for it.  Good for me that someone left this store open in the chaos, I ran inside and locked the place down.  There isn't a thing in all of <city> that can bust through these walls and barred windows, I'd reckon I'm the luckiest <name_b> in town.",
+    "dynamic_line": {
+      "gendered_line": "I'm just an average person, really.  When a horde of those <swear> <zombies> came knockin' on my door, I ran for it.  Good for me that someone left this store open in the chaos, I ran inside and locked the place down.  There isn't a thing in all of <city> that can bust through these walls and barred windows, I'd reckon I'm the luckiest <name_b> in town.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "Why would someone leave a gun store open in all this chaos?",

--- a/data/json/npcs/other/TALK_NPC_APARTMENT_SURVIVOR.json
+++ b/data/json/npcs/other/TALK_NPC_APARTMENT_SURVIVOR.json
@@ -35,7 +35,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NPC_APARTMENT_SURVIVOR_CALM",
-    "dynamic_line": "Oh, you're not one of the <zombies>.  Come on in, just don't cause any trouble.",
+    "dynamic_line": {
+      "gendered_line": "Oh, you're not one of the <zombies>.  Come on in, just don't cause any trouble.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "Alright, let's chat.", "topic": "TALK_NPC_APARTMENT_SURVIVOR_INTRO" },
       { "text": "I'll be back later.", "topic": "TALK_DONE" }
@@ -75,7 +78,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NPC_APARTMENT_SURVIVOR_STORY",
-    "dynamic_line": "I used to live here before <the_cataclysm>.  I was asleep when a horde of <zombies> busted through the front, and in the chaos I wound up here.  When the screaming stopped, I peaked out the door to find my neighbor stumbling about with his face half-eaten, and I haven't left since.",
+    "dynamic_line": {
+      "gendered_line": "I used to live here before <the_cataclysm>.  I was asleep when a horde of <zombies> busted through the front, and in the chaos I wound up here.  When the screaming stopped, I peaked out the door to find my neighbor stumbling about with his face half-eaten, and I haven't left since.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "Wow.", "topic": "TALK_NONE" } ]
   }
 ]

--- a/data/json/npcs/other/TALK_NPC_CAMPER.json
+++ b/data/json/npcs/other/TALK_NPC_CAMPER.json
@@ -8,7 +8,7 @@
       "context": "first_meeting",
       "value": "yes",
       "yes": "<greet>.",
-      "no": "Hey, stranger.  Glad to see a new face around here."
+      "no": { "gendered_line": "Hey, stranger.  Glad to see a new face around here.", "relevant_genders": [ "npc", "u" ] }
     },
     "speaker_effect": { "effect": { "npc_add_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" } },
     "responses": [
@@ -57,7 +57,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NPC_CAMPER_SURVIVOR_STORY",
-    "dynamic_line": "I was out here camping when <the_cataclysm> disturbed me.  I didn't know anything was wrong until two <zombies> stumbled up here, and tried to kill me.  I figured staying here would be my best bet, away from the cities.",
+    "dynamic_line": {
+      "gendered_line": "I was out here camping when <the_cataclysm> disturbed me.  I didn't know anything was wrong until two <zombies> stumbled up here, and tried to kill me.  I figured staying here would be my best bet, away from the cities.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "Wow.", "topic": "TALK_NONE" } ]
   }
 ]

--- a/data/json/npcs/other/TALK_NPC_MOONSHINER.json
+++ b/data/json/npcs/other/TALK_NPC_MOONSHINER.json
@@ -8,7 +8,7 @@
       "context": "first_meeting",
       "value": "yes",
       "yes": "Hey <name_g>.",
-      "no": "Haven't seen someone new in a while.  What brings you around here?"
+      "no": { "gendered_line": "Haven't seen someone new in a while.  What brings you around here?", "relevant_genders": [ "npc" ] }
     },
     "speaker_effect": { "effect": { "npc_add_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" } },
     "responses": [
@@ -66,7 +66,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NPC_MOONSHINER_STORY",
-    "dynamic_line": "I run this distillery you're standing in, before <the_cataclysm> it wasn't so legal with the law.  I was in <city> making a deal on my product when a horde of rioters busted in, so I ran for it.  I thought my business would be a nice place to stay, so I came out here.",
+    "dynamic_line": {
+      "gendered_line": "I run this distillery you're standing in, before <the_cataclysm> it wasn't so legal with the law.  I was in <city> making a deal on my product when a horde of rioters busted in, so I ran for it.  I thought my business would be a nice place to stay, so I came out here.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "Huh.", "topic": "TALK_NONE" } ]
   }
 ]

--- a/data/json/npcs/other/TALK_NPC_PREPPER_SURVIVOR.json
+++ b/data/json/npcs/other/TALK_NPC_PREPPER_SURVIVOR.json
@@ -35,7 +35,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NPC_PREPPER_SURVIVOR_CALM",
-    "dynamic_line": "Oh, you're not one of the <zombies>.  Come on in, just don't cause any trouble.",
+    "dynamic_line": {
+      "gendered_line": "Oh, you're not one of the <zombies>.  Come on in, just don't cause any trouble.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "Alright, let's chat.", "topic": "TALK_NPC_PREPPER_SURVIVOR_INTRO" },
       { "text": "I'll be back later.", "topic": "TALK_DONE" }
@@ -80,7 +83,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NPC_PREPPER_SURVIVOR_STORY",
-    "dynamic_line": "They all said I was crazy for preparing for <the_cataclysm>.  Now, they're all dead, and I'm still kickin'.  When the riots turned to hordes, I was ready; all I had to do was dodge a few <zombies> to get back to my bastion.  I've been living safely here ever since.",
+    "dynamic_line": {
+      "gendered_line": "They all said I was crazy for preparing for <the_cataclysm>.  Now, they're all dead, and I'm still kickin'.  When the riots turned to hordes, I was ready; all I had to do was dodge a few <zombies> to get back to my bastion.  I've been living safely here ever since.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Interesting.", "topic": "TALK_NPC_PREPPER_SURVIVOR_INTRO" },
       { "text": "Can I stay here for a while?", "topic": "TALK_NPC_PREPPER_SURVIVOR_STAY" }

--- a/data/json/npcs/other/TALK_shelter_survivors.json
+++ b/data/json/npcs/other/TALK_shelter_survivors.json
@@ -28,7 +28,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NPC_EVAC_SURVIVOR_CALM",
-    "dynamic_line": "Oh, you're not one of them.  Those <zombies>, I mean.  Come on in, just don't cause any trouble.",
+    "dynamic_line": {
+      "gendered_line": "Oh, you're not one of them.  Those <zombies>, I mean.  Come on in, just don't cause any trouble.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "Alright, let's chat.", "topic": "TALK_NPC_EVAC_SURVIVOR_INTRO" },
       { "text": "I'll be back later.", "topic": "TALK_DONE" }
@@ -68,7 +71,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_NPC_EVAC_SURVIVOR_STORY",
-    "dynamic_line": "I found this emergency shelter when I was running from the chaos back in the cities.  Fortunately, the place hadn't been looted yet and there weren't any <zombies> lurking around; just the spot to stay 'till who knows when.",
+    "dynamic_line": {
+      "gendered_line": "I found this emergency shelter when I was running from the chaos back in the cities.  Fortunately, the place hadn't been looted yet and there weren't any <zombies> lurking around; just the spot to stay 'till who knows when.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "Wow.", "topic": "TALK_NONE" } ]
   }
 ]

--- a/data/json/npcs/other/camp_start.json
+++ b/data/json/npcs/other/camp_start.json
@@ -22,7 +22,10 @@
   {
     "id": "TALK_FACTION_CAMP_START",
     "type": "talk_topic",
-    "dynamic_line": [ "Hey, I did some surveying and I believe this is a good spot to set up at." ],
+    "dynamic_line": {
+      "gendered_line": "Hey, I did some surveying and I believe this is a good spot to set up at.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "Let's stay here, then.  I trust your decisions.",

--- a/data/json/npcs/other/homeless/TALK_homeless_survivor.json
+++ b/data/json/npcs/other/homeless/TALK_homeless_survivor.json
@@ -55,11 +55,20 @@
     "type": "talk_topic",
     "id": "TALK_NPC_HOMELESS_SURVIVOR_STORY",
     "dynamic_line": [
-      "I was homeless before everything went down, just camping out here for a while.  Stuck up <name_b>s shunned me for my condition, but they're all dead now.  I guess I'm better off than they are.",
-      "I guess you probably wouldn't have noticed this place before shit hit the fan, but I've been down here for quite a while.",
+      {
+        "gendered_line": "I was homeless before everything went down, just camping out here for a while.  Stuck up <name_b>s shunned me for my condition, but they're all dead now.  I guess I'm better off than they are.",
+        "relevant_genders": [ "npc" ]
+      },
+      {
+        "gendered_line": "I guess you probably wouldn't have noticed this place before shit hit the fan, but I've been down here for quite a while.",
+        "relevant_genders": [ "u" ]
+      },
       "Nothing to it.  Before <the_cataclysm>, it didn't take much to find yourself here.  And I guess it just made sense to stay.  We seem to be doing better than most, anyway.",
       "Surviving, as I always have.  Is that what you mean?",
-      "It's hard to say exactly what I'm doing out here, but I guess one thing just leads to another and… well, you're just being nice when you ask, aren't you?  It doesn't matter now anyway.  I'm here and I'm still alive."
+      {
+        "gendered_line": "It's hard to say exactly what I'm doing out here, but I guess one thing just leads to another and… well, you're just being nice when you ask, aren't you?  It doesn't matter now anyway.  I'm here and I'm still alive.",
+        "relevant_genders": [ "npc" ]
+      }
     ],
     "responses": [ { "text": "Hm.", "topic": "TALK_NONE" } ]
   }

--- a/data/json/npcs/other/homeless/group_camp/TALK_homeless_broker.json
+++ b/data/json/npcs/other/homeless/group_camp/TALK_homeless_broker.json
@@ -75,7 +75,10 @@
     "type": "talk_topic",
     "id": "TALK_NPC_HOMELESS_BROKER_STORY",
     "dynamic_line": [
-      "I was homeless for a while before <the_cataclysm>.  I met some buddies out on the road and we were camping out here.  Now we're just scraping by on what we can find, mostly.  We're willing to trade, though.  Who knows, you might find yourself a good deal.",
+      {
+        "gendered_line": "I was homeless for a while before <the_cataclysm>.  I met some buddies out on the road and we were camping out here.  Now we're just scraping by on what we can find, mostly.  We're willing to trade, though.  Who knows, you might find yourself a good deal.",
+        "relevant_genders": [ "npc" ]
+      },
       "Making ends meet, even in the worst circumstances.  We've been camping out here now, trading with whoever passes by.  If something catches your eye, let me know.",
       "We got tired of being out on the road and decided to stay here for a bit.  We've found a lot of useful stuff out and about, so if you see anything you need I'll make you a deal."
     ],

--- a/data/json/npcs/other/meteorologist.json
+++ b/data/json/npcs/other/meteorologist.json
@@ -65,8 +65,14 @@
         "type": "general",
         "context": "meeting",
         "value": "yes",
-        "yes": "Air temperature, precipitation, but what about… oh, I'm sorry, I didn't notice you.  Hello.",
-        "no": "I have not seen living people for a long time.  Glad to see another survivor.  Greetings, <name_g>."
+        "yes": {
+          "gendered_line": "Air temperature, precipitation, but what about… oh, I'm sorry, I didn't notice you.  Hello.",
+          "relevant_genders": [ "npc" ]
+        },
+        "no": {
+          "gendered_line": "I have not seen living people for a long time.  Glad to see another survivor.  Greetings, <name_g>.",
+          "relevant_genders": [ "npc" ]
+        }
       }
     },
     "speaker_effect": {
@@ -107,7 +113,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_meteorologist_safety",
-    "dynamic_line": "Help?  Help with what?  Oh, yes, yes.  If you know a place with many survivors, can you take me there?  I doubt I can survive alone…",
+    "dynamic_line": {
+      "gendered_line": "Help?  Help with what?  Oh, yes, yes.  If you know a place with many survivors, can you take me there?  I doubt I can survive alone…",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "Let's go.",
@@ -152,13 +161,16 @@
   {
     "type": "talk_topic",
     "id": "TALK_meteorologist_safe",
-    "dynamic_line": "I'm glad you still alive.",
+    "dynamic_line": { "gendered_line": "I'm glad you still alive.", "relevant_genders": [ "npc" ] },
     "responses": [ { "text": "Me too.", "topic": "TALK_DONE" } ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_meteorologist_Background",
-    "dynamic_line": "I'm just a regular meteorologist.  In recent years I have worked at a weather station, monitored the weather, state of air, read and wrote reports, drew up schedules… in general, complete boredom.  In my free time I was studying electronics and radio engineering, making various devices, some for work, some just for fun.  When the first riots began, I gathered all my things that I managed to take with me and settled here.  Since then I've been sitting here, wasting my time doing all sorts of nonsense.",
+    "dynamic_line": {
+      "gendered_line": "I'm just a regular meteorologist.  In recent years I have worked at a weather station, monitored the weather, state of air, read and wrote reports, drew up schedules… in general, complete boredom.  In my free time I was studying electronics and radio engineering, making various devices, some for work, some just for fun.  When the first riots began, I gathered all my things that I managed to take with me and settled here.  Since then I've been sitting here, wasting my time doing all sorts of nonsense.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "<done_conversation_section>", "topic": "TALK_NONE" } ]
   },
   {

--- a/data/json/npcs/prisoners/mi-go_prisoners.json
+++ b/data/json/npcs/prisoners/mi-go_prisoners.json
@@ -40,7 +40,10 @@
       "Hallelujah, rescue!",
       "I can't believe my eyes.  Thank you, thank you!",
       "You're… you're actually real!",
-      "How are you here?  Are you one of them, somehow?  What's going on?"
+      {
+        "gendered_line": "How are you here?  Are you one of them, somehow?  What's going on?",
+        "relevant_genders": [ "u" ]
+      }
     ],
     "responses": [
       {

--- a/data/json/npcs/random_encounters/camper_van_traveler.json
+++ b/data/json/npcs/random_encounters/camper_van_traveler.json
@@ -106,7 +106,10 @@
       "context": "first_meeting",
       "value": "yes",
       "yes": "<greet>",
-      "no": "I didn't think anyone was around here.  Pleased to meet you, I'm <npc_name>."
+      "no": {
+        "gendered_line": "I didn't think anyone was around here.  Pleased to meet you, I'm <npc_name>.",
+        "relevant_genders": [ "npc" ]
+      }
     },
     "speaker_effect": {
       "effect": [
@@ -138,19 +141,28 @@
       "type": "dialogue",
       "context": "travel_direction",
       "value": "north",
-      "yes": "I'm going north, up towards the border and the big wide wilderness.  I heard that there's some sort of safe spot up there, where people didn't go crazy and try to kill each other.  I don't know whether or not that's true, but at the very least, the colder climate might help keep the <zombies> down.",
+      "yes": {
+        "gendered_line": "I'm going north, up towards the border and the big wide wilderness.  I heard that there's some sort of safe spot up there, where people didn't go crazy and try to kill each other.  I don't know whether or not that's true, but at the very least, the colder climate might help keep the <zombies> down.",
+        "relevant_genders": [ "npc" ]
+      },
       "no": {
         "npc_has_var": "travel_direction",
         "type": "dialogue",
         "context": "travel_direction",
         "value": "south",
-        "yes": "I'm going south.  Hopefully somebody down there fared better than the people I knew up here.  Besides, I won't have to worry about freezing my <swear> butt off when winter comes.",
+        "yes": {
+          "gendered_line": "I'm going south.  Hopefully somebody down there fared better than the people I knew up here.  Besides, I won't have to worry about freezing my <swear> butt off when winter comes.",
+          "relevant_genders": [ "npc" ]
+        },
         "no": {
           "npc_has_var": "travel_direction",
           "type": "dialogue",
           "context": "travel_direction",
           "value": "east",
-          "yes": "I'm going east, towards the coastline.  I heard some rumors that Rhode Island was still holding itself together, so I'm going to go and check that out.  Heck, I might just go out to sea myself, live on an old oil rig or something like that.",
+          "yes": {
+            "gendered_line": "I'm going east, towards the coastline.  I heard some rumors that Rhode Island was still holding itself together, so I'm going to go and check that out.  Heck, I might just go out to sea myself, live on an old oil rig or something like that.",
+            "relevant_genders": [ "npc" ]
+          },
           "no": {
             "npc_has_var": "travel_direction",
             "type": "dialogue",
@@ -187,19 +199,34 @@
     "id": "TALK_NPC_CAMPER_VAN_TRAVELER_INTERESTING_THINGS",
     "dynamic_line": {
       "math": [ "npc_randomize_dialogue_direction", "==", "0" ],
-      "yes": "I haven't found anything out of the ordinary, just a bunch of <zombies> and the ruins of our old lives.",
+      "yes": {
+        "gendered_line": "I haven't found anything out of the ordinary, just a bunch of <zombies> and the ruins of our old lives.",
+        "relevant_genders": [ "npc" ]
+      },
       "no": {
         "math": [ "npc_randomize_dialogue_direction", "==", "1" ],
-        "yes": "Actually, I came across a group of farmers on my way here.  They were a little suspicious, but turned out to be pretty nice.  Good place to buy some food, if they're still around.",
+        "yes": {
+          "gendered_line": "Actually, I came across a group of farmers on my way here.  They were a little suspicious, but turned out to be pretty nice.  Good place to buy some food, if they're still around.",
+          "relevant_genders": [ "npc" ]
+        },
         "no": {
           "math": [ "npc_randomize_dialogue_direction", "==", "2" ],
-          "yes": "I found a small cabin out in the woods, someone was living there and had some serious chemistry equipment.  I managed to get good medical supplies from there.  They even had some oddball things too, like <swear> napalm and black powder.",
+          "yes": {
+            "gendered_line": "I found a small cabin out in the woods, someone was living there and had some serious chemistry equipment.  I managed to get good medical supplies from there.  They even had some oddball things too, like <swear> napalm and black powder.",
+            "relevant_genders": [ "npc" ]
+          },
           "no": {
             "math": [ "npc_randomize_dialogue_direction", "==", "3" ],
-            "yes": "I ran in to someone living in an old barn, didn't want anything to do with the world.  The odd thing is, they looked like one of those old, Wild West cowboys.",
+            "yes": {
+              "gendered_line": "I ran in to someone living in an old barn, didn't want anything to do with the world.  The odd thing is, they looked like one of those old, Wild West cowboys.",
+              "relevant_genders": [ "npc" ]
+            },
             "no": {
               "math": [ "npc_randomize_dialogue_direction", "==", "4" ],
-              "yes": "I came across an abandoned house, half of it was collapsed in, looked like it was from way before <the_cataclysm>.  I was poking around to see what was there, and I found a whole bunker underneath the place.  I don't know what the heck was up with that, but I wouldn't want to find out.",
+              "yes": {
+                "gendered_line": "I came across an abandoned house, half of it was collapsed in, looked like it was from way before <the_cataclysm>.  I was poking around to see what was there, and I found a whole bunker underneath the place.  I don't know what the heck was up with that, but I wouldn't want to find out.",
+                "relevant_genders": [ "npc" ]
+              },
               "no": "ERROR: out of bounds on randomize_directions."
             }
           }
@@ -288,7 +315,10 @@
     "type": "talk_topic",
     "id": "TALK_NPC_CAMPER_VAN_TRAVELER_BACKSTORY",
     "//": "This should also be included as part of a randomly selected list of backgrounds in the future.",
-    "dynamic_line": "I used to travel a lot before <the_cataclysm>, and I've had this camper with me for a while now.  I was at home when the riots started, so I grabbed everything I could from my house and hopped in the camper.  I nearly wrecked on my way out of town when some crazy people tried to smash my van, but I made it out.  I've been on the move ever since.",
+    "dynamic_line": {
+      "gendered_line": "I used to travel a lot before <the_cataclysm>, and I've had this camper with me for a while now.  I was at home when the riots started, so I grabbed everything I could from my house and hopped in the camper.  I nearly wrecked on my way out of town when some crazy people tried to smash my van, but I made it out.  I've been on the move ever since.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "<end_talking>", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/random_encounters/camper_van_traveler.json
+++ b/data/json/npcs/random_encounters/camper_van_traveler.json
@@ -150,10 +150,7 @@
         "type": "dialogue",
         "context": "travel_direction",
         "value": "south",
-        "yes": {
-          "gendered_line": "I'm going south.  Hopefully somebody down there fared better than the people I knew up here.  Besides, I won't have to worry about freezing my <swear> butt off when winter comes.",
-          "relevant_genders": [ "npc" ]
-        },
+        "yes": "I'm going south.  Hopefully somebody down there fared better than the people I knew up here.  Besides, I won't have to worry about freezing my <swear> butt off when winter comes.",
         "no": {
           "npc_has_var": "travel_direction",
           "type": "dialogue",

--- a/data/json/npcs/random_encounters/free_merchant_caravans.json
+++ b/data/json/npcs/random_encounters/free_merchant_caravans.json
@@ -71,7 +71,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_MERCHANT_1",
-    "dynamic_line": "Well well, another traveler.  Don't try anything, you're outnumbered here and we're well armed.",
+    "dynamic_line": {
+      "gendered_line": "Well well, another traveler.  Don't try anything, you're outnumbered here and we're well armed.",
+      "relevant_genders": [ "u" ]
+    },
     "speaker_effect": { "effect": { "npc_first_topic": "TALK_CARAVAN_MERCHANT_2" } },
     "responses": [
       { "text": "Are you threatening me?", "topic": "TALK_CARAVAN_MERCHANT_Threatening" },
@@ -135,7 +138,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_MERCHANT_Others",
-    "dynamic_line": "No offense, but my clients definitely would not like me giving strangers directions to their hideouts.  You'll have to find them on their own terms.",
+    "dynamic_line": {
+      "gendered_line": "No offense, but my clients definitely would not like me giving strangers directions to their hideouts.  You'll have to find them on their own terms.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       {
         "text": "I can understand that.  Well, let's trade.",

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -54,7 +54,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_REFUGEE_A2",
-    "dynamic_line": "You again.  Any good news?  Haven't heard any in a long time.",
+    "dynamic_line": { "gendered_line": "You again.  Any good news?  Haven't heard any in a long time.", "relevant_genders": [ "npc" ] },
     "responses": [
       { "text": "What's your story?", "topic": "TALK_CARAVAN_REFUGEE_A_Story" },
       { "text": "No, I don’t have any.", "topic": "TALK_DONE" }
@@ -184,7 +184,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_CARAVAN_REFUGEE_B1_Job",
-    "dynamic_line": "I'm a refugee, but don't get the wrong idea.  I've got big dreams of settling down after this and starting a big family.  I just need to find the right place and the right person.  Last couple of places didn't work out so well.",
+    "dynamic_line": {
+      "gendered_line": "I'm a refugee, but don't get the wrong idea.  I've got big dreams of settling down after this and starting a big family.  I just need to find the right place and the right person.  Last couple of places didn't work out so well.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "So you're not attached right now?", "topic": "TALK_CARAVAN_REFUGEE_B1_Attached" },
       {

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_1_Reena_Sandhu.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_1_Reena_Sandhu.json
@@ -75,7 +75,10 @@
       "yes": {
         "npc_has_effect": "beggar_has_eaten",
         "yes": "So, any luck with convincing the others to come on your crazy adventure yet?",
-        "no": "I'm sorry to say it after all you've done for me, but… I don't suppose you've got anything to eat?"
+        "no": {
+          "gendered_line": "I'm sorry to say it after all you've done for me, but… I don't suppose you've got anything to eat?",
+          "relevant_genders": [ "u" ]
+        }
       },
       "no": {
         "npc_has_effect": "beggar_has_eaten",
@@ -106,9 +109,14 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_1_INTRO",
     "dynamic_line": {
-      "npc_has_effect": "beggar_has_eaten",
-      "yes": "They won't let me in.  They say they're too full.  I'm allowed to camp out here as long as I keep it clean and don't make a fuss, but I'm reduced to begging to survive.",
-      "no": "They won't let me in.  They say they're too full.  I'm allowed to camp out here as long as I keep it clean and don't make a fuss, but I'm so hungry."
+      "concatenate": [
+        "They won't let me in.  They say they're too full.  I'm allowed to camp out here as long as I keep it clean and don't make a fuss",
+        {
+          "npc_has_effect": "beggar_has_eaten",
+          "yes": ", but I'm reduced to begging to survive.",
+          "no": ", but I'm so hungry."
+        }
+      ]
     },
     "responses": [
       { "text": "Why don't you go somewhere else?", "topic": "TALK_REFUGEE_BEGGAR_1_LEAVE" },
@@ -328,7 +336,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_1_RECRUIT2",
-    "dynamic_line": "Well… you have shown that you can survive out there, and you've been able to provide food, so I know you're thriving more than we are here.  All right, I'll tell you what.  I'm not going anywhere without my friends here, we've been through way too much together.  If you can convince Luo, Brandon, and Yusuke to come along, then I'll go.",
+    "dynamic_line": {
+      "gendered_line": "Well… you have shown that you can survive out there, and you've been able to provide food, so I know you're thriving more than we are here.  All right, I'll tell you what.  I'm not going anywhere without my friends here, we've been through way too much together.  If you can convince Luo, Brandon, and Yusuke to come along, then I'll go.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "OK.  For now let's talk about something else.", "topic": "TALK_NONE" },
       { "text": "OK, I'll talk to them too.", "topic": "TALK_DONE" }
@@ -337,7 +348,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_1_RECRUITED",
-    "dynamic_line": "Well… you have shown that you can survive out there, and you've been able to provide food, so I know you're thriving more than we are here.  All right, I'll tell you what.  I'm not going anywhere without my friends here, we've been through way too much together.  If you can convince Luo, Brandon, and Yusuke to come along, then I'll go.",
+    "dynamic_line": {
+      "gendered_line": "Well… you have shown that you can survive out there, and you've been able to provide food, so I know you're thriving more than we are here.  All right, I'll tell you what.  I'm not going anywhere without my friends here, we've been through way too much together.  If you can convince Luo, Brandon, and Yusuke to come along, then I'll go.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [ { "text": "All right!  Let's get going.", "topic": "TALK_DONE", "effect": "follow" } ]
   }
 ]

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_2_Dino_Dave.json
@@ -108,7 +108,10 @@
     "dynamic_line": {
       "npc_has_effect": "beggar_has_eaten",
       "yes": "Oh nice.  Crunchings and munchings.  That's a cool, a cool thing.",
-      "no": "Yeah, I'm real hungry and they put drugs in most of the food.  I can see you're not like that."
+      "no": {
+        "gendered_line": "Yeah, I'm real hungry and they put drugs in most of the food.  I can see you're not like that.",
+        "relevant_genders": [ "u" ]
+      }
     },
     "responses": [
       { "text": "Actually can I ask you something else?", "topic": "TALK_NONE" },

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_3_Luo_Meizhen.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_3_Luo_Meizhen.json
@@ -92,7 +92,7 @@
     "id": "TALK_REFUGEE_BEGGAR_3",
     "dynamic_line": {
       "npc_has_effect": "insulted_luo",
-      "yes": "Fuck off, dickwaddle.",
+      "yes": { "gendered_line": "Fuck off, dickwaddle.", "relevant_genders": [ "u" ] },
       "no": {
         "u_has_var": "luo_recruited",
         "type": "general",
@@ -114,11 +114,14 @@
               "yes": "Hey there.  Good to see you again.",
               "no": "Careful, I'm getting hangry again and am not totally responsible for my own actions."
             },
-            "no": "Look, I'm sorry for freaking out earlier.  You might be an asshole but I'm sure you didn't mean it like that.  My blood sugar is hella low, I get a bit cranky.  We cool?"
+            "no": {
+              "gendered_line": "Look, I'm sorry for freaking out earlier.  You might be an asshole but I'm sure you didn't mean it like that.  My blood sugar is hella low, I get a bit cranky.  We cool?",
+              "relevant_genders": [ "u" ]
+            }
           },
           "no": {
             "npc_has_effect": "beggar_has_eaten",
-            "yes": "Hey there, not-asshole.  Good to see you again.",
+            "yes": { "gendered_line": "Hey there, not-asshole.  Good to see you again.", "relevant_genders": [ "u" ] },
             "no": "Don't bother with these assholes."
           }
         }
@@ -387,7 +390,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_3_INSULTED",
-    "dynamic_line": "Oooooh.  Oh.  You did not just fucking go there.  Let's leave the fatties to die, hey?  Wanna know how easy it is to find fucking *thyroid medication* after the apocalypse, asshat?  Besides, there are more skills than heavy lifting needed now… no, you know what?  Screw it.  You're not worth my time.",
+    "dynamic_line": {
+      "gendered_line": "Oooooh.  Oh.  You did not just fucking go there.  Let's leave the fatties to die, hey?  Wanna know how easy it is to find fucking *thyroid medication* after the apocalypse, asshat?  Besides, there are more skills than heavy lifting needed now… no, you know what?  Screw it.  You're not worth my time.",
+      "relevant_genders": [ "u" ]
+    },
     "speaker_effect": [
       {
         "effect": [

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_4_Brandon_Garder.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_4_Brandon_Garder.json
@@ -64,7 +64,7 @@
     "id": "TALK_REFUGEE_BEGGAR_4",
     "dynamic_line": {
       "npc_has_effect": "beggar_has_eaten",
-      "yes": "Thanks again for the grub, my friend.",
+      "yes": { "gendered_line": "Thanks again for the grub, my friend.", "relevant_genders": [ "u" ] },
       "no": "Hey, are you a big fan of survival of the fittest?"
     },
     "responses": [
@@ -118,7 +118,10 @@
     "dynamic_line": {
       "npc_has_effect": "beggar_has_eaten",
       "yes": "That's awful kind of you, you really are a wonderful person.",
-      "no": "Oh, wow!  You're a real gem, you know that?  Thanks for even thinking of it."
+      "no": {
+        "gendered_line": "Oh, wow!  You're a real gem, you know that?  Thanks for even thinking of it.",
+        "relevant_genders": [ "u" ]
+      }
     },
     "responses": [
       { "text": "Actually can I ask you something else?", "topic": "TALK_NONE" },
@@ -289,7 +292,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_4_RECRUIT2",
-    "dynamic_line": "Well… I'll be honest, I didn't even think Dave could be sorted out, and you've gone and called my bluff!  It's a darn fine thing you've done for that poor soul.  Listen, I wasn't… entirely serious about wanting to come with you, but if you can convince the others to go, then I guess I'll come along.",
+    "dynamic_line": {
+      "gendered_line": "Well… I'll be honest, I didn't even think Dave could be sorted out, and you've gone and called my bluff!  It's a darn fine thing you've done for that poor soul.  Listen, I wasn't… entirely serious about wanting to come with you, but if you can convince the others to go, then I guess I'll come along.",
+      "relevant_genders": [ "u" ]
+    },
     "speaker_effect": [ { "effect": { "u_add_var": "brendan_recruited", "type": "general", "context": "recruit", "value": "yes" } } ],
     "responses": [
       { "text": "What were you saying before?", "topic": "TALK_NONE" },

--- a/data/json/npcs/refugee_center/beggars/BEGGAR_5_Yusuke_Taylor.json
+++ b/data/json/npcs/refugee_center/beggars/BEGGAR_5_Yusuke_Taylor.json
@@ -58,7 +58,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_5",
-    "dynamic_line": "Hey there, friend.",
+    "dynamic_line": { "gendered_line": "Hey there, friend.", "relevant_genders": [ "u" ] },
     "//": "STUB FILE: not all text implemented yet.  TK: different greetings and a whole segment on getting the beggars to join up.",
     "responses": [
       { "text": "What are you doing out here?", "topic": "TALK_REFUGEE_BEGGAR_5_TALK1" },
@@ -180,7 +180,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_BEGGAR_5_TRAVEL1",
-    "dynamic_line": "Well now, that's quite a kind offer, and I appreciate you looking past my full-body pubic hair.  Sorry though.  I've come to feel sort of responsible for this little gaggle of squatters.  As long as I'm the only one providing for them, I don't think I can leave.",
+    "dynamic_line": {
+      "gendered_line": "Well now, that's quite a kind offer, and I appreciate you looking past my full-body pubic hair.  Sorry though.  I've come to feel sort of responsible for this little gaggle of squatters.  As long as I'm the only one providing for them, I don't think I can leave.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       {
         "condition": {

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Aleesha_Seward.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Aleesha_Seward.json
@@ -86,7 +86,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Aleesha_1",
-    "dynamic_line": "*seems impossibly young at first glance, her dark face nervous when she sees you looking her way.  On closer inspection as you approach, you see that she is likely in her early teens, but the contrast to the weary faces around makes her age stand out.  \"Oh, uh… hi.  You look new.  I'm Aleesha.\"",
+    "dynamic_line": {
+      "gendered_line": "*seems impossibly young at first glance, her dark face nervous when she sees you looking her way.  On closer inspection as you approach, you see that she is likely in her early teens, but the contrast to the weary faces around makes her age stand out.  \"Oh, uh… hi.  You look new.  I'm Aleesha.\"",
+      "relevant_genders": [ "u" ]
+    },
     "speaker_effect": {
       "effect": [
         { "u_add_var": "u_met_Aleesha_Seward", "type": "general", "context": "meeting", "value": "yes" },
@@ -108,7 +111,7 @@
           "Hey there.",
           "Oh, hey, it's you again.",
           "What's up?",
-          "You're back, and still alive!  Whoa.",
+          { "gendered_line": "You're back, and still alive!  Whoa.", "relevant_genders": [ "u" ] },
           "Aw hey, look who's back."
         ],
         "\""

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Alonso_Lautrec.json
@@ -189,7 +189,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Alonso_1a",
-    "dynamic_line": "*leans casually against the brick wall of the shelter.  \"Hello again, gorgeous\"",
+    "dynamic_line": {
+      "gendered_line": "*leans casually against the brick wall of the shelter.  \"Hello again, gorgeous\"",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "Hi, Alonso.  What's up?", "topic": "TALK_REFUGEE_Alonso_2" },
       { "text": "Hi Alonso.  I can't stay to talk.", "topic": "TALK_DONE" }
@@ -378,7 +381,7 @@
       "context": "none",
       "value": "asked",
       "no": "My jewel of the New England, I give to you my biggest prize.",
-      "yes": "Yo, you're crazy hot!  I'm not stupid!"
+      "yes": { "gendered_line": "Yo, you're crazy hot!  I'm not stupid!", "relevant_genders": [ "u" ] }
     },
     "speaker_effect": {
       "sentinel": "service_provided",
@@ -418,7 +421,7 @@
       "context": "none",
       "value": "asked",
       "no": "My jewel of the New England, I give to you my biggest prize.",
-      "yes": "Yo, you're crazy hot!  I'm not stupid!"
+      "yes": { "gendered_line": "Yo, you're crazy hot!  I'm not stupid!", "relevant_genders": [ "u" ] }
     },
     "speaker_effect": {
       "sentinel": "service_provided",

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Boris_Borichenko.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Boris_Borichenko.json
@@ -188,7 +188,10 @@
     "dynamic_line": {
       "concatenate": [
         "*stares at you for a moment before nodding in recognition.  \"",
-        [ "Well, well.  You are back.", "So, you have survived." ],
+        [
+          { "gendered_line": "Well, well.  You are back.", "relevant_genders": [ "u" ] },
+          { "gendered_line": "So, you have survived.", "relevant_genders": [ "u" ] }
+        ],
         "\""
       ]
     },
@@ -204,7 +207,11 @@
     "dynamic_line": {
       "concatenate": [
         "*nods at you, his eyes lighting up a little as you approach.  \"",
-        [ "Well, well.  I'm glad you are back.", "It is good to see you again, my friend.", "Hello, my friend." ],
+        [
+          { "gendered_line": "Well, well.  I'm glad you are back.", "relevant_genders": [ "u" ] },
+          { "gendered_line": "It is good to see you again, my friend.", "relevant_genders": [ "u" ] },
+          { "gendered_line": "Hello, my friend.", "relevant_genders": [ "u" ] }
+        ],
         "\""
       ]
     },
@@ -387,7 +394,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Boris_Teach",
-    "dynamic_line": "Yes, my friend.  You have done so much for me, I would be glad to teach you what I can.  I must ask a small amount in trade, for materials.  I hope you understand.",
+    "dynamic_line": {
+      "gendered_line": "Yes, my friend.  You have done so much for me, I would be glad to teach you what I can.  I must ask a small amount in trade, for materials.  I hope you understand.",
+      "relevant_genders": [ "u" ]
+    },
     "speaker_effect": { "effect": { "math": [ "n_timer_flag_Boris_teach", "=", "time('now')" ] } },
     "responses": [
       { "text": "Great!  Let's get started.", "topic": "TALK_TRAIN" },
@@ -449,7 +459,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Boris_Refuse_Boris_Mission_1",
-    "dynamic_line": "Have you had a problem with memory, friend?  I was the one who asked you this, I thought I explained why I could not.",
+    "dynamic_line": {
+      "gendered_line": "Have you had a problem with memory, friend?  I was the one who asked you this, I thought I explained why I could not.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "Oh.  Right.  It's been a long apocalypse.  What were you saying?", "topic": "TALK_NONE" },
       {
@@ -461,7 +474,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Boris_MakeDoWith2",
-    "dynamic_line": "Hmm, well it is not ideal but I appreciate you trying and being willing to help.  I will have to do my best despite the bad memories.  Thank you, my friend.",
+    "dynamic_line": {
+      "gendered_line": "Hmm, well it is not ideal but I appreciate you trying and being willing to help.  I will have to do my best despite the bad memories.  Thank you, my friend.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [ { "text": "OK, let's get to work.", "topic": "TALK_DONE" } ],
     "speaker_effect": {
       "effect": [
@@ -474,7 +490,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Boris_MakeDoWith3",
-    "dynamic_line": "Thank you for trying, my friend.  With you and me that will be five, I will do my best to be strong and assist in the cleanup.",
+    "dynamic_line": {
+      "gendered_line": "Thank you for trying, my friend.  With you and me that will be five, I will do my best to be strong and assist in the cleanup.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [ { "text": "OK, let's get to work.", "topic": "TALK_DONE" } ],
     "speaker_effect": {
       "effect": [
@@ -487,7 +506,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Boris_MakeDoWith4",
-    "dynamic_line": "That is quite alright, four should be enough though I appreciate your offer.  Four people will make the job much easier and I will do my best even if it is painful.  My thanks, friend.",
+    "dynamic_line": {
+      "gendered_line": "That is quite alright, four should be enough though I appreciate your offer.  Four people will make the job much easier and I will do my best even if it is painful.  My thanks, friend.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [ { "text": "Good to hear.  I'm sure everyone will appreciate that place being cleaned up.", "topic": "TALK_DONE" } ],
     "speaker_effect": {
       "effect": [

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Dana_Nunez.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Dana_Nunez.json
@@ -511,7 +511,7 @@
       "context": "general",
       "value": "phase_1",
       "no": "Huh.  I've made a few friends here, but not so much as I'd stick around here with no future prospects, hoping someone downstairs dies to make room for me.  It does sound nice, if they're looking for more workers.",
-      "yes": "Have you heard anything back from the ranch about jobs yet?"
+      "yes": { "gendered_line": "Have you heard anything back from the ranch about jobs yet?", "relevant_genders": [ "u" ] }
     },
     "speaker_effect": { "effect": { "u_add_var": "Nunez_Tacoma", "type": "recruit", "context": "general", "value": "phase_1" } },
     "responses": [

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Draco_Dune.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Draco_Dune.json
@@ -80,7 +80,7 @@
       "type": "general",
       "context": "meeting",
       "value": "yes",
-      "yes": "Always good to see you, friend.",
+      "yes": { "gendered_line": "Always good to see you, friend.", "relevant_genders": [ "u" ] },
       "no": "Well now, good to see another new face!  Welcome to the center, friend, I'm Draco."
     },
     "speaker_effect": {
@@ -97,7 +97,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Draco_1a",
-    "dynamic_line": "Always good to see you, friend.",
+    "dynamic_line": { "gendered_line": "Always good to see you, friend.", "relevant_genders": [ "u" ] },
     "responses": [
       {
         "text": "Hi, Draco, how are you doing?",
@@ -262,7 +262,10 @@
       "type": "general",
       "context": "mission",
       "value": "yes",
-      "yes": "My savior!  My patron of the arts!  You're always welcome here, friend.",
+      "yes": {
+        "gendered_line": "My savior!  My patron of the arts!  You're always welcome here, friend.",
+        "relevant_genders": [ "u" ]
+      },
       "no": "Man, just imagine what I could do with a new guitar."
     },
     "speaker_effect": { "effect": { "math": [ "u_general_meeting_Draco_Dune_convo_depth", "=", "7" ] } },
@@ -315,7 +318,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Draco_10_question",
-    "dynamic_line": "Where you say you're from again?  You're not as worldly as you look.  I'm talking about weed.  Marijuana.  Wondered if you've happened upon any.",
+    "dynamic_line": {
+      "gendered_line": "Where you say you're from again?  You're not as worldly as you look.  I'm talking about weed.  Marijuana.  Wondered if you've happened upon any.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "Oh.  Uh, sure.", "topic": "TALK_REFUGEE_Draco_10_approve" },
       {
@@ -434,7 +440,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Draco_10_sold",
-    "dynamic_line": "Sold!  Thanks for helping me out, friend.",
+    "dynamic_line": { "gendered_line": "Sold!  Thanks for helping me out, friend.", "relevant_genders": [ "u" ] },
     "responses": [
       { "text": "No problem, Draco.", "topic": "TALK_REFUGEE_Draco_7" },
       { "text": "You're welcome.  Later.", "topic": "TALK_DONE" }
@@ -443,7 +449,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Draco_Dance",
-    "dynamic_line": "Sure thing, friend!  Let's see how you can move to this one.",
+    "dynamic_line": { "gendered_line": "Sure thing, friend!  Let's see how you can move to this one.", "relevant_genders": [ "u" ] },
     "responses": [
       { "text": "Just a sec, got somethig I need to do first.", "topic": "TALK_DONE" },
       {
@@ -503,7 +509,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Draco_Dance_3",
-    "dynamic_line": "Oh my, am I dealing with a professional dancer here?  Sweet moves, friend.",
+    "dynamic_line": {
+      "gendered_line": "Oh my, am I dealing with a professional dancer here?  Sweet moves, friend.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [ { "text": "Thanks!", "topic": "TALK_REFUGEE_Draco_7" }, { "text": "Cheers!  Later.", "topic": "TALK_DONE" } ]
   },
   {
@@ -515,7 +524,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Draco_Dance_5",
-    "dynamic_line": "Daym.  You're probably the best dancer I've ever had the honor of meeting.  Well done.  Well done indeed.",
+    "dynamic_line": {
+      "gendered_line": "Daym.  You're probably the best dancer I've ever had the honor of meeting.  Well done.  Well done indeed.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [ { "text": "Thanks!", "topic": "TALK_REFUGEE_Draco_7" }, { "text": "Cheers!  Later.", "topic": "TALK_DONE" } ]
   },
   {

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Fatima_Al_Jadir.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Fatima_Al_Jadir.json
@@ -178,7 +178,10 @@
         "context": "flag",
         "value": "yes",
         "no": "Sure, I could teach you the basics, I'll have to charge you though.  Let's say, 5 merch for a teaching session, plus a bit in trade depending on how in-depth you're looking for?",
-        "yes": "Sure, I could teach you the basics, it'll cost you merch though.  Since you helped me out, I can shave a bit off the price, let's say 4 merch, plus a bit in trade depending on how in-depth you're looking for?"
+        "yes": {
+          "gendered_line": "Sure, I could teach you the basics, it'll cost you merch though.  Since you helped me out, I can shave a bit off the price, let's say 4 merch, plus a bit in trade depending on how in-depth you're looking for?",
+          "relevant_genders": [ "u" ]
+        }
       }
     },
     "speaker_effect": { "effect": { "u_add_var": "Fatima_Teacher", "type": "knowledge", "context": "trade", "value": "yes" } },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Jenny_Forcette.json
@@ -396,7 +396,10 @@
     "type": "talk_topic",
     "id": "TALK_REFUGEE_JENNY_Project1_helped",
     "//": "The talk_response to lead here should be in TALK_REFUGEE_JENNY_Project1, and should have these components, saved here until we can check for the pneumatics proficiency in conditions: What do you need to know?  I'm pretty handy with pneumatic devices, I can probably help. 'u_add_var: Jenny_pneumatics value: mission_complete'.",
-    "dynamic_line": "\"Holy shit, what are the odds?  OK, stand back and hold on.\"  Jenny begins peppering you with questions, which you answer to the best of your ability.  She seems quite satisfied.  \"Well, I can't thank you enough,\" she smiles after a few minutes.  \"You probably just saved me weeks of reinventing the wheel.  Here, it's not much but it's all I've got.\"  She hands you a bundle of the local currency.",
+    "dynamic_line": {
+      "gendered_line": "\"Holy shit, what are the odds?  OK, stand back and hold on.\"  Jenny begins peppering you with questions, which you answer to the best of your ability.  She seems quite satisfied.  \"Well, I can't thank you enough,\" she smiles after a few minutes.  \"You probably just saved me weeks of reinventing the wheel.  Here, it's not much but it's all I've got.\"  She hands you a bundle of the local currency.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "Tell me more about your project.", "topic": "TALK_REFUGEE_JENNY_Project2" },
       { "text": "What were you saying before?", "topic": "TALK_NONE" },
@@ -426,7 +429,10 @@
     "id": "TALK_REFUGEE_JENNY_Project3",
     "dynamic_line": {
       "math": [ "time_since(n_timer_flag_Jenny_project_timer)", ">=", "time('7 d')" ],
-      "no": "Things are coming along.  I have a lot of studying to do before I know how to fix my design issues, but the book you brought definitely has everything I need.  Now that I've got some progress to show, administration is much more willing to help me get the parts I need.  You've been a great gofer, but I can probably handle the rest on my own.  Check back in a week or two!",
+      "no": {
+        "gendered_line": "Things are coming along.  I have a lot of studying to do before I know how to fix my design issues, but the book you brought definitely has everything I need.  Now that I've got some progress to show, administration is much more willing to help me get the parts I need.  You've been a great gofer, but I can probably handle the rest on my own.  Check back in a week or two!",
+        "relevant_genders": [ "u" ]
+      },
       "yes": {
         "math": [ "time_since(n_timer_flag_Jenny_project_timer)", ">=", "time('14 d')" ],
         "no": "I'm really making headway.  We've done some live demonstrations with a working device, and now it's just a matter of manufacturing a few of them.  We should be ready for release in a week or two.",

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_John_Clemens.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_John_Clemens.json
@@ -97,7 +97,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_John_1",
-    "dynamic_line": "*turns to look at you, lifting an enormous cowboy hat off his eyes.  He appears to be in the process of growing out a set of bushy muttonchops and a handlebar moustache.  Bright blue eyes peer out from his wrinkled face.  \"Howdy, pardner.  They call me Clemens.  John Clemens.  I'm an ol' cowhand.\"",
+    "dynamic_line": {
+      "gendered_line": "*turns to look at you, lifting an enormous cowboy hat off his eyes.  He appears to be in the process of growing out a set of bushy muttonchops and a handlebar moustache.  Bright blue eyes peer out from his wrinkled face.  \"Howdy, pardner.  They call me Clemens.  John Clemens.  I'm an ol' cowhand.\"",
+      "relevant_genders": [ "u" ]
+    },
     "speaker_effect": {
       "effect": [
         { "u_add_var": "u_met_John_Clemens", "type": "general", "context": "meeting", "value": "yes" },
@@ -112,7 +115,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_John_1a",
-    "dynamic_line": "*tips his cowboy hat and sets his feet far apart as he faces you.  \"Howdy, pardner.\"",
+    "dynamic_line": {
+      "gendered_line": "*tips his cowboy hat and sets his feet far apart as he faces you.  \"Howdy, pardner.\"",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "Hi, John.  Got a minute?", "topic": "TALK_REFUGEE_John_2" },
       { "text": "Hi John.  I can't stay to talk.", "topic": "TALK_DONE" }

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Mangalpreet_Singh.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Mangalpreet_Singh.json
@@ -93,7 +93,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Mangalpreet_1",
-    "dynamic_line": "*is a well-kept middle aged woman with dark hair tied back in a long braid.  She looks surprised as you approach.  \"Ah!  You are new.  I'm sorry, I'm Mangalpreet.\"",
+    "dynamic_line": {
+      "gendered_line": "*is a well-kept middle aged woman with dark hair tied back in a long braid.  She looks surprised as you approach.  \"Ah!  You are new.  I'm sorry, I'm Mangalpreet.\"",
+      "relevant_genders": [ "u" ]
+    },
     "speaker_effect": {
       "effect": [
         { "u_add_var": "u_met_Mangalpreet_Singh", "type": "general", "context": "meeting", "value": "yes" },
@@ -148,16 +151,16 @@
         "I have my family.  I have the Guru Granth Sahib",
         {
           "math": [ "u_counter_refugee_center_refugee_happiness", ">=", "7" ],
-          "yes": ".  For a while, I thought these might not be enough but… I am allowing myself to hope.  Still, w",
-          "no": ".  I have these things, but I do not have peace.  No one here does.  W"
+          "yes": ".  For a while, I thought these might not be enough but… I am allowing myself to hope",
+          "no": ".  I have these things, but I do not have peace.  No one here does"
         },
         {
           "u_has_var": "Boris_mission_1",
           "type": "mission",
           "context": "completed",
           "value": "yes",
-          "yes": "e have so much work to do to make a home here.",
-          "no": "e are crowded, we are plagued by the sounds and the memories of the dead.  The situation is grim."
+          "yes": ".  Still, we have so much work to do to make a home here.",
+          "no": ".  We are crowded, we are plagued by the sounds and the memories of the dead.  The situation is grim."
         }
       ]
     },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Uyen_Tran.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Uyen_Tran.json
@@ -108,7 +108,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Uyen_1",
-    "dynamic_line": "*studies you with interest, her eyes lined with fatigue but still alert.  She brushes a lock of hair off her forehead.  \"Hi there.  You look new, nice to meet you.  My name's Uyen.\"",
+    "dynamic_line": {
+      "gendered_line": "*studies you with interest, her eyes lined with fatigue but still alert.  She brushes a lock of hair off her forehead.  \"Hi there.  You look new, nice to meet you.  My name's Uyen.\"",
+      "relevant_genders": [ "npc" ]
+    },
     "speaker_effect": {
       "effect": [
         { "u_add_var": "u_met_Uyen_Tran", "type": "general", "context": "meeting", "value": "yes" },

--- a/data/json/npcs/refugee_center/surface_refugees/NPC_Vanessa_Toby.json
+++ b/data/json/npcs/refugee_center/surface_refugees/NPC_Vanessa_Toby.json
@@ -143,7 +143,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_REFUGEE_Vanessa_1a",
-    "dynamic_line": "*peers at you for a while before speaking.  \"Oh, you're back.\"",
+    "dynamic_line": { "gendered_line": "*peers at you for a while before speaking.  \"Oh, you're back.\"", "relevant_genders": [ "u" ] },
     "responses": [
       { "text": "Hi, Vanessa.  What's up?", "topic": "TALK_REFUGEE_Vanessa_2" },
       { "text": "Nevermind.  I'm going.", "topic": "TALK_DONE" }
@@ -178,10 +178,9 @@
       "concatenate": [
         {
           "math": [ "u_counter_refugee_center_refugee_happiness", ">=", "5" ],
-          "yes": "Well, I",
-          "no": "You want the sarcastic version, or the really sarcastic version?  I"
+          "yes": "Well, I'm stuck in a dank shitty brick building with two dozen strangers, the world's dead",
+          "no": "You want the sarcastic version, or the really sarcastic version?  I'm stuck in a dank shitty brick building with two dozen strangers, the world's dead"
         },
-        "'m stuck in a dank shitty brick building with two dozen strangers, the world's dead",
         {
           "u_has_var": "tacoma_started",
           "type": "knowledge",

--- a/data/json/npcs/refugee_center/surface_refugees/shared_dialogue.json
+++ b/data/json/npcs/refugee_center/surface_refugees/shared_dialogue.json
@@ -4,10 +4,16 @@
     "id": "TALK_REFUGEE_Refuse_Boris_Mission_1",
     "dynamic_line": [
       "Sorry, but you couldn't pay me enough to go back there.",
-      "No way, sorry.  I was in there when things went bad.  It'll be hard enough to go back after it's cleaned up, I can't bear to look at it right now.",
+      {
+        "gendered_line": "No way, sorry.  I was in there when things went bad.  It'll be hard enough to go back after it's cleaned up, I can't bear to look at it right now.",
+        "relevant_genders": [ "npc" ]
+      },
       "I can't.  Too many memories back there.  Sorry.",
       "I wish I could, but no.  I can't face the memories.",
-      "Sorry, no.  That's too much to ask from me.  I was back there when it went wrong.",
+      {
+        "gendered_line": "Sorry, no.  That's too much to ask from me.  I was back there when it went wrong.",
+        "relevant_genders": [ "npc" ]
+      },
       "You won't get much luck asking those of us who were back there I'm afraid.  Sorry."
     ],
     "speaker_effect": { "effect": { "npc_add_var": "cleanup_asked", "type": "mission", "context": "Boris_mission_1", "value": "yes" } },

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_broker.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_broker.json
@@ -203,7 +203,10 @@
   {
     "id": "TALK_FREE_MERCHANT_STOCKS_RANCH",
     "type": "talk_topic",
-    "dynamic_line": "I'm so glad we've got that up and running.  One of the people evacuated here had a connection to a functioning ranch, and we got him and a crew out there as quickly as we were able.  We're hoping they'll be able to supply us in enough foodstuffs to make this place self-sufficient and even to trade with other communities as they arise."
+    "dynamic_line": {
+      "gendered_line": "I'm so glad we've got that up and running.  One of the people evacuated here had a connection to a functioning ranch, and we got him and a crew out there as quickly as we were able.  We're hoping they'll be able to supply us in enough foodstuffs to make this place self-sufficient and even to trade with other communities as they arise.",
+      "relevant_genders": [ "npc" ]
+    }
   },
   {
     "id": "TALK_FREE_MERCHANT_STOCKS_Boris_Mission_1",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_guard3.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_guard3.json
@@ -24,7 +24,10 @@
   {
     "id": "TALK_EVAC_GUARD3_NEW",
     "type": "talk_topic",
-    "dynamic_line": "I haven't been here for long but I do my best to watch who comes and goes.  You can't always predict who will bring trouble.",
+    "dynamic_line": {
+      "gendered_line": "I haven't been here for long but I do my best to watch who comes and goes.  You can't always predict who will bring trouble.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "…", "topic": "TALK_EVAC_GUARD3" } ]
   },
   {
@@ -45,7 +48,7 @@
   {
     "id": "TALK_EVAC_GUARD3_HIDE2",
     "type": "talk_topic",
-    "dynamic_line": "You're new here, who the hell put you up to this crap?",
+    "dynamic_line": { "gendered_line": "You're new here, who the hell put you up to this crap?", "relevant_genders": [ "u" ] },
     "responses": [
       {
         "text": "Get bent, traitor!",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_guard_generic.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_guard_generic.json
@@ -47,7 +47,10 @@
     "dynamic_line": [
       "Nothing too fancy.  We have a rota of anyone able bodied that can handle themselves.",
       "None of your business really, is it.",
-      "I've seen my share of zombies, I'm one of the ones that's ready to take em on.  Nothing more.",
+      {
+        "gendered_line": "I've seen my share of zombies, I'm one of the ones that's ready to take em on.  Nothing more.",
+        "relevant_genders": [ "npc" ]
+      },
       "Gotta earn my keep.",
       "It's honest work, and now and then I get to take a zombie down."
     ],

--- a/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_free_merchant_teamster.json
@@ -158,7 +158,10 @@
         "yes": "Matter of fact, yeah.  Ran into a bunch of farmers.  They don't want much to do with our caravans, but someone like you they might be OK with.",
         "no": {
           "math": [ "npc_randomize_dialogue_direction", "==", "2" ],
-          "yes": "There's been rumors.  Folks talkin' about some kind of secret lab, out in the wilds, with survivors in it.  I haven't seen it myself, mind you.",
+          "yes": {
+            "gendered_line": "There's been rumors.  Folks talkin' about some kind of secret lab, out in the wilds, with survivors in it.  I haven't seen it myself, mind you.",
+            "relevant_genders": [ "npc" ]
+          },
           "no": {
             "math": [ "npc_randomize_dialogue_direction", "==", "3" ],
             "yes": "Well, a few of my caravans have come back now talkin' about this giant metal castle on top of a rock, in the middle of nowhere.  They ain't been crazy enough to check it out, but you could if you want.",
@@ -260,7 +263,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_FREE_MERCHANT_TEAMSTER_Boris_Mission_1",
-    "dynamic_line": "Yeah, I'll help out.  I've pretty much been waiting for someone to ask, the mess is in my way but I've been too busy to organize it myself.  Boris is the one to talk to, you say?  I'll let him know.",
+    "dynamic_line": {
+      "gendered_line": "Yeah, I'll help out.  I've pretty much been waiting for someone to ask, the mess is in my way but I've been too busy to organize it myself.  Boris is the one to talk to, you say?  I'll let him know.",
+      "relevant_genders": [ "npc" ]
+    },
     "speaker_effect": {
       "effect": [
         { "npc_add_var": "cleanup_asked", "type": "mission", "context": "Boris_mission_1", "value": "yes" },
@@ -275,7 +281,10 @@
   {
     "id": "TALK_FREE_MERCHANT_TEAMSTER_Godco_Trader",
     "type": "talk_topic",
-    "dynamic_line": "Oh yeah, they're my rookie representative.  I figured that those people wouldn't cause too much trouble for them, so I sent them over there.  What about them?",
+    "dynamic_line": {
+      "gendered_line": "Oh yeah, they're my rookie representative.  I figured that those people wouldn't cause too much trouble for them, so I sent them over there.  What about them?",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "I think they're gouging the prices for the people living there.",

--- a/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
+++ b/data/json/npcs/refugee_center/surface_staff/NPC_old_guard_doctor.json
@@ -49,7 +49,10 @@
   {
     "id": "TALK_SCIENCE_REP_NEW",
     "type": "talk_topic",
-    "dynamic_line": "I'm a doctor, one of the several at the outpost.  We were the lucky ones.  Came here right went things started to go wrong, never left.",
+    "dynamic_line": {
+      "gendered_line": "I'm a doctor, one of the several at the outpost.  We were the lucky ones.  Came here right went things started to go wrong, never left.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "So what are you doing right now?", "topic": "TALK_SCIENCE_REP_NEW_DOING" },
       { "text": "Never mind…", "topic": "TALK_SCIENCE_REP" }

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -8,7 +8,10 @@
       "context": "meeting",
       "value": "yes",
       "yes": [ "Welcome back.", "Hello again.  What do you need?", "*looks up.  \"Hey.\"" ],
-      "no": "*waves you over.  \"I haven't seen you before.  Welcome to our little homely house.\""
+      "no": {
+        "gendered_line": "*waves you over.  \"I haven't seen you before.  Welcome to our little homely house.\"",
+        "relevant_genders": [ "u" ]
+      }
     },
     "responses": [
       {
@@ -312,7 +315,7 @@
   {
     "id": "TALK_EVAC_MERCHANT_DEAL_NEGOTIATE",
     "type": "talk_topic",
-    "dynamic_line": [ "Sure, we could use some around here for repairs and whatnot.  What are the terms?" ],
+    "dynamic_line": "Sure, we could use some around here for repairs and whatnot.  What are the terms?",
     "responses": [
       {
         "text": "Well, how about 250 merch for 100 pounds of…",
@@ -324,7 +327,7 @@
   {
     "id": "TALK_EVAC_MERCHANT_DEAL_NEGOTIATE_CHEM",
     "type": "talk_topic",
-    "dynamic_line": [ "Chemicals?  I'm sure we could find some use for them, and we are in need of medical supplies.  What's the offer?" ],
+    "dynamic_line": "Chemicals?  I'm sure we could find some use for them, and we are in need of medical supplies.  What's the offer?",
     "responses": [
       {
         "text": "Well, how about 300 merch for 10 liters of…",
@@ -336,7 +339,7 @@
   {
     "id": "TALK_EVAC_MERCHANT_DEAL_NEGOTIATE_MISC",
     "type": "talk_topic",
-    "dynamic_line": [ "We are running a bit short on toilet paper, soap, toothpaste…  What's the offer?" ],
+    "dynamic_line": "We are running a bit short on toilet paper, soap, toothpaste…  What's the offer?",
     "responses": [
       {
         "text": "Well, how about 200 merch for 75 pounds of…",

--- a/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
+++ b/data/json/npcs/refugee_center/surface_staff/Smokes/free_merchant_shopkeep_talk.json
@@ -8,10 +8,7 @@
       "context": "meeting",
       "value": "yes",
       "yes": [ "Welcome back.", "Hello again.  What do you need?", "*looks up.  \"Hey.\"" ],
-      "no": {
-        "gendered_line": "*waves you over.  \"I haven't seen you before.  Welcome to our little homely house.\"",
-        "relevant_genders": [ "u" ]
-      }
+      "no": "*waves you over.  \"I haven't seen you before.  Welcome to our little homely house.\""
     },
     "responses": [
       {

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_arsonist.json
@@ -227,8 +227,8 @@
     "id": "TALK_ARSONIST_MUTATION_INSULT",
     "dynamic_line": {
       "u_has_any_trait": [ "CANINE_EARS", "LUPINE_EARS", "FELINE_EARS", "URSINE_EARS", "ELFA_EARS" ],
-      "yes": "As if you're one to talk.  Screw You.",
-      "no": "Screw You!"
+      "yes": { "gendered_line": "As if you're one to talk.  Screw You.", "relevant_genders": [ "u" ] },
+      "no": { "gendered_line": "Screw You!", "relevant_genders": [ "u" ] }
     },
     "responses": [
       {

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_hunter.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_hunter.json
@@ -15,8 +15,8 @@
     "type": "talk_topic",
     "dynamic_line": {
       "u_is_wearing": "badge_marshal",
-      "yes": "I thought I smelled a pig.  I jest… please don't arrest me.",
-      "no": "Huh, thought I smelled someone new.  Can I help you?"
+      "yes": { "gendered_line": "I thought I smelled a pig.  I jest… please don't arrest me.", "relevant_genders": [ "npc" ] },
+      "no": { "gendered_line": "Huh, thought I smelled someone new.  Can I help you?", "relevant_genders": [ "npc" ] }
     },
     "responses": [
       { "text": "You… smelled me?", "topic": "TALK_EVAC_HUNTER_SMELL" },
@@ -65,7 +65,10 @@
     "dynamic_line": [
       "Feed a man a fish, he's full for a day.  Feed a man a bullet, he's full for the rest of his life.",
       "Spot your prey before something nastier spots you.",
-      "I've heard that cougars sometimes leap.  Maybe it's just a myth.",
+      {
+        "gendered_line": "I've heard that cougars sometimes leap.  Maybe it's just a myth.",
+        "relevant_genders": [ "npc" ]
+      },
       "The Jabberwock is real, don't listen to what anybody else says.  If you see it, RUN.",
       "Zombified animals aren't good for eating, but sometimes you might find usable fur on 'em.",
       "A steady diet of cooked meat and clean water will keep you alive forever, but your taste buds and your colon may start to get angry at you.  Eat a piece of fruit every once in a while.",

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_old_guard_representative.json
@@ -84,7 +84,10 @@
   {
     "id": "TALK_OLD_GUARD_REP_NEW_DOWNSIDE",
     "type": "talk_topic",
-    "dynamic_line": "Well… I was like any other civilian till they conscripted me so I'll tell it to you straight.  They're the best hope we got right now.  They are stretched impossibly thin but are willing to do what is needed to maintain order.  They don't care much about looters since they understand most everyone is dead, but if you have something they need… you WILL give it to them.  Since most survivors here have nothing they want, they are welcomed as champions.",
+    "dynamic_line": {
+      "gendered_line": "Well… I was like any other civilian till they conscripted me so I'll tell it to you straight.  They're the best hope we got right now.  They are stretched impossibly thin but are willing to do what is needed to maintain order.  They don't care much about looters since they understand most everyone is dead, but if you have something they need… you WILL give it to them.  Since most survivors here have nothing they want, they are welcomed as champions.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "Hmmm…", "topic": "TALK_OLD_GUARD_REP" } ]
   },
   {
@@ -118,7 +121,10 @@
   {
     "id": "TALK_OLD_GUARD_REP_EXODII_1",
     "type": "talk_topic",
-    "dynamic_line": "If you want to know what our next steps are, I'm not at liberty to tell you.  Truth be told, I don't even know myself.  They don't share that sort of information with me.",
+    "dynamic_line": {
+      "gendered_line": "If you want to know what our next steps are, I'm not at liberty to tell you.  Truth be told, I don't even know myself.  They don't share that sort of information with me.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "Actually, I've met them.  They seem open to trade and things.  Thought you might want to know.",

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_scavenger_mercenary.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_scavenger_mercenary.json
@@ -83,7 +83,11 @@
   {
     "id": "TALK_SCAVENGER_MERC",
     "type": "talk_topic",
-    "dynamic_line": { "u_is_wearing": "badge_marshal", "yes": "I haven't done anything wrong…", "no": "…" },
+    "dynamic_line": {
+      "u_is_wearing": "badge_marshal",
+      "yes": { "gendered_line": "I haven't done anything wrong…", "relevant_genders": [ "npc" ] },
+      "no": "…"
+    },
     "responses": [
       { "text": "Who are you?", "topic": "TALK_SCAVENGER_MERC_NEW" },
       { "text": "Any tips for surviving?", "topic": "TALK_SCAVENGER_MERC_TIPS" },

--- a/data/json/npcs/refugee_center/surface_visitors/NPC_visiting_scavenger.json
+++ b/data/json/npcs/refugee_center/surface_visitors/NPC_visiting_scavenger.json
@@ -35,7 +35,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_RC_SURVIVOR_Story",
-    "dynamic_line": "I found a map to this place in an evac center and thought I'd see if it was just full of <zombies> or if there was something up.  Didn't expect to find so many survivors still alive though.",
+    "dynamic_line": {
+      "gendered_line": "I found a map to this place in an evac center and thought I'd see if it was just full of <zombies> or if there was something up.  Didn't expect to find so many survivors still alive though.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       {
         "text": "You looking for a travelling companion?  I could use someone to watch my back.",
@@ -50,7 +53,10 @@
     "id": "TALK_RC_SURVIVOR_Tips",
     "dynamic_line": {
       "math": [ "npc_randomize_dialogue_direction", "==", "0" ],
-      "yes": "Sure.  Seen more'n I'd like to think about honestly.  Like, I think these zombies are evolving?  I've seen new things come out that I swear aren't natural.  One of them looked like it was sparking with electricity.",
+      "yes": {
+        "gendered_line": "Sure.  Seen more'n I'd like to think about honestly.  Like, I think these zombies are evolving?  I've seen new things come out that I swear aren't natural.  One of them looked like it was sparking with electricity.",
+        "relevant_genders": [ "npc" ]
+      },
       "no": {
         "math": [ "npc_randomize_dialogue_direction", "==", "1" ],
         "yes": "Come to think of it, yeah.  The other day, I met this weird old man in the woods.  Obsessed with rabbits.  He seemed like a nice fellow, open to visitors, if you'd like I can send you his way to trade.",
@@ -59,7 +65,10 @@
           "yes": "I could point you to some acquaintances of mine that have a farm, they're decent folk, if you have goods to trade.  Be careful around them, I get a vibe like they don't like visitors too much, and honestly it makes me nervous that they made it through this so together.  Kinda of ominous, you know?",
           "no": {
             "math": [ "npc_randomize_dialogue_direction", "==", "3" ],
-            "yes": "There's so much weird stuff out there in the wilderness now.  A while back, I found this weird cartoon sign with a map on it, pointing to some kind of trade center.  Haven't been there yet but I can show you my copy of the map if you want.",
+            "yes": {
+              "gendered_line": "There's so much weird stuff out there in the wilderness now.  A while back, I found this weird cartoon sign with a map on it, pointing to some kind of trade center.  Haven't been there yet but I can show you my copy of the map if you want.",
+              "relevant_genders": [ "npc" ]
+            },
             "no": "ERROR: out of bounds on randomize_directions."
           }
         }

--- a/data/json/npcs/robofac/NPC_Cranberry_Foster.json
+++ b/data/json/npcs/robofac/NPC_Cranberry_Foster.json
@@ -376,7 +376,10 @@
   {
     "id": "TALK_ROBOFAC_MERC_1_OTHER_MERCS",
     "type": "talk_topic",
-    "dynamic_line": "Surprise!\"  They do jazz hands.  \"Sorry.  Well, I'm told that I'm part of a small group right now.  Maybe you were the first."
+    "dynamic_line": {
+      "gendered_line": "Surprise!\"  They do jazz hands.  \"Sorry.  Well, I'm told that I'm part of a small group right now.  Maybe you were the first.",
+      "relevant_genders": [ "u" ]
+    }
   },
   {
     "id": "TALK_ROBOFAC_MERC_1_WHO",
@@ -438,7 +441,10 @@
   {
     "id": "TALK_ROBOFAC_MERC_1_COINS",
     "type": "talk_topic",
-    "dynamic_line": "Yeah.  Have you noticed how they pay us in these tiny little gold coins?\"  Cranberry holds one up for emphasis.  \"It's bizarre.  You'd think they have a gold mine in there, but no, they don't, so they make me cross the damn world grabbing gold bars.  As far as scrip goes, it seems inconvenient as hell to make.",
+    "dynamic_line": {
+      "gendered_line": "Yeah.  Have you noticed how they pay us in these tiny little gold coins?\"  Cranberry holds one up for emphasis.  \"It's bizarre.  You'd think they have a gold mine in there, but no, they don't, so they make me cross the damn world grabbing gold bars.  As far as scrip goes, it seems inconvenient as hell to make.",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "You sound frustrated about it.", "topic": "TALK_ROBOFAC_MERC_1_GOLD_MISSION" },
       { "text": "Now that you mention it, it does seem rather strange.", "topic": "TALK_ROBOFAC_MERC_1_MAIN" }
@@ -451,9 +457,12 @@
       "Thinking I should go hunt something soon…",
       "Just wondering if things will get better someday.",
       "Hmm?  Nothing, I guess I just like resting in this place.  I feel good today.",
-      "Have you ever noticed how… wait no, never mind.",
+      { "gendered_line": "Have you ever noticed how… wait no, never mind.", "relevant_genders": [ "u" ] },
       "Wondering if the whole world is like this now.  It has to be, right?  I was watching some foreign news channels when everything was going down, and it sounded like things were just as bad there…",
-      "Hey, did you notice that there's working wi-fi here?  Not that anything else is online anymore, but still.",
+      {
+        "gendered_line": "Hey, did you notice that there's working wi-fi here?  Not that anything else is online anymore, but still.",
+        "relevant_genders": [ "u" ]
+      },
       "Just vibing."
     ],
     "responses": [ { "text": "I see.", "topic": "TALK_ROBOFAC_MERC_1_MAIN" } ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_carpenter2.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_carpenter2.json
@@ -35,7 +35,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_RANCH_CONSTRUCTION_2_JOB",
-    "dynamic_line": "I was among one of the first groups of immigrants sent here to fortify the outpost.  I might have exaggerated my construction skills to get the hell out of the refugee center.  Unless you are a trader, there isn't much work there and food was really becoming scarce when I left.",
+    "dynamic_line": {
+      "gendered_line": "I was among one of the first groups of immigrants sent here to fortify the outpost.  I might have exaggerated my construction skills to get the hell out of the refugee center.  Unless you are a trader, there isn't much work there and food was really becoming scarce when I left.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "I see.", "topic": "TALK_RANCH_CONSTRUCTION_2" } ]
   }
 ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_generic.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_generic.json
@@ -6,7 +6,7 @@
       "Unfortunately, I don't have anything that can help.",
       "I don't know what I could offer.",
       "Afraid not.  Maybe somebody else could help.",
-      "Have you asked the scavenger boss if they'd have anything?",
+      { "gendered_line": "Have you asked the scavenger boss if they'd have anything?", "relevant_genders": [ "u" ] },
       "Maybe the scrapper would have some spare parts?"
     ],
     "responses": [ { "text": "OK.", "topic": "TALK_NONE" }, { "text": "I've got to go…", "topic": "TALK_DONE" } ]

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_sickly_laborer.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_sickly_laborer.json
@@ -37,19 +37,28 @@
   {
     "type": "talk_topic",
     "id": "TALK_RANCH_ILL_1_JOB",
-    "dynamic_line": "I was just a laborer till they could find me something a bit more permanent, but being constantly sick has prevented me from doing much of anything.",
+    "dynamic_line": {
+      "gendered_line": "I was just a laborer till they could find me something a bit more permanent, but being constantly sick has prevented me from doing much of anything.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "That's sad.", "topic": "TALK_RANCH_ILL_1" } ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_RANCH_ILL_1_HIRE",
-    "dynamic_line": "I don't know what you could do.  I've tried everything.  Just give me time…",
+    "dynamic_line": {
+      "gendered_line": "I don't know what you could do.  I've tried everything.  Just give me time…",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "OK.", "topic": "TALK_RANCH_ILL_1" } ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_RANCH_ILL_1_SICK",
-    "dynamic_line": "I keep getting sick!  At first I thought it was something I ate, but now it seems like I can't keep anything down…",
+    "dynamic_line": {
+      "gendered_line": "I keep getting sick!  At first I thought it was something I ate, but now it seems like I can't keep anything down…",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "Uhm.", "topic": "TALK_RANCH_ILL_1" } ]
   },
   {

--- a/data/json/npcs/tacoma_ranch/NPC_ranch_woodcutter1.json
+++ b/data/json/npcs/tacoma_ranch/NPC_ranch_woodcutter1.json
@@ -36,7 +36,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_RANCH_WOODCUTTER_JOB",
-    "dynamic_line": "I'm one of the migrants that got diverted to this outpost when I arrived at the refugee center.  They said I was big enough to swing an axe, so my profession became lumberjack… didn't have any say in it.  If I want to eat, then I'll be cutting wood from now till kingdom come.",
+    "dynamic_line": {
+      "gendered_line": "I'm one of the migrants that got diverted to this outpost when I arrived at the refugee center.  They said I was big enough to swing an axe, so my profession became lumberjack… didn't have any say in it.  If I want to eat, then I'll be cutting wood from now till kingdom come.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [ { "text": "Oh.", "topic": "TALK_RANCH_WOODCUTTER" } ]
   },
   {

--- a/data/json/npcs/tacoma_ranch/Nunez/NPC_Dana_Tacoma.json
+++ b/data/json/npcs/tacoma_ranch/Nunez/NPC_Dana_Tacoma.json
@@ -76,7 +76,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_TACOMA_Dana_1",
-    "dynamic_line": "*stands in the middle of a cramped kitchen, covered in flour.  The scene looks reminiscent of easier times, but the illusion is broken as he apron shifts to reveal a heavy machete and holstered pistol on  her belt.  She looks up as you approach, then beams in recognition.  \"Welcome to Dana's Bakery, stranger!\"  She laughs brightly.  \"Glad you made out this way.  What can I do for you?\"",
+    "dynamic_line": {
+      "gendered_line": "*stands in the middle of a cramped kitchen, covered in flour.  The scene looks reminiscent of easier times, but the illusion is broken as he apron shifts to reveal a heavy machete and holstered pistol on  her belt.  She looks up as you approach, then beams in recognition.  \"Welcome to Dana's Bakery, stranger!\"  She laughs brightly.  \"Glad you made out this way.  What can I do for you?\"",
+      "relevant_genders": [ "u" ]
+    },
     "responses": [
       { "text": "Hi Dana, how are things here?", "topic": "TALK_TACOMA_Dana_2" },
       { "text": "Got any bread for sale?", "topic": "TALK_TACOMA_Dana_Baking" },

--- a/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
+++ b/data/json/npcs/tacoma_ranch/Nunez/NPC_Pablo_Tacoma.json
@@ -173,7 +173,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_TACOMA_Pablo_Bakery-Firebricks1",
-    "dynamic_line": "Seriously?  You've already done so much.  I won't say no, though.",
+    "dynamic_line": { "gendered_line": "Seriously?  You've already done so much.  I won't say no, though.", "relevant_genders": [ "u" ] },
     "speaker_effect": {
       "effect": [
         { "assign_mission": "MISSION_TACOMA_Pablo_Firebricks" },

--- a/data/json/npcs/valhalla_cult/TALK_valhallist_gode.json
+++ b/data/json/npcs/valhalla_cult/TALK_valhallist_gode.json
@@ -39,7 +39,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_VALHALLIST_GODE_WHO",
-    "dynamic_line": "I'm a wanderer like you who found purpose and a home with the gods.  I'm not who I was, but somebody new.  A disciple of the truth to spread the word of the mighty.",
+    "dynamic_line": {
+      "gendered_line": "I'm a wanderer like you who found purpose and a home with the gods.  I'm not who I was, but somebody new.  A disciple of the truth to spread the word of the mighty.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What are you a prophet of?", "topic": "TALK_VALHALLIST_GODE_Religion" },
       { "text": "What is that purpose?", "topic": "TALK_VALHALLIST_GODE_PURPOSE" },

--- a/data/json/npcs/valhalla_cult/TALK_valhallist_leader.json
+++ b/data/json/npcs/valhalla_cult/TALK_valhallist_leader.json
@@ -2,7 +2,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_VALHALLIST_LEADER_1",
-    "dynamic_line": "Who are you to come before me?",
+    "dynamic_line": { "gendered_line": "Who are you to come before me?", "relevant_genders": [ "u" ] },
     "speaker_effect": { "effect": { "npc_first_topic": "TALK_VALHALLIST_LEADER_2" } },
     "responses": [
       { "text": "I don't know, who are you?", "topic": "TALK_VALHALLIST_LEADER_WHO" },

--- a/data/json/npcs/valhalla_cult/TALK_valhallist_mechanic.json
+++ b/data/json/npcs/valhalla_cult/TALK_valhallist_mechanic.json
@@ -72,7 +72,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_VALHALLIST_MECHANIC_Job",
-    "dynamic_line": "I'm one of the mechanics here.  I do maintenance work on all the vehicles around here, including some non-automotive machinery.",
+    "dynamic_line": {
+      "gendered_line": "I'm one of the mechanics here.  I do maintenance work on all the vehicles around here, including some non-automotive machinery.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "Good to know.", "topic": "TALK_NONE" },
       { "text": "A pleasure chatting.  Gotta go!", "topic": "TALK_DONE" }

--- a/data/json/npcs/valhalla_cult/TALK_valhallist_member.json
+++ b/data/json/npcs/valhalla_cult/TALK_valhallist_member.json
@@ -28,7 +28,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_VALHALLIST_MEMBER_WHO",
-    "dynamic_line": "I'm a wanderer like you who found purpose and a home with the gods.  I'm not who I was, but somebody new.",
+    "dynamic_line": {
+      "gendered_line": "I'm a wanderer like you who found purpose and a home with the gods.  I'm not who I was, but somebody new.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What is that purpose?", "topic": "TALK_VALHALLIST_MEMBER_PURPOSE" },
       { "text": "I have to go.", "topic": "TALK_DONE" }

--- a/data/json/npcs/valhalla_cult/valhallist_leader_backstory.json
+++ b/data/json/npcs/valhalla_cult/valhallist_leader_backstory.json
@@ -14,7 +14,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_VALHALLIST_LEADER_Ex_Job",
-    "dynamic_line": "I was a big history buff back then, but I worked in dead-end accounting for a university.  I had three friends who I hung with after-hours; we were out on the town when <the_cataclysm> came.",
+    "dynamic_line": {
+      "gendered_line": "I was a big history buff back then, but I worked in dead-end accounting for a university.  I had three friends who I hung with after-hours; we were out on the town when <the_cataclysm> came.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "When did you build this place?", "topic": "TALK_VALHALLIST_LEADER_Compound" },
       { "text": "<done_conversation_section>", "topic": "TALK_VALHALLIST_LEADER_2" },
@@ -24,7 +27,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_VALHALLIST_LEADER_Compound",
-    "dynamic_line": "One of my buddies wanted to get in the re-enacting business, so they started setting up this place as a to-scale model of what a Norse fort might have looked like.  I was planning on getting in to it with them, but <the_cataclysm> put a stop to it.  We came here from town, found the place wasn't occupied by those horrors, and set up camp here.  The Norse-obsessed guy decided to make a full religion out of it, and managed to bring back a large group fleeing one of those FEMA camps.",
+    "dynamic_line": {
+      "gendered_line": "One of my buddies wanted to get in the re-enacting business, so they started setting up this place as a to-scale model of what a Norse fort might have looked like.  I was planning on getting in to it with them, but <the_cataclysm> put a stop to it.  We came here from town, found the place wasn't occupied by those horrors, and set up camp here.  The Norse-obsessed guy decided to make a full religion out of it, and managed to bring back a large group fleeing one of those FEMA camps.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What did you do before <the_cataclysm>?", "topic": "TALK_VALHALLIST_LEADER_Ex_Job" },
       { "text": "How did you come to power here?", "topic": "TALK_VALHALLIST_LEADER_Position" },
@@ -35,7 +41,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_VALHALLIST_LEADER_Position",
-    "dynamic_line": "One of my buddies was the head before me.  They were really interested in Norse mythology, almost obsessed with it.  After <the_cataclysm>, they started preaching to a group who ran from town, and set up here.  I followed along, not wanting to abandon them in the wilderness.",
+    "dynamic_line": {
+      "gendered_line": "One of my buddies was the head before me.  They were really interested in Norse mythology, almost obsessed with it.  After <the_cataclysm>, they started preaching to a group who ran from town, and set up here.  I followed along, not wanting to abandon them in the wilderness.",
+      "relevant_genders": [ "npc" ]
+    },
     "responses": [
       { "text": "What did you do before <the_cataclysm>?", "topic": "TALK_VALHALLIST_LEADER_Ex_Job" },
       { "text": "What happened after that?", "topic": "TALK_VALHALLIST_LEADER_Position_2" },
@@ -52,7 +61,10 @@
   {
     "type": "talk_topic",
     "id": "TALK_VALHALLIST_LEADER_Position_3",
-    "dynamic_line": "*begins to weep, hanging their head down.*  \"I'm sorry, I couldn't save them.  They all died to that horrid monster.  I buried all three of them, and was chosen to rule by a will one of them left.  I realized then that my friend was right; only the strong survive, and only the strong live long enough to enjoy that.",
+    "dynamic_line": {
+      "gendered_line": "*begins to weep, hanging their head down.*  \"I'm sorry, I couldn't save them.  They all died to that horrid monster.  I buried all three of them, and was chosen to rule by a will one of them left.  I realized then that my friend was right; only the strong survive, and only the strong live long enough to enjoy that.",
+      "relevant_genders": [ "npc" ]
+    },
     "speaker_effect": { "effect": { "u_add_var": "u_know_valhallistslore", "type": "dialogue", "context": "backstory", "value": "yes" } },
     "responses": [
       { "text": "I'm sorry for your loss.  <done_conversation_section>", "topic": "TALK_VALHALLIST_LEADER_2" },

--- a/data/json/npcs/your_followers/luo_follower.json
+++ b/data/json/npcs/your_followers/luo_follower.json
@@ -58,7 +58,7 @@
   {
     "type": "talk_topic",
     "id": "TALK_FRIEND_LUO_CHAT",
-    "dynamic_line": "Seen any good movies lately?",
+    "dynamic_line": { "gendered_line": "Seen any good movies lately?", "relevant_genders": [ "u" ] },
     "//": "TK: custom chat topics here that actually include small talk that expands her character, while still giving the socialize bonus.",
     "responses": [
       {

--- a/lang/string_extractor/parsers/talk_topic.py
+++ b/lang/string_extractor/parsers/talk_topic.py
@@ -48,16 +48,23 @@ def parse_dynamic_line(json, origin, comment=[]):
             text = json["gendered_line"]
             subjects = json["relevant_genders"]
             options = [gender_options(subject) for subject in subjects]
+            gendered_comment = [
+                *comment,
+                "You don't need to translate genders that "
+                "aren't in your language",
+                "Check: https://github.com/CleverRaven/"
+                "Cataclysm-DDA/blob/master/doc/"
+                "TRANSLATING.md#grammatical-gender"]
             for context_list in itertools.product(*options):
                 context = " ".join(context_list)
                 write_text(text, origin, context=context,
-                           comment=comment, c_format=False)
+                           comment=gendered_comment, c_format=False)
 
         for key in dynamic_line_string_keys:
             if key in json:
                 parse_dynamic_line(json[key], origin, comment=comment)
 
-    elif type(json) == str:
+    elif type(json) is str:
         if not is_tag(json):
             write_text(json, origin, comment=comment, c_format=False)
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
I18N "Adds a gendered_line to some dialogues."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
[gendered_line](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/TRANSLATING.md#grammatical-gender) 
> For NPC dialogue some languages may wish to have alternate translations depending on the gender of the conversation participants.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
After this PR, separate entries should appear in the translation files for different genders of participants.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The changed files have been linted, extraction from them works, the .po file has been created with the additional entries, game loads .mo correctly.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
At the same time I changed a couple of lines in the files: Mangalpreet/Vanessa Toby/Jack Isherwood. There were either some cryptic concatenations or non-working hacks for gendered_line.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
