### PR TITLE
Delete basement_bionic from "alt_map_key" mod

### DIFF
--- a/data/mods/alt_map_key/overmap_terrain.json
+++ b/data/mods/alt_map_key/overmap_terrain.json
@@ -2106,12 +2106,6 @@
   },
   {
     "type": "overmap_terrain",
-    "id": "basement_bionic",
-    "copy-from": "basement_bionic",
-    "sym": "b"
-  },
-  {
-    "type": "overmap_terrain",
     "id": "rock",
     "copy-from": "rock",
     "name": "solid rock",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Fix circular dependency in alt-map-key"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fix #70123 

The game throws errors about a circular dependency in the `basement_bionic` object every time you load a world.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Delete the `basement_bionic` object. As far as I can tell this has been removed from the game, because I couldn't find anything in the data folder that contains an entry with `"id": "basement_bionic"`. Since there's no other such JSON Object, the `copy-from` property would make the existing object refer to itself, resulting in a circular dependency.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Not fixing it, since I don't know enough `basement_bionic`.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Load the world - no error.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

So there is one other entry of `"basement_bionic"`, and it's in the Graphical Overmap mod here:

https://github.com/CleverRaven/Cataclysm-DDA/blob/cdc30581dc882eacf5a9bfd887bbaa0fa61a8b72/data/mods/Graphical_Overmap/go_overmap_terrain_residential.json#L17C1-L22C5?plain=1

 so I assume that would cause the game to complain about a circular dependency. However, I couldn't test it because I don't see the "Graphical Overmap" mod when creating a world??

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
