### PR TITLE
Add ASCII Art Separation Line

### DIFF
--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5930,6 +5930,7 @@ void item::ascii_art_info( std::vector<iteminfo> &info, const iteminfo_query * /
             art = itype_variant().art;
         }
         if( art.is_valid() ) {
+            insert_separation_line( info );
             for( const std::string &line : art->picture ) {
                 info.emplace_back( "DESCRIPTION", line );
             }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5931,6 +5931,7 @@ void item::ascii_art_info( std::vector<iteminfo> &info, const iteminfo_query * /
         }
         if( art.is_valid() ) {
             insert_separation_line( info );
+            
             for( const std::string &line : art->picture ) {
                 info.emplace_back( "DESCRIPTION", line );
             }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -5931,7 +5931,6 @@ void item::ascii_art_info( std::vector<iteminfo> &info, const iteminfo_query * /
         }
         if( art.is_valid() ) {
             insert_separation_line( info );
-            
             for( const std::string &line : art->picture ) {
                 info.emplace_back( "DESCRIPTION", line );
             }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Added a separation line above the ASCII art section in item descriptions."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Resolves #68682 It can be difficult to tell in some cases which part of the item description is part of the ASCII art and which part is not.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adding a separation line, like many other item info sections have, makes it much easier to tell which part is which. It's not a huge change but I think it helps readability, and functions a little more consistently with how other sections behave.
The separation line is drawn only when the ASCII art section is also drawn (ASCII art is enabled and valid art is found) which is consistent with how other separation lines are used elsewhere.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not adding the separation line.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
I built the game from a recent experimental build and examined items in various contexts that both had and didn't have ASCII art. Everything behaved as expected, where the line only shows up if an item has art, and doesn't otherwise.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
