### PR TITLE
inv_ui: always use alpha invlets for multiselector

### DIFF
--- a/src/faction_camp.cpp
+++ b/src/faction_camp.cpp
@@ -4944,7 +4944,6 @@ drop_locations basecamp::give_basecamp_equipment( inventory_filter_preset &prese
 {
     inventory_multiselector inv_s( get_player_character(), preset, column_title );
 
-    inv_s.set_invlet_type( inventory_selector::SELECTOR_INVLET_ALPHA );
     inv_s.add_basecamp_items( *this );
     inv_s.set_title( title );
 
@@ -4990,7 +4989,6 @@ drop_locations basecamp::give_equipment( Character *pc, const inventory_filter_p
     inventory_multiselector inv_s( *pc, preset, msg,
                                    make_raw_stats, /*allow_select_contained =*/ true );
 
-    inv_s.set_invlet_type( inventory_selector::SELECTOR_INVLET_ALPHA );
     inv_s.add_character_items( *pc );
     inv_s.add_nearby_items( PICKUP_RANGE );
     inv_s.set_title( title );
@@ -5038,8 +5036,6 @@ drop_locations basecamp::get_equipment( tinymap *target_bay, const tripoint &tar
 
     inventory_multiselector inv_s( *pc, preset, msg,
                                    make_raw_stats, /*allow_select_contained =*/ true );
-
-    inv_s.set_invlet_type( inventory_selector::SELECTOR_INVLET_ALPHA );
 
     inv_s.add_remote_map_items( target_bay, target );
     inv_s.set_title( title );

--- a/src/game_inventory.cpp
+++ b/src/game_inventory.cpp
@@ -1624,7 +1624,6 @@ drop_locations game_menus::inv::ebooksave( Character &who, item_location &ereade
 
     inventory_multiselector inv_s( who, preset, _( "SELECT BOOKS TO SCAN" ),
                                    make_raw_stats, /*allow_select_contained=*/true );
-    inv_s.set_invlet_type( inventory_selector::SELECTOR_INVLET_ALPHA );
     inv_s.add_character_items( who );
     inv_s.add_nearby_items( PICKUP_RANGE );
     inv_s.set_title( _( "Scan which books?" ) );

--- a/src/inventory_ui.cpp
+++ b/src/inventory_ui.cpp
@@ -3501,6 +3501,7 @@ inventory_multiselector::inventory_multiselector( Character &p,
     ctxt.register_action( "DECREASE_COUNT" );
 
     max_chosen_count = std::numeric_limits<decltype( max_chosen_count )>::max();
+    set_invlet_type( inventory_selector::SELECTOR_INVLET_ALPHA );
 
     for( inventory_column * const &elem : get_all_columns() ) {
         elem->set_multiselect( true );
@@ -4475,7 +4476,6 @@ trade_selector::trade_selector( trade_ui *parent, Character &u,
     ctxt.register_action( ACTION_BANKBALANCE );
     resize( size, origin );
     _ui = create_or_get_ui_adaptor();
-    set_invlet_type( inventory_selector::SELECTOR_INVLET_ALPHA );
 }
 
 trade_selector::select_t trade_selector::to_trade() const

--- a/src/iuse.cpp
+++ b/src/iuse.cpp
@@ -8473,7 +8473,6 @@ std::optional<int> iuse::wash_items( Character *p, bool soft_items, bool hard_it
     };
     inventory_multiselector inv_s( *p, preset, _( "ITEMS TO CLEAN" ),
                                    make_raw_stats, /*allow_select_contained=*/true );
-    inv_s.set_invlet_type( inventory_selector::SELECTOR_INVLET_ALPHA );
     inv_s.add_character_items( *p );
     inv_s.add_nearby_items( PICKUP_RANGE );
     inv_s.set_title( _( "Multiclean" ) );


### PR DESCRIPTION

#### Summary
None

#### Purpose of change
Some inventory_ui multiselectors still use numeric invlets, which conflict with amount selection.

#### Describe the solution
Set multiselector to use alphabetic invlets by default

#### Describe alternatives you've considered
Waiting for imgui

#### Testing
Insert into item, multidrop, compare, pickup, multi-unload, etc should show alphabetic invlets and typing numbers should select amount instead

Before:
![Screenshot from 2024-01-21 05-14-00](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/9beb18e1-caef-4fe0-a76a-c0bba3adf72f)


After:

![Screenshot from 2024-01-21 05-15-27](https://github.com/CleverRaven/Cataclysm-DDA/assets/68240139/2a910495-4e41-4bc0-b17a-f3d7a956a369)


#### Additional context
N/A
