### PR TITLE
effect_tremorsense duration

### DIFF
--- a/data/mods/Magiclysm/Spells/earthshaper.json
+++ b/data/mods/Magiclysm/Spells/earthshaper.json
@@ -813,7 +813,7 @@
     "max_level": 10,
     "base_casting_time": 400,
     "base_energy_cost": 350,
-    "min_duration": 30000,
+    "min_duration": 0,
     "max_duration": 300000,
     "duration_increment": 30000
   },

--- a/data/mods/Magiclysm/Spells/earthshaper.json
+++ b/data/mods/Magiclysm/Spells/earthshaper.json
@@ -813,7 +813,7 @@
     "max_level": 10,
     "base_casting_time": 400,
     "base_energy_cost": 350,
-    "min_duration": 0
+    "min_duration": 0,
     "max_duration": 300000,
     "duration_increment": 30000
   },

--- a/data/mods/Magiclysm/Spells/earthshaper.json
+++ b/data/mods/Magiclysm/Spells/earthshaper.json
@@ -813,7 +813,7 @@
     "max_level": 10,
     "base_casting_time": 400,
     "base_energy_cost": 350,
-    "min_duration": 0,
+    "min_duration": 0
     "max_duration": 300000,
     "duration_increment": 30000
   },

--- a/data/mods/Magiclysm/Spells/earthshaper.json
+++ b/data/mods/Magiclysm/Spells/earthshaper.json
@@ -824,7 +824,7 @@
     "effect": [
       {
         "u_add_effect": "effect_tremorsense",
-        "duration": { "math": [ "(u_spell_level('earthshaper_danger_sense') * 30000)" ] }
+        "duration": { "math": [ "(u_spell_level('earthshaper_danger_sense') * 300)" ] }
       }
     ],
     "false_effect": [ { "u_message": "Without a direct connection to the living earth, the spell fails.", "type": "bad" } ]

--- a/data/mods/Magiclysm/effects/effects.json
+++ b/data/mods/Magiclysm/effects/effects.json
@@ -765,7 +765,7 @@
     "apply_message": "",
     "remove_message": "You can no longer discern the vibrations of the living earth.",
     "rating": "good",
-    "max_duration": "30 minutes",
+    "max_duration": "50 minutes",
     "enchantments": [
       {
         "values": [ { "value": "MOTION_VISION_RANGE", "add": { "math": [ "( u_spell_level('earthshaper_danger_sense') * 3)" ] } } ]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "[Magiclysm] Tremorsense duration"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
`effect_tremorsense` duration is set by an EOC as: 
`"duration": { "math": [ "(u_spell_level('earthshaper_danger_sense') * 30000)" ] }`
Seems the constant was pulled from the main spell, but spell's `duration` field unit are moves, not turns. As the EOC's `duration` field unit are turns by default, it effectively increases the duration by x100
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
1. Divide the formula constant by 100
2. Set the spell's `"min_duration": 0,` so the duration at lvl 1 properly displays 5 min, instead of 10 min
3. Increase the max duration of the effect `effect_tremorsense` from 30 min to 50 min, as that's the intended duration at lvl 10, otherwise the buff duration caps at lvl 6
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Applied the three changes mentioned above
Added the lvl 1 spell to the Novice Earthshaper profession (also added a pocketwatch to measure time)
Created a new Novice Earthshaper
Casted Tremorsense at t = 0 (1st image), waited for 300 s so the buff went away (2nd image)

![1](https://github.com/CleverRaven/Cataclysm-DDA/assets/95231551/4e41d413-4f6e-4d01-b065-41c0861d80f3)

![2](https://github.com/CleverRaven/Cataclysm-DDA/assets/95231551/03d0f36b-02a1-4f38-86f6-61cd4da95f9c)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
