### PR TITLE
[Magiclysm] Slightly increase elf HP

### DIFF
--- a/data/mods/Magiclysm/mutations/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/fantasy_species.json
@@ -306,7 +306,8 @@
     "description": "Elves are more lithe and frail than humans, but possess an almost otherworldly grace (-1 STR, +2 DEX).",
     "category": [ "SPECIES_ELF" ],
     "threshreq": [ "THRESH_SPECIES_ELF" ],
-    "passive_mods": { "str_mod": -1, "dex_mod": 2 }
+    "passive_mods": { "str_mod": -1, "dex_mod": 2 },
+    "enchantments": [ { "condition": "ALWAYS", "values": [ { "value": "MAX_HP", "multiply": -0.12 } ] } ]
   },
   {
     "type": "mutation",

--- a/data/mods/Magiclysm/traits/fantasy_species.json
+++ b/data/mods/Magiclysm/traits/fantasy_species.json
@@ -19,7 +19,6 @@
       "LIGHTSTEP",
       "WILDWALKER",
       "ANTIJUNK",
-      "FLIMSY",
       "WEAKSTOMACH",
       "PALE",
       "DISIMMUNE",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Slightly increase elf HP"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Elves should be physically weaker than humans (-2 Constitution and all that), but -25% HP was a _significant_ disadvantage and far more of a difference than -2 Constitution would lead to. 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Remove Flimsy from elves' starting traits and attach an enchantment to the Elven Build trait reducing their HP by 12% (half the previous value). This also means they can take Flimsy or Tough at character gen and will be even weaker or not quite as strong as a human of comparable strength. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Pre-change: Baseline elf had 60 HP on all limbs
Post-change: Baseline elf had 71 HP on all limbs, still lower than the default human 84.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

It's pretty weird that picking a elf told you that you were physically "Powerful" at character creation when they started with Flimsy and -1 Strength. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
