### PR TITLE
Restore pebbles to creating sets of ten per craft.

### DIFF
--- a/data/json/items/ammo.json
+++ b/data/json/items/ammo.json
@@ -580,7 +580,6 @@
     "range": 10,
     "dispersion": 14,
     "loudness": 0,
-    "count": 1,
     "effects": [ "NEVER_MISFIRES", "NON_FOULING" ]
   },
   {

--- a/data/json/recipes/recipe_ammo.json
+++ b/data/json/recipes/recipe_ammo.json
@@ -10,6 +10,7 @@
     "autolearn": true,
     "flags": [ "BLIND_EASY" ],
     "qualities": [ { "id": "HAMMER", "level": 1 } ],
+    "result_mult": 10,
     "components": [ [ [ "rock", 1 ], [ "rock_flaking_any", 1, "LIST" ] ] ]
   },
   {


### PR DESCRIPTION
#### Summary

Bugfixes "Fix pebble crafting regression, they once again yield 10 per craft."

#### Purpose of change

Crafting pebbles went from yielding 10 per craft to 1 per craft. This looks like it was an unintentional side-effect from #71096.

#### Describe the solution

<s>JSON edit to restore `count: 10` to pebbles item.</s>

JSON edit to add `"result_mult": 10` to the pebble recipe.

#### Describe alternatives you've considered

<s>Changing the pebbles recipe would possibly (probably) be better, but I went for the shortest-route to restore previous functionality.</s>

Restoring `"count": 10` to the pebbles item, but that breaks lots of things, as mentioned in the discussions below.

#### Testing

Loaded game with patches applied. Made pebbles. Sighed with relief that I now had ample amounts of slingshot ammo again.

#### Additional context

None