### PR TITLE
Extended json support (relative, proportional, extend, delete) reports errors

### DIFF
--- a/data/json/items/armor/bespoke_armor/custom_underwear.json
+++ b/data/json/items/armor/bespoke_armor/custom_underwear.json
@@ -42,7 +42,7 @@
     "name": { "str": "nomad bodymesh", "str_pl": "nomad bodymeshes" },
     "description": "A simple, thin, skintight layer of breathable fabric that protects your skin.  It has integrated feet and precisely placed rubberized pads to protect critical points from impact and abrasion, and has been reinforced with a loose mesh of advanced polymer threads.",
     "copy-from": "nomad_bodyglove_1",
-    "extend": { "material": [ "kevlar" ] },
+    "//extend": { "material": [ "kevlar" ] },
     "armor": [
       {
         "material": [

--- a/data/json/items/chemicals_and_resources.json
+++ b/data/json/items/chemicals_and_resources.json
@@ -2076,7 +2076,7 @@
     "description": "Blood mixed with acidic compounds, smells putrid, a means of refining this could net some useful chemicals.",
     "comestible_type": "INVALID",
     "charges": 1,
-    "delete": { "ammo_type": "components" },
+    "//delete": { "ammo_type": "components" },
     "flags": [ "DROP_ACTION_ONLY_IF_LIQUID" ],
     "drop_action": { "type": "emit_actor", "emits": [ "emit_acid_drop" ], "scale_qty": true }
   },

--- a/data/json/items/gun/flintlock.json
+++ b/data/json/items/gun/flintlock.json
@@ -34,7 +34,7 @@
     "price": 43000,
     "price_postapoc": 2750,
     "proportional": { "dispersion": 1.3, "weight": 1.25, "volume": 1.25 },
-    "relative": { "weight": "400 g", "range": -1, "ranged_damage": { "damage_type": "bullet", "amount": -2 } },
+    "relative": { "range": -1, "ranged_damage": { "damage_type": "bullet", "amount": -2 } },
     "extend": { "flags": [ "RELOAD_ONE" ] },
     "pocket_data": [ { "pocket_type": "MAGAZINE", "rigid": true, "ammo_restriction": { "flintlock": 2 } } ]
   },

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -864,7 +864,7 @@
     ],
     "looks_like": "survivor_machete",
     "replace_materials": { "steel": "qt_steel", "wood": "kevlar" },
-    "proportional": { "price_postapoc": 1.15, "price": 1.15 },
+    "proportional": { "price": 1.15 },
     "relative": { "melee_damage": { "cut": 5 }, "qualities": [ [ "BUTCHER", 4 ] ], "price_postapoc": 2000 }
   },
   {

--- a/data/json/monsters/fish.json
+++ b/data/json/monsters/fish.json
@@ -1016,7 +1016,7 @@
     "volume": "30 L",
     "weight": "40 kg",
     "delete": {
-      "reproduction": { "baby_monster": "mon_crayfish_giant_larva", "baby_count": 3, "baby_timer": 21 },
+      "//reproduction": { "baby_monster": "mon_crayfish_giant_larva", "baby_count": 3, "baby_timer": 21 },
       "baby_flags": [ "AUTUMN" ]
     },
     "dissect": "dissect_crustacean_small",

--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -172,7 +172,7 @@
     "upgrades": { "half_life": 42, "into": "mon_worm" },
     "families": [ "prof_intro_biology", "prof_physiology", "prof_wp_basic_bug" ],
     "delete": {
-      "reproduction": { "baby_egg": "egg_worm", "baby_count": 3, "baby_timer": 15 },
+      "//reproduction": { "baby_egg": "egg_worm", "baby_count": 3, "baby_timer": 15 },
       "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ]
     }
   },
@@ -890,7 +890,7 @@
     "upgrades": { "half_life": 30, "into": "mon_fly" },
     "stomach_size": 100,
     "delete": {
-      "reproduction": { "baby_egg": "egg_fly", "baby_count": 3, "baby_timer": 15 },
+      "//reproduction": { "baby_egg": "egg_fly", "baby_count": 3, "baby_timer": 15 },
       "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ]
     }
   },
@@ -979,7 +979,7 @@
     "zombify_into": "mon_meat_cocoon_tiny",
     "upgrades": { "half_life": 30, "into": "mon_mosquito_giant" },
     "delete": {
-      "reproduction": { "baby_egg": "egg_mosquito", "baby_count": 3, "baby_timer": 15 },
+      "//reproduction": { "baby_egg": "egg_mosquito", "baby_count": 3, "baby_timer": 15 },
       "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ]
     }
   },
@@ -1072,7 +1072,7 @@
       "anger_triggers": [ "PLAYER_CLOSE", "PLAYER_WEAK", "HOSTILE_SEEN" ],
       "flags": [ "GRABS" ],
       "special_attacks": [ "grab" ],
-      "reproduction": { "baby_egg": "egg_spider_cellar", "baby_count": 3, "baby_timer": 15 },
+      "//reproduction": { "baby_egg": "egg_spider_cellar", "baby_count": 3, "baby_timer": 15 },
       "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ]
     }
   },
@@ -1301,7 +1301,7 @@
     "zombify_into": "mon_meat_cocoon_tiny",
     "upgrades": { "half_life": 30, "into": "mon_spider_jumping_giant" },
     "delete": {
-      "reproduction": { "baby_egg": "egg_spider_jumping", "baby_count": 3, "baby_timer": 15 },
+      "//reproduction": { "baby_egg": "egg_spider_jumping", "baby_count": 3, "baby_timer": 15 },
       "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ]
     }
   },
@@ -1403,7 +1403,7 @@
     "zombify_into": "mon_meat_cocoon_small",
     "upgrades": { "half_life": 30, "into": "mon_spider_trapdoor_giant" },
     "delete": {
-      "reproduction": { "baby_egg": "egg_spider_trapdoor", "baby_count": 3, "baby_timer": 15 },
+      "//reproduction": { "baby_egg": "egg_spider_trapdoor", "baby_count": 3, "baby_timer": 15 },
       "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ]
     }
   },
@@ -1492,7 +1492,7 @@
     "zombify_into": "mon_meat_cocoon_small",
     "upgrades": { "half_life": 30, "into": "mon_spider_web" },
     "delete": {
-      "reproduction": { "baby_egg": "egg_spider_web", "baby_count": 3, "baby_timer": 15 },
+      "//reproduction": { "baby_egg": "egg_spider_web", "baby_count": 3, "baby_timer": 15 },
       "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ]
     },
     "trap_avoids": [ "tr_sinkhole" ]
@@ -1588,7 +1588,7 @@
     "zombify_into": "mon_meat_cocoon_tiny",
     "upgrades": { "half_life": 30, "into": "mon_spider_widow_giant" },
     "delete": {
-      "reproduction": { "baby_egg": "egg_spider_widow", "baby_count": 3, "baby_timer": 15 },
+      "//reproduction": { "baby_egg": "egg_spider_widow", "baby_count": 3, "baby_timer": 15 },
       "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ]
     }
   },
@@ -1679,7 +1679,7 @@
     "zombify_into": "mon_meat_cocoon_small",
     "upgrades": { "half_life": 30, "into": "mon_spider_wolf_giant" },
     "delete": {
-      "reproduction": { "baby_egg": "egg_spider_wolf", "baby_count": 3, "baby_timer": 15 },
+      "//reproduction": { "baby_egg": "egg_spider_wolf", "baby_count": 3, "baby_timer": 15 },
       "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ]
     }
   },
@@ -2635,7 +2635,7 @@
     "stomach_size": 50,
     "special_attacks": [ [ "EAT_CROP", 80 ], [ "GRAZE", 800 ] ],
     "delete": {
-      "reproduction": { "baby_monster": "mon_aphid", "baby_count": 1, "baby_timer": 20 },
+      "//reproduction": { "baby_monster": "mon_aphid", "baby_count": 1, "baby_timer": 20 },
       "baby_flags": [ "SPRING", "SUMMER" ]
     },
     "biosignature": { "biosig_item": "honeydew", "biosig_timer": 7000 },
@@ -2692,7 +2692,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 8 } ],
     "dissect": "dissect_insect_sample_single",
     "delete": {
-      "reproduction": { "baby_egg": "egg_mantis", "baby_count": 1, "baby_timer": 30 },
+      "//reproduction": { "baby_egg": "egg_mantis", "baby_count": 1, "baby_timer": 30 },
       "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ]
     },
     "upgrades": { "half_life": 42, "into": "mon_mantis_giant" },
@@ -2816,7 +2816,7 @@
       "cooldown": 8,
       "max_range": 5,
       "allow_no_target": false,
-      "upgrades": { "half_life": 42, "into": "mon_mantis_mega" }
+      "//upgrades": { "half_life": 42, "into": "mon_mantis_mega" }
     },
     "armor": { "bash": 10, "cut": 16, "bullet": 13, "electric": 3 }
   },
@@ -3005,7 +3005,7 @@
     "weight": "1 kg",
     "stomach_size": 30,
     "delete": {
-      "reproduction": { "baby_egg": "egg_grasshopper", "baby_count": 3, "baby_timer": 15 },
+      "//reproduction": { "baby_egg": "egg_grasshopper", "baby_count": 3, "baby_timer": 15 },
       "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ]
     },
     "upgrades": { "half_life": 35, "into": "mon_grasshopper_giant" }
@@ -3363,7 +3363,7 @@
     "weight": "4 kg",
     "melee_damage": [ { "damage_type": "cut", "amount": 1 } ],
     "delete": {
-      "reproduction": { "baby_egg": "egg_strider", "baby_count": 3, "baby_timer": 10 },
+      "//reproduction": { "baby_egg": "egg_strider", "baby_count": 3, "baby_timer": 10 },
       "baby_flags": [ "SPRING", "SUMMER", "AUTUMN" ]
     },
     "upgrades": { "half_life": 40, "into": "mon_strider_giant" }
@@ -3848,6 +3848,6 @@
     "volume": "10 L",
     "weight": "15 kg",
     "upgrades": { "half_life": 14, "into": "mon_water_scorpion" },
-    "delete": { "reproduction": { "baby_egg": "egg_water_bug", "baby_count": 3, "baby_timer": 10 } }
+    "//delete": { "reproduction": { "baby_egg": "egg_water_bug", "baby_count": 3, "baby_timer": 10 } }
   }
 ]

--- a/data/json/monsters/insect_spider.json
+++ b/data/json/monsters/insect_spider.json
@@ -2811,13 +2811,7 @@
     ],
     "zombify_into": "mon_meat_cocoon_large",
     "extend": { "flags": [ "DESTROYS", "PUSH_MON", "PUSH_VEH" ] },
-    "delete": {
-      "type": "leap",
-      "cooldown": 8,
-      "max_range": 5,
-      "allow_no_target": false,
-      "//upgrades": { "half_life": 42, "into": "mon_mantis_mega" }
-    },
+    "delete": { "special_attacks": [ "leap" ], "//upgrades": { "half_life": 42, "into": "mon_mantis_mega" } },
     "armor": { "bash": 10, "cut": 16, "bullet": 13, "electric": 3 }
   },
   {

--- a/data/json/monsters/mammal.json
+++ b/data/json/monsters/mammal.json
@@ -1256,7 +1256,7 @@
     "melee_dice_sides": 1,
     "stomach_size": 115,
     "melee_damage": [ { "damage_type": "cut", "amount": 2 } ],
-    "delete": { "zombify_into": "mon_zombie_dog" },
+    "//delete": { "zombify_into": "mon_zombie_dog" },
     "fear_triggers": [ "HURT" ],
     "reproduction": { "baby_monster": "mon_dog_beagle_pup", "baby_count": 4, "baby_timer": 270 },
     "//": "1-4 puppies & 270 days per-litter for size tiny canines",
@@ -1521,7 +1521,7 @@
     "vision_night": 6,
     "harvest": "dog_tiny_with_skull",
     "fear_triggers": [ "HURT" ],
-    "delete": { "zombify_into": "mon_zombie_dog" },
+    "//delete": { "zombify_into": "mon_zombie_dog" },
     "reproduction": { "baby_monster": "mon_dog_chihuahua_pup", "baby_count": 3, "baby_timer": 240 },
     "//": "1-3 puppies & 240 days per-litter for size tiny canines",
     "petfood": {
@@ -1614,7 +1614,7 @@
     "vision_night": 6,
     "fear_triggers": [ "HURT" ],
     "harvest": "dog_small_with_skull_leather",
-    "delete": { "zombify_into": "mon_zombie_dog" },
+    "//delete": { "zombify_into": "mon_zombie_dog" },
     "reproduction": { "baby_monster": "mon_dog_dachshund_pup", "baby_count": 4, "baby_timer": 270 },
     "//": "1-4 puppies & 270 days per-litter for size small canines",
     "petfood": {

--- a/data/json/monsters/zed_acid.json
+++ b/data/json/monsters/zed_acid.json
@@ -309,7 +309,7 @@
       [ "ACID_BARF", 10 ]
     ],
     "bleed_rate": 50,
-    "proportional": { "hp": 1.8, "speed": 1.3, "volume": 1.4, "weigth": 1.1 },
+    "proportional": { "hp": 1.8, "speed": 1.3, "volume": 1.4, "weight": 1.1 },
     "special_when_hit": [ "ACIDSPLASH", 100 ]
   }
 ]

--- a/data/json/monsters/zed_soldiers.json
+++ b/data/json/monsters/zed_soldiers.json
@@ -117,6 +117,11 @@
     "looks_like": "mon_zombie_soldier",
     "diff": 20,
     "bleed_rate": 50,
+    "death_function": {
+      "message": "The %s's body dissolves into acid.",
+      "effect": { "id": "death_acid", "hit_self": true },
+      "corpse_type": "NO_CORPSE"
+    },
     "delete": { "//upgrades": { "half_life": 42, "into_group": "GROUP_SOLDIER_UPGRADE" }, "categories": [ "CLASSIC" ] },
     "relative": { "hp": 20, "speed": 10, "melee_skill": 1, "vision_day": 10, "vision_night": 10 },
     "extend": {
@@ -136,11 +141,6 @@
           "ranges": [ [ 2, 20, "DEFAULT" ] ]
         }
       ],
-      "death_function": {
-        "message": "The %s's body dissolves into acid.",
-        "effect": { "id": "death_acid", "hit_self": true },
-        "corpse_type": "NO_CORPSE"
-      },
       "flags": [ "ACIDPROOF", "ACID_BLOOD" ]
     }
   },
@@ -153,6 +153,11 @@
     "looks_like": "mon_zombie_soldier",
     "diff": 20,
     "bleed_rate": 50,
+    "death_function": {
+      "message": "The %s's body dissolves into acid.",
+      "effect": { "id": "death_acid", "hit_self": true },
+      "corpse_type": "NO_CORPSE"
+    },
     "delete": { "//upgrades": { "half_life": 42, "into_group": "GROUP_SOLDIER_UPGRADE" }, "categories": [ "CLASSIC" ] },
     "relative": { "hp": 40, "speed": -10, "melee_skill": 2, "armor": { "bash": 5 } },
     "extend": {
@@ -173,11 +178,6 @@
           "ranges": [ [ 2, 8, "DEFAULT" ] ]
         }
       ],
-      "death_function": {
-        "message": "The %s's body dissolves into acid.",
-        "effect": { "id": "death_acid", "hit_self": true },
-        "corpse_type": "NO_CORPSE"
-      },
       "flags": [ "ACIDPROOF", "ACID_BLOOD" ]
     }
   },

--- a/data/json/monsters/zed_soldiers.json
+++ b/data/json/monsters/zed_soldiers.json
@@ -105,7 +105,7 @@
     "looks_like": "mon_zombie_soldier_blackops_1",
     "bleed_rate": 0,
     "relative": { "hp": 20, "speed": 10, "melee_skill": 1, "dodge": 1, "vision_night": 15 },
-    "delete": { "upgrades": { "half_life": 45, "into": "mon_zombie_soldier_blackops_2" } },
+    "//delete": { "upgrades": { "half_life": 45, "into": "mon_zombie_soldier_blackops_2" } },
     "extend": { "special_attacks": [ { "type": "leap", "cooldown": 10, "max_range": 3 } ], "flags": [ "KEENNOSE" ] }
   },
   {
@@ -117,7 +117,7 @@
     "looks_like": "mon_zombie_soldier",
     "diff": 20,
     "bleed_rate": 50,
-    "delete": { "upgrades": { "half_life": 42, "into_group": "GROUP_SOLDIER_UPGRADE" }, "categories": [ "CLASSIC" ] },
+    "delete": { "//upgrades": { "half_life": 42, "into_group": "GROUP_SOLDIER_UPGRADE" }, "categories": [ "CLASSIC" ] },
     "relative": { "hp": 20, "speed": 10, "melee_skill": 1, "vision_day": 10, "vision_night": 10 },
     "extend": {
       "special_attacks": [
@@ -153,7 +153,7 @@
     "looks_like": "mon_zombie_soldier",
     "diff": 20,
     "bleed_rate": 50,
-    "delete": { "upgrades": { "half_life": 42, "into_group": "GROUP_SOLDIER_UPGRADE" }, "categories": [ "CLASSIC" ] },
+    "delete": { "//upgrades": { "half_life": 42, "into_group": "GROUP_SOLDIER_UPGRADE" }, "categories": [ "CLASSIC" ] },
     "relative": { "hp": 40, "speed": -10, "melee_skill": 2, "armor": { "bash": 5 } },
     "extend": {
       "special_attacks": [

--- a/data/json/recipes/armor/pets_cow.json
+++ b/data/json/recipes/armor/pets_cow.json
@@ -138,7 +138,7 @@
     "time": "7 h 45 m",
     "using": [ [ "sewing_standard", 90 ], [ "clasps", 5 ] ],
     "components": [ [ [ "bone", 46 ], [ "bone_human", 46 ], [ "bone_demihuman", 46 ] ], [ [ "armor_blarmor", 3 ] ] ],
-    "extend": { "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_carving" } ] }
+    "//extend": { "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_carving" } ] }
   },
   {
     "result": "leatherbone_armor_cow",

--- a/data/json/recipes/armor/pets_horse.json
+++ b/data/json/recipes/armor/pets_horse.json
@@ -138,7 +138,7 @@
     "time": "6 h 30 m",
     "using": [ [ "sewing_standard", 75 ], [ "clasps", 4 ] ],
     "components": [ [ [ "bone", 39 ], [ "bone_human", 39 ], [ "bone_demihuman", 39 ] ], [ [ "armor_blarmor", 3 ] ] ],
-    "extend": { "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_carving" } ] }
+    "//extend": { "proficiencies": [ { "proficiency": "prof_closures" }, { "proficiency": "prof_carving" } ] }
   },
   {
     "result": "leatherbone_armor_horse",

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -53,7 +53,7 @@
     "type": "recipe",
     "time": "5 h",
     "using": [ [ "tailoring_leather_patchwork", 2 ], [ "strap_large", 1 ] ],
-    "extend": { "proficiencies": [ { "proficiency": "prof_leatherworking_basic" }, { "proficiency": "prof_leatherworking" } ] },
+    "//extend": { "proficiencies": [ { "proficiency": "prof_leatherworking_basic" }, { "proficiency": "prof_leatherworking" } ] },
     "components": [ [ [ "fastener_small", 2, "LIST" ] ] ]
   },
   {
@@ -774,7 +774,7 @@
     "time": "5 h 30 m",
     "copy-from": "chestpouch",
     "using": [ [ "tailoring_leather_patchwork", 4 ], [ "fastener_small", 1 ], [ "strap_small", 1 ], [ "clasps", 1 ] ],
-    "extend": { "proficiencies": [ { "proficiency": "prof_leatherworking" }, { "proficiency": "prof_leatherworking_basic" } ] }
+    "//extend": { "proficiencies": [ { "proficiency": "prof_leatherworking" }, { "proficiency": "prof_leatherworking_basic" } ] }
   },
   {
     "result": "tacvest",

--- a/src/assign.cpp
+++ b/src/assign.cpp
@@ -51,10 +51,8 @@ bool assign( const JsonObject &jo, const std::string_view name, units::volume &v
 
     // Object via which to report errors which differs for proportional/relative values
     const JsonObject *err = &jo;
-    JsonObject relative = jo.get_object( "relative" );
-    relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
-    proportional.allow_omitted_members();
+    const JsonObject &relative = jo.get_subobject( "relative" );
+    const JsonObject &proportional = jo.get_subobject( "proportional" );
 
     // Do not require strict parsing for relative and proportional values as rules
     // such as +10% are well-formed independent of whether they affect base value
@@ -115,10 +113,8 @@ bool assign( const JsonObject &jo, const std::string_view name, units::mass &val
 
     // Object via which to report errors which differs for proportional/relative values
     const JsonObject *err = &jo;
-    JsonObject relative = jo.get_object( "relative" );
-    relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
-    proportional.allow_omitted_members();
+    const JsonObject &relative = jo.get_subobject( "relative" );
+    const JsonObject &proportional = jo.get_subobject( "proportional" );
 
     // Do not require strict parsing for relative and proportional values as rules
     // such as +10% are well-formed independent of whether they affect base value
@@ -179,10 +175,8 @@ bool assign( const JsonObject &jo, const std::string_view name, units::length &v
 
     // Object via which to report errors which differs for proportional/relative values
     const JsonObject *err = &jo;
-    JsonObject relative = jo.get_object( "relative" );
-    relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
-    proportional.allow_omitted_members();
+    const JsonObject &relative = jo.get_subobject( "relative" );
+    const JsonObject &proportional = jo.get_subobject( "proportional" );
 
     // Do not require strict parsing for relative and proportional values as rules
     // such as +10% are well-formed independent of whether they affect base value
@@ -243,10 +237,8 @@ bool assign( const JsonObject &jo, const std::string_view name, units::money &va
 
     // Object via which to report errors which differs for proportional/relative values
     const JsonObject *err = &jo;
-    JsonObject relative = jo.get_object( "relative" );
-    relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
-    proportional.allow_omitted_members();
+    const JsonObject &relative = jo.get_subobject( "relative" );
+    const JsonObject &proportional = jo.get_subobject( "proportional" );
 
     // Do not require strict parsing for relative and proportional values as rules
     // such as +10% are well-formed independent of whether they affect base value
@@ -312,10 +304,8 @@ bool assign( const JsonObject &jo, const std::string_view name, units::energy &v
 
     // Object via which to report errors which differs for proportional/relative values
     const JsonObject *err = &jo;
-    JsonObject relative = jo.get_object( "relative" );
-    relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
-    proportional.allow_omitted_members();
+    const JsonObject &relative = jo.get_subobject( "relative" );
+    const JsonObject &proportional = jo.get_subobject( "proportional" );
 
     // Do not require strict parsing for relative and proportional values as rules
     // such as +10% are well-formed independent of whether they affect base value
@@ -381,10 +371,8 @@ bool assign( const JsonObject &jo, const std::string_view name, units::power &va
 
     // Object via which to report errors which differs for proportional/relative values
     const JsonObject *err = &jo;
-    JsonObject relative = jo.get_object( "relative" );
-    relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
-    proportional.allow_omitted_members();
+    const JsonObject &relative = jo.get_subobject( "relative" );
+    const JsonObject &proportional = jo.get_subobject( "proportional" );
 
     // Do not require strict parsing for relative and proportional values as rules
     // such as +10% are well-formed independent of whether they affect base value
@@ -640,10 +628,8 @@ bool assign( const JsonObject &jo, const std::string_view name, damage_instance 
 
     // Object via which to report errors which differs for proportional/relative values
     const JsonObject &err = jo;
-    JsonObject relative = jo.get_object( "relative" );
-    relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
-    proportional.allow_omitted_members();
+    const JsonObject &relative = jo.get_subobject( "relative" );
+    const JsonObject &proportional = jo.get_subobject( "proportional" );
 
     // Currently, we load only either relative or proportional when loading damage
     // There's no good reason for this, but it's simple for now

--- a/src/assign.h
+++ b/src/assign.h
@@ -45,10 +45,8 @@ bool assign( const JsonObject &jo, std::string_view name, T &val, bool strict = 
 
     // Object via which to report errors which differs for proportional/relative values
     const JsonObject *err = &jo;
-    JsonObject relative = jo.get_object( "relative" );
-    relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
-    proportional.allow_omitted_members();
+    const JsonObject &relative = jo.get_subobject( "relative" );
+    const JsonObject &proportional = jo.get_subobject( "proportional" );
 
     // Do not require strict parsing for relative and proportional values as rules
     // such as +10% are well-formed independent of whether they affect base value
@@ -151,10 +149,8 @@ namespace details
 template <typename T, typename Set>
 bool assign_set( const JsonObject &jo, const std::string_view name, Set &val )
 {
-    JsonObject add = jo.get_object( "extend" );
-    add.allow_omitted_members();
-    JsonObject del = jo.get_object( "delete" );
-    del.allow_omitted_members();
+    const JsonObject &add = jo.get_subobject( "extend" );
+    const JsonObject &del = jo.get_subobject( "delete" );
 
     if( jo.has_string( name ) || jo.has_array( name ) ) {
         val = jo.get_tags<T, Set>( name );
@@ -268,10 +264,8 @@ std::enable_if_t<std::is_same_v<std::decay_t<T>, time_duration>, bool>assign(
     // Object via which to report errors which differs for proportional/relative values
     JsonObject err = jo;
     err.allow_omitted_members();
-    JsonObject relative = jo.get_object( "relative" );
-    relative.allow_omitted_members();
-    JsonObject proportional = jo.get_object( "proportional" );
-    proportional.allow_omitted_members();
+    const JsonObject &relative = jo.get_subobject( "relative" );
+    const JsonObject &proportional = jo.get_subobject( "proportional" );
 
     // Do not require strict parsing for relative and proportional values as rules
     // such as +10% are well-formed independent of whether they affect base value

--- a/src/flexbuffer_json-inl.h
+++ b/src/flexbuffer_json-inl.h
@@ -861,6 +861,20 @@ inline JsonArray JsonObject::get_array( const std::string_view key ) const
     return JsonArray{};
 }
 
+inline const JsonObject &JsonObject::get_subobject( const std::string_view key ) const
+{
+    static JsonObject empty;
+    auto child_iter = child_objects_.find( std::string( key ) );
+    if( child_iter != child_objects_.end() ) {
+        return child_iter->second;
+    }
+    std::optional<JsonValue> member_opt = get_member_opt( key );
+    if( member_opt.has_value() ) {
+        return child_objects_.emplace( key, std::move( *member_opt ) ).first->second;
+    }
+    return empty;
+}
+
 inline JsonObject JsonObject::get_object( const std::string_view key ) const
 {
     std::optional<JsonValue> member_opt = get_member_opt( key );

--- a/src/flexbuffer_json.h
+++ b/src/flexbuffer_json.h
@@ -529,6 +529,7 @@ class JsonObject : JsonWithPath
         flexbuffers::TypedVector keys_ = flexbuffers::TypedVector::EmptyTypedVector();
         flexbuffers::Vector values_ = flexbuffers::Vector::EmptyVector();
         mutable tiny_bitset visited_fields_bitset_;
+        mutable std::unordered_map<std::string, JsonObject> child_objects_;
 
         static const auto &empty_object_() {
             // NOLINTNEXTLINE(cata-almost-never-auto)
@@ -610,6 +611,7 @@ class JsonObject : JsonWithPath
         int get_int( std::string_view key ) const;
         double get_float( std::string_view key ) const;
         JsonArray get_array( std::string_view key ) const;
+        const JsonObject &get_subobject( std::string_view key ) const;
         JsonObject get_object( std::string_view key ) const;
 
         template<typename E, typename = std::enable_if_t<std::is_enum_v<E>>>

--- a/src/generic_factory.h
+++ b/src/generic_factory.h
@@ -734,8 +734,7 @@ template < typename MemberType, std::enable_if_t < !supports_proportional<Member
 inline bool handle_proportional( const JsonObject &jo, const std::string_view name, MemberType & )
 {
     if( jo.has_object( "proportional" ) ) {
-        JsonObject proportional = jo.get_object( "proportional" );
-        proportional.allow_omitted_members();
+        const JsonObject &proportional = jo.get_subobject( "proportional" );
         if( proportional.has_member( name ) ) {
             debugmsg( "Member %s of type %s does not support proportional", name,
                       demangle( typeid( MemberType ).name() ) );
@@ -754,8 +753,7 @@ inline bool handle_proportional( const JsonObject &jo, const std::string_view na
                                  MemberType &member )
 {
     if( jo.has_object( "proportional" ) ) {
-        JsonObject proportional = jo.get_object( "proportional" );
-        proportional.allow_omitted_members();
+        const JsonObject &proportional = jo.get_subobject( "proportional" );
         // We need to check this here, otherwise we get problems with unvisited members
         if( !proportional.has_member( name ) ) {
             return false;
@@ -784,8 +782,7 @@ template < typename MemberType,
 inline bool handle_relative( const JsonObject &jo, const std::string_view name, MemberType & )
 {
     if( jo.has_object( "relative" ) ) {
-        JsonObject relative = jo.get_object( "relative" );
-        relative.allow_omitted_members();
+        const JsonObject &relative = jo.get_subobject( "relative" );
         if( !relative.has_member( name ) ) {
             return false;
         }
@@ -803,8 +800,7 @@ template<typename MemberType, std::enable_if_t<supports_relative<MemberType>::va
 inline bool handle_relative( const JsonObject &jo, const std::string_view name, MemberType &member )
 {
     if( jo.has_object( "relative" ) ) {
-        JsonObject relative = jo.get_object( "relative" );
-        relative.allow_omitted_members();
+        const JsonObject &relative = jo.get_subobject( "relative" );
         // This needs to happen here, otherwise we get unvisited members
         if( !relative.has_member( name ) ) {
             return false;
@@ -1078,13 +1074,11 @@ public:
             return false;
         } else {
             if( jo.has_object( "extend" ) ) {
-                JsonObject tmp = jo.get_object( "extend" );
-                tmp.allow_omitted_members();
+                const JsonObject &tmp = jo.get_subobject( "extend" );
                 derived.insert_values_from( tmp, member_name, container );
             }
             if( jo.has_object( "delete" ) ) {
-                JsonObject tmp = jo.get_object( "delete" );
-                tmp.allow_omitted_members();
+                const JsonObject &tmp = jo.get_subobject( "delete" );
                 derived.erase_values_from( tmp, member_name, container );
             }
             return true;
@@ -1104,8 +1098,7 @@ public:
                >
     bool do_relative( const JsonObject &jo, const std::string_view name, C & ) const {
         if( jo.has_object( "relative" ) ) {
-            JsonObject relative = jo.get_object( "relative" );
-            relative.allow_omitted_members();
+            const JsonObject &relative = jo.get_subobject( "relative" );
             if( !relative.has_member( name ) ) {
                 return false;
             }
@@ -1120,8 +1113,7 @@ public:
                int > = 0, std::enable_if_t<supports_relative<C>::value> * = nullptr >
     bool do_relative( const JsonObject &jo, const std::string_view name, C &member ) const {
         if( jo.has_object( "relative" ) ) {
-            JsonObject relative = jo.get_object( "relative" );
-            relative.allow_omitted_members();
+            const JsonObject &relative = jo.get_subobject( "relative" );
             const Derived &derived = static_cast<const Derived &>( *this );
             // This needs to happen here, otherwise we get unvisited members
             if( !relative.has_member( name ) ) {
@@ -1153,9 +1145,15 @@ public:
                int > = 0 >
     bool operator()( const JsonObject &jo, const std::string_view member_name,
                      C &member, bool /*was_loaded*/ ) const {
+        if( jo.has_object( "extend" ) && jo.get_subobject( "extend" ).has_member( member_name ) ) {
+            debugmsg( "%s does not support extend", member_name );
+        }
+        if( jo.has_object( "delete" ) && jo.get_subobject( "delete" ).has_member( member_name ) ) {
+            debugmsg( "%s does not support delete", member_name );
+        }
         return read_normal( jo, member_name, member ) ||
-        handle_proportional( jo, member_name, member ) ||
-        do_relative( jo, member_name, member );
+               handle_proportional( jo, member_name, member ) ||
+               do_relative( jo, member_name, member );
     }
 };
 

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -2992,8 +2992,7 @@ void islot_armor::load( const JsonObject &jo )
     get_optional( jo, was_loaded, "environmental_protection", _env_resist );
     get_optional( jo, was_loaded, "environmental_protection_with_filter", _env_resist_w_filter );
 
-    JsonObject relative = jo.get_object( "relative" );
-    relative.allow_omitted_members();
+    const JsonObject &relative = jo.get_subobject( "relative" );
     get_relative( relative, "material_thickness", _material_thickness, 0.f );
     get_relative( relative, "environmental_protection", _env_resist, 0 );
     get_relative( relative, "environmental_protection_with_filter", _env_resist_w_filter, 0 );
@@ -3002,8 +3001,7 @@ void islot_armor::load( const JsonObject &jo )
         _rel_encumb = relative.get_float( "encumbrance" );
     }
 
-    JsonObject proportional = jo.get_object( "proportional" );
-    proportional.allow_omitted_members();
+    const JsonObject &proportional = jo.get_subobject( "proportional" );
     get_proportional( proportional, "material_thickness", _material_thickness, 0.f );
     get_proportional( proportional, "environmental_protection", _env_resist, 0 );
     get_proportional( proportional, "environmental_protection_with_filter", _env_resist_w_filter, 0 );
@@ -3234,10 +3232,8 @@ void Item_factory::load( islot_comestible &slot, const JsonObject &jo, const std
 {
     bool strict = src == "dda";
 
-    JsonObject relative = jo.get_object( "relative" );
-    JsonObject proportional = jo.get_object( "proportional" );
-    relative.allow_omitted_members();
-    proportional.allow_omitted_members();
+    const JsonObject &relative = jo.get_subobject( "relative" );
+    const JsonObject &proportional = jo.get_subobject( "proportional" );
 
     // !slot.comesttype.empty() for was_loaded - we don't have a proper was_loaded, but
     // if it's been loaded before, this should have a value. If it's not, we'll catch it later.
@@ -4111,16 +4107,14 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
     }
     def.melee_proportional.clear();
     if( jo.has_object( "proportional" ) ) {
-        JsonObject jprop = jo.get_object( "proportional" );
-        jprop.allow_omitted_members();
+        const JsonObject &jprop = jo.get_subobject( "proportional" );
         if( jprop.has_object( "melee_damage" ) ) {
             def.melee_proportional = load_damage_map( jprop.get_object( "melee_damage" ) );
         }
     }
     def.melee_relative.clear();
     if( jo.has_object( "relative" ) ) {
-        JsonObject jrel = jo.get_object( "relative" );
-        jrel.allow_omitted_members();
+        const JsonObject &jrel = jo.get_subobject( "relative" );
         if( jrel.has_object( "melee_damage" ) ) {
             def.melee_relative = load_damage_map( jrel.get_object( "melee_damage" ) );
         }
@@ -4292,18 +4286,15 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         set_qualities_from_json( jo, "qualities", def );
     } else {
         if( jo.has_object( "extend" ) ) {
-            JsonObject tmp = jo.get_object( "extend" );
-            tmp.allow_omitted_members();
+            const JsonObject &tmp = jo.get_subobject( "extend" );
             extend_qualities_from_json( tmp, "qualities", def );
         }
         if( jo.has_object( "delete" ) ) {
-            JsonObject tmp = jo.get_object( "delete" );
-            tmp.allow_omitted_members();
+            const JsonObject &tmp = jo.get_subobject( "delete" );
             delete_qualities_from_json( tmp, "qualities", def );
         }
         if( jo.has_object( "relative" ) ) {
-            JsonObject tmp = jo.get_object( "relative" );
-            tmp.allow_omitted_members();
+            const JsonObject &tmp = jo.get_subobject( "relative" );
             relative_qualities_from_json( tmp, "qualities", def );
         }
     }
@@ -4320,13 +4311,11 @@ void Item_factory::load_basic_info( const JsonObject &jo, itype &def, const std:
         set_techniques_from_json( jo, "techniques", def );
     } else {
         if( jo.has_object( "extend" ) ) {
-            JsonObject tmp = jo.get_object( "extend" );
-            tmp.allow_omitted_members();
+            const JsonObject &tmp = jo.get_subobject( "extend" );
             extend_techniques_from_json( tmp, "techniques", def );
         }
         if( jo.has_object( "delete" ) ) {
-            JsonObject tmp = jo.get_object( "delete" );
-            tmp.allow_omitted_members();
+            const JsonObject &tmp = jo.get_subobject( "delete" );
             delete_techniques_from_json( tmp, "techniques", def );
         }
     }
@@ -5011,7 +5000,7 @@ void Item_factory::load_item_group( const JsonObject &jsobj, const item_group_id
     // Otherwise, read from the object into the fresh itemgroup
     // And don't read if it has copy-from because it will not handle that correctly.
     if( jsobj.has_member( "extend" ) ) {
-        load_item_group_data( jsobj.get_object( "extend" ), ig, subtype );
+        load_item_group_data( jsobj.get_subobject( "extend" ), ig, subtype );
     } else if( !jsobj.has_member( "copy-from" ) ) {
         load_item_group_data( jsobj, ig, subtype );
     }

--- a/src/mapdata.cpp
+++ b/src/mapdata.cpp
@@ -352,7 +352,7 @@ bool map_bash_info::load( const JsonObject &jsobj, const std::string_view member
         return false;
     }
 
-    JsonObject j = jsobj.get_object( member );
+    const JsonObject &j = jsobj.get_object( member );
     str_min = j.get_int( "str_min", 0 );
     str_max = j.get_int( "str_max", 0 );
 
@@ -432,7 +432,7 @@ bool map_deconstruct_info::load( const JsonObject &jsobj, const std::string_view
 
 bool map_shoot_info::load( const JsonObject &jsobj, const std::string_view member, bool was_loaded )
 {
-    JsonObject j = jsobj.get_object( member );
+    const JsonObject &j = jsobj.get_object( member );
 
     optional( j, was_loaded, "chance_to_hit", chance_to_hit, 100 );
 

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1162,13 +1162,8 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         reproduces = true;
     }
 
-    if( jo.has_member( "baby_flags" ) ) {
-        // Because this determines mating season and some monsters have a mating season but not in-game offspring, declare this separately
-        baby_flags.clear();
-        for( const std::string line : jo.get_array( "baby_flags" ) ) {
-            baby_flags.push_back( line );
-        }
-    }
+    // Because this determines mating season and some monsters have a mating season but not in-game offspring, declare this separately
+    optional( jo, was_loaded, "baby_flags", baby_flags, auto_flags_reader<> {} );
 
     if( jo.has_member( "biosignature" ) ) {
         JsonObject biosig = jo.get_object( "biosignature" );

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -821,16 +821,14 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     }
     armor_proportional.reset();
     if( jo.has_object( "proportional" ) ) {
-        JsonObject jprop = jo.get_object( "proportional" );
-        jprop.allow_omitted_members();
+        const JsonObject &jprop = jo.get_subobject( "proportional" );
         if( jprop.has_object( "armor" ) ) {
             armor_proportional = load_resistances_instance( jprop.get_object( "armor" ) );
         }
     }
     armor_relative.reset();
     if( jo.has_object( "relative" ) ) {
-        JsonObject jrel = jo.get_object( "relative" );
-        jrel.allow_omitted_members();
+        const JsonObject &jrel = jo.get_subobject( "relative" );
         if( jrel.has_object( "armor" ) ) {
             armor_relative = load_resistances_instance( jrel.get_object( "armor" ) );
         }
@@ -864,8 +862,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     }
 
     if( jo.has_object( "extend" ) ) {
-        JsonObject tmp = jo.get_object( "extend" );
-        tmp.allow_omitted_members();
+        const JsonObject &tmp = jo.get_subobject( "extend" );
         if( tmp.has_array( "weakpoint_sets" ) ) {
             for( JsonValue jval : tmp.get_array( "weakpoint_sets" ) ) {
                 weakpoints_deferred.emplace_back( jval.get_string() );
@@ -879,8 +876,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
     }
 
     if( jo.has_object( "delete" ) ) {
-        JsonObject tmp = jo.get_object( "delete" );
-        tmp.allow_omitted_members();
+        const JsonObject &tmp = jo.get_subobject( "delete" );
         if( tmp.has_array( "weakpoint_sets" ) ) {
             for( JsonValue jval : tmp.get_array( "weakpoint_sets" ) ) {
                 weakpoints_id set_id( jval.get_string() );
@@ -907,15 +903,13 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         families.load( jo.get_array( "families" ) );
     } else {
         if( jo.has_object( "extend" ) ) {
-            JsonObject tmp = jo.get_object( "extend" );
-            tmp.allow_omitted_members();
+            const JsonObject &tmp = jo.get_subobject( "extend" );
             if( tmp.has_array( "families" ) ) {
                 families.load( tmp.get_array( "families" ) );
             }
         }
         if( jo.has_object( "delete" ) ) {
-            JsonObject tmp = jo.get_object( "delete" );
-            tmp.allow_omitted_members();
+            const JsonObject &tmp = jo.get_subobject( "delete" );
             if( tmp.has_array( "families" ) ) {
                 families.remove( tmp.get_array( "families" ) );
             }
@@ -957,13 +951,11 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         // Note: regeneration_modifers left as is, new modifiers are added to it!
         // Note: member name prefixes are compatible with those used by generic_typed_reader
         if( jo.has_object( "extend" ) ) {
-            JsonObject tmp = jo.get_object( "extend" );
-            tmp.allow_omitted_members();
+            const JsonObject &tmp = jo.get_subobject( "extend" );
             add_regeneration_modifiers( tmp, "regeneration_modifiers", src );
         }
         if( jo.has_object( "delete" ) ) {
-            JsonObject tmp = jo.get_object( "delete" );
-            tmp.allow_omitted_members();
+            const JsonObject &tmp = jo.get_subobject( "delete" );
             remove_regeneration_modifiers( tmp, "regeneration_modifiers", src );
         }
     }
@@ -1007,8 +999,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         melee_damage = load_damage_instance( jo.get_object( "melee_damage" ) );
     } else if( jo.has_object( "relative" ) ) {
         std::optional<damage_instance> tmp_dmg;
-        JsonObject rel = jo.get_object( "relative" );
-        rel.allow_omitted_members();
+        const JsonObject &rel = jo.get_subobject( "relative" );
         if( rel.has_array( "melee_damage" ) ) {
             tmp_dmg = load_damage_instance( rel.get_array( "melee_damage" ) );
         } else if( rel.has_object( "melee_damage" ) ) {
@@ -1024,8 +1015,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         }
     } else if( jo.has_object( "proportional" ) ) {
         std::optional<damage_instance> tmp_dmg;
-        JsonObject prop = jo.get_object( "proportional" );
-        prop.allow_omitted_members();
+        const JsonObject &prop = jo.get_subobject( "proportional" );
         if( prop.has_array( "melee_damage" ) ) {
             tmp_dmg = load_damage_instance( prop.get_array( "melee_damage" ) );
         } else if( prop.has_object( "melee_damage" ) ) {
@@ -1117,13 +1107,11 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         // Note: special_attacks left as is, new attacks are added to it!
         // Note: member name prefixes are compatible with those used by generic_typed_reader
         if( jo.has_object( "extend" ) ) {
-            JsonObject tmp = jo.get_object( "extend" );
-            tmp.allow_omitted_members();
+            const JsonObject &tmp = jo.get_subobject( "extend" );
             add_special_attacks( tmp, "special_attacks", src );
         }
         if( jo.has_object( "delete" ) ) {
-            JsonObject tmp = jo.get_object( "delete" );
-            tmp.allow_omitted_members();
+            const JsonObject &tmp = jo.get_subobject( "delete" );
             remove_special_attacks( tmp, "special_attacks", src );
         }
     }
@@ -1210,8 +1198,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         }
     } else {
         if( jo.has_member( "extend" ) ) {
-            JsonObject exjo = jo.get_object( "extend" );
-            exjo.allow_omitted_members();
+            const JsonObject &exjo = jo.get_subobject( "extend" );
             if( exjo.has_member( "flags" ) ) {
                 if( exjo.has_string( "flags" ) ) {
                     pre_flags_.emplace( exjo.get_string( "flags" ) );
@@ -1223,8 +1210,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
             }
         }
         if( jo.has_member( "delete" ) ) {
-            JsonObject deljo = jo.get_object( "delete" );
-            deljo.allow_omitted_members();
+            const JsonObject &deljo = jo.get_subobject( "delete" );
             if( deljo.has_member( "flags" ) ) {
                 if( deljo.has_string( "flags" ) ) {
                     auto iter = pre_flags_.find( mon_flag_str_id( deljo.get_string( "flags" ) ) );
@@ -1285,8 +1271,7 @@ void species_type::load( const JsonObject &jo, const std::string_view )
         }
     } else {
         if( jo.has_member( "extend" ) ) {
-            JsonObject exjo = jo.get_object( "extend" );
-            exjo.allow_omitted_members();
+            const JsonObject &exjo = jo.get_subobject( "extend" );
             if( exjo.has_member( "flags" ) ) {
                 if( exjo.has_string( "flags" ) ) {
                     flags.emplace( exjo.get_string( "flags" ) );
@@ -1298,8 +1283,7 @@ void species_type::load( const JsonObject &jo, const std::string_view )
             }
         }
         if( jo.has_member( "delete" ) ) {
-            JsonObject deljo = jo.get_object( "delete" );
-            deljo.allow_omitted_members();
+            const JsonObject &deljo = jo.get_subobject( "delete" );
             if( deljo.has_member( "flags" ) ) {
                 if( deljo.has_string( "flags" ) ) {
                     auto iter = flags.find( mon_flag_str_id( deljo.get_string( "flags" ) ) );

--- a/src/requirements.cpp
+++ b/src/requirements.cpp
@@ -429,7 +429,7 @@ void requirement_data::load_requirement( const JsonObject &jsobj, const requirem
     requirement_data ext;
 
     if( check_extend && jsobj.has_object( "extend" ) ) {
-        JsonObject jext = jsobj.get_object( "extend" );
+        const JsonObject &jext = jsobj.get_subobject( "extend" );
         if( jext.has_member( "components" ) ) {
             load_obj_list( jext.get_array( "components" ), ext.components );
         }


### PR DESCRIPTION
#### Summary
Infrastructure "Extra JSON features (relative, proportional, extend, delete) report when fields are not loaded"

#### Purpose of change
Make it so these bugs are reported by the game, not by manually testing and finding they don't work.

#### Describe the solution
See commits. I'll write something nicer here when I undraft this.

#### Describe alternatives you've considered
Doing this for all JSON objects. That's vastly more work, and these are really the only ones that should be shared between multiple different pieces of loading code.

#### Testing
Load the game.

#### Additional context
I have not fixed mods.
I'm trying to figure out how the `special_attacks` syntax works for delete.
`get_subobject` is somewhat hacky, especially when there is no subobject.