### PR TITLE
Update non-forged caltrops recipe

### DIFF
--- a/data/json/recipes/recipe_traps.json
+++ b/data/json/recipes/recipe_traps.json
@@ -38,11 +38,12 @@
     "skill_used": "fabrication",
     "skills_required": [ "traps", 2 ],
     "difficulty": 3,
-    "time": "30 m",
+    "time": "20 m",
     "autolearn": true,
-    "qualities": [ { "id": "HAMMER", "level": 1 } ],
-    "tools": [ [ [ "boltcutters", -1 ], [ "toolset", -1 ] ] ],
-    "components": [ [ [ "wire_barbed", 3 ], [ "wire", 9 ], [ "nail", 10 ], [ "bronze_nail", 10 ] ] ]
+    "using": [ [ "welding_standard", 5 ] ],
+    "proficiencies": [ { "proficiency": "prof_welding_basic" }, { "proficiency": "prof_metalworking" } ],
+    "qualities": [ { "id": "HAMMER", "level": 2 }, { "id": "SAW_M", "level": 1 }, { "id": "VISE", "level": 1 } ],
+    "components": [ [ [ "wire_barbed", 10 ], [ "wire", 10 ], [ "nail", 10 ], [ "bronze_nail", 10 ] ] ]
   },
   {
     "type": "recipe",


### PR DESCRIPTION
#### Summary
Balance "Caltrops from nails/wire make sense"

#### Purpose of change

Non-forged caltrops can only be made with bolt cutters or the integrated multitool to create the edge, and have no binder to keep the two nails/wires of each caltrop from pushing apart.

#### Describe the solution

Add welding them together, change specified tool requirements to metal sawing. Lowered base time to 20m(45m w/ no profs).

#### Describe alternatives you've considered

-Adding metal sawing 1 to bolt cutters so they can still be made w/ those like https://www.youtube.com/watch?v=UXu2PKi81V0 demonstrates. Those aren't sharp enough for anti-personnel according to video maker, so I decided not to.

-Remove wire options for being too squashable.

-Metal sawing 2 instead of 1

#### Testing

![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/99621099/058516d3-ed44-4a91-9c0c-36bf44835563)

#### Additional context

https://www.youtube.com/watch?v=njO0Cab4En4 Reference fabrication video ~~for Loctite cap holders~~
Making five caltrops as implied by our components takes less than 20m, but I rounded up.
