### PR TITLE
Add Kantele + Minor fixes

### DIFF
--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -998,7 +998,7 @@
           { "item": "saxophone", "prob": 50 },
           { "item": "trumpet", "prob": 50 },
           { "item": "tuba", "prob": 25 },
-          { "item": "kantele", "prob": 5 },
+          { "item": "kantele", "prob": 10 },
           { "item": "ukulele", "prob": 50 },
           { "item": "fog_machine", "prob": 1, "charges": [ 0, 500 ] },
           { "item": "violin", "prob": 90 },
@@ -1035,7 +1035,7 @@
       [ "acoustic_guitar", 100 ],
       [ "violin", 80 ],
       [ "ukulele", 90 ],
-      [ "kantele", 5 ],
+      [ "kantele", 10 ],
       [ "banjo", 100 ],
       [ "guitar_electric", 100 ]
     ]

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -998,6 +998,7 @@
           { "item": "saxophone", "prob": 50 },
           { "item": "trumpet", "prob": 50 },
           { "item": "tuba", "prob": 25 },
+          { "item": "kantele", "prob": 5 },
           { "item": "ukulele", "prob": 50 },
           { "item": "fog_machine", "prob": 1, "charges": [ 0, 500 ] },
           { "item": "violin", "prob": 90 },
@@ -1030,7 +1031,7 @@
     "id": "mussto_stringinst",
     "type": "item_group",
     "//": "for music store",
-    "items": [ [ "acoustic_guitar", 100 ], [ "violin", 80 ], [ "ukulele", 90 ], [ "banjo", 100 ], [ "guitar_electric", 100 ] ]
+    "items": [ [ "acoustic_guitar", 100 ], [ "violin", 80 ], [ "ukulele", 90 ], [ "kantele", 5 ], [ "banjo", 100 ], [ "guitar_electric", 100 ] ]
   },
   {
     "id": "bowling_alcohol",

--- a/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
+++ b/data/json/itemgroups/Locations_MapExtras/locations_commercial.json
@@ -1031,7 +1031,14 @@
     "id": "mussto_stringinst",
     "type": "item_group",
     "//": "for music store",
-    "items": [ [ "acoustic_guitar", 100 ], [ "violin", 80 ], [ "ukulele", 90 ], [ "kantele", 5 ], [ "banjo", 100 ], [ "guitar_electric", 100 ] ]
+    "items": [
+      [ "acoustic_guitar", 100 ],
+      [ "violin", 80 ],
+      [ "ukulele", 90 ],
+      [ "kantele", 5 ],
+      [ "banjo", 100 ],
+      [ "guitar_electric", 100 ]
+    ]
   },
   {
     "id": "bowling_alcohol",

--- a/data/json/itemgroups/collections_domestic.json
+++ b/data/json/itemgroups/collections_domestic.json
@@ -1102,6 +1102,7 @@
       { "item": "flute", "prob": 10 },
       { "item": "harmonica_holder", "prob": 10 },
       { "item": "banjo", "prob": 5 },
+      { "item": "kantele", "prob": 1 },
       { "item": "ukulele", "prob": 15 },
       { "item": "guitar_electric", "prob": 20 },
       { "item": "gobag", "prob": 5 },

--- a/data/json/items/tool/musical_instruments.json
+++ b/data/json/items/tool/musical_instruments.json
@@ -94,6 +94,38 @@
     "melee_damage": { "bash": 4 }
   },
   {
+    "id": "kantele",
+    "looks_like": "violin",
+    "type": "TOOL",
+    "category": "tools",
+    "name": { "str": "kantele" },
+    "description": "A traditional Finnish string instrument. According to myth the first one was fashioned from a great pike's bone.  This ordinary wooden one doesn't seem quite as special.",
+    "weight": "550 g",
+    "volume": "3000 ml",
+    "longest_side": "46 cm",
+    "price": 5500,
+    "price_postapoc": 250,
+    "to_hit": 1,
+    "material": [ "wood" ],
+    "symbol": "(",
+    "color": "brown",
+    "use_action": [ { "type": "play_instrument" } ],
+    "tick_action": {
+      "type": "musical_instrument",
+      "volume": 10,
+      "fun": -5,
+      "fun_bonus": 2,
+      "speed_penalty": 13,
+      "description_frequency": 20,
+      "player_descriptions": [
+        "You play a riveting tune on your kantele.",
+        "You play an enchanting composition on your kantele.",
+        "You play a somber piece on your kantele."
+      ]
+    },
+    "melee_damage": { "bash": 4 }
+  },
+  {
     "id": "flute",
     "type": "TOOL",
     "category": "tools",

--- a/data/json/items/tool/musical_instruments.json
+++ b/data/json/items/tool/musical_instruments.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "banjo",
+    "looks_like": "acoustic_guitar",
     "type": "TOOL",
     "category": "tools",
     "name": { "str": "banjo" },
@@ -33,6 +34,7 @@
   },
   {
     "id": "bone_flute",
+    "looks_like": "flute",
     "type": "TOOL",
     "category": "tools",
     "name": { "str": "bone flute" },
@@ -64,6 +66,7 @@
   },
   {
     "id": "clarinet",
+    "looks_like": "flute",
     "type": "TOOL",
     "category": "tools",
     "name": { "str": "clarinet" },
@@ -95,7 +98,7 @@
   },
   {
     "id": "kantele",
-    "looks_like": "violin",
+    "looks_like": "acoustic_guitar",
     "type": "TOOL",
     "category": "tools",
     "name": { "str": "kantele" },
@@ -158,6 +161,7 @@
   },
   {
     "id": "trumpet",
+    "looks_like": "flute",
     "type": "TOOL",
     "category": "tools",
     "name": { "str": "trumpet" },
@@ -189,6 +193,7 @@
   },
   {
     "id": "ukulele",
+    "looks_like": "acoustic_guitar",
     "type": "TOOL",
     "category": "tools",
     "name": { "str": "ukulele" },
@@ -221,6 +226,7 @@
   },
   {
     "id": "violin",
+    "looks_like": "acoustic_guitar",
     "type": "TOOL",
     "category": "tools",
     "name": { "str": "violin" },
@@ -253,6 +259,7 @@
   },
   {
     "id": "violin_golden",
+    "looks_like": "acoustic_guitar",
     "type": "TOOL",
     "category": "tools",
     "name": { "str": "golden fiddle" },
@@ -284,6 +291,7 @@
   },
   {
     "id": "krar_golden",
+    "looks_like": "acoustic_guitar",
     "type": "TOOL",
     "category": "tools",
     "name": { "str": "golden krar" },
@@ -312,6 +320,7 @@
   {
     "type": "TOOL_ARMOR",
     "id": "harmonica_holder",
+    "looks_like": "flute",
     "name": { "str_pl": "harmonicas with holders", "str": "harmonica with a holder" },
     "category": "tools",
     "weight": "200 g",
@@ -377,6 +386,7 @@
   {
     "type": "TOOL_ARMOR",
     "id": "guitar_electric",
+    "looks_like": "acoustic_guitar",
     "name": { "str": "electric guitar" },
     "category": "tools",
     "weight": "3750 g",
@@ -418,6 +428,7 @@
   {
     "type": "TOOL_ARMOR",
     "id": "bagpipes",
+    "looks_like": "flute",
     "name": { "str_sp": "bagpipes" },
     "category": "tools",
     "weight": "2500 g",
@@ -457,6 +468,7 @@
   {
     "type": "TOOL_ARMOR",
     "id": "tuba",
+    "looks_like": "flute",
     "name": { "str": "tuba" },
     "category": "tools",
     "weight": "13600 g",
@@ -498,6 +510,7 @@
   {
     "type": "TOOL_ARMOR",
     "id": "saxophone",
+    "looks_like": "flute",
     "name": { "str": "saxophone" },
     "category": "tools",
     "weight": "2200 g",

--- a/data/json/items/tool/musical_instruments.json
+++ b/data/json/items/tool/musical_instruments.json
@@ -102,7 +102,7 @@
     "type": "TOOL",
     "category": "tools",
     "name": { "str": "kantele" },
-    "description": "A traditional Finnish string instrument. According to myth the first one was fashioned from a great pike's bone.  This ordinary wooden one doesn't seem quite as special.",
+    "description": "A traditional Finnish string instrument.  According to myth the first one was fashioned from a great pike's bone.  This ordinary wooden one doesn't seem quite as special.",
     "weight": "550 g",
     "volume": "3000 ml",
     "longest_side": "46 cm",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Adds kantele"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Got to listen to one of these in person the other day, and felt like adding it to the game.  More variety in instruments never hurt.  Adds looks_like values to instruments after I noticed a lot of missing tiles playing with UltiCata.

#### Describe the solution

Adds the kantele, allowing it to spawn rarely in music stores and very rarely in house bedrooms.

#### Describe alternatives you've considered

Having a little less music in the world?

#### Testing

Loaded the game, spawned 15 music stores and found only 3 kantele. 
Picked one up, it has correct weight and dimensions, playing it makes the proper text appear in the log.

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/52714184/46ab6b54-5cb5-4cd6-bc48-1c2153421b25)

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/52714184/9bcfd6b7-549f-4f7d-93a0-ecdbddade51c)


#### Additional context

This might be a fun instrument for one of the magic mods to use.  Kantele myth is heavily associated with spellcasting.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
