### PR TITLE
Remove craft_command.h and recipe.h from character.h

### DIFF
--- a/src/activity_actor_definitions.h
+++ b/src/activity_actor_definitions.h
@@ -22,6 +22,7 @@
 #include "memory_fast.h"
 #include "pickup.h"
 #include "point.h"
+#include "recipe.h"
 #include "string_id.h"
 #include "type_id.h"
 #include "units.h"

--- a/src/character.h
+++ b/src/character.h
@@ -47,7 +47,6 @@
 #include "player_activity.h"
 #include "point.h"
 #include "ranged.h"
-#include "recipe.h"
 #include "ret_val.h"
 #include "stomach.h"
 #include "string_formatter.h"
@@ -106,6 +105,7 @@ template <typename E> struct enum_traits;
 
 enum npc_attitude : int;
 enum action_id : int;
+enum class recipe_filter_flags : int;
 enum class steed_type : int;
 enum class proficiency_bonus_type : int;
 

--- a/src/character.h
+++ b/src/character.h
@@ -32,7 +32,6 @@
 #include "character_id.h"
 #include "city.h"
 #include "coordinates.h"
-#include "craft_command.h"
 #include "creature.h"
 #include "damage.h"
 #include "debug.h"
@@ -66,6 +65,7 @@ class SkillLevelMap;
 class basecamp;
 class bionic_collection;
 class character_martial_arts;
+class craft_command;
 class dispersion_sources;
 class effect;
 class effect_source;

--- a/tests/crafting_test.cpp
+++ b/tests/crafting_test.cpp
@@ -17,6 +17,7 @@
 #include "cata_utility.h"
 #include "cata_catch.h"
 #include "character.h"
+#include "craft_command.h"
 #include "game.h"
 #include "inventory.h"
 #include "item.h"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
@Brambor asked a question in Discord, which made me look at this https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/7617238475/job/20745814812, which made me look at this:
```
 98578 ms: src/recipe.h (included 221 times, avg 446 ms), included via:
  55x: avatar.h character.h craft_command.h 
  44x: character.h craft_command.h 
  18x: game.h character.h craft_command.h 
  17x: activity_actor_definitions.h character.h craft_command.h 
  8x: bionics.h effect_on_condition.h condition.h dialogue.h npc.h character.h craft_command.h 
  8x: vehicle.h clzones.h avatar.h character.h craft_command.h 
  ...

97879 ms: src/craft_command.h (included 220 times, avg 444 ms), included via:
  55x: avatar.h character.h 
  45x: character.h 
  18x: game.h character.h 
  17x: activity_actor_definitions.h character.h 
  8x: bionics.h effect_on_condition.h condition.h dialogue.h npc.h character.h 
  8x: vehicle.h clzones.h avatar.h character.h 
  ```

#### Describe the solution
Remove the headers, which do not need to be included.

#### Describe alternatives you've considered


#### Testing
From
```
% cat obj/*.inc | grep -v '.h:' | grep craft_command.h | wc -l
220
% cat obj/*.inc | grep -v '.h:' | grep recipe.h | wc -l
221
```
to
```
% cat obj/*.d | grep -v '.h:' | grep recipe.h | wc -l
142
% cat obj/*.d | grep -v '.h:' | grep craft_command.h | wc -l
130
```

#### Additional context
@Brambor If you've got IWYU running, it'd be great to do it on the whole codebase.