### PR TITLE
Remove displacement field from engines

### DIFF
--- a/data/json/items/vehicle/engine.json
+++ b/data/json/items/vehicle/engine.json
@@ -49,191 +49,176 @@
     "id": "1cyl_combustion",
     "copy-from": "engine_gasoline",
     "type": "ENGINE",
-    "name": { "str": "1-cylinder engine" },
+    "name": { "str": "0.05 L 1-cylinder engine" },
     "//": "50 cc moped engine, lawnmower engine, golf cart engine",
     "description": "A 50 cc single-cylinder 4-stroke combustion engine.",
     "weight": "3750 g",
     "volume": "12 L",
     "price": 10000,
     "price_postapoc": 1000,
-    "displacement": 5,
     "faults": [ "fault_engine_starter" ]
   },
   {
     "id": "1cyl_combustion_large",
     "copy-from": "engine_gasoline",
     "type": "ENGINE",
-    "name": { "str": "large 1-cylinder engine" },
+    "name": { "str": "0.2 L large 1-cylinder engine" },
     "//": "200 cc scooter, dirt bike engine",
     "description": "A high-compression, 200 cc single-cylinder 4-stroke combustion engine.",
     "weight": "28 kg",
     "volume": "42 L",
     "price": 10000,
     "price_postapoc": 1250,
-    "displacement": 20,
     "faults": [ "fault_engine_starter" ]
   },
   {
     "id": "engine_1cyl_diesel_large",
     "copy-from": "engine_diesel",
     "type": "ENGINE",
-    "name": { "str": "large 1-cylinder diesel engine" },
+    "name": { "str": "0.2 L large 1-cylinder diesel engine" },
     "//": "200 cc scooter, dirtbike, or diesel generator",
     "description": "A high-compression, 200 cc single-cylinder 4-stroke diesel combustion engine.",
     "weight": "28 kg",
     "volume": "42 L",
     "price": 10000,
     "price_postapoc": 1250,
-    "displacement": 20,
     "faults": [ "fault_engine_starter" ]
   },
   {
     "id": "1cyl_combustion_small",
     "copy-from": "engine_gasoline",
     "type": "ENGINE",
-    "name": { "str": "small 1-cylinder engine" },
+    "name": { "str": "0.02 L small 1-cylinder engine" },
     "//": "25 cc hedge trimmer engine, bicycle motor",
     "description": "A small, 25 cc single-cylinder 2-stroke combustion engine.",
     "weight": "2200 g",
     "volume": "6 L",
     "price": 6000,
     "price_postapoc": 750,
-    "displacement": 2,
     "faults": [  ]
   },
   {
     "id": "aero_engine_light",
     "copy-from": "engine_gasoline",
     "type": "ENGINE",
-    "name": { "str": "light aero-engine" },
+    "name": { "str": "5.24 L light aero-engine" },
     "description": "An air-cooled, 4-cylinder, horizontally opposed internal combustion engine, rated for 150 horsepower.  Commonly used on light aircraft.",
     "weight": "126 kg",
     "volume": "182 L",
     "price": 80000,
-    "price_postapoc": 2000,
-    "displacement": 524
+    "price_postapoc": 2000
   },
   {
     "id": "i4_combustion",
     "copy-from": "engine_gasoline",
     "type": "ENGINE",
-    "name": { "str": "I4 engine" },
+    "name": { "str": "1.6 L I4 engine" },
     "//": "1600 cc normal car engine motor",
     "description": "A small, 1600 cc 4-cylinder combustion engine, commonly called a straight-four.",
     "weight": "120 kg",
     "volume": "164 L",
     "price": 15000,
-    "price_postapoc": 1250,
-    "displacement": 160
+    "price_postapoc": 1250
   },
   {
     "id": "i4_diesel",
     "copy-from": "engine_diesel",
     "type": "ENGINE",
-    "name": { "str": "I4 diesel engine" },
+    "name": { "str": "1.6 L I4 diesel engine" },
     "description": "A small, yet powerful 4-cylinder diesel engine, commonly called a straight-four.",
     "weight": "120 kg",
     "volume": "166 L",
     "price": 16000,
-    "price_postapoc": 1250,
-    "displacement": 160
+    "price_postapoc": 1250
   },
   {
     "id": "i6_diesel",
     "copy-from": "engine_diesel",
     "type": "ENGINE",
-    "name": { "str": "I6 diesel engine" },
+    "name": { "str": "6 L I6 diesel engine" },
     "description": "An industrial-sized 6-cylinder diesel engine, commonly called a straight-six.  About as powerful as a V6 engine but significantly larger for use in heavy equipment.",
     "weight": "580 kg",
     "volume": "500 L",
     "price": 27000,
-    "price_postapoc": 1500,
-    "displacement": 600
+    "price_postapoc": 1500
   },
   {
     "id": "v2_combustion",
     "copy-from": "engine_gasoline",
     "type": "ENGINE",
-    "name": { "str": "V2 engine" },
+    "name": { "str": "0.6 L V2 engine" },
     "//": "600 cc fast motorbike or small car motor",
     "description": "A 600 cc, 2-cylinder 4-stroke combustion engine, commonly called a V-twin.",
     "weight": "42 kg",
     "volume": "70 L",
     "price": 10000,
-    "price_postapoc": 1000,
-    "displacement": 60
+    "price_postapoc": 1000
   },
   {
     "id": "v6_combustion",
     "copy-from": "engine_gasoline",
     "type": "ENGINE",
-    "name": { "str": "V6 engine" },
+    "name": { "str": "2.8 L V6 engine" },
     "description": "A powerful 6-cylinder combustion engine.",
     "weight": "203 kg",
     "volume": "191 L",
     "price": 18000,
-    "price_postapoc": 1500,
-    "displacement": 280
+    "price_postapoc": 1500
   },
   {
     "id": "v6_diesel",
     "copy-from": "engine_diesel",
     "type": "ENGINE",
-    "name": { "str": "V6 diesel engine" },
+    "name": { "str": "2.8 L V6 diesel engine" },
     "description": "A powerful 6-cylinder diesel engine.",
     "weight": "207 kg",
     "volume": "194 L",
     "price": 20000,
-    "price_postapoc": 1500,
-    "displacement": 280
+    "price_postapoc": 1500
   },
   {
     "id": "v8_combustion",
     "copy-from": "engine_gasoline",
     "type": "ENGINE",
-    "name": { "str": "V8 engine" },
+    "name": { "str": "4.5 L V8 engine" },
     "description": "A large and very powerful 8-cylinder combustion engine.",
     "weight": "238 kg",
     "volume": "251 L",
     "price": 25000,
-    "price_postapoc": 1750,
-    "displacement": 450
+    "price_postapoc": 1750
   },
   {
     "id": "v8_diesel",
     "copy-from": "engine_diesel",
     "type": "ENGINE",
-    "name": { "str": "V8 diesel engine" },
+    "name": { "str": "4.5 L V8 diesel engine" },
     "description": "A large and very powerful 8-cylinder diesel engine.",
     "weight": "242 kg",
     "volume": "256 L",
     "price": 26500,
-    "price_postapoc": 1750,
-    "displacement": 450
+    "price_postapoc": 1750
   },
   {
     "id": "v12_combustion",
     "copy-from": "engine_gasoline",
     "type": "ENGINE",
-    "name": { "str": "V12 engine" },
+    "name": { "str": "7 L V12 engine" },
     "description": "A massive and extremely powerful 12-cylinder combustion engine, usually built into high-end sports cars.",
     "weight": "240 kg",
     "volume": "248 L",
     "price": 36000,
-    "price_postapoc": 2250,
-    "displacement": 700
+    "price_postapoc": 2250
   },
   {
     "id": "v12_diesel",
     "copy-from": "engine_diesel",
     "type": "ENGINE",
-    "name": { "str": "V12 diesel engine" },
+    "name": { "str": "7 L V12 diesel engine" },
     "description": "A massive and extremely powerful 12-cylinder diesel engine, usually built into heavy trucks.",
     "weight": "244 kg",
     "volume": "253 L",
     "price": 32000,
-    "price_postapoc": 2250,
-    "displacement": 700
+    "price_postapoc": 2250
   },
   {
     "id": "steam_watts_small",
@@ -332,39 +317,36 @@
     "id": "small_turbine_engine",
     "copy-from": "engine_gasoline",
     "type": "ENGINE",
-    "name": { "str": "1,350 HP gas turbine engine" },
+    "name": { "str": "27 L 1,350 HP gas turbine engine" },
     "description": "A gas turbine engine, usually used for military vehicles.  Known for its high rate of fuel consumption.",
     "//": "Based on AGT1500 engine.",
     "weight": "1134 kg",
     "volume": "900 L",
     "price": 96000,
-    "price_postapoc": 2500,
-    "displacement": 2700
+    "price_postapoc": 2500
   },
   {
     "id": "medium_turbine_engine",
     "copy-from": "engine_gasoline",
     "type": "ENGINE",
-    "name": { "str": "1,900 HP gas turbine engine" },
+    "name": { "str": "38 L 1,900 HP gas turbine engine" },
     "description": "A large gas turbine engine, usually used for military helicopters.  Known for its high rate of fuel consumption.",
     "//": "Based on T700 turboshaft engine. Much lighter weight than the 1,350 HP small gas turbine.  Doubled the published weight to account for a transmission.",
     "weight": "400 kg",
     "volume": "400 L",
     "price": 192000,
-    "price_postapoc": 5000,
-    "displacement": 3800
+    "price_postapoc": 5000
   },
   {
     "id": "large_turbine_engine",
     "copy-from": "engine_gasoline",
     "type": "ENGINE",
-    "name": { "str": "6,000 HP gas turbine engine" },
+    "name": { "str": "119.5 L 6,000 HP gas turbine engine" },
     "description": "A massive gas turbine engine, used to power the V-22 Osprey.  Known for its high rate of fuel consumption.",
     "//": "Based on Rolls-Royce T406.",
     "weight": "900 kg",
     "volume": "900 L",
     "price": 960000,
-    "price_postapoc": 7500,
-    "displacement": 11995
+    "price_postapoc": 7500
   }
 ]

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -3216,7 +3216,6 @@ Unless specified as optional, the following fields are mandatory for parts with 
                               // To be a fuel an item needs to be made of only one material,
                               // this material has to produce energy, *ie* have a `data_fuel` entry,
                               // and it needs to have consumable charges.
-"displacement": 280           // engine displacement, meaasured in cubic centimeters (cm3)
 ```
 
 #### The following optional fields are specific to WHEELs.

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -1625,7 +1625,6 @@ stacking_info item::stacks_with( const item &rhs, bool check_components, bool co
     tname::segment_bitset bits;
     if( type == rhs.type ) {
         bits.set( tname::segments::TYPE );
-        bits.set( tname::segments::ENGINE_DISPLACEMENT );
         bits.set( tname::segments::WHEEL_DIAMETER );
         bits.set( tname::segments::WHITEBLACKLIST, _stacks_whiteblacklist( *this, rhs ) );
     }
@@ -6234,11 +6233,6 @@ int item::get_free_mod_locations( const gunmod_location &location ) const
         }
     }
     return result;
-}
-
-int item::engine_displacement() const
-{
-    return type->engine ? type->engine->displacement : 0;
 }
 
 const std::string &item::symbol() const

--- a/src/item.h
+++ b/src/item.h
@@ -2705,10 +2705,6 @@ class item : public visitable
          *
          *@{*/
 
-        /** for combustion engines the displacement (cc) */
-        int engine_displacement() const;
-        /*@}*/
-
         /**
          * @name Bionics / CBMs
          * Functions specific to CBMs

--- a/src/item_tname.cpp
+++ b/src/item_tname.cpp
@@ -96,16 +96,6 @@ std::string durability( item const &it, unsigned int /* quantity */,
     return {};
 }
 
-std::string engine_displacement( item const &it, unsigned int /* quantity */,
-                                 segment_bitset const &/* segments */ )
-{
-    if( it.is_engine() && it.engine_displacement() > 0 ) {
-        return string_format( pgettext( "vehicle adjective", "%gL " ),
-                              it.engine_displacement() / 100.0f );
-    }
-    return {};
-}
-
 std::string wheel_diameter( item const &it, unsigned int /* quantity */,
                             segment_bitset const &/* segments */ )
 {
@@ -536,7 +526,6 @@ std::unordered_map<tname::segments, decl_f_print_segment *> const segment_map = 
     { tname::segments::OVERHEAT, overheat_symbol },
     { tname::segments::FAVORITE_PRE, pre_asterisk },
     { tname::segments::DURABILITY, durability },
-    { tname::segments::ENGINE_DISPLACEMENT, engine_displacement },
     { tname::segments::WHEEL_DIAMETER, wheel_diameter },
     { tname::segments::BURN, burn },
     { tname::segments::TYPE, label },

--- a/src/item_tname.h
+++ b/src/item_tname.h
@@ -22,7 +22,6 @@ enum class segments : std::size_t {
     OVERHEAT,
     FAVORITE_PRE,
     DURABILITY,
-    ENGINE_DISPLACEMENT,
     WHEEL_DIAMETER,
     BURN,
     WEAPON_MODS,

--- a/src/veh_interact.cpp
+++ b/src/veh_interact.cpp
@@ -2950,9 +2950,6 @@ void veh_interact::display_details( const vpart_info *part )
                         battery->capacity );
     } else {
         units::power part_power = part->power;
-        if( part_power == 0_W ) {
-            part_power = units::from_watt( item( part->base_item ).engine_displacement() );
-        }
         if( part_power != 0_W ) {
             fold_and_print( w_details, point( col_2, line + 5 ), column_width, c_white,
                             _( "Power: <color_light_gray>%+8d</color>" ), units::to_watt( part_power ) );

--- a/src/vehicle_part.cpp
+++ b/src/vehicle_part.cpp
@@ -119,9 +119,6 @@ std::string vehicle_part::name( bool with_prefix ) const
             res += " "; // aligns names when printing degrading and non-degrading parts with prefixes
         }
     }
-    if( base.engine_displacement() ) {
-        res += string_format( _( "%gL " ), base.engine_displacement() / 100.0 );
-    }
     if( base.is_wheel() ) {
         res += string_format( _( "%d\" " ), base.type->wheel->diameter );
     }

--- a/tests/item_tname_test.cpp
+++ b/tests/item_tname_test.cpp
@@ -264,21 +264,6 @@ TEST_CASE( "diamond_item", "[item][tname][diamond]" )
     CHECK( katana.tname() == "diamond katana" );
 }
 
-TEST_CASE( "engine_displacement_volume", "[item][tname][engine]" )
-{
-    item vtwin = item( "v2_combustion" );
-    item v12diesel = item( "v12_diesel" );
-    item turbine = item( "small_turbine_engine" );
-
-    REQUIRE( vtwin.engine_displacement() == 60 );
-    REQUIRE( v12diesel.engine_displacement() == 700 );
-    REQUIRE( turbine.engine_displacement() == 2700 );
-
-    CHECK( vtwin.tname() == "0.6L V2 engine" );
-    CHECK( v12diesel.tname() == "7L V12 diesel engine" );
-    CHECK( turbine.tname() == "27L 1,350 HP gas turbine engine" );
-}
-
 TEST_CASE( "wheel_diameter", "[item][tname][wheel]" )
 {
     item wheel17 = item( "wheel" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Removing the old `displacement` field from engines, which has only been used for generating the volume prefix of the engine name since #65414. 
Caught this while testing #71251.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Removing `displacement` from engines and instead adding it directly to the name.
Also added a space between the value and unit.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Keeping it in case it's still needed somewhere I didn't catch.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Started the game up and saw the changes.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
