### PR TITLE
fix: review rolling trash cans spawn

### DIFF
--- a/data/json/mapgen/house/2storymodern01.json
+++ b/data/json/mapgen/house/2storymodern01.json
@@ -231,7 +231,7 @@
       "place_loot": [ { "item": "television", "x": 11, "y": 10, "chance": 100 } ],
       "place_vehicles": [
         { "vehicle": "suv", "x": 3, "y": 18, "chance": 20, "status": 50, "rotation": 270 },
-        { "vehicle": "rolling_trash_can", "x": 5, "y": 4, "chance": 80, "status": 0 }
+        { "vehicle": "rolling_trash_can", "x": 5, "y": 3, "chance": 80, "status": 0 }
       ],
       "rotation": [ 2 ]
     }
@@ -292,7 +292,7 @@
       "items": { "$": { "item": "table_foyer", "chance": 30 } },
       "place_vehicles": [
         { "vehicle": "bicycle", "x": 21, "y": 3, "chance": 30, "status": 100, "rotation": 180 },
-        { "vehicle": "rolling_trash_can", "x": 17, "y": 4, "chance": 80, "status": 0 }
+        { "vehicle": "rolling_trash_can", "x": 17, "y": 3, "chance": 80, "status": 0 }
       ],
       "rotation": [ 2 ]
     }
@@ -346,7 +346,7 @@
       },
       "furniture": { "$": "f_table", ",": "f_chair", "(": "f_piano", "[": "f_region_flower_decorative" },
       "items": { "$": { "item": "table_foyer", "chance": 30 } },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 17, "y": 4, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 17, "y": 3, "chance": 80, "status": 0 } ],
       "rotation": [ 2 ]
     }
   },

--- a/data/json/mapgen/house/2storymodern01.json
+++ b/data/json/mapgen/house/2storymodern01.json
@@ -231,7 +231,7 @@
       "place_loot": [ { "item": "television", "x": 11, "y": 10, "chance": 100 } ],
       "place_vehicles": [
         { "vehicle": "suv", "x": 3, "y": 18, "chance": 20, "status": 50, "rotation": 270 },
-        { "vehicle": "rolling_trash_can", "x": 5, "y": 3, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 5, "y": 3, "chance": 80, "status": 0 }
       ],
       "rotation": [ 2 ]
     }

--- a/data/json/mapgen/house/2storymodern01.json
+++ b/data/json/mapgen/house/2storymodern01.json
@@ -231,7 +231,7 @@
       "place_loot": [ { "item": "television", "x": 11, "y": 10, "chance": 100 } ],
       "place_vehicles": [
         { "vehicle": "suv", "x": 3, "y": 18, "chance": 20, "status": 50, "rotation": 270 },
-        { "vehicle": "rolling_trash_can", "x": 5, "y": 3, "chance": 80, "status": 0 }
+        { "vehicle": "rolling_trash_can", "x": 5, "y": 3, "chance": 80, "status": 0 },
       ],
       "rotation": [ 2 ]
     }

--- a/data/json/mapgen/house/bungalow02.json
+++ b/data/json/mapgen/house/bungalow02.json
@@ -65,7 +65,7 @@
       "place_loot": [ { "item": "television", "x": 13, "y": 19 } ],
       "place_vehicles": [
         { "vehicle": "car", "x": 5, "y": 6, "chance": 20, "rotation": 90 },
-        { "vehicle": "rolling_trash_can", "x": 17, "y": 1, "chance": 80, "status": 0 }
+        { "vehicle": "rolling_trash_can", "x": 17, "y": 0, "chance": 80, "status": 0 }
       ]
     }
   },

--- a/data/json/mapgen/house/bungalow09.json
+++ b/data/json/mapgen/house/bungalow09.json
@@ -50,7 +50,7 @@
         "l": "t_carpet_yellow",
         "s": "t_carpet_yellow"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 9, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 9, "y": 0, "chance": 80, "status": 0 } ],
       "place_loot": [ { "item": "laptop", "x": 17, "y": 5, "chance": 100 }, { "item": "television", "x": 9, "y": 7, "chance": 100 } ]
     }
   },

--- a/data/json/mapgen/house/bungalow12.json
+++ b/data/json/mapgen/house/bungalow12.json
@@ -66,7 +66,7 @@
         { "item": "television", "x": 19, "y": 17, "chance": 100 },
         { "item": "television", "x": 11, "y": 15, "chance": 100 }
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 17, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 17, "y": 0, "chance": 80, "status": 0 } ],
       "vehicles": { ")": { "vehicle": "swivel_chair", "chance": 100, "status": 1 } }
     }
   },

--- a/data/json/mapgen/house/bungalow17.json
+++ b/data/json/mapgen/house/bungalow17.json
@@ -46,7 +46,7 @@
         "&": "t_region_groundcover_urban",
         "Q": "t_floor_waxed"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 } ],
       "furniture": { "&": "f_boulder_large", "/": [ [ "f_null", 4 ], "f_ladder" ] }
     }
   },

--- a/data/json/mapgen/house/bungalow19.json
+++ b/data/json/mapgen/house/bungalow19.json
@@ -68,7 +68,7 @@
         "?": [ "f_indoor_plant", "f_indoor_plant_y" ],
         "/": "f_rack"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 4, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 4, "y": 0, "chance": 80, "status": 0 } ],
       "items": {
         "$": { "item": "table_foyer", "chance": 50, "repeat": [ 2, 3 ] },
         "/": { "item": "clothing_outdoor_shoes", "chance": 50, "repeat": [ 2, 3 ] }

--- a/data/json/mapgen/house/bungalow22.json
+++ b/data/json/mapgen/house/bungalow22.json
@@ -63,7 +63,7 @@
         "(": { "item": "clothing_outdoor_shoes", "chance": 50, "repeat": [ 1, 2 ] },
         "?": { "item": "table_foyer", "chance": 60 }
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 9, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 9, "y": 0, "chance": 80, "status": 0 } ],
       "vehicles": { "&": { "vehicle": "swivel_chair", "chance": 100, "status": 1 } },
       "place_loot": [
         { "item": "2x4", "x": 5, "y": 10, "chance": 80, "repeat": [ 2, 3 ] },

--- a/data/json/mapgen/house/garden_house_1.json
+++ b/data/json/mapgen/house/garden_house_1.json
@@ -72,7 +72,7 @@
         "7": "f_cupboard",
         "8": "f_counter"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 10, "y": 2, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 10, "y": 1, "chance": 80, "status": 0 } ],
       "items": {
         "c": { "item": "kitchen_counters", "chance": 10 },
         "1": [ { "item": "SUS_dishes", "chance": 100 }, { "item": "SUS_silverware", "chance": 100 } ],

--- a/data/json/mapgen/house/house01.json
+++ b/data/json/mapgen/house/house01.json
@@ -55,7 +55,7 @@
         "A": "t_thconc_floor",
         "~": "t_thconc_floor"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 12, "y": 0, "chance": 80, "status": 0 } ],
       "furniture": { "!": "f_region_flower" },
       "place_loot": [ { "item": "television", "x": 11, "y": 9 }, { "item": "stereo", "x": 10, "y": 9 } ],
       "place_nested": [

--- a/data/json/mapgen/house/house04.json
+++ b/data/json/mapgen/house/house04.json
@@ -39,7 +39,7 @@
         { "point": "terrain", "id": "t_tree_young", "x": [ 0, 14 ], "y": 0, "chance": 5 },
         { "point": "terrain", "id": "t_tree_apple", "x": [ 0, 14 ], "y": 0, "chance": 10, "repeat": [ 1, 2 ] }
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 0, "y": 1, "chance": 80, "status": 0 } ],
       "place_loot": [
         { "group": "cleaning", "x": 13, "y": 6, "chance": 90, "repeat": [ 1, 2 ] },
         { "group": "guns_pistol_common", "x": 2, "y": 13, "chance": 5, "ammo": 90, "magazine": 100 },

--- a/data/json/mapgen/house/house05.json
+++ b/data/json/mapgen/house/house05.json
@@ -33,7 +33,7 @@
         "...........^............"
       ],
       "palettes": [ "domestic_general_and_variant_palette" ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 } ],
       "place_loot": [
         { "group": "guns_pistol_common", "x": 2, "y": 13, "chance": 5, "ammo": 90, "magazine": 100 },
         { "item": "television", "x": 2, "y": 3, "chance": 85 },

--- a/data/json/mapgen/house/house06.json
+++ b/data/json/mapgen/house/house06.json
@@ -35,7 +35,7 @@
       "palettes": [ "domestic_general_and_variant_palette" ],
       "set": [ { "point": "terrain", "id": "t_tree_apple", "x": [ 0, 14 ], "y": [ 0, 0 ], "chance": 40, "repeat": [ 1, 2 ] } ],
       "terrain": { "%": [ "t_region_shrub", "t_region_shrub_fruit", "t_region_shrub_decorative" ] },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 } ],
       "place_loot": [
         { "group": "livingroom", "x": [ 1, 10 ], "y": [ 8, 13 ], "chance": 90, "repeat": [ 1, 5 ] },
         { "group": "consumer_electronics", "x": [ 1, 6 ], "y": [ 15, 21 ], "chance": 50, "repeat": [ 1, 3 ] },

--- a/data/json/mapgen/house/house07.json
+++ b/data/json/mapgen/house/house07.json
@@ -39,7 +39,7 @@
         "%": [ "t_region_shrub", "t_region_shrub_fruit", "t_region_shrub_decorative" ],
         "$": [ [ "t_region_tree_fruit", 2 ], [ "t_region_tree_nut", 2 ], "t_region_tree_shade" ]
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 3, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 } ],
       "place_loot": [ { "group": "livingroom", "x": [ 1, 10 ], "y": [ 1, 13 ], "chance": 90, "repeat": [ 1, 5 ] } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ]
     }

--- a/data/json/mapgen/house/house08.json
+++ b/data/json/mapgen/house/house08.json
@@ -42,7 +42,7 @@
         { "point": "terrain", "id": "t_tree", "x": [ 2, 11 ], "y": [ 16, 21 ], "repeat": [ 2, 6 ] },
         { "point": "terrain", "id": "t_tree_young", "x": [ 2, 11 ], "y": [ 16, 21 ], "repeat": [ 3, 5 ] }
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 } ],
       "place_loot": [ { "group": "guns_pistol_common", "x": 4, "y": 10, "chance": 10, "ammo": 90, "magazine": 100 } ],
       "place_nested": [
         {

--- a/data/json/mapgen/house/house11.json
+++ b/data/json/mapgen/house/house11.json
@@ -53,7 +53,7 @@
       ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 5, "y": 2, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 },
         { "vehicle": "suburban_home", "x": 17, "y": 10, "chance": 15, "rotation": 270 }
       ]
     }

--- a/data/json/mapgen/house/house15.json
+++ b/data/json/mapgen/house/house15.json
@@ -36,7 +36,7 @@
       "terrain": { "%": "t_region_shrub_fruit", "!": "t_region_groundcover_urban", "'": "t_concrete" },
       "furniture": { "!": "f_bluebell", "$": [ "f_treadmill", "f_treadmill_mechanical" ] },
       "place_loot": [ { "group": "livingroom", "x": [ 7, 16 ], "y": [ 7, 9 ], "chance": 90, "repeat": [ 1, 6 ] } ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 1, 22 ], "y": [ 2, 21 ], "chance": 5 } ]
     }
   },

--- a/data/json/mapgen/house/house18.json
+++ b/data/json/mapgen/house/house18.json
@@ -43,7 +43,7 @@
         "t": "t_linoleum_gray"
       },
       "place_loot": [ { "item": "television", "x": 4, "y": 2, "chance": 70 }, { "item": "television", "x": 15, "y": 7, "chance": 70 } ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 8 } ]
     }
   },

--- a/data/json/mapgen/house/house20.json
+++ b/data/json/mapgen/house/house20.json
@@ -55,7 +55,7 @@
         "N": "t_thconc_floor",
         "~": "t_thconc_floor"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 3, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 } ],
       "furniture": { "!": "f_region_flower" }
     }
   },

--- a/data/json/mapgen/house/house24.json
+++ b/data/json/mapgen/house/house24.json
@@ -54,7 +54,7 @@
         "~": "t_thconc_floor"
       },
       "furniture": { "!": "f_region_flower" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 3, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 } ],
       "place_item": [ { "item": "stereo", "x": 15, "y": 20, "chance": 100 }, { "item": "television", "x": 10, "y": 15, "chance": 100 } ]
     }
   },

--- a/data/json/mapgen/house/house26.json
+++ b/data/json/mapgen/house/house26.json
@@ -48,7 +48,7 @@
         "9": "t_linoleum_white",
         "t": "t_linoleum_white"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 12, "y": 0, "chance": 80, "status": 0 } ],
       "furniture": { "!": "f_region_flower" }
     }
   },

--- a/data/json/mapgen/house/house30.json
+++ b/data/json/mapgen/house/house30.json
@@ -48,7 +48,7 @@
         "t": "t_linoleum_white"
       },
       "furniture": { "!": "f_region_flower" },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 8, "y": 1, "chance": 80, "status": 0 } ]
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 6, "y": 1, "chance": 80, "status": 0 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house32.json
+++ b/data/json/mapgen/house/house32.json
@@ -42,7 +42,7 @@
         "N": "t_thconc_floor",
         "~": "t_thconc_floor"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 17, "y": 1, "chance": 80, "status": 0 } ]
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 16, "y": 1, "chance": 80, "status": 0 } ]
     }
   },
   {

--- a/data/json/mapgen/house/house35.json
+++ b/data/json/mapgen/house/house35.json
@@ -50,7 +50,7 @@
         "'": "t_linoleum_gray"
       },
       "furniture": { ":": [ "f_indoor_plant", "f_indoor_plant_y" ] },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 } ],
       "place_loot": [
         { "item": "hose", "x": 9, "y": 22 },
         { "item": "television", "x": 16, "y": 14 },

--- a/data/json/mapgen/house/house37.json
+++ b/data/json/mapgen/house/house37.json
@@ -74,7 +74,7 @@
         { "item": "stereo", "x": 13, "y": 18, "chance": 35 }
       ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 11, "y": 1, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 11, "y": 0, "chance": 80, "status": 0 },
         { "vehicle": "car", "x": 4, "y": 4, "chance": 35, "rotation": 270 }
       ]
     }

--- a/data/json/mapgen/house/house38.json
+++ b/data/json/mapgen/house/house38.json
@@ -59,7 +59,7 @@
         { "item": "stereo", "x": 14, "y": 18, "chance": 35 }
       ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 5, "y": 1, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 5, "y": 0, "chance": 80, "status": 0 },
         { "vehicle": "car", "x": 18, "y": 6, "chance": 35, "rotation": 270 }
       ]
     }

--- a/data/json/mapgen/house/house39.json
+++ b/data/json/mapgen/house/house39.json
@@ -69,7 +69,7 @@
       "furniture": { "!": "f_region_flower", ":": [ "f_indoor_plant", "f_indoor_plant_y" ] },
       "place_loot": [ { "item": "hose", "x": 19, "y": 18, "chance": 35 } ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 1, "y": 0, "chance": 80, "status": 0 },
         { "vehicle": "car", "x": 4, "y": 6, "chance": 35, "rotation": 270 }
       ]
     }

--- a/data/json/mapgen/house/house_detatched1.json
+++ b/data/json/mapgen/house/house_detatched1.json
@@ -82,7 +82,7 @@
       "place_monsters": [ { "chance": 5, "density": 1, "monster": "GROUP_ZOMBIE", "x": 7, "y": 10 } ],
       "place_vehicles": [
         { "vehicle": "bikeshop", "x": 19, "y": 14, "rotation": 270, "chance": 20 },
-        { "vehicle": "rolling_trash_can", "x": 15, "y": 1, "chance": 80, "status": 0 }
+        { "vehicle": "rolling_trash_can", "x": 15, "y": 0, "chance": 80, "status": 0 }
       ]
     }
   },

--- a/data/json/mapgen/house/house_detatched3.json
+++ b/data/json/mapgen/house/house_detatched3.json
@@ -54,7 +54,7 @@
         ")": "t_wall_glass",
         "]": "t_door_glass_c"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 6, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 6, "y": 0, "chance": 80, "status": 0 } ],
       "furniture": { "?": "f_beaded_door", "!": "f_region_flower", "(": "f_chair" },
       "place_item": [ { "item": "television", "repeat": 1, "x": 2, "y": 12 }, { "item": "lawnmower", "repeat": 1, "x": 7, "y": 20 } ],
       "place_items": [

--- a/data/json/mapgen/house/house_detatched4.json
+++ b/data/json/mapgen/house/house_detatched4.json
@@ -64,7 +64,7 @@
         "=": "t_water_pool_outdoors",
         "/": "t_water_pool_shallow_outdoors"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 } ],
       "furniture": { "?": "f_beaded_door", "!": "f_region_flower" },
       "place_item": [ { "item": "television", "repeat": 1, "x": 5, "y": 3 } ],
       "place_items": [

--- a/data/json/mapgen/house/house_detatched5.json
+++ b/data/json/mapgen/house/house_detatched5.json
@@ -70,7 +70,7 @@
         "]": "t_door_glass_c",
         "&": "t_sandbox"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 1, "y": 0, "chance": 80, "status": 0 } ],
       "furniture": { "?": "f_beaded_door", "!": "f_region_flower", ",": "f_brazier", "(": "f_camp_chair" },
       "place_item": [ { "item": "television", "repeat": 1, "x": 14, "y": 7 }, { "item": "lawnmower", "repeat": 1, "x": 12, "y": 12 } ],
       "place_items": [

--- a/data/json/mapgen/house/house_detatched6.json
+++ b/data/json/mapgen/house/house_detatched6.json
@@ -54,7 +54,7 @@
         "*": "t_door_metal_pickable",
         "§": "t_region_groundcover_urban"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 } ],
       "furniture": { "?": "f_beaded_door", ",": "f_pinball_machine", "§": "f_wooden_flagpole" },
       "place_item": [
         { "item": "television", "repeat": 1, "x": 2, "y": 4 },

--- a/data/json/mapgen/house/house_dogs.json
+++ b/data/json/mapgen/house/house_dogs.json
@@ -47,7 +47,7 @@
         ".ŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦŦ.",
         "........................"
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 6, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 6, "y": 0, "chance": 80, "status": 0 } ],
       "palettes": [
         { "distribution": [ [ "standard_domestic_palette", 10 ], [ "standard_domestic_abandoned_palette", 2 ] ] },
         "standard_domestic_landscaping_palette"

--- a/data/json/mapgen/house/house_duplex.json
+++ b/data/json/mapgen/house/house_duplex.json
@@ -47,7 +47,7 @@
       },
       "place_vehicles": [
         { "vehicle": "rolling_trash_can", "x": 6, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 }
+        { "vehicle": "rolling_trash_can", "x": 18, "y": 1, "chance": 80, "status": 0 }
       ],
       "furniture": { "!": "f_region_flower" },
       "place_item": [ { "item": "television", "x": 9, "y": 7 }, { "item": "stereo", "x": 12, "y": 8 } ],

--- a/data/json/mapgen/house/house_duplex10.json
+++ b/data/json/mapgen/house/house_duplex10.json
@@ -53,8 +53,8 @@
       "place_vehicles": [
         { "chance": 30, "fuel": 10, "rotation": 90, "status": -1, "vehicle": "car_sports", "x": 9, "y": 7 },
         { "chance": 35, "fuel": 10, "rotation": 90, "status": -1, "vehicle": "car", "x": 16, "y": 7 },
-        { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 21, "y": 1, "chance": 80, "status": 0 }
+        { "vehicle": "rolling_trash_can", "x": 1, "y": 1, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 20, "y": 1, "chance": 80, "status": 0 }
       ]
     },
     "om_terrain": "house_duplex10",

--- a/data/json/mapgen/house/house_duplex2.json
+++ b/data/json/mapgen/house/house_duplex2.json
@@ -46,8 +46,8 @@
         "-": "t_linoleum_gray"
       },
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 6, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 }
+        { "vehicle": "rolling_trash_can", "x": 6, "y": 0, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 16, "y": 0, "chance": 80, "status": 0 }
       ],
       "furniture": { "!": "f_region_flower" },
       "place_item": [

--- a/data/json/mapgen/house/house_duplex4.json
+++ b/data/json/mapgen/house/house_duplex4.json
@@ -46,8 +46,8 @@
         "-": "t_linoleum_gray"
       },
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 6, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 }
+        { "vehicle": "rolling_trash_can", "x": 6, "y": 0, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 12, "y": 0, "chance": 80, "status": 0 }
       ],
       "furniture": { "!": "f_region_flower" },
       "place_item": [ { "item": "television", "x": 11, "y": 13 }, { "item": "television", "x": 13, "y": 13 } ]

--- a/data/json/mapgen/house/house_duplex5.json
+++ b/data/json/mapgen/house/house_duplex5.json
@@ -48,7 +48,7 @@
         "-": "t_linoleum_gray"
       },
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 4, "y": 1, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 3, "y": 1, "chance": 80, "status": 0 },
         { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 }
       ],
       "furniture": { "!": "f_region_flower" },

--- a/data/json/mapgen/house/house_duplex6.json
+++ b/data/json/mapgen/house/house_duplex6.json
@@ -60,7 +60,7 @@
         "-": "t_linoleum_gray"
       },
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 4, "y": 1, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 3, "y": 1, "chance": 80, "status": 0 },
         { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 }
       ],
       "furniture": { "!": "f_region_flower" },

--- a/data/json/mapgen/house/house_duplex8.json
+++ b/data/json/mapgen/house/house_duplex8.json
@@ -49,7 +49,7 @@
       },
       "place_vehicles": [
         { "vehicle": "rolling_trash_can", "x": 4, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 }
+        { "vehicle": "rolling_trash_can", "x": 12, "y": 0, "chance": 80, "status": 0 }
       ],
       "furniture": { "!": "f_region_flower" }
     }

--- a/data/json/mapgen/house/house_duplex9.json
+++ b/data/json/mapgen/house/house_duplex9.json
@@ -58,8 +58,8 @@
       "place_vehicles": [
         { "chance": 35, "fuel": 10, "rotation": 90, "status": -1, "vehicle": "car", "x": 8, "y": 7 },
         { "chance": 30, "fuel": 10, "rotation": 90, "status": -1, "vehicle": "car_sports", "x": 16, "y": 7 },
-        { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 21, "y": 1, "chance": 80, "status": 0 }
+        { "vehicle": "rolling_trash_can", "x": 1, "y": 0, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 22, "y": 1, "chance": 80, "status": 0 }
       ]
     }
   },

--- a/data/json/mapgen/house/house_garage.json
+++ b/data/json/mapgen/house/house_garage.json
@@ -53,7 +53,7 @@
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ],
       "place_vehicles": [
         { "vehicle": "suburban_home", "x": 17, "y": 6, "chance": 15, "fuel": 70, "status": 0, "rotation": 90 },
-        { "vehicle": "rolling_trash_can", "x": 3, "y": 1, "chance": 80, "status": 0 }
+        { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 }
       ]
     }
   },

--- a/data/json/mapgen/house/house_garage6.json
+++ b/data/json/mapgen/house/house_garage6.json
@@ -80,7 +80,7 @@
       ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 3, "y": 1, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 3, "y": 0, "chance": 80, "status": 0 },
         { "vehicle": "suburban_home", "x": 17, "y": 7, "chance": 10, "rotation": 90 }
       ]
     }

--- a/data/json/mapgen/house/house_garage_prepper.json
+++ b/data/json/mapgen/house/house_garage_prepper.json
@@ -64,7 +64,7 @@
         ",": "t_door_boarded",
         "(": "t_door_metal_pickable"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 } ],
       "furniture": { "!": "f_region_flower", ";": "f_console_broken", "{": "f_table", "}": "f_chair", ")": "f_locker" },
       "set": [
         { "point": "trap", "id": "tr_beartrap", "x": [ 10, 11 ], "y": 2, "repeat": [ 1, 2 ] },

--- a/data/json/mapgen/house/house_library.json
+++ b/data/json/mapgen/house/house_library.json
@@ -41,7 +41,7 @@
         "S": "t_linoleum_gray",
         "Q": "t_linoleum_gray"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 } ],
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 2, 21 ], "y": [ 2, 21 ], "chance": 2 } ]
     }
   }

--- a/data/json/mapgen/house/house_patio.json
+++ b/data/json/mapgen/house/house_patio.json
@@ -77,7 +77,7 @@
         }
       ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 15, "y": 1, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 15, "y": 0, "chance": 80, "status": 0 },
         { "vehicle": "suburban_home", "x": 5, "y": 4, "chance": 10, "rotation": 90 }
       ]
     }

--- a/data/json/mapgen/house/house_prepper.json
+++ b/data/json/mapgen/house/house_prepper.json
@@ -50,7 +50,7 @@
         "=": "t_door_locked",
         "/": "t_door_metal_pickable"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 } ],
       "furniture": { "!": "f_region_flower" },
       "place_loot": [ { "item": "television", "x": 5, "y": 6 }, { "item": "stereo", "x": 6, "y": 6 } ],
       "place_items": [
@@ -105,7 +105,7 @@
         ".######################.",
         "............^..........."
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 } ],
       "palettes": [ "standard_domestic_palette" ],
       "place_npcs": [ { "class": "prepper_survivor", "x": 13, "y": 20 } ],
       "place_zones": [ { "type": "LOOT_UNSORTED", "faction": "no_faction", "x": [ 11, 15 ], "y": 21 } ],

--- a/data/json/mapgen/house/house_quiverfull.json
+++ b/data/json/mapgen/house/house_quiverfull.json
@@ -62,8 +62,8 @@
         { "monster": "GROUP_QUIVERFULL", "x": [ 2, 14 ], "y": [ 15, 21 ], "chance": 1 }
       ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 },
-        { "vehicle": "rolling_trash_can", "x": 3, "y": 1, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 2, "y": 0, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 3, "y": 0, "chance": 80, "status": 0 },
         { "vehicle": "tricycle", "x": 10, "y": 8, "chance": 50, "status": 0 },
         { "vehicle": "tricycle", "x": 4, "y": 21, "chance": 50, "status": 0 }
       ]

--- a/data/json/mapgen/house/house_tool_shed.json
+++ b/data/json/mapgen/house/house_tool_shed.json
@@ -44,7 +44,7 @@
         "q": "t_thconc_floor",
         "!": "t_thconc_floor"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 6, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 6, "y": 0, "chance": 80, "status": 0 } ],
       "set": [
         { "point": "terrain", "id": "t_tree_apple", "x": [ 0, 14 ], "y": [ 0, 0 ], "repeat": [ 1, 2 ] },
         { "point": "terrain", "id": "t_tree", "x": [ 2, 14 ], "y": [ 17, 21 ], "repeat": [ 1, 3 ] },

--- a/data/json/mapgen/house/house_wooded.json
+++ b/data/json/mapgen/house/house_wooded.json
@@ -54,7 +54,7 @@
         ")": "t_wall_glass",
         "]": "t_door_glass_c"
       },
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 2, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 1, "y": 0, "chance": 80, "status": 0 } ],
       "furniture": { "!": "f_region_flower", "}": [ "f_indoor_plant", "f_indoor_plant_y" ] },
       "place_loot": [ { "item": "television", "x": 3, "y": 18 }, { "item": "stereo", "x": 5, "y": 15 } ]
     }

--- a/data/json/mapgen/house/urban_12_house.json
+++ b/data/json/mapgen/house/urban_12_house.json
@@ -60,7 +60,7 @@
       },
       "place_loot": [ { "item": "television", "x": 40, "y": 5, "chance": 100 }, { "item": "stereo", "x": 41, "y": 5, "chance": 50 } ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 7, "y": 1, "chance": 80, "status": 0 },
         { "vehicle": "suburban_home", "x": 11, "y": 9, "chance": 100, "rotation": 270 }
       ]
     }

--- a/data/json/mapgen/house/urban_15_house.json
+++ b/data/json/mapgen/house/urban_15_house.json
@@ -54,7 +54,7 @@
       "furniture": { "0": "f_counter" },
       "place_loot": [ { "item": "television", "x": 16, "y": 14, "chance": 100 }, { "item": "stereo", "x": 16, "y": 15, "chance": 50 } ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 40, "y": 1, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 34, "y": 1, "chance": 80, "status": 0 },
         { "vehicle": "suburban_home_compact", "x": 37, "y": 9, "chance": 50, "rotation": 270 }
       ]
     }

--- a/data/json/mapgen/house/urban_20_house.json
+++ b/data/json/mapgen/house/urban_20_house.json
@@ -75,7 +75,7 @@
       },
       "place_monsters": [ { "monster": "GROUP_ZOMBIE", "x": [ 1, 22 ], "y": [ 1, 22 ], "density": 0.03 } ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 12, "y": 1, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 12, "y": 0, "chance": 80, "status": 0 },
         { "vehicle": "suburban_home", "x": 15, "y": 14, "chance": 40, "rotation": 0 }
       ],
       "place_item": [ { "item": "television", "x": 18, "y": 3 } ]

--- a/data/json/mapgen/house/urban_4_house_basement.json
+++ b/data/json/mapgen/house/urban_4_house_basement.json
@@ -120,7 +120,7 @@
       "furniture": { "!": "f_region_flower", "0": "f_stool", "]": "f_sofa", "}": "f_table" },
       "place_loot": [ { "item": "television", "x": 8, "y": 5, "chance": 100 }, { "item": "stereo", "x": 9, "y": 5, "chance": 100 } ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 16, "y": 23, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 16, "y": 22, "chance": 80, "status": 0 },
         { "vehicle": "suburban_home", "x": 36, "y": 12, "chance": 30, "rotation": 270 }
       ]
     }

--- a/data/json/mapgen/house/urban_5_house.json
+++ b/data/json/mapgen/house/urban_5_house.json
@@ -72,7 +72,7 @@
       "furniture": { "!": "f_region_flower", "0": "f_stool", "]": "f_sofa", "}": "f_table" },
       "place_loot": [ { "item": "television", "x": 28, "y": 14, "chance": 100 }, { "item": "stereo", "x": 28, "y": 15, "chance": 100 } ],
       "place_vehicles": [
-        { "vehicle": "rolling_trash_can", "x": 17, "y": 23, "chance": 80, "status": 0 },
+        { "vehicle": "rolling_trash_can", "x": 17, "y": 22, "chance": 80, "status": 0 },
         { "vehicle": "suburban_home", "x": 37, "y": 12, "chance": 30, "rotation": 270 }
       ]
     }

--- a/data/json/mapgen/house/urban_8_house_brick_garden.json
+++ b/data/json/mapgen/house/urban_8_house_brick_garden.json
@@ -59,7 +59,7 @@
         { "chunks": [ [ "greenhouse_6x6_herbal", 100 ] ], "x": 8, "y": 8 },
         { "chunks": [ [ "greenhouse_6x6_vegetable", 100 ] ], "x": 8, "y": 15 }
       ],
-      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 31, "y": 1, "chance": 80, "status": 0 } ],
+      "place_vehicles": [ { "vehicle": "rolling_trash_can", "x": 31, "y": 0, "chance": 80, "status": 0 } ],
       "place_loot": [
         { "item": "television", "x": 29, "y": 6, "chance": 100 },
         { "item": "stereo", "x": 29, "y": 7, "chance": 50 },

--- a/data/json/npcs/items_generic.json
+++ b/data/json/npcs/items_generic.json
@@ -372,7 +372,7 @@
       [ "ibuprofen", 25 ],
       [ "acetaminophen", 25 ],
       [ "naproxen", 25 ],
-      [ "atomic_light", 1 ],
+      [ "atomic_light_off", 1 ],
       [ "ax", 5 ],
       [ "backpack", 5 ],
       [ "bacon", 2 ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
grep for rolling_trash_can and check that every time it wants to spawn one it's not over other terrain definitions aka **boring work**.

it took me understanding that mapgen uses 0 based indexing to fix this relatively easy

resolves #70223


<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
also fix a bug where npcs can spawn with an "open" atomic powered light source, poor soul, don't give 'em that!
![Screenshot from 2024-01-21 16-26-29](https://github.com/CleverRaven/Cataclysm-DDA/assets/58050969/2ae1067a-185a-411a-989d-33644ff0e7cd)

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
