### PR TITLE
Construction pre/post_special supports arrays

### DIFF
--- a/data/json/construction.json
+++ b/data/json/construction.json
@@ -4912,7 +4912,7 @@
     "time": "360 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ] ],
     "components": [ [ [ "2x4", 12 ] ], [ [ "nail", 24 ], [ "bronze_nail", 24 ] ] ],
-    "pre_special": "check_empty_up_OK",
+    "pre_special": [ "check_empty", "check_up_OK" ],
     "post_terrain": "t_wood_stairs_up_half"
   },
   {
@@ -4974,7 +4974,7 @@
     "time": "300 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "DIG", "level": 2 } ] ],
     "components": [ [ [ "material_soil", 50 ] ], [ [ "stick", 12 ], [ "stick_long", 6 ], [ "2x4", 6 ] ], [ [ "rock", 20 ] ] ],
-    "pre_special": "check_ramp_low",
+    "pre_special": [ "check_empty", "check_stable", "check_up_OK", "check_nofloor_above" ],
     "post_terrain": "t_earth_ramp_up_low",
     "post_special": "done_ramp_low"
   },
@@ -4989,7 +4989,7 @@
     "time": "300 m",
     "qualities": [ [ { "id": "HAMMER", "level": 2 } ], [ { "id": "DIG", "level": 2 } ] ],
     "components": [ [ [ "material_soil", 50 ] ], [ [ "stick", 10 ], [ "2x4", 8 ] ], [ [ "rock", 20 ] ] ],
-    "pre_special": "check_ramp_high",
+    "pre_special": [ "check_empty", "check_stable", "check_up_OK", "check_nofloor_above", "check_ramp_high" ],
     "post_terrain": "t_earth_ramp_up_high",
     "post_special": "done_ramp_high"
   },
@@ -5005,7 +5005,7 @@
     "tools": [ [ [ "con_mix", 125 ] ] ],
     "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
     "components": [ [ [ "concrete", 5 ] ], [ [ "water", 5 ], [ "water_clean", 5 ] ] ],
-    "pre_special": "check_ramp_low",
+    "pre_special": [ "check_empty", "check_stable", "check_up_OK", "check_nofloor_above" ],
     "post_terrain": "t_ramp_up_low",
     "post_special": "done_ramp_low"
   },
@@ -5021,7 +5021,7 @@
     "tools": [ [ [ "con_mix", 125 ] ] ],
     "qualities": [ [ { "id": "SMOOTH", "level": 2 } ] ],
     "components": [ [ [ "concrete", 5 ] ], [ [ "water", 5 ], [ "water_clean", 5 ] ] ],
-    "pre_special": "check_ramp_high",
+    "pre_special": [ "check_empty", "check_stable", "check_up_OK", "check_nofloor_above", "check_ramp_high" ],
     "post_terrain": "t_ramp_up_high",
     "post_special": "done_ramp_high"
   },
@@ -6980,7 +6980,7 @@
     "on_display": true,
     "qualities": [ { "id": "DIG", "level": 1 } ],
     "pre_flags": [ "DIGGABLE", "FLAT" ],
-    "pre_special": "check_channel",
+    "pre_special": [ "check_empty", "check_channel" ],
     "post_terrain": "t_water_moving_sh",
     "byproducts": [ { "group": "digging_soil_loam_50L", "count": 5 } ],
     "activity_level": "EXTRA_EXERCISE",

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -930,7 +930,7 @@ bool can_construct( const construction &con, const tripoint_bub_ms &p )
     const furn_id f = here.furn( p );
     const ter_id t = here.ter( p );
     if( con.pre_specials.size() > 1 ) { // pre-functions
-        for( auto &special : con.pre_specials ) {
+        for( const auto &special : con.pre_specials ) {
             if( !special( p ) ) {
                 return false;
             }
@@ -1176,7 +1176,7 @@ void complete_construction( Character *you )
     // This comes after clearing the activity, in case the function interrupts
     // activities
     if( built.post_specials.size() > 1 ) { // pre-functions
-        for( auto &special : built.post_specials ) {
+        for( const auto &special : built.post_specials ) {
             special( terp, *you );
         }
     } else {

--- a/src/construction.h
+++ b/src/construction.h
@@ -83,9 +83,12 @@ struct construction {
 
         // Custom constructibility check
         bool ( *pre_special )( const tripoint_bub_ms & );
+        std::vector<bool ( * )( const tripoint_bub_ms & )> pre_specials;
+        // Custom while constructing effects
+        void ( *do_turn_special )( const tripoint_bub_ms &, Character & );
         // Custom after-effects
         void ( *post_special )( const tripoint_bub_ms &, Character & );
-        void ( *do_turn_special )( const tripoint_bub_ms &, Character & );
+        std::vector<void ( * )( const tripoint_bub_ms &, Character & )> post_specials;
         // Custom error message display
         void ( *explain_failure )( const tripoint_bub_ms & );
         // Whether it's furniture or terrain


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

pre/post_specials are hardcoded in an ugly way where lots of them call each other leading to less clarity on what each does without digging
I'd like to allow EoC to be used alongside/in place of them but this seemed like a sensible first step

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Where before you could do `"pre_special": "<pre_special_id>"` now you can also do `"pre_special": [ "<pre_special_id>", "<pre_special_id2>" ]` with construction only being allowed if all pre_specials return true
Where before you could do `"post_special": "<post_special_id>"` now you can also do `"post_special": [ "<post_special_id>", "<post_special_id2>" ]` with each being performed in order
Will change existing pre and post specials to fit this change

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Doing the same for do_turn_special
Also allowing nested brackets for || behaviour like recipes do

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Used two simple pre_specials to test:
```
bool construct::check_adjacent_pavement( const tripoint_bub_ms &p )
{
    for( const point &offset : four_adjacent_offsets ) {
        const ter_t &t = get_map().ter( p + offset ).obj();
        if(t.id.id() == ter_t_pavement ) {
            return true;
        }
    }
    return false;
}

bool construct::check_grass( const tripoint_bub_ms &p )
{
    const ter_t &t = get_map().ter( p ).obj();
    return t.id.id() == ter_t_grass;
}
```

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

I thought I'd be able to delete more than this but oh well

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
