### PR TITLE
Softer edged mx_spider

### DIFF
--- a/data/json/mapgen/map_extras/spider.json
+++ b/data/json/mapgen/map_extras/spider.json
@@ -3,6 +3,12 @@
     "type": "mapgen",
     "method": "json",
     "nested_mapgen_id": "spider_webs",
+    "object": { "mapgensize": [ 1, 1 ], "place_fields": [ { "field": "fd_web", "x": 0, "y": 0, "intensity": [ 1, 3 ] } ] }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
+    "nested_mapgen_id": "spider_webs_weak",
     "object": { "mapgensize": [ 1, 1 ], "place_fields": [ { "field": "fd_web", "x": 0, "y": 0 } ] }
   },
   {
@@ -14,38 +20,50 @@
   {
     "type": "mapgen",
     "method": "json",
+    "nested_mapgen_id": "spider_nest",
+    "object": {
+      "mapgensize": [ 17, 17 ],
+      "rows": [
+        "      .....      ",
+        "    .........    ",
+        "   ...,,,,,...   ",
+        "  ...,,,,,,,...  ",
+        " ...,,,ooo,,,... ",
+        " ..,,,ooooo,,,.. ",
+        "..,,,oooxooo,,,..",
+        "..,,oooxxxooo,,..",
+        "..,,ooxxXxxoo,,..",
+        "..,,oooxxxooo,,..",
+        "..,,,oooxooo,,,..",
+        " ..,,,ooooo,,,.. ",
+        " ...,,,ooo,,,... ",
+        "  ...,,,,,,,...  ",
+        "   ...,,,,,...   ",
+        "    .........    ",
+        "      .....      "
+      ],
+      "//": "Null terrain definitions to avoid error",
+      "terrain": { "x": "t_null", "o": "t_null", ",": "t_null", ".": "t_null" },
+      "furniture": { "X": "f_egg_sackws" },
+      "monsters": { "X": { "monster": "GROUP_SPIDER", "chance": 1, "density": 0.5 } },
+      "nested": {
+        "X": { "chunks": [ "spider_webs" ] },
+        "x": { "chunks": [ "spider_webs" ] },
+        "o": { "chunks": [ [ "spider_webs", 2 ], [ "spider_webs_weak", 2 ], [ "null", 1 ] ] },
+        ",": { "chunks": [ "spider_webs", "spider_webs_weak", "null" ] },
+        ".": { "chunks": [ [ "spider_webs_weak", 1 ], [ "null", 2 ] ] }
+      }
+    }
+  },
+  {
+    "type": "mapgen",
+    "method": "json",
     "update_mapgen_id": "mx_spider",
     "object": {
-      "rows": [
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "           X            ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        ",
-        "                        "
+      "place_nested": [
+        { "chunks": [ "spider_nest" ], "x": [ 0, 6 ], "y": [ 0, 6 ] },
+        { "chunks": [ "spider_nest", "null" ], "x": [ 0, 6 ], "y": [ 0, 6 ] }
       ],
-      "terrain": { "X": "t_dirt" },
-      "furniture": { "X": "f_egg_sackws" },
-      "monsters": { "X": { "monster": "GROUP_SPIDER", "chance": 1, "density": 1 } },
-      "nested": { " ": { "chunks": [ [ "spider_webs", 10 ], [ "null", 1 ] ] } },
       "flags": [ "ERASE_ALL_BEFORE_PLACING_TERRAIN" ]
     }
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

mx_spider sticks out bc it fills the whole OMT

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Spawns one or two sacks surrounded by web that gets patchier and less intensity further out
Each group spawned is half the density to compensate for the potential double spawn

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Before
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/60a1be99-3b50-4b21-bd0d-9141ae2ffe89)

After
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/45b925df-5303-4394-a1bc-8f01c720d205)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context


<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
