### PR TITLE
[XEDRA Evolved] Create Class Hobbies

### DIFF
--- a/data/mods/Xedra_Evolved/player/professions.json
+++ b/data/mods/Xedra_Evolved/player/professions.json
@@ -460,10 +460,7 @@
     "name": "Awakened Eater",
     "description": "Ever since the Cataclysm you've been able to clearly see elements of other realities that have intruded your own. You also think you'd be able to consume these intrusions to give you power far beyond a normal human.",
     "points": 4,
-    "spells": [
-      { "id": "spring_heeled_leap", "level": 4 },
-      { "id": "spell_dodge", "level": 4 }
-    ],
+    "spells": [ { "id": "spring_heeled_leap", "level": 4 }, { "id": "spell_dodge", "level": 4 } ],
     "traits": [ "EATER" ]
   },
   {
@@ -473,10 +470,7 @@
     "name": "Awakened Dreamer",
     "description": "Ever since the Cataclysm you've become far more aware of the weakened gap between realities. Specifically, of what is on the other side.  Surprisingly, it doesn't seem universally hostile, and you think you'd be able to bring some of these entities over if you desired.",
     "points": 4,
-    "spells": [
-      { "id": "create_dream_dross", "level": 4 },
-      { "id": "summon_shifter", "level": 4 }
-    ],
+    "spells": [ { "id": "create_dream_dross", "level": 4 }, { "id": "summon_shifter", "level": 4 } ],
     "traits": [ "DREAMER" ]
   },
   {

--- a/data/mods/Xedra_Evolved/player/professions.json
+++ b/data/mods/Xedra_Evolved/player/professions.json
@@ -455,6 +455,52 @@
   },
   {
     "type": "profession",
+    "subtype": "hobby",
+    "id": "hobby_eater",
+    "name": "Awakened Eater",
+    "description": "Ever since the Cataclysm you've been able to clearly see elements of other realities that have intruded your own. You also think you'd be able to consume these intrusions to give you power far beyond a normal human.",
+    "points": 4,
+    "spells": [
+      { "id": "spring_heeled_leap", "level": 4 },
+      { "id": "spell_dodge", "level": 4 }
+    ],
+    "traits": [ "EATER" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "hobby_dreamer",
+    "name": "Awakened Dreamer",
+    "description": "Ever since the Cataclysm you've become far more aware of the weakened gap between realities. Specifically, of what is on the other side.  Surprisingly, it doesn't seem universally hostile, and you think you'd be able to bring some of these entities over if you desired.",
+    "points": 4,
+    "spells": [
+      { "id": "create_dream_dross", "level": 4 },
+      { "id": "summon_shifter", "level": 4 }
+    ],
+    "traits": [ "DREAMER" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "hobby_inventor",
+    "name": "Awakened Inventor",
+    "description": "Ever since the Cataclysm you've begun having crazy ideas on how to create technological devices. While conventional logic would label these designs as silly or even insane, something tells you that they'd work regardless.",
+    "points": 4,
+    "traits": [ "INVENTOR" ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "hobby_dreamsmith",
+    "name": "Awakened Dreamsmith",
+    "description": "Ever since the Cataclysm you've gained an instinctive sense of how to work dreamdross into tools and armor. It will still take some effort to put these vague ideas to proper use",
+    "//": "TODO: add some basic recipes they could know, if possible",
+    "points": 4,
+    "spells": [ { "id": "spell_oneiric_hammer", "level": 0 } ],
+    "traits": [ "DREAMSMITH" ]
+  },
+  {
+    "type": "profession",
     "id": "paraclesian_ierde",
     "name": { "male": "Ierde", "female": "Ierda" },
     "description": "With the dimensional spillage that preceded the Cataclysm you are the spirit of a place that slowly gained sentience, a genius loci.  As the world reshapes itself you have decided to wander from your birthplace and determine where you will end up.",

--- a/data/mods/Xedra_Evolved/player/professions.json
+++ b/data/mods/Xedra_Evolved/player/professions.json
@@ -458,7 +458,7 @@
     "subtype": "hobby",
     "id": "hobby_eater",
     "name": "Awakened Eater",
-    "description": "Ever since the Cataclysm you've been able to clearly see elements of other realities that have intruded your own. You also think you'd be able to consume these intrusions to give you power far beyond a normal human.",
+    "description": "Ever since the Cataclysm you've been able to clearly see elements of other realities that have intruded your own.  You also think you'd be able to consume these intrusions to give you power far beyond a normal human.",
     "points": 4,
     "spells": [ { "id": "spring_heeled_leap", "level": 4 }, { "id": "spell_dodge", "level": 4 } ],
     "traits": [ "EATER" ]
@@ -468,7 +468,7 @@
     "subtype": "hobby",
     "id": "hobby_dreamer",
     "name": "Awakened Dreamer",
-    "description": "Ever since the Cataclysm you've become far more aware of the weakened gap between realities. Specifically, of what is on the other side.  Surprisingly, it doesn't seem universally hostile, and you think you'd be able to bring some of these entities over if you desired.",
+    "description": "Ever since the Cataclysm you've become far more aware of the weakened gap between realities.  Specifically, of what is on the other side.  Surprisingly, it doesn't seem universally hostile, and you think you'd be able to bring some of these entities over if you desired.",
     "points": 4,
     "spells": [ { "id": "create_dream_dross", "level": 4 }, { "id": "summon_shifter", "level": 4 } ],
     "traits": [ "DREAMER" ]
@@ -478,7 +478,7 @@
     "subtype": "hobby",
     "id": "hobby_inventor",
     "name": "Awakened Inventor",
-    "description": "Ever since the Cataclysm you've begun having crazy ideas on how to create technological devices. While conventional logic would label these designs as silly or even insane, something tells you that they'd work regardless.",
+    "description": "Ever since the Cataclysm you've begun having crazy ideas on how to create technological devices.  While conventional logic would label these designs as silly or even insane, something tells you that they'd work regardless.",
     "points": 4,
     "traits": [ "INVENTOR" ]
   },
@@ -487,7 +487,7 @@
     "subtype": "hobby",
     "id": "hobby_dreamsmith",
     "name": "Awakened Dreamsmith",
-    "description": "Ever since the Cataclysm you've gained an instinctive sense of how to work dreamdross into tools and armor. It will still take some effort to put these vague ideas to proper use",
+    "description": "Ever since the Cataclysm you've gained an instinctive sense of how to work dreamdross into tools and armor.  It will still take some effort to put these vague ideas to proper use",
     "//": "TODO: add some basic recipes they could know, if possible",
     "points": 4,
     "spells": [ { "id": "spell_oneiric_hammer", "level": 0 } ],


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Create hobbies for XEDRA Evolved hobbies"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Currently there are 4 professions that give the classes in XEDRA Evolved, but for characters that don't want to start off as part of the military there aren't any options.  The hobbies allow far more roleplayability options.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add 4 hobbies that grant the class traits + one or two basic spells.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Also add more specific hobbies that give 1 high tier spell, such as a hobby that gives just lucid dreaming.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Confirmed that dreamer and eater are not both selectable
Confirmed that inventor and dreamsmith are not both selectable
Confirmed that picking the dreamer and eater hobbies give the defined spells at the correct level.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
PR that allows spells from hobbies was merged.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
