### PR TITLE
Unhardcode deconstruction giving skill

### DIFF
--- a/data/json/furniture_and_terrain/furniture-industrial.json
+++ b/data/json/furniture_and_terrain/furniture-industrial.json
@@ -275,7 +275,7 @@
     "required_str": -1,
     "flags": [ "TRANSPARENT", "CONTAINER", "SEALED", "FLAMMABLE", "PLACE_ITEM" ],
     "deconstruct": {
-      "skill": { "skill": "electronics", "amount": 40, "min": 1, "max": 8 },
+      "skill": { "skill": "electronics", "min": 1, "max": 8 },
       "items": [
         { "item": "wire", "count": [ 1, 3 ] },
         { "item": "pipe", "count": [ 1, 2 ] },

--- a/data/json/furniture_and_terrain/furniture-industrial.json
+++ b/data/json/furniture_and_terrain/furniture-industrial.json
@@ -275,6 +275,7 @@
     "required_str": -1,
     "flags": [ "TRANSPARENT", "CONTAINER", "SEALED", "FLAMMABLE", "PLACE_ITEM" ],
     "deconstruct": {
+      "skill": { "skill": "electronics", "amount": 40, "min": 1, "max": 8 },
       "items": [
         { "item": "wire", "count": [ 1, 3 ] },
         { "item": "pipe", "count": [ 1, 2 ] },

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -14,7 +14,7 @@
     "connect_groups": "COUNTER",
     "connects_to": "COUNTER",
     "deconstruct": {
-      "skill": { "skill": "electronics", "amount": 20, "min": 1, "max": 4 },
+      "skill": { "skill": "electronics", "multiplier": 0.5, "min": 1, "max": 4 },
       "furn_set": "f_counter",
       "items": [
         { "item": "processor", "count": [ 1, 2 ] },
@@ -65,7 +65,7 @@
     "connect_groups": "COUNTER",
     "connects_to": "COUNTER",
     "deconstruct": {
-      "skill": { "skill": "electronics", "amount": 40, "min": 1, "max": 8 },
+      "skill": { "skill": "electronics", "min": 1, "max": 8 },
       "furn_set": "f_counter",
       "items": [
         { "item": "processor", "count": [ 1, 2 ] },
@@ -113,6 +113,7 @@
     "required_str": -1,
     "flags": [ "TRANSPARENT", "NOITEM", "INDOORS", "SHORT", "PERMEABLE" ],
     "deconstruct": {
+      "skill": { "skill": "electronics", "min": 1, "max": 8 },
       "furn_set": "f_table",
       "items": [
         { "item": "processor", "count": [ 1, 2 ] },

--- a/data/json/furniture_and_terrain/furniture-tools.json
+++ b/data/json/furniture_and_terrain/furniture-tools.json
@@ -14,6 +14,7 @@
     "connect_groups": "COUNTER",
     "connects_to": "COUNTER",
     "deconstruct": {
+      "skill": { "skill": "electronics", "amount": 20, "min": 1, "max": 4 },
       "furn_set": "f_counter",
       "items": [
         { "item": "processor", "count": [ 1, 2 ] },
@@ -64,6 +65,7 @@
     "connect_groups": "COUNTER",
     "connects_to": "COUNTER",
     "deconstruct": {
+      "skill": { "skill": "electronics", "amount": 40, "min": 1, "max": 8 },
       "furn_set": "f_counter",
       "items": [
         { "item": "processor", "count": [ 1, 2 ] },

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -5605,7 +5605,7 @@ This terrain is the roof of the tile below it, try to destroy that too. Further 
 {
     "furn_set": "f_safe",
     "ter_set": "t_dirt",
-    "skill": { "skill": "electronics", "amount": 40, "min": 1, "max": 8 },
+    "skill": { "skill": "electronics", "multiplier": 0.5, "min": 1, "max": 8 },
     "items": "deconstructed_item_result_group"
 }
 ```
@@ -5616,7 +5616,9 @@ The terrain / furniture that will be set after the original has been deconstruct
 
 ##### `skill`
 
-(Optional) The skill that will be practised after deconstruction. Amount is the amount of xp given, min is the minimum level to recieve xp, max is the level cap after which no xp is recieved but practise still occurs delaying rust.
+(Optional) The skill that will be practised after deconstruction.
+Min is the minimum level to recieve xp, max is the level cap after which no xp is recieved but practise still occurs delaying rust and multiplier multiplies the base xp given which is based on the mean of min and max.
+If skill is specified, multiplier defaults to 1.0, min to 0 and max to 10.
 
 ##### `items`
 

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -235,6 +235,7 @@ Use the `Home` key to return to the top.
         - [`items`](#items-1)
       - [`map_deconstruct_info`](#map_deconstruct_info)
         - [`furn_set`, `ter_set`](#furn_set-ter_set-1)
+        - [`skill`](#skill)
         - [`items`](#items-2)
       - [`plant_data`](#plant_data-1)
         - [`transform`](#transform)
@@ -5604,6 +5605,7 @@ This terrain is the roof of the tile below it, try to destroy that too. Further 
 {
     "furn_set": "f_safe",
     "ter_set": "t_dirt",
+    "skill": { "skill": "electronics", "amount": 40, "min": 1, "max": 8 },
     "items": "deconstructed_item_result_group"
 }
 ```
@@ -5611,6 +5613,10 @@ This terrain is the roof of the tile below it, try to destroy that too. Further 
 ##### `furn_set`, `ter_set`
 
 The terrain / furniture that will be set after the original has been deconstructed. "furn_set" is optional (it defaults to no furniture), "ter_set" is only used upon "deconstruct" entries in terrain and is mandatory there.
+
+##### `skill`
+
+(Optional) The skill that will be practised after deconstruction. Amount is the amount of xp given, min is the minimum level to recieve xp, max is the level cap after which no xp is recieved but practise still occurs delaying rust.
 
 ##### `items`
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1493,14 +1493,12 @@ void construct::done_deconstruct( const tripoint_bub_ms &p, Character &player_ch
 {
     map &here = get_map();
 
-    auto deconstruction_practice_skill = [ &player_character ]( auto &skill ) {
-        if( skill.id )  { // Practise a skill if specified and within the level range
-            if( player_character.get_skill_level( skill.id ) >= skill.min ) {
-                // Uses a modified version of the complete_construction formula using 20 minutes with halved yield before the multiplier
-                player_character.practice( skill.id,
-                                           static_cast<int>( skill.multiplier * ( 5 / 6 ) * ( 10 + 7.5 * ( skill.min +
-                                                   skill.max ) ) ), skill.max );
-            }
+    auto deconstruction_practice_skill = [ &player_character ]( auto & skill ) {
+        if( player_character.get_skill_level( skill.id ) >= skill.min ) {
+            // Uses a modified version of the complete_construction formula using 20 minutes with halved yield before the multiplier
+            player_character.practice( skill.id,
+                                       static_cast<int>( skill.multiplier * ( 5.0 / 6.0 ) * ( 10 + 7.5 * ( skill.min +
+                                               skill.max ) ) ), skill.max );
         }
     };
 
@@ -1520,7 +1518,9 @@ void construct::done_deconstruct( const tripoint_bub_ms &p, Character &player_ch
         item &item_here = here.i_at( p ).size() != 1 ? null_item_reference() : here.i_at( p ).only_item();
         const std::vector<item *> drop = here.spawn_items( p,
                                          item_group::items_from( f.deconstruct.drop_group, calendar::turn ) );
-        deconstruction_practice_skill( f.deconstruct.skill );
+        if( f.deconstruct.skill.has_value() ) {
+            deconstruction_practice_skill( f.deconstruct.skill.value() );
+        }
         // if furniture has liquid in it and deconstructs into watertight containers then fill them
         if( f.has_flag( "LIQUIDCONT" ) && item_here.made_of( phase_id::LIQUID ) ) {
             for( item *it : drop ) {
@@ -1557,7 +1557,9 @@ void construct::done_deconstruct( const tripoint_bub_ms &p, Character &player_ch
         here.ter_set( p, t.deconstruct.ter_set );
         add_msg( _( "The %s is disassembled." ), t.name() );
         here.spawn_items( p, item_group::items_from( t.deconstruct.drop_group, calendar::turn ) );
-        deconstruction_practice_skill( t.deconstruct.skill );
+        if( t.deconstruct.skill.has_value() ) {
+            deconstruction_practice_skill( t.deconstruct.skill.value() );
+        }
     }
 }
 

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -76,9 +76,6 @@ static const construction_str_id construction_constr_veh( "constr_veh" );
 
 static const flag_id json_flag_FILTHY( "FILTHY" );
 static const flag_id json_flag_PIT( "PIT" );
-static const furn_str_id furn_f_console( "f_console" );
-static const furn_str_id furn_f_console_broken( "f_console_broken" );
-static const furn_str_id furn_f_machinery_electronic( "f_machinery_electronic" );
 
 static const item_group_id Item_spawn_data_allclothes( "allclothes" );
 static const item_group_id Item_spawn_data_grave( "grave" );
@@ -100,7 +97,6 @@ static const mtype_id mon_zombie_rot( "mon_zombie_rot" );
 
 static const quality_id qual_CUT( "CUT" );
 
-static const skill_id skill_electronics( "electronics" );
 static const skill_id skill_fabrication( "fabrication" );
 
 static const trait_id trait_DEBUG_HS( "DEBUG_HS" );
@@ -1503,19 +1499,11 @@ void construct::done_deconstruct( const tripoint_bub_ms &p, Character &player_ch
             add_msg( m_info, _( "That %s can not be disassembled!" ), f.name() );
             return;
         }
-        if( f.id.id() == furn_f_console_broken )  {
-            if( player_character.get_skill_level( skill_electronics ) >= 1 ) {
-                player_character.practice( skill_electronics, 20, 4 );
-            }
-        }
-        if( f.id.id() == furn_f_console )  {
-            if( player_character.get_skill_level( skill_electronics ) >= 1 ) {
-                player_character.practice( skill_electronics, 40, 8 );
-            }
-        }
-        if( f.id.id() == furn_f_machinery_electronic )  {
-            if( player_character.get_skill_level( skill_electronics ) >= 1 ) {
-                player_character.practice( skill_electronics, 40, 8 );
+        if( f.deconstruct.skill.first )  { // Practise a skill if specified and within the level range
+            const skill_id id = f.deconstruct.skill.first;
+            std::vector<int> values = f.deconstruct.skill.second;
+            if( player_character.get_skill_level( skill_name ) >= skill_values[1] ) {
+                player_character.practice( skill_name, skill_values[0], skill_values[2] );
             }
         }
         if( f.deconstruct.furn_set.str().empty() ) {

--- a/src/construction.cpp
+++ b/src/construction.cpp
@@ -1493,12 +1493,13 @@ void construct::done_deconstruct( const tripoint_bub_ms &p, Character &player_ch
 {
     map &here = get_map();
 
-    auto deconstruction_practice_skill = [ &player_character ]( auto skill ) {
-        if( skill.first )  { // Practise a skill if specified and within the level range
-            const skill_id id = skill.first;
-            std::vector<int> values = skill.second;
-            if( player_character.get_skill_level( id ) >= values[1] ) {
-                player_character.practice( id, values[0], values[2] );
+    auto deconstruction_practice_skill = [ &player_character ]( auto &skill ) {
+        if( skill.id )  { // Practise a skill if specified and within the level range
+            if( player_character.get_skill_level( skill.id ) >= skill.min ) {
+                // Uses a modified version of the complete_construction formula using 20 minutes with halved yield before the multiplier
+                player_character.practice( skill.id,
+                                           static_cast<int>( skill.multiplier * ( 5 / 6 ) * ( 10 + 7.5 * ( skill.min +
+                                                   skill.max ) ) ), skill.max );
             }
         }
     };

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -424,10 +424,10 @@ bool map_deconstruct_info::load( const JsonObject &jsobj, const std::string_view
     }
     if( j.has_object( "skill" ) ) {
         JsonObject jo = j.get_object( "skill" );
-        const skill_id id = skill_id( jo.get_string( "skill" ) );
-        const std::vector<int> values = { jo.get_int( "amount", 0 ), jo.get_int( "min", 0 ), jo.get_int( "max", 0 ) };
-        skill.first = id;
-        skill.second = values;
+        skill.id = skill_id( jo.get_string( "skill" ) );
+        skill.multiplier = jo.get_float( "multiplier", 1 );
+        skill.min = jo.get_int( "min", 0 );
+        skill.max = jo.get_int( "max", 10 );
     }
     can_do = true;
     deconstruct_above = j.get_bool( "deconstruct_above", false );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -421,6 +421,12 @@ bool map_deconstruct_info::load( const JsonObject &jsobj, const std::string_view
 
     if( !is_furniture ) {
         ter_set = ter_str_id( j.get_string( "ter_set" ) );
+    } else if( j.has_object( "skill" ) ) {
+        JsonObject jo = j.get_object( "skill" );
+        const skill_id id = skill_id( jo.get_string( "skill" ) );
+        const std::vector<int> values = { jo.get_int( "amount", 0 ), jo.get_int( "min", 0 ), jo.get_int( "max", 0 ) };
+        skill.first = id;
+        skill.second = values;
     }
     can_do = true;
     deconstruct_above = j.get_bool( "deconstruct_above", false );

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -421,7 +421,8 @@ bool map_deconstruct_info::load( const JsonObject &jsobj, const std::string_view
 
     if( !is_furniture ) {
         ter_set = ter_str_id( j.get_string( "ter_set" ) );
-    } else if( j.has_object( "skill" ) ) {
+    }
+    if( j.has_object( "skill" ) ) {
         JsonObject jo = j.get_object( "skill" );
         const skill_id id = skill_id( jo.get_string( "skill" ) );
         const std::vector<int> values = { jo.get_int( "amount", 0 ), jo.get_int( "min", 0 ), jo.get_int( "max", 0 ) };

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -424,10 +424,7 @@ bool map_deconstruct_info::load( const JsonObject &jsobj, const std::string_view
     }
     if( j.has_object( "skill" ) ) {
         JsonObject jo = j.get_object( "skill" );
-        skill.id = skill_id( jo.get_string( "skill" ) );
-        skill.multiplier = jo.get_float( "multiplier", 1 );
-        skill.min = jo.get_int( "min", 0 );
-        skill.max = jo.get_int( "max", 10 );
+        skill = { skill_id( jo.get_string( "skill" ) ), jo.get_int( "min", 0 ), jo.get_int( "max", 10 ), jo.get_float( "multiplier", 1.0 ) };
     }
     can_do = true;
     deconstruct_above = j.get_bool( "deconstruct_above", false );

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -86,7 +86,7 @@ struct map_deconstruct_info {
     ter_str_id ter_set;    // terrain to set (REQUIRED for terrain))
     furn_str_id furn_set;    // furniture to set (only used by furniture, not terrain)
     map_deconstruct_info();
-    map_deconstruct_skill skill;
+    std::optional<map_deconstruct_skill> skill;
     bool load( const JsonObject &jsobj, std::string_view member, bool is_furniture,
                const std::string &context );
 };

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -80,6 +80,8 @@ struct map_deconstruct_info {
     ter_str_id ter_set;    // terrain to set (REQUIRED for terrain))
     furn_str_id furn_set;    // furniture to set (only used by furniture, not terrain)
     map_deconstruct_info();
+    std::pair<skill_id, std::vector<int>>
+                                       skill; // skill to practise, amount of xp, min level required to gain xp, max level after which no xp is gained
     bool load( const JsonObject &jsobj, std::string_view member, bool is_furniture,
                const std::string &context );
 };

--- a/src/mapdata.h
+++ b/src/mapdata.h
@@ -70,6 +70,12 @@ struct map_bash_info {
     bool load( const JsonObject &jsobj, std::string_view member, map_object_type obj_type,
                const std::string &context );
 };
+struct map_deconstruct_skill {
+    skill_id id; // Id of skill to increase on successful deconstruction
+    int min; // Minimum level to recieve xp
+    int max; // Level cap after which no xp is recieved but practise still occurs delaying rust
+    double multiplier; // Multiplier of the base xp given that's calced using the mean of the min and max
+};
 struct map_deconstruct_info {
     // Only if true, the terrain/furniture can be deconstructed
     bool can_do;
@@ -80,8 +86,7 @@ struct map_deconstruct_info {
     ter_str_id ter_set;    // terrain to set (REQUIRED for terrain))
     furn_str_id furn_set;    // furniture to set (only used by furniture, not terrain)
     map_deconstruct_info();
-    std::pair<skill_id, std::vector<int>>
-                                       skill; // skill to practise, amount of xp, min level required to gain xp, max level after which no xp is gained
+    map_deconstruct_skill skill;
     bool load( const JsonObject &jsobj, std::string_view member, bool is_furniture,
                const std::string &context );
 };


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Hardcode bad
This "feature" is underused bc it's hardcoded

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Adds a new field to the deconstruct field of terrain and furniture that allows specifying a skill to train, and the range of levels it can train and a multiplier for xp gained.
The formula for xp received is proportional to the mean of the min and max levels and based off the construction formula.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Making the xp gained proportional to the max level or your current level instead.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked it worked checking the @ menu and using debug messages

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Happy to add this to more uses in this PR if peeps have suggestions

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
