### PR TITLE
[MoM] Fix Ch47 holster contain volume

### DIFF
--- a/data/mods/MindOverMatter/items/teleporter_start_items.json
+++ b/data/mods/MindOverMatter/items/teleporter_start_items.json
@@ -84,7 +84,19 @@
     "copy-from": "holster",
     "type": "ARMOR",
     "name": { "str": "Ch47 holster" },
-    "description": "A holster for the Ch47.  You could put one of the primitive local ranged weapons in here too, if you had to."
+    "description": "A holster for the Ch47.  You could put one of the primitive local ranged weapons in here too, if you had to.",
+    "pocket_data": [
+      {
+        "magazine_well": "350 ml",
+        "pocket_type": "CONTAINER",
+        "holster": true,
+        "min_item_volume": "250 ml",
+        "max_contains_volume": "1500 ml",
+        "max_contains_weight": "2 kg",
+        "max_item_length": "30 cm",
+        "moves": 50
+      }
+    ]
   },
   {
     "id": "itzcuauhtli_tunic",

--- a/data/mods/MindOverMatter/items/teleporter_start_items.json
+++ b/data/mods/MindOverMatter/items/teleporter_start_items.json
@@ -22,7 +22,7 @@
     "range": 45,
     "ammo_effects": [ "PLASMA", "PLASMA_BUBBLE", "INCENDIARY" ],
     "ammo": [ "mom_fusion_ammo" ],
-    "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "item_restriction": [ "mom_fusion_mag" ] } ],
+    "pocket_data": [ { "pocket_type": "MAGAZINE_WELL", "magazine_well": "25 ml", "item_restriction": [ "mom_fusion_mag" ] } ],
     "flags": [ "NEVER_JAMS", "NON_FOULING", "NEEDS_NO_LUBE" ]
   },
   {
@@ -45,8 +45,8 @@
     "type": "AMMO",
     "name": { "str": "Ch47 power cartridge" },
     "description": "Power cartridges for the Ch47.  You had better make every shot count, because there's no way you're finding any more of these.",
-    "weight": "20 g",
-    "volume": "192 ml",
+    "weight": "1 g",
+    "volume": "1 ml",
     "price": 160,
     "price_postapoc": 800,
     "flags": [ "IRREPLACEABLE_CONSUMABLE" ],
@@ -91,7 +91,7 @@
         "pocket_type": "CONTAINER",
         "holster": true,
         "min_item_volume": "250 ml",
-        "max_contains_volume": "1500 ml",
+        "max_contains_volume": "1000 ml",
         "max_contains_weight": "2 kg",
         "max_item_length": "30 cm",
         "moves": 50

--- a/data/mods/MindOverMatter/professions.json
+++ b/data/mods/MindOverMatter/professions.json
@@ -368,12 +368,7 @@
           { "item": "itzcuauhtli_hat" },
           { "item": "itzcuauhtli_holster" },
           { "item": "matrix_crystal_teleportation" },
-          {
-            "item": "mom_fusion_pistol",
-            "ammo-item": "mom_fusion_ammo",
-            "charges": 40,
-            "contents-item": [ "mom_fusion_mag" ]
-          },
+          { "item": "mom_fusion_pistol" },
           { "item": "mom_fusion_mag", "ammo-item": "mom_fusion_ammo", "charges": 40 }
         ]
       },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "[MoM] Fix Ch47 holster contain volume"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

I was adding duplicate magazines for the Ch47, causing weird weight issues until it was loaded, unloaded, and reloaded. Also the ammo was MUCH too heavy, causing further issues. 

Fixes #71254
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove the duplicate empty magazine the Ch47 comes with. Now the Itzcuauhtli liaison has a gun, and a magazine, and a holster that fits it all. Change the size and weight of the ammo, since it represents some kind of sci fi matrix technology plasma suspension and not actual bullets. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

It works. Gun now starts in holster and stays in holster. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
