### PR TITLE
Expand/Adjust police firearm loot

### DIFF
--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/police_armory.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/police_armory.json
@@ -788,10 +788,10 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "group": "police_armory_box_some_40sw" },
-      { "group": "police_armory_box_some_40sw", "prob": 75 },
+      { "group": "police_armory_box_some_357sigjhp" },
+      { "group": "police_armory_box_some_357sigjhp", "prob": 75 },
       { "item": "ammo_box_2", "count": [ 30, 40 ] },
-      { "group": "police_armory_box_full_40sw", "count": [ 0, 6 ] }
+      { "group": "police_armory_box_full_357sigjhp", "count": [ 0, 6 ] }
     ]
   },
   {
@@ -799,10 +799,10 @@
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "group": "police_armory_box_some_40fmj" },
-      { "group": "police_armory_box_some_40fmj", "prob": 75 },
+      { "group": "police_armory_box_some_357sigfmj" },
+      { "group": "police_armory_box_some_357sigfmj", "prob": 75 },
       { "item": "ammo_box_2", "count": [ 30, 40 ] },
-      { "group": "police_armory_box_full_40fmj", "count": [ 0, 6 ] }
+      { "group": "police_armory_box_full_357sigfmj", "count": [ 0, 6 ] }
     ]
   },
   {

--- a/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/police_armory.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/arsenal/police_armory.json
@@ -6,27 +6,57 @@
     "//1": "This is the final list that spawns somewhere in a police locker.",
     "subtype": "distribution",
     "entries": [
-      { "group": "police_armory_any_9mm", "prob": 45 },
+      { "group": "police_armory_any_9mm", "prob": 60 },
+      { "group": "police_armory_any_357sig", "prob": 5 },
       { "group": "police_armory_any_40", "prob": 30 },
-      { "group": "police_armory_any_five7", "prob": 10 },
-      { "group": "police_armory_usp_45", "prob": 15 }
+      { "group": "police_armory_any_45", "prob": 20 },
+      { "group": "police_armory_five7", "prob": 1 }
     ]
   },
   {
     "type": "item_group",
     "id": "police_armory_any_assaultrifle",
-    "//": "Weighted list of midrange rifles for police (ar-15 and 223 or m4 and 556) and their ammo.",
+    "//": "Weighted list of short-to-medium-range longarms used by police that aren't shotguns.  Submachine guns are included here.  Weighted heavily towards .223/556 and AR-15s.",
     "//1": "This is the final list that spawns somewhere in a police locker.",
     "subtype": "distribution",
-    "entries": [ { "group": "police_armory_ar15_223", "prob": 80 }, { "group": "police_armory_m4_556", "prob": 20 } ]
+    "entries": [
+      { "group": "police_armory_patrolrifle_stanag", "prob": 80 },
+      { "group": "police_armory_any_smg", "prob": 20 },
+      { "group": "police_armory_mini14", "prob": 5 },
+      { "group": "police_armory_m1a", "prob": 5 },
+      { "group": "police_armory_aug", "prob": 1 },
+      { "group": "police_armory_g36", "prob": 1 },
+      { "group": "police_armory_hk417", "prob": 1 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_any_smg",
+    "//": "Weighted list of submachine guns for police and their ammo.  Though largely replaced by 5.56 carbines, these still have a presence in police lockers.  Weighted towards 9mm MP5 variants and UMP variants.",
+    "//1": "This is a semifinal list that applies to the item group above.",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "police_armory_any_9mm_smg", "prob": 50 },
+      { "group": "police_armory_ump40", "prob": 30 },
+      { "group": "police_armory_ump45", "prob": 25 },
+      { "group": "police_armory_p90", "prob": 3 },
+      { "group": "police_armory_mp7", "prob": 1 }
+    ]
   },
   {
     "type": "item_group",
     "id": "police_armory_any_sniperrifle",
-    "//": "Weighted list of sniper rifles for police (m24 or remington 700) and their ammo.",
+    "//": "Weighted list of sniper rifles for police and their ammo.  Weighted heavily towards .308 and the M24 (standing in for the Remington 700 Police in .308), but also rarely includes some modern and powerful rifles.",
     "//1": "This is the final list that spawns somewhere in a police locker.",
     "subtype": "distribution",
-    "entries": [ { "group": "police_armory_M24", "prob": 50 }, { "group": "police_armory_remington_700", "prob": 50 } ]
+    "entries": [
+      { "group": "police_armory_any_308sniper", "prob": 85 },
+      { "group": "police_armory_ar15sniper", "prob": 10 },
+      { "group": "police_armory_remington_700", "prob": 5 },
+      { "group": "police_armory_axmc_300", "prob": 5 },
+      { "group": "police_armory_any_338sniper", "prob": 4 },
+      { "group": "police_armory_any_50sniper", "prob": 1 }
+    ]
   },
   {
     "type": "item_group",
@@ -47,9 +77,24 @@
     "//": "Pick one of multiple interchangeable 9mm variants and its ammo.",
     "subtype": "distribution",
     "entries": [
-      { "group": "police_armory_usp_9mm", "prob": 25 },
-      { "group": "police_armory_glock_19", "prob": 50 },
-      { "group": "police_armory_m9", "prob": 25 }
+      { "group": "police_armory_usp_9mm", "prob": 5 },
+      { "group": "police_armory_glock_19", "prob": 30 },
+      { "group": "police_armory_glock_17", "prob": 45 },
+      { "group": "police_armory_m9", "prob": 5 },
+      { "group": "police_armory_sp2022", "prob": 10 },
+      { "group": "police_armory_px4_9mm", "prob": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_any_9mm_smg",
+    "//": "Pick one of multiple interchangeable 9mm smg variants and its ammo.",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "police_armory_mp5", "prob": 80 },
+      { "group": "police_armory_coltsmg", "prob": 10 },
+      { "group": "police_armory_apc9", "prob": 5 },
+      { "group": "police_armory_ump9", "prob": 5 }
     ]
   },
   {
@@ -90,16 +135,184 @@
   },
   {
     "type": "item_group",
+    "id": "police_armory_glock_17",
+    "//": "One or more Glock 17 pistols, empty mags, full mags, JHP and FMJ ammo with a chance of +P and +P+ ammo.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "glock_17" },
+      { "item": "glock_17", "prob": 50 },
+      { "item": "glock_17", "prob": 25 },
+      { "item": "glock17_17", "count": [ 1, 4 ] },
+      { "group": "police_armory_full_glock17mag_9mm", "count": [ 0, 4 ] },
+      { "group": "police_armory_full_glock17mag_9mmfmj", "count": [ 0, 4 ] },
+      { "group": "police_armory_boxes_9mm" },
+      { "group": "police_armory_boxes_9mmfmj" },
+      { "group": "police_armory_boxes_9mmP", "prob": 25 },
+      { "group": "police_armory_boxes_9mmP2", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
     "id": "police_armory_m9",
     "//": "One or more Beretta 9mm pistols, empty mags, full mags, JHP and FMJ ammo with a chance of +P and +P+ ammo.",
     "subtype": "collection",
     "entries": [
-      { "item": "m9" },
-      { "item": "m9", "prob": 50 },
-      { "item": "m9", "prob": 25 },
+      { "item": "m9", "variant": "m9" },
+      { "item": "m9", "variant": "m9", "prob": 50 },
+      { "item": "m9", "variant": "m9", "prob": 25 },
       { "item": "m9mag", "count": [ 1, 4 ] },
       { "group": "police_armory_full_m9mag_9mm", "count": [ 0, 4 ] },
       { "group": "police_armory_full_m9mag_9mmfmj", "count": [ 0, 4 ] },
+      { "group": "police_armory_boxes_9mm" },
+      { "group": "police_armory_boxes_9mmfmj" },
+      { "group": "police_armory_boxes_9mmP", "prob": 25 },
+      { "group": "police_armory_boxes_9mmP2", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_sp2022",
+    "//": "One or more SIG SP2022 9mm pistols, empty mags, full mags, JHP and FMJ ammo with a chance of +P and +P+ ammo.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "sp2022" },
+      { "item": "sp2022", "prob": 50 },
+      { "item": "sp2022", "prob": 25 },
+      { "item": "sp2022mag_15rd_9mm", "count": [ 1, 4 ] },
+      { "group": "police_armory_full_sp2022mag_9mm", "count": [ 0, 4 ] },
+      { "group": "police_armory_full_sp2022mag_9mmfmj", "count": [ 0, 4 ] },
+      { "group": "police_armory_boxes_9mm" },
+      { "group": "police_armory_boxes_9mmfmj" },
+      { "group": "police_armory_boxes_9mmP", "prob": 25 },
+      { "group": "police_armory_boxes_9mmP2", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_px4_9mm",
+    "//": "One or more Px4 9mm pistols, empty mags, full mags, JHP and FMJ ammo with a chance of +P and +P+ ammo.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "px4" },
+      { "item": "px4", "prob": 50 },
+      { "item": "px4", "prob": 25 },
+      { "item": "px4mag", "count": [ 1, 4 ] },
+      { "group": "police_armory_full_px4mag_9mm", "count": [ 0, 4 ] },
+      { "group": "police_armory_full_px4mag_9mmfmj", "count": [ 0, 4 ] },
+      { "group": "police_armory_boxes_9mm" },
+      { "group": "police_armory_boxes_9mmfmj" },
+      { "group": "police_armory_boxes_9mmP", "prob": 25 },
+      { "group": "police_armory_boxes_9mmP2", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_mp5",
+    "//": "One or more mp5-type submachine guns, empty mags, full mags, JHP and FMJ ammo with a chance of +P and +P+ ammo.",
+    "subtype": "collection",
+    "entries": [
+      { "group": "police_armory_mp5_pick" },
+      { "item": "mp5mag", "count": [ 1, 7 ] },
+      { "group": "police_armory_full_mp5mag_9mm", "count": [ 0, 2 ] },
+      { "group": "police_armory_full_mp5mag_9mmfmj", "count": [ 0, 3 ] },
+      { "group": "police_armory_boxes_9mm" },
+      { "group": "police_armory_boxes_9mmfmj" },
+      { "group": "police_armory_boxes_9mmP", "prob": 25 },
+      { "group": "police_armory_boxes_9mmP2", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_mp5_pick",
+    "//": "Chooses the MP5 type that will spawn in the above group.",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "police_armory_mp5standard_pick", "prob": 85 },
+      { "group": "police_armory_mp5sd_pick", "prob": 10 },
+      { "group": "police_armory_mp5k_pick", "prob": 5 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_mp5standard_pick",
+    "//": "1-3 guns of the same type",
+    "subtype": "collection",
+    "entries": [
+      { "item": "hk_mp5", "contents-item": [ "sights_mount", "red_dot_sight", "suppressor" ] },
+      { "item": "hk_mp5", "contents-item": [ "sights_mount", "red_dot_sight", "suppressor" ], "prob": 50 },
+      { "item": "hk_mp5", "contents-item": [ "sights_mount", "red_dot_sight", "suppressor" ], "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_mp5sd_pick",
+    "//": "1-3 guns of the same type",
+    "subtype": "collection",
+    "entries": [
+      { "item": "hk_mp5sd", "contents-item": [ "sights_mount", "red_dot_sight" ] },
+      { "item": "hk_mp5sd", "contents-item": [ "sights_mount", "red_dot_sight" ], "prob": 50 },
+      { "item": "hk_mp5sd", "contents-item": [ "sights_mount", "red_dot_sight" ], "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_mp5k_pick",
+    "//": "1-3 guns of the same type",
+    "subtype": "collection",
+    "entries": [
+      { "item": "hk_mp5k", "contents-item": [ "sights_mount", "red_dot_sight", "suppressor" ] },
+      { "item": "hk_mp5k", "contents-item": [ "sights_mount", "red_dot_sight", "suppressor" ], "prob": 50 },
+      { "item": "hk_mp5k", "contents-item": [ "sights_mount", "red_dot_sight", "suppressor" ], "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_coltsmg",
+    "//": "One or more Colt 635 submachine guns, empty mags, full mags, JHP and FMJ ammo with a chance of +P and +P+ ammo.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "colt_ro635" },
+      { "item": "colt_ro635", "prob": 50 },
+      { "item": "colt_ro635", "prob": 25 },
+      { "item": "uzimag", "count": [ 1, 7 ] },
+      { "group": "police_armory_full_uzimag_9mm", "count": [ 0, 2 ] },
+      { "group": "police_armory_full_uzimag_9mmfmj", "count": [ 0, 3 ] },
+      { "group": "police_armory_boxes_9mm" },
+      { "group": "police_armory_boxes_9mmfmj" },
+      { "group": "police_armory_boxes_9mmP", "prob": 25 },
+      { "group": "police_armory_boxes_9mmP2", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_apc9",
+    "//": "One or more APC9k submachine guns, empty mags, full mags, JHP and FMJ ammo with a chance of +P and +P+ ammo.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "bt_apc9k" },
+      { "item": "bt_apc9k", "prob": 50 },
+      { "item": "bt_apc9k", "prob": 25 },
+      { "item": "btmp9mag_9x19mm_30", "count": [ 1, 7 ] },
+      { "group": "police_armory_full_mp9mag_9mm", "count": [ 0, 2 ] },
+      { "group": "police_armory_full_mp9mag_9mmfmj", "count": [ 0, 3 ] },
+      { "group": "police_armory_boxes_9mm" },
+      { "group": "police_armory_boxes_9mmfmj" },
+      { "group": "police_armory_boxes_9mmP", "prob": 25 },
+      { "group": "police_armory_boxes_9mmP2", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_ump9",
+    "//": "One or more UMP-9 submachine guns, empty mags, full mags, JHP and FMJ ammo with a chance of +P and +P+ ammo.",
+    "subtype": "collection",
+    "entries": [
+      { "group": "modular_ump_9", "contents-item": [ "red_dot_sight", "suppressor" ] },
+      { "group": "modular_ump_9", "contents-item": [ "red_dot_sight", "suppressor" ], "prob": 50 },
+      { "group": "modular_ump_9", "contents-item": [ "red_dot_sight", "suppressor" ], "prob": 25 },
+      { "item": "ump9mag", "count": [ 1, 7 ] },
+      { "group": "police_armory_full_ump9mag_9mm", "count": [ 0, 2 ] },
+      { "group": "police_armory_full_ump9mag_9mmfmj", "count": [ 0, 3 ] },
       { "group": "police_armory_boxes_9mm" },
       { "group": "police_armory_boxes_9mmfmj" },
       { "group": "police_armory_boxes_9mmP", "prob": 25 },
@@ -135,6 +348,20 @@
     "entries": [ { "item": "9mmfmj", "charges": [ 15, 15 ] } ]
   },
   {
+    "id": "police_armory_full_glock17mag_9mm",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "glock17_17",
+    "entries": [ { "item": "9mm", "charges": [ 17, 17 ] } ]
+  },
+  {
+    "id": "police_armory_full_glock17mag_9mmfmj",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "glock17_17",
+    "entries": [ { "item": "9mmfmj", "charges": [ 17, 17 ] } ]
+  },
+  {
     "id": "police_armory_full_m9mag_9mm",
     "type": "item_group",
     "subtype": "collection",
@@ -147,6 +374,90 @@
     "subtype": "collection",
     "container-item": "m9mag",
     "entries": [ { "item": "9mmfmj", "charges": [ 15, 15 ] } ]
+  },
+  {
+    "id": "police_armory_full_sp2022mag_9mm",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "sp2022mag_15rd_9mm",
+    "entries": [ { "item": "9mm", "charges": [ 15, 15 ] } ]
+  },
+  {
+    "id": "police_armory_full_sp2022mag_9mmfmj",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "sp2022mag_15rd_9mm",
+    "entries": [ { "item": "9mmfmj", "charges": [ 15, 15 ] } ]
+  },
+  {
+    "id": "police_armory_full_px4mag_9mm",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "px4mag",
+    "entries": [ { "item": "9mm", "charges": [ 17, 17 ] } ]
+  },
+  {
+    "id": "police_armory_full_px4mag_9mmfmj",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "px4mag",
+    "entries": [ { "item": "9mmfmj", "charges": [ 17, 17 ] } ]
+  },
+  {
+    "id": "police_armory_full_mp5mag_9mm",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "mp5mag",
+    "entries": [ { "item": "9mm", "charges": [ 30, 30 ] } ]
+  },
+  {
+    "id": "police_armory_full_mp5mag_9mmfmj",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "mp5mag",
+    "entries": [ { "item": "9mmfmj", "charges": [ 30, 30 ] } ]
+  },
+  {
+    "id": "police_armory_full_uzimag_9mm",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "uzimag",
+    "entries": [ { "item": "9mm", "charges": [ 32, 32 ] } ]
+  },
+  {
+    "id": "police_armory_full_uzimag_9mmfmj",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "uzimag",
+    "entries": [ { "item": "9mmfmj", "charges": [ 32, 32 ] } ]
+  },
+  {
+    "id": "police_armory_full_mp9mag_9mm",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "btmp9mag_9x19mm_30",
+    "entries": [ { "item": "9mm", "charges": [ 30, 30 ] } ]
+  },
+  {
+    "id": "police_armory_full_mp9mag_9mmfmj",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "btmp9mag_9x19mm_30",
+    "entries": [ { "item": "9mmfmj", "charges": [ 30, 30 ] } ]
+  },
+  {
+    "id": "police_armory_full_ump9mag_9mm",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ump9mag",
+    "entries": [ { "item": "9mm", "charges": [ 30, 30 ] } ]
+  },
+  {
+    "id": "police_armory_full_ump9mag_9mmfmj",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ump9mag",
+    "entries": [ { "item": "9mmfmj", "charges": [ 30, 30 ] } ]
   },
   {
     "id": "police_armory_boxes_9mm",
@@ -250,18 +561,13 @@
   },
   {
     "type": "item_group",
-    "id": "police_armory_any_five7",
-    "//": "Weighted chance of silenced 57 vs normal 57.",
-    "subtype": "distribution",
-    "entries": [ { "group": "police_armory_five7", "prob": 85 }, { "group": "police_armory_five7_silenced", "prob": 15 } ]
-  },
-  {
-    "type": "item_group",
     "id": "police_armory_five7",
     "//": "One or more FiveSeveN pistols, empty mags, full mags, SS190 ammo and a chance of extra ammo.",
     "subtype": "collection",
     "entries": [
-      { "item": "fn57", "count": [ 1, 3 ] },
+      { "item": "fn57" },
+      { "item": "fn57", "prob": 50 },
+      { "item": "fn57", "prob": 25 },
       { "item": "fn57mag", "count": [ 1, 4 ] },
       { "group": "police_armory_full_fn57mag_57mm", "count": [ 1, 4 ] },
       { "group": "police_armory_boxes_57mm" },
@@ -270,15 +576,17 @@
   },
   {
     "type": "item_group",
-    "id": "police_armory_five7_silenced",
-    "//": "Suppressed FiveSeveNs, SB193 ammo, empty and full mags.",
+    "id": "police_armory_p90",
+    "//": "One or more P90 'submachine guns', empty mags, full mags, SS190 ammo and a chance of extra ammo.",
     "subtype": "collection",
     "entries": [
-      { "item": "fn57", "count": [ 1, 2 ], "contents-item": [ "suppressor_compact" ] },
-      { "item": "fn57mag", "count": [ 1, 3 ] },
-      { "group": "police_armory_full_fn57mag_57mm_ss", "count": [ 1, 3 ] },
-      { "group": "police_armory_boxes_57mm_ss" },
-      { "group": "police_armory_boxes_57mm_ss", "prob": 10 }
+      { "item": "fn_p90", "contents-item": [ "red_dot_sight", "suppressor_compact" ] },
+      { "item": "fn_p90", "contents-item": [ "red_dot_sight", "suppressor_compact" ], "prob": 50 },
+      { "item": "fn_p90", "contents-item": [ "red_dot_sight", "suppressor_compact" ], "prob": 25 },
+      { "item": "fnp90mag", "count": [ 1, 7 ] },
+      { "group": "police_armory_full_p90mag_57mm", "count": [ 1, 4 ] },
+      { "group": "police_armory_boxes_57mm" },
+      { "group": "police_armory_boxes_57mm", "prob": 30 }
     ]
   },
   {
@@ -289,11 +597,11 @@
     "entries": [ { "item": "57mm", "charges": [ 20, 20 ] } ]
   },
   {
-    "id": "police_armory_full_fn57mag_57mm_ss",
+    "id": "police_armory_full_p90mag_57mm",
     "type": "item_group",
     "subtype": "collection",
-    "container-item": "fn57mag",
-    "entries": [ { "item": "57mm_ss", "charges": [ 20, 20 ] } ]
+    "container-item": "fnp90mag",
+    "entries": [ { "item": "57mm", "charges": [ 50, 50 ] } ]
   },
   {
     "id": "police_armory_boxes_57mm",
@@ -307,29 +615,11 @@
     ]
   },
   {
-    "id": "police_armory_boxes_57mm_ss",
-    "type": "item_group",
-    "subtype": "collection",
-    "entries": [
-      { "group": "police_armory_box_some_57mm_ss" },
-      { "group": "police_armory_box_some_57mm_ss", "prob": 50 },
-      { "item": "ammo_box_2", "count": [ 5, 10 ] },
-      { "group": "police_armory_box_full_57mm_ss", "count": [ 0, 5 ] }
-    ]
-  },
-  {
     "id": "police_armory_box_full_57mm",
     "type": "item_group",
     "subtype": "collection",
     "container-item": "ammo_box_2",
     "entries": [ { "item": "57mm", "charges": [ 60, 60 ] } ]
-  },
-  {
-    "id": "police_armory_box_full_57mm_ss",
-    "type": "item_group",
-    "subtype": "collection",
-    "container-item": "ammo_box_2",
-    "entries": [ { "item": "57mm_ss", "charges": [ 60, 60 ] } ]
   },
   {
     "id": "police_armory_box_some_57mm",
@@ -339,18 +629,220 @@
     "entries": [ { "item": "57mm", "charges": [ 1, 60 ] } ]
   },
   {
-    "id": "police_armory_box_some_57mm_ss",
+    "type": "item_group",
+    "id": "police_armory_mp7",
+    "//": "One or more MP7 'submachine guns', empty mags, full mags, 4.6mm ammo and a chance of extra ammo.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "hk_mp7", "contents-item": [ "red_dot_sight", "suppressor_compact" ] },
+      { "item": "hk_mp7", "contents-item": [ "red_dot_sight", "suppressor_compact" ], "prob": 50 },
+      { "item": "hk_mp7", "contents-item": [ "red_dot_sight", "suppressor_compact" ], "prob": 25 },
+      { "item": "hk46mag", "count": [ 1, 3 ] },
+      { "item": "hk46bigmag", "count": [ 1, 4 ] },
+      { "group": "police_armory_full_mp7mag_46mm", "count": [ 1, 4 ] },
+      { "group": "police_armory_boxes_46mm" },
+      { "group": "police_armory_boxes_46mm", "prob": 30 }
+    ]
+  },
+  {
+    "id": "police_armory_full_mp7mag_46mm",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "hk46bigmag",
+    "entries": [ { "item": "46mm", "charges": [ 40, 40 ] } ]
+  },
+  {
+    "id": "police_armory_boxes_46mm",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "police_armory_box_some_46mm" },
+      { "group": "police_armory_box_some_46mm", "prob": 60 },
+      { "item": "ammo_box_2", "count": [ 15, 25 ] },
+      { "group": "police_armory_box_full_46mm", "count": [ 0, 8 ] }
+    ]
+  },
+  {
+    "id": "police_armory_box_full_46mm",
     "type": "item_group",
     "subtype": "collection",
     "container-item": "ammo_box_2",
-    "entries": [ { "item": "57mm_ss", "charges": [ 1, 60 ] } ]
+    "entries": [ { "item": "46mm", "charges": [ 60, 60 ] } ]
+  },
+  {
+    "id": "police_armory_box_some_46mm",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ammo_box_2",
+    "entries": [ { "item": "46mm", "charges": [ 1, 60 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_any_357sig",
+    "//": "Pick one of multiple interchangeable .357 SIG variants.",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "police_armory_p226_357", "prob": 30 },
+      { "group": "police_armory_glock_31", "prob": 60 },
+      { "group": "police_armory_p320_357", "prob": 10 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_p226_357",
+    "//": "One or more Sig P226 .357 pistols, empty mags, full mags, JHP and FMJ ammo with a chance of extra for each.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "p226_357sig" },
+      { "item": "p226_357sig", "prob": 50 },
+      { "item": "p226_357sig", "prob": 25 },
+      { "item": "p226mag_12rd_357sig", "count": [ 1, 4 ] },
+      { "group": "police_armory_full_p226mag_357sigjhp", "count": [ 0, 4 ] },
+      { "group": "police_armory_full_p226mag_357sigfmj", "count": [ 0, 4 ] },
+      { "group": "police_armory_boxes_357sigjhp" },
+      { "group": "police_armory_boxes_357sigfmj" },
+      { "group": "police_armory_boxes_357sigjhp", "prob": 15 },
+      { "group": "police_armory_boxes_357sigfmj", "prob": 15 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_glock_31",
+    "//": "One or more Glock 31 pistols, empty mags, full mags, JHP and FMJ ammo with a chance of extra for each.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "glock_31" },
+      { "item": "glock_31", "prob": 50 },
+      { "item": "glock_31", "prob": 25 },
+      { "item": "glock40mag", "count": [ 1, 4 ] },
+      { "group": "police_armory_full_glock40mag_357sigjhp", "count": [ 0, 4 ] },
+      { "group": "police_armory_full_glock40mag_357sigfmj", "count": [ 0, 4 ] },
+      { "group": "police_armory_boxes_357sigjhp" },
+      { "group": "police_armory_boxes_357sigfmj" },
+      { "group": "police_armory_boxes_357sigjhp", "prob": 15 },
+      { "group": "police_armory_boxes_357sigfmj", "prob": 15 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_p320_357",
+    "//": "One or more SIG P320 .357 pistols, empty mags, full mags, JHP and FMJ ammo with a chance of extra for each.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "p320_357sig" },
+      { "item": "p320_357sig", "prob": 50 },
+      { "item": "p320_357sig", "prob": 25 },
+      { "item": "p320mag_13rd_357sig", "count": [ 1, 4 ] },
+      { "group": "police_armory_full_p320mag_357sigjhp", "count": [ 0, 4 ] },
+      { "group": "police_armory_full_p320mag_357sigfmj", "count": [ 0, 4 ] },
+      { "group": "police_armory_boxes_357sigjhp" },
+      { "group": "police_armory_boxes_357sigfmj" },
+      { "group": "police_armory_boxes_357sigjhp", "prob": 15 },
+      { "group": "police_armory_boxes_357sigfmj", "prob": 15 }
+    ]
+  },
+  {
+    "id": "police_armory_full_p226mag_357sigjhp",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "p226mag_12rd_357sig",
+    "entries": [ { "item": "357sig_jhp", "charges": [ 12, 12 ] } ]
+  },
+  {
+    "id": "police_armory_full_p226mag_357sigfmj",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "p226mag_12rd_357sig",
+    "entries": [ { "item": "357sig_fmj", "charges": [ 12, 12 ] } ]
+  },
+  {
+    "id": "police_armory_full_glock40mag_357sigjhp",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "glock40mag",
+    "entries": [ { "item": "357sig_jhp", "charges": [ 15, 15 ] } ]
+  },
+  {
+    "id": "police_armory_full_glock40mag_357sigfmj",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "glock40mag",
+    "entries": [ { "item": "357sig_fmj", "charges": [ 15, 15 ] } ]
+  },
+  {
+    "id": "police_armory_full_p320mag_357sigjhp",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "p320mag_13rd_357sig",
+    "entries": [ { "item": "357sig_jhp", "charges": [ 13, 13 ] } ]
+  },
+  {
+    "id": "police_armory_full_p320mag_357sigfmj",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "p320mag_13rd_357sig",
+    "entries": [ { "item": "357sig_fmj", "charges": [ 13, 13 ] } ]
+  },
+  {
+    "id": "police_armory_boxes_357sigjhp",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "police_armory_box_some_40sw" },
+      { "group": "police_armory_box_some_40sw", "prob": 75 },
+      { "item": "ammo_box_2", "count": [ 30, 40 ] },
+      { "group": "police_armory_box_full_40sw", "count": [ 0, 6 ] }
+    ]
+  },
+  {
+    "id": "police_armory_boxes_357sigfmj",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "police_armory_box_some_40fmj" },
+      { "group": "police_armory_box_some_40fmj", "prob": 75 },
+      { "item": "ammo_box_2", "count": [ 30, 40 ] },
+      { "group": "police_armory_box_full_40fmj", "count": [ 0, 6 ] }
+    ]
+  },
+  {
+    "id": "police_armory_box_full_357sigjhp",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ammo_box_2",
+    "entries": [ { "item": "357sig_jhp", "charges": [ 60, 60 ] } ]
+  },
+  {
+    "id": "police_armory_box_full_357sigfmj",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ammo_box_2",
+    "entries": [ { "item": "357sig_fmj", "charges": [ 60, 60 ] } ]
+  },
+  {
+    "id": "police_armory_box_some_357sigjhp",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ammo_box_2",
+    "entries": [ { "item": "357sig_jhp", "charges": [ 1, 60 ] } ]
+  },
+  {
+    "id": "police_armory_box_some_357sigfmj",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ammo_box_2",
+    "entries": [ { "item": "357sig_fmj", "charges": [ 1, 60 ] } ]
   },
   {
     "type": "item_group",
     "id": "police_armory_any_40",
     "//": "Pick one of multiple interchangeable .40 variants.",
     "subtype": "distribution",
-    "entries": [ { "group": "police_armory_sig_40" }, { "group": "police_armory_glock_22" } ]
+    "entries": [
+      { "group": "police_armory_sig_40", "prob": 20 },
+      { "group": "police_armory_glock_22", "prob": 70 },
+      { "group": "police_armory_px4_40", "prob": 10 }
+    ]
   },
   {
     "type": "item_group",
@@ -361,7 +853,7 @@
       { "item": "sig_40" },
       { "item": "sig_40", "prob": 50 },
       { "item": "sig_40", "prob": 25 },
-      { "item": "sig40mag", "count": [ 1, 6 ] },
+      { "item": "sig40mag", "count": [ 1, 4 ] },
       { "group": "police_armory_full_sig40mag_40sw", "count": [ 0, 4 ] },
       { "group": "police_armory_full_sig40mag_40fmj", "count": [ 0, 4 ] },
       { "group": "police_armory_boxes_40sw" },
@@ -379,9 +871,45 @@
       { "item": "glock_22" },
       { "item": "glock_22", "prob": 50 },
       { "item": "glock_22", "prob": 25 },
-      { "item": "glock40mag", "count": [ 1, 6 ] },
+      { "item": "glock40mag", "count": [ 1, 4 ] },
       { "group": "police_armory_full_glock40mag_40sw", "count": [ 0, 4 ] },
       { "group": "police_armory_full_glock40mag_40fmj", "count": [ 0, 4 ] },
+      { "group": "police_armory_boxes_40sw" },
+      { "group": "police_armory_boxes_40fmj" },
+      { "group": "police_armory_boxes_40sw", "prob": 15 },
+      { "group": "police_armory_boxes_40fmj", "prob": 15 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_px4_40",
+    "//": "One or more Px4 .40 pistols, empty mags, full mags, JHP and FMJ ammo with a chance of extra for each.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "px4_40" },
+      { "item": "px4_40", "prob": 50 },
+      { "item": "px4_40", "prob": 25 },
+      { "item": "px4_40mag", "count": [ 1, 4 ] },
+      { "group": "police_armory_full_px4_40mag_40sw", "count": [ 0, 4 ] },
+      { "group": "police_armory_full_px4_40mag_40fmj", "count": [ 0, 4 ] },
+      { "group": "police_armory_boxes_40sw" },
+      { "group": "police_armory_boxes_40fmj" },
+      { "group": "police_armory_boxes_40sw", "prob": 15 },
+      { "group": "police_armory_boxes_40fmj", "prob": 15 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_ump40",
+    "//": "One or more UMP 40 submachine guns, empty mags, full mags, JHP and FMJ ammo with a chance of extra for each.",
+    "subtype": "collection",
+    "entries": [
+      { "group": "modular_ump_40", "contents-item": [ "red_dot_sight", "suppressor" ] },
+      { "group": "modular_ump_40", "contents-item": [ "red_dot_sight", "suppressor" ], "prob": 50 },
+      { "group": "modular_ump_40", "contents-item": [ "red_dot_sight", "suppressor" ], "prob": 25 },
+      { "item": "ump40mag", "count": [ 1, 7 ] },
+      { "group": "police_armory_full_ump40mag_40sw", "count": [ 0, 2 ] },
+      { "group": "police_armory_full_ump40mag_40fmj", "count": [ 0, 3 ] },
       { "group": "police_armory_boxes_40sw" },
       { "group": "police_armory_boxes_40fmj" },
       { "group": "police_armory_boxes_40sw", "prob": 15 },
@@ -415,6 +943,34 @@
     "subtype": "collection",
     "container-item": "glock40mag",
     "entries": [ { "item": "40fmj", "charges": [ 15, 15 ] } ]
+  },
+  {
+    "id": "police_armory_full_px4_40mag_40sw",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "px4_40mag",
+    "entries": [ { "item": "40sw", "charges": [ 14, 14 ] } ]
+  },
+  {
+    "id": "police_armory_full_px4_40mag_40fmj",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "px4_40mag",
+    "entries": [ { "item": "40fmj", "charges": [ 14, 14 ] } ]
+  },
+  {
+    "id": "police_armory_full_ump40mag_40sw",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ump40mag",
+    "entries": [ { "item": "40sw", "charges": [ 30, 30 ] } ]
+  },
+  {
+    "id": "police_armory_full_ump40mag_40fmj",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ump40mag",
+    "entries": [ { "item": "40fmj", "charges": [ 30, 30 ] } ]
   },
   {
     "id": "police_armory_boxes_40sw",
@@ -468,16 +1024,57 @@
   },
   {
     "type": "item_group",
+    "id": "police_armory_any_45",
+    "//": "Pick one of multiple interchangeable .45 pistol variants and its ammo.",
+    "subtype": "distribution",
+    "entries": [ { "group": "police_armory_glock_21", "prob": 90 }, { "group": "police_armory_usp_45", "prob": 10 } ]
+  },
+  {
+    "type": "item_group",
     "id": "police_armory_usp_45",
     "//": "One or more USP 45 pistols, empty mags, full mags, JHP and FMJ ammo with a chance of +P ammo.",
     "subtype": "collection",
     "entries": [
-      { "item": "usp_45" },
-      { "item": "usp_45", "prob": 50 },
-      { "item": "usp_45", "prob": 25 },
-      { "item": "usp45mag", "count": [ 1, 5 ] },
+      { "item": "usp_45", "variant": "usp_45" },
+      { "item": "usp_45", "variant": "usp_45", "prob": 50 },
+      { "item": "usp_45", "variant": "usp_45", "prob": 25 },
+      { "item": "usp45mag", "count": [ 1, 4 ] },
       { "group": "police_armory_full_usp45mag_45_acp", "count": [ 0, 4 ] },
       { "group": "police_armory_full_usp45mag_45_jhp", "count": [ 0, 4 ] },
+      { "group": "police_armory_boxes_45_acp" },
+      { "group": "police_armory_boxes_45_jhp" },
+      { "group": "police_armory_boxes_45_super", "prob": 30 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_glock_21",
+    "//": "One or more Glock 21 pistols, empty mags, full mags, JHP and FMJ ammo with a chance of +P ammo.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "glock_21" },
+      { "item": "glock_21", "prob": 50 },
+      { "item": "glock_21", "prob": 25 },
+      { "item": "glock_21mag", "count": [ 1, 4 ] },
+      { "group": "police_armory_full_glock_21mag_45_acp", "count": [ 0, 4 ] },
+      { "group": "police_armory_full_glock_21mag_45_jhp", "count": [ 0, 4 ] },
+      { "group": "police_armory_boxes_45_acp" },
+      { "group": "police_armory_boxes_45_jhp" },
+      { "group": "police_armory_boxes_45_super", "prob": 30 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_ump45",
+    "//": "One or more UMP 45 submachine guns, empty mags, full mags, JHP and FMJ ammo with a chance of +P ammo.",
+    "subtype": "collection",
+    "entries": [
+      { "group": "modular_ump_45", "contents-item": [ "red_dot_sight", "suppressor" ] },
+      { "group": "modular_ump_45", "contents-item": [ "red_dot_sight", "suppressor" ], "prob": 50 },
+      { "group": "modular_ump_45", "contents-item": [ "red_dot_sight", "suppressor" ], "prob": 25 },
+      { "item": "ump45mag", "count": [ 1, 7 ] },
+      { "group": "police_armory_full_ump45_45_acp", "count": [ 0, 2 ] },
+      { "group": "police_armory_full_ump45_45_jhp", "count": [ 0, 3 ] },
       { "group": "police_armory_boxes_45_acp" },
       { "group": "police_armory_boxes_45_jhp" },
       { "group": "police_armory_boxes_45_super", "prob": 30 }
@@ -496,6 +1093,34 @@
     "subtype": "collection",
     "container-item": "usp45mag",
     "entries": [ { "item": "45_jhp", "charges": [ 12, 12 ] } ]
+  },
+  {
+    "id": "police_armory_full_glock_21mag_45_acp",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "glock_21mag",
+    "entries": [ { "item": "45_acp", "charges": [ 13, 13 ] } ]
+  },
+  {
+    "id": "police_armory_full_glock_21mag_45_jhp",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "glock_21mag",
+    "entries": [ { "item": "45_jhp", "charges": [ 13, 13 ] } ]
+  },
+  {
+    "id": "police_armory_full_ump45_45_acp",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ump45mag",
+    "entries": [ { "item": "45_acp", "charges": [ 25, 25 ] } ]
+  },
+  {
+    "id": "police_armory_full_ump45_45_jhp",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ump45mag",
+    "entries": [ { "item": "45_jhp", "charges": [ 25, 25 ] } ]
   },
   {
     "id": "police_armory_boxes_45_jhp",
@@ -574,27 +1199,191 @@
   },
   {
     "type": "item_group",
-    "id": "police_armory_ar15_223",
-    "//": "One or more ar15s, empty mags, full mags, 223 remington ammo.",
+    "id": "police_armory_patrolrifle_stanag",
+    "//": "One or more STANAG-compatible 5.56 rifles, empty mags, full mags, 223 remington training ammo and mk318-type duty ammo.",
     "subtype": "collection",
     "entries": [
-      { "group": "police_armory_ar15_pick1" },
-      { "group": "police_armory_ar15_pick1", "prob": 50 },
-      { "group": "police_armory_ar15_pick1", "prob": 25 },
+      { "group": "police_armory_patrolrifle_anystanag" },
       { "item": "stanag30", "count": [ 1, 7 ] },
-      { "group": "police_armory_full_stanag30_223", "count": [ 1, 4 ] },
+      { "group": "police_armory_full_stanag30_223", "count": [ 1, 3 ] },
+      { "group": "police_armory_full_stanag30_556_mk318", "count": [ 1, 2 ] },
+      { "group": "police_armory_boxes_223" },
+      { "group": "police_armory_boxes_556_mk318" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_patrolrifle_anystanag",
+    "//": "Chooses the STANAG-compatible 5.56 rifle type that will spawn in the above group.",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "police_armory_ar15short_pick", "prob": 24 },
+      { "group": "police_armory_ar15medium_pick", "prob": 50 },
+      { "group": "police_armory_ar15long_pick", "prob": 10 },
+      { "group": "police_armory_m4_pick", "prob": 10 },
+      { "group": "police_armory_m4cqbr_pick", "prob": 5 },
+      { "group": "police_armory_hk416_pick", "prob": 1 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_ar15short_pick",
+    "//": "1-3 rifles of one type",
+    "subtype": "collection",
+    "entries": [
+      { "group": "ar15_223short", "contents-item": "red_dot_sight" },
+      { "group": "ar15_223short", "contents-item": "red_dot_sight", "prob": 50 },
+      { "group": "ar15_223short", "contents-item": "red_dot_sight", "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_ar15medium_pick",
+    "//": "1-3 rifles of one type",
+    "subtype": "collection",
+    "entries": [
+      { "group": "ar15_223medium", "contents-item": "red_dot_sight" },
+      { "group": "ar15_223medium", "contents-item": "red_dot_sight", "prob": 50 },
+      { "group": "ar15_223medium", "contents-item": "red_dot_sight", "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_ar15long_pick",
+    "//": "1-3 rifles weighted of one type",
+    "subtype": "collection",
+    "entries": [ { "group": "ar15_223long" }, { "group": "ar15_223long", "prob": 50 }, { "group": "ar15_223long", "prob": 25 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_m4_pick",
+    "//": "1-3 rifles of one type",
+    "subtype": "collection",
+    "entries": [
+      { "item": "modular_m4_carbine", "variant": "modular_m4a1", "contents-item": "red_dot_sight" },
+      { "item": "modular_m4_carbine", "variant": "modular_m4a1", "contents-item": "red_dot_sight", "prob": 50 },
+      { "item": "modular_m4_carbine", "variant": "modular_m4a1", "contents-item": "red_dot_sight", "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_m4cqbr_pick",
+    "//": "1-3 rifles of one type",
+    "subtype": "collection",
+    "entries": [
+      { "item": "modular_m4_carbine", "variant": "m4_cqbr", "contents-item": [ "red_dot_sight", "suppressor" ] },
+      {
+        "item": "modular_m4_carbine",
+        "variant": "m4_cqbr",
+        "contents-item": [ "red_dot_sight", "suppressor" ],
+        "prob": 50
+      },
+      {
+        "item": "modular_m4_carbine",
+        "variant": "m4_cqbr",
+        "contents-item": [ "red_dot_sight", "suppressor" ],
+        "prob": 25
+      }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_hk416_pick",
+    "//": "1-3 rifles weighted towards 1 rifle",
+    "subtype": "collection",
+    "entries": [
+      { "item": "modular_m27_assault_rifle", "variant": "modular_h&k416a5", "contents-item": "holo_sight" },
+      {
+        "item": "modular_m27_assault_rifle",
+        "variant": "modular_h&k416a5",
+        "contents-item": "holo_sight",
+        "prob": 50
+      },
+      {
+        "item": "modular_m27_assault_rifle",
+        "variant": "modular_h&k416a5",
+        "contents-item": "holo_sight",
+        "prob": 25
+      }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_mini14",
+    "//": "One or more Mini-14 rifles, empty mags, full mags, and 223 remington ammo.  Any PD still issuing this probably doesn't believe in modern ammo.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "ruger_mini" },
+      { "item": "ruger_mini", "prob": 50 },
+      { "item": "ruger_mini", "prob": 25 },
+      { "item": "ruger20", "count": [ 1, 3 ] },
+      { "item": "ruger30", "count": [ 1, 3 ] },
+      { "group": "police_armory_full_rugermag_223", "count": [ 1, 5 ] },
       { "group": "police_armory_boxes_223" }
     ]
   },
   {
     "type": "item_group",
-    "id": "police_armory_ar15_pick1",
-    "//": "Pick a random ar-15 chambered in 223 weighted towards medium barrels.",
-    "subtype": "distribution",
+    "id": "police_armory_aug",
+    "//": "One or more Steyr AUG rifles, empty mags, full mags, 223 remington training ammo and mk318-type duty ammo.",
+    "subtype": "collection",
     "entries": [
-      { "group": "ar15_223medium", "prob": 50 },
-      { "group": "ar15_223long", "prob": 30 },
-      { "group": "ar15_223short", "prob": 20 }
+      { "item": "steyr_aug", "contents-item": "holo_sight" },
+      { "item": "steyr_aug", "contents-item": "holo_sight", "prob": 50 },
+      { "item": "steyr_aug", "contents-item": "holo_sight", "prob": 25 },
+      { "item": "augmag_30rd", "count": [ 1, 7 ] },
+      { "group": "police_armory_full_augmag_223", "count": [ 1, 3 ] },
+      { "group": "police_armory_full_augmag_556_mk318", "count": [ 1, 2 ] },
+      { "group": "police_armory_boxes_223" },
+      { "group": "police_armory_boxes_556_mk318" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_g36",
+    "//": "One or more G36 rifles, empty mags, full mags, 223 remington training ammo and mk318-type duty ammo.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "hk_g36", "contents-item": "holo_sight" },
+      { "item": "hk_g36", "contents-item": "holo_sight", "prob": 50 },
+      { "item": "hk_g36", "contents-item": "holo_sight", "prob": 25 },
+      { "item": "g36mag_30rd", "count": [ 1, 7 ] },
+      { "group": "police_armory_full_g36mag_223", "count": [ 1, 3 ] },
+      { "group": "police_armory_full_g36mag_556_mk318", "count": [ 1, 2 ] },
+      { "group": "police_armory_boxes_223" },
+      { "group": "police_armory_boxes_556_mk318" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_hk417",
+    "//": "One or more HK417 rifles, empty mags, full mags, 308 ammo and 7.62x51 ammo.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "hk417_13", "contents-item": [ "holo_sight", "suppressor" ] },
+      { "item": "hk417_13", "contents-item": [ "holo_sight", "suppressor" ], "prob": 50 },
+      { "item": "hk417_13", "contents-item": [ "holo_sight", "suppressor" ], "prob": 25 },
+      { "item": "hk417mag_20rd", "count": [ 1, 7 ] },
+      { "group": "police_armory_full_hk417mag_308", "count": [ 0, 3 ] },
+      { "group": "police_armory_full_hk417mag_762_51", "count": [ 0, 3 ] },
+      { "group": "police_armory_boxes_308" },
+      { "group": "police_armory_boxes_762_51", "prob": 25 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_m1a",
+    "//": "One or more M1A rifles, empty mags, full mags, 308 ammo and 7.62x51 ammo.  This is standing in for M-14 rifles acquired through the 1033 DoD program.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "m1a" },
+      { "item": "m1a", "prob": 50 },
+      { "item": "m1a", "prob": 25 },
+      { "item": "m14mag", "count": [ 1, 7 ] },
+      { "group": "police_armory_full_m14mag_308", "count": [ 0, 3 ] },
+      { "group": "police_armory_full_m14mag_762_51", "count": [ 0, 3 ] },
+      { "group": "police_armory_boxes_308" },
+      { "group": "police_armory_boxes_762_51", "prob": 25 }
     ]
   },
   {
@@ -605,6 +1394,83 @@
     "entries": [ { "item": "223", "charges": [ 30, 30 ] } ]
   },
   {
+    "id": "police_armory_full_stanag30_556_mk262",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "stanag30",
+    "entries": [ { "item": "556_mk262", "charges": [ 30, 30 ] } ]
+  },
+  {
+    "id": "police_armory_full_stanag30_556_mk318",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "stanag30",
+    "entries": [ { "item": "556_mk318", "charges": [ 30, 30 ] } ]
+  },
+  {
+    "id": "police_armory_full_rugermag_223",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ruger20",
+    "entries": [ { "item": "223", "charges": [ 20, 20 ] } ]
+  },
+  {
+    "id": "police_armory_full_augmag_223",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "augmag_30rd",
+    "entries": [ { "item": "223", "charges": [ 30, 30 ] } ]
+  },
+  {
+    "id": "police_armory_full_augmag_556_mk318",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "augmag_30rd",
+    "entries": [ { "item": "556_mk318", "charges": [ 30, 30 ] } ]
+  },
+  {
+    "id": "police_armory_full_g36mag_223",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "g36mag_30rd",
+    "entries": [ { "item": "223", "charges": [ 30, 30 ] } ]
+  },
+  {
+    "id": "police_armory_full_g36mag_556_mk318",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "g36mag_30rd",
+    "entries": [ { "item": "556_mk318", "charges": [ 30, 30 ] } ]
+  },
+  {
+    "id": "police_armory_full_hk417mag_308",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "hk417mag_20rd",
+    "entries": [ { "item": "308", "charges": [ 20, 20 ] } ]
+  },
+  {
+    "id": "police_armory_full_hk417mag_762_51",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "hk417mag_20rd",
+    "entries": [ { "item": "762_51", "charges": [ 20, 20 ] } ]
+  },
+  {
+    "id": "police_armory_full_m14mag_308",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "m14mag",
+    "entries": [ { "item": "308", "charges": [ 20, 20 ] } ]
+  },
+  {
+    "id": "police_armory_full_m14mag_762_51",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "m14mag",
+    "entries": [ { "item": "762_51", "charges": [ 20, 20 ] } ]
+  },
+  {
     "id": "police_armory_boxes_223",
     "type": "item_group",
     "subtype": "collection",
@@ -612,7 +1478,7 @@
       { "group": "police_armory_box_some_223" },
       { "group": "police_armory_box_some_223", "prob": 50 },
       { "item": "ammo_box_2", "count": [ 50, 75 ] },
-      { "group": "police_armory_box_full_223", "count": [ 0, 10 ] }
+      { "group": "police_armory_box_full_223", "count": [ 0, 7 ] }
     ]
   },
   {
@@ -632,51 +1498,83 @@
     "on_overflow": "spill"
   },
   {
-    "type": "item_group",
-    "id": "police_armory_m4_556",
-    "//": "One or more m4s, empty mags, full mags, 556 nato ammo.",
-    "subtype": "collection",
-    "entries": [
-      { "item": "modular_m4_carbine" },
-      { "item": "modular_m4_carbine", "prob": 50 },
-      { "item": "stanag30", "count": [ 1, 5 ] },
-      { "group": "police_armory_full_stanag30_556", "count": [ 1, 4 ] },
-      { "group": "police_armory_boxes_556" }
-    ]
-  },
-  {
-    "id": "police_armory_boxes_556",
+    "id": "police_armory_boxes_556_mk262",
     "type": "item_group",
     "subtype": "collection",
     "entries": [
-      { "group": "police_armory_box_some_556" },
-      { "group": "police_armory_box_some_556", "prob": 50 },
+      { "group": "police_armory_box_some_556_mk262" },
+      { "group": "police_armory_box_some_556_mk262", "prob": 50 },
       { "item": "ammo_box_2", "count": [ 50, 75 ] },
-      { "group": "police_armory_box_full_556", "count": [ 0, 10 ] }
+      { "group": "police_armory_box_full_556_mk262", "count": [ 0, 5 ] }
     ]
   },
   {
-    "id": "police_armory_full_stanag30_556",
-    "type": "item_group",
-    "subtype": "collection",
-    "container-item": "stanag30",
-    "entries": [ { "item": "556", "charges": [ 30, 30 ] } ]
-  },
-  {
-    "id": "police_armory_box_full_556",
+    "id": "police_armory_box_full_556_mk262",
     "type": "item_group",
     "subtype": "collection",
     "container-item": "ammo_box_2",
-    "entries": [ { "item": "223", "charges": [ 30, 30 ] } ],
+    "entries": [ { "item": "556_mk262", "charges": [ 30, 30 ] } ],
     "on_overflow": "spill"
   },
   {
-    "id": "police_armory_box_some_556",
+    "id": "police_armory_box_some_556_mk262",
     "type": "item_group",
     "subtype": "collection",
     "container-item": "ammo_box_2",
-    "entries": [ { "item": "556", "charges": [ 1, 30 ] } ],
+    "entries": [ { "item": "556_mk262", "charges": [ 1, 30 ] } ],
     "on_overflow": "spill"
+  },
+  {
+    "id": "police_armory_boxes_556_mk318",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "police_armory_box_some_556_mk318" },
+      { "group": "police_armory_box_some_556_mk318", "prob": 50 },
+      { "item": "ammo_box_2", "count": [ 50, 75 ] },
+      { "group": "police_armory_box_full_556_mk318", "count": [ 0, 5 ] }
+    ]
+  },
+  {
+    "id": "police_armory_box_full_556_mk318",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ammo_box_2",
+    "entries": [ { "item": "556_mk318", "charges": [ 30, 30 ] } ],
+    "on_overflow": "spill"
+  },
+  {
+    "id": "police_armory_box_some_556_mk318",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ammo_box_2",
+    "entries": [ { "item": "556_mk318", "charges": [ 1, 30 ] } ],
+    "on_overflow": "spill"
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_ar15sniper",
+    "//": "One or more scoped, rifle-length AR-15 rifles, empty mags, full mags, and boxes of 5.56 Mk262.",
+    "subtype": "collection",
+    "entries": [
+      { "group": "ar15_223long", "contents-item": [ "rifle_scope", "bipod" ] },
+      { "group": "ar15_223long", "contents-item": [ "rifle_scope", "bipod" ], "prob": 50 },
+      { "item": "stanag20", "count": [ 0, 2 ] },
+      { "item": "stanag30", "count": [ 0, 2 ] },
+      { "group": "police_armory_full_stanag30_556_mk262", "count": [ 0, 3 ] },
+      { "group": "police_armory_boxes_556_mk262" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_any_308sniper",
+    "//": "Pick one of multiple interchangeable 308 sniper variants and its ammo.",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "police_armory_M24", "prob": 70 },
+      { "group": "police_armory_ar10", "prob": 20 },
+      { "group": "police_armory_axmc_308", "prob": 10 }
+    ]
   },
   {
     "type": "item_group",
@@ -689,6 +1587,65 @@
       { "group": "police_armory_boxes_308" },
       { "group": "police_armory_boxes_762_51", "prob": 25 }
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_ar10",
+    "//": "One or more scoped AR-10 rifles, empty mags, full mags, and boxes of 308 and 762.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "ar10", "contents-item": [ "rifle_scope", "bipod" ] },
+      { "item": "ar10", "contents-item": [ "rifle_scope", "bipod" ], "prob": 50 },
+      { "item": "ar10mag_10rd", "count": [ 0, 2 ] },
+      { "item": "ar10mag_20rd", "count": [ 0, 2 ] },
+      { "group": "police_armory_full_ar10mag_308", "count": [ 0, 3 ] },
+      { "group": "police_armory_full_ar10mag_762_51", "count": [ 0, 3 ] },
+      { "group": "police_armory_boxes_308" },
+      { "group": "police_armory_boxes_762_51", "prob": 25 }
+    ]
+  },
+  {
+    "id": "police_armory_full_ar10mag_308",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ar10mag_20rd",
+    "entries": [ { "item": "308", "charges": [ 20, 20 ] } ]
+  },
+  {
+    "id": "police_armory_full_ar10mag_762_51",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ar10mag_20rd",
+    "entries": [ { "item": "762_51", "charges": [ 20, 20 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_axmc_308",
+    "//": "One or more scoped AXMC rifles in 308, empty mags, full mags, and boxes of 308 and 762.",
+    "subtype": "collection",
+    "entries": [
+      { "group": "axmc_308", "contents-item": [ "rifle_scope", "bipod" ] },
+      { "group": "axmc_308", "contents-item": [ "rifle_scope", "bipod" ], "prob": 25 },
+      { "item": "ai_308mag_10", "count": [ 0, 2 ] },
+      { "group": "police_armory_full_ai_mag_308", "count": [ 0, 3 ] },
+      { "group": "police_armory_full_ai_mag_762_51", "count": [ 0, 3 ] },
+      { "group": "police_armory_boxes_308" },
+      { "group": "police_armory_boxes_762_51", "prob": 25 }
+    ]
+  },
+  {
+    "id": "police_armory_full_ai_mag_308",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ai_308mag_10",
+    "entries": [ { "item": "308", "charges": [ 10, 10 ] } ]
+  },
+  {
+    "id": "police_armory_full_ai_mag_762_51",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ai_308mag_10",
+    "entries": [ { "item": "762_51", "charges": [ 10, 10 ] } ]
   },
   {
     "id": "police_armory_boxes_308",
@@ -778,10 +1735,226 @@
   },
   {
     "type": "item_group",
+    "id": "police_armory_axmc_300",
+    "//": "One or more AXMC rifles in 300 win mag, empty mags, full mags, and boxes of 300 win mag",
+    "subtype": "collection",
+    "entries": [
+      { "group": "axmc_300", "contents-item": [ "rifle_scope", "bipod" ] },
+      { "group": "axmc_300", "contents-item": [ "rifle_scope", "bipod" ], "prob": 10 },
+      { "item": "ai_338mag", "count": [ 0, 3 ] },
+      { "item": "ai_338mag_10", "count": [ 0, 1 ] },
+      { "group": "police_armory_full_ai_mag_300", "count": [ 0, 2 ] },
+      { "group": "police_armory_boxes_300" }
+    ]
+  },
+  {
+    "id": "police_armory_full_ai_mag_300",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ai_338mag",
+    "entries": [ { "item": "300_winmag", "charges": [ 5, 5 ] } ]
+  },
+  {
+    "id": "police_armory_boxes_300",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "police_armory_box_some_300" },
+      { "group": "police_armory_box_some_300", "prob": 50 },
+      { "item": "ammo_box_army_20_300wm", "count": [ 5, 20 ] },
+      { "group": "police_armory_box_full_300", "count": [ 0, 3 ] }
+    ]
+  },
+  {
+    "id": "police_armory_box_full_300",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ammo_box_army_20_300wm",
+    "entries": [ { "item": "300_winmag", "charges": [ 20, 20 ] } ]
+  },
+  {
+    "id": "police_armory_box_some_300",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ammo_box_army_20_300wm",
+    "entries": [ { "item": "300_winmag", "charges": [ 1, 20 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_any_338sniper",
+    "//": "Pick one of multiple interchangeable .338 sniper variants and its ammo.",
+    "subtype": "distribution",
+    "entries": [
+      { "group": "police_armory_axmc", "prob": 30 },
+      { "group": "police_armory_tac338", "prob": 30 },
+      { "group": "police_armory_mrad", "prob": 40 }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_axmc",
+    "//": "One or more AXMC rifles in 338 lapua, empty mags, full mags, and boxes of 338 hpbt",
+    "subtype": "collection",
+    "entries": [
+      { "group": "axmc", "contents-item": [ "rifle_scope", "bipod" ] },
+      { "group": "axmc", "contents-item": [ "rifle_scope", "bipod" ], "prob": 10 },
+      { "item": "ai_338mag", "count": [ 0, 3 ] },
+      { "item": "ai_338mag_10", "count": [ 0, 1 ] },
+      { "group": "police_armory_full_ai_mag_338", "count": [ 0, 2 ] },
+      { "group": "police_armory_boxes_338" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_tac338",
+    "//": "One or more TAC-338 rifles in 338 lapua, empty mags, full mags, and boxes of 338 hpbt",
+    "subtype": "collection",
+    "entries": [
+      { "item": "tac338" },
+      { "item": "tac338", "prob": 10 },
+      { "item": "ai_338mag", "count": [ 0, 3 ] },
+      { "item": "ai_338mag_10", "count": [ 0, 1 ] },
+      { "group": "police_armory_full_ai_mag_338", "count": [ 0, 2 ] },
+      { "group": "police_armory_boxes_338" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_mrad",
+    "//": "One or more MRAD rifles in 338 lapua, empty mags, full mags, and boxes of 338 hpbt",
+    "subtype": "collection",
+    "entries": [
+      { "item": "mrad_smr", "contents-item": [ "rifle_scope", "bipod" ] },
+      { "item": "mrad_smr", "contents-item": [ "rifle_scope", "bipod" ], "prob": 10 },
+      { "item": "mrad_338lapua_mag", "count": [ 0, 3 ] },
+      { "group": "police_armory_full_mradmag_338", "count": [ 0, 2 ] },
+      { "group": "police_armory_boxes_338" }
+    ]
+  },
+  {
+    "id": "police_armory_full_ai_mag_338",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ai_338mag",
+    "entries": [ { "item": "338lapua_hpbt", "charges": [ 5, 5 ] } ]
+  },
+  {
+    "id": "police_armory_full_mradmag_338",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "mrad_338lapua_mag",
+    "entries": [ { "item": "338lapua_hpbt", "charges": [ 10, 10 ] } ]
+  },
+  {
+    "id": "police_armory_boxes_338",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "police_armory_box_some_338" },
+      { "group": "police_armory_box_some_338", "prob": 50 },
+      { "item": "ammo_box_army_10_338", "count": [ 5, 20 ] },
+      { "group": "police_armory_box_full_338", "count": [ 0, 3 ] }
+    ]
+  },
+  {
+    "id": "police_armory_box_full_338",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ammo_box_army_10_338",
+    "entries": [ { "item": "338lapua_hpbt", "charges": [ 10, 10 ] } ]
+  },
+  {
+    "id": "police_armory_box_some_338",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ammo_box_army_10_338",
+    "entries": [ { "item": "338lapua_hpbt", "charges": [ 1, 10 ] } ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_any_50sniper",
+    "//": "Pick one of multiple interchangeable .50 BMG sniper variants and its ammo.",
+    "subtype": "distribution",
+    "entries": [ { "group": "police_armory_as50", "prob": 20 }, { "group": "police_armory_tac50", "prob": 80 } ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_as50",
+    "//": "One or more AS-50 rifles, empty mags, full mags, and boxes of match 50 BMG.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "as50" },
+      { "item": "as50", "prob": 10 },
+      { "item": "as50mag", "count": [ 0, 3 ] },
+      { "group": "police_armory_full_as50mag", "count": [ 0, 2 ] },
+      { "group": "police_armory_boxes_50" }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "police_armory_tac50",
+    "//": "One or more TAC-50 rifles, empty mags, full mags, and boxes of match 50 BMG.",
+    "subtype": "collection",
+    "entries": [
+      { "item": "tac50" },
+      { "item": "tac50", "prob": 10 },
+      { "item": "tac50mag", "count": [ 0, 3 ] },
+      { "group": "police_armory_full_tac50mag", "count": [ 0, 2 ] },
+      { "group": "police_armory_boxes_50" }
+    ]
+  },
+  {
+    "id": "police_armory_full_as50mag",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "as50mag",
+    "entries": [ { "item": "50match", "charges": [ 5, 5 ] } ]
+  },
+  {
+    "id": "police_armory_full_tac50mag",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "tac50mag",
+    "entries": [ { "item": "50match", "charges": [ 5, 5 ] } ]
+  },
+  {
+    "id": "police_armory_boxes_50",
+    "type": "item_group",
+    "subtype": "collection",
+    "entries": [
+      { "group": "police_armory_box_some_50" },
+      { "group": "police_armory_box_some_50", "prob": 50 },
+      { "item": "ammo_box_army_10_50bmg", "count": [ 5, 20 ] },
+      { "group": "police_armory_box_full_50", "count": [ 0, 3 ] }
+    ]
+  },
+  {
+    "id": "police_armory_box_full_50",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ammo_box_army_10_50bmg",
+    "entries": [ { "item": "50match", "charges": [ 10, 10 ] } ]
+  },
+  {
+    "id": "police_armory_box_some_50",
+    "type": "item_group",
+    "subtype": "collection",
+    "container-item": "ammo_box_army_10_50bmg",
+    "entries": [ { "item": "50match", "charges": [ 1, 10 ] } ]
+  },
+  {
+    "type": "item_group",
     "id": "police_armory_shotgun_pick1",
     "//": "Pick a random police shotgun.",
     "subtype": "distribution",
-    "entries": [ { "item": "mossberg_500", "prob": 50 }, { "item": "remington_870", "prob": 50 } ]
+    "entries": [
+      { "item": "mossberg_500", "variant": "mossberg_500_security", "prob": 30 },
+      { "item": "remington_870_express", "prob": 35 },
+      { "item": "mossberg_590", "variant": "mossberg_590", "prob": 23 },
+      { "item": "mossberg_930", "variant": "mossberg_930", "prob": 8 },
+      { "item": "mossberg_930", "variant": "m1014", "prob": 2 },
+      { "item": "remington_870_breacher", "prob": 2 }
+    ]
   },
   {
     "id": "police_armory_boxes_shotshells",
@@ -790,12 +1963,10 @@
     "entries": [
       { "group": "police_armory_box_some_shot_beanbag" },
       { "group": "police_armory_box_some_shot_beanbag", "prob": 50 },
-      { "group": "police_armory_box_some_shot_he" },
       { "group": "police_armory_box_some_shot_00", "prob": 75 },
       { "item": "ammo_box_4", "count": [ 25, 40 ] },
       { "group": "police_armory_box_full_shot_beanbag", "count": [ 0, 8 ] },
-      { "group": "police_armory_box_full_shot_00", "count": [ 0, 2 ], "prob": 50 },
-      { "group": "police_armory_box_full_shot_he", "count": [ 0, 2 ], "prob": 50 }
+      { "group": "police_armory_box_full_shot_00", "count": [ 0, 2 ], "prob": 50 }
     ]
   },
   {
@@ -811,20 +1982,6 @@
     "subtype": "collection",
     "container-item": "ammo_box_4",
     "entries": [ { "item": "shot_beanbag", "charges": [ 1, 20 ] } ]
-  },
-  {
-    "id": "police_armory_box_full_shot_he",
-    "type": "item_group",
-    "subtype": "collection",
-    "container-item": "ammo_box_4",
-    "entries": [ { "item": "shot_he", "charges": [ 20, 20 ] } ]
-  },
-  {
-    "id": "police_armory_box_some_shot_he",
-    "type": "item_group",
-    "subtype": "collection",
-    "container-item": "ammo_box_4",
-    "entries": [ { "item": "shot_he", "charges": [ 1, 20 ] } ]
   },
   {
     "id": "police_armory_box_full_shot_00",

--- a/data/json/itemgroups/Weapons_Mods_Ammo/field_drops.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/field_drops.json
@@ -22,6 +22,183 @@
     ]
   },
   {
+    "id": "field_ar15_223",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for Armalite Rifles (though other stanag compliants could work too), loaded with .223 ammo",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "stanag30", "ammo-item": "223", "charges": 30, "prob": 50 },
+          { "item": "stanag30", "ammo-item": "223", "charges": [ 0, 5 ], "prob": 50 }
+        ],
+        "prob": 100
+      },
+      {
+        "distribution": [
+          { "item": "stanag30", "ammo-item": "223", "charges": 30, "prob": 30 },
+          { "item": "stanag30", "ammo-item": "223", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 70
+      },
+      {
+        "distribution": [
+          { "item": "stanag30", "ammo-item": "223", "charges": 30, "prob": 30 },
+          { "item": "stanag30", "ammo-item": "223", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_ar15_mk318",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for Armalite Rifles (though other stanag compliants could work too), loaded with Mk318-type 'duty' ammo",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "stanag30", "ammo-item": "556_mk318", "charges": 30, "prob": 50 },
+          { "item": "stanag30", "ammo-item": "556_mk318", "charges": [ 0, 5 ], "prob": 50 }
+        ],
+        "prob": 100
+      },
+      {
+        "distribution": [
+          { "item": "stanag30", "ammo-item": "556_mk318", "charges": 30, "prob": 30 },
+          { "item": "stanag30", "ammo-item": "556_mk318", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 70
+      },
+      {
+        "distribution": [
+          { "item": "stanag30", "ammo-item": "556_mk318", "charges": 30, "prob": 30 },
+          { "item": "stanag30", "ammo-item": "556_mk318", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_mini14",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for Mini-14 rifles",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "ruger20", "ammo-item": "223", "charges": 20, "prob": 50 },
+          { "item": "ruger20", "ammo-item": "223", "charges": [ 0, 5 ], "prob": 50 }
+        ],
+        "prob": 100
+      },
+      {
+        "distribution": [
+          { "item": "ruger20", "ammo-item": "223", "charges": 20, "prob": 30 },
+          { "item": "ruger20", "ammo-item": "223", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 70
+      },
+      {
+        "distribution": [
+          { "item": "ruger20", "ammo-item": "223", "charges": 20, "prob": 30 },
+          { "item": "ruger20", "ammo-item": "223", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_g36",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for G36 rifles",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "g36mag_30rd", "ammo-item": "556_mk318", "charges": 30, "prob": 50 },
+          { "item": "g36mag_30rd", "ammo-item": "556_mk318", "charges": [ 0, 5 ], "prob": 50 }
+        ],
+        "prob": 100
+      },
+      {
+        "distribution": [
+          { "item": "g36mag_30rd", "ammo-item": "556_mk318", "charges": 30, "prob": 30 },
+          { "item": "g36mag_30rd", "ammo-item": "556_mk318", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 70
+      },
+      {
+        "distribution": [
+          { "item": "g36mag_30rd", "ammo-item": "556_mk318", "charges": 30, "prob": 30 },
+          { "item": "g36mag_30rd", "ammo-item": "556_mk318", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_steyraug",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for Steyr AUG rifles",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "augmag_30rd", "ammo-item": "556_mk318", "charges": 30, "prob": 50 },
+          { "item": "augmag_30rd", "ammo-item": "556_mk318", "charges": [ 0, 5 ], "prob": 50 }
+        ],
+        "prob": 100
+      },
+      {
+        "distribution": [
+          { "item": "augmag_30rd", "ammo-item": "556_mk318", "charges": 30, "prob": 30 },
+          { "item": "augmag_30rd", "ammo-item": "556_mk318", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 70
+      },
+      {
+        "distribution": [
+          { "item": "augmag_30rd", "ammo-item": "556_mk318", "charges": 30, "prob": 30 },
+          { "item": "augmag_30rd", "ammo-item": "556_mk318", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_hk417",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for HK417 rifles",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [ { "item": "hk417mag_20rd", "charges": 20, "prob": 50 }, { "item": "hk417mag_20rd", "charges": [ 0, 5 ], "prob": 50 } ],
+        "prob": 100
+      },
+      {
+        "distribution": [ { "item": "hk417mag_20rd", "charges": 20, "prob": 30 }, { "item": "hk417mag_20rd", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 70
+      },
+      {
+        "distribution": [ { "item": "hk417mag_20rd", "charges": 20, "prob": 30 }, { "item": "hk417mag_20rd", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 50
+      }
+    ]
+  },
+  {
     "id": "field_xedra_rifle",
     "type": "item_group",
     "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
@@ -106,6 +283,42 @@
     "entries": [ { "item": "3006", "charges": [ 1, 6 ], "prob": 100 } ]
   },
   {
+    "id": "field_308",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for any sniper in 308 since its just shells",
+    "subtype": "collection",
+    "entries": [ { "item": "308", "charges": [ 1, 6 ], "prob": 100 } ]
+  },
+  {
+    "id": "field_300",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for any sniper in 300 win mag since its just shells",
+    "subtype": "collection",
+    "entries": [ { "item": "300_winmag", "charges": [ 1, 6 ], "prob": 100 } ]
+  },
+  {
+    "id": "field_338",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for any sniper in 338 lapua since its just shells",
+    "subtype": "collection",
+    "entries": [ { "item": "338lapua_hpbt", "charges": [ 1, 6 ], "prob": 100 } ]
+  },
+  {
+    "id": "field_50bmg",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for any sniper in 3006 since its just shells",
+    "subtype": "collection",
+    "entries": [ { "item": "50match", "charges": [ 1, 6 ], "prob": 100 } ]
+  },
+  {
     "id": "field_fn57",
     "type": "item_group",
     "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
@@ -123,6 +336,50 @@
       },
       {
         "distribution": [ { "item": "fn57mag", "charges": 20, "prob": 30 }, { "item": "fn57mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_p90",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the P90",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [ { "item": "fnp90mag", "charges": 50, "prob": 50 }, { "item": "fnp90mag", "charges": [ 0, 5 ], "prob": 50 } ],
+        "prob": 100
+      },
+      {
+        "distribution": [ { "item": "fnp90mag", "charges": 50, "prob": 30 }, { "item": "fnp90mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 70
+      },
+      {
+        "distribution": [ { "item": "fnp90mag", "charges": 50, "prob": 30 }, { "item": "fnp90mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_mp7",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the MP7",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [ { "item": "hk46bigmag", "charges": 40, "prob": 50 }, { "item": "hk46bigmag", "charges": [ 0, 5 ], "prob": 50 } ],
+        "prob": 100
+      },
+      {
+        "distribution": [ { "item": "hk46bigmag", "charges": 40, "prob": 30 }, { "item": "hk46bigmag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 70
+      },
+      {
+        "distribution": [ { "item": "hk46bigmag", "charges": 40, "prob": 30 }, { "item": "hk46bigmag", "charges": [ 0, 5 ], "prob": 70 } ],
         "prob": 50
       }
     ]
@@ -150,23 +407,23 @@
     ]
   },
   {
-    "id": "field_glock_22",
+    "id": "field_glock_17",
     "type": "item_group",
     "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
     "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
-    "//3": "this group is for the glock 22",
+    "//3": "this group is for the glock 17",
     "subtype": "collection",
     "entries": [
       {
-        "distribution": [ { "item": "glock40mag", "charges": 15, "prob": 50 }, { "item": "glock40mag", "charges": [ 0, 5 ], "prob": 50 } ],
+        "distribution": [ { "item": "glock17_17", "charges": 17, "prob": 50 }, { "item": "glock17_17", "charges": [ 0, 5 ], "prob": 50 } ],
         "prob": 100
       },
       {
-        "distribution": [ { "item": "glock40mag", "charges": 15, "prob": 30 }, { "item": "glock40mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "distribution": [ { "item": "glock17_17", "charges": 17, "prob": 30 }, { "item": "glock17_17", "charges": [ 0, 5 ], "prob": 70 } ],
         "prob": 70
       },
       {
-        "distribution": [ { "item": "glock40mag", "charges": 15, "prob": 30 }, { "item": "glock40mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "distribution": [ { "item": "glock17_17", "charges": 17, "prob": 30 }, { "item": "glock17_17", "charges": [ 0, 5 ], "prob": 70 } ],
         "prob": 50
       }
     ]
@@ -194,6 +451,324 @@
     ]
   },
   {
+    "id": "field_usp_9mm",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the usp 9mm",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [ { "item": "usp9mag", "charges": 15, "prob": 50 }, { "item": "usp9mag", "charges": [ 0, 5 ], "prob": 50 } ],
+        "prob": 100
+      },
+      {
+        "distribution": [ { "item": "usp9mag", "charges": 15, "prob": 30 }, { "item": "usp9mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 70
+      },
+      {
+        "distribution": [ { "item": "usp9mag", "charges": 15, "prob": 30 }, { "item": "usp9mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_sp2022_9mm",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the sig sp2022 9mm",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "sp2022mag_15rd_9mm", "charges": 15, "prob": 50 },
+          { "item": "sp2022mag_15rd_9mm", "charges": [ 0, 5 ], "prob": 50 }
+        ],
+        "prob": 100
+      },
+      {
+        "distribution": [
+          { "item": "sp2022mag_15rd_9mm", "charges": 15, "prob": 30 },
+          { "item": "sp2022mag_15rd_9mm", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 70
+      },
+      {
+        "distribution": [
+          { "item": "sp2022mag_15rd_9mm", "charges": 15, "prob": 30 },
+          { "item": "sp2022mag_15rd_9mm", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_px4_9mm",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the px4 9mm",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [ { "item": "px4mag", "charges": 17, "prob": 50 }, { "item": "px4mag", "charges": [ 0, 5 ], "prob": 50 } ],
+        "prob": 100
+      },
+      {
+        "distribution": [ { "item": "px4mag", "charges": 17, "prob": 30 }, { "item": "px4mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 70
+      },
+      {
+        "distribution": [ { "item": "px4mag", "charges": 17, "prob": 30 }, { "item": "px4mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_mp5",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the MP5",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [ { "item": "mp5mag", "charges": 30, "prob": 50 }, { "item": "mp5mag", "charges": [ 0, 5 ], "prob": 50 } ],
+        "prob": 100
+      },
+      {
+        "distribution": [ { "item": "mp5mag", "charges": 30, "prob": 30 }, { "item": "mp5mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 70
+      },
+      {
+        "distribution": [ { "item": "mp5mag", "charges": 30, "prob": 30 }, { "item": "mp5mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_uzi",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the UZI/Colt SMG",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [ { "item": "uzimag", "charges": 32, "prob": 50 }, { "item": "uzimag", "charges": [ 0, 5 ], "prob": 50 } ],
+        "prob": 100
+      },
+      {
+        "distribution": [ { "item": "uzimag", "charges": 32, "prob": 30 }, { "item": "uzimag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 70
+      },
+      {
+        "distribution": [ { "item": "uzimag", "charges": 32, "prob": 30 }, { "item": "uzimag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_apc9",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the APC9",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "btmp9mag_9x19mm_30", "charges": 30, "prob": 50 },
+          { "item": "btmp9mag_9x19mm_30", "charges": [ 0, 5 ], "prob": 50 }
+        ],
+        "prob": 100
+      },
+      {
+        "distribution": [
+          { "item": "btmp9mag_9x19mm_30", "charges": 30, "prob": 30 },
+          { "item": "btmp9mag_9x19mm_30", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 70
+      },
+      {
+        "distribution": [
+          { "item": "btmp9mag_9x19mm_30", "charges": 30, "prob": 30 },
+          { "item": "btmp9mag_9x19mm_30", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_ump9",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the UMP in 9mm",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [ { "item": "ump9mag", "charges": 30, "prob": 50 }, { "item": "ump9mag", "charges": [ 0, 5 ], "prob": 50 } ],
+        "prob": 100
+      },
+      {
+        "distribution": [ { "item": "ump9mag", "charges": 30, "prob": 30 }, { "item": "ump9mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 70
+      },
+      {
+        "distribution": [ { "item": "ump9mag", "charges": 30, "prob": 30 }, { "item": "ump9mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_glock_31",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the glock 31",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "glock40mag", "ammo-item": "357sig_jhp", "charges": 15, "prob": 50 },
+          { "item": "glock40mag", "ammo-item": "357sig_jhp", "charges": [ 0, 5 ], "prob": 50 }
+        ],
+        "prob": 100
+      },
+      {
+        "distribution": [
+          { "item": "glock40mag", "ammo-item": "357sig_jhp", "charges": 15, "prob": 30 },
+          { "item": "glock40mag", "ammo-item": "357sig_jhp", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 70
+      },
+      {
+        "distribution": [
+          { "item": "glock40mag", "ammo-item": "357sig_jhp", "charges": 15, "prob": 30 },
+          { "item": "glock40mag", "ammo-item": "357sig_jhp", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_p226_357sig",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the P226 .357 SIG",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "p226mag_12rd_357sig", "charges": 12, "prob": 50 },
+          { "item": "p226mag_12rd_357sig", "charges": [ 0, 5 ], "prob": 50 }
+        ],
+        "prob": 100
+      },
+      {
+        "distribution": [
+          { "item": "p226mag_12rd_357sig", "charges": 12, "prob": 30 },
+          { "item": "p226mag_12rd_357sig", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 70
+      },
+      {
+        "distribution": [
+          { "item": "p226mag_12rd_357sig", "charges": 12, "prob": 30 },
+          { "item": "p226mag_12rd_357sig", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_p320_357sig",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the P320 .357 SIG",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "p320mag_13rd_357sig", "charges": 13, "prob": 50 },
+          { "item": "p320mag_13rd_357sig", "charges": [ 0, 5 ], "prob": 50 }
+        ],
+        "prob": 100
+      },
+      {
+        "distribution": [
+          { "item": "p320mag_13rd_357sig", "charges": 13, "prob": 30 },
+          { "item": "p320mag_13rd_357sig", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 70
+      },
+      {
+        "distribution": [
+          { "item": "p320mag_13rd_357sig", "charges": 13, "prob": 30 },
+          { "item": "p320mag_13rd_357sig", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_glock_22",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the glock 22",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "glock40mag", "ammo-item": "40sw", "charges": 15, "prob": 50 },
+          { "item": "glock40mag", "ammo-item": "40sw", "charges": [ 0, 5 ], "prob": 50 }
+        ],
+        "prob": 100
+      },
+      {
+        "distribution": [
+          { "item": "glock40mag", "ammo-item": "40sw", "charges": 15, "prob": 30 },
+          { "item": "glock40mag", "ammo-item": "40sw", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 70
+      },
+      {
+        "distribution": [
+          { "item": "glock40mag", "ammo-item": "40sw", "charges": 15, "prob": 30 },
+          { "item": "glock40mag", "ammo-item": "40sw", "charges": [ 0, 5 ], "prob": 70 }
+        ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_px4_40",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the px4 40",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [ { "item": "px4_40mag", "charges": 14, "prob": 50 }, { "item": "px4_40mag", "charges": [ 0, 5 ], "prob": 50 } ],
+        "prob": 100
+      },
+      {
+        "distribution": [ { "item": "px4_40mag", "charges": 14, "prob": 30 }, { "item": "px4_40mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 70
+      },
+      {
+        "distribution": [ { "item": "px4_40mag", "charges": 14, "prob": 30 }, { "item": "px4_40mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 50
+      }
+    ]
+  },
+  {
     "id": "field_sig_40",
     "type": "item_group",
     "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
@@ -211,6 +786,50 @@
       },
       {
         "distribution": [ { "item": "sig40mag", "charges": 12, "prob": 30 }, { "item": "sig40mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_ump40",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the UMP in .40 S&W",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [ { "item": "ump40mag", "charges": 30, "prob": 50 }, { "item": "ump40mag", "charges": [ 0, 5 ], "prob": 50 } ],
+        "prob": 100
+      },
+      {
+        "distribution": [ { "item": "ump40mag", "charges": 30, "prob": 30 }, { "item": "ump40mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 70
+      },
+      {
+        "distribution": [ { "item": "ump40mag", "charges": 30, "prob": 30 }, { "item": "ump40mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_glock_21",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the glock 21",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [ { "item": "glock_21mag", "charges": 13, "prob": 50 }, { "item": "glock_21mag", "charges": [ 0, 5 ], "prob": 50 } ],
+        "prob": 100
+      },
+      {
+        "distribution": [ { "item": "glock_21mag", "charges": 13, "prob": 30 }, { "item": "glock_21mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 70
+      },
+      {
+        "distribution": [ { "item": "glock_21mag", "charges": 13, "prob": 30 }, { "item": "glock_21mag", "charges": [ 0, 5 ], "prob": 70 } ],
         "prob": 50
       }
     ]
@@ -238,23 +857,54 @@
     ]
   },
   {
-    "id": "field_usp_9mm",
+    "id": "field_ump45",
     "type": "item_group",
     "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
     "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
-    "//3": "this group is for the glock 22",
+    "//3": "this group is for the UMP in .45 ACP",
     "subtype": "collection",
     "entries": [
       {
-        "distribution": [ { "item": "usp9mag", "charges": 15, "prob": 50 }, { "item": "usp9mag", "charges": [ 0, 5 ], "prob": 50 } ],
+        "distribution": [ { "item": "ump45mag", "charges": 25, "prob": 50 }, { "item": "ump45mag", "charges": [ 0, 5 ], "prob": 50 } ],
         "prob": 100
       },
       {
-        "distribution": [ { "item": "usp9mag", "charges": 15, "prob": 30 }, { "item": "usp9mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "distribution": [ { "item": "ump45mag", "charges": 25, "prob": 30 }, { "item": "ump45mag", "charges": [ 0, 5 ], "prob": 70 } ],
         "prob": 70
       },
       {
-        "distribution": [ { "item": "usp9mag", "charges": 15, "prob": 30 }, { "item": "usp9mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "distribution": [ { "item": "ump45mag", "charges": 25, "prob": 30 }, { "item": "ump40mag", "charges": [ 0, 5 ], "prob": 70 } ],
+        "prob": 50
+      }
+    ]
+  },
+  {
+    "id": "field_as50",
+    "type": "item_group",
+    "//": "this is a distribution for ammo and magazines an active combatant would have immediately on hand.  Most should be expended.",
+    "//2": "usually takes the form of 100% chance for first mag, 70% for second, 50% for third with reducing chances of them being mostly expended.",
+    "//3": "this group is for the AS50 AMR",
+    "subtype": "collection",
+    "entries": [
+      {
+        "distribution": [
+          { "item": "as50mag", "ammo-item": "50match", "charges": 5, "prob": 50 },
+          { "item": "as50mag", "ammo-item": "50match", "charges": [ 0, 1 ], "prob": 50 }
+        ],
+        "prob": 100
+      },
+      {
+        "distribution": [
+          { "item": "as50mag", "ammo-item": "50match", "charges": 5, "prob": 30 },
+          { "item": "as50mag", "ammo-item": "50match", "charges": [ 0, 1 ], "prob": 70 }
+        ],
+        "prob": 70
+      },
+      {
+        "distribution": [
+          { "item": "as50mag", "ammo-item": "50match", "charges": 5, "prob": 30 },
+          { "item": "as50mag", "ammo-item": "50match", "charges": [ 0, 1 ], "prob": 70 }
+        ],
         "prob": 50
       }
     ]

--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -1361,7 +1361,7 @@
             "ammo-item": "223",
             "charges": [ 0, 30 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           {
@@ -1378,7 +1378,7 @@
             "ammo-item": "223",
             "charges": [ 0, 30 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           {
@@ -1395,7 +1395,7 @@
             "ammo-item": "223",
             "charges": [ 0, 30 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           {
@@ -1413,7 +1413,7 @@
             "ammo-item": "556_mk318",
             "charges": [ 0, 30 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           {
@@ -1431,7 +1431,7 @@
             "ammo-item": "556_mk318",
             "charges": [ 0, 30 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           {
@@ -1449,7 +1449,7 @@
             "ammo-item": "556_mk318",
             "charges": [ 0, 30 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           {
@@ -1466,7 +1466,7 @@
             "ammo-item": "223",
             "charges": [ 0, 20 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_mini14" }
@@ -1480,7 +1480,7 @@
             "ammo-item": "556_mk318",
             "charges": [ 0, 30 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_steyraug" }
@@ -1494,7 +1494,7 @@
             "ammo-item": "556_mk318",
             "charges": [ 0, 30 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_g36" }
@@ -1508,7 +1508,7 @@
             "variant": "mossberg_500_security",
             "charges": [ 0, 6 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_shotgun" }
@@ -1522,7 +1522,7 @@
             "variant": "mossberg_590",
             "charges": [ 0, 9 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_shotgun" }
@@ -1536,7 +1536,7 @@
             "variant": "mossberg_930",
             "charges": [ 0, 8 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_shotgun" }
@@ -1550,7 +1550,7 @@
             "variant": "m1014",
             "charges": [ 0, 8 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_shotgun" }
@@ -1563,7 +1563,7 @@
             "item": "remington_870_express",
             "charges": [ 0, 7 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_shotgun" }
@@ -1576,7 +1576,7 @@
             "item": "remington_700",
             "charges": [ 0, 4 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_3006" }
@@ -1585,7 +1585,7 @@
       },
       {
         "collection": [
-          { "item": "M24", "charges": [ 0, 4 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "M24", "charges": [ 0, 4 ], "contents-item": "shoulder_strap", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_308" }
         ],
         "prob": 10
@@ -1612,21 +1612,21 @@
     "type": "item_group",
     "id": "sidearms_cop",
     "items": [
-      { "item": "fn57", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 1 },
-      { "item": "glock_19", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 50 },
-      { "item": "glock_17", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 60 },
-      { "item": "m9", "variant": "m9", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 3 },
-      { "item": "sp2022", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 10 },
-      { "item": "px4", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 5 },
-      { "item": "usp_9mm", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 3 },
-      { "item": "glock_31", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 4 },
-      { "item": "p226_357sig", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 2 },
-      { "item": "p320_357sig", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 2 },
-      { "item": "glock_22", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 30 },
-      { "item": "px4_40", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 5 },
-      { "item": "sig_40", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 10 },
-      { "item": "glock_21", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 10 },
-      { "item": "usp_45", "variant": "usp_45", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 2 }
+      { "item": "fn57", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ], "prob": 1 },
+      { "item": "glock_19", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ], "prob": 50 },
+      { "item": "glock_17", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ], "prob": 60 },
+      { "item": "m9", "variant": "m9", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ], "prob": 3 },
+      { "item": "sp2022", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ], "prob": 10 },
+      { "item": "px4", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ], "prob": 5 },
+      { "item": "usp_9mm", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ], "prob": 3 },
+      { "item": "glock_31", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ], "prob": 4 },
+      { "item": "p226_357sig", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ], "prob": 2 },
+      { "item": "p320_357sig", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ], "prob": 2 },
+      { "item": "glock_22", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ], "prob": 30 },
+      { "item": "px4_40", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ], "prob": 5 },
+      { "item": "sig_40", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ], "prob": 10 },
+      { "item": "glock_21", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ], "prob": 10 },
+      { "item": "usp_45", "variant": "usp_45", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ], "prob": 2 }
     ]
   },
   {
@@ -1636,49 +1636,49 @@
     "items": [
       {
         "collection": [
-          { "item": "fn57", "prob": 100, "charges": [ 0, 20 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "fn57", "prob": 100, "charges": [ 0, 20 ], "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_fn57" }
         ],
         "prob": 1
       },
       {
         "collection": [
-          { "item": "glock_19", "prob": 100, "charges": [ 0, 15 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "glock_19", "prob": 100, "charges": [ 0, 15 ], "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_glock_19" }
         ],
         "prob": 50
       },
       {
         "collection": [
-          { "item": "glock_17", "prob": 100, "charges": [ 0, 17 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "glock_17", "prob": 100, "charges": [ 0, 17 ], "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_glock_17" }
         ],
         "prob": 60
       },
       {
         "collection": [
-          { "item": "m9", "variant": "m9", "prob": 100, "charges": [ 0, 15 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "m9", "variant": "m9", "prob": 100, "charges": [ 0, 15 ], "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_m9" }
         ],
         "prob": 3
       },
       {
         "collection": [
-          { "item": "sp2022", "prob": 100, "charges": [ 0, 15 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "sp2022", "prob": 100, "charges": [ 0, 15 ], "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_sp2022_9mm" }
         ],
         "prob": 10
       },
       {
         "collection": [
-          { "item": "px4", "prob": 100, "charges": [ 0, 17 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "px4", "prob": 100, "charges": [ 0, 17 ], "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_px4_9mm" }
         ],
         "prob": 5
       },
       {
         "collection": [
-          { "item": "usp_9mm", "prob": 100, "charges": [ 0, 15 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "usp_9mm", "prob": 100, "charges": [ 0, 15 ], "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_usp_9mm" }
         ],
         "prob": 3
@@ -1699,49 +1699,49 @@
       },
       {
         "collection": [
-          { "item": "p226_357sig", "prob": 100, "charges": [ 0, 12 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "p226_357sig", "prob": 100, "charges": [ 0, 12 ], "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_p226_357sig" }
         ],
         "prob": 2
       },
       {
         "collection": [
-          { "item": "p320_357sig", "prob": 100, "charges": [ 0, 13 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "p320_357sig", "prob": 100, "charges": [ 0, 13 ], "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_p320_357sig" }
         ],
         "prob": 2
       },
       {
         "collection": [
-          { "item": "glock_22", "ammo-item": "40sw", "prob": 100, "charges": [ 0, 15 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "glock_22", "ammo-item": "40sw", "prob": 100, "charges": [ 0, 15 ], "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_glock_22" }
         ],
         "prob": 30
       },
       {
         "collection": [
-          { "item": "px4_40", "prob": 100, "charges": [ 0, 14 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "px4_40", "prob": 100, "charges": [ 0, 14 ], "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_px4_40" }
         ],
         "prob": 5
       },
       {
         "collection": [
-          { "item": "sig_40", "prob": 100, "charges": [ 0, 12 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "sig_40", "prob": 100, "charges": [ 0, 12 ], "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_sig_40" }
         ],
         "prob": 10
       },
       {
         "collection": [
-          { "item": "glock_21", "prob": 100, "charges": [ 0, 13 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "glock_21", "prob": 100, "charges": [ 0, 13 ], "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_glock_21" }
         ],
         "prob": 10
       },
       {
         "collection": [
-          { "item": "usp_45", "variant": "usp_45", "prob": 100, "charges": [ 0, 12 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "usp_45", "variant": "usp_45", "prob": 100, "charges": [ 0, 12 ], "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_usp_45" }
         ],
         "prob": 2
@@ -1784,7 +1784,7 @@
             "ammo-item": "556_mk318",
             "charges": [ 0, 30 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           {
@@ -1802,7 +1802,7 @@
             "ammo-item": "556_mk318",
             "charges": [ 0, 30 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           {
@@ -1820,7 +1820,7 @@
             "ammo-item": "556_mk318",
             "charges": [ 0, 30 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           {
@@ -1836,7 +1836,7 @@
             "group": "modular_ump_9",
             "charges": [ 0, 30 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_ump9" }
@@ -1849,7 +1849,7 @@
             "group": "modular_ump_40",
             "charges": [ 0, 30 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_ump40" }
@@ -1862,7 +1862,7 @@
             "group": "modular_ump_45",
             "charges": [ 0, 25 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_ump45" }
@@ -1871,21 +1871,21 @@
       },
       {
         "collection": [
-          { "item": "hk_mp5", "charges": [ 0, 30 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "hk_mp5", "charges": [ 0, 30 ], "contents-item": "shoulder_strap", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_mp5" }
         ],
         "prob": 30
       },
       {
         "collection": [
-          { "item": "hk_mp5k", "charges": [ 0, 30 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "hk_mp5k", "charges": [ 0, 30 ], "contents-item": "shoulder_strap", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_mp5" }
         ],
         "prob": 5
       },
       {
         "collection": [
-          { "item": "hk_mp5sd", "charges": [ 0, 30 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "hk_mp5sd", "charges": [ 0, 30 ], "contents-item": "shoulder_strap", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_mp5" }
         ],
         "prob": 5
@@ -1896,7 +1896,7 @@
             "item": "colt_ro635",
             "charges": [ 0, 32 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_uzi" }
@@ -1905,21 +1905,21 @@
       },
       {
         "collection": [
-          { "item": "bt_apc9k", "charges": [ 0, 32 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "bt_apc9k", "charges": [ 0, 32 ], "contents-item": "shoulder_strap", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_apc9" }
         ],
         "prob": 5
       },
       {
         "collection": [
-          { "item": "fn_p90", "charges": [ 0, 50 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "fn_p90", "charges": [ 0, 50 ], "contents-item": "shoulder_strap", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_p90" }
         ],
         "prob": 1
       },
       {
         "collection": [
-          { "item": "hk_mp7", "charges": [ 0, 20 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "hk_mp7", "charges": [ 0, 20 ], "contents-item": "shoulder_strap", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_mp7" }
         ],
         "prob": 1
@@ -1931,7 +1931,7 @@
             "variant": "m1014",
             "charges": [ 0, 8 ],
             "contents-item": "shoulder_strap",
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_shotgun" }
@@ -1940,14 +1940,14 @@
       },
       {
         "collection": [
-          { "item": "hk417_13", "charges": [ 0, 20 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "hk417_13", "charges": [ 0, 20 ], "contents-item": "shoulder_strap", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_hk417" }
         ],
         "prob": 3
       },
       {
         "collection": [
-          { "item": "M24", "charges": [ 0, 5 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "M24", "charges": [ 0, 5 ], "contents-item": "shoulder_strap", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_308" }
         ],
         "prob": 7
@@ -1958,7 +1958,7 @@
             "group": "axmc_308",
             "charges": [ 0, 10 ],
             "contents-item": [ "rifle_scope", "bipod", "shoulder_strap" ],
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_308" }
@@ -1971,7 +1971,7 @@
             "group": "axmc_300",
             "charges": [ 0, 5 ],
             "contents-item": [ "rifle_scope", "bipod", "shoulder_strap" ],
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_300" }
@@ -1980,7 +1980,7 @@
       },
       {
         "collection": [
-          { "item": "tac338", "charges": [ 0, 5 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "tac338", "charges": [ 0, 5 ], "contents-item": "shoulder_strap", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_338" }
         ],
         "prob": 1
@@ -1991,7 +1991,7 @@
             "item": "mrad_smr",
             "charges": [ 0, 5 ],
             "contents-item": [ "rifle_scope", "bipod", "shoulder_strap" ],
-            "damage": [ 0, 1 ],
+            "damage": [ 0, 3 ],
             "dirt": [ 0, 7050 ]
           },
           { "group": "field_338" }
@@ -2000,14 +2000,14 @@
       },
       {
         "collection": [
-          { "item": "tac50", "charges": [ 0, 5 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "tac50", "charges": [ 0, 5 ], "contents-item": "shoulder_strap", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_50bmg" }
         ],
         "prob": 1
       },
       {
         "collection": [
-          { "item": "as50", "charges": [ 0, 5 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "item": "as50", "charges": [ 0, 5 ], "contents-item": "shoulder_strap", "damage": [ 0, 3 ], "dirt": [ 0, 7050 ] },
           { "group": "field_as50" }
         ],
         "prob": 1

--- a/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
+++ b/data/json/itemgroups/Weapons_Mods_Ammo/guns.json
@@ -1162,54 +1162,431 @@
   {
     "type": "item_group",
     "id": "longguns_cop",
+    "subtype": "distribution",
     "items": [
-      { "group": "modular_ar15", "prob": 20, "charges": [ 0, 30 ], "contents-item": "shoulder_strap" },
-      { "item": "mossberg_500", "prob": 10, "charges": [ 0, 6 ], "contents-item": "shoulder_strap" },
-      { "item": "remington_700", "prob": 5, "charges": [ 0, 4 ], "contents-item": "shoulder_strap" },
-      { "item": "remington_870", "prob": 10, "charges": [ 0, 5 ], "contents-item": "shoulder_strap" }
+      { "group": "ar15_223medium", "ammo-item": "223", "charges": [ 0, 30 ], "contents-item": "shoulder_strap", "prob": 90 },
+      {
+        "group": "ar15_223short",
+        "ammo-item": "223",
+        "charges": [ 0, 30 ],
+        "contents-item": "shoulder_strap",
+        "prob": 70
+      },
+      {
+        "group": "ar15_223long",
+        "ammo-item": "223",
+        "charges": [ 0, 30 ],
+        "contents-item": "shoulder_strap",
+        "prob": 40
+      },
+      {
+        "item": "modular_m4_carbine",
+        "variant": "modular_m4a1",
+        "ammo-item": "556_mk318",
+        "charges": [ 0, 30 ],
+        "contents-item": "shoulder_strap",
+        "prob": 8
+      },
+      {
+        "item": "modular_m4_carbine",
+        "variant": "m4_cqbr",
+        "ammo-item": "556_mk318",
+        "charges": [ 0, 30 ],
+        "contents-item": "shoulder_strap",
+        "prob": 8
+      },
+      {
+        "item": "modular_m27_assault_rifle",
+        "variant": "modular_h&k416a5",
+        "ammo-item": "556_mk318",
+        "charges": [ 0, 30 ],
+        "contents-item": "shoulder_strap",
+        "prob": 3
+      },
+      { "item": "ruger_mini", "ammo-item": "223", "charges": [ 0, 20 ], "contents-item": "shoulder_strap", "prob": 5 },
+      {
+        "item": "steyr_aug",
+        "ammo-item": "556_mk318",
+        "charges": [ 0, 30 ],
+        "contents-item": "shoulder_strap",
+        "prob": 1
+      },
+      {
+        "item": "hk_g36",
+        "ammo-item": "556_mk318",
+        "charges": [ 0, 30 ],
+        "contents-item": "shoulder_strap",
+        "prob": 1
+      },
+      {
+        "item": "mossberg_500",
+        "variant": "mossberg_500_security",
+        "charges": [ 0, 6 ],
+        "contents-item": "shoulder_strap",
+        "prob": 40
+      },
+      {
+        "item": "mossberg_590",
+        "variant": "mossberg_590",
+        "charges": [ 0, 9 ],
+        "contents-item": "shoulder_strap",
+        "prob": 15
+      },
+      {
+        "item": "mossberg_930",
+        "variant": "mossberg_930",
+        "charges": [ 0, 8 ],
+        "contents-item": "shoulder_strap",
+        "prob": 7
+      },
+      {
+        "item": "mossberg_930",
+        "variant": "m1014",
+        "charges": [ 0, 8 ],
+        "contents-item": "shoulder_strap",
+        "prob": 2
+      },
+      { "item": "remington_870_express", "charges": [ 0, 7 ], "contents-item": "shoulder_strap", "prob": 70 },
+      { "item": "remington_700", "charges": [ 0, 4 ], "contents-item": "shoulder_strap", "prob": 2 },
+      { "item": "M24", "charges": [ 0, 5 ], "contents-item": "shoulder_strap", "prob": 10 }
     ]
   },
   {
     "type": "item_group",
     "id": "longguns_cop_loaded",
-    "//": "loaded in the back of a trunk or something",
+    "//": "loaded in the back of a trunk or something (fully loaded, excluding sniper rifles)",
+    "subtype": "distribution",
     "items": [
-      { "group": "nested_ar15", "prob": 20 },
-      { "group": "nested_mossberg_500", "prob": 10 },
-      { "group": "nested_remington_700", "prob": 5 },
-      { "group": "nested_remington_870", "prob": 10 }
+      { "group": "ar15_223medium", "ammo-item": "223", "charges": [ 30, 30 ], "contents-item": "shoulder_strap", "prob": 90 },
+      {
+        "group": "ar15_223short",
+        "ammo-item": "223",
+        "charges": [ 30, 30 ],
+        "contents-item": "shoulder_strap",
+        "prob": 70
+      },
+      {
+        "group": "ar15_223long",
+        "ammo-item": "223",
+        "charges": [ 30, 30 ],
+        "contents-item": "shoulder_strap",
+        "prob": 40
+      },
+      {
+        "item": "modular_m4_carbine",
+        "variant": "modular_m4a1",
+        "ammo-item": "556_mk318",
+        "charges": [ 30, 30 ],
+        "contents-item": "shoulder_strap",
+        "prob": 8
+      },
+      {
+        "item": "modular_m4_carbine",
+        "variant": "m4_cqbr",
+        "ammo-item": "556_mk318",
+        "charges": [ 30, 30 ],
+        "contents-item": "shoulder_strap",
+        "prob": 8
+      },
+      {
+        "item": "modular_m27_assault_rifle",
+        "variant": "modular_h&k416a5",
+        "ammo-item": "556_mk318",
+        "charges": [ 30, 30 ],
+        "contents-item": "shoulder_strap",
+        "prob": 3
+      },
+      {
+        "item": "ruger_mini",
+        "ammo-item": "223",
+        "charges": [ 20, 20 ],
+        "contents-item": "shoulder_strap",
+        "prob": 5
+      },
+      {
+        "item": "steyr_aug",
+        "ammo-item": "556_mk318",
+        "charges": [ 30, 30 ],
+        "contents-item": "shoulder_strap",
+        "prob": 1
+      },
+      {
+        "item": "hk_g36",
+        "ammo-item": "556_mk318",
+        "charges": [ 30, 30 ],
+        "contents-item": "shoulder_strap",
+        "prob": 1
+      },
+      {
+        "item": "mossberg_500",
+        "variant": "mossberg_500_security",
+        "charges": [ 6, 6 ],
+        "contents-item": "shoulder_strap",
+        "prob": 40
+      },
+      {
+        "item": "mossberg_590",
+        "variant": "mossberg_590",
+        "charges": [ 9, 9 ],
+        "contents-item": "shoulder_strap",
+        "prob": 15
+      },
+      {
+        "item": "mossberg_930",
+        "variant": "mossberg_930",
+        "charges": [ 8, 8 ],
+        "contents-item": "shoulder_strap",
+        "prob": 7
+      },
+      {
+        "item": "mossberg_930",
+        "variant": "m1014",
+        "charges": [ 8, 8 ],
+        "contents-item": "shoulder_strap",
+        "prob": 2
+      },
+      { "item": "remington_870_express", "charges": [ 7, 7 ], "contents-item": "shoulder_strap", "prob": 70 }
     ]
   },
   {
     "type": "item_group",
     "id": "longguns_cop_in_field",
     "//": "gun plus potential expended magazines",
+    "subtype": "distribution",
     "items": [
       {
         "collection": [
-          { "group": "modular_ar15", "prob": 100, "charges": [ 0, 30 ], "contents-item": "shoulder_strap" },
-          { "group": "field_ar15" }
+          {
+            "group": "ar15_223medium",
+            "ammo-item": "223",
+            "charges": [ 0, 30 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          {
+            "distribution": [ { "group": "field_ar15_223", "prob": 40 }, { "group": "field_ar15_mk318", "prob": 60 } ],
+            "prob": 100
+          }
         ],
-        "prob": 20
+        "prob": 90
       },
       {
         "collection": [
-          { "item": "mossberg_500", "prob": 100, "charges": [ 0, 6 ], "contents-item": "shoulder_strap" },
-          { "group": "field_shotgun" }
+          {
+            "group": "ar15_223short",
+            "ammo-item": "223",
+            "charges": [ 0, 30 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          {
+            "distribution": [ { "group": "field_ar15_223", "prob": 40 }, { "group": "field_ar15_mk318", "prob": 60 } ],
+            "prob": 100
+          }
         ],
-        "prob": 10
+        "prob": 70
       },
       {
         "collection": [
-          { "item": "remington_700", "prob": 100, "charges": [ 0, 4 ], "contents-item": "shoulder_strap" },
-          { "group": "field_3006" }
+          {
+            "group": "ar15_223long",
+            "ammo-item": "223",
+            "charges": [ 0, 30 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          {
+            "distribution": [ { "group": "field_ar15_223", "prob": 40 }, { "group": "field_ar15_mk318", "prob": 60 } ],
+            "prob": 100
+          }
+        ],
+        "prob": 40
+      },
+      {
+        "collection": [
+          {
+            "item": "modular_m4_carbine",
+            "variant": "modular_m4a1",
+            "ammo-item": "556_mk318",
+            "charges": [ 0, 30 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          {
+            "distribution": [ { "group": "field_ar15_223", "prob": 40 }, { "group": "field_ar15_mk318", "prob": 60 } ],
+            "prob": 100
+          }
+        ],
+        "prob": 8
+      },
+      {
+        "collection": [
+          {
+            "item": "modular_m4_carbine",
+            "variant": "m4_cqbr",
+            "ammo-item": "556_mk318",
+            "charges": [ 0, 30 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          {
+            "distribution": [ { "group": "field_ar15_223", "prob": 40 }, { "group": "field_ar15_mk318", "prob": 60 } ],
+            "prob": 100
+          }
+        ],
+        "prob": 8
+      },
+      {
+        "collection": [
+          {
+            "item": "modular_m27_assault_rifle",
+            "variant": "modular_h&k416a5",
+            "ammo-item": "556_mk318",
+            "charges": [ 0, 30 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          {
+            "distribution": [ { "group": "field_ar15_223", "prob": 40 }, { "group": "field_ar15_mk318", "prob": 60 } ],
+            "prob": 100
+          }
+        ],
+        "prob": 3
+      },
+      {
+        "collection": [
+          {
+            "item": "ruger_mini",
+            "ammo-item": "223",
+            "charges": [ 0, 20 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_mini14" }
         ],
         "prob": 5
       },
       {
         "collection": [
-          { "item": "remington_870", "prob": 100, "charges": [ 0, 5 ], "contents-item": "shoulder_strap" },
+          {
+            "item": "steyr_aug",
+            "ammo-item": "556_mk318",
+            "charges": [ 0, 30 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_steyraug" }
+        ],
+        "prob": 1
+      },
+      {
+        "collection": [
+          {
+            "item": "hk_g36",
+            "ammo-item": "556_mk318",
+            "charges": [ 0, 30 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_g36" }
+        ],
+        "prob": 1
+      },
+      {
+        "collection": [
+          {
+            "item": "mossberg_500",
+            "variant": "mossberg_500_security",
+            "charges": [ 0, 6 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
           { "group": "field_shotgun" }
+        ],
+        "prob": 40
+      },
+      {
+        "collection": [
+          {
+            "item": "mossberg_590",
+            "variant": "mossberg_590",
+            "charges": [ 0, 9 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_shotgun" }
+        ],
+        "prob": 15
+      },
+      {
+        "collection": [
+          {
+            "item": "mossberg_930",
+            "variant": "mossberg_930",
+            "charges": [ 0, 8 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_shotgun" }
+        ],
+        "prob": 7
+      },
+      {
+        "collection": [
+          {
+            "item": "mossberg_930",
+            "variant": "m1014",
+            "charges": [ 0, 8 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_shotgun" }
+        ],
+        "prob": 2
+      },
+      {
+        "collection": [
+          {
+            "item": "remington_870_express",
+            "charges": [ 0, 7 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_shotgun" }
+        ],
+        "prob": 70
+      },
+      {
+        "collection": [
+          {
+            "item": "remington_700",
+            "charges": [ 0, 4 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_3006" }
+        ],
+        "prob": 2
+      },
+      {
+        "collection": [
+          { "item": "M24", "charges": [ 0, 4 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_308" }
         ],
         "prob": 10
       }
@@ -1219,9 +1596,15 @@
     "type": "item_group",
     "id": "longguns_cop_in_field_no_gun",
     "//": "guns lost but still have mags",
+    "subtype": "distribution",
     "items": [
-      { "group": "field_ar15", "prob": 20 },
-      { "group": "field_shotgun", "prob": 20 },
+      { "group": "field_ar15_223", "prob": 70 },
+      { "group": "field_ar15_mk318", "prob": 80 },
+      { "group": "field_mini14", "prob": 5 },
+      { "group": "field_steyraug", "prob": 1 },
+      { "group": "field_g36", "prob": 1 },
+      { "group": "field_shotgun", "prob": 80 },
+      { "group": "field_308", "prob": 20 },
       { "group": "field_3006", "prob": 5 }
     ]
   },
@@ -1229,13 +1612,21 @@
     "type": "item_group",
     "id": "sidearms_cop",
     "items": [
-      { "item": "fn57", "prob": 20, "charges": [ 0, 20 ] },
-      { "item": "glock_19", "prob": 15, "charges": [ 0, 15 ] },
-      { "item": "glock_22", "prob": 20, "ammo-item": "40sw", "charges": [ 0, 15 ] },
-      { "item": "m9", "variant": "m9", "prob": 5, "charges": [ 0, 15 ] },
-      { "item": "sig_40", "prob": 20, "charges": [ 0, 12 ] },
-      { "item": "usp_45", "prob": 10, "charges": [ 0, 12 ] },
-      { "item": "usp_9mm", "prob": 10, "charges": [ 0, 15 ] }
+      { "item": "fn57", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 1 },
+      { "item": "glock_19", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 50 },
+      { "item": "glock_17", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 60 },
+      { "item": "m9", "variant": "m9", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 3 },
+      { "item": "sp2022", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 10 },
+      { "item": "px4", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 5 },
+      { "item": "usp_9mm", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 3 },
+      { "item": "glock_31", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 4 },
+      { "item": "p226_357sig", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 2 },
+      { "item": "p320_357sig", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 2 },
+      { "item": "glock_22", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 30 },
+      { "item": "px4_40", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 5 },
+      { "item": "sig_40", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 10 },
+      { "item": "glock_21", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 10 },
+      { "item": "usp_45", "variant": "usp_45", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ], "prob": 2 }
     ]
   },
   {
@@ -1243,30 +1634,117 @@
     "id": "sidearms_cop_in_field",
     "//": "gun plus potential expended magazines",
     "items": [
-      { "collection": [ { "item": "fn57", "prob": 100, "charges": [ 0, 20 ] }, { "group": "field_fn57" } ], "prob": 20 },
       {
-        "collection": [ { "item": "glock_19", "prob": 100, "charges": [ 0, 15 ] }, { "group": "field_glock_19" } ],
-        "prob": 15
+        "collection": [
+          { "item": "fn57", "prob": 100, "charges": [ 0, 20 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_fn57" }
+        ],
+        "prob": 1
       },
       {
-        "collection": [ { "item": "glock_22", "ammo-item": "40sw", "prob": 100, "charges": [ 0, 15 ] }, { "group": "field_glock_22" } ],
-        "prob": 20
+        "collection": [
+          { "item": "glock_19", "prob": 100, "charges": [ 0, 15 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_glock_19" }
+        ],
+        "prob": 50
       },
       {
-        "collection": [ { "item": "m9", "variant": "m9", "prob": 100, "charges": [ 0, 15 ] }, { "group": "field_m9" } ],
+        "collection": [
+          { "item": "glock_17", "prob": 100, "charges": [ 0, 17 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_glock_17" }
+        ],
+        "prob": 60
+      },
+      {
+        "collection": [
+          { "item": "m9", "variant": "m9", "prob": 100, "charges": [ 0, 15 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_m9" }
+        ],
+        "prob": 3
+      },
+      {
+        "collection": [
+          { "item": "sp2022", "prob": 100, "charges": [ 0, 15 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_sp2022_9mm" }
+        ],
+        "prob": 10
+      },
+      {
+        "collection": [
+          { "item": "px4", "prob": 100, "charges": [ 0, 17 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_px4_9mm" }
+        ],
         "prob": 5
       },
       {
-        "collection": [ { "item": "sig_40", "prob": 100, "charges": [ 0, 12 ] }, { "group": "field_sig_40" } ],
-        "prob": 20
+        "collection": [
+          { "item": "usp_9mm", "prob": 100, "charges": [ 0, 15 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_usp_9mm" }
+        ],
+        "prob": 3
       },
       {
-        "collection": [ { "item": "usp_45", "prob": 100, "charges": [ 0, 12 ] }, { "group": "field_usp_45" } ],
+        "collection": [
+          {
+            "item": "glock_31",
+            "ammo-item": "357sig_jhp",
+            "prob": 100,
+            "charges": [ 0, 15 ],
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_glock_31" }
+        ],
+        "prob": 4
+      },
+      {
+        "collection": [
+          { "item": "p226_357sig", "prob": 100, "charges": [ 0, 12 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_p226_357sig" }
+        ],
+        "prob": 2
+      },
+      {
+        "collection": [
+          { "item": "p320_357sig", "prob": 100, "charges": [ 0, 13 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_p320_357sig" }
+        ],
+        "prob": 2
+      },
+      {
+        "collection": [
+          { "item": "glock_22", "ammo-item": "40sw", "prob": 100, "charges": [ 0, 15 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_glock_22" }
+        ],
+        "prob": 30
+      },
+      {
+        "collection": [
+          { "item": "px4_40", "prob": 100, "charges": [ 0, 14 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_px4_40" }
+        ],
+        "prob": 5
+      },
+      {
+        "collection": [
+          { "item": "sig_40", "prob": 100, "charges": [ 0, 12 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_sig_40" }
+        ],
         "prob": 10
       },
       {
-        "collection": [ { "item": "usp_9mm", "prob": 100, "charges": [ 0, 15 ] }, { "group": "field_usp_9mm" } ],
+        "collection": [
+          { "item": "glock_21", "prob": 100, "charges": [ 0, 13 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_glock_21" }
+        ],
         "prob": 10
+      },
+      {
+        "collection": [
+          { "item": "usp_45", "variant": "usp_45", "prob": 100, "charges": [ 0, 12 ], "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_usp_45" }
+        ],
+        "prob": 2
       }
     ]
   },
@@ -1275,14 +1753,272 @@
     "id": "sidearms_cop_in_field_no_gun",
     "//": "guns lost but still have mags",
     "items": [
-      { "group": "field_fn57", "prob": 20 },
-      { "group": "field_glock_19", "prob": 15 },
-      { "group": "field_glock_22", "prob": 20 },
-      { "group": "field_m9", "prob": 5 },
-      { "group": "field_sig_40", "prob": 20 },
-      { "group": "field_usp_45", "prob": 10 },
-      { "group": "field_usp_9mm", "prob": 10 }
+      { "group": "field_fn57", "prob": 1 },
+      { "group": "field_glock_19", "prob": 50 },
+      { "group": "field_glock_17", "prob": 60 },
+      { "group": "field_m9", "prob": 3 },
+      { "group": "field_sp2022_9mm", "prob": 10 },
+      { "group": "field_px4_9mm", "prob": 5 },
+      { "group": "field_usp_9mm", "prob": 3 },
+      { "group": "field_glock_31", "prob": 4 },
+      { "group": "field_p226_357sig", "prob": 2 },
+      { "group": "field_p320_357sig", "prob": 2 },
+      { "group": "field_glock_22", "prob": 30 },
+      { "group": "field_px4_40", "prob": 5 },
+      { "group": "field_sig_40", "prob": 10 },
+      { "group": "field_glock_21", "prob": 10 },
+      { "group": "field_usp_45", "prob": 2 }
     ]
+  },
+  {
+    "type": "item_group",
+    "id": "guns_swat",
+    "//": "Guns issued to paramilitary forces in addition to standard police issue.",
+    "items": [
+      { "group": "longguns_cop_in_field", "prob": 50 },
+      {
+        "collection": [
+          {
+            "item": "modular_m4_carbine",
+            "variant": "modular_m4a1",
+            "ammo-item": "556_mk318",
+            "charges": [ 0, 30 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          {
+            "distribution": [ { "group": "field_ar15_223", "prob": 40 }, { "group": "field_ar15_mk318", "prob": 60 } ],
+            "prob": 100
+          }
+        ],
+        "prob": 40
+      },
+      {
+        "collection": [
+          {
+            "item": "modular_m4_carbine",
+            "variant": "m4_cqbr",
+            "ammo-item": "556_mk318",
+            "charges": [ 0, 30 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          {
+            "distribution": [ { "group": "field_ar15_223", "prob": 40 }, { "group": "field_ar15_mk318", "prob": 60 } ],
+            "prob": 100
+          }
+        ],
+        "prob": 30
+      },
+      {
+        "collection": [
+          {
+            "item": "modular_m27_assault_rifle",
+            "variant": "modular_h&k416a5",
+            "ammo-item": "556_mk318",
+            "charges": [ 0, 30 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          {
+            "distribution": [ { "group": "field_ar15_223", "prob": 40 }, { "group": "field_ar15_mk318", "prob": 60 } ],
+            "prob": 100
+          }
+        ],
+        "prob": 10
+      },
+      {
+        "collection": [
+          {
+            "group": "modular_ump_9",
+            "charges": [ 0, 30 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_ump9" }
+        ],
+        "prob": 5
+      },
+      {
+        "collection": [
+          {
+            "group": "modular_ump_40",
+            "charges": [ 0, 30 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_ump40" }
+        ],
+        "prob": 20
+      },
+      {
+        "collection": [
+          {
+            "group": "modular_ump_45",
+            "charges": [ 0, 25 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_ump45" }
+        ],
+        "prob": 15
+      },
+      {
+        "collection": [
+          { "item": "hk_mp5", "charges": [ 0, 30 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_mp5" }
+        ],
+        "prob": 30
+      },
+      {
+        "collection": [
+          { "item": "hk_mp5k", "charges": [ 0, 30 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_mp5" }
+        ],
+        "prob": 5
+      },
+      {
+        "collection": [
+          { "item": "hk_mp5sd", "charges": [ 0, 30 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_mp5" }
+        ],
+        "prob": 5
+      },
+      {
+        "collection": [
+          {
+            "item": "colt_ro635",
+            "charges": [ 0, 32 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_uzi" }
+        ],
+        "prob": 5
+      },
+      {
+        "collection": [
+          { "item": "bt_apc9k", "charges": [ 0, 32 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_apc9" }
+        ],
+        "prob": 5
+      },
+      {
+        "collection": [
+          { "item": "fn_p90", "charges": [ 0, 50 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_p90" }
+        ],
+        "prob": 1
+      },
+      {
+        "collection": [
+          { "item": "hk_mp7", "charges": [ 0, 20 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_mp7" }
+        ],
+        "prob": 1
+      },
+      {
+        "collection": [
+          {
+            "item": "mossberg_930",
+            "variant": "m1014",
+            "charges": [ 0, 8 ],
+            "contents-item": "shoulder_strap",
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_shotgun" }
+        ],
+        "prob": 5
+      },
+      {
+        "collection": [
+          { "item": "hk417_13", "charges": [ 0, 20 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_hk417" }
+        ],
+        "prob": 3
+      },
+      {
+        "collection": [
+          { "item": "M24", "charges": [ 0, 5 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_308" }
+        ],
+        "prob": 7
+      },
+      {
+        "collection": [
+          {
+            "group": "axmc_308",
+            "charges": [ 0, 10 ],
+            "contents-item": [ "rifle_scope", "bipod", "shoulder_strap" ],
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_308" }
+        ],
+        "prob": 5
+      },
+      {
+        "collection": [
+          {
+            "group": "axmc_300",
+            "charges": [ 0, 5 ],
+            "contents-item": [ "rifle_scope", "bipod", "shoulder_strap" ],
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_300" }
+        ],
+        "prob": 2
+      },
+      {
+        "collection": [
+          { "item": "tac338", "charges": [ 0, 5 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_338" }
+        ],
+        "prob": 1
+      },
+      {
+        "collection": [
+          {
+            "item": "mrad_smr",
+            "charges": [ 0, 5 ],
+            "contents-item": [ "rifle_scope", "bipod", "shoulder_strap" ],
+            "damage": [ 0, 1 ],
+            "dirt": [ 0, 7050 ]
+          },
+          { "group": "field_338" }
+        ],
+        "prob": 2
+      },
+      {
+        "collection": [
+          { "item": "tac50", "charges": [ 0, 5 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_50bmg" }
+        ],
+        "prob": 1
+      },
+      {
+        "collection": [
+          { "item": "as50", "charges": [ 0, 5 ], "contents-item": "shoulder_strap", "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+          { "group": "field_as50" }
+        ],
+        "prob": 1
+      }
+    ]
+  },
+  {
+    "type": "item_group",
+    "id": "guns_cop",
+    "//": "Police issue weapons of all types",
+    "items": [ { "group": "longguns_cop", "prob": 20 }, { "group": "sidearms_cop", "prob": 80 } ]
   },
   {
     "type": "item_group",
@@ -1357,32 +2093,6 @@
       { "group": "field_sig_40", "prob": 20 },
       { "group": "field_usp_45", "prob": 10 },
       { "group": "field_usp_9mm", "prob": 10 }
-    ]
-  },
-  {
-    "type": "item_group",
-    "id": "guns_cop",
-    "//": "Police issue weapons of all types",
-    "items": [ { "group": "longguns_cop", "prob": 20 }, { "group": "sidearms_cop", "prob": 80 } ]
-  },
-  {
-    "type": "item_group",
-    "id": "guns_swat",
-    "//": "Guns issued to paramilitary forces in addition to standard police issue.",
-    "items": [
-      { "group": "guns_cop", "prob": 100 },
-      { "group": "modular_ump_9", "prob": 5, "charges-min": 0, "charges-max": 30 },
-      { "group": "modular_ump_40", "prob": 40, "charges-min": 0, "charges-max": 30 },
-      { "group": "modular_ump_45", "prob": 30, "charges-min": 0, "charges-max": 25 },
-      { "item": "hk_mp5", "prob": 50, "charges-min": 0, "charges-max": 30 },
-      { "item": "hk_mp5k", "prob": 10, "charges-min": 0, "charges-max": 30 },
-      { "item": "hk_mp5sd", "prob": 5, "charges-min": 0, "charges-max": 30 },
-      { "item": "fn_p90", "prob": 25 },
-      { "item": "mossberg_930", "variant": "m1014", "prob": 10, "charges-min": 0, "charges-max": 8 },
-      { "item": "modular_m4_carbine", "variant": "modular_m4a1", "prob": 35, "charges-min": 0, "charges-max": 30 },
-      { "item": "as50", "prob": 5, "charges-min": 0, "charges-max": 10 },
-      { "group": "axmc", "prob": 10, "charges-min": 0, "charges-max": 10 },
-      { "item": "hk417_13", "prob": 30, "charges-min": 0, "charges-max": 20 }
     ]
   },
   {

--- a/data/json/monsterdrops/zombie_cop.json
+++ b/data/json/monsterdrops/zombie_cop.json
@@ -59,10 +59,7 @@
         "collection": [
           { "item": "tacvest", "damage": [ 1, 4 ] },
           {
-            "distribution": [
-              { "group": "longguns_cop_in_field",  "prob": 10 },
-              { "group": "longguns_cop_in_field_no_gun", "prob": 90 }
-            ],
+            "distribution": [ { "group": "longguns_cop_in_field", "prob": 10 }, { "group": "longguns_cop_in_field_no_gun", "prob": 90 } ],
             "prob": 50
           },
           { "group": "cop_holster_field", "damage": [ 1, 4 ], "prob": 90 }

--- a/data/json/monsterdrops/zombie_cop.json
+++ b/data/json/monsterdrops/zombie_cop.json
@@ -67,14 +67,14 @@
           },
           { "group": "cop_holster_field", "damage": [ 1, 4 ], "prob": 80 }
         ],
-        "prob": 70
+        "prob": 40
       },
       {
         "collection": [
           { "group": "longguns_cop", "prob": 10, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
-          { "group": "cop_holster", "damage": [ 1, 4 ], "prob": 80 }
+          { "group": "cop_holster", "damage": [ 1, 4 ], "prob": 90 }
         ],
-        "prob": 30
+        "prob": 60
       }
     ]
   },
@@ -167,7 +167,7 @@
     "id": "cop_holster",
     "type": "item_group",
     "subtype": "distribution",
-    "entries": [ { "item": "holster", "contents-group": "sidearms_cop", "prob": 20 }, { "item": "holster", "prob": 80 } ]
+    "entries": [ { "item": "holster", "contents-group": "sidearms_cop", "prob": 10 }, { "item": "holster", "prob": 90 } ]
   },
   {
     "id": "cop_holster_field",
@@ -192,7 +192,8 @@
       { "group": "swat_pants", "damage": [ 0, 4 ] },
       { "group": "swat_shoes", "damage": [ 0, 4 ] },
       { "group": "swat_torso", "damage": [ 0, 4 ] },
-      { "group": "swat_weapons", "prob": 50, "damage": [ 0, 1 ], "dirt": [ 0, 7050 ] },
+      { "group": "swat_weapons", "prob": 50 },
+      { "group": "cop_holster", "prob": 30 },
       { "group": "underwear", "damage": [ 0, 4 ] },
       { "group": "clothing_glasses", "prob": 5 },
       { "group": "clothing_watch", "prob": 10 },

--- a/data/json/monsterdrops/zombie_cop.json
+++ b/data/json/monsterdrops/zombie_cop.json
@@ -60,21 +60,21 @@
           { "item": "tacvest", "damage": [ 1, 4 ] },
           {
             "distribution": [
-              { "group": "longguns_cop_in_field", "prob": 10, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
+              { "group": "longguns_cop_in_field",  "prob": 10 },
               { "group": "longguns_cop_in_field_no_gun", "prob": 90 }
             ],
-            "prob": 100
+            "prob": 50
           },
-          { "group": "cop_holster_field", "damage": [ 1, 4 ], "prob": 80 }
+          { "group": "cop_holster_field", "damage": [ 1, 4 ], "prob": 90 }
         ],
-        "prob": 40
+        "prob": 30
       },
       {
         "collection": [
-          { "group": "longguns_cop", "prob": 10, "damage": [ 0, 1 ], "dirt": [ 1500, 7050 ] },
-          { "group": "cop_holster", "damage": [ 1, 4 ], "prob": 90 }
+          { "group": "longguns_cop", "prob": 10, "damage": [ 0, 3 ], "dirt": [ 1500, 7050 ] },
+          { "group": "cop_holster", "damage": [ 0, 3 ], "dirt": [ 1500, 7050 ], "prob": 90 }
         ],
-        "prob": 60
+        "prob": 90
       }
     ]
   },
@@ -176,7 +176,8 @@
     "//": "same as above but with the assumption that you have storage for magazines",
     "entries": [
       { "collection": [ { "item": "holster" }, { "group": "sidearms_cop_in_field" } ], "prob": 20 },
-      { "collection": [ { "item": "holster" }, { "group": "sidearms_cop_in_field_no_gun" } ], "prob": 80 }
+      { "collection": [ { "item": "holster" }, { "group": "sidearms_cop_in_field_no_gun" } ], "prob": 60 },
+      { "item": "holster", "prob": 60 }
     ]
   },
   {
@@ -192,8 +193,8 @@
       { "group": "swat_pants", "damage": [ 0, 4 ] },
       { "group": "swat_shoes", "damage": [ 0, 4 ] },
       { "group": "swat_torso", "damage": [ 0, 4 ] },
-      { "group": "swat_weapons", "prob": 50 },
-      { "group": "cop_holster", "prob": 30 },
+      { "group": "swat_weapons", "prob": 25 },
+      { "group": "cop_holster", "prob": 70 },
       { "group": "underwear", "damage": [ 0, 4 ] },
       { "group": "clothing_glasses", "prob": 5 },
       { "group": "clothing_watch", "prob": 10 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Balance "Expand/Adjust police firearm loot"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Police gun loot was both a bit bland and was perhaps too forgiving, giving players a constant stream of ammo from zombie drops.  A number of guns that are technically in the game have very few, or sometimes no, chances of spawning, while 5.7x28mm is highly over represented. 

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

- Added several existing guns to the loot pool of the police armory and drops from zombie cops.  The loot should sway more towards Glocks, AR-15s, and basic shotguns, but there's a few oddballs thrown in.
- Added functionality for field drops to newly added guns (for gun+magazines, or magazines but no gun).
- Specified variants on a few gun listings, no more Mk23s on cops.
- 5.7x28 bonanza from cops is over, their guns and ammo will still spawn but very rarely.
- Removed suppressed 5.7s and explosive slugs from cop armory.
- Cops now carry a mixture of .223 Remington and 5.56 Mk 318, standing in for premium "duty" ammo that is common with police these days.
- Any issues with .357 SIG ammo spawning with .40 S&W guns should be fixed.
- All dropped guns should have a chance of spawning damaged and dirty
- Lowered chances of police zombies dropping long guns or their ammo.  Slightly adjusted pistol and pistol ammo drops.
-  SWAT zombies will now use field drops with spare magazines, helpful with some of the rarer gun drops.

**9mm pistols (Overall the most common):**
Glock 17 (common), Glock 19 (common), Sig SP2022 9mm (rare), Beretta Px4 9mm (rare), Beretta M9 (rare), USP 9mm (rare)

**.357 SIG pistols (Overall rare):**
Glock 31 (common), SIG P226 .357 (uncommon), SIG P320 .357 (rare)

**.40 S&W pistols (Overall uncommon, second to 9mm):**
Glock 22 (common), SIG Pro .40 (uncommon), Beretta Px4 .40 (rare)

**.45 ACP pistols (Overall uncommon):**
Glock 21 (common), USP .45 (rare)

**FN Five-seveN and its ammo is now very rare.**

**Rifles (Less common on zombie drops, relatively unchanged in armories)**
AR-15 Medium (Common), AR-15 Short (Uncommon), AR-15 Long (Uncommon), M4A1 (Rare), M4 CQBR (Rare), HK416 (Very Rare), Mini-14 (Very Rare), Steyr AUG (Extremely Rare), HK G36 (Extremely Rare), HK417 (Extremely Rare), M1A (Rare, only in armories)

**Shotguns (Less common than Rifles, but still somewhat common)**
Remington 870 Express (Common), Mossberg 500 Security (Uncommon), Mossberg 590A1 (Rare), Mossberg 930 (Rare), M1014 (Very Rare), 870 Breacher (Very Rare, only in armories and in existing SWAT zombie spawns)

**Submachine guns (Now have a small chance of spawning in armories in place of assault rifles.  Overall rare.  Otherwise only spawn only on SWAT zombies.)**
MP5A2 (Common), UMP .40 S&W (Uncommon), UMP .45 ACP (Uncommon), Colt 635 SMG (Rare), MP5K (Very Rare), MP5SD (Very Rare), UMP 9mm (Very Rare), APC9K PRO (Very Rare), P90 (Extremely Rare), MP7 (Extremely Rare)

**Sniper Rifles (Overall Rare to Very Rare.  Remington 700 and M24 spawn on cops, the rest only spawn on SWAT)**
M24 (Common), AR-10 Scoped (Rare), AR-15 Scoped (Rare), Remington 700 .30-06 (Very Rare), AXMC .308 (Very Rare), AXMC .300WM (Very Rare), AXMC .338 (Very Rare), TAC-338 (Extremely Rare), MRAD .338 (Very Rare), TAC-50 (Extremely Rare), AS50 (Extremely Rare)


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

This change adds significant length to all affected files.  It doesn't seem to impact the game itself, but given that there are at least three loot pool systems for guns that I see, it may be worth doing some organizing and separating files in the future, as some item groups may be redundant.  I attempted to make headway there while making this PR, but decided against pursuing it.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Game loads without errors.  Tested various itemgroups with debug, feel pretty happy with it.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Cop Pistols
![Screenshot from 2024-01-21 12-51-41](https://github.com/CleverRaven/Cataclysm-DDA/assets/49455167/0c751b54-39f8-441a-8643-4f882145ef65)

Cop Long Guns
![Screenshot from 2024-01-21 12-52-24](https://github.com/CleverRaven/Cataclysm-DDA/assets/49455167/d3498de8-d848-4f2d-8e81-24b756d62fff)

SWAT Long Guns (Off screen is 2 AR15s, 2 M4s, 2 Remington 870s)
![Screenshot from 2024-01-21 12-53-55](https://github.com/CleverRaven/Cataclysm-DDA/assets/49455167/dd1e694e-975c-4de7-b06b-0dd3f765bbfd)


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
