### PR TITLE
eoc/json: assassin EOCs should not run for NPCs

### DIFF
--- a/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
+++ b/data/json/effects_on_condition/npc_eocs/generic_npc_eocs.json
@@ -232,6 +232,7 @@
     "type": "effect_on_condition",
     "id": "EOC_BANDIT_ASSASSIN",
     "recurrence": [ "60 days", "100 days" ],
+    "global": true,
     "condition": {
       "and": [
         { "math": [ "u_val('faction_like: hells_raiders')", "<", "-40" ] },
@@ -255,6 +256,7 @@
     "type": "effect_on_condition",
     "id": "EOC_BANDIT_ASSASSIN_2",
     "recurrence": [ "60 days", "100 days" ],
+    "global": true,
     "condition": {
       "and": [
         { "math": [ "u_val('faction_like: hells_raiders')", "<", "-60" ] },
@@ -278,6 +280,7 @@
     "type": "effect_on_condition",
     "id": "EOC_BANDIT_ASSASSIN_3",
     "recurrence": [ "60 days", "100 days" ],
+    "global": true,
     "condition": {
       "and": [
         { "math": [ "u_val('faction_like: hells_raiders')", "<", "-90" ] },
@@ -300,10 +303,11 @@
     "type": "effect_on_condition",
     "id": "EOC_OLD_GUARD_ASSASSIN",
     "recurrence": [ "60 days", "100 days" ],
+    "global": true,
     "condition": {
       "and": [
         { "math": [ "u_val('faction_like: old_guard')", "<", "-45" ] },
-        { "math": [ "government_assassins_sent", "<=", "6" ] },
+        { "math": [ "u_government_assassins_sent", "<=", "6" ] },
         { "days_since_cataclysm": 9 },
         { "not": { "is_weather": "portal_storm" } },
         { "not": { "u_near_om_location": "godco_enter", "range": 8 } },

--- a/data/mods/MindOverMatter/effectoncondition/eoc_premonition_instances.json
+++ b/data/mods/MindOverMatter/effectoncondition/eoc_premonition_instances.json
@@ -107,6 +107,7 @@
     "id": "EOC_BANDIT_ASSASSIN",
     "//": "Copy EoC: original in json/effect_on_condition.json",
     "recurrence": [ "60 days", "100 days" ],
+    "global": true,
     "condition": {
       "and": [
         { "math": [ "u_val('faction_like: hells_raiders')", "<", "-40" ] },
@@ -179,6 +180,7 @@
     "id": "EOC_BANDIT_ASSASSIN_2",
     "//": "Copy EoC: original in json/effect_on_condition.json",
     "recurrence": [ "60 days", "100 days" ],
+    "global": true,
     "condition": {
       "and": [
         { "math": [ "u_val('faction_like: hells_raiders')", "<", "-60" ] },
@@ -253,6 +255,7 @@
     "id": "EOC_BANDIT_ASSASSIN_3",
     "//": "Copy EoC: original in json/effect_on_condition.json",
     "recurrence": [ "60 days", "100 days" ],
+    "global": true,
     "condition": {
       "and": [
         { "math": [ "u_val('faction_like: hells_raiders')", "<", "-90" ] },
@@ -326,6 +329,7 @@
     "id": "EOC_OLD_GUARD_ASSASSIN",
     "//": "Copy EoC: original in json/effect_on_condition.json",
     "recurrence": [ "60 days", "100 days" ],
+    "global": true,
     "condition": {
       "and": [
         { "math": [ "u_val('faction_like: old_guard')", "<", "-45" ] },
@@ -375,7 +379,7 @@
         "spawn_message": "A professional-looking individual steps out of hiding and begins rapidly approaching you.",
         "spawn_message_plural": "Professional-looking individuals step out of hiding and begin rapidly approaching you."
       },
-      { "math": [ "government_assassins_sent", "+=", "2" ] }
+      { "math": [ "u_government_assassins_sent", "+=", "2" ] }
     ]
   },
   {
@@ -391,7 +395,7 @@
         "spawn_message": "A professional-looking individual steps out of hiding and begins rapidly approaching you.",
         "spawn_message_plural": "Professional-looking individuals step out of hiding and begin rapidly approaching you."
       },
-      { "math": [ "government_assassins_sent", "+=", "2" ] }
+      { "math": [ "u_government_assassins_sent", "+=", "2" ] }
     ]
   }
 ]


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Assassin EOCs aren't global so they run and spawn assassins for each NPC
* Fixes: #71098

#### Describe the solution
Add `"global": true`
Fix a couple of variables that weren't scoped properly in #70936

#### Describe alternatives you've considered
N/A

#### Testing
Change recurrence of  EOC_BANDIT_ASSASSIN to 1 day, go to a Hub 01 and wait. Only one assassin should spawn, rather than one for each Hub NPC.

#### Additional context
N/A
