### PR TITLE
[Magiclysm] Add Cleansing Flame fire trail spell

### DIFF
--- a/data/mods/Magiclysm/Spells/attunements/Cleansing_Flame.json
+++ b/data/mods/Magiclysm/Spells/attunements/Cleansing_Flame.json
@@ -3,7 +3,7 @@
     "id": "burning_trail",
     "type": "SPELL",
     "name": "Burning Trail",
-    "description": "Speak a short phrase and transform your footsteps into burning pits of flame, leaving a trail of fire behind you.  Each step will consume mana, but you will be immune to fire while the spell is in effect. ",
+    "description": "Speak a short phrase and transform your footsteps into burning pits of flame, leaving a trail of fire behind you.  Each step will consume mana, but you will be immune to fire while the spell is in effect.",
     "valid_targets": [ "self" ],
     "flags": [ "CONCENTRATE", "VERBAL", "NO_HANDS", "MUST_HAVE_CLASS_TO_LEARN", "NO_FAIL" ],
     "effect": "effect_on_condition",

--- a/data/mods/Magiclysm/Spells/attunements/Cleansing_Flame.json
+++ b/data/mods/Magiclysm/Spells/attunements/Cleansing_Flame.json
@@ -1,14 +1,67 @@
 [
   {
+    "id": "burning_trail",
+    "type": "SPELL",
+    "name": "Burning Trail",
+    "description": "Speak a short phrase and transform your footsteps into burning pits of flame, leaving a trail of fire behind you.  Each step will consume mana, but you will be immune to fire while the spell is in effect. ",
+    "valid_targets": [ "self" ],
+    "flags": [ "CONCENTRATE", "VERBAL", "NO_HANDS", "MUST_HAVE_CLASS_TO_LEARN", "NO_FAIL" ],
+    "effect": "effect_on_condition",
+    "effect_str": "EOC_CLEANSING_FLAME_FIRE_FOOSTEPS",
+    "shape": "blast",
+    "energy_source": "MANA",
+    "spell_class": "CLEANSING_FLAME",
+    "difficulty": 8,
+    "min_damage": 1,
+    "max_damage": 1,
+    "max_level": 1,
+    "base_casting_time": { "math": [ "u_effect_intensity('effect_burning_trail') > -1 ? 0 : 50" ] },
+    "base_energy_cost": 25
+  },
+  {
     "type": "effect_on_condition",
     "id": "EOC_CLEANSING_FLAME_FIRE_FOOSTEPS",
-    "condition": { "math": [ "u_val('mana')", ">=", "4" ] },
+    "condition": { "not": { "u_has_effect": "effect_burning_trail" } },
     "effect": [
-      { "math": [ "u_val('mana')", "-=", "4" ] },
-      { "u_add_effect": "effect_cleansing_flame_fire_immunity", "duration": "2 s" },
-      { "u_set_field": "fd_fire", "radius": 0, "hit_player": false }
+      { "u_add_effect": "effect_burning_trail", "duration": "PERMANENT" },
+      { "u_add_effect": "effect_flame_immunity", "duration": "2 s" },
+      { "queue_eocs": "EOC_CLEANSING_FLAME_FIRE_FOOSTEPS_2", "time_in_future": 1 }
     ],
-    "false_effect": [ { "u_message": "You do not have enough mana to fuel your searing footsteps!", "type": "bad" } ]
+    "false_effect": [
+      { "u_lose_effect": "effect_burning_trail" },
+      { "queue_eocs": "EOC_CLEANSING_FLAME_FIRE_FOOSTEPS_CLEANUP", "time_in_future": 2 }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CLEANSING_FLAME_FIRE_FOOSTEPS_2",
+    "condition": { "u_has_effect": "effect_burning_trail" },
+    "effect": [
+      {
+        "run_eocs": [
+          {
+            "id": "EOC_CLEANSING_FLAME_FIRE_FOOSTEPS_3",
+            "condition": { "math": [ "u_val('mana')", ">=", "1" ] },
+            "effect": [
+              { "math": [ "u_val('mana')", "-=", "1" ] },
+              { "u_add_effect": "effect_flame_immunity", "duration": "2 s" },
+              { "u_set_field": "fd_fire", "radius": 0, "hit_player": false },
+              { "queue_eocs": "EOC_CLEANSING_FLAME_FIRE_FOOSTEPS_2", "time_in_future": 1 }
+            ],
+            "false_effect": [
+              { "u_message": "You do not have enough mana to fuel your searing footsteps!", "type": "bad" },
+              { "u_lose_effect": "effect_burning_trail" },
+              { "queue_eocs": "EOC_CLEANSING_FLAME_FIRE_FOOSTEPS_CLEANUP", "time_in_future": 2 }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_CLEANSING_FLAME_FIRE_FOOSTEPS_CLEANUP",
+    "effect": [ { "u_lose_effect": "effect_flame_immunity" } ]
   },
   {
     "type": "ter_furn_transform",

--- a/data/mods/Magiclysm/Spells/attunements/Cleansing_Flame.json
+++ b/data/mods/Magiclysm/Spells/attunements/Cleansing_Flame.json
@@ -1,5 +1,16 @@
 [
   {
+    "type": "effect_on_condition",
+    "id": "EOC_CLEANSING_FLAME_FIRE_FOOSTEPS",
+    "condition": { "math": [ "u_val('mana')", ">=", "4" ] },
+    "effect": [
+      { "math": [ "u_val('mana')", "-=", "4" ] },
+      { "u_add_effect": "effect_cleansing_flame_fire_immunity", "duration": "2 s" },
+      { "u_set_field": "fd_fire", "radius": 0, "hit_player": false }
+    ],
+    "false_effect": [ { "u_message": "You do not have enough mana to fuel your searing footsteps!", "type": "bad" } ]
+  },
+  {
     "type": "ter_furn_transform",
     "id": "immolate_transform",
     "furniture": [

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -910,6 +910,15 @@
   },
   {
     "type": "effect_type",
+    "id": "effect_burning_trail",
+    "name": [ "Burning Trail" ],
+    "desc": [ "Fire trails in your wake." ],
+    "apply_message": "",
+    "remove_message": "The flames you leave behind die down.",
+    "rating": "good"
+  },
+  {
+    "type": "effect_type",
     "id": "effect_cloak_of_fog",
     "name": [ "Cloak of Fog" ],
     "desc": [ "The fog shields you from sight." ],
@@ -1145,7 +1154,8 @@
       "effect_terra_armor",
       "gravity_mage_melee",
       "eff_storm_elemental_electric_melee",
-      "effect_flame_immunity"
+      "effect_flame_immunity",
+      "effect_burning_trail"
     ]
   }
 ]

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1022,7 +1022,7 @@
     "rating": "good",
     "show_in_info": true,
     "removes_effects": [ "onfire", "blisters" ],
-    "enchantments": [ { "values": [ { "value": "CLIMATE_CONTROL_CHILL", "add": 1000 }, { "value": "ARMOR_HEAT", "add": -1000 } ] } ]
+    "enchantments": [ "ench_heat_and_fire_immunity" ]
   },
   {
     "id": "effect_dispel_magic",

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -1006,6 +1006,16 @@
     "flags": [ "DIMENSIONAL_ANCHOR" ]
   },
   {
+    "type": "effect_type",
+    "id": "effect_flame_immunity",
+    "name": [ "Flame Immunity" ],
+    "desc": [ "You are immune to heat and fire." ],
+    "rating": "good",
+    "show_in_info": true,
+    "removes_effects": [ "onfire", "blisters" ],
+    "enchantments": [ { "values": [ { "value": "CLIMATE_CONTROL_CHILL", "add": 1000 }, { "value": "ARMOR_HEAT", "add": -1000 } ] } ]
+  },
+  {
     "id": "effect_dispel_magic",
     "type": "effect_type",
     "name": [ "Dispel Magic" ],
@@ -1053,6 +1063,9 @@
       "effect_magus_spiderclimb",
       "effect_biomancer_swim_speed",
       "effect_biomancer_carrion_feast",
+      "effect_biomancer_slow_bleeding_01",
+      "effect_biomancer_slow_bleeding_02",
+      "effect_biomancer_slow_bleeding_03",
       "effect_classless_watch",
       "effect_obfuscating_aura",
       "effect_shape_of_dust",
@@ -1115,6 +1128,9 @@
       "effect_acid_res_aura",
       "effect_acid_res_aura_greater",
       "effect_thorns_electric",
+      "effect_biomancer_slow_bleeding_01",
+      "effect_biomancer_slow_bleeding_02",
+      "effect_biomancer_slow_bleeding_03",
       "haste",
       "synaptic_stim",
       "slow_freeze_effect",
@@ -1125,9 +1141,11 @@
       "ice_energy",
       "ice_age_eff",
       "effect_biomancer_remove_instability",
+      "effect_biomancer_hyper_regeneration",
       "effect_terra_armor",
       "gravity_mage_melee",
-      "eff_storm_elemental_electric_melee"
+      "eff_storm_elemental_electric_melee",
+      "effect_flame_immunity"
     ]
   }
 ]

--- a/data/mods/Magiclysm/enchantments/Cleansing_Flame.json
+++ b/data/mods/Magiclysm/enchantments/Cleansing_Flame.json
@@ -6,5 +6,13 @@
     "description": "Your Cleansing Flame abilities grant you good resistance to temperature conditions.  You are also immune to infection, as your body cleanses every tainted part of you, constantly.",
     "condition": "ALWAYS",
     "values": [ { "value": "CLIMATE_CONTROL_HEAT", "add": 30 }, { "value": "CLIMATE_CONTROL_CHILL", "add": 10 } ]
+  },
+  {
+    "type": "enchantment",
+    "id": "ench_heat_and_fire_immunity",
+    "name": { "str": "Total Fire Immunity" },
+    "description": "You are utterly immune to fire and heat.",
+    "condition": "ALWAYS",
+    "values": [ { "value": "CLIMATE_CONTROL_CHILL", "add": 1000 }, { "value": "ARMOR_HEAT", "add": -1000 } ]
   }
 ]

--- a/data/mods/Magiclysm/traits/attunements.json
+++ b/data/mods/Magiclysm/traits/attunements.json
@@ -211,7 +211,7 @@
     "valid": false,
     "description": "The Cleansing Flame is the fire that burns away the chaff, in preparation for the regrowth of new life.",
     "enchantments": [ "CLEANSING_FLAME" ],
-    "spells_learned": [ [ "immolate", 5 ], [ "cleansingflame_hermes_heal", 5 ] ],
+    "spells_learned": [ [ "immolate", 5 ], [ "cleansingflame_hermes_heal", 5 ], [ "burning_trail", 5 ] ],
     "prereqs": [ "DRUID", "KELVINIST" ],
     "cancels": [
       "ARTIFICER",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add Cleansing Flame fire trail spell"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Poking around the Magiclysm idea repository and I saw 
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/411694b3-df87-420a-910f-57de3c0449dc)

And I thought, oh, I already did that for Salamanders for XE, I should port that over.

So I am.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Add Burning Trail, a spell that makes the Cleansing Flame immune to fire and leave a trail of fire behind themselves when cast. It has a minimal mana cost to activate but takes 1 mana every turn to maintain. Casting the spell again cancels the effect, as does running out of mana.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
~~I'm not going to finish this before Shabbat but I wanted to put it up so I didn't forget it~~Right, Shabbat isn't until 4:30 today. 

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/6bf412ac-ba34-4e0f-bbaf-c03e031efc7b)

Slightly more complicated than just copy-paste from Salamander, but it works.

I now rest from my labors.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
