### PR TITLE
Add IsDebuggerActive from Catch2

### DIFF
--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -162,7 +162,7 @@ extern "C" {
         }
     } catch( const std::exception &e ) {
         if( !isDebuggerActive() ) {
-            type = typeid(e).name();
+            type = typeid( e ).name();
             msg = e.what();
             // call here to avoid `msg = e.what()` going out of scope
             log_crash( type, msg );

--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -161,10 +161,12 @@ extern "C" {
             type = msg = "Unexpected termination";
         }
     } catch( const std::exception &e ) {
-        type = typeid( e ).name();
-        msg = e.what();
-        // call here to avoid `msg = e.what()` going out of scope
-        log_crash( type, msg );
+        if( !isDebuggerActive() ) {
+            type = typeid(e).name();
+            msg = e.what();
+            // call here to avoid `msg = e.what()` going out of scope
+            log_crash( type, msg );
+        }
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wold-style-cast"
@@ -176,7 +178,9 @@ extern "C" {
         type = "Unknown exception";
         msg = "Not derived from std::exception";
     }
-    log_crash( type, msg );
+    if( !isDebuggerActive() ) {
+        log_crash( type, msg );
+    }
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wold-style-cast"

--- a/src/crash.cpp
+++ b/src/crash.cpp
@@ -135,7 +135,9 @@ extern "C" {
             default:
                 return;
         }
-        log_crash( "Signal", msg );
+        if( !isDebuggerActive() ) {
+            log_crash( "Signal", msg );
+        }
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wold-style-cast"

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1059,23 +1059,20 @@ static constexpr int bt_cnt = 20;
 static void *bt[bt_cnt];
 #endif
 
+bool isDebuggerActive()
+{
 #if defined(_WIN32)
-// From catch.hpp: both _MSVC_VER and __MINGW32__
-bool isDebuggerActive()
-{
+    // From catch.hpp: both _MSVC_VER and __MINGW32__
     return IsDebuggerPresent() != 0;
-}
 #elif defined(__linux__)
-// From catch.hpp:
-// The standard POSIX way of detecting a debugger is to attempt to
-// ptrace() the process, but this needs to be done from a child and not
-// this process itself to still allow attaching to this process later
-// if wanted, so is rather heavy. Under Linux we have the PID of the
-// "debugger" (which doesn't need to be gdb, of course, it could also
-// be strace, for example) in /proc/$PID/status, so just get it from
-// there instead.
-bool isDebuggerActive()
-{
+    // From catch.hpp:
+    // The standard POSIX way of detecting a debugger is to attempt to
+    // ptrace() the process, but this needs to be done from a child and not
+    // this process itself to still allow attaching to this process later
+    // if wanted, so is rather heavy. Under Linux we have the PID of the
+    // "debugger" (which doesn't need to be gdb, of course, it could also
+    // be strace, for example) in /proc/$PID/status, so just get it from
+    // there instead.
     std::ifstream in( "/proc/self/status" );
     for( std::string line; std::getline( in, line ); ) {
         static const int PREFIX_LEN = 11;
@@ -1089,13 +1086,10 @@ bool isDebuggerActive()
     }
 
     return false;
-}
 #else
-bool isDebuggerActive()
-{
     return false;
-}
 #endif
+}
 
 #if !defined(_WIN32) && !defined(__ANDROID__) && !defined(LIBBACKTRACE)
 static void write_demangled_frame( std::ostream &out, const char *frame )

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -524,6 +524,8 @@ void realDebugmsg( const char *filename, const char *line, const char *funcname,
         return;
     }
 
+    // Enable the following to step in debug messages with a debugger
+#if 0
     if( isDebuggerActive() ) {
 #if defined(_WIN32)
         DebugBreak();
@@ -533,6 +535,7 @@ void realDebugmsg( const char *filename, const char *line, const char *funcname,
         return;
 #endif
     }
+#endif //
 
     // Show excessive repetition prompt once per excessive set
     bool excess_repetition = rep_folder.repeat_count == repetition_folder::repetition_threshold;

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -524,6 +524,16 @@ void realDebugmsg( const char *filename, const char *line, const char *funcname,
         return;
     }
 
+    if( isDebuggerActive() ) {
+#if defined(_WIN32)
+        DebugBreak();
+        return;
+#elif defined( __linux__ )
+        raise( SIGTRAP );
+        return;
+#endif
+    }
+
     // Show excessive repetition prompt once per excessive set
     bool excess_repetition = rep_folder.repeat_count == repetition_folder::repetition_threshold;
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1059,38 +1059,6 @@ static constexpr int bt_cnt = 20;
 static void *bt[bt_cnt];
 #endif
 
-bool isDebuggerActive()
-{
-#if defined(_WIN32)
-    // From catch.hpp: both _MSVC_VER and __MINGW32__
-    return IsDebuggerPresent() != 0;
-#elif defined(__linux__)
-    // From catch.hpp:
-    // The standard POSIX way of detecting a debugger is to attempt to
-    // ptrace() the process, but this needs to be done from a child and not
-    // this process itself to still allow attaching to this process later
-    // if wanted, so is rather heavy. Under Linux we have the PID of the
-    // "debugger" (which doesn't need to be gdb, of course, it could also
-    // be strace, for example) in /proc/$PID/status, so just get it from
-    // there instead.
-    std::ifstream in( "/proc/self/status" );
-    for( std::string line; std::getline( in, line ); ) {
-        static const int PREFIX_LEN = 11;
-        //NOLINTNEXTLINE(cata-text-style)
-        if( line.compare( 0, PREFIX_LEN, "TracerPid:\t" ) == 0 ) {
-            // We're traced if the PID is not 0 and no other PID starts
-            // with 0 digit, so it's enough to check for just a single
-            // character.
-            return line.length() > PREFIX_LEN && line[PREFIX_LEN] != '0';
-        }
-    }
-
-    return false;
-#else
-    return false;
-#endif
-}
-
 #if !defined(_WIN32) && !defined(__ANDROID__) && !defined(LIBBACKTRACE)
 static void write_demangled_frame( std::ostream &out, const char *frame )
 {
@@ -1509,6 +1477,38 @@ std::ostream &DebugLog( DebugLevel lev, DebugClass cl )
 
     static NullStream null_stream;
     return null_stream;
+}
+
+bool isDebuggerActive()
+{
+#if defined(_WIN32)
+    // From catch.hpp: both _MSVC_VER and __MINGW32__
+    return IsDebuggerPresent() != 0;
+#elif defined(__linux__)
+    // From catch.hpp:
+    // The standard POSIX way of detecting a debugger is to attempt to
+    // ptrace() the process, but this needs to be done from a child and not
+    // this process itself to still allow attaching to this process later
+    // if wanted, so is rather heavy. Under Linux we have the PID of the
+    // "debugger" (which doesn't need to be gdb, of course, it could also
+    // be strace, for example) in /proc/$PID/status, so just get it from
+    // there instead.
+    std::ifstream in( "/proc/self/status" );
+    for( std::string line; std::getline( in, line ); ) {
+        static const int PREFIX_LEN = 11;
+        //NOLINTNEXTLINE(cata-text-style)
+        if( line.compare( 0, PREFIX_LEN, "TracerPid:\t" ) == 0 ) {
+            // We're traced if the PID is not 0 and no other PID starts
+            // with 0 digit, so it's enough to check for just a single
+            // character.
+            return line.length() > PREFIX_LEN && line[PREFIX_LEN] != '0';
+        }
+    }
+
+    return false;
+#else
+    return false;
+#endif
 }
 
 std::string game_info::operating_system()

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1076,6 +1076,7 @@ bool isDebuggerActive()
     std::ifstream in( "/proc/self/status" );
     for( std::string line; std::getline( in, line ); ) {
         static const int PREFIX_LEN = 11;
+        //NOLINTNEXTLINE(cata-text-style)
         if( line.compare( 0, PREFIX_LEN, "TracerPid:\t" ) == 0 ) {
             // We're traced if the PID is not 0 and no other PID starts
             // with 0 digit, so it's enough to check for just a single

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1046,6 +1046,43 @@ static constexpr int bt_cnt = 20;
 static void *bt[bt_cnt];
 #endif
 
+#if defined(_WIN32)
+// From catch.hpp: both _MSVC_VER and __MINGW32__
+bool isDebuggerActive()
+{
+    return IsDebuggerPresent() != 0;
+}
+#elif defined(__linux__)
+// From catch.hpp:
+// The standard POSIX way of detecting a debugger is to attempt to
+// ptrace() the process, but this needs to be done from a child and not
+// this process itself to still allow attaching to this process later
+// if wanted, so is rather heavy. Under Linux we have the PID of the
+// "debugger" (which doesn't need to be gdb, of course, it could also
+// be strace, for example) in /proc/$PID/status, so just get it from
+// there instead.
+bool isDebuggerActive()
+{
+    std::ifstream in( "/proc/self/status" );
+    for( std::string line; std::getline( in, line ); ) {
+        static const int PREFIX_LEN = 11;
+        if( line.compare( 0, PREFIX_LEN, "TracerPid:\t" ) == 0 ) {
+            // We're traced if the PID is not 0 and no other PID starts
+            // with 0 digit, so it's enough to check for just a single
+            // character.
+            return line.length() > PREFIX_LEN && line[PREFIX_LEN] != '0';
+        }
+    }
+
+    return false;
+}
+#else
+bool isDebuggerActive()
+{
+    return false;
+}
+#endif
+
 #if !defined(_WIN32) && !defined(__ANDROID__) && !defined(LIBBACKTRACE)
 static void write_demangled_frame( std::ostream &out, const char *frame )
 {

--- a/src/debug.h
+++ b/src/debug.h
@@ -284,6 +284,11 @@ extern std::unordered_set<debug_filter> enabled_filters;
 std::string filter_name( debug_filter value );
 } // namespace debugmode
 
+// From catch.hpp:
+// Returns true if the current process is being debugged (either
+// running under the debugger or has a debugger attached post facto).
+bool isDebuggerActive();
+
 #if defined(BACKTRACE)
 /**
  * Write a stack backtrace to the given ostream

--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -2643,6 +2643,7 @@ static void debug_menu_game_state()
     add_msg( m_info, _( "Body Mass Index: %.0f\nBasal Metabolic Rate: %i" ), player_character.get_bmi(),
              player_character.get_bmr() );
     add_msg( m_info, _( "Player activity level: %s" ), player_character.activity_level_str() );
+    add_msg( m_info, _( "Is debugger active: %s" ), isDebuggerActive() ? _( "Yes" ) : _( "No" ) );
     g->invalidate_main_ui_adaptor();
     g->disp_NPCs();
 }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Infrastructure "Step in the debugger when crashing"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Allow BACKTRACE / LIBBACKTRACE builds to step into the debugger, if active.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Copy `IsDebuggerActive()` from the already included Catch2 project. Did not included the heavy `catch.hpp` for just two functions, copied the implementations in `debug.cpp`.
The Debug menu reports if under a debugger when getting info about the game state.
`log_crash()` and `debug_error_prompt()` are *not* called when the debugger is active. Instead, a trap is raised into the debugger.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
✅ Visual Studio 2022 debugging an MSVC build
✅ WinDbg debugging an MSYS2 UCRT64 build
✅ GNU gdb debugging a Linux build
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
