### PR TITLE
Guilt message fixes

### DIFF
--- a/src/kill_tracker.cpp
+++ b/src/kill_tracker.cpp
@@ -58,7 +58,7 @@ int kill_tracker::guilt_kill_count( const mtype_id &mon ) const
         flag = mon_flag_GUILT_OTHERS;
     } else { // worst case scenario when no guilt flags are found
         auto noflag = kills.find( mon );
-        if ( noflag!= kills.end() ) {
+        if( noflag != kills.end() ) {
             return noflag->second;
         }
     }

--- a/src/kill_tracker.cpp
+++ b/src/kill_tracker.cpp
@@ -46,37 +46,28 @@ int kill_tracker::kill_count( const species_id &spec ) const
 
 int kill_tracker::guilt_kill_count( const mtype_id &mon ) const
 {
-    int animals = 0;
-    int children = 0;
-    int humans = 0;
-    int others = 0;
-    for( const auto &it : kills ) {
-        if( it.first->has_flag( mon_flag_GUILT_ANIMAL ) ) {
-            animals += it.second;
-        } else if( it.first->has_flag( mon_flag_GUILT_CHILD ) ) {
-            children += it.second;
-        } else if( it.first->has_flag( mon_flag_GUILT_HUMAN ) ) {
-            humans += it.second;
-        } else if( it.first->has_flag( mon_flag_GUILT_OTHERS ) ) {
-            others += it.second;
+    int count = 0;
+    mon_flag_id flag;
+    if( mon->has_flag( mon_flag_GUILT_ANIMAL ) ) {
+        flag = mon_flag_GUILT_ANIMAL;
+    } else if( mon->has_flag( mon_flag_GUILT_CHILD ) ) {
+        flag = mon_flag_GUILT_CHILD;
+    } else if( mon->has_flag( mon_flag_GUILT_HUMAN ) ) {
+        flag = mon_flag_GUILT_HUMAN;
+    } else if( mon->has_flag( mon_flag_GUILT_OTHERS ) ) {
+        flag = mon_flag_GUILT_OTHERS;
+    } else { // worst case scenario when no guilt flags are found
+        auto noflag = kills.find( mon );
+        if ( noflag!= kills.end() ) {
+            return noflag->second;
         }
     }
-
-    if( mon->has_flag( mon_flag_GUILT_ANIMAL ) ) {
-        return animals;
-    } else if( mon->has_flag( mon_flag_GUILT_CHILD ) ) {
-        return children;
-    } else if( mon->has_flag( mon_flag_GUILT_HUMAN ) ) {
-        return humans;
-    } else if( mon->has_flag( mon_flag_GUILT_OTHERS ) ) {
-        return others;
+    for( const auto &it : kills ) {
+        if( it.first->has_flag( flag ) ) {
+            count += it.second;
+        }
     }
-    // worst case scenario when no guilt flags are found
-    auto noflag = kills.find( mon );
-    if( noflag != kills.end() ) {
-        return noflag->second;
-    }
-    return 0;
+    return count;
 }
 
 int kill_tracker::monster_kill_count() const

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1516,12 +1516,13 @@ void spell_effect::guilt( const spell &sp, Creature &caster, const tripoint &tar
         const int guilt_mult = sp.get_effective_level();
 
         // different message as we kill more of the same monster
-        std::string msg = _( "You feel guilty for killing %s." ); // default guilt message
+        std::string msg;
         game_message_type msgtype = m_bad; // default guilt message type
         std::map<int, std::string> guilt_thresholds;
-        guilt_thresholds[75] = _( "You feel ashamed for killing %s." );
-        guilt_thresholds[50] = _( "You regret killing %s." );
-        guilt_thresholds[25] = _( "You feel remorse for killing %s." );
+        guilt_thresholds[ ceil( max_kills*0.25 ) ] = _( "You feel guilty for killing %s." );
+        guilt_thresholds[ ceil( max_kills*0.5 ) ] = _( "You feel remorse for killing %s." );
+        guilt_thresholds[ ceil( max_kills*0.75 ) ] = _( "You regret killing %s." );
+        guilt_thresholds[max_kills] = _( "You feel ashamed for killing %s." );
 
         Character &guy = *guilt_target;
         if( guy.has_trait( trait_PSYCHOPATH ) || guy.has_trait( trait_KILLER ) ||
@@ -1544,7 +1545,7 @@ void spell_effect::guilt( const spell &sp, Creature &caster, const tripoint &tar
             msgtype = m_neutral;
         } else {
             for( const std::pair<const int, std::string> &guilt_threshold : guilt_thresholds ) {
-                if( kill_count >= guilt_threshold.first ) {
+                if( kill_count < guilt_threshold.first ) {
                     msg = guilt_threshold.second;
                     break;
                 }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1519,9 +1519,9 @@ void spell_effect::guilt( const spell &sp, Creature &caster, const tripoint &tar
         std::string msg;
         game_message_type msgtype = m_bad; // default guilt message type
         std::map<int, std::string> guilt_thresholds;
-        guilt_thresholds[ ceil( max_kills*0.25 ) ] = _( "You feel guilty for killing %s." );
-        guilt_thresholds[ ceil( max_kills*0.5 ) ] = _( "You feel remorse for killing %s." );
-        guilt_thresholds[ ceil( max_kills*0.75 ) ] = _( "You regret killing %s." );
+        guilt_thresholds[ ceil( max_kills * 0.25 ) ] = _( "You feel guilty for killing %s." );
+        guilt_thresholds[ ceil( max_kills * 0.5 ) ] = _( "You feel remorse for killing %s." );
+        guilt_thresholds[ ceil( max_kills * 0.75 ) ] = _( "You regret killing %s." );
         guilt_thresholds[max_kills] = _( "You feel ashamed for killing %s." );
 
         Character &guy = *guilt_target;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #71269

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

The guilt_thresholds check works correctly now, before it was assuming the map was adding entries in line order rather than sorting them
guilt_thresholds multiply max_kills to make the thresholds better for max_kills != 100
Removes redundant parts of guilt_kill_count

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Allow multiple guilt flags

Considering doing the below in a future PR:
- Replacing guilt flags with an unhardcoded field or seperate spells or something
- Iterating guilt kill counters in character_kills_monster instead, would be better left until after the above field has been added so it could check against a bool rather than 4 flags tho
- Make max_kills and guilt messages depend on the guilt category


<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Checked messages appear as expected

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
