### PR TITLE
IFAK Pouches are now less encumbering when worn as pockets

### DIFF
--- a/data/json/items/containers/containers.json
+++ b/data/json/items/containers/containers.json
@@ -3650,7 +3650,8 @@
         "max_contains_weight": "4000 g",
         "max_item_length": "20 cm",
         "moves": 100,
-        "rigid": false
+        "rigid": false,
+        "volume_encumber_modifier": 0.3
       }
     ],
     "symbol": ")",


### PR DESCRIPTION
#### Summary

Bugfixes "IFAK Pouches are now less encumbering when worn as MOLLE pockets"

#### Purpose of change

IFAK Pouches could be attached to a MOLLE-compatible vest, but were way more encumbering than other comparable storage options.

#### Describe the solution

Set volume_encumber_modifier 0.3 as per [design docs](https://docs.cataclysmdda.org/ARMOR_BALANCE_AND_DESIGN.html) for "reasonable value for armor and strapped pouches designed for combat, but accessible", in line with other MOLLE strapped pouches.

#### Describe alternatives you've considered

None.

#### Testing

Loaded existing game with change applied. Sighed with relief as my MOLLE-strapped IFAK is no longer mega-encumbering.

#### Additional context

None.

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->