### PR TITLE
Remove vegetables from spaghetti al pesto recipe

### DIFF
--- a/data/json/recipes/food/pasta.json
+++ b/data/json/recipes/food/pasta.json
@@ -111,7 +111,7 @@
       "cookbook_foodfashions": { "skill_level": 4, "recipe_name": "Spaghetti Luchetto" }
     },
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
-    "tools": [ [ [ "surface_heat", 7, "LIST" ] ] ],
+    "tools": [ [ [ "surface_heat", 7, "LIST" ] ] ]
     "//": "There are ways to cook pasta that don't require boiling the water, and they are a lot more efficient, so this uses surface_heat",
     "//1": "pasta by weight is 5u flour + heating the water (2u)",
     "components": [ [ [ "spaghetti_raw", 1 ] ], [ [ "water_clean", 1 ] ], [ [ "sauce_pesto", 1 ] ] ]

--- a/data/json/recipes/food/pasta.json
+++ b/data/json/recipes/food/pasta.json
@@ -114,8 +114,7 @@
     "tools": [ [ [ "surface_heat", 7, "LIST" ] ] ],
     "//": "There are ways to cook pasta that don't require boiling the water, and they are a lot more efficient, so this uses surface_heat",
     "//1": "pasta by weight is 5u flour + heating the water (2u)",
-    "components": [ [ [ "spaghetti_raw", 1 ] ], [ [ "water_clean", 1 ] ], [ [ "sauce_pesto", 1 ] ]
-    ]
+    "components": [ [ [ "spaghetti_raw", 1 ] ], [ [ "water_clean", 1 ] ], [ [ "sauce_pesto", 1 ] ] ]
   },
   {
     "result": "noodles_fast",

--- a/data/json/recipes/food/pasta.json
+++ b/data/json/recipes/food/pasta.json
@@ -111,25 +111,10 @@
       "cookbook_foodfashions": { "skill_level": 4, "recipe_name": "Spaghetti Luchetto" }
     },
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
-    "tools": [ [ [ "surface_heat", 13, "LIST" ] ] ],
+    "tools": [ [ [ "surface_heat", 7, "LIST" ] ] ],
     "//": "There are ways to cook pasta that don't require boiling the water, and they are a lot more efficient, so this uses surface_heat",
-    "//1": "pasta by weight is 5u flour, 6u for veggies + heating the water (2u)",
-    "components": [
-      [ [ "spaghetti_raw", 1 ] ],
-      [ [ "water_clean", 1 ] ],
-      [ [ "seasoning_italian", 4 ], [ "sauce_pesto", 1 ], [ "wild_herbs", 10 ] ],
-      [
-        [ "veggy", 3 ],
-        [ "veggy_wild", 3 ],
-        [ "rehydrated_veggy", 3 ],
-        [ "rehydrated_corn_kernels", 3 ],
-        [ "dry_veggy", 3 ],
-        [ "dry_corn", 1 ],
-        [ "mushroom", 3 ],
-        [ "mushroom_cooked", 3 ],
-        [ "morel_cooked", 3 ],
-        [ "dry_mushroom", 3 ]
-      ]
+    "//1": "pasta by weight is 5u flour + heating the water (2u)",
+    "components": [ [ [ "spaghetti_raw", 1 ] ], [ [ "water_clean", 1 ] ], [ [ "sauce_pesto", 1 ] ]
     ]
   },
   {

--- a/data/json/recipes/food/pasta.json
+++ b/data/json/recipes/food/pasta.json
@@ -111,7 +111,7 @@
       "cookbook_foodfashions": { "skill_level": 4, "recipe_name": "Spaghetti Luchetto" }
     },
     "qualities": [ { "id": "CUT", "level": 2 }, { "id": "COOK", "level": 3 } ],
-    "tools": [ [ [ "surface_heat", 7, "LIST" ] ] ]
+    "tools": [ [ [ "surface_heat", 7, "LIST" ] ] ],
     "//": "There are ways to cook pasta that don't require boiling the water, and they are a lot more efficient, so this uses surface_heat",
     "//1": "pasta by weight is 5u flour + heating the water (2u)",
     "components": [ [ [ "spaghetti_raw", 1 ] ], [ [ "water_clean", 1 ] ], [ [ "sauce_pesto", 1 ] ] ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Angry italians at my doorstep
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Removed additional vegetables as component of spaghetti al pesto
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->