### PR TITLE
Fix maple tree in sugar house not responding to action

### DIFF
--- a/data/json/mapgen/sugar_house.json
+++ b/data/json/mapgen/sugar_house.json
@@ -115,7 +115,7 @@
         "C": { "item": "SUS_cookware", "chance": 100 },
         "c": { "item": "sugar_house_kitchen_items", "chance": 75, "repeat": [ 1, 2 ] }
       },
-      "item": { "M": { "item": "bucket", "chance": 100 } },
+      "item": { "M": [ { "item": "bucket", "chance": 100 }, { "item": "tree_spile", "chance": 100 } ] },
       "place_loot": [
         { "item": "stepladder", "x": 3, "y": 44, "chance": 100 },
         { "group": "sugar_house_drum", "x": 2, "y": 40, "chance": 60 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

- Fix #69514

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
In the sugar house, `tapped_maple` were placed by mapgen and also bucket were placed there, but the spile was missing. This caused `tree_maple_tapped`, which is an examine_action when `tapped_maple` is used, to return without any processing if the spile is missing at that function part, `iexamine::tree_maple_tapped`. As a result, it was not possible to insert the missing spile or remove the bucket ( it means that the terrain returns to `t_tree_maple` ), in other words, there was no way to execute any action.
Now, putting to the spile, it is hoped that the action will be revived ~, and the sap collection mechanism, as originally intended, will also begin to work~.
Without the presence of the spile ( as an item ), it seems that the mechanism of sap accumulating into the container still remains working ( meaning that sap will accumulate when the time is harvest, no matter if this PR is not applied ).
However, there is still no way to peaceful way to get the sap out of the container, as it remains inaccessible via actions, only by cutting down the tree into logs, allowing the container to be taken out.
In this case, bucketfuls of sap would require cutting down trees to gather it, ~which is a bit unsustainable. As a more sustainable alternative,~ this fix is needed to avoid public accusations that the sugar house owner cut down a tree to collect a bucket of sap in the post-apocalyptic.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

- Placing `t_tree_maple` instead of placing `tapped_maple`, and keeping the buckets and spiles together nearby, and requiring the player to actively set up them.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
In-game testing was done. Actions can be performed on the maple tree in the sugar house and that maple sap is accumulated in auto-placed bucket during the harvest season.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

It seems to me that the amount of maple syrup left in the sugar house tanks is too little( about 5l? ).
Even kitchen in my house has 500 ml.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
