### PR TITLE
math_parser: remove diag func. declarations from header

### DIFF
--- a/src/math_parser.cpp
+++ b/src/math_parser.cpp
@@ -1,7 +1,6 @@
 #include "math_parser.h"
 
 #include <algorithm>
-#include <array>
 #include <cstddef>
 #include <locale>
 #include <map>
@@ -92,12 +91,12 @@ std::optional<S> _get_dialogue_func( C const &cnt, std::string_view token )
 
 std::optional<scoped_diag_eval> get_dialogue_eval( std::string_view token )
 {
-    return _get_dialogue_func<scoped_diag_eval, pdiag_func_eval>( dialogue_eval_f, token );
+    return _get_dialogue_func<scoped_diag_eval, pdiag_func_eval>( get_all_diag_eval_funcs(), token );
 }
 
 std::optional<scoped_diag_ass> get_dialogue_ass( std::string_view token )
 {
-    return _get_dialogue_func<scoped_diag_ass, pdiag_func_ass>( dialogue_assign_f, token );
+    return _get_dialogue_func<scoped_diag_ass, pdiag_func_ass>( get_all_diag_ass_funcs(), token );
 }
 
 constexpr std::optional<pbin_op> get_binary_op( std::string_view token )

--- a/src/math_parser_diag.cpp
+++ b/src/math_parser_diag.cpp
@@ -9,12 +9,45 @@
 #include "field.h"
 #include "game.h"
 #include "magic.h"
+#include "math_parser_diag_value.h"
 #include "math_parser_shim.h"
 #include "mtype.h"
 #include "options.h"
 #include "string_input_popup.h"
 #include "units.h"
 #include "weather.h"
+
+/*
+General guidelines for writing dialogue functions
+
+The typical parsing function takes the form:
+
+std::function<double( dialogue & )> myfunction_eval( char scope,
+        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
+{
+    diag_value myval( std::string{} );
+    if( kwargs.count( "mykwarg" ) != 0 ) {
+        myval = *kwargs.at( "mykwarg" );
+    }
+
+    ...parse-time code...
+
+    return[effect_id = params[0], myval, beta = is_beta( scope )]( dialogue const & d ) {
+        ...run-time code...
+    };
+}
+
+- Don't validate the number of arguments (params). The math parser already does that
+- Only use variadic functions if all arguments are treated the same way,
+  regardless of how many there are (including zero)
+- Use kwargs for optional arguments
+- Prefer splitting functions instead of using mandatory kwargs
+  ex: school_level() split from spell_level() instead of spell_level('school':blorg)
+- Use parameter-less functions diag_value::str(), dbl(), and var() only at parse-time
+- Use conversion functions diag_value::str( d ) and dbl( d ) only at run-time
+- Always throw on errors at parse-time
+- Never throw at run-time. Use a debugmsg() and recover gracefully
+*/
 
 namespace
 {
@@ -48,8 +81,6 @@ T _read_from_string( std::string_view s, const std::vector<std::pair<std::string
     };
     return detail::read_from_json_string_common<T>( s, units, error );
 }
-
-} // namespace
 
 std::function<double( dialogue & )> u_val( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &/* kwargs */ )
@@ -406,8 +437,6 @@ std::function<double( dialogue & )> attack_speed_eval( char scope,
     };
 }
 
-namespace
-{
 template<class ID>
 using f_monster_match = bool ( * )( Creature const &critter, ID const &id );
 
@@ -479,8 +508,6 @@ std::function<double( dialogue & )> _monsters_nearby_eval( char scope,
         return static_cast<double>( targets.size() );
     };
 }
-
-} // namespace
 
 std::function<double( dialogue & )> monsters_nearby_eval( char scope,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
@@ -782,8 +809,6 @@ std::function<void( dialogue &, double )> proficiency_ass( char scope,
     };
 }
 
-namespace
-{
 double _test_add( diag_value const &v, dialogue const &d )
 {
     double ret{};
@@ -822,7 +847,6 @@ std::function<double( dialogue & )> _test_func( std::vector<diag_value> const &p
         return ret;
     };
 }
-} // namespace
 
 std::function<double( dialogue & )> test_diag( char /* scope */,
         std::vector<diag_value> const &params, diag_kwargs const &kwargs )
@@ -941,4 +965,77 @@ std::function<void( dialogue &, double )> weather_ass( char /* scope */,
         };
     }
     throw std::invalid_argument( string_format( "Unknown weather aspect %s", params[0].str() ) );
+}
+
+// { "name", { "scopes", num_args, function } }
+// kwargs are not included in num_args
+std::map<std::string_view, dialogue_func_eval> const dialogue_eval_f{
+    { "_test_diag_", { "g", -1, test_diag } },
+    { "_test_str_len_", { "g", -1, test_str_len } },
+    { "addiction_intensity", { "un", 1, addiction_intensity_eval } },
+    { "addiction_turns", { "un", 1, addiction_turns_eval } },
+    { "armor", { "un", 2, armor_eval } },
+    { "attack_speed", { "un", 0, attack_speed_eval } },
+    { "charge_count", { "un", 1, charge_count_eval } },
+    { "coverage", { "un", 1, coverage_eval } },
+    { "distance", { "g", 2, distance_eval } },
+    { "effect_intensity", { "un", 1, effect_intensity_eval } },
+    { "encumbrance", { "un", 1, encumbrance_eval } },
+    { "energy", { "g", 1, energy_eval } },
+    { "field_strength", { "ung", 1, field_strength_eval } },
+    { "game_option", { "g", 1, option_eval } },
+    { "has_trait", { "un", 1, has_trait_eval } },
+    { "has_proficiency", { "un", 1, knows_proficiency_eval } },
+    { "has_var", { "g", 1, has_var_eval } },
+    { "hp", { "un", 1, hp_eval } },
+    { "hp_max", { "un", 1, hp_max_eval } },
+    { "item_count", { "un", 1, item_count_eval } },
+    { "item_rad", { "un", 1, item_rad_eval } },
+    { "monsters_nearby", { "ung", -1, monsters_nearby_eval } },
+    { "mon_species_nearby", { "ung", -1, monster_species_nearby_eval } },
+    { "mon_groups_nearby", { "ung", -1, monster_groups_nearby_eval } },
+    { "num_input", { "g", 2, num_input_eval } },
+    { "pain", { "un", 0, pain_eval } },
+    { "school_level", { "un", 1, school_level_eval}},
+    { "school_level_adjustment", { "un", 1, school_level_adjustment_eval } },
+    { "skill", { "un", 1, skill_eval } },
+    { "skill_exp", { "un", 1, skill_exp_eval } },
+    { "spell_count", { "un", 0, spell_count_eval}},
+    { "spell_exp", { "un", 1, spell_exp_eval}},
+    { "spell_level", { "un", 1, spell_level_eval}},
+    { "spell_level_adjustment", { "un", 1, spell_level_adjustment_eval } },
+    { "proficiency", { "un", 1, proficiency_eval } },
+    { "val", { "un", -1, u_val } },
+    { "value_or", { "g", 2, value_or_eval } },
+    { "vitamin", { "un", 1, vitamin_eval } },
+    { "warmth", { "un", 1, warmth_eval } },
+    { "weather", { "g", 1, weather_eval } },
+};
+
+std::map<std::string_view, dialogue_func_ass> const dialogue_assign_f{
+    { "addiction_turns", { "un", 1, addiction_turns_ass } },
+    { "hp", { "un", 1, hp_ass } },
+    { "pain", { "un", 0, pain_ass } },
+    { "school_level_adjustment", { "un", 1, school_level_adjustment_ass } },
+    { "spellcasting_adjustment", { "u", 1, spellcasting_adjustment_ass } },
+    { "skill", { "un", 1, skill_ass } },
+    { "skill_exp", { "un", 1, skill_exp_ass } },
+    { "spell_exp", { "un", 1, spell_exp_ass}},
+    { "spell_level", { "un", 1, spell_level_ass}},
+    { "spell_level_adjustment", { "un", 1, spell_level_adjustment_ass } },
+    { "proficiency", { "un", 1, proficiency_ass } },
+    { "val", { "un", -1, u_val_ass } },
+    { "vitamin", { "un", 1, vitamin_ass } },
+    { "weather", { "g", 1, weather_ass } },
+};
+
+} // namespace
+
+std::map<std::string_view, dialogue_func_eval> const &get_all_diag_eval_funcs()
+{
+    return dialogue_eval_f;
+}
+std::map<std::string_view, dialogue_func_ass> const &get_all_diag_ass_funcs()
+{
+    return dialogue_assign_f;
 }

--- a/src/math_parser_diag.h
+++ b/src/math_parser_diag.h
@@ -7,7 +7,9 @@
 #include <string_view>
 #include <vector>
 
-#include "math_parser_diag_value.h"
+struct diag_value;
+struct deref_diag_value;
+using diag_kwargs = std::map<std::string, deref_diag_value>;
 
 struct dialogue;
 struct dialogue_func {
@@ -39,159 +41,7 @@ struct dialogue_func_ass : dialogue_func {
 using pdiag_func_eval = dialogue_func_eval const *;
 using pdiag_func_ass = dialogue_func_ass const *;
 
-using decl_diag_eval = std::function<double( dialogue & )> ( char scope,
-                       std::vector<diag_value> const &params, diag_kwargs const &kwargs );
-using decl_diag_ass = std::function<void( dialogue &, double )> ( char scope,
-                      std::vector<diag_value> const &params, diag_kwargs const &kwargs );
-
-decl_diag_eval addiction_intensity_eval;
-decl_diag_eval addiction_turns_eval;
-decl_diag_ass addiction_turns_ass;
-decl_diag_eval armor_eval;
-decl_diag_eval attack_speed_eval;
-decl_diag_eval charge_count_eval;
-decl_diag_eval coverage_eval;
-decl_diag_eval distance_eval;
-decl_diag_eval dodge_eval;
-decl_diag_eval effect_intensity_eval;
-decl_diag_eval encumbrance_eval;
-decl_diag_eval field_strength_eval;
-decl_diag_eval has_trait_eval;
-decl_diag_eval has_var_eval;
-decl_diag_eval knows_proficiency_eval;
-decl_diag_eval hp_eval;
-decl_diag_ass hp_ass;
-decl_diag_eval hp_max_eval;
-decl_diag_eval item_count_eval;
-decl_diag_eval item_rad_eval;
-decl_diag_eval monsters_nearby_eval;
-decl_diag_eval monster_species_nearby_eval;
-decl_diag_eval monster_groups_nearby_eval;
-decl_diag_eval num_input_eval;
-decl_diag_eval option_eval;
-decl_diag_eval pain_eval;
-decl_diag_ass pain_ass;
-decl_diag_eval energy_eval;
-decl_diag_eval school_level_eval;
-decl_diag_eval school_level_adjustment_eval;
-decl_diag_ass school_level_adjustment_ass;
-decl_diag_eval skill_eval;
-decl_diag_ass skill_ass;
-decl_diag_eval skill_exp_eval;
-decl_diag_ass skill_exp_ass;
-decl_diag_ass spellcasting_adjustment_ass;
-decl_diag_eval spell_count_eval;
-decl_diag_eval spell_exp_eval;
-decl_diag_ass spell_exp_ass;
-decl_diag_eval spell_level_eval;
-decl_diag_ass spell_level_ass;
-decl_diag_eval spell_level_adjustment_eval;
-decl_diag_ass spell_level_adjustment_ass;
-decl_diag_eval proficiency_eval;
-decl_diag_ass proficiency_ass;
-decl_diag_eval test_diag;
-decl_diag_eval test_str_len;
-decl_diag_eval u_val;
-decl_diag_ass u_val_ass;
-decl_diag_eval value_or_eval;
-decl_diag_eval vitamin_eval;
-decl_diag_ass vitamin_ass;
-decl_diag_eval warmth_eval;
-decl_diag_eval weather_eval;
-decl_diag_ass weather_ass;
-
-/*
-General guidelines for writing dialogue functions
-
-The typical parsing function takes the form:
-
-std::function<double( dialogue & )> myfunction_eval( char scope,
-        std::vector<diag_value> const &params, diag_kwargs const &kwargs )
-{
-    diag_value myval( std::string{} );
-    if( kwargs.count( "mykwarg" ) != 0 ) {
-        myval = *kwargs.at( "mykwarg" );
-    }
-
-    ...parse-time code...
-
-    return[effect_id = params[0], myval, beta = is_beta( scope )]( dialogue const & d ) {
-        ...run-time code...
-    };
-}
-
-- Don't validate the number of arguments (params). The math parser already does that
-- Only use variadic functions if all arguments are treated the same way,
-  regardless of how many there are (including zero)
-- Use kwargs for optional arguments
-- Prefer splitting functions instead of using mandatory kwargs
-  ex: school_level() split from spell_level() instead of spell_level('school':blorg)
-- Use parameter-less functions diag_value::str(), dbl(), and var() only at parse-time
-- Use conversion functions diag_value::str( d ) and dbl( d ) only at run-time
-- Always throw on errors at parse-time
-- Never throw at run-time. Use a debugmsg() and recover gracefully
-*/
-
-// { "name", { "scopes", num_args, function } }
-// kwargs are not included in num_args
-inline std::map<std::string_view, dialogue_func_eval> const dialogue_eval_f{
-    { "_test_diag_", { "g", -1, test_diag } },
-    { "_test_str_len_", { "g", -1, test_str_len } },
-    { "addiction_intensity", { "un", 1, addiction_intensity_eval } },
-    { "addiction_turns", { "un", 1, addiction_turns_eval } },
-    { "armor", { "un", 2, armor_eval } },
-    { "attack_speed", { "un", 0, attack_speed_eval } },
-    { "charge_count", { "un", 1, charge_count_eval } },
-    { "coverage", { "un", 1, coverage_eval } },
-    { "distance", { "g", 2, distance_eval } },
-    { "effect_intensity", { "un", 1, effect_intensity_eval } },
-    { "encumbrance", { "un", 1, encumbrance_eval } },
-    { "energy", { "g", 1, energy_eval } },
-    { "field_strength", { "ung", 1, field_strength_eval } },
-    { "game_option", { "g", 1, option_eval } },
-    { "has_trait", { "un", 1, has_trait_eval } },
-    { "has_proficiency", { "un", 1, knows_proficiency_eval } },
-    { "has_var", { "g", 1, has_var_eval } },
-    { "hp", { "un", 1, hp_eval } },
-    { "hp_max", { "un", 1, hp_max_eval } },
-    { "item_count", { "un", 1, item_count_eval } },
-    { "item_rad", { "un", 1, item_rad_eval } },
-    { "monsters_nearby", { "ung", -1, monsters_nearby_eval } },
-    { "mon_species_nearby", { "ung", -1, monster_species_nearby_eval } },
-    { "mon_groups_nearby", { "ung", -1, monster_groups_nearby_eval } },
-    { "num_input", { "g", 2, num_input_eval } },
-    { "pain", { "un", 0, pain_eval } },
-    { "school_level", { "un", 1, school_level_eval}},
-    { "school_level_adjustment", { "un", 1, school_level_adjustment_eval } },
-    { "skill", { "un", 1, skill_eval } },
-    { "skill_exp", { "un", 1, skill_exp_eval } },
-    { "spell_count", { "un", 0, spell_count_eval}},
-    { "spell_exp", { "un", 1, spell_exp_eval}},
-    { "spell_level", { "un", 1, spell_level_eval}},
-    { "spell_level_adjustment", { "un", 1, spell_level_adjustment_eval } },
-    { "proficiency", { "un", 1, proficiency_eval } },
-    { "val", { "un", -1, u_val } },
-    { "value_or", { "g", 2, value_or_eval } },
-    { "vitamin", { "un", 1, vitamin_eval } },
-    { "warmth", { "un", 1, warmth_eval } },
-    { "weather", { "g", 1, weather_eval } },
-};
-
-inline std::map<std::string_view, dialogue_func_ass> const dialogue_assign_f{
-    { "addiction_turns", { "un", 1, addiction_turns_ass } },
-    { "hp", { "un", 1, hp_ass } },
-    { "pain", { "un", 0, pain_ass } },
-    { "school_level_adjustment", { "un", 1, school_level_adjustment_ass } },
-    { "spellcasting_adjustment", { "u", 1, spellcasting_adjustment_ass } },
-    { "skill", { "un", 1, skill_ass } },
-    { "skill_exp", { "un", 1, skill_exp_ass } },
-    { "spell_exp", { "un", 1, spell_exp_ass}},
-    { "spell_level", { "un", 1, spell_level_ass}},
-    { "spell_level_adjustment", { "un", 1, spell_level_adjustment_ass } },
-    { "proficiency", { "un", 1, proficiency_ass } },
-    { "val", { "un", -1, u_val_ass } },
-    { "vitamin", { "un", 1, vitamin_ass } },
-    { "weather", { "g", 1, weather_ass } },
-};
+std::map<std::string_view, dialogue_func_eval> const &get_all_diag_eval_funcs();
+std::map<std::string_view, dialogue_func_ass> const &get_all_diag_ass_funcs();
 
 #endif // CATA_SRC_MATH_PARSER_DIAG_H

--- a/src/math_parser_diag_value.h
+++ b/src/math_parser_diag_value.h
@@ -2,7 +2,6 @@
 #ifndef CATA_SRC_MATH_PARSER_DIAG_VALUE_H
 #define CATA_SRC_MATH_PARSER_DIAG_VALUE_H
 
-#include <map>
 #include <string>
 #include <string_view>
 #include <variant>
@@ -64,7 +63,5 @@ struct deref_diag_value {
         bool mutable _used = false;
         diag_value _val;
 };
-
-using diag_kwargs = std::map<std::string, deref_diag_value>;
 
 #endif // CATA_SRC_MATH_PARSER_DIAG_VALUE_H

--- a/src/math_parser_shim.cpp
+++ b/src/math_parser_shim.cpp
@@ -1,5 +1,6 @@
 #include "math_parser_shim.h"
-#include "math_parser_diag.h"
+
+#include "math_parser_diag_value.h"
 #include "math_parser_func.h"
 
 #include <map>


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Clean up a math_parser include.

#### Describe the solution
Move

#### Describe alternatives you've considered
Leave it there

#### Testing
It compiles

#### Additional context
This is mostly for style to match recent PRs. It won't have any impact on compilation time because this header was only included a couple of times.
