### PR TITLE
[Magiclysm] Fix Tremorsense removal EoC, revamp Reading the Earthbones

### DIFF
--- a/data/mods/Magiclysm/Spells/earthshaper.json
+++ b/data/mods/Magiclysm/Spells/earthshaper.json
@@ -787,7 +787,7 @@
         {
           "case": 0,
           "effect": [
-            { "u_spawn_item": "item_earthshaper_map_01" },
+            { "u_spawn_item": "item_earthshaper_map_01", "suppress_message": true },
             { "run_eocs": "EOC_EARTHSHAPER_MAP_ITEM_01" },
             { "u_remove_item_with": "item_earthshaper_map_01" }
           ]
@@ -795,7 +795,7 @@
         {
           "case": 3,
           "effect": [
-            { "u_spawn_item": "item_earthshaper_map_02" },
+            { "u_spawn_item": "item_earthshaper_map_02", "suppress_message": true },
             { "run_eocs": "EOC_EARTHSHAPER_MAP_ITEM_02" },
             { "u_remove_item_with": "item_earthshaper_map_02" }
           ]
@@ -803,7 +803,7 @@
         {
           "case": 6,
           "effect": [
-            { "u_spawn_item": "item_earthshaper_map_03" },
+            { "u_spawn_item": "item_earthshaper_map_03", "suppress_message": true },
             { "run_eocs": "EOC_EARTHSHAPER_MAP_ITEM_03" },
             { "u_remove_item_with": "item_earthshaper_map_03" }
           ]
@@ -811,7 +811,7 @@
         {
           "case": 9,
           "effect": [
-            { "u_spawn_item": "item_earthshaper_map_04" },
+            { "u_spawn_item": "item_earthshaper_map_04", "suppress_message": true },
             { "run_eocs": "EOC_EARTHSHAPER_MAP_ITEM_04" },
             { "u_remove_item_with": "item_earthshaper_map_04" }
           ]
@@ -819,7 +819,7 @@
         {
           "case": 12,
           "effect": [
-            { "u_spawn_item": "item_earthshaper_map_05" },
+            { "u_spawn_item": "item_earthshaper_map_05", "suppress_message": true },
             { "run_eocs": "EOC_EARTHSHAPER_MAP_ITEM_05" },
             { "u_remove_item_with": "item_earthshaper_map_05" }
           ]
@@ -827,7 +827,7 @@
         {
           "case": 15,
           "effect": [
-            { "u_spawn_item": "item_earthshaper_map_06" },
+            { "u_spawn_item": "item_earthshaper_map_06", "suppress_message": true },
             { "run_eocs": "EOC_EARTHSHAPER_MAP_ITEM_06" },
             { "u_remove_item_with": "item_earthshaper_map_06" }
           ]

--- a/data/mods/Magiclysm/Spells/earthshaper.json
+++ b/data/mods/Magiclysm/Spells/earthshaper.json
@@ -781,21 +781,126 @@
     "type": "effect_on_condition",
     "id": "EOC_EARTHSHAPER_MAP",
     "condition": { "math": [ "u_val('pos_z')", "<=", "0" ] },
-    "effect": [ { "u_cast_spell": { "id": "earthshaper_map_real" } } ],
+    "effect": {
+      "switch": { "math": [ "u_spell_level('earthshaper_reveal_world_map')" ] },
+      "cases": [
+        {
+          "case": 0,
+          "effect": [
+            { "u_spawn_item": "item_earthshaper_map_01" },
+            { "run_eocs": "EOC_EARTHSHAPER_MAP_ITEM_01" },
+            { "u_remove_item_with": "item_earthshaper_map_01" }
+          ]
+        },
+        {
+          "case": 3,
+          "effect": [
+            { "u_spawn_item": "item_earthshaper_map_02" },
+            { "run_eocs": "EOC_EARTHSHAPER_MAP_ITEM_02" },
+            { "u_remove_item_with": "item_earthshaper_map_02" }
+          ]
+        },
+        {
+          "case": 6,
+          "effect": [
+            { "u_spawn_item": "item_earthshaper_map_03" },
+            { "run_eocs": "EOC_EARTHSHAPER_MAP_ITEM_03" },
+            { "u_remove_item_with": "item_earthshaper_map_03" }
+          ]
+        },
+        {
+          "case": 9,
+          "effect": [
+            { "u_spawn_item": "item_earthshaper_map_04" },
+            { "run_eocs": "EOC_EARTHSHAPER_MAP_ITEM_04" },
+            { "u_remove_item_with": "item_earthshaper_map_04" }
+          ]
+        },
+        {
+          "case": 12,
+          "effect": [
+            { "u_spawn_item": "item_earthshaper_map_05" },
+            { "run_eocs": "EOC_EARTHSHAPER_MAP_ITEM_05" },
+            { "u_remove_item_with": "item_earthshaper_map_05" }
+          ]
+        },
+        {
+          "case": 15,
+          "effect": [
+            { "u_spawn_item": "item_earthshaper_map_06" },
+            { "run_eocs": "EOC_EARTHSHAPER_MAP_ITEM_06" },
+            { "u_remove_item_with": "item_earthshaper_map_06" }
+          ]
+        }
+      ]
+    },
     "false_effect": [ { "u_message": "Without a direct connection to the living earth, the spell fails." } ]
   },
   {
-    "id": "earthshaper_map_real",
-    "type": "SPELL",
-    "name": "Reading the Earthbones Real Spell",
-    "description": "This is the spell that actually fires when you cast Reading the Earthbones.  It's a bug if you have it.",
-    "valid_targets": [ "none" ],
-    "message": "The secrets of the living earth are revealed to you.",
-    "flags": [ "NO_HANDS", "SILENT" ],
-    "effect": "map",
-    "shape": "blast",
-    "max_level": 1,
-    "min_aoe": { "math": [ "( 7 + (u_spell_level('earthshaper_reveal_world_map') * 2.2) )" ] }
+    "type": "effect_on_condition",
+    "id": "EOC_EARTHSHAPER_MAP_ITEM_01",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "item_earthshaper_map_01" } ],
+        "true_eocs": [ { "id": "EOC_EARTHSHAPER_MAP_ITEM_01_ACTIVATE", "effect": { "u_activate": "reveal_map" } } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EARTHSHAPER_MAP_ITEM_02",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "item_earthshaper_map_02" } ],
+        "true_eocs": [ { "id": "EOC_EARTHSHAPER_MAP_ITEM_02_ACTIVATE", "effect": { "u_activate": "reveal_map" } } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EARTHSHAPER_MAP_ITEM_03",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "item_earthshaper_map_03" } ],
+        "true_eocs": [ { "id": "EOC_EARTHSHAPER_MAP_ITEM_03_ACTIVATE", "effect": { "u_activate": "reveal_map" } } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EARTHSHAPER_MAP_ITEM_04",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "item_earthshaper_map_04" } ],
+        "true_eocs": [ { "id": "EOC_EARTHSHAPER_MAP_ITEM_04_ACTIVATE", "effect": { "u_activate": "reveal_map" } } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EARTHSHAPER_MAP_ITEM_05",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "item_earthshaper_map_05" } ],
+        "true_eocs": [ { "id": "EOC_EARTHSHAPER_MAP_ITEM_05_ACTIVATE", "effect": { "u_activate": "reveal_map" } } ]
+      }
+    ]
+  },
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_EARTHSHAPER_MAP_ITEM_06",
+    "effect": [
+      {
+        "u_run_inv_eocs": "random",
+        "search_data": [ { "id": "item_earthshaper_map_06" } ],
+        "true_eocs": [ { "id": "EOC_EARTHSHAPER_MAP_ITEM_06_ACTIVATE", "effect": { "u_activate": "reveal_map" } } ]
+      }
+    ]
   },
   {
     "id": "earthshaper_danger_sense",
@@ -832,7 +937,8 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_EARTHSHAPER_DANGERSENSE_CHECKER",
-    "recurrence": 1,
+    "eoc_type": "EVENT",
+    "required_event": "avatar_moves",
     "condition": { "and": [ { "math": [ "u_val('pos_z')", ">=", "1" ] }, { "u_has_effect": "effect_tremorsense" } ] },
     "effect": [
       { "u_lose_effect": "effect_tremorsense" },

--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -1518,6 +1518,7 @@
         { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
         { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "stream", "om_terrain_match_type": "PREFIX" },
         "solid_earth",
         "empty_rock"
       ],
@@ -1539,6 +1540,7 @@
         { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
         { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "stream", "om_terrain_match_type": "PREFIX" },
         "solid_earth",
         "empty_rock"
       ],
@@ -1560,6 +1562,7 @@
         { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
         { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "stream", "om_terrain_match_type": "PREFIX" },
         "solid_earth",
         "empty_rock"
       ],
@@ -1581,6 +1584,7 @@
         { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
         { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "stream", "om_terrain_match_type": "PREFIX" },
         "solid_earth",
         "empty_rock"
       ],
@@ -1602,8 +1606,10 @@
         { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
         { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "stream", "om_terrain_match_type": "PREFIX" },
         "solid_earth",
-        "empty_rock"
+        "empty_rock",
+        "tream"
       ],
       "message": "The earth reveals its secrets."
     }
@@ -1623,6 +1629,7 @@
         { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
         { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
         { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "stream", "om_terrain_match_type": "PREFIX" },
         "solid_earth",
         "empty_rock"
       ],

--- a/data/mods/Magiclysm/items/ethereal_items.json
+++ b/data/mods/Magiclysm/items/ethereal_items.json
@@ -1502,5 +1502,131 @@
         { "has": "WORN", "condition": { "not": "u_has_weapon" }, "values": [ { "value": "ATTACK_SPEED", "multiply": -0.1 } ] }
       ]
     }
+  },
+  {
+    "id": "item_earthshaper_map_01",
+    "copy-from": "abstractmap",
+    "type": "GENERIC",
+    "category": "maps",
+    "name": "earthshaper map",
+    "description": "This is a magical map that, if everything works correctly, you'll never actually see.",
+    "color": "brown",
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 15,
+      "terrain": [
+        { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
+        { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        "solid_earth",
+        "empty_rock"
+      ],
+      "message": "The earth reveals its secrets."
+    }
+  },
+  {
+    "id": "item_earthshaper_map_02",
+    "copy-from": "abstractmap",
+    "type": "GENERIC",
+    "category": "maps",
+    "name": "earthshaper map",
+    "description": "This is a magical map that, if everything works correctly, you'll never actually see.",
+    "color": "brown",
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 20,
+      "terrain": [
+        { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
+        { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        "solid_earth",
+        "empty_rock"
+      ],
+      "message": "The earth reveals its secrets."
+    }
+  },
+  {
+    "id": "item_earthshaper_map_03",
+    "copy-from": "abstractmap",
+    "type": "GENERIC",
+    "category": "maps",
+    "name": "earthshaper map",
+    "description": "This is a magical map that, if everything works correctly, you'll never actually see.",
+    "color": "brown",
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 25,
+      "terrain": [
+        { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
+        { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        "solid_earth",
+        "empty_rock"
+      ],
+      "message": "The earth reveals its secrets."
+    }
+  },
+  {
+    "id": "item_earthshaper_map_04",
+    "copy-from": "abstractmap",
+    "type": "GENERIC",
+    "category": "maps",
+    "name": "earthshaper map",
+    "description": "This is a magical map that, if everything works correctly, you'll never actually see.",
+    "color": "brown",
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 30,
+      "terrain": [
+        { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
+        { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        "solid_earth",
+        "empty_rock"
+      ],
+      "message": "The earth reveals its secrets."
+    }
+  },
+  {
+    "id": "item_earthshaper_map_05",
+    "copy-from": "abstractmap",
+    "type": "GENERIC",
+    "category": "maps",
+    "name": "earthshaper map",
+    "description": "This is a magical map that, if everything works correctly, you'll never actually see.",
+    "color": "brown",
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 35,
+      "terrain": [
+        { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
+        { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        "solid_earth",
+        "empty_rock"
+      ],
+      "message": "The earth reveals its secrets."
+    }
+  },
+  {
+    "id": "item_earthshaper_map_06",
+    "copy-from": "abstractmap",
+    "type": "GENERIC",
+    "category": "maps",
+    "name": "earthshaper map",
+    "description": "This is a magical map that, if everything works correctly, you'll never actually see.",
+    "color": "brown",
+    "use_action": {
+      "type": "reveal_map",
+      "radius": 40,
+      "terrain": [
+        { "om_terrain": "field", "om_terrain_match_type": "PREFIX" },
+        { "om_terrain": "swamp", "om_terrain_match_type": "TYPE" },
+        { "om_terrain": "forest", "om_terrain_match_type": "PREFIX" },
+        "solid_earth",
+        "empty_rock"
+      ],
+      "message": "The earth reveals its secrets."
+    }
   }
 ]

--- a/data/mods/Magiclysm/obsoletion.json
+++ b/data/mods/Magiclysm/obsoletion.json
@@ -1,0 +1,15 @@
+[
+  {
+    "id": "earthshaper_map_real",
+    "type": "SPELL",
+    "name": "Reading the Earthbones Real Spell",
+    "description": "This is the spell that actually fires when you cast Reading the Earthbones.  It's a bug if you have it.",
+    "valid_targets": [ "none" ],
+    "message": "The secrets of the living earth are revealed to you.",
+    "flags": [ "NO_HANDS", "SILENT" ],
+    "effect": "map",
+    "shape": "blast",
+    "max_level": 1,
+    "min_aoe": { "math": [ "( 7 + (u_spell_level('earthshaper_reveal_world_map') * 2.2) )" ] }
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Fix Tremorsense removal EoC, revamp Reading the Earthbones"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

GuardianDII had some reasonable concerns when I first made Reading the Earthbones that thanks to EoCs I can now address. Previously it used the map spell function because that was all that was available, but now that item EoCs exist I can use the reveal_map EoC to only reveal _natural_ earthen terrain--no roads, no lakes, no towns, etc, just fields, forests, rock, and dirt.  You can see something is there because it won't be revealed, but you'll actually have to go there to see what it is. 

Also, Tremorsense is supposed to cancel itself if you go above Z level 0 but that EoC didn't work. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

As described--fix Tremorsense using an avatar_moves event EoC that checks your Z level, and fix Reading the Earthbones to use a reveal_map item use_action called by EoC.

Reading the Earthbones reveals solid rock but not deep rock, so anything below Z level -3 won't be detected (to allow people to keep hiding things down there).
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Reading the Earthbones
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/120433252/3a9743a6-563b-4218-8e3a-cc058349aa23)


Tremorsense cancels itself as expected.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
