### PR TITLE
delete redundant melee gun modes, disassociate gun_mode from added bayonet damage

### DIFF
--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -221,6 +221,7 @@
     "location": "underbarrel",
     "//": "underbarrel to interfere with other stuff in the underbarrel slot on the SKS.",
     "mod_targets": [ "shotgun", "rifle" ],
+    "is_bayonet": true,
     "qualities": [ [ "CUT", 1 ], [ "COOK", 1 ], [ "BUTCHER", -18 ] ],
     "flags": [ "SLOW_WIELD", "IRREMOVABLE", "ALLOWS_REMOTE_USE" ],
     "melee_damage": { "stab": 10 }
@@ -529,6 +530,7 @@
     "gunmod_data": {
       "location": "underbarrel",
       "mod_targets": [ "shotgun", "rifle", "smg", "launcher", "crossbow" ],
+      "is_bayonet": true,
       "blacklist_mod": [ "knife_combat_army", "knife_combat", "enfield_bayonet", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
       "install_time": "5 m"
     },
@@ -641,6 +643,7 @@
     "color": "light_gray",
     "location": "underbarrel",
     "mod_targets": [ "pistol" ],
+    "is_bayonet": true,
     "min_skills": [ [ "weapon", 1 ], [ "melee", 1 ] ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 15 ] ],
     "flags": [  ],

--- a/data/json/items/gunmod/underbarrel.json
+++ b/data/json/items/gunmod/underbarrel.json
@@ -221,7 +221,6 @@
     "location": "underbarrel",
     "//": "underbarrel to interfere with other stuff in the underbarrel slot on the SKS.",
     "mod_targets": [ "shotgun", "rifle" ],
-    "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
     "qualities": [ [ "CUT", 1 ], [ "COOK", 1 ], [ "BUTCHER", -18 ] ],
     "flags": [ "SLOW_WIELD", "IRREMOVABLE", "ALLOWS_REMOTE_USE" ],
     "melee_damage": { "stab": 10 }
@@ -531,7 +530,6 @@
       "location": "underbarrel",
       "mod_targets": [ "shotgun", "rifle", "smg", "launcher", "crossbow" ],
       "blacklist_mod": [ "knife_combat_army", "knife_combat", "enfield_bayonet", "knife_combat_marine", "makeshift_bayonet", "sword_bayonet" ],
-      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
       "install_time": "5 m"
     },
     "extend": { "flags": [ "PUMP_RAIL_COMPATIBLE" ] }
@@ -645,7 +643,6 @@
     "mod_targets": [ "pistol" ],
     "min_skills": [ [ "weapon", 1 ], [ "melee", 1 ] ],
     "qualities": [ [ "CUT", 1 ], [ "BUTCHER", 15 ] ],
-    "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
     "flags": [  ],
     "melee_damage": { "stab": 6 }
   },

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -318,7 +318,6 @@
         "u_shotgun",
         "u_shotgun_mod"
       ],
-      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
       "install_time": "5 s"
     },
     "min_skills": [ [ "weapon", 2 ], [ "melee", 1 ] ],
@@ -391,7 +390,6 @@
         "u_shotgun",
         "u_shotgun_mod"
       ],
-      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
       "install_time": "5 s"
     },
     "min_skills": [ [ "weapon", 2 ], [ "melee", 1 ] ],
@@ -452,7 +450,6 @@
         "u_shotgun",
         "u_shotgun_mod"
       ],
-      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
       "install_time": "5 s"
     },
     "min_skills": [ [ "weapon", 2 ], [ "melee", 1 ] ],
@@ -1683,7 +1680,6 @@
         "u_shotgun",
         "u_shotgun_mod"
       ],
-      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
       "install_time": "5 s"
     },
     "min_skills": [ [ "weapon", 2 ], [ "melee", 2 ] ],

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -295,6 +295,7 @@
     "gunmod_data": {
       "location": "bayonet lug",
       "mod_targets": [ "pistol", "smg", "rifle", "shotgun", "launcher", "crossbow" ],
+      "is_bayonet": true,
       "blacklist_mod": [
         "crafted_suppressor",
         "filter_suppressor",
@@ -367,6 +368,7 @@
     "gunmod_data": {
       "location": "bayonet lug",
       "mod_targets": [ "pistol", "smg", "rifle", "shotgun", "launcher", "crossbow" ],
+      "is_bayonet": true,
       "blacklist_mod": [
         "crafted_suppressor",
         "filter_suppressor",
@@ -427,6 +429,7 @@
     "gunmod_data": {
       "location": "bayonet lug",
       "mod_targets": [ "pistol", "smg", "rifle", "shotgun", "launcher", "crossbow" ],
+      "is_bayonet": true,
       "blacklist_mod": [
         "crafted_suppressor",
         "filter_suppressor",
@@ -1657,6 +1660,7 @@
     "gunmod_data": {
       "location": "bayonet lug",
       "mod_targets": [ "smg", "rifle", "shotgun", "launcher", "crossbow" ],
+      "is_bayonet": true,
       "blacklist_mod": [
         "crafted_suppressor",
         "filter_suppressor",
@@ -3086,6 +3090,7 @@
     "gunmod_data": {
       "location": "bayonet lug",
       "mod_targets": [ "number4_mki" ],
+      "is_bayonet": true,
       "blacklist_mod": [
         "crafted_suppressor",
         "filter_suppressor",
@@ -3135,6 +3140,7 @@
     "gunmod_data": {
       "location": "bayonet lug",
       "mod_targets": [ "type99", "type_99_sniper" ],
+      "is_bayonet": true,
       "blacklist_mod": [
         "crafted_suppressor",
         "filter_suppressor",

--- a/data/json/items/melee/swords_and_blades.json
+++ b/data/json/items/melee/swords_and_blades.json
@@ -3109,7 +3109,6 @@
         "u_shotgun",
         "u_shotgun_mod"
       ],
-      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
       "install_time": "5 s"
     },
     "min_skills": [ [ "weapon", 2 ], [ "melee", 1 ] ],
@@ -3159,7 +3158,6 @@
         "u_shotgun",
         "u_shotgun_mod"
       ],
-      "mode_modifier": [ [ "REACH", "bayonet", 1, [ "MELEE" ] ] ],
       "install_time": "5 s"
     },
     "techniques": [ "WBLOCK_2" ],

--- a/doc/JSON_INFO.md
+++ b/doc/JSON_INFO.md
@@ -4211,6 +4211,7 @@ Gun mods can be defined like this:
 "cooling_value_multiplier": 0.5,      // Multiply gun's "cooling_value" by this number; works the same as overheat_threshold_multiplier
 "heat_per_shot_modifier":  -2,        //  Add a flat amount to gun's "heat_per_shot"; works the same as overheat_threshold_modifier
 "heat_per_shot_multiplier": 2.0,      // Multiply the gun's "heat_per_shot" by this number; works the same as overheat_threshold_multiplier
+"is_bayonet": true,     // Optional, if true, the melee damage of this item is added to the base damage of the gun. Defaults to false.
 "blacklist_slot": [ "rail", "underbarrel" ],      // prevents installation of the gunmod if the specified slot(s) are present on the gun.
 "blacklist_mod": [ "m203", "m320" ],      // prevents installation of the gunmod if the specified mods(s) are present on the gun.
 ```

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7394,7 +7394,7 @@ int item::damage_melee( const damage_type_id &dt ) const
     if( is_gun() ) {
         std::vector<int> opts = { res };
         for( const item *mod : gunmods() ) {
-            if( mod->type->gunmod->location.str() == "bayonet lug" ) {
+            if( mod->type->gunmod->location.str() == "bayonet lug" || "underbarrel" ) {
                 opts.push_back( mod->damage_melee( dt ) );
             }
         }

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7390,12 +7390,12 @@ int item::damage_melee( const damage_type_id &dt ) const
         res *= 1.3;
     }
 
-    // consider any melee gunmods
+    // consider any attached bayonets
     if( is_gun() ) {
         std::vector<int> opts = { res };
-        for( const std::pair<const gun_mode_id, gun_mode> &e : gun_all_modes() ) {
-            if( e.second.target != this && e.second.melee() ) {
-                opts.push_back( e.second.target->damage_melee( dt ) );
+        for( const item *mod : gunmods() ) {
+            if( mod->type->gunmod->location.str() == "bayonet lug" ) {
+                opts.push_back( mod->damage_melee( dt ) );
             }
         }
         return *std::max_element( opts.begin(), opts.end() );

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -7394,7 +7394,7 @@ int item::damage_melee( const damage_type_id &dt ) const
     if( is_gun() ) {
         std::vector<int> opts = { res };
         for( const item *mod : gunmods() ) {
-            if( mod->type->gunmod->location.str() == "bayonet lug" || "underbarrel" ) {
+            if( mod->type->gunmod->is_bayonet ) {
                 opts.push_back( mod->damage_melee( dt ) );
             }
         }

--- a/src/item_factory.cpp
+++ b/src/item_factory.cpp
@@ -3464,6 +3464,8 @@ void Item_factory::load( islot_gunmod &slot, const JsonObject &jo, const std::st
             slot.add_mod.emplace( gunmod_location( curr.get_string( 0 ) ), curr.get_int( 1 ) );
         }
     }
+
+    assign( jo, "is_bayonet", slot.is_bayonet );
     assign( jo, "blacklist_mod", slot.blacklist_mod );
     assign( jo, "blacklist_slot", slot.blacklist_slot );
     assign( jo, "barrel_length", slot.barrel_length );

--- a/src/itype.h
+++ b/src/itype.h
@@ -897,6 +897,9 @@ struct islot_gunmod : common_ranged_data {
     /** Additional gunmod slots to add to the gun */
     std::map<gunmod_location, int> add_mod;
 
+    // wheter the item is supposed to work as a bayonet when attached
+    bool is_bayonet = false;
+
     /** Not compatible on weapons that have this mod slot */
     std::set<gunmod_location> blacklist_slot;
 


### PR DESCRIPTION
#### Summary
Bugfixes "delete redundant melee gun modes, disassociate gun_mode from added bayonet damage"

#### Purpose of change
It was kinda annoying having a melee gun mode but have it no purpose since reach attacks were removed from bayonets. This deletes said gun mode from bayonets and fixes them to not use mode_modifier as a requirement for adding melee damage

Appearently fixes #69337
fixes #70762

#### Describe the solution
Delete mode_modifiers from bayonets in json
Add a new json field for gunmods: is_bayonet. This will make sure the gunmod is a bayonet, and add the sufficient damage if it is. It'l also come in handy in a pr I'm working on, where I intend to return the reach attacks to sufficiently long gun + bayonet combinations.

Issues to fix:
- [x] don't let bipods in "underbarrel" get added to the damage 
- [ ] ~~the current damage messages are a mix of bash and pierce, make only pierce messages come up in close combat~~ is very strictly too hardcoded, and I don't want to get my hands dirty with it.

#### Describe alternatives you've considered
Not doing this or
Return to the original way where I just checked the gunmod locations (underbarrel and bayonet lug)

#### Testing
Fixed a bayonet to an m4, it adjusted the damage correctly for it. No gun modes needed.

#### Additional context
Hey @tenmillimaster is this a good way to do this?
