### PR TITLE
Marine fish size review

### DIFF
--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -1338,11 +1338,11 @@
   {
     "id": "mon_fish_blackfish",
     "type": "MONSTER",
-    "copy-from": "mon_fish_tiny",
+    "copy-from": "mon_fish_small",
     "name": { "str_sp": "black sea bass" },
     "description": "A small, robust fish, the black sea bass is known for its dark, mottled color and meaty texture.",
     "volume": "1330 ml",
-    "weight": "500 g",
+    "weight": "850 g",
     "reproduction": { "baby_egg": "egg_blackfish", "baby_count": 2, "baby_timer": 15 }
   },
   {
@@ -1357,8 +1357,8 @@
     "copy-from": "mon_fish_tiny",
     "name": { "str_sp": "scup" },
     "description": "Also known as porgy, the scup is a small fish commonly found in Atlantic coastal waters, recognizable by its silver body with blue and purple tinges.",
-    "volume": "770 ml",
-    "weight": "340 g",
+    "volume": "800 ml",
+    "weight": "500 g",
     "reproduction": { "baby_egg": "egg_porgy", "baby_count": 3, "baby_timer": 16 }
   },
   {

--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -1307,7 +1307,7 @@
     "id": "mon_fish_mackerel",
     "type": "MONSTER",
     "copy-from": "mon_fish_tiny",
-    "name": { "str_sp": "atlantic mackerel" },
+    "name": { "str_sp": "Atlantic mackerel" },
     "description": "An Atlantic mackerel, known for its distinctive striped pattern.",
     "volume": "850 ml",
     "weight": "425 g",

--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -1309,8 +1309,8 @@
     "copy-from": "mon_fish_medium",
     "name": { "str_sp": "atlantic mackerel" },
     "description": "An Atlantic mackerel, known for its distinctive striped pattern.",
-    "volume": "3000 ml",
-    "weight": "1600 g",
+    "volume": "850 ml",
+    "weight": "425 g",
     "reproduction": { "baby_egg": "egg_mackerel", "baby_count": 3, "baby_timer": 20 }
   },
   {
@@ -1323,9 +1323,9 @@
     "id": "mon_fish_flounder",
     "type": "MONSTER",
     "copy-from": "mon_fish_medium",
-    "name": { "str_sp": "flounder" },
-    "description": "A flatfish, the flounder, also known as a fluke, likes to stay camouflaged against the ocean floor.",
-    "volume": "2500 ml",
+    "name": { "str_sp": "summer flounder" },
+    "description": "A flatfish, the summer flounder, also known as a fluke, likes to stay camouflaged against the ocean floor.",
+    "volume": "4 L",
     "weight": "1400 g",
     "reproduction": { "baby_egg": "egg_flounder", "baby_count": 2, "baby_timer": 22 }
   },
@@ -1341,8 +1341,8 @@
     "copy-from": "mon_fish_small",
     "name": { "str_sp": "black sea bass" },
     "description": "A small, robust fish, the black sea bass is known for its dark, mottled color and meaty texture.",
-    "volume": "1500 ml",
-    "weight": "600 g",
+    "volume": "1330 ml",
+    "weight": "500 g",
     "reproduction": { "baby_egg": "egg_blackfish", "baby_count": 2, "baby_timer": 15 }
   },
   {
@@ -1357,8 +1357,8 @@
     "copy-from": "mon_fish_small",
     "name": { "str_sp": "scup" },
     "description": "Also known as porgy, the scup is a small fish commonly found in Atlantic coastal waters, recognizable by its silver body with blue and purple tinges.",
-    "volume": "1300 ml",
-    "weight": "550 g",
+    "volume": "770 ml",
+    "weight": "340 g",
     "reproduction": { "baby_egg": "egg_porgy", "baby_count": 3, "baby_timer": 16 }
   },
   {
@@ -1373,8 +1373,8 @@
     "copy-from": "mon_fish_small",
     "name": { "str_sp": "bluefish" },
     "description": "The bluefish, a moderately proportioned marine fish, is known for its aggressive nature and sharp teeth.  It sports a distinct blue-green coloration.",
-    "volume": "1600 ml",
-    "weight": "700 g",
+    "volume": "6785 ml",
+    "weight": "1500 g",
     "reproduction": { "baby_egg": "egg_bluefish", "baby_count": 2, "baby_timer": 18 }
   },
   {
@@ -1389,8 +1389,8 @@
     "copy-from": "mon_fish_large",
     "name": { "str_sp": "Atlantic cod" },
     "description": "A large, white-meat fish known for its mild flavor and flaky texture.  Highly prized in both commercial and recreational fishing.",
-    "volume": "35000 ml",
-    "weight": "22 kg",
+    "volume": "31450 ml",
+    "weight": "30 kg",
     "reproduction": { "baby_egg": "egg_cod", "baby_count": 3, "baby_timer": 19 }
   },
   {
@@ -1405,8 +1405,8 @@
     "copy-from": "mon_fish_large",
     "name": { "str_sp": "haddock" },
     "description": "A popular food fish, the haddock is recognized by its dark lateral line and a black blotch above the pectoral fin.",
-    "volume": "25500 ml",
-    "weight": "11 kg",
+    "volume": "6785 ml",
+    "weight": "1800 g",
     "reproduction": { "baby_egg": "egg_haddock", "baby_count": 3, "baby_timer": 18 }
   },
   {
@@ -1421,8 +1421,8 @@
     "copy-from": "mon_fish_huge",
     "name": { "str_sp": "Atlantic bluefin tuna" },
     "description": "One of the largest and fastest fish in the waters of New England, the bluefin tuna is a streamlined predator with a dark blue back and silvery sides.",
-    "volume": "125000 ml",
-    "weight": "98 kg",
+    "volume": "250 L",
+    "weight": "200 kg",
     "reproduction": { "baby_egg": "egg_bluefin_tuna", "baby_count": 1, "baby_timer": 22 }
   },
   {
@@ -1437,8 +1437,8 @@
     "copy-from": "mon_fish_huge",
     "name": { "str_sp": "Atlantic halibut" },
     "description": "The largest flatfish in the ocean, known for its dense, firm texture and mild flavor.",
-    "volume": "75000 ml",
-    "weight": "42 kg",
+    "volume": "75 L",
+    "weight": "25 kg",
     "reproduction": { "baby_egg": "egg_halibut", "baby_count": 2, "baby_timer": 20 }
   },
   {
@@ -1454,8 +1454,8 @@
     "name": { "str_sp": "pollock" },
     "looks_like": "mon_fish_cod",
     "description": "A member of the cod family, pollock is a versatile fish known for its white, delicate meat and mild taste.",
-    "volume": "28000 ml",
-    "weight": "17 kg",
+    "volume": "6785 ml",
+    "weight": "2250 g",
     "reproduction": { "baby_egg": "egg_pollock", "baby_count": 3, "baby_timer": 17 }
   },
   {

--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -1357,7 +1357,6 @@
     "copy-from": "mon_fish_tiny",
     "name": { "str_sp": "scup" },
     "description": "Also known as porgy, the scup is a small fish commonly found in Atlantic coastal waters, recognizable by its silver body with blue and purple tinges.",
-    "volume": "800 ml",
     "weight": "500 g",
     "reproduction": { "baby_egg": "egg_porgy", "baby_count": 3, "baby_timer": 16 }
   },

--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -1374,7 +1374,6 @@
     "name": { "str_sp": "bluefish" },
     "description": "The bluefish, a moderately proportioned marine fish, is known for its aggressive nature and sharp teeth.  It sports a distinct blue-green coloration.",
     "volume": "6785 ml",
-    "weight": "1500 g",
     "reproduction": { "baby_egg": "egg_bluefish", "baby_count": 2, "baby_timer": 18 }
   },
   {

--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -1306,7 +1306,7 @@
   {
     "id": "mon_fish_mackerel",
     "type": "MONSTER",
-    "copy-from": "mon_fish_medium",
+    "copy-from": "mon_fish_tiny",
     "name": { "str_sp": "atlantic mackerel" },
     "description": "An Atlantic mackerel, known for its distinctive striped pattern.",
     "volume": "850 ml",
@@ -1322,7 +1322,7 @@
   {
     "id": "mon_fish_flounder",
     "type": "MONSTER",
-    "copy-from": "mon_fish_medium",
+    "copy-from": "mon_fish_tiny",
     "name": { "str_sp": "summer flounder" },
     "description": "A flatfish, the summer flounder, also known as a fluke, likes to stay camouflaged against the ocean floor.",
     "volume": "4 L",
@@ -1338,7 +1338,7 @@
   {
     "id": "mon_fish_blackfish",
     "type": "MONSTER",
-    "copy-from": "mon_fish_small",
+    "copy-from": "mon_fish_tiny",
     "name": { "str_sp": "black sea bass" },
     "description": "A small, robust fish, the black sea bass is known for its dark, mottled color and meaty texture.",
     "volume": "1330 ml",
@@ -1354,7 +1354,7 @@
   {
     "id": "mon_fish_porgy",
     "type": "MONSTER",
-    "copy-from": "mon_fish_small",
+    "copy-from": "mon_fish_tiny",
     "name": { "str_sp": "scup" },
     "description": "Also known as porgy, the scup is a small fish commonly found in Atlantic coastal waters, recognizable by its silver body with blue and purple tinges.",
     "volume": "770 ml",
@@ -1402,7 +1402,7 @@
   {
     "id": "mon_fish_haddock",
     "type": "MONSTER",
-    "copy-from": "mon_fish_large",
+    "copy-from": "mon_fish_medium",
     "name": { "str_sp": "haddock" },
     "description": "A popular food fish, the haddock is recognized by its dark lateral line and a black blotch above the pectoral fin.",
     "volume": "6785 ml",
@@ -1434,7 +1434,7 @@
   {
     "id": "mon_fish_halibut",
     "type": "MONSTER",
-    "copy-from": "mon_fish_huge",
+    "copy-from": "mon_fish_large",
     "name": { "str_sp": "Atlantic halibut" },
     "description": "The largest flatfish in the ocean, known for its dense, firm texture and mild flavor.",
     "volume": "75 L",
@@ -1450,7 +1450,7 @@
   {
     "id": "mon_fish_pollock",
     "type": "MONSTER",
-    "copy-from": "mon_fish_large",
+    "copy-from": "mon_fish_medium",
     "name": { "str_sp": "pollock" },
     "looks_like": "mon_fish_cod",
     "description": "A member of the cod family, pollock is a versatile fish known for its white, delicate meat and mild taste.",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Our marine fish were given sizes which were way too high above average in most cases.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Reviewed the weights and volumes for our marine fish, as well as which of the abstracts they copy from.
Also renamed our flounder to summer flounder and fixed the capitalization for the mackerel.

Methods of calculation same as #61614
- Flounder was calculated in reverse, with the length being the diameter and the division by 5 being height. Halibut was calculated proportionally because I could not find average length, most sources online only give record-worthy lengths
- Blackfish and Porgy divided by 4, the rest divided by 5
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
All of the information was obtained from the corresponding [fishbase](https://fishbase.se) profiles, with the exception of the halibut and haddock which had values from Wikipedia helping, and flounder, cod and tuna which I used https://animaldiversity.org/ for as well

Additional notes:
- Our tuna is still slightly below average but I was worried of taking it beyond the 250kg mark
- Haddock would be larger if we used the values from the UK, but values from Canada show slightly smaller fish
- Halibuts are weird, because the averages for males are over 10x smaller than sizes females can reach. I went with a top-average weight for males, because we don't support sexual dimorphism (yet?)
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
