### PR TITLE
Monster upgrades fixes

### DIFF
--- a/data/json/monsters/civilians.json
+++ b/data/json/monsters/civilians.json
@@ -117,7 +117,7 @@
     "speed": 0,
     "//": "So they are not perpetually fleeing despite lying in a hospital bed",
     "morale": 0,
-    "upgrades": { "into": "mon_zombie_crawler", "into_group": "GROUP_NULL" },
+    "upgrades": { "into": "mon_zombie_crawler" },
     "delete": { "flags": [ "SEES", "HEARS" ] },
     "copy-from": "mon_civilian_stationary"
   },

--- a/data/json/monsters/feral_humans.json
+++ b/data/json/monsters/feral_humans.json
@@ -174,7 +174,7 @@
     "id": "mon_feral_human_pipe_fungal_infected",
     "type": "MONSTER",
     "copy-from": "mon_feral_human_pipe",
-    "upgrades": { "age_grow": 4, "into_group": "GROUP_NULL", "into": "mon_feral_human_pipe_fungal_corpse" },
+    "upgrades": { "age_grow": 4, "into": "mon_feral_human_pipe_fungal_corpse" },
     "burn_into": "mon_starer_pipe",
     "extend": { "flags": [ "NO_FUNG_DMG" ], "species": [ "FUNGUS" ] }
   },
@@ -182,7 +182,7 @@
     "id": "mon_feral_human_crowbar_fungal_infected",
     "type": "MONSTER",
     "copy-from": "mon_feral_human_crowbar",
-    "upgrades": { "age_grow": 4, "into_group": "GROUP_NULL", "into": "mon_feral_human_crowbar_fungal_corpse" },
+    "upgrades": { "age_grow": 4, "into": "mon_feral_human_crowbar_fungal_corpse" },
     "burn_into": "mon_starer_crowbar",
     "extend": { "flags": [ "NO_FUNG_DMG" ], "species": [ "FUNGUS" ] }
   },
@@ -190,7 +190,7 @@
     "id": "mon_feral_human_axe_fungal_infected",
     "type": "MONSTER",
     "copy-from": "mon_feral_human_axe",
-    "upgrades": { "age_grow": 4, "into_group": "GROUP_NULL", "into": "mon_feral_human_axe_fungal_corpse" },
+    "upgrades": { "age_grow": 4, "into": "mon_feral_human_axe_fungal_corpse" },
     "burn_into": "mon_starer_axe",
     "extend": { "flags": [ "NO_FUNG_DMG" ], "species": [ "FUNGUS" ] }
   },
@@ -200,7 +200,7 @@
     "description": "Delicate fungal stalks sprout in rows from sores covering this person's body, and their facial expression is pure agony.",
     "copy-from": "mon_feral_human_pipe",
     "default_faction": "fungus",
-    "upgrades": { "half_life": 14, "into_group": "GROUP_NULL", "into": "mon_fungaloid" },
+    "upgrades": { "half_life": 14, "into": "mon_fungaloid" },
     "extend": { "special_attacks": [ [ "FUNGUS", 40 ] ], "flags": [ "NO_FUNG_DMG", "IMMOBILE" ] },
     "death_function": { "effect": { "id": "death_fungus", "hit_self": true } }
   },
@@ -210,7 +210,7 @@
     "description": "Delicate fungal stalks sprout in rows from sores on this person's arms, and their facial expression is pure agony.  Their mouth opens and closes softly in a silent moan.",
     "copy-from": "mon_feral_human_crowbar",
     "default_faction": "fungus",
-    "upgrades": { "half_life": 14, "into_group": "GROUP_NULL", "into": "mon_fungaloid" },
+    "upgrades": { "half_life": 14, "into": "mon_fungaloid" },
     "extend": { "special_attacks": [ [ "FUNGUS", 40 ] ], "flags": [ "NO_FUNG_DMG", "IMMOBILE" ] },
     "death_function": { "effect": { "id": "death_fungus", "hit_self": true } }
   },
@@ -220,7 +220,7 @@
     "description": "Delicate fungal stalks sprout in rows from sores on this person's arms, and their facial expression is pure agony.",
     "copy-from": "mon_feral_human_axe",
     "default_faction": "fungus",
-    "upgrades": { "half_life": 14, "into_group": "GROUP_NULL", "into": "mon_fungaloid" },
+    "upgrades": { "half_life": 14, "into": "mon_fungaloid" },
     "extend": { "special_attacks": [ [ "FUNGUS", 40 ] ], "flags": [ "NO_FUNG_DMG", "IMMOBILE" ] },
     "death_function": { "effect": { "id": "death_fungus", "hit_self": true } }
   },

--- a/data/json/monsters/fungus.json
+++ b/data/json/monsters/fungus.json
@@ -175,7 +175,7 @@
       }
     ],
     "death_drops": [ { "group": "wreckage", "count": 5 }, { "group": "trash_forest", "count": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "armor": { "bash": 4, "cut": 10, "stab": 20, "acid": 3, "bullet": 20, "electric": 3 }
   },
   {

--- a/data/json/monsters/zanimal_upgrade.json
+++ b/data/json/monsters/zanimal_upgrade.json
@@ -81,7 +81,7 @@
     "proportional": { "hp": 4, "speed": 1.25, "attack_cost": 1.25 },
     "relative": { "melee_skill": 1, "melee_dice": 1, "melee_damage": -2 },
     "bleed_rate": 0,
-    "upgrades": {  },
+    "upgrades": false,
     "grab_strength": 60,
     "special_attacks": [
       { "id": "smash", "throw_strength": 81 },

--- a/data/json/monsters/zed-winged.json
+++ b/data/json/monsters/zed-winged.json
@@ -183,7 +183,7 @@
     "copy-from": "mon_spawn_raptor",
     "color": "light_gray",
     "description": "An uncanny shadow envelops this creature.  You can make out the outline of three flapping wings connected to a jagged, pointed object.",
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "NIGHT_INVISIBILITY" ] },
     "vision_day": 10,
     "vision_night": 25,
@@ -206,7 +206,7 @@
       "corpse_type": "NO_CORPSE",
       "message": "The %s explodes!"
     },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "type": "MONSTER",
@@ -225,7 +225,7 @@
       { "id": "impale", "damage_max_instance": [ { "damage_type": "stab", "amount": 15, "armor_multiplier": 0.6 } ] }
     ],
     "special_when_hit": [ "ZAPBACK", 100 ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "ELECTRIC" ] }
   }
 ]

--- a/data/mods/DinoMod/monsters/fungus.json
+++ b/data/mods/DinoMod/monsters/fungus.json
@@ -15,7 +15,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -34,7 +34,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "HEARS", "BASHES", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "SWIMS" ]
   },
   {
@@ -53,7 +53,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM", "SWIMS" ]
   },
   {
@@ -72,7 +72,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -91,7 +91,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -111,7 +111,7 @@
     "vision_night": 5,
     "grab_strength": 100,
     "special_attacks": [ { "id": "bite_grab" }, [ "FUNGUS", 200 ], [ "LUNGE", 20 ] ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "GRABS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -131,7 +131,7 @@
     "vision_night": 5,
     "grab_strength": 100,
     "special_attacks": [ { "id": "bite_grab" }, [ "FUNGUS", 200 ], [ "LUNGE", 20 ] ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "GRABS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -156,7 +156,7 @@
       { "id": "grab_drag" },
       { "id": "drag_followup" }
     ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -176,7 +176,7 @@
     "vision_night": 5,
     "grab_strength": 75,
     "special_attacks": [ { "id": "bite_grab", "cooldown": 20 }, [ "FUNGUS", 200 ], [ "scratch", 20 ], [ "LUNGE", 20 ] ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "GRABS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -196,7 +196,7 @@
     "vision_night": 5,
     "grab_strength": 75,
     "special_attacks": [ { "id": "bite_grab", "cooldown": 20 }, [ "FUNGUS", 200 ], [ "scratch", 20 ], [ "LUNGE", 20 ] ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "GRABS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -216,7 +216,7 @@
     "vision_night": 5,
     "grab_strength": 100,
     "special_attacks": [ { "id": "bite_grab", "cooldown": 20 }, [ "FUNGUS", 200 ], [ "scratch", 20 ], [ "LUNGE", 20 ] ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "GRABS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -236,7 +236,7 @@
     "vision_night": 5,
     "grab_strength": 75,
     "special_attacks": [ { "id": "bite_grab", "cooldown": 5 }, [ "FUNGUS", 200 ], [ "scratch", 20 ], [ "LUNGE", 5 ] ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "GRABS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -255,7 +255,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 }, [ "scratch", 20 ], [ "LUNGE", 5 ] ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -274,7 +274,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 }, [ "scratch", 20 ], [ "LUNGE", 10 ] ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -293,7 +293,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 }, [ "scratch", 20 ], [ "LUNGE", 5 ] ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -312,7 +312,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "BASHES", "DESTROYS", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -331,7 +331,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "HEARS", "PET_MOUNTABLE", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -350,7 +350,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "HEARS", "PET_MOUNTABLE", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -369,7 +369,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "HEARS", "PET_MOUNTABLE", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -388,7 +388,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "LONGSWIPE", 20 ] ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES", "DESTROYS" ]
   },
   {
@@ -407,7 +407,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "LONGSWIPE", 30 ] ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
@@ -426,7 +426,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "LONGSWIPE", 30 ] ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
@@ -450,7 +450,7 @@
       [ "scratch", 10 ],
       { "type": "bite", "cooldown": 5 }
     ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -474,7 +474,7 @@
       [ "scratch", 10 ],
       { "type": "bite", "cooldown": 5 }
     ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM" ]
   },
   {
@@ -493,7 +493,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
@@ -512,7 +512,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
@@ -531,7 +531,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
@@ -550,7 +550,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
@@ -573,7 +573,7 @@
       { "id": "slam", "cooldown": 10, "damage_max_instance": [ { "damage_type": "bash", "amount": 12 } ] },
       [ "SMASH", 30 ]
     ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
@@ -596,7 +596,7 @@
       { "id": "slam", "cooldown": 10, "damage_max_instance": [ { "damage_type": "bash", "amount": 12 } ] },
       [ "SMASH", 30 ]
     ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES" ]
   },
   {
@@ -605,7 +605,7 @@
     "name": { "str": "fungal brontosaurus zombie" },
     "description": "This was once a massive, long-necked, four-legged dinosaur herbivore with a bulky torso and a long, whip-like tail.  Fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together an enormous shambling mass of mold-covered flesh.",
     "copy-from": "mon_zapatosaurus_fungus",
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_ziplodocus_fungus",
@@ -613,7 +613,7 @@
     "name": { "str": "fungal diplodocus zombie" },
     "description": "Once a huge, long-necked, four-legged plant eating dinosaur with a tiny head and long, whip-like tail, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together an enormous shambling mass of mold-covered flesh.",
     "copy-from": "mon_zapatosaurus_fungus",
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zarosaurus_fungus",
@@ -621,7 +621,7 @@
     "name": { "str": "fungal barosaurus zombie" },
     "description": "Once a huge, long-necked, four-legged plant eating dinosaur with a long, whip-like tail, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together an enormous shambling mass of mold-covered flesh.",
     "copy-from": "mon_zapatosaurus_fungus",
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zamarasaurus_fungus",
@@ -629,7 +629,7 @@
     "name": { "str": "fungal camarasaurus zombie" },
     "description": "Once a huge, long-necked, four-legged plant eating dinosaur with a long, whip-like tail, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together an enormous shambling mass of mold-covered flesh.",
     "copy-from": "mon_zapatosaurus_fungus",
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zrachiosaurus_fungus",
@@ -638,7 +638,7 @@
     "description": "Once a gigantic, long-necked, four-legged plant eating dinosaur with longer forelegs and a long, whip-like tail, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together an enormous shambling mass of mold-covered flesh.",
     "copy-from": "mon_zapatosaurus_fungus",
     "proportional": { "hp": 2, "speed": 0.65 },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zalamosaurus_fungus",
@@ -647,7 +647,7 @@
     "description": "Once a gigantic, long-necked, four-legged plant eating dinosaur with longer forelegs and spiked tail protected by natural bone armor, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together an enormous shambling mass of mold-covered flesh.",
     "copy-from": "mon_zapatosaurus_fungus",
     "proportional": { "hp": 1.5, "speed": 0.8, "armor": { "bash": 2, "cut": 2 } },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_ztegosaurus_fungus",
@@ -669,7 +669,7 @@
       { "id": "slam", "cooldown": 10, "damage_max_instance": [ { "damage_type": "bash", "amount": 12 } ] },
       [ "SMASH", 30 ]
     ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
@@ -692,7 +692,7 @@
       { "id": "slam", "cooldown": 10, "damage_max_instance": [ { "damage_type": "bash", "amount": 12 } ] },
       [ "SMASH", 30 ]
     ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
@@ -702,7 +702,7 @@
     "description": "Once a heavily armored four legged dinosaur with a long tail, a beak, and large shoulder spikes, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together a shambling mass of mold-covered flesh and bone.",
     "copy-from": "mon_zodosaurus_fungus",
     "proportional": { "hp": 0.7 },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zargoyleosaurus_fungus",
@@ -711,7 +711,7 @@
     "description": "Once a lightly armored four legged dinosaur with a rigid spiked tail, a beak, and sturdy spikes along the sides, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together a shambling mass of mold-covered flesh and bone.",
     "copy-from": "mon_zodosaurus_fungus",
     "proportional": { "hp": 0.8 },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zauropelta_fungus",
@@ -719,7 +719,7 @@
     "name": { "str": "fungal sauropelta zombie" },
     "description": "Once a heavily armored four legged dinosaur with a beak, a long tail, and long wicked-looking spikes jutting out of the neck, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together a shambling mass of mold-covered flesh and bone.",
     "copy-from": "mon_zodosaurus_fungus",
-    "upgrades": {  },
+    "upgrades": false,
     "armor": { "bash": 16, "bullet": 7, "cut": 30 }
   },
   {
@@ -730,7 +730,7 @@
     "copy-from": "mon_zankylosaurus_fungus",
     "proportional": { "hp": 0.6 },
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zanoplosaurus_fungus",
@@ -740,7 +740,7 @@
     "copy-from": "mon_zankylosaurus_fungus",
     "proportional": { "hp": 0.6 },
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zedmontonia_fungus",
@@ -751,7 +751,7 @@
     "melee_damage": [ { "damage_type": "stab", "amount": 10 } ],
     "proportional": { "hp": 0.65 },
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zzuul_fungus",
@@ -760,7 +760,7 @@
     "description": "Once a four-legged armored dinosaur covered with spikes with a wicked club tail, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together a shambling mass of mold-covered flesh and bone.",
     "copy-from": "mon_zankylosaurus_fungus",
     "proportional": { "hp": 0.4, "speed": 1.2 },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zyoplosaurus_fungus",
@@ -769,7 +769,7 @@
     "description": "Once a heavily armored four legged dinosaur with a beak and a long tail ending in a spiked club of bone, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together a shambling mass of mold-covered flesh and bone.",
     "copy-from": "mon_zankylosaurus_fungus",
     "proportional": { "hp": 0.35, "speed": 1.2 },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zankylosaurus_fungus",
@@ -793,7 +793,7 @@
       { "id": "slam", "cooldown": 10, "damage_max_instance": [ { "damage_type": "bash", "amount": 12 } ] },
       [ "SMASH", 30 ]
     ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
@@ -818,7 +818,7 @@
       { "id": "slam", "cooldown": 10, "damage_max_instance": [ { "damage_type": "bash", "amount": 12 } ] },
       [ "SMASH", 30 ]
     ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
@@ -843,7 +843,7 @@
       { "id": "slam", "cooldown": 10, "damage_max_instance": [ { "damage_type": "bash", "amount": 12 } ] },
       [ "SMASH", 30 ]
     ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
@@ -862,7 +862,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
@@ -881,7 +881,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
@@ -900,7 +900,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "BASHES" ]
   },
   {
@@ -910,7 +910,7 @@
     "description": "Once a bulky, beaked four-legged dinosaur herbivore, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together a shambling mass of mold-covered flesh and bone.",
     "copy-from": "mon_zamptosaurus_fungus",
     "proportional": { "hp": 3 },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zaiasaura_fungus",
@@ -919,7 +919,7 @@
     "description": "This was once a huge, four-legged dinosaur herbivore with hooves, a heavy tail, and a flat beak.  Fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together a shambling mass of mold-covered flesh and bone.",
     "copy-from": "mon_zamptosaurus_fungus",
     "proportional": { "hp": 3 },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zryposaurus_fungus",
@@ -928,7 +928,7 @@
     "description": "Once a huge, four-legged dinosaur herbivore with a toothless beak and a narrow arching nasal hump, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together a shambling mass of mold-covered flesh and bone.",
     "copy-from": "mon_zamptosaurus_fungus",
     "proportional": { "hp": 4 },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zrosaurolophus_fungus",
@@ -937,7 +937,7 @@
     "description": "Once a huge, four-legged dinosaur herbivore with hooves and a broad beak and a small nasal crest, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together a shambling mass of mold-covered flesh and bone.",
     "copy-from": "mon_zamptosaurus_fungus",
     "proportional": { "hp": 4 },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zaurolophus_fungus",
@@ -946,7 +946,7 @@
     "description": "Once a huge, four-legged dinosaur herbivore with hooves and a broad beak and a spiky head crest, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together a shambling mass of mold-covered flesh and bone.",
     "copy-from": "mon_zamptosaurus_fungus",
     "proportional": { "hp": 4 },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zedmontosaurus_fungus",
@@ -955,7 +955,7 @@
     "description": "Once a huge, four-legged dinosaur herbivore with a broad, toothless beak, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together a shambling mass of mold-covered flesh and bone.",
     "copy-from": "mon_zamptosaurus_fungus",
     "proportional": { "hp": 5 },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zarasaurolophus_fungus",
@@ -964,7 +964,7 @@
     "description": "Once a huge, four-legged dinosaur herbivore with a blunt head crest, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together a shambling mass of mold-covered flesh and bone.",
     "copy-from": "mon_zamptosaurus_fungus",
     "proportional": { "hp": 4 },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zambeosaurus_fungus",
@@ -974,7 +974,7 @@
     "copy-from": "mon_zamptosaurus_fungus",
     "proportional": { "hp": 4 },
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 }, [ "SHRIEK", 5 ] ],
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zorythosaurus_fungus",
@@ -984,7 +984,7 @@
     "copy-from": "mon_zamptosaurus_fungus",
     "proportional": { "hp": 4 },
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 }, [ "SHRIEK", 5 ] ],
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zypacrosaurus_fungus",
@@ -994,7 +994,7 @@
     "copy-from": "mon_zamptosaurus_fungus",
     "proportional": { "hp": 4 },
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 }, [ "SHRIEK", 5 ] ],
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zachycephalosaurus_fungus",
@@ -1012,7 +1012,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
   },
   {
@@ -1031,7 +1031,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
   },
   {
@@ -1050,7 +1050,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
   },
   {
@@ -1069,7 +1069,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
   },
   {
@@ -1088,7 +1088,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
   },
   {
@@ -1107,7 +1107,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE" ]
   },
   {
@@ -1122,7 +1122,7 @@
       { "id": "slam", "cooldown": 10, "damage_max_instance": [ { "damage_type": "bash", "amount": 12 } ] },
       [ "SMASH", 30 ]
     ],
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zachyrhinosaurus_fungus",
@@ -1136,7 +1136,7 @@
       { "id": "slam", "cooldown": 10, "damage_max_instance": [ { "damage_type": "bash", "amount": 12 } ] },
       [ "SMASH", 30 ]
     ],
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zasmosaurus_fungus",
@@ -1145,7 +1145,7 @@
     "description": "This was once a four-legged dinosaur with a tall bony crest from which three short horns emerge above the eyes and beak.  Fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together a shambling mass of mold-covered flesh.",
     "copy-from": "mon_zriceratops_fungus",
     "proportional": { "armor": { "bash": 2 } },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zentaceratops_fungus",
@@ -1154,7 +1154,7 @@
     "description": "This was once a massive, four-legged dinosaur herbivore, with a tall bony crest from which four long horns and a short nose horn emerged.  Fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together a shambling mass of mold-covered flesh.",
     "copy-from": "mon_zriceratops_fungus",
     "proportional": { "armor": { "bash": 2 } },
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zosmoceratops_fungus",
@@ -1164,7 +1164,7 @@
     "copy-from": "mon_zriceratops_fungus",
     "proportional": { "melee_dice": 2, "melee_damage": 0.65 },
     "special_attacks": [ [ "FUNGUS", 200 ], { "id": "impale" }, [ "stretch_horn_DinoMod", 10 ] ],
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zorosaurus_fungus",
@@ -1174,7 +1174,7 @@
     "copy-from": "mon_zriceratops_fungus",
     "proportional": { "melee_dice": 2, "melee_damage": 0.65 },
     "special_attacks": [ [ "FUNGUS", 200 ], { "id": "impale" }, [ "stretch_horn_DinoMod", 5 ] ],
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zriceratops_fungus",
@@ -1192,7 +1192,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], { "id": "impale" } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "PET_MOUNTABLE", "BASHES" ]
   },
   {
@@ -1211,7 +1211,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ] ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "PET_MOUNTABLE", "BASHES" ]
   },
   {
@@ -1230,7 +1230,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "SMELLS", "HEARS", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY", "WARM", "BASHES", "FLIES" ]
   },
   {
@@ -1243,7 +1243,7 @@
     "hp": 249,
     "description": "This was once a large, feathered reptile with a long, pointy, toothless beak and a long, pointy head crest, fungal tendrils now sprout from its mouth, eyes, and other orifices, holding together a shambling mass of mold-covered feathers.",
     "copy-from": "mon_zteranodon_fungus",
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "id": "mon_zosasaurus_fungus",
@@ -1261,7 +1261,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "HEARS", "DESTROYS", "WARM", "SWIMS", "AQUATIC", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY" ]
   },
   {
@@ -1280,7 +1280,7 @@
     "vision_day": 5,
     "vision_night": 5,
     "special_attacks": [ [ "FUNGUS", 200 ], [ "scratch", 10 ], { "type": "bite", "cooldown": 5 } ],
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [ "SEES", "HEARS", "SWIMS", "AQUATIC", "POISON", "STUMBLES", "NO_BREATHE", "FILTHY" ]
   }
 ]

--- a/data/mods/DinoMod/monsters/mutant_dino.json
+++ b/data/mods/DinoMod/monsters/mutant_dino.json
@@ -70,7 +70,7 @@
     "hp": 200,
     "melee_dice": 4,
     "description": "A bulky, beaked dinosaur with hooved front legs and two heads.  The four eyes are wide and rolling.",
-    "upgrades": {  },
+    "upgrades": false,
     "harvest": "mutant_bird_flightless"
   }
 ]

--- a/data/mods/DinoMod/monsters/zed-dinosaur.json
+++ b/data/mods/DinoMod/monsters/zed-dinosaur.json
@@ -451,7 +451,7 @@
     "copy-from": "mon_zyrannosaurus",
     "description": "A massive dinosaur corpse with enormous teeth wrapped with heavy chains to allow some control.",
     "fungalize_into": "mon_zyrannosaurus_fungus",
-    "upgrades": {  },
+    "upgrades": false,
     "aggression": 0
   },
   {
@@ -1459,7 +1459,7 @@
     "name": { "str": "chained Pachycephalosaurus zombie" },
     "copy-from": "mon_zachycephalosaurus",
     "description": "A feathered dinosaur corpse with a domed head with heavy chains to allow some control.",
-    "upgrades": {  },
+    "upgrades": false,
     "aggression": 0,
     "speed": 80,
     "attack_cost": 80
@@ -1743,7 +1743,7 @@
     "description": "The ragged but flying corpse of a large, feathered reptile with a long, pointy, toothless beak and a long, rigid neck.",
     "burn_into": "mon_zuetzalcoatlus_scorched",
     "fungalize_into": "mon_zuetzalcoatlus_fungus",
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "type": "MONSTER",
@@ -1767,7 +1767,7 @@
     "description": "The ragged bloated corpse of a huge aquatic dinosaur the size of a house, with a crocodile-like head and swimming fins.",
     "burn_into": "mon_zosasaurus_scorched",
     "fungalize_into": "mon_zosasaurus_fungus",
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [
       "SEES",
       "HEARS",
@@ -1805,7 +1805,7 @@
     "description": "The ragged bloated corpse of a large aquatic dinosaur the size of a car, with a crocodile-like head, long neck, and swimming fins.",
     "burn_into": "mon_zlesiosaurus_scorched",
     "fungalize_into": "mon_zlesiosaurus_fungus",
-    "upgrades": {  },
+    "upgrades": false,
     "flags": [
       "SEES",
       "HEARS",

--- a/data/mods/DinoMod/monsters/zed-dinosaur_CBM.json
+++ b/data/mods/DinoMod/monsters/zed-dinosaur_CBM.json
@@ -52,7 +52,7 @@
     ],
     "description": "A shiny finned dinosaur corpse covered with bloody armor and crackling bionics.  It shambles quickly as it hunts.  Is that a laser rifle on its head?",
     "special_when_hit": [ "ZAPBACK", 20 ],
-    "upgrades": {  },
+    "upgrades": false,
     "dissect": "dissect_CBM_DINO"
   },
   {
@@ -77,7 +77,7 @@
     ],
     "description": "The shuffling corpse of a bipedal dinosaur dotted with crackling bionics, tattered feathers, and black putrid liquid with glowing curved claws.",
     "special_when_hit": [ "ZAPBACK", 75 ],
-    "upgrades": {  },
+    "upgrades": false,
     "dissect": "dissect_CBM_DINO"
   },
   {
@@ -95,7 +95,7 @@
     "special_attacks": [ { "id": "bio_op_takedown", "cooldown": 20 } ],
     "description": "The shuffling corpse of a bipedal dinosaur dotted with crackling bionics, tattered feathers, and black putrid liquid with glowing curved claws.",
     "special_when_hit": [ "ZAPBACK", 75 ],
-    "upgrades": {  },
+    "upgrades": false,
     "dissect": "dissect_CBM_DINO"
   },
   {
@@ -116,7 +116,7 @@
     ],
     "description": "A bipedal dinosaur covered with tattered feathers, black goo, and crackling bionics.  Each foot has a large glowing sickle-like claw.",
     "special_when_hit": [ "ZAPBACK", 75 ],
-    "upgrades": {  },
+    "upgrades": false,
     "dissect": "dissect_CBM_DINO"
   },
   {
@@ -138,7 +138,7 @@
     ],
     "description": "The massive shuffling corpse of a four legged dinosaur with a long neck and tail.  The body is dotted with crackling bionics and has two rows of tall glowing spines down the neck and back.",
     "special_when_hit": [ "ZAPBACK", 75 ],
-    "upgrades": {  },
+    "upgrades": false,
     "dissect": "dissect_CBM_DINO"
   },
   {
@@ -156,7 +156,7 @@
     "special_attacks": [ { "id": "bio_op_takedown", "cooldown": 20 } ],
     "description": "The shuffling corpse of a bipedal dinosaur with a round hard-looking domed head.  The body is dotted with crackling bionics, tattered feathers, and black putrid liquid and carries glowing, curved claws.",
     "special_when_hit": [ "ZAPBACK", 75 ],
-    "upgrades": {  },
+    "upgrades": false,
     "dissect": "dissect_CBM_DINO"
   },
   {
@@ -174,7 +174,7 @@
     "special_attacks": [ { "id": "bio_op_takedown", "cooldown": 20 } ],
     "description": "A massive shambling rhino-like dinosaur corpse dotted with crackling bionics with a bony crest and three wicked looking glowing horns.  Its black eyes ooze like tears.",
     "special_when_hit": [ "ZAPBACK", 75 ],
-    "upgrades": {  },
+    "upgrades": false,
     "dissect": "dissect_CBM_DINO"
   }
 ]

--- a/data/mods/DinoMod/monsters/zinosaur_upgrade.json
+++ b/data/mods/DinoMod/monsters/zinosaur_upgrade.json
@@ -16,7 +16,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -39,7 +39,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -61,7 +61,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -83,7 +83,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -376,7 +376,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -425,7 +425,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -447,7 +447,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -469,7 +469,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -491,7 +491,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -514,7 +514,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -536,7 +536,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -558,7 +558,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -580,7 +580,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -602,7 +602,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -624,7 +624,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -646,7 +646,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -800,7 +800,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -822,7 +822,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1086,7 +1086,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1108,7 +1108,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1130,7 +1130,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1152,7 +1152,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1174,7 +1174,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1196,7 +1196,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1218,7 +1218,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1240,7 +1240,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1262,7 +1262,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1284,7 +1284,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1306,7 +1306,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1328,7 +1328,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1350,7 +1350,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1372,7 +1372,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1659,7 +1659,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -1681,7 +1681,7 @@
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
     "bleed_rate": 50,
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]
@@ -2403,7 +2403,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2425,7 +2425,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2447,7 +2447,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2469,7 +2469,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2491,7 +2491,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2513,7 +2513,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2535,7 +2535,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2557,7 +2557,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2579,7 +2579,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2601,7 +2601,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2623,7 +2623,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2645,7 +2645,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2667,7 +2667,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2689,7 +2689,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2711,7 +2711,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2733,7 +2733,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2755,7 +2755,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2777,7 +2777,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2799,7 +2799,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2821,7 +2821,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2843,7 +2843,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2865,7 +2865,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2887,7 +2887,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2909,7 +2909,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2931,7 +2931,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -2953,7 +2953,7 @@
     "bleed_rate": 50,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
-    "upgrades": {  },
+    "upgrades": false,
     "categories": [ "DINOSAUR" ]
   },
   {
@@ -3346,7 +3346,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3370,7 +3370,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3394,7 +3394,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3418,7 +3418,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3442,7 +3442,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3466,7 +3466,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3498,7 +3498,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3522,7 +3522,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3562,7 +3562,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3586,7 +3586,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_nat_armored", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3610,7 +3610,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_nat_armored", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3634,7 +3634,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_nat_armored", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3658,7 +3658,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_nat_armored", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3682,7 +3682,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_nat_armored", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3706,7 +3706,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_nat_armored", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3730,7 +3730,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_nat_armored", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3754,7 +3754,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_nat_armored", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3778,7 +3778,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_nat_armored", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3802,7 +3802,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_nat_armored", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3827,7 +3827,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_nat_armored", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3851,7 +3851,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_nat_armored", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3875,7 +3875,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_nat_armored", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3899,7 +3899,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3923,7 +3923,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3947,7 +3947,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3971,7 +3971,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -3995,7 +3995,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4019,7 +4019,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4043,7 +4043,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4067,7 +4067,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4091,7 +4091,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4115,7 +4115,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4139,7 +4139,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4163,7 +4163,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4187,7 +4187,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4211,7 +4211,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4235,7 +4235,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4259,7 +4259,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4283,7 +4283,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4307,7 +4307,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4331,7 +4331,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4355,7 +4355,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4379,7 +4379,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4403,7 +4403,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4427,7 +4427,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4451,7 +4451,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4475,7 +4475,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4499,7 +4499,7 @@
     },
     "bleed_rate": 50,
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_skeleton" ],
-    "upgrades": {  },
+    "upgrades": false,
     "extend": { "flags": [ "HARDTOSHOOT" ] },
     "harvest": "mr_bones",
     "categories": [ "DINOSAUR" ],
@@ -4538,7 +4538,7 @@
     "extend": { "flags": [ "DRIPS_GASOLINE", "LOUDMOVES" ] },
     "special_attacks": [ { "id": "bite_grab", "cooldown": 30 }, [ "FLAMETHROWER", 30 ] ],
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_syn_armored" ],
-    "upgrades": {  },
+    "upgrades": false,
     "death_drops": [
       { "item": "wheel", "count": 4 },
       { "group": "supplies_spares_vehicle", "count": 10 },
@@ -4564,7 +4564,7 @@
     "extend": { "flags": [ "DRIPS_GASOLINE", "LOUDMOVES" ] },
     "special_attacks": [ { "id": "bite_grab", "cooldown": 30 }, [ "FLAMETHROWER", 30 ] ],
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_syn_armored" ],
-    "upgrades": {  },
+    "upgrades": false,
     "death_drops": [
       { "item": "wheel", "count": 4 },
       { "group": "supplies_spares_vehicle", "count": 10 },
@@ -4612,7 +4612,7 @@
       }
     ],
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_syn_armored" ],
-    "upgrades": {  },
+    "upgrades": false,
     "death_drops": [
       { "item": "mil_plate", "count": 4 },
       { "group": "helicopter", "count": 20 },
@@ -4659,7 +4659,7 @@
       }
     ],
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_syn_armored" ],
-    "upgrades": {  },
+    "upgrades": false,
     "death_drops": [
       { "item": "mil_plate", "count": 4 },
       { "group": "helicopter", "count": 20 },
@@ -4706,7 +4706,7 @@
       }
     ],
     "families": [ "prof_intro_biology", "prof_wp_zombie", "prof_wp_syn_armored" ],
-    "upgrades": {  },
+    "upgrades": false,
     "death_drops": [
       { "item": "mil_plate", "count": 4 },
       { "group": "helicopter", "count": 20 },
@@ -4728,7 +4728,7 @@
     "relative": { "melee_dice": 1, "melee_damage": -4, "armor": { "bash": 4, "cut": 6, "bullet": 5 } },
     "bleed_rate": 0,
     "special_attacks": [ [ "SMASH", 20 ] ],
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "type": "MONSTER",
@@ -4743,7 +4743,7 @@
     "relative": { "melee_dice": 1, "melee_damage": -4, "armor": { "bash": 4, "cut": 6, "bullet": 5 } },
     "bleed_rate": 0,
     "special_attacks": [ [ "SMASH", 20 ] ],
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "type": "MONSTER",
@@ -4758,7 +4758,7 @@
     "relative": { "melee_dice": 1, "melee_damage": -4, "armor": { "bash": 4, "cut": 6, "bullet": 5 } },
     "bleed_rate": 0,
     "special_attacks": [ [ "SMASH", 20 ] ],
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "type": "MONSTER",
@@ -4773,7 +4773,7 @@
     "relative": { "melee_dice": 1, "melee_damage": -4, "armor": { "bash": 4, "cut": 6, "bullet": 5 } },
     "bleed_rate": 0,
     "special_attacks": [ [ "SMASH", 20 ] ],
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "type": "MONSTER",
@@ -4788,7 +4788,7 @@
     "relative": { "melee_dice": 1, "melee_damage": -4, "armor": { "bash": 4, "cut": 6, "bullet": 5 } },
     "bleed_rate": 0,
     "special_attacks": [ [ "SMASH", 20 ] ],
-    "upgrades": {  }
+    "upgrades": false
   },
   {
     "type": "MONSTER",

--- a/data/mods/DinoMod/obsolete/monsters.json
+++ b/data/mods/DinoMod/obsolete/monsters.json
@@ -15,7 +15,7 @@
     "melee_damage": [ { "damage_type": "cut", "amount": 0 } ],
     "hp": 50,
     "description": "The raggedly flying corpse  of a feathered reptile over three feet long, with short wings and a big colorful beak.",
-    "upgrades": {  },
+    "upgrades": false,
     "armor": { "bash": 4, "cut": 4, "bullet": 1 }
   },
   {
@@ -34,7 +34,7 @@
       "vision_night": 1,
       "armor": { "bash": 4, "cut": 6, "bullet": 5 }
     },
-    "upgrades": {  },
+    "upgrades": false,
     "special_attacks": [ [ "SMASH", 30 ] ],
     "extend": { "flags": [ "GROUP_BASH", "PUSH_MON", "PUSH_VEH" ] },
     "categories": [ "DINOSAUR" ]

--- a/data/mods/Magiclysm/monsters/zombified_monsters.json
+++ b/data/mods/Magiclysm/monsters/zombified_monsters.json
@@ -256,7 +256,7 @@
     "description": "Delicate fungal stalks sprout in rows from sores covering this person's body, and their facial expression is pure agony.",
     "copy-from": "mon_feral_human_magician",
     "default_faction": "fungus",
-    "upgrades": { "half_life": 14, "into_group": "GROUP_NULL", "into": "mon_fungaloid" },
+    "upgrades": { "half_life": 14, "into": "mon_fungaloid" },
     "special_attacks": [ [ "FUNGUS", 40 ] ],
     "death_function": { "effect": { "id": "death_fungus", "hit_self": true } },
     "extend": { "flags": [ "NO_FUNG_DMG", "IMMOBILE" ] }

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1147,7 +1147,7 @@ void mtype::load( const JsonObject &jo, const std::string &src )
             }
             mandatory( up, was_loaded, "into_group", upgrade_group, string_id_reader<::MonsterGroup> {} );
             upgrade_into = mtype_id::NULL_ID();
-        } else if ( up.has_string( "into" ) ) {
+        } else if( up.has_string( "into" ) ) {
             mandatory( up, was_loaded, "into", upgrade_into, string_id_reader<::mtype> {} );
             upgrade_group = mongroup_id::NULL_ID();
         }

--- a/src/monstergenerator.cpp
+++ b/src/monstergenerator.cpp
@@ -1141,9 +1141,16 @@ void mtype::load( const JsonObject &jo, const std::string &src )
         JsonObject up = jo.get_object( "upgrades" );
         optional( up, was_loaded, "half_life", half_life, -1 );
         optional( up, was_loaded, "age_grow", age_grow, -1 );
-        optional( up, was_loaded, "into_group", upgrade_group, string_id_reader<::MonsterGroup> {},
-                  mongroup_id::NULL_ID() );
-        optional( up, was_loaded, "into", upgrade_into, string_id_reader<::mtype> {}, mtype_id::NULL_ID() );
+        if( up.has_string( "into_group" ) ) {
+            if( up.has_string( "into" ) ) {
+                jo.throw_error_at( "upgrades", "Cannot specify both into_group and into." );
+            }
+            mandatory( up, was_loaded, "into_group", upgrade_group, string_id_reader<::MonsterGroup> {} );
+            upgrade_into = mtype_id::NULL_ID();
+        } else if ( up.has_string( "into" ) ) {
+            mandatory( up, was_loaded, "into", upgrade_into, string_id_reader<::mtype> {} );
+            upgrade_group = mongroup_id::NULL_ID();
+        }
         bool multi = !!upgrade_multi_range;
         optional( up, was_loaded, "multiple_spawns", multi, false );
         if( multi && jo.has_bool( "multiple_spawns" ) ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Partially addresses #71199

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

`"into"` properly overrides inherited `"into_group"` and vice versa, an error gets thrown if both are used together
`"into_group": "GROUP_NULL"` that was used to work around this has been removed from the JSON
`"upgrades": {  }` has been replaced in JSON with the working `"upgrades": false` syntax


<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Going for a prettier but more intrusive approach

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked the error gets thrown correctly
Tested both changes

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
