### PR TITLE
Extract UI widget clauses text for translation

### DIFF
--- a/lang/string_extractor/parsers/widget.py
+++ b/lang/string_extractor/parsers/widget.py
@@ -15,3 +15,13 @@ def parse_widget(json, origin):
             comment = "Text in portion of UI widget \"{}\"".format(id)
             if "text" in phrase:
                 write_text(phrase["text"], origin, comment=comment)
+    if "default_clause" in json:
+        write_text(json["default_clause"]["text"], origin,
+                   comment="Default clause of UI widget \"{}\"".format(id))
+    if "clauses" in json:
+        for clause in json["clauses"]:
+            if "text" not in clause:
+                continue
+            write_text(clause["text"], origin,
+                       comment="Clause text \"{}\" of UI widget \"{}\""
+                       .format(clause["id"], id))


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
`clauses` and `default_clause` in `widget` JSON are not translated.

```json
{
    "id": "body_temp_template",
    "type": "widget",
    "style": "clause",
    "clauses": [
      {
        "id": "scorching",
        "text": "Scorching!", // <-
        "color": "red",
        "condition": { "math": [ "u_val('body_temp')", ">", "9500" ] }
      },
      {
        "id": "very_hot",
        "text": "Very hot!", // <-
        "color": "light_red",
        "condition": { "and": [ { "math": [ "u_val('body_temp')", "<=", "9500" ] }, { "math": [ "u_val('body_temp')", ">", "8000" ] } ] }
      }
    ]
}
```
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Update the string extractor script to pick up text in `clauses` and `default_clause` in `widget` JSON objects.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
They appears in the translation template after this patch:
```po

#. ~ Clause text "scorching" of UI widget "body_temp_template"
#: data/json/ui/body_temp.json
msgid "Scorching!"
msgstr ""

#. ~ Clause text "very_hot" of UI widget "body_temp_template"
#: data/json/ui/body_temp.json
msgid "Very hot!"
msgstr ""

#. ~ Clause text "comfortable" of UI widget "body_temp_template"
#: data/json/ui/body_temp.json
msgid "Comfortable"
msgstr ""

#. ~ Clause text "very_cold" of UI widget "body_temp_template"
#: data/json/ui/body_temp.json
msgid "Very cold!"
msgstr ""

```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
