### PR TITLE
PERCENTAGE_DAMAGE spells use the right bodypart's hp

### DIFF
--- a/src/anatomy.cpp
+++ b/src/anatomy.cpp
@@ -325,14 +325,18 @@ std::vector<bodypart_id> anatomy::get_all_eligable_parts( int min_hit, int max_h
     return ret;
 }
 
-bodypart_id anatomy::select_body_part_projectile_attack( const double range_min,
-        const double range_max, const double value ) const
+bodypart_id anatomy::get_max_hitsize_bodypart() const
 {
-    // Find the body part with the biggest hitsize - we will treat this as the center of mass
-    const bodypart_id biggest_bp = *std::max_element( cached_bps.begin(), cached_bps.end(),
+    return *std::max_element( cached_bps.begin(), cached_bps.end(),
     []( const bodypart_id & lhs, const bodypart_id & rhs ) {
         return lhs->hit_size < rhs->hit_size;
     } );
+}
+
+bodypart_id anatomy::select_body_part_projectile_attack( const double range_min,
+        const double range_max, const double value ) const
+{
+    const bodypart_id biggest_bp = get_max_hitsize_bodypart();
 
     // A little wrapper telling the targeting graph how to connect and weight bodypart_ids
     struct bp_wrapper {

--- a/src/anatomy.h
+++ b/src/anatomy.h
@@ -47,6 +47,8 @@ class anatomy
                                           bool nonstandard ) const;
         std::vector<bodypart_id> get_all_eligable_parts( int min_hit, int max_hit,
                 bool can_attack_high ) const;
+        // Find the body part with the biggest hitsize - we will treat this as the center of mass for targeting
+        bodypart_id get_max_hitsize_bodypart() const;
         // Based on the value provided (which is between range_min and range_max),
         // select an appropriate body part to hit with a projectile attack
         bodypart_id select_body_part_projectile_attack( double range_min, double range_max,

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -2993,6 +2993,11 @@ std::unordered_map<std::string, std::string> &Creature::get_values()
     return values;
 }
 
+bodypart_id Creature::get_max_hitsize_bodypart() const
+{
+    return anatomy( get_all_body_parts() ).get_max_hitsize_bodypart();
+}
+
 bodypart_id Creature::select_body_part( int min_hit, int max_hit, bool can_attack_high,
                                         int hit_roll ) const
 {

--- a/src/creature.h
+++ b/src/creature.h
@@ -1312,6 +1312,8 @@ class Creature : public viewer
         // This is done this way in order to not destroy focus since `do_aim` is on a per-move basis.
         int archery_aim_counter = 0;
 
+        // Find the body part with the biggest hitsize - we will treat this as the center of mass for targeting
+        bodypart_id get_max_hitsize_bodypart() const;
         // Select a bodypart depending on the attack's hitsize/limb restrictions
         bodypart_id select_body_part( int min_hit, int max_hit, bool can_attack_high, int hit_roll ) const;
         bodypart_id select_blocking_part( bool arm, bool leg, bool nonstandard ) const;

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -567,7 +567,8 @@ static void damage_targets( const spell &sp, Creature &caster,
 
             for( damage_unit &val : atk.proj.impact.damage_units ) {
                 if( sp.has_flag( spell_flag::PERCENTAGE_DAMAGE ) ) {
-                    val.amount = cr->get_hp( cr->get_root_body_part() ) * sp.damage( caster ) / 100.0;
+                    // TODO: should target all bodyparts or at least get the value from the affected bodypart once spells can hit non max hitsize bodyparts
+                    val.amount = cr->get_hp( cr->get_max_hitsize_bodypart() ) * sp.damage( caster ) / 100.0;
                 }
                 val.amount *= damage_mitigation_multiplier;
             }

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -567,7 +567,7 @@ static void damage_targets( const spell &sp, Creature &caster,
 
             for( damage_unit &val : atk.proj.impact.damage_units ) {
                 if( sp.has_flag( spell_flag::PERCENTAGE_DAMAGE ) ) {
-                    // TODO: should target all bodyparts or at least get the value from the affected bodypart once spells can hit non max hitsize bodyparts
+                    // TODO: Change once spells don't always target get_max_hitsize_bodypart(). Should target each bodypart with it's respecive %
                     val.amount = cr->get_hp( cr->get_max_hitsize_bodypart() ) * sp.damage( caster ) / 100.0;
                 }
                 val.amount *= damage_mitigation_multiplier;


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #57875

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Uses the same function as the eventual perfectly aimed hit does to ensure it works even on non humanoid body creatures.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Just using `{ body_part_torso }`

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Tested using a lvl 20 disruption bolt with `"valid_targets": [ "self" ],`
![image](https://github.com/CleverRaven/Cataclysm-DDA/assets/45432782/900dc3fc-2c96-42df-87b4-27e940acf090)
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
