### PR TITLE
Allow appending and prepending copy-from descriptions

### DIFF
--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -148,8 +148,7 @@
       {
         "id": "flag_chestrig",
         "name": { "str": "patriot's chest rig" },
-        "description": "An American flag is proudly embroidered across the front of each pouch, with a tiny, eagle-winged .50-caliber bullet crowning each banner.",
-        "append": true
+        "description_append": "An American flag is proudly embroidered across the front of each pouch, with a tiny, eagle-winged .50-caliber bullet crowning each banner."
       }
     ],
     "weight": "425 g",

--- a/data/json/items/armor/gloves.json
+++ b/data/json/items/armor/gloves.json
@@ -42,34 +42,19 @@
   {
     "id": "chainmail_junk_hands",
     "type": "ARMOR",
-    "category": "armor",
+    "copy-from": "lc_chainmail_hands",
     "name": { "str": "pair of chainmail gloves", "str_pl": "pairs of chainmail gloves" },
-    "description": "A pair of customized chainmail gloves that fully enclose the hands.  The metal shows signs of rust and corrosion.",
-    "weight": "957 g",
-    "volume": "500 ml",
-    "price": 5012,
-    "price_postapoc": 2500,
-    "to_hit": -1,
-    "material": [ "budget_steel_chain" ],
-    "symbol": "[",
-    "color": "light_red",
-    "material_thickness": 2,
-    "flags": [ "VARSIZE", "STURDY", "OUTER" ],
-    "armor": [
-      {
-        "material": [ { "type": "budget_steel_chain", "covered_by_mat": 100, "thickness": 1.2 } ],
-        "covers": [ "hand_l", "hand_r" ],
-        "coverage": 100,
-        "encumbrance": 14
-      }
-    ]
+    "description_append": "The metal shows signs of rust and corrosion.",
+    "inherit_extended_description": false,
+    "replace_materials": { "lc_steel_chain": "budget_steel_chain" }
   },
   {
     "id": "lc_chainmail_hands",
     "type": "ARMOR",
     "category": "armor",
     "name": { "str": "pair of mild steel chainmail gloves", "str_pl": "pairs of mild steel chainmail gloves" },
-    "description": "A pair of customized steel chainmail gloves that fully enclose the hands.",
+    "description": "A pair of customized chainmail gloves that fully enclose the hands.",
+    "description_append": "Made from mild steel.",
     "weight": "957 g",
     "volume": "500 ml",
     "price": 5012,
@@ -110,6 +95,8 @@
     "type": "ARMOR",
     "copy-from": "lc_chainmail_hands",
     "name": { "str": "pair of medium steel chainmail gloves", "str_pl": "pairs of medium steel chainmail gloves" },
+    "description_append": "Made from medium steel.",
+    "inherit_extended_description": false,
     "replace_materials": { "lc_steel_chain": "mc_steel_chain" }
   },
   {
@@ -133,6 +120,8 @@
     "type": "ARMOR",
     "copy-from": "lc_chainmail_hands",
     "name": { "str": "pair of high steel chainmail gloves", "str_pl": "pairs of high steel chainmail gloves" },
+    "description_append": "Made from high steel.",
+    "inherit_extended_description": false,
     "replace_materials": { "lc_steel_chain": "hc_steel_chain" }
   },
   {
@@ -156,6 +145,8 @@
     "type": "ARMOR",
     "copy-from": "lc_chainmail_hands",
     "name": { "str": "pair of hardened steel chainmail gloves", "str_pl": "pairs of hardened steel chainmail gloves" },
+    "description_append": "Made from hardened steel.",
+    "inherit_extended_description": false,
     "replace_materials": { "lc_steel_chain": "ch_steel_chain" }
   },
   {
@@ -178,8 +169,9 @@
     "id": "qt_chainmail_hands",
     "type": "ARMOR",
     "copy-from": "lc_chainmail_hands",
-    "material": [ "qt_steel_chain" ],
     "name": { "str": "pair of tempered steel chainmail gloves", "str_pl": "pairs of tempered steel chainmail gloves" },
+    "description_append": "Made from tempered steel.",
+    "inherit_extended_description": false,
     "replace_materials": { "lc_steel_chain": "qt_steel_chain" }
   },
   {

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -769,16 +769,14 @@ Same works with variants
     {
       "id": "fuck_you",
       "name": { "str": "insulting mug" },
-      "description": "It says \"<fuck_you>, <name_b>!\"",
-      "append": true,
+      "description_append": "It says \"<fuck_you>, <name_b>!\"",
       "expand_snippets": true,
       "weight": 1
     },
     {
       "id": "worst_dad",
       "name": { "str": "bad dad mug" },
-      "description": "It says \"Worlds Worst Dad\"",
-      "append": true,
+      "description_append": "It says \"Worlds Worst Dad\"",
       "weight": 1
     }
   ],
@@ -803,15 +801,13 @@ Using `expand_snippets` on item itself will work as all variants have `"expand_s
     {
       "id": "fuck_you",
       "name": { "str": "insulting mug" },
-      "description": "It says \"<fuck_you>, <name_b>!\"",
-      "append": true,
+      "description_append": "It says \"<fuck_you>, <name_b>!\"",
       "weight": 1
     },
     {
       "id": "worst_dad",
       "name": { "str": "bad mug" },
-      "description": "This mug never appears, because it doesnn't have any snippets",
-      "append": true,
+      "description_append": "This mug never appears, because it doesn't have any snippets",
       "weight": 1
     }
   ],
@@ -3354,6 +3350,9 @@ Weakpoints only match if they share the same id, so it's important to define the
 "symbol": "[",                   // The item symbol as it appears on the map. Must be a Unicode string exactly 1 console cell width.
 "looks_like": "sheet_cotton",              // hint to tilesets if this item has no tile, use the looks_like tile
 "description": "Socks. Put 'em on your feet.", // Description of the item
+"description_prepend": "Come in a pair.",      // Description to add to the beginning of its inherited item's (potentially prepended/appended/both) description
+"description_append": "Before one gets lost!", // Description to add to the end of its inherited item's (potentially prepended/appended/both) description
+"inherit_extended_description": false,         // Whether this item should combine the prepend/append from its copy-from into its base description. Shouldn't be used with "description". Defaults to true.
 "snippet_category": "snippet_category",        // Can be used instead of description, if author want to have multiple ways to describe an item. See #Snippets
 "ascii_picture": "ascii_socks", // Id of the asci_art used for this item
 "phase": "solid",                            // (Optional, default = "solid") What phase it is
@@ -3391,15 +3390,16 @@ Weakpoints only match if they share the same id, so it's important to define the
 "variant_type": "gun"      // Possible options: "gun", "generic" - controls which options enable/disable seeing the variants of this item.
 "variants": [              // Cosmetic variants this item can have
   {
-    "id": "variant_a",                           // id used in spawning to spawn this variant specifically
-    "name": { "str": "Variant A" },             // The name used instead of the default name when this variant is selected
-    "description": "A fancy variant A",         // The description used instead of the default when this variant is selected
-    "ascii_picture": "valid_ascii_art_id",      // An ASCII art picture used when this variant is selected. If there is none, the default (if it exists) is used.
-    "symbol": "/",                              // Valid unicode character to replace the item symbol. If not specified, no change will be made.
-    "color": "red",                             // Replacement color of item symbol. If not specified, no change will be made.
-    "weight": 2,                                // The relative chance of this variant being selected over other variants when this item is spawned with no explicit variant. Defaults to 1. If it is 0, this variant will not be selected
-    "append": true,                             // If this description should just be appended to the base item description instead of completely overwriting it.
-    "expand_snippets": true                     // Allows to use snippet tags, see #Snippets
+    "id": "variant_a",                                  // id used in spawning to spawn this variant specifically
+    "name": { "str": "Variant A" },                     // The name used instead of the default name when this variant is selected
+    "description": "A fancy variant A.",                // The description used instead of the default when this variant is selected
+    "description_prepend": "A very fancy pair indeed.", // The description to be added to the front of the base item description instead of completely overwriting it. Shouldn't be used alongside "description".
+    "description_append": "This pair is very fancy",    // The description to be added to the end of to the base item description instead of completely overwriting it. Shouldn't be used alongside "description".
+    "ascii_picture": "valid_ascii_art_id",              // An ASCII art picture used when this variant is selected. If there is none, the default (if it exists) is used.
+    "symbol": "/",                                      // Valid unicode character to replace the item symbol. If not specified, no change will be made.
+    "color": "red",                                     // Replacement color of item symbol. If not specified, no change will be made.
+    "weight": 2,                                        // The relative chance of this variant being selected over other variants when this item is spawned with no explicit variant. Defaults to 1. If it is 0, this variant will not be selected
+    "expand_snippets": true                             // Allows to use snippet tags, see #Snippets
   }
 ],
 "flags": ["VARSIZE"],                        // Indicates special effects, see JSON_FLAGS.md

--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -7,7 +7,7 @@ def parse_generic(json, origin):
     name = ""
     description = ""
     comment = []
-    inherits_description = true
+    inherits_description = True
     inherited_description_id = ""
     if "copy-from" in json:
         inherited_description_id = json["copy-from"]
@@ -27,21 +27,27 @@ def parse_generic(json, origin):
         write_text(json["description"], origin, c_format=False,
                    comment=comment + ["Description of \"{}\"".format(name)])
         description = json["description"]
-        inherits_description = false
+        inherits_description = False
     if "description_prepend" in json:
         if inherits_description:
             write_text(json["description_prepend"], origin, c_format=False,
-                    comment=comment + ["Partial description of \"{}\" to add to the start of its inherited description from \"{}\"".format(name, inherited_description_id)])
+                       comment=comment + ["Partial description of \"{}\" to 
+                       add to the start of its inherited description from 
+                       \"{}\"".format(name, inherited_description_id)])
         else:
             write_text(json["description_prepend"], origin, c_format=False,
-                    comment=comment + ["Partial description of \"{}\" to add to the start of \"{}\"".format(name, description)])
+                       comment=comment + ["Partial description of \"{}\" to 
+                       add to the start of \"{}\"".format(name, description)])
     if "description_append" in json:
         if inherits_description:
             write_text(json["description_append"], origin, c_format=False,
-                    comment=comment + ["Partial description of \"{}\" to add to the end of its inherited description from \"{}\"".format(name, inherited_description_id)])
+                       comment=comment + ["Partial description of \"{}\" to 
+                       add to the end of its inherited description from 
+                       \"{}\"".format(name, inherited_description_id)])
         else:
             write_text(json["description_append"], origin, c_format=False,
-                    comment=comment + ["Partial description of \"{}\" to add to the end of \"{}\"".format(name, description)])
+                       comment=comment + ["Partial description of \"{}\" to 
+                       add to the end of \"{}\"".format(name, description)])
 
     if "use_action" in json:
         parse_use_action(json["use_action"], origin, name)

--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -32,8 +32,8 @@ def parse_generic(json, origin):
         if inherits_description:
             write_text(json["description_prepend"], origin, c_format=False,
                        comment=comment + ["Partial description of \"{}\" to "
-                       "add to the start of its inherited description from \"{}\""
-                       .format(name, inherited_description_id)])
+                       "add to the start of its inherited description from "
+                       "\"{}\"".format(name, inherited_description_id)])
         else:
             write_text(json["description_prepend"], origin, c_format=False,
                        comment=comment + ["Partial description of \"{}\" to "
@@ -42,13 +42,12 @@ def parse_generic(json, origin):
         if inherits_description:
             write_text(json["description_append"], origin, c_format=False,
                        comment=comment + ["Partial description of \"{}\" to "
-                       "add to the end of its inherited description from \"{}\""
-                       .format(name, inherited_description_id)])
+                       "add to the end of its inherited description from "
+                       "\"{}\"".format(name, inherited_description_id)])
         else:
             write_text(json["description_append"], origin, c_format=False,
                        comment=comment + ["Partial description of \"{}\" to "
-                       "add to the end of \"{}\""
-                       .format(name, description)])
+                       "add to the end of \"{}\"".format(name, description)])
 
     if "use_action" in json:
         parse_use_action(json["use_action"], origin, name)

--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -33,7 +33,7 @@ def parse_generic(json, origin):
             write_text(json["description_prepend"], origin, c_format=False,
                        comment=comment + ["Partial description of \"{}\" to "
                        "add to the start of its inherited description from "
-                       "\"{}\"".format(name, inherited_description_id)])
+                                          "\"{}\"".format(name, inherited_description_id)])
         else:
             write_text(json["description_prepend"], origin, c_format=False,
                        comment=comment + ["Partial description of \"{}\" to "
@@ -43,7 +43,7 @@ def parse_generic(json, origin):
             write_text(json["description_append"], origin, c_format=False,
                        comment=comment + ["Partial description of \"{}\" to "
                        "add to the end of its inherited description from "
-                       "\"{}\"".format(name, inherited_description_id)])
+                                          "\"{}\"".format(name, inherited_description_id)])
         else:
             write_text(json["description_append"], origin, c_format=False,
                        comment=comment + ["Partial description of \"{}\" to "

--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -31,23 +31,21 @@ def parse_generic(json, origin):
     if "description_prepend" in json:
         if inherits_description:
             write_text(json["description_prepend"], origin, c_format=False,
-                       comment=comment + ["Partial description of \"{}\" to 
-                       add to the start of its inherited description from 
-                       \"{}\"".format(name, inherited_description_id)])
+                       comment=comment + ["Partial description of \"{}\" to add to the start of its inherited description from \"{}\""
+                       .format(name, inherited_description_id)])
         else:
             write_text(json["description_prepend"], origin, c_format=False,
-                       comment=comment + ["Partial description of \"{}\" to 
-                       add to the start of \"{}\"".format(name, description)])
+                       comment=comment + ["Partial description of \"{}\" to add to the start of \"{}\""
+                       .format(name, description)])
     if "description_append" in json:
         if inherits_description:
             write_text(json["description_append"], origin, c_format=False,
-                       comment=comment + ["Partial description of \"{}\" to 
-                       add to the end of its inherited description from 
-                       \"{}\"".format(name, inherited_description_id)])
+                       comment=comment + ["Partial description of \"{}\" to add to the end of its inherited description from \"{}\""
+                       .format(name, inherited_description_id)])
         else:
             write_text(json["description_append"], origin, c_format=False,
-                       comment=comment + ["Partial description of \"{}\" to 
-                       add to the end of \"{}\"".format(name, description)])
+                       comment=comment + ["Partial description of \"{}\" to add to the end of \"{}\""
+                       .format(name, description)])
 
     if "use_action" in json:
         parse_use_action(json["use_action"], origin, name)

--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -60,15 +60,15 @@ def parse_generic(json, origin):
             write_text(variant["name"], origin,
                     comment="Variant name of item \"{}\"".format(name),
                     plural=True)
-            if "description" in json["variants":
+            if "description" in json["variants"]:
                 write_text(variant["description"], origin,
                         comment="Description of variant \"{}\" of item \"{}\""
                         .format(variant_name, name))
-            if "description_prepend" in json["variants":
+            if "description_prepend" in json["variants"]:
                 write_text(variant["description_prepend"], origin,
                         comment="Partial description of variant \"{}\" of item \"{}\" to add to the start of \"{}\""
                         .format(variant_name, name, description))
-            if "description_append" in json["variants":
+            if "description_append" in json["variants"]:
                 write_text(variant["description_append"], origin,
                         comment="Partial description of variant \"{}\" of item \"{}\" to add to the end of \"{}\""
                         .format(variant_name, name, description))

--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -31,24 +31,23 @@ def parse_generic(json, origin):
     if "description_prepend" in json:
         if inherits_description:
             write_text(json["description_prepend"], origin, c_format=False,
-                       comment=comment +
-                       ["Partial description of \"{}\" to add to the start of its inherited description from \"{}\""
+                       comment=comment + ["Partial description of \"{}\" to "
+                       "add to the start of its inherited description from \"{}\""
                        .format(name, inherited_description_id)])
         else:
             write_text(json["description_prepend"], origin, c_format=False,
-                       comment=comment +
-                       ["Partial description of \"{}\" to add to the start of \"{}\""
-                       .format(name, description)])
+                       comment=comment + ["Partial description of \"{}\" to "
+                       "add to the start of \"{}\"".format(name, description)])
     if "description_append" in json:
         if inherits_description:
             write_text(json["description_append"], origin, c_format=False,
-                       comment=comment +
-                       ["Partial description of \"{}\" to add to the end of its inherited description from \"{}\""
+                       comment=comment + ["Partial description of \"{}\" to "
+                       "add to the end of its inherited description from \"{}\""
                        .format(name, inherited_description_id)])
         else:
             write_text(json["description_append"], origin, c_format=False,
-                       comment=comment +
-                       ["Partial description of \"{}\" to add to the end of \"{}\""
+                       comment=comment + ["Partial description of \"{}\" to "
+                       "add to the end of \"{}\""
                        .format(name, description)])
 
     if "use_action" in json:
@@ -69,17 +68,19 @@ def parse_generic(json, origin):
                        comment="Variant name of item \"{}\"".format(name),
                        plural=True)
             if "description" in json["variants"]:
-                write_text(variant["description"], origin, comment=
-                           "Description of variant \"{}\" of item \"{}\""
-                           .format(variant_name, name))
+                write_text(variant["description"], origin,
+                           comment="Description of variant \"{}\" of item "
+                           "\"{}\"".format(variant_name, name))
             if "description_prepend" in json["variants"]:
-                write_text(variant["description_prepend"], origin, comment=
-                           "Partial description of variant \"{}\" of item \"{}\" to add to the start of \"{}\""
-                        .format(variant_name, name, description))
+                write_text(variant["description_prepend"], origin,
+                           comment="Partial description of variant \"{}\" of "
+                           "item \"{}\" to add to the start of \"{}\""
+                           .format(variant_name, name, description))
             if "description_append" in json["variants"]:
                 write_text(variant["description_append"], origin,
-                        comment="Partial description of variant \"{}\" of item \"{}\" to add to the end of \"{}\""
-                        .format(variant_name, name, description))
+                           comment="Partial description of variant \"{}\" of "
+                           "item \"{}\" to add to the end of \"{}\""
+                           .format(variant_name, name, description))
 
     if "snippet_category" in json and type(json["snippet_category"]) is list:
         # snippet_category is either a simple string (the category ident)

--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -31,20 +31,24 @@ def parse_generic(json, origin):
     if "description_prepend" in json:
         if inherits_description:
             write_text(json["description_prepend"], origin, c_format=False,
-                       comment=comment + ["Partial description of \"{}\" to add to the start of its inherited description from \"{}\""
+                       comment=comment +
+                       ["Partial description of \"{}\" to add to the start of its inherited description from \"{}\""
                        .format(name, inherited_description_id)])
         else:
             write_text(json["description_prepend"], origin, c_format=False,
-                       comment=comment + ["Partial description of \"{}\" to add to the start of \"{}\""
+                       comment=comment +
+                       ["Partial description of \"{}\" to add to the start of \"{}\""
                        .format(name, description)])
     if "description_append" in json:
         if inherits_description:
             write_text(json["description_append"], origin, c_format=False,
-                       comment=comment + ["Partial description of \"{}\" to add to the end of its inherited description from \"{}\""
+                       comment=comment +
+                       ["Partial description of \"{}\" to add to the end of its inherited description from \"{}\""
                        .format(name, inherited_description_id)])
         else:
             write_text(json["description_append"], origin, c_format=False,
-                       comment=comment + ["Partial description of \"{}\" to add to the end of \"{}\""
+                       comment=comment +
+                       ["Partial description of \"{}\" to add to the end of \"{}\""
                        .format(name, description)])
 
     if "use_action" in json:
@@ -62,15 +66,15 @@ def parse_generic(json, origin):
         for variant in json["variants"]:
             variant_name = get_singular_name(variant["name"])
             write_text(variant["name"], origin,
-                    comment="Variant name of item \"{}\"".format(name),
-                    plural=True)
+                       comment="Variant name of item \"{}\"".format(name),
+                       plural=True)
             if "description" in json["variants"]:
-                write_text(variant["description"], origin,
-                        comment="Description of variant \"{}\" of item \"{}\""
-                        .format(variant_name, name))
+                write_text(variant["description"], origin, comment=
+                           "Description of variant \"{}\" of item \"{}\""
+                           .format(variant_name, name))
             if "description_prepend" in json["variants"]:
-                write_text(variant["description_prepend"], origin,
-                        comment="Partial description of variant \"{}\" of item \"{}\" to add to the start of \"{}\""
+                write_text(variant["description_prepend"], origin, comment=
+                           "Partial description of variant \"{}\" of item \"{}\" to add to the start of \"{}\""
                         .format(variant_name, name, description))
             if "description_append" in json["variants"]:
                 write_text(variant["description_append"], origin,

--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -66,16 +66,16 @@ def parse_generic(json, origin):
             write_text(variant["name"], origin,
                        comment="Variant name of item \"{}\"".format(name),
                        plural=True)
-            if "description" in json["variants"]:
+            if "description" in variant:
                 write_text(variant["description"], origin,
                            comment="Description of variant \"{}\" of item "
                            "\"{}\"".format(variant_name, name))
-            if "description_prepend" in json["variants"]:
+            if "description_prepend" in variant:
                 write_text(variant["description_prepend"], origin,
                            comment="Partial description of variant \"{}\" of "
                            "item \"{}\" to add to the start of \"{}\""
                            .format(variant_name, name, description))
-            if "description_append" in json["variants"]:
+            if "description_append" in variant:
                 write_text(variant["description_append"], origin,
                            comment="Partial description of variant \"{}\" of "
                            "item \"{}\" to add to the end of \"{}\""

--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -5,7 +5,14 @@ from ..write_text import write_text
 
 def parse_generic(json, origin):
     name = ""
+    description = ""
     comment = []
+    inherits_description = true
+    inherited_description_id = ""
+    if "copy-from" in json:
+        inherited_description_id = json["copy-from"]
+    if "//" in json:
+        comment.append(json["//"])
     if "//isbn13" in json:
         comment.append("ISBN {}".format(json["//isbn13"]))
 
@@ -19,6 +26,22 @@ def parse_generic(json, origin):
     if "description" in json:
         write_text(json["description"], origin, c_format=False,
                    comment=comment + ["Description of \"{}\"".format(name)])
+        description = json["description"]
+        inherits_description = false
+    if "description_prepend" in json:
+        if inherits_description:
+            write_text(json["description_prepend"], origin, c_format=False,
+                    comment=comment + ["Partial description of \"{}\" to add to the start of its inherited description from \"{}\"".format(name, inherited_description_id)])
+        else:
+            write_text(json["description_prepend"], origin, c_format=False,
+                    comment=comment + ["Partial description of \"{}\" to add to the start of \"{}\"".format(name, description)])
+    if "description_append" in json:
+        if inherits_description:
+            write_text(json["description_append"], origin, c_format=False,
+                    comment=comment + ["Partial description of \"{}\" to add to the end of its inherited description from \"{}\"".format(name, inherited_description_id)])
+        else:
+            write_text(json["description_append"], origin, c_format=False,
+                    comment=comment + ["Partial description of \"{}\" to add to the end of \"{}\"".format(name, description)])
 
     if "use_action" in json:
         parse_use_action(json["use_action"], origin, name)
@@ -35,11 +58,20 @@ def parse_generic(json, origin):
         for variant in json["variants"]:
             variant_name = get_singular_name(variant["name"])
             write_text(variant["name"], origin,
-                       comment="Variant name of item \"{}\"".format(name),
-                       plural=True)
-            write_text(variant["description"], origin,
-                       comment="Description of variant \"{1}\" of item \"{0}\""
-                       .format(name, variant_name))
+                    comment="Variant name of item \"{}\"".format(name),
+                    plural=True)
+            if "description" in json["variants":
+                write_text(variant["description"], origin,
+                        comment="Description of variant \"{}\" of item \"{}\""
+                        .format(variant_name, name))
+            if "description_prepend" in json["variants":
+                write_text(variant["description_prepend"], origin,
+                        comment="Partial description of variant \"{}\" of item \"{}\" to add to the start of \"{}\""
+                        .format(variant_name, name, description))
+            if "description_append" in json["variants":
+                write_text(variant["description_append"], origin,
+                        comment="Partial description of variant \"{}\" of item \"{}\" to add to the end of \"{}\""
+                        .format(variant_name, name, description))
 
     if "snippet_category" in json and type(json["snippet_category"]) is list:
         # snippet_category is either a simple string (the category ident)

--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -22,33 +22,6 @@ def parse_generic(json, origin):
                    plural=True, c_format=False)
     elif "id" in json:
         name = json["id"]
-
-    if "description" in json:
-        write_text(json["description"], origin, c_format=False,
-                   comment=comment + ["Description of \"{}\"".format(name)])
-        description = json["description"]
-        inherits_description = False
-    if "description_prepend" in json:
-        if inherits_description:
-            write_text(json["description_prepend"], origin, c_format=False,
-                       comment=comment + ["Partial description of \"{}\" to "
-                       "add to the start of its inherited description from "
-                                          "\"{}\"".format(name, inherited_description_id)])
-        else:
-            write_text(json["description_prepend"], origin, c_format=False,
-                       comment=comment + ["Partial description of \"{}\" to "
-                       "add to the start of \"{}\"".format(name, description)])
-    if "description_append" in json:
-        if inherits_description:
-            write_text(json["description_append"], origin, c_format=False,
-                       comment=comment + ["Partial description of \"{}\" to "
-                       "add to the end of its inherited description from "
-                                          "\"{}\"".format(name, inherited_description_id)])
-        else:
-            write_text(json["description_append"], origin, c_format=False,
-                       comment=comment + ["Partial description of \"{}\" to "
-                       "add to the end of \"{}\"".format(name, description)])
-
     if "use_action" in json:
         parse_use_action(json["use_action"], origin, name)
     if "tick_action" in json:
@@ -66,10 +39,6 @@ def parse_generic(json, origin):
             write_text(variant["name"], origin,
                        comment="Variant name of item \"{}\"".format(name),
                        plural=True)
-            if "description" in variant:
-                write_text(variant["description"], origin,
-                           comment="Description of variant \"{}\" of item "
-                           "\"{}\"".format(variant_name, name))
             if "description_prepend" in variant:
                 write_text(variant["description_prepend"], origin,
                            comment="Partial description of variant \"{}\" of "

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9344,22 +9344,12 @@ const // TODO: Fallback to type->extended_description() if variant description u
         return ""; // Shouldn't this throw an error?
     }
     auto variant = itype_variant();
-    if( !variant.alt_description.empty() ) {
-        return variant.alt_description.translated();
+    if( get_option<std::string>( "USE_LANG" ).empty() &&
+        to_translation( variant.alt_description.translated() ) == variant.alt_description ) {
+        // No translation found for variant description so fallback to base item description
+        return type->description.translated();
     }
-    translation ret( type->extended_description() );
-    if( !variant.alt_description_prepend.empty() ) {
-        ret = string_format( "%s  %s", variant.alt_description_prepend.translated(),
-                             ret );
-    }
-    if( !variant.alt_description_append.empty() ) {
-        ret = string_format( "%s  %s", ret,
-                             variant.alt_description_append.translated() );
-    }
-    if( get_option<std::string>( "USE_LANG" ).empty() && _( ret.translated() ) == ret ) { // No translation
-        return type->extended_description();
-    }
-    return _( ret );
+    return variant.alt_description.translated();
 }
 
 void item::clear_itype_variant()

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -387,7 +387,7 @@ item::item( const itype *type, time_point turn, int qty ) : type( type ), bday( 
         if( !type->extend_description ) {
             set_var( "description", SNIPPET.expand( type->description.translated() ) );
         } else {
-            set_var( "description", SNIPPET.expand( extended_description() ) );
+            set_var( "description", SNIPPET.expand( type->extended_description() ) );
         }
     }
 
@@ -2472,7 +2472,7 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
                 if( !type->extend_description ) {
                     info.emplace_back( "DESCRIPTION", type->description.translated() );
                 } else {
-                    info.emplace_back( "DESCRIPTION", extended_description() );
+                    info.emplace_back( "DESCRIPTION", type->extended_description() );
                 }
             }
         }
@@ -9357,18 +9357,11 @@ std::string item::variant_description() const
             return _( string_format( "%s  %s", type->description.translated(),
                                      itype_variant().alt_description.translated() ) );
         }
-        return _( string_format( "%s  %s", extended_description(),
+        return _( string_format( "%s  %s", type->extended_description(),
                                  itype_variant().alt_description.translated() ) );
     } else {
         return itype_variant().alt_description.translated();
     }
-}
-
-std::string item::extended_description() const
-{
-    return _( string_format( "%s  %s %s", type->description_prepend.translated(),
-                             type->description.translated(),
-                             type->description_append.translated() ) );
 }
 
 void item::clear_itype_variant()

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9351,31 +9351,25 @@ std::string item::variant_description() const
         return ""; // Shouldn't this throw an error?
     }
     auto variant = itype_variant();
-    std::string base_description;
+    std::string ret;
     if( variant.alt_description.empty() ) {
         if( type->extend_description ) {
-            base_description = type->description.translated();
+            ret = type->description.translated();
         } else {
-            base_description = type->extended_description();
+            ret = type->extended_description();
         }
     } else {
-        base_description = variant.alt_description.translated();
+        ret = variant.alt_description.translated();
     }
-    if( variant.alt_extend_description ) {
-        if( variant.alt_description_prepend.empty() ) {
-            return _( string_format( "%s  %s", base_description,
-                                     variant.alt_description_append.translated() ) );
-        } else if( variant.alt_description_append.empty() ) {
-            return _( string_format( "%s  %s", variant.alt_description_prepend.translated(),
-                                     base_description ) );
-        } else {
-            return _( string_format( "%s  %s  %s", variant.alt_description_prepend.translated(),
-                                     base_description,
-                                     variant.alt_description_append.translated() ) );
-        }
-    } else {
-        return base_description;
+    if( !variant.alt_description_prepend.empty() ) {
+        ret = string_format( "%s  %s", variant.alt_description_prepend.translated(),
+                             ret );
     }
+    if( !variant.alt_description_append.empty() ) {
+        ret = string_format( "%s  %s", ret,
+                             variant.alt_description_append.translated() );
+    }
+    return _( ret );
 }
 
 void item::clear_itype_variant()

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9348,19 +9348,33 @@ void item::set_itype_variant( const std::string &variant )
 std::string item::variant_description() const
 {
     if( !has_itype_variant() ) {
-        return "";
+        return ""; // Shouldn't this throw an error?
     }
-
-    // append the description instead of fully overwriting it
-    if( itype_variant().append ) {
-        if( !type->extend_description ) {
-            return _( string_format( "%s  %s", type->description.translated(),
-                                     itype_variant().alt_description.translated() ) );
+    auto variant = itype_variant();
+    std::string base_description;
+    if( variant.alt_description.empty() ) {
+        if( type->extend_description ) {
+            base_description = type->description.translated();
+        } else {
+            base_description = type->extended_description();
         }
-        return _( string_format( "%s  %s", type->extended_description(),
-                                 itype_variant().alt_description.translated() ) );
     } else {
-        return itype_variant().alt_description.translated();
+        base_description = variant.alt_description.translated();
+    }
+    if( variant.alt_extend_description ) {
+        if( variant.alt_description_prepend.empty() ) {
+            return _( string_format( "%s  %s", base_description,
+                                     variant.alt_description_append.translated() ) );
+        } else if( variant.alt_description_append.empty() ) {
+            return _( string_format( "%s  %s", variant.alt_description_prepend.translated(),
+                                     base_description ) );
+        } else {
+            return _( string_format( "%s  %s  %s", variant.alt_description_prepend.translated(),
+                                     base_description,
+                                     variant.alt_description_append.translated() ) );
+        }
+    } else {
+        return base_description;
     }
 }
 

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9354,9 +9354,9 @@ std::string item::variant_description() const
     std::string ret;
     if( variant.alt_description.empty() ) {
         if( type->extend_description ) {
-            ret = type->description.translated();
-        } else {
             ret = type->extended_description();
+        } else {
+            ret = type->description.translated();
         }
     } else {
         ret = variant.alt_description.translated();

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9344,12 +9344,10 @@ const // TODO: Fallback to type->extended_description() if variant description u
         return ""; // Shouldn't this throw an error?
     }
     auto variant = itype_variant();
-    std::string ret;
-    if( variant.alt_description.empty() ) {
-        ret = type->extended_description();
-    } else {
-        ret = variant.alt_description.translated(); // Just return?
+    if( !variant.alt_description.empty() ) {
+        return variant.alt_description.translated();
     }
+    translation ret( type->extended_description() );
     if( !variant.alt_description_prepend.empty() ) {
         ret = string_format( "%s  %s", variant.alt_description_prepend.translated(),
                              ret );
@@ -9357,6 +9355,9 @@ const // TODO: Fallback to type->extended_description() if variant description u
     if( !variant.alt_description_append.empty() ) {
         ret = string_format( "%s  %s", ret,
                              variant.alt_description_append.translated() );
+    }
+    if( get_option<std::string>( "USE_LANG" ).empty() && _( ret.translated() ) == ret ) { // No translation
+        return type->extended_description();
     }
     return _( ret );
 }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -9337,7 +9337,8 @@ void item::set_itype_variant( const std::string &variant )
     debugmsg( "item '%s' has no variant '%s'!", typeId().str(), variant );
 }
 
-std::string item::variant_description() const
+std::string item::variant_description()
+const // TODO: Fallback to type->extended_description() if variant description untranslated
 {
     if( !has_itype_variant() ) {
         return ""; // Shouldn't this throw an error?
@@ -9347,7 +9348,7 @@ std::string item::variant_description() const
     if( variant.alt_description.empty() ) {
         ret = type->extended_description();
     } else {
-        ret = variant.alt_description.translated();
+        ret = variant.alt_description.translated(); // Just return?
     }
     if( !variant.alt_description_prepend.empty() ) {
         ret = string_format( "%s  %s", variant.alt_description_prepend.translated(),
@@ -9357,7 +9358,7 @@ std::string item::variant_description() const
         ret = string_format( "%s  %s", ret,
                              variant.alt_description_append.translated() );
     }
-    return ret;
+    return _( ret );
 }
 
 void item::clear_itype_variant()

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -384,11 +384,7 @@ item::item( const itype *type, time_point turn, int qty ) : type( type ), bday( 
     }
 
     if( type->expand_snippets ) {
-        if( !type->extend_description ) {
-            set_var( "description", SNIPPET.expand( type->description.translated() ) );
-        } else {
-            set_var( "description", SNIPPET.expand( type->extended_description() ) );
-        }
+        set_var( "description", SNIPPET.expand( type->extended_description() ) );
     }
 
     if( has_itype_variant() && itype_variant().expand_snippets ) {
@@ -2469,11 +2465,7 @@ void item::basic_info( std::vector<iteminfo> &info, const iteminfo_query *parts,
                                    craft_data_->making->result_name(),
                                    percent_progress ) );
             } else {
-                if( !type->extend_description ) {
-                    info.emplace_back( "DESCRIPTION", type->description.translated() );
-                } else {
-                    info.emplace_back( "DESCRIPTION", type->extended_description() );
-                }
+                info.emplace_back( "DESCRIPTION", type->extended_description() );
             }
         }
         insert_separation_line( info );
@@ -9353,11 +9345,7 @@ std::string item::variant_description() const
     auto variant = itype_variant();
     std::string ret;
     if( variant.alt_description.empty() ) {
-        if( type->extend_description ) {
-            ret = type->extended_description();
-        } else {
-            ret = type->description.translated();
-        }
+        ret = type->extended_description();
     } else {
         ret = variant.alt_description.translated();
     }
@@ -9369,7 +9357,7 @@ std::string item::variant_description() const
         ret = string_format( "%s  %s", ret,
                              variant.alt_description_append.translated() );
     }
-    return _( ret );
+    return ret;
 }
 
 void item::clear_itype_variant()

--- a/src/item.h
+++ b/src/item.h
@@ -2396,6 +2396,9 @@ class item : public visitable
 
         void clear_itype_variant();
 
+        // Extended description after appending
+        std::string extended_description() const;
+
         // Description of the item provided by the variant, or an empty string
         std::string variant_description() const;
 

--- a/src/item.h
+++ b/src/item.h
@@ -2396,9 +2396,6 @@ class item : public visitable
 
         void clear_itype_variant();
 
-        // Extended description after appending
-        std::string extended_description() const;
-
         // Description of the item provided by the variant, or an empty string
         std::string variant_description() const;
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4212,6 +4212,16 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         jo.read( "description", def.description );
     }
 
+    if( jo.has_member( "description_prepend" ) ) {
+        jo.read( "description_prepend", def.description_prepend );
+        def.extend_description = true;
+    }
+
+    if( jo.has_member( "description_append" ) ) {
+        jo.read( "description_append", def.description_append );
+        def.extend_description = true;
+    }
+
     if( jo.has_string( "symbol" ) ) {
         def.sym = jo.get_string( "symbol" );
     }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4210,6 +4210,11 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
 
     if( jo.has_member( "description" ) ) {
         jo.read( "description", def.description );
+    } else if( !def.description.empty() && ( !def.description_prepend.empty() ||
+               !def.description_append.empty() ) ) {
+        def.description = no_translation( def.extended_description() );
+        def.description_prepend = no_translation( "" );
+        def.description_append = no_translation( "" );
     }
 
     if( jo.has_member( "description_prepend" ) ) {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4217,26 +4217,24 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         jo.throw_error( "name unspecified for item type" );
     }
 
-    if( jo.has_member( "description" ) ) {
-        jo.read( "description", def.description );
-    } else if( !def.description.empty() && ( !def.description_prepend.empty() ||
-               !def.description_append.empty() ) ) {
+    if( !jo.read( "description", def.description ) && ( !def.description_prepend.empty() ||
+            !def.description_append.empty() ) ) {
+        if( !jo.read( "inherit_extended_description", def.inherit_extended_description ) ) {
+            def.inherit_extended_description = true;
+        }
         if( def.inherit_extended_description ) {
             def.description = no_translation( def.extended_description() );
         }
-        def.description_prepend = no_translation( "" );
-        def.description_append = no_translation( "" );
-        def.extend_description = false;
     }
-
+    def.description_prepend = no_translation( "" );
+    def.description_append = no_translation( "" );
+    def.extend_description = false;
     if( jo.read( "description_prepend", def.description_prepend ) ) {
         def.extend_description = true;
     }
     if( jo.read( "description_append", def.description_append ) ) {
         def.extend_description = true;
     }
-
-    jo.read( "inherit_extended_description", def.inherit_extended_description, true );
 
     if( jo.has_string( "symbol" ) ) {
         def.sym = jo.get_string( "symbol" );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4215,6 +4215,7 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         def.description = no_translation( def.extended_description() );
         def.description_prepend = no_translation( "" );
         def.description_append = no_translation( "" );
+        def.extend_description = false;
     }
 
     if( jo.has_member( "description_prepend" ) ) {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2778,16 +2778,12 @@ void itype_variant_data::load( const JsonObject &jo )
     if( jo.has_member( "description" ) ) {
         if( jo.has_bool( "append" ) && jo.get_bool( "append" ) ) { // Legacy behaviour
             jo.read( "description", alt_description_append );
-            alt_extend_description = true;
         } else {
             jo.read( "description", alt_description );
         }
     }
-
-    if( jo.read( "description_prepend", alt_description_prepend ) ||
-        jo.read( "description_append", alt_description_append ) ) {
-        alt_extend_description = true;
-    }
+    jo.read( "description_prepend", alt_description_prepend );
+    jo.read( "description_append", alt_description_append );
 
     optional( jo, false, "symbol", alt_sym, std::nullopt );
     if( jo.has_string( "color" ) ) {

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4229,8 +4229,10 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         def.extend_description = false;
     }
 
-    if( jo.read( "description_prepend", def.description_prepend ) ||
-        jo.read( "description_append", def.description_append ) ) {
+    if( jo.read( "description_prepend", def.description_prepend ) ) {
+        def.extend_description = true;
+    }
+    if( jo.read( "description_append", def.description_append ) ) {
         def.extend_description = true;
     }
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -4221,21 +4221,20 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         jo.read( "description", def.description );
     } else if( !def.description.empty() && ( !def.description_prepend.empty() ||
                !def.description_append.empty() ) ) {
-        def.description = no_translation( def.extended_description() );
+        if( def.inherit_extended_description ) {
+            def.description = no_translation( def.extended_description() );
+        }
         def.description_prepend = no_translation( "" );
         def.description_append = no_translation( "" );
         def.extend_description = false;
     }
 
-    if( jo.has_member( "description_prepend" ) ) {
-        jo.read( "description_prepend", def.description_prepend );
+    if( jo.read( "description_prepend", def.description_prepend ) ||
+        jo.read( "description_append", def.description_append ) ) {
         def.extend_description = true;
     }
 
-    if( jo.has_member( "description_append" ) ) {
-        jo.read( "description_append", def.description_append );
-        def.extend_description = true;
-    }
+    jo.read( "inherit_extended_description", def.inherit_extended_description, true );
 
     if( jo.has_string( "symbol" ) ) {
         def.sym = jo.get_string( "symbol" );

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2774,14 +2774,27 @@ void itype_variant_data::load( const JsonObject &jo )
     alt_name.make_plural();
     mandatory( jo, false, "id", id );
     mandatory( jo, false, "name", alt_name );
-    mandatory( jo, false, "description", alt_description );
+
+    if( jo.has_member( "description" ) ) {
+        if( jo.has_bool( "append" ) && jo.get_bool( "append" ) ) { // Legacy behaviour
+            jo.read( "description", alt_description_append );
+            alt_extend_description = true;
+        } else {
+            jo.read( "description", alt_description );
+        }
+    }
+
+    if( jo.read( "description_prepend", alt_description_prepend ) ||
+        jo.read( "description_append", alt_description_append ) ) {
+        alt_extend_description = true;
+    }
+
     optional( jo, false, "symbol", alt_sym, std::nullopt );
     if( jo.has_string( "color" ) ) {
         alt_color = color_from_string( jo.get_string( "color" ) );
     }
     optional( jo, false, "ascii_picture", art );
     optional( jo, false, "weight", weight, 1 );
-    optional( jo, false, "append", append );
     optional( jo, false, "expand_snippets", expand_snippets );
 }
 

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -167,7 +167,7 @@ std::string itype::extended_description() const
     if( !description_append.empty() ) {
         ret = string_format( "%s  %s", ret, description_append.translated() );
     }
-    return ret;
+    return _( ret );
 }
 
 // Members of iuse struct, which is slowly morphing into a class.

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -158,13 +158,13 @@ int itype::charges_per_volume( const units::volume &vol ) const
 std::string itype::extended_description() const
 {
     if( description_prepend.empty() ) {
-        return _( string_format( "%s %s", description.translated(),
+        return _( string_format( "%s  %s", description.translated(),
                                  description_append.translated() ) );
     } else if( description_append.empty() ) {
-        return _( string_format( "%s %s", description_prepend.translated(),
-                                 description.translated(), ) );
+        return _( string_format( "%s  %s", description_prepend.translated(),
+                                 description.translated() ) );
     } else {
-        return _( string_format( "%s %s %s", description_prepend.translated(),
+        return _( string_format( "%s  %s  %s", description_prepend.translated(),
                                  description.translated(),
                                  description_append.translated() ) );
     }

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -158,15 +158,16 @@ int itype::charges_per_volume( const units::volume &vol ) const
 std::string itype::extended_description() const
 {
     std::string ret = description.translated();
+    if( !extend_description ) {
+        return ret;
+    }
     if( !description_prepend.empty() ) {
-        ret = string_format( "%s  %s", description_prepend.translated(),
-                             ret );
+        ret = string_format( "%s  %s", description_prepend.translated(), ret );
     }
     if( !description_append.empty() ) {
-        ret = string_format( "%s  %s", ret,
-                             description_append.translated() );
+        ret = string_format( "%s  %s", ret, description_append.translated() );
     }
-    return _( ret );
+    return ret;
 }
 
 // Members of iuse struct, which is slowly morphing into a class.

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -155,14 +155,14 @@ int itype::charges_per_volume( const units::volume &vol ) const
     return ( count_by_charges() ? stack_size : 1 ) * vol / volume;
 }
 
-std::string itype::extended_description( const bool append = true, const bool prepend = true ) const
+std::string itype::extended_description() const
 {
     std::string ret = description.translated();
-    if( prepend && !description_prepend.empty() ) {
+    if( !description_prepend.empty() ) {
         ret = string_format( "%s  %s", description_prepend.translated(),
                              ret );
     }
-    if( append && !description_append.empty() ) {
+    if( !description_append.empty() ) {
         ret = string_format( "%s  %s", ret,
                              description_append.translated() );
     }

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -155,19 +155,18 @@ int itype::charges_per_volume( const units::volume &vol ) const
     return ( count_by_charges() ? stack_size : 1 ) * vol / volume;
 }
 
-std::string itype::extended_description() const
+std::string itype::extended_description( const bool append = true, const bool prepend = true ) const
 {
-    if( description_prepend.empty() ) {
-        return _( string_format( "%s  %s", description.translated(),
-                                 description_append.translated() ) );
-    } else if( description_append.empty() ) {
-        return _( string_format( "%s  %s", description_prepend.translated(),
-                                 description.translated() ) );
-    } else {
-        return _( string_format( "%s  %s  %s", description_prepend.translated(),
-                                 description.translated(),
-                                 description_append.translated() ) );
+    std::string ret = description.translated();
+    if( prepend && !description_prepend.empty() ) {
+        ret = string_format( "%s  %s", description_prepend.translated(),
+                             ret );
     }
+    if( append && !description_append.empty() ) {
+        ret = string_format( "%s  %s", ret,
+                             description_append.translated() );
+    }
+    return _( ret );
 }
 
 // Members of iuse struct, which is slowly morphing into a class.

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -157,9 +157,17 @@ int itype::charges_per_volume( const units::volume &vol ) const
 
 std::string itype::extended_description() const
 {
-    return _( string_format( "%s %s %s", description_prepend.translated(),
-                             description.translated(),
-                             description_append.translated() ) );
+    if( description_prepend.empty() ) {
+        return _( string_format( "%s %s", description.translated(),
+                                 description_append.translated() ) );
+    } else if( description_append.empty() ) {
+        return _( string_format( "%s %s", description_prepend.translated(),
+                                 description.translated(), ) );
+    } else {
+        return _( string_format( "%s %s %s", description_prepend.translated(),
+                                 description.translated(),
+                                 description_append.translated() ) );
+    }
 }
 
 // Members of iuse struct, which is slowly morphing into a class.

--- a/src/itype.cpp
+++ b/src/itype.cpp
@@ -155,6 +155,13 @@ int itype::charges_per_volume( const units::volume &vol ) const
     return ( count_by_charges() ? stack_size : 1 ) * vol / volume;
 }
 
+std::string itype::extended_description() const
+{
+    return _( string_format( "%s %s %s", description_prepend.translated(),
+                             description.translated(),
+                             description_append.translated() ) );
+}
+
 // Members of iuse struct, which is slowly morphing into a class.
 bool itype::has_use() const
 {

--- a/src/itype.h
+++ b/src/itype.h
@@ -1339,11 +1339,11 @@ struct itype {
         translation description_prepend;
         // Flavor text to add to the end of the description
         translation description_append;
-        // Whether the desciption needs appending/prepending
+        // Whether the desciption needs appending/prepending/both
         bool extend_description = false;
-        // Whether the inherited item should use the extended base item's desciption
+        // Whether the inherited item should use the base item's extended_desciption()
         bool inherit_extended_description = true;
-        // Extended description after appending // No idea if this belongs here or not
+        // Extended description after prepending/appending/both
         std::string extended_description() const;
 
     protected:

--- a/src/itype.h
+++ b/src/itype.h
@@ -657,7 +657,6 @@ struct itype_variant_data {
     translation alt_description;
     translation alt_description_append;
     translation alt_description_prepend;
-    bool alt_extend_description = false;
     ascii_art_id art;
     std::optional<std::string> alt_sym;
     std::optional<nc_color> alt_color = std::nullopt;

--- a/src/itype.h
+++ b/src/itype.h
@@ -1334,6 +1334,9 @@ struct itype {
         explosion_data explosion;
 
         translation description; // Flavor text
+        translation description_prepend; // Flavor text to add to the front of the description
+        translation description_append; // Flavor text to add to the end of the description
+        bool extend_description = false; // Whether the desciption needs appending/prepending
 
     protected:
         // private because is should only be accessed through itype::nname!

--- a/src/itype.h
+++ b/src/itype.h
@@ -1338,6 +1338,9 @@ struct itype {
         translation description_append; // Flavor text to add to the end of the description
         bool extend_description = false; // Whether the desciption needs appending/prepending
 
+        std::string extended_description()
+        const; // Extended description after appending // No idea if this belongs here or not
+
     protected:
         // private because is should only be accessed through itype::nname!
         // nname() is used for display purposes

--- a/src/itype.h
+++ b/src/itype.h
@@ -655,11 +655,12 @@ struct itype_variant_data {
     std::string id;
     translation alt_name;
     translation alt_description;
+    translation alt_description_append;
+    translation alt_description_prepend;
+    bool alt_extend_description = false;
     ascii_art_id art;
     std::optional<std::string> alt_sym;
     std::optional<nc_color> alt_color = std::nullopt;
-
-    bool append = false; // if the description should be appended to the base description.
     // Expand the description when generated and save it on the item
     bool expand_snippets = false;
 

--- a/src/itype.h
+++ b/src/itype.h
@@ -1332,19 +1332,14 @@ struct itype {
         cata::value_ptr<memory_card_info> memory_card_data;
         // How should the item explode
         explosion_data explosion;
-
         // Flavor text
         translation description;
-        // Flavor text to add to the front of the description
-        translation description_prepend;
-        // Flavor text to add to the end of the description
-        translation description_append;
-        // Whether the desciption needs appending/prepending/both
-        bool extend_description = false;
+        // Extended description that may be inherited
+        std::string extended_description;
+        // Partial description that may be inherited
+        std::string unextended_description;
         // Whether the inherited item should use the base item's extended_desciption()
         bool inherit_extended_description = true;
-        // Extended description after prepending/appending/both
-        std::string extended_description() const;
 
     protected:
         // private because is should only be accessed through itype::nname!

--- a/src/itype.h
+++ b/src/itype.h
@@ -1333,13 +1333,18 @@ struct itype {
         // How should the item explode
         explosion_data explosion;
 
-        translation description; // Flavor text
-        translation description_prepend; // Flavor text to add to the front of the description
-        translation description_append; // Flavor text to add to the end of the description
-        bool extend_description = false; // Whether the desciption needs appending/prepending
-
-        std::string extended_description()
-        const; // Extended description after appending // No idea if this belongs here or not
+        // Flavor text
+        translation description;
+        // Flavor text to add to the front of the description
+        translation description_prepend;
+        // Flavor text to add to the end of the description
+        translation description_append;
+        // Whether the desciption needs appending/prepending
+        bool extend_description = false;
+        // Whether the inherited item should use the extended base item's desciption
+        bool inherit_extended_description = true;
+        // Extended description after appending // No idea if this belongs here or not
+        std::string extended_description() const;
 
     protected:
         // private because is should only be accessed through itype::nname!


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Aid for #71112 and #70352
Less repetition -> less translation needed + less typo opportunities + less bloat -> yay

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds optional "description_prepend" and "description_append" to items and item variants that add text to the start or end of the description respectively. Combined with copy-from this allows adding to descriptions without repetition.
Adds a disgustingly named (please suggest alternatives) "inherit_extended_description" bool that defaults to true but can be specified to false in which case items that inherit from that item will only use the "description" not the extended description after prepending/appending/both, useful for stuff like steel grades where the base item can append its grade without it being inherited to save adding abstract entries for all steel graded stuff.
The old "append" behaviour for item variants is still supported to avoid making this PR harder to review, will remove in a follow-up PR.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Adding better context to translator comments but that would require searching through the json to find information about copy-from members which is probably expensive even without doing it recursively and only checking the same file
I've no idea if extended_description() is defined in a sensible place nor whether everything should be public
Idk if there's much performance benefit if any to having the extend_description bool

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested with custom test stuff like below and the changes in the PR
```
  {
    "id": "magic_1_ball",
    "type": "GENERIC",
    "category": "other",
    "name": { "str": "Magic 1-Ball" },
    "description": "Once I were a 1-Ball.",
    ...
  },
  {
    "id": "magic_2_ball",
    "type": "GENERIC",
    "copy-from": "magic_1_ball",
    "name": { "str": "Magic 2-Ball" },
    "description_prepend": "Twice a 2-Ball.",
    "description_append": "Twice a 2-Ball."
  },
  {
    "id": "magic_3_ball",
    "type": "GENERIC",
    "copy-from": "magic_2_ball",
    "name": { "str": "Magic 3-Ball" },
    "description_append": "I even became a 3-Ball."
  },
  {
    "id": "magic_4_ball",
    "type": "GENERIC",
    "copy-from": "magic_3_ball",
    "name": { "str": "Magic 4-Ball" },
    "description_prepend": "I came to be a 4-Ball.",
    "description_append": "But decided a 4-Ball was my true form."
  },
```

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/df724209-ebb8-4168-b629-21a3b8c4d03f)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
