### PR TITLE
Moose teleport patch

### DIFF
--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1177,6 +1177,13 @@ void monster::move()
                     can_z_move = false;
                 }
 
+                if (can_climb()) {
+                    add_msg_debug(debugmode::DF_MONMOVE, "%s can climb", name());
+                }
+                else {
+                    add_msg_debug(debugmode::DF_MONMOVE, "%s cannot climb", name());
+                }
+
                 // If we're trying to go up but can't fly, check if we can climb. If we can't, then don't
                 // This prevents non-climb/fly enemies running up walls
                 if( candidate.z > posz() && !( via_ramp || flies() ) ) {
@@ -1194,16 +1201,21 @@ void monster::move()
                 if( !can_z_move &&
                     posx() / ( SEEX * 2 ) == candidate.x / ( SEEX * 2 ) &&
                     posy() / ( SEEY * 2 ) == candidate.y / ( SEEY * 2 ) ) {
+                    add_msg_debug(debugmode::DF_MONMOVE, "%s is attempting zlvl teleport", name());
                     const tripoint upper = candidate.z > posz() ? candidate : pos();
                     const tripoint lower = candidate.z > posz() ? pos() : candidate;
                     if( here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, upper ) &&
                         here.has_flag( ter_furn_flag::TFLAG_GOES_UP, lower ) ) {
                         can_z_move = true;
+                        add_msg_debug(debugmode::DF_MONMOVE, "%s can z move for some reason", name());
                     }
                 }
 
                 if( !can_z_move ) {
                     continue;
+                }
+                else {
+                    add_msg_debug(debugmode::DF_MONMOVE, "%s is attempting vertical movement", name());
                 }
             }
 

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1191,7 +1191,7 @@ void monster::move()
 
                 // Last chance - we can still do the z-level stair teleport bullshit that isn't removed yet
                 // TODO: Remove z-level stair bullshit teleport after aligning all stairs
-                if( !can_z_move && //pos().xy() != candidate.xy() &&
+                if( !can_z_move && pos().xy() != candidate.xy() &&
                     posx() / ( SEEX * 2 ) == candidate.x / ( SEEX * 2 ) &&
                     posy() / ( SEEY * 2 ) == candidate.y / ( SEEY * 2 ) ) {
                     const tripoint upper = candidate.z > posz() ? candidate : pos();

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1191,7 +1191,7 @@ void monster::move()
 
                 // Last chance - we can still do the z-level stair teleport bullshit that isn't removed yet
                 // TODO: Remove z-level stair bullshit teleport after aligning all stairs
-                if( !can_z_move && pos().xy() != candidate.xy() &&
+                if( !can_z_move && //pos().xy() != candidate.xy() &&
                     posx() / ( SEEX * 2 ) == candidate.x / ( SEEX * 2 ) &&
                     posy() / ( SEEY * 2 ) == candidate.y / ( SEEY * 2 ) ) {
                     const tripoint upper = candidate.z > posz() ? candidate : pos();

--- a/src/monmove.cpp
+++ b/src/monmove.cpp
@@ -1177,13 +1177,6 @@ void monster::move()
                     can_z_move = false;
                 }
 
-                if (can_climb()) {
-                    add_msg_debug(debugmode::DF_MONMOVE, "%s can climb", name());
-                }
-                else {
-                    add_msg_debug(debugmode::DF_MONMOVE, "%s cannot climb", name());
-                }
-
                 // If we're trying to go up but can't fly, check if we can climb. If we can't, then don't
                 // This prevents non-climb/fly enemies running up walls
                 if( candidate.z > posz() && !( via_ramp || flies() ) ) {
@@ -1198,24 +1191,19 @@ void monster::move()
 
                 // Last chance - we can still do the z-level stair teleport bullshit that isn't removed yet
                 // TODO: Remove z-level stair bullshit teleport after aligning all stairs
-                if( !can_z_move &&
+                if( !can_z_move && pos().xy() != candidate.xy() &&
                     posx() / ( SEEX * 2 ) == candidate.x / ( SEEX * 2 ) &&
                     posy() / ( SEEY * 2 ) == candidate.y / ( SEEY * 2 ) ) {
-                    add_msg_debug(debugmode::DF_MONMOVE, "%s is attempting zlvl teleport", name());
                     const tripoint upper = candidate.z > posz() ? candidate : pos();
                     const tripoint lower = candidate.z > posz() ? pos() : candidate;
                     if( here.has_flag( ter_furn_flag::TFLAG_GOES_DOWN, upper ) &&
                         here.has_flag( ter_furn_flag::TFLAG_GOES_UP, lower ) ) {
                         can_z_move = true;
-                        add_msg_debug(debugmode::DF_MONMOVE, "%s can z move for some reason", name());
                     }
                 }
 
                 if( !can_z_move ) {
                     continue;
-                }
-                else {
-                    add_msg_debug(debugmode::DF_MONMOVE, "%s is attempting vertical movement", name());
                 }
             }
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixed issue where non-climbing monsters could sometimes teleport up ladders"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #70862 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Problem was caused by code used to allow climbing non-aligned stairs triggering for aligned ones, after code to handle those had already run. Added check to prevent non-aligned stair handling from checking aligned stairs.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Attempted to replicate issue with several non-climbing monsters, all of which failed. Ensured that stairs and ladders remained functional for the player.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
