### PR TITLE
fix EOC_GENERIC_SPELL_MUTATION

### DIFF
--- a/data/json/effects_on_condition/mutation_eocs/mutation_activation_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_activation_eocs.json
@@ -3,7 +3,7 @@
     "type": "effect_on_condition",
     "id": "EOC_GENERIC_SPELL_MUTATION",
     "//energy_amount": "optional, how much stamina you spend on activation of the mutation - EoC works exclusively with stamina, to consume calories, fatigue or thirst use corresponding booleans in mutation; default zero if you don't need to consume stamina",
-    "//prep_time": "time you spend to prepare the activation, in seconds. Omit to make activation instant",
+    "//prep_time": "time you spend to prepare the activation, in seconds. Use 0 to make activation instant",
     "//spell_to_cast": "spell that would be casted if activation is successful",
     "//message_success": "message that would be printed if activation is successful",
     "//message_fail": "message, that would be printed, if you have less stamina than required",
@@ -15,16 +15,20 @@
     },
     "effect": [
       { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "context_val": "prep_time" } },
-      { "math": [ "stamina", "-=", "_energy_amount" ] },
-      { "queue_eocs": [ "EOC_GENERIC_SPELL_MUTATION_ACT" ], "time_in_future": { "context_val": "prep_time" } }
+      { "math": [ "u_val('stamina')", "-=", "_energy_amount" ] },
+      {
+        "if": { "math": [ "_prep_time", ">", "1" ] },
+        "then": { "queue_eocs": [ "EOC_GENERIC_SPELL_MUTATION_ACT" ], "time_in_future": { "math": [ "_prep_time - 1" ] } },
+        "else": { "run_eocs": [ "EOC_GENERIC_SPELL_MUTATION_ACT" ] }
+      }
     ],
     "false_effect": [ { "u_message": { "context_val": "message_fail" }, "type": "bad" } ]
   },
   {
     "type": "effect_on_condition",
     "id": "EOC_GENERIC_SPELL_MUTATION_ACT",
-    "//": "no proper way to check activity type to ensure player still prepare the mutation, so only level is checked for now",
-    "condition": { "math": [ "u_val('activity_level')", "==", "0" ] },
+    "//": "no proper way to check activity type to ensure player still prepare the mutation, so only level is checked for now (if spell is not instant)",
+    "condition": { "or": [ { "math": [ "u_val('activity_level')", "==", "0" ] }, { "math": [ "_prep_time", "==", "0" ] } ] },
     "effect": [
       {
         "u_cast_spell": { "id": { "context_val": "spell_to_cast" }, "message": { "context_val": "message_success" } },


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Apparently there was some changes in EoC, that messed EOC_GENERIC_SPELL_MUTATION, and there was bunch of my mistakes that i didn't spot
fix #71201
#### Describe the solution
1. Made it possible to activate mutation instantly by tweaking condition of EOC_GENERIC_SPELL_MUTATION_ACT to allow _prep_time less than 1
2. Made spell activation one second before the end of activity - i ought to just use `{ "math": [ "max(_prep_time - 1, 0)" ] }`, but for some dubious reason EoC simply refused to activate if prep_time was zero, so if-then-esle is used instead
3. Can't reproduce 
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/67688115/d7bc90a2-5dd2-40df-9131-94f30e60e6e9)
4. `stamina` -> `u_val('stamina')`
#### Testing
Tested both instant and delayed activation, seems to work now
#### Additional context
I need to find how to make basic test to ensure this EoC works as expected