### PR TITLE
Add soldering proficiency requirements to recipes/other/parts.json

### DIFF
--- a/data/json/recipes/other/parts.json
+++ b/data/json/recipes/other/parts.json
@@ -116,6 +116,7 @@
     "decomp_learn": 1,
     "book_learn": [ [ "radio_book", 3 ], [ "manual_electronics", 1 ] ],
     "using": [ [ "soldering_standard", 4 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "circuit", 1 ] ], [ [ "e_scrap", 3 ] ], [ [ "cable", 1 ] ] ]
   },
@@ -166,6 +167,7 @@
     "time": "6 m 30 s",
     "book_learn": [ [ "manual_electronics", 1 ], [ "textbook_electronics", 2 ], [ "advanced_electronics", 2 ] ],
     "using": [ [ "soldering_standard", 3 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "amplifier", 2 ] ], [ [ "cable", 20 ] ] ]
   },
@@ -198,6 +200,7 @@
     "decomp_learn": 2,
     "book_learn": [ [ "manual_electronics", 1 ], [ "radio_book", 1 ], [ "textbook_electronics", 2 ] ],
     "using": [ [ "soldering_standard", 4 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "circuit", 2 ] ], [ [ "e_scrap", 5 ] ], [ [ "cable", 2 ] ], [ [ "amplifier", 1 ] ] ]
   },
@@ -214,6 +217,7 @@
     "decomp_learn": 3,
     "book_learn": [ [ "manual_electronics", 1 ], [ "textbook_electronics", 2 ], [ "textbook_anarch", 3 ] ],
     "using": [ [ "soldering_standard", 7 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "circuit", 3 ] ], [ [ "e_scrap", 7 ] ], [ [ "cable", 3 ] ], [ [ "amplifier", 2 ] ] ]
   },
@@ -398,6 +402,7 @@
     "decomp_learn": 3,
     "book_learn": [ [ "manual_electronics", 2 ], [ "mag_electronics", 2 ] ],
     "using": [ [ "soldering_standard", 5 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "e_scrap", 1 ] ], [ [ "scrap", 1 ] ], [ [ "cable", 2 ] ] ]
   },
@@ -415,6 +420,7 @@
     "decomp_learn": 2,
     "book_learn": [ [ "manual_electronics", 2 ], [ "mag_electronics", 2 ], [ "manual_mechanics", 2 ] ],
     "using": [ [ "soldering_standard", 5 ], [ "steel_tiny", 1 ], [ "welding_standard", 2 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SCREW_FINE", "level": 1 } ],
     "components": [ [ [ "cable", 28 ] ], [ [ "e_scrap", 3 ] ], [ [ "scrap", 1 ] ], [ [ "bearing", 4 ] ] ]
   },
@@ -432,6 +438,7 @@
     "decomp_learn": 2,
     "book_learn": [ [ "manual_electronics", 2 ], [ "mag_electronics", 2 ], [ "manual_mechanics", 2 ] ],
     "using": [ [ "soldering_standard", 5 ], [ "steel_standard", 1 ], [ "welding_standard", 2 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "HAMMER", "level": 1 }, { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "e_scrap", 15 ] ],
@@ -532,6 +539,7 @@
     "autolearn": true,
     "book_learn": [ [ "recipe_lab_elec", 5 ], [ "textbook_robots", 5 ] ],
     "using": [ [ "soldering_standard", 14 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "e_scrap", 5 ] ],
@@ -557,6 +565,7 @@
     "book_learn": [ [ "textbook_mechanics", 8 ], [ "textbook_robots", 7 ] ],
     "//": "50cm weld to graft all the extra stuff to it",
     "using": [ [ "soldering_standard", 30 ], [ "welding_standard", 50 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [
       { "id": "HAMMER", "level": 2 },
       { "id": "SAW_M", "level": 1 },
@@ -586,7 +595,7 @@
     "autolearn": true,
     "using": [ [ "soldering_standard", 40 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "proficiencies": [ { "proficiency": "prof_plasticworking" } ],
+    "proficiencies": [ { "proficiency": "prof_plasticworking" }, { "proficiency": "prof_elec_soldering" } ],
     "components": [ [ [ "e_scrap", 5 ] ], [ [ "amplifier", 1 ] ], [ [ "cable", 5 ] ], [ [ "plastic_chunk", 5 ] ] ]
   },
   {
@@ -602,6 +611,7 @@
     "reversible": true,
     "autolearn": true,
     "using": [ [ "soldering_standard", 150 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "small_lcd_screen", 10 ] ], [ [ "processor", 3 ] ], [ [ "RAM", 2 ] ], [ [ "cable", 20 ] ] ]
   },
@@ -618,7 +628,7 @@
     "book_learn": [ [ "textbook_electronics", 6 ], [ "advanced_electronics", 6 ] ],
     "using": [ [ "soldering_standard", 50 ], [ "plastic_molding", 3 ] ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
-    "proficiencies": [ { "proficiency": "prof_plasticworking" } ],
+    "proficiencies": [ { "proficiency": "prof_plasticworking" }, { "proficiency": "prof_elec_soldering" } ],
     "components": [ [ [ "lens", 4 ] ], [ [ "e_scrap", 10 ] ], [ [ "amplifier", 4 ] ], [ [ "cable", 20 ] ], [ [ "plastic_chunk", 5 ] ] ]
   },
   {
@@ -634,6 +644,7 @@
     "time": "1 h 30 m",
     "autolearn": true,
     "using": [ [ "soldering_standard", 10 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "SCREW", "level": 1 }, { "id": "SAW_M", "level": 1 } ],
     "components": [ [ [ "camera", 2 ], [ "camera_pro", 2 ], [ "smart_phone", 2 ] ], [ [ "power_supply", 1 ] ], [ [ "cable", 5 ] ] ]
   },
@@ -666,6 +677,7 @@
     "decomp_learn": 2,
     "book_learn": [ [ "mag_electronics", 2 ] ],
     "using": [ [ "soldering_standard", 6 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [ [ [ "amplifier", 1 ] ], [ [ "scrap_aluminum", 2 ] ], [ [ "cable", 4 ] ], [ [ "plastic_chunk", 1 ] ] ]
   },
@@ -677,6 +689,7 @@
     "subcategory": "CSC_ELECTRONIC_TOOLS",
     "skill_used": "electronics",
     "using": [ [ "soldering_standard", 10 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "difficulty": 2,
     "time": "10 m",
     "reversible": true,
@@ -881,6 +894,7 @@
     "decomp_learn": 4,
     "book_learn": [ [ "repeater_mod_guide", 2 ] ],
     "using": [ [ "soldering_standard", 15 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "qualities": [ { "id": "SCREW", "level": 1 } ],
     "components": [
       [ [ "processor", 1 ] ],
@@ -904,6 +918,7 @@
     "skills_required": [ "fabrication", 2 ],
     "book_learn": [ [ "advanced_electronics", 3 ], [ "textbook_electronics", 2 ] ],
     "using": [ [ "soldering_standard", 5 ] ],
+    "proficiencies": [ { "proficiency": "prof_elec_soldering" } ],
     "difficulty": 4,
     "time": "15 m",
     "reversible": true,


### PR DESCRIPTION
#### Summary

Bugfixes "Added soldering proficiency requirements to many parts recipes that were missing it."

#### Purpose of change

None of the recipes in `recipes/other/parts.json` had a proficiency requirement for electronics soldering, yet many of them used solder and soldering irons, and absolutely represented fiddly electronic soldering tasks. I've not examined any other file; this PR is an incremental improvement, not a full audit.

#### Describe the solution

Added `prof_elec_soldering` requirement to all recipes that already used soldering and for which it made sense to do so.

#### Describe alternatives you've considered

Not doing this.

#### Testing

Loaded an existing game. Browsed a number of changed recipes to ensure they now had the proficiency which they did not have before.

#### Additional context

None