### PR TITLE
2024-01-25 fix includes

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -81,6 +81,7 @@
 #if defined(__ANDROID__)
 // used by android_version() function for __system_property_get().
 #include <sys/system_properties.h>
+#include "input_context.h"
 #endif
 
 #if (defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)) && !defined(CATA_IS_ON_BSD)

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -21,6 +21,7 @@
 #include "filesystem.h"
 #include "flexbuffer_json-inl.h"
 #include "flexbuffer_json.h"
+#include "input_context.h" // IWYU pragma: keep
 #include "json.h"
 #include "json_error.h"
 #include "json_loader.h"

--- a/src/veh_utils.cpp
+++ b/src/veh_utils.cpp
@@ -10,6 +10,7 @@
 
 #include "calendar.h"
 #include "character.h"
+#include "craft_command.h"
 #include "enums.h"
 #include "game_constants.h"
 #include "input_context.h"


### PR DESCRIPTION
#### Summary
None

#### Purpose of change

Aggressive `#include` pruning in two parallel PRs broke builds

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

#### Testing

https://github.com/andrei8l/Cataclysm-DDA/actions/runs/7659856626
All builds passed, including Android

#### Additional context
Janitor reporting for duty!