### PR TITLE
Updates biosilicified chitin material and armor

### DIFF
--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -160,7 +160,7 @@
     "price_postapoc": 1250,
     "name": { "str": "pair of biosilicified chitin arm guards", "str_pl": "pairs of biosilicified chitin arm guards" },
     "description": "A pair of arm guards crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
-    "material": [ "acidchitin" ]
+    "material": [ "acidchitin" ],
   },
   {
     "id": "xl_armguard_acidchitin",

--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -160,7 +160,7 @@
     "price_postapoc": 1250,
     "name": { "str": "pair of biosilicified chitin arm guards", "str_pl": "pairs of biosilicified chitin arm guards" },
     "description": "A pair of arm guards crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
-    "material": [ "acidchitin" ],
+    "material": [ "acidchitin" ]
   },
   {
     "id": "xl_armguard_acidchitin",

--- a/data/json/items/armor/arms_armor.json
+++ b/data/json/items/armor/arms_armor.json
@@ -160,9 +160,7 @@
     "price_postapoc": 1250,
     "name": { "str": "pair of biosilicified chitin arm guards", "str_pl": "pairs of biosilicified chitin arm guards" },
     "description": "A pair of arm guards crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
-    "material": [ "acidchitin" ],
-    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25, "encumbrance": 1.5, "warmth": 1.5 },
-    "material_thickness": 4
+    "material": [ "acidchitin" ]
   },
   {
     "id": "xl_armguard_acidchitin",
@@ -172,7 +170,6 @@
     "description": "A pair of arm guards crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle and sized for the largest of survivors.",
     "material": [ "acidchitin" ],
     "proportional": { "weight": 1.25, "volume": 1.25 },
-    "material_thickness": 5,
     "extend": { "flags": [ "OVERSIZE" ] }
   },
   {

--- a/data/json/items/armor/boots.json
+++ b/data/json/items/armor/boots.json
@@ -310,9 +310,7 @@
     "description": "Boots crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
     "price_postapoc": 1750,
     "material": [ "acidchitin" ],
-    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25, "encumbrance": 1.5, "warmth": 1.5 },
-    "relative": { "melee_damage": { "bash": 2 } },
-    "material_thickness": 5
+    "relative": { "melee_damage": { "bash": 2 } }
   },
   {
     "id": "xl_boots_acidchitin",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -283,9 +283,7 @@
     "description": "A pair of gauntlets crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
     "material": [ "acidchitin" ],
     "price_postapoc": 1750,
-    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25, "encumbrance": 1.5, "warmth": 1.5 },
-    "relative": { "melee_damage": { "bash": 1 } },
-    "material_thickness": 5
+    "relative": { "melee_damage": { "bash": 1 } }
   },
   {
     "id": "xl_gauntlets_acidchitin",

--- a/data/json/items/armor/helmets.json
+++ b/data/json/items/armor/helmets.json
@@ -767,9 +767,7 @@
     "description": "A helmet crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
     "price_postapoc": 1750,
     "material": [ "acidchitin" ],
-    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25, "warmth": 1.5 },
-    "relative": { "melee_damage": { "bash": 1 } },
-    "material_thickness": 5
+    "relative": { "melee_damage": { "bash": 1 } }
   },
   {
     "id": "xl_helmet_acidchitin",

--- a/data/json/items/armor/legs_armor.json
+++ b/data/json/items/armor/legs_armor.json
@@ -160,9 +160,7 @@
     "price_postapoc": 1250,
     "name": { "str": "pair of biosilicified chitin leg guards", "str_pl": "pairs of biosilicified chitin leg guards" },
     "description": "A pair of leg guards crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
-    "material": [ "acidchitin" ],
-    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25, "encumbrance": 1.5, "warmth": 1.5 },
-    "material_thickness": 5
+    "material": [ "acidchitin" ]
   },
   {
     "id": "xl_legguard_acidchitin",

--- a/data/json/items/armor/pets_cow_armor.json
+++ b/data/json/items/armor/pets_cow_armor.json
@@ -36,7 +36,7 @@
     "material": [ "acidchitin" ],
     "weight": "40 kg",
     "volume": "180 L",
-    "material_thickness": 5,
+    "material_thickness": 7,
     "environmental_protection": 7
   },
   {
@@ -48,7 +48,7 @@
     "description": "A makeshift assembly of criniere, peytral and croupiere made from chitin fitted to a thin mesh.  You could put this on a friendly cow.",
     "price": 110000,
     "price_postapoc": 7000,
-    "material": [ "chitin", "steel" ],
+    "material": [ "chitin" ],
     "weight": "40 kg",
     "volume": "180 L",
     "material_thickness": 7,

--- a/data/json/items/armor/pets_horse_armor.json
+++ b/data/json/items/armor/pets_horse_armor.json
@@ -36,7 +36,7 @@
     "material": [ "acidchitin" ],
     "weight": "35 kg",
     "volume": "150 L",
-    "material_thickness": 4,
+    "material_thickness": 6,
     "environmental_protection": 7
   },
   {
@@ -48,7 +48,7 @@
     "description": "A makeshift assembly of criniere, peytral and croupiere made from chitin fitted to a thin mesh.  You could put this on a friendly horse.",
     "price": 100000,
     "price_postapoc": 6000,
-    "material": [ "chitin", "steel" ],
+    "material": [ "chitin" ],
     "weight": "35 kg",
     "volume": "150 L",
     "material_thickness": 6,

--- a/data/json/items/armor/suits_protection.json
+++ b/data/json/items/armor/suits_protection.json
@@ -86,10 +86,8 @@
     "name": { "str": "biosilicified chitin armor" },
     "description": "Leg and body armor crafted from the carefully cleaned and pruned biosilicified exoskeletons of acidic ants.  Acid-resistant but brittle.",
     "material": [ "acidchitin" ],
-    "material_thickness": 5,
     "environmental_protection": 2,
     "price_postapoc": 3500,
-    "proportional": { "weight": 1.125, "volume": 1.13, "price": 1.25, "encumbrance": 1.5, "warmth": 1.5 },
     "relative": { "melee_damage": { "bash": 1 } }
   },
   {

--- a/data/json/items/generic.json
+++ b/data/json/items/generic.json
@@ -438,7 +438,6 @@
     "description": "A lump of exoskeleton that has undergone biosilicification.  It is acid-resistant but rather brittle.",
     "material": [ "acidchitin" ],
     "flags": [ "NO_SALVAGE" ],
-    "proportional": { "weight": 1.25 },
     "relative": { "melee_damage": { "bash": 2 } }
   },
   {

--- a/data/json/items/vehicle/plating.json
+++ b/data/json/items/vehicle/plating.json
@@ -159,8 +159,7 @@
     "copy-from": "chitin_plate",
     "name": { "str": "biosilicified chitin armor kit" },
     "description": "A piece of durable silica-coated chitin plating made for a vehicle.",
-    "material": [ "acidchitin" ],
-    "proportional": { "price": 1.333, "weight": 1.2, "volume": 1.18, "melee_damage": { "bash": 1.25 } }
+    "material": [ "acidchitin" ]
   },
   {
     "type": "GENERIC",

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -253,30 +253,6 @@
   },
   {
     "type": "material",
-    "id": "acidchitin",
-    "name": "Biosilicified Chitin",
-    "density": 4.5,
-    "specific_heat_liquid": 4.186,
-    "specific_heat_solid": 2.108,
-    "latent_heat": 333,
-    "chip_resist": 8,
-    "breathability": "GOOD",
-    "salvaged_into": "acidchitin_piece",
-    "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
-    "bash_dmg_verb": "cracked",
-    "cut_dmg_verb": "chipped",
-    "//": "Normal chitin has low but non-zero flammability according to the US NFPA.",
-    "burn_data": [
-      { "fuel": 0, "smoke": 0, "burn": 0.0001 },
-      { "fuel": 0.2, "smoke": 3, "burn": 0.005, "volume_per_turn": "200 ml" },
-      { "fuel": 0.35, "smoke": 5, "burn": 0.015, "volume_per_turn": "200 ml" }
-    ],
-    "burn_products": [ [ "corpse_ash", 0.035 ] ],
-    "resist": { "bash": 2.3, "cut": 3.7, "acid": 16, "heat": 4, "bullet": 1.2 },
-    "repair_difficulty": 8
-  },
-  {
-    "type": "material",
     "id": "bone",
     "name": "Bone",
     "density": 1.4,
@@ -485,6 +461,30 @@
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
     "resist": { "bash": 2.5, "cut": 4, "acid": 6, "heat": 2.5, "bullet": 1.4 },
+    "repair_difficulty": 5
+  },
+  {
+    "type": "material",
+    "id": "acidchitin",
+    "name": "Biosilicified Chitin",
+    "density": 1.45,
+    "specific_heat_liquid": 4.186,
+    "specific_heat_solid": 2.108,
+    "latent_heat": 333,
+    "chip_resist": 10,
+    "breathability": "GOOD",
+    "wind_resist": 90,
+    "salvaged_into": "acidchitin_piece",
+    "dmg_adj": [ "scratched", "cut", "cracked", "shattered" ],
+    "bash_dmg_verb": "cracked",
+    "cut_dmg_verb": "chipped",
+    "burn_data": [
+      { "fuel": 0, "smoke": 0, "burn": 0.0001 },
+      { "fuel": 0.2, "smoke": 3, "burn": 0.001, "volume_per_turn": "200 ml" },
+      { "fuel": 0.35, "smoke": 5, "burn": 0.05, "volume_per_turn": "200 ml" }
+    ],
+    "burn_products": [ [ "corpse_ash", 0.035 ] ],
+    "resist": { "bash": 2.2, "cut": 3.5, "acid": 20, "heat": 4, "bullet": 1.2 },
     "repair_difficulty": 5
   },
   {

--- a/data/json/materials.json
+++ b/data/json/materials.json
@@ -471,7 +471,7 @@
     "specific_heat_liquid": 4.186,
     "specific_heat_solid": 2.108,
     "latent_heat": 333,
-    "chip_resist": 10,
+    "chip_resist": 7,
     "breathability": "GOOD",
     "wind_resist": 90,
     "salvaged_into": "acidchitin_piece",
@@ -484,7 +484,7 @@
       { "fuel": 0.35, "smoke": 5, "burn": 0.05, "volume_per_turn": "200 ml" }
     ],
     "burn_products": [ [ "corpse_ash", 0.035 ] ],
-    "resist": { "bash": 2.2, "cut": 3.5, "acid": 20, "heat": 4, "bullet": 1.2 },
+    "resist": { "bash": 1, "cut": 6, "acid": 20, "heat": 4, "bullet": 1.2 },
     "repair_difficulty": 5
   },
   {

--- a/data/json/recipes/recipe_others.json
+++ b/data/json/recipes/recipe_others.json
@@ -1969,7 +1969,7 @@
     "reversible": true,
     "autolearn": true,
     "components": [
-      [ [ "acidchitin_piece", 25 ] ],
+      [ [ "acidchitin_piece", 20 ] ],
       [ [ "rope_natural", 1, "LIST" ] ],
       [ [ "rope_natural_short", 2, "LIST" ], [ "adhesive", 4, "LIST" ] ]
     ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Balanced and improved acidproof chitin"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

There's very few reasons to make stuff out of acidproof chitin. Despite the name, the armor is not actually acidproof, just slightly more resistant to it than chitin.

Adding insult to injury, for some reason it's also heavier, more encumbering, significantly less protective, and for some reason warmer. There's effectively no reason to ever use it, it's kind of... a jackass of all trades, except it was also made worse in every single possible way alongside that.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Most acid chitin stats are now equal to chitin stats, with the following differences: It chips more, has 20-25% less M/R protection overall, has 20 acid resistance and 4 heat resistance. The acid resistance stat makes armor made out of it quite good at protecting you from acid, but not by any means immune, It still hurts a lot, but it lets you fight on the pool of acid for some small amount of time, which I think is the best of both worlds. Also it burns slower.

All acid chitin armor has had its thickness, encumbrance, and warmth made equal with chitin. There's already enough tradeoffs involved, it doesn't need even more.

Also, fixed an oversight in which chitin pet armor double dipped on chitin and steel resistances despite not even using the latter in its recipe, making armored pets nigh untouchable.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Making the armor fully acidproof - devs don't like it, armor has holes and fabric.
Some cool combination dualchitin armor - out of scope.
Making the armor BRITTLE rather than weaker - maybe.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned myself in, examined all recipes, spawned biochitin armor, fought a giant ant, was concerned by heavy acid damage, realized I forgot to put my boots on. Tried again, values seem good.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Has anyone ever used biosilsdclsdicdisf chitin armor???

Should its name be changed to acidproof because its so annoying to type

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
