### PR TITLE
Fixes TCL Security Drone drops

### DIFF
--- a/data/json/monsters/lab_security_drones.json
+++ b/data/json/monsters/lab_security_drones.json
@@ -120,7 +120,7 @@
         "monster_message": "Remain still.  Scanning for authorization."
       }
     ],
-    "revert_to_itype": "bot_manhack",
+    "revert_to_itype": "bot_lab_security_drone_YM",
     "extend": { "flags": [ "COLDPROOF", "PRIORITIZE_TARGETS" ] },
     "death_drops": { "groups": [ [ "robots", 4 ], [ "eyebot", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
@@ -180,7 +180,7 @@
         "monster_message": "Remain still.  Scanning for authorization."
       }
     ],
-    "revert_to_itype": "bot_manhack",
+    "revert_to_itype": "bot_lab_security_drone_BM",
     "extend": { "flags": [ "COLDPROOF", "PRIORITIZE_TARGETS" ] },
     "death_drops": { "groups": [ [ "robots", 4 ], [ "eyebot", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },
@@ -266,7 +266,7 @@
         "monster_message": "Remain still.  Scanning for authorization."
       }
     ],
-    "revert_to_itype": "bot_manhack",
+    "revert_to_itype": "bot_lab_security_drone_BM2",
     "extend": { "flags": [ "COLDPROOF", "PRIORITIZE_TARGETS" ] },
     "death_drops": { "groups": [ [ "robots", 4 ], [ "eyebot", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },

--- a/data/json/monsters/lab_security_drones.json
+++ b/data/json/monsters/lab_security_drones.json
@@ -120,7 +120,7 @@
         "monster_message": "Remain still.  Scanning for authorization."
       }
     ],
-    "revert_to_itype": "bot_lab_security_drone_YM"
+    "revert_to_itype": "bot_lab_security_drone_YM",
     "extend": { "flags": [ "COLDPROOF", "PRIORITIZE_TARGETS" ] },
     "death_drops": { "groups": [ [ "robots", 4 ], [ "eyebot", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },

--- a/data/json/monsters/lab_security_drones.json
+++ b/data/json/monsters/lab_security_drones.json
@@ -120,7 +120,7 @@
         "monster_message": "Remain still.  Scanning for authorization."
       }
     ],
-    "revert_to_itype": "bot_lab_security_drone_YM",
+    "revert_to_itype": "bot_lab_security_drone_YM"
     "extend": { "flags": [ "COLDPROOF", "PRIORITIZE_TARGETS" ] },
     "death_drops": { "groups": [ [ "robots", 4 ], [ "eyebot", 1 ] ] },
     "death_function": { "corpse_type": "BROKEN" },


### PR DESCRIPTION
#### Summary
Bugfixes "Fixes TCL Security Drone drops"

#### Purpose of change
I noticed that, after hacking and disabling some of the TCL security drones, they dropped generic manhack items instead of the deactivated drones. This has them drop their proper item forms.

#### Describe the solution
Fixes the bug

#### Describe alternatives you've considered

#### Testing

#### Additional context
