### PR TITLE
inv_ui: fix highlight on return

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -2030,6 +2030,7 @@ int game::inventory_item_menu( item_location locThisItem,
         bool exit = false;
         bool first_execution = true;
         static int lang_version = detail::get_current_language_version();
+        catacurses::window w_info;
         do {
             //lang check here is needed to redraw the menu when using "Toggle language to English" option
             if( first_execution || lang_version != detail::get_current_language_version() ) {
@@ -2118,8 +2119,6 @@ int game::inventory_item_menu( item_location locThisItem,
 
                 data = item_info_data( oThisItem.tname(), oThisItem.type_name(), vThisItem, vDummy, iScrollPos );
                 data.without_getch = true;
-
-                catacurses::window w_info;
 
                 ui = std::make_unique<ui_adaptor>();
                 ui->on_screen_resize( [&]( ui_adaptor & ui ) {

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -265,7 +265,7 @@ void game_menus::inv::common( avatar &you )
         inv_s.add_character_items( you );
         inv_s.set_filter( filter );
         if( location != item_location::nowhere ) {
-            inv_s.highlight( location );
+            inv_s.highlight_one_of( { location } );
         }
 
         location = inv_s.execute();
@@ -300,7 +300,7 @@ void game_menus::inv::common( item_location &loc, avatar &you )
         inv_s.add_contained_items( loc );
         inv_s.set_filter( filter );
         if( location != item_location::nowhere ) {
-            inv_s.highlight( location );
+            inv_s.highlight_one_of( { location } );
         }
 
         location = inv_s.execute();

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3290,7 +3290,7 @@ item_location inventory_pick_selector::execute()
                         return input.entry->any_item();
                     }
                 }
-            } else if( input.action == "ANY_INPUT" ) {
+            } else if( input.action != "MOUSE_MOVE" && input.action != "COORDINATE" ) {
                 return input.entry->any_item();
             } else {
                 if( !dragActive && highlight( input.entry->any_item() ) ) {


### PR DESCRIPTION

#### Summary
None
#### Purpose of change
Highlight-on-return is broken for inventory UI
* Fixes: #65241

#### Describe the solution
1. Highlight after sorting - same as in the `E`at UI
2. Fix unrelated crash in the same chain
3. Since I was here, also fix selection with invlet when it shadows another action


#### Describe alternatives you've considered
Waiting for imgui

#### Testing
<details>
<summary>before</summary>

[0 - before.webm](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/7a2e7d4d-4a00-4fc8-87f5-af38aef1a767)


</details>

<details>
<summary>after</summary>

[1 - after.webm](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/17d1a666-69fd-444f-9206-9a5ca6b408f5)

</details>

For 3, assign `q` as an invlet for a flashlight (shadows default keybinding for `Cancel`), then try to activate it by invlet. Before patch, it only gets highlighted. After patch, it gets activated.

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
