### PR TITLE
Turn on 3D FOV by default and combine its two options into one

### DIFF
--- a/src/action.cpp
+++ b/src/action.cpp
@@ -645,6 +645,9 @@ bool can_butcher_at( const tripoint &p )
 
 bool can_move_vertical_at( const tripoint &p, int movez )
 {
+    if( p.z + movez < -OVERMAP_DEPTH || p.z + movez >= OVERMAP_HEIGHT ) {
+        return false;
+    }
     Character &player_character = get_player_character();
     map &here = get_map();
     // TODO: unify this with game::move_vertical

--- a/src/cached_options.cpp
+++ b/src/cached_options.cpp
@@ -1,6 +1,5 @@
 #include "cached_options.h"
 
-bool fov_3d;
 int fov_3d_z_range;
 bool keycode_mode;
 bool log_from_top;

--- a/src/cached_options.h
+++ b/src/cached_options.h
@@ -10,7 +10,6 @@
 // They should be updated when the corresponding option is changed (in
 // options.cpp).
 
-extern bool fov_3d;
 extern int fov_3d_z_range;
 extern bool keycode_mode;
 extern bool log_from_top;

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2829,12 +2829,14 @@ float Character::fine_detail_vision_mod( const tripoint &p ) const
     float ambient_light{};
     tripoint const check_p = p == tripoint_min ? pos() : p;
     tripoint const avatar_p = get_avatar().pos();
-    // Light might not have been calculated on the NPC's z-level
-    if( is_avatar() || check_p.z == avatar_p.z ||
-        std::abs( avatar_p.z - check_p.z ) <= fov_3d_z_range ) {
+    if( is_avatar() || check_p.z == avatar_p.z ) {
         ambient_light = std::max( 1.0f,
                                   LIGHT_AMBIENT_LIT - get_map().ambient_light_at( check_p ) + 1.0f );
     } else {
+        // light map is not calculated outside the player character's z-level
+        // even if fov_3d_z_range > 0, and building light map on multiple levels
+        // could be expensive, so make NPCs able to see things in this case to
+        // not interfere with NPC activity.
         ambient_light = 1.0f;
     }
 

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -2831,7 +2831,7 @@ float Character::fine_detail_vision_mod( const tripoint &p ) const
     tripoint const avatar_p = get_avatar().pos();
     // Light might not have been calculated on the NPC's z-level
     if( is_avatar() || check_p.z == avatar_p.z ||
-        ( fov_3d && std::abs( avatar_p.z - check_p.z ) <= fov_3d_z_range ) ) {
+        std::abs( avatar_p.z - check_p.z ) <= fov_3d_z_range ) {
         ambient_light = std::max( 1.0f,
                                   LIGHT_AMBIENT_LIT - get_map().ambient_light_at( check_p ) + 1.0f );
     } else {
@@ -11377,8 +11377,7 @@ bool Character::sees( const Creature &critter ) const
 {
     // This handles only the player/npc specific stuff (monsters don't have traits or bionics).
     const int dist = rl_dist( pos(), critter.pos() );
-    // No seeing across z-levels with experimental 3D vision disabled
-    if( !fov_3d && pos().z != critter.pos().z ) {
+    if( std::abs( pos().z - critter.pos().z ) > fov_3d_z_range ) {
         return false;
     }
     if( dist <= 3 && has_active_mutation( trait_ANTENNAE ) ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -348,7 +348,7 @@ bool Creature::sees( const Creature &critter ) const
         return true;
     }
 
-    if( !fov_3d && posz() != critter.posz() ) {
+    if( std::abs( posz() - critter.posz() ) > fov_3d_z_range ) {
         return false;
     }
 
@@ -476,7 +476,7 @@ bool Creature::sees( const Creature &critter ) const
 
 bool Creature::sees( const tripoint &t, bool is_avatar, int range_mod ) const
 {
-    if( !fov_3d && posz() != t.z ) {
+    if( std::abs( posz() - t.z ) > fov_3d_z_range ) {
         return false;
     }
 
@@ -1370,7 +1370,7 @@ bool Creature::stumble_invis( const Creature &player, const bool stumblemsg )
     if( player.has_trait( trait_DEBUG_CLOAK ) ) {
         return false;
     }
-    if( !fov_3d && posz() != player.posz() ) {
+    if( std::abs( posz() - player.posz() ) > fov_3d_z_range ) {
         return false;
     }
     if( stumblemsg ) {

--- a/src/creature.cpp
+++ b/src/creature.cpp
@@ -1370,7 +1370,7 @@ bool Creature::stumble_invis( const Creature &player, const bool stumblemsg )
     if( player.has_trait( trait_DEBUG_CLOAK ) ) {
         return false;
     }
-    if( std::abs( posz() - player.posz() ) > fov_3d_z_range ) {
+    if( this == &player || !is_adjacent( &player, true ) ) {
         return false;
     }
     if( stumblemsg ) {

--- a/src/editmap.cpp
+++ b/src/editmap.cpp
@@ -1661,7 +1661,7 @@ bool editmap::move_target( const std::string &action, int moveorigin )
     if( eget_direction( mp, action ) ) {
         target.x = limited_shift( target.x, mp.x, 0, MAPSIZE_X );
         target.y = limited_shift( target.y, mp.y, 0, MAPSIZE_Y );
-        target.z = limited_shift( target.z, mp.z, -OVERMAP_DEPTH, OVERMAP_HEIGHT + 1 );
+        target.z = limited_shift( target.z, mp.z, -OVERMAP_DEPTH, OVERMAP_HEIGHT );
         if( move_origin ) {
             origin += mp;
         }

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -7581,7 +7581,7 @@ look_around_result game::look_around(
     ctxt.set_iso( true );
     ctxt.register_directions();
     ctxt.register_action( "COORDINATE" );
-    if( change_lv ) {
+    if( change_lv && fov_3d_z_range > 0 ) {
         ctxt.register_action( "LEVEL_UP" );
         ctxt.register_action( "LEVEL_DOWN" );
     }
@@ -7615,7 +7615,7 @@ look_around_result game::look_around(
 
     const int old_levz = m.get_abs_sub().z();
     const int min_levz = std::max( old_levz - fov_3d_z_range, -OVERMAP_DEPTH );
-    const int max_levz = std::min( old_levz + fov_3d_z_range, OVERMAP_HEIGHT );
+    const int max_levz = std::min( old_levz + fov_3d_z_range, OVERMAP_HEIGHT - 1 );
 
     m.update_visibility_cache( old_levz );
     const visibility_variables &cache = m.get_visibility_variables_cache();
@@ -7755,8 +7755,8 @@ look_around_result game::look_around(
             }
         } else if( action == "LEVEL_UP" || action == "LEVEL_DOWN" ) {
             const int dz = action == "LEVEL_UP" ? 1 : -1;
-            lz = clamp( lz + dz, min_levz, max_levz - 1 );
-            center.z = clamp( center.z + dz, min_levz, max_levz - 1 );
+            lz = clamp( lz + dz, min_levz, max_levz );
+            center.z = clamp( center.z + dz, min_levz, max_levz );
 
             add_msg_debug( debugmode::DF_GAME, "levx: %d, levy: %d, levz: %d",
                            get_map().get_abs_sub().x(), get_map().get_abs_sub().y(), center.z );
@@ -11886,8 +11886,11 @@ void game::vertical_move( int movez, bool force, bool peeking )
 
     // TODO: Use u.posz() instead of m.abs_sub
     const int z_after = m.get_abs_sub().z() + movez;
-    if( z_after < -OVERMAP_DEPTH || z_after > OVERMAP_HEIGHT ) {
-        debugmsg( "Tried to move outside allowed range of z-levels" );
+    if( z_after < -OVERMAP_DEPTH ) {
+        add_msg( m_info, _( "Halfway down, the way down becomes blocked off." ) );
+        return;
+    } else if( z_after >= OVERMAP_HEIGHT ) {
+        add_msg( m_info, _( "Halfway up, the way up becomes blocked off." ) );
         return;
     }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -1201,7 +1201,7 @@ std::set<tripoint_bub_ms> map::get_moving_vehicle_targets( const Creature &z, in
         if( !v.v->is_moving() ) {
             continue;
         }
-        if( !fov_3d && v.pos.z != zpos.z() ) {
+        if( std::abs( v.pos.z - zpos.z() ) > fov_3d_z_range ) {
             continue;
         }
         if( rl_dist( zpos, tripoint_bub_ms( v.pos ) ) > max_range + 40 ) {
@@ -7234,7 +7234,8 @@ point map::sees_cache_key( const tripoint &from, const tripoint &to ) const
 bool map::sees( const tripoint &F, const tripoint &T, const int range,
                 int &bresenham_slope ) const
 {
-    if( ( range >= 0 && range < rl_dist( F, T ) ) ||
+    if( std::abs( F.z - T.z ) > fov_3d_z_range ||
+        ( range >= 0 && range < rl_dist( F, T ) ) ||
         !inbounds( T ) ) {
         bresenham_slope = 0;
         return false; // Out of range!
@@ -7247,7 +7248,7 @@ bool map::sees( const tripoint &F, const tripoint &T, const int range,
     bool visible = true;
 
     // Ugly `if` for now
-    if( !fov_3d || F.z == T.z ) {
+    if( F.z == T.z ) {
         bresenham( F.xy(), T.xy(), bresenham_slope,
         [this, &visible, &T]( const point & new_point ) {
             // Exit before checking the last square, it's still visible even if opaque.
@@ -7575,11 +7576,11 @@ void map::reachable_flood_steps( std::vector<tripoint> &reachable_pts, const tri
 bool map::clear_path( const tripoint &f, const tripoint &t, const int range,
                       const int cost_min, const int cost_max ) const
 {
-    // Ugly `if` for now
-    if( !fov_3d && f.z != t.z ) {
+    if( std::abs( f.z - t.z ) > fov_3d_z_range ) {
         return false;
     }
 
+    // Ugly `if` for now
     if( f.z == t.z ) {
         if( ( range >= 0 && range < rl_dist( f.xy(), t.xy() ) ) ||
             !inbounds( t ) ) {

--- a/src/melee.cpp
+++ b/src/melee.cpp
@@ -554,7 +554,7 @@ bool Character::melee_attack( Creature &t, bool allow_special, const matec_id &f
         add_msg_if_player( m_info, _( "You lack the substance to affect anything." ) );
         return false;
     }
-    if( !is_adjacent( &t, fov_3d ) ) {
+    if( !is_adjacent( &t, true ) ) {
         return false;
     }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2844,19 +2844,11 @@ void options_manager::add_options_debug()
        );
 
     add_empty_line();
-    add_option_group( "debug", Group( "3dfov_opts", to_translation( "3D Field Of Vision Options" ),
-                                      to_translation( "Options regarding 3D field of vision." ) ),
-    [&]( const std::string & page_id ) {
-        add( "FOV_3D", page_id, to_translation( "Experimental 3D field of vision" ),
-             to_translation( "If true and the world is in Z-level mode, the vision will extend beyond current Z-level.  If false, vision is limited to current Z-level." ),
-             false
-           );
 
-        add( "FOV_3D_Z_RANGE", page_id, to_translation( "Vertical range of 3D field of vision" ),
-             to_translation( "How many levels up and down the experimental 3D field of vision reaches and is drawn on screen.  (This many levels up, this many levels down.)  3D vision of the full height of the world can slow the game down a lot.  Seeing fewer Z-levels is faster." ),
-             0, OVERMAP_LAYERS, 4
-           );
-    } );
+    add( "FOV_3D_Z_RANGE", "debug", to_translation( "Vertical range of 3D field of vision" ),
+         to_translation( "How many levels up and down the experimental 3D field of vision reaches and is drawn on screen.  (This many levels up, this many levels down.)  3D vision of the full height of the world can slow the game down a lot.  Seeing fewer Z-levels is faster.  Setting this to 0 disables vertical vision and displays only one level below with colored blocks instead." ),
+         0, OVERMAP_LAYERS, 4
+       );
 
     add_empty_line();
 
@@ -2891,8 +2883,6 @@ void options_manager::add_options_debug()
              to_translation( "Maximum distance for auto occlusion handling.  Values above zero overwrite tileset settings." ),
              0.0, 60.0, 0.0, 0.1
            );
-
-        get_option( "FOV_3D_Z_RANGE" ).setPrerequisite( "FOV_3D" );
     } );
 }
 
@@ -4035,7 +4025,6 @@ void options_manager::update_options_cache()
     log_from_top = ::get_option<std::string>( "LOG_FLOW" ) == "new_top";
     message_ttl = ::get_option<int>( "MESSAGE_TTL" );
     message_cooldown = ::get_option<int>( "MESSAGE_COOLDOWN" );
-    fov_3d = ::get_option<bool>( "FOV_3D" );
     fov_3d_z_range = ::get_option<int>( "FOV_3D_Z_RANGE" );
     keycode_mode = ::get_option<std::string>( "SDL_KEYBOARD_MODE" ) == "keycode";
     use_pinyin_search = ::get_option<bool>( "USE_PINYIN_SEARCH" );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2846,7 +2846,11 @@ void options_manager::add_options_debug()
     add_empty_line();
 
     add( "FOV_3D_Z_RANGE", "debug", to_translation( "Vertical range of 3D field of vision" ),
-         to_translation( "How many levels up and down the experimental 3D field of vision reaches and is drawn on screen.  (This many levels up, this many levels down.)  3D vision of the full height of the world can slow the game down a lot.  Seeing fewer Z-levels is faster.  Setting this to 0 disables vertical vision and displays only one level below with colored blocks instead." ),
+         to_translation(
+             "How many levels up and down the 3D field of vision reaches.  (This many levels up, this many levels down.)  "
+             "3D vision of the full height of the world can slow the game down a lot.  Seeing fewer Z-levels is faster.  "
+             "Setting this to 0 disables vertical vision.  In tiles mode this also affects how many levels up and down are "
+             "drawn on screen, and setting this to 0 displays only one level below with colored blocks instead." ),
          0, OVERMAP_LAYERS, 4
        );
 

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -244,8 +244,6 @@ class target_ui
         // List of visible hostile targets
         std::vector<Creature *> targets;
 
-        // 'true' if map has z levels and 3D fov is on
-        bool allow_zlevel_shift = false;
         // Snap camera to cursor. Can be permanently toggled in settings
         // or temporarily in this window
         bool snap_to_target = false;
@@ -2464,7 +2462,6 @@ target_handler::trajectory target_ui::run()
 
     map &here = get_map();
     // Load settings
-    allow_zlevel_shift = get_option<bool>( "FOV_3D" );
     snap_to_target = get_option<bool>( "SNAP_TO_TARGET" );
     if( mode == TargetMode::Turrets ) {
         // Due to how cluttered the display would become, disable it by default
@@ -2756,7 +2753,7 @@ void target_ui::init_window_and_input()
     ctxt.register_action( "zoom_out" );
     ctxt.register_action( "zoom_in" );
     ctxt.register_action( "TOGGLE_MOVE_CURSOR_VIEW" );
-    if( allow_zlevel_shift ) {
+    if( fov_3d_z_range > 0 ) {
         ctxt.register_action( "LEVEL_UP" );
         ctxt.register_action( "LEVEL_DOWN" );
     }
@@ -3777,7 +3774,7 @@ void target_ui::panel_cursor_info( int &text_y )
 
     std::vector<std::string> labels;
     labels.push_back( label_range );
-    if( allow_zlevel_shift ) {
+    if( fov_3d_z_range > 0 ) {
         labels.push_back( string_format( _( "Elevation: %d" ), dst.z - src.z ) );
     }
     labels.push_back( string_format( _( "Targets: %d" ), targets.size() ) );

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -244,20 +244,6 @@ class target_ui
         // List of visible hostile targets
         std::vector<Creature *> targets;
 
-        // Snap camera to cursor. Can be permanently toggled in settings
-        // or temporarily in this window
-        bool snap_to_target = false;
-        // If true, LEVEL_UP, LEVEL_DOWN and directional keys
-        // responsible for moving cursor will shift view instead.
-        bool shifting_view = false;
-
-        // Compact layout
-        bool compact = false;
-        // Tiny layout - when extremely short on space
-        bool tiny = false;
-        // Narrow layout - to keep in theme with
-        // "compact" and "labels-narrow" sidebar styles.
-        bool narrow = false;
         // Window
         catacurses::window w_target;
         // Input context
@@ -293,6 +279,20 @@ class target_ui
         // If true, draws turret lines
         // relevant for TargetMode::Turrets
         bool draw_turret_lines = false;
+        // Snap camera to cursor. Can be permanently toggled in settings
+        // or temporarily in this window
+        bool snap_to_target = false;
+        // If true, LEVEL_UP, LEVEL_DOWN and directional keys
+        // responsible for moving cursor will shift view instead.
+        bool shifting_view = false;
+
+        // Compact layout
+        bool compact = false;
+        // Tiny layout - when extremely short on space
+        bool tiny = false;
+        // Narrow layout - to keep in theme with
+        // "compact" and "labels-narrow" sidebar styles.
+        bool narrow = false;
 
         // Create window and set up input context
         void init_window_and_input();

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -2861,7 +2861,7 @@ bool target_ui::set_cursor_pos( const tripoint &new_pos )
     map &here = get_map();
     if( new_pos != src ) {
         // On Z axis, make sure we do not exceed map boundaries
-        valid_pos.z = clamp( valid_pos.z, -OVERMAP_DEPTH, OVERMAP_HEIGHT );
+        valid_pos.z = clamp( valid_pos.z, -OVERMAP_DEPTH, OVERMAP_HEIGHT - 1 );
         // Or current view range
         valid_pos.z = clamp( valid_pos.z - src.z, -fov_3d_z_range, fov_3d_z_range ) + src.z;
 
@@ -3220,7 +3220,7 @@ void target_ui::cycle_targets( int direction )
 void target_ui::set_view_offset( const tripoint &new_offset ) const
 {
     tripoint new_( new_offset.xy(), clamp( new_offset.z, -fov_3d_z_range, fov_3d_z_range ) );
-    new_.z = clamp( new_.z + src.z, -OVERMAP_DEPTH, OVERMAP_HEIGHT ) - src.z;
+    new_.z = clamp( new_.z + src.z, -OVERMAP_DEPTH, OVERMAP_HEIGHT - 1 ) - src.z;
 
     bool changed_z = you->view_offset.z != new_.z;
     you->view_offset = new_;

--- a/tests/char_sight_test.cpp
+++ b/tests/char_sight_test.cpp
@@ -122,7 +122,6 @@ TEST_CASE( "npc_light_and_fine_detail_vision_mod", "[character][npc][sight][ligh
     CAPTURE( u_shift );
     u.setpos( u.pos() + u_shift );
     scoped_weather_override weather_clear( WEATHER_CLEAR );
-    restore_on_out_of_scope<int> restore_fov_3d_z_range( fov_3d_z_range );
 
     time_point time_dst;
     float expected_vision{};
@@ -136,20 +135,19 @@ TEST_CASE( "npc_light_and_fine_detail_vision_mod", "[character][npc][sight][ligh
         expected_vision = 7.3;
     }
 
-    fov_3d_z_range = 2;
     set_time( time_dst );
     REQUIRE( u.fine_detail_vision_mod() == expected_vision );
     SECTION( "NPC on same z-level" ) {
         n.setpos( u.pos() + tripoint_east );
         CHECK( n.fine_detail_vision_mod() == u.fine_detail_vision_mod() );
     }
-    SECTION( "NPC on a different z-level, but in 3d fov range" ) {
+    SECTION( "NPC on a different z-level" ) {
         n.setpos( u.pos() + tripoint_above );
-        CHECK( n.fine_detail_vision_mod() == u.fine_detail_vision_mod() );
-    }
-    SECTION( "NPC on a different z-level, outside of 3d fov range" ) {
-        n.setpos( u.pos() + tripoint{ 0, 0, fov_3d_z_range + 1 } );
-        CHECK( n.fine_detail_vision_mod() == Approx( 1.0 ) ); // light not calculated
+        // light map is not calculated outside the player character's z-level
+        // even if fov_3d_z_range > 0, and building light map on multiple levels
+        // could be expensive, so make NPCs able to see things in this case to
+        // not interfere with NPC activity.
+        CHECK( n.fine_detail_vision_mod() == Approx( 1.0 ) );
     }
 }
 

--- a/tests/char_sight_test.cpp
+++ b/tests/char_sight_test.cpp
@@ -122,7 +122,6 @@ TEST_CASE( "npc_light_and_fine_detail_vision_mod", "[character][npc][sight][ligh
     CAPTURE( u_shift );
     u.setpos( u.pos() + u_shift );
     scoped_weather_override weather_clear( WEATHER_CLEAR );
-    restore_on_out_of_scope<bool> restore_fov_3d( fov_3d );
     restore_on_out_of_scope<int> restore_fov_3d_z_range( fov_3d_z_range );
 
     time_point time_dst;
@@ -137,37 +136,20 @@ TEST_CASE( "npc_light_and_fine_detail_vision_mod", "[character][npc][sight][ligh
         expected_vision = 7.3;
     }
 
-    SECTION( "3d fov off" ) {
-        fov_3d = false;
-        set_time( time_dst );
-        REQUIRE( u.fine_detail_vision_mod() == expected_vision );
-        SECTION( "NPC on same z-level" ) {
-            n.setpos( u.pos() + tripoint_east );
-            CHECK( n.fine_detail_vision_mod() == u.fine_detail_vision_mod() );
-        }
-        SECTION( "NPC on a different z-level" ) {
-            n.setpos( u.pos() + tripoint_above );
-            CHECK( n.fine_detail_vision_mod() == Approx( 1.0 ) ); // light not calculated
-        }
+    fov_3d_z_range = 2;
+    set_time( time_dst );
+    REQUIRE( u.fine_detail_vision_mod() == expected_vision );
+    SECTION( "NPC on same z-level" ) {
+        n.setpos( u.pos() + tripoint_east );
+        CHECK( n.fine_detail_vision_mod() == u.fine_detail_vision_mod() );
     }
-
-    SECTION( "3d fov on" ) {
-        fov_3d = true;
-        fov_3d_z_range = 2;
-        set_time( time_dst );
-        REQUIRE( u.fine_detail_vision_mod() == expected_vision );
-        SECTION( "NPC on same z-level" ) {
-            n.setpos( u.pos() + tripoint_east );
-            CHECK( n.fine_detail_vision_mod() == u.fine_detail_vision_mod() );
-        }
-        SECTION( "NPC on a different z-level, but in 3d fov range" ) {
-            n.setpos( u.pos() + tripoint_above );
-            CHECK( n.fine_detail_vision_mod() == u.fine_detail_vision_mod() );
-        }
-        SECTION( "NPC on a different z-level, outside of 3d fov range" ) {
-            n.setpos( u.pos() + tripoint{ 0, 0, fov_3d_z_range + 1 } );
-            CHECK( n.fine_detail_vision_mod() == Approx( 1.0 ) ); // light not calculated
-        }
+    SECTION( "NPC on a different z-level, but in 3d fov range" ) {
+        n.setpos( u.pos() + tripoint_above );
+        CHECK( n.fine_detail_vision_mod() == u.fine_detail_vision_mod() );
+    }
+    SECTION( "NPC on a different z-level, outside of 3d fov range" ) {
+        n.setpos( u.pos() + tripoint{ 0, 0, fov_3d_z_range + 1 } );
+        CHECK( n.fine_detail_vision_mod() == Approx( 1.0 ) ); // light not calculated
     }
 }
 

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -27,6 +27,7 @@
 #include "ret_val.h"
 #include "submap.h"
 #include "type_id.h"
+#include "weather.h"
 
 // Remove all vehicles from the map
 void clear_vehicles( map *target )
@@ -136,6 +137,8 @@ void clear_map( int zmin, int zmax )
         clear_items( z );
     }
     here.process_items();
+    get_weather().weather_override = WEATHER_NULL;
+    get_weather().set_nextweather( calendar::turn );
 }
 
 void clear_map_and_put_player_underground()

--- a/tests/map_helpers.cpp
+++ b/tests/map_helpers.cpp
@@ -27,7 +27,6 @@
 #include "ret_val.h"
 #include "submap.h"
 #include "type_id.h"
-#include "weather.h"
 
 // Remove all vehicles from the map
 void clear_vehicles( map *target )
@@ -137,8 +136,6 @@ void clear_map( int zmin, int zmax )
         clear_items( z );
     }
     here.process_items();
-    get_weather().weather_override = WEATHER_NULL;
-    get_weather().set_nextweather( calendar::turn );
 }
 
 void clear_map_and_put_player_underground()

--- a/tests/monster_vision_test.cpp
+++ b/tests/monster_vision_test.cpp
@@ -22,9 +22,6 @@ static const time_point midday = calendar::turn_zero + 12_hours;
 
 TEST_CASE( "monsters_should_not_see_through_floors", "[vision]" )
 {
-    override_option opt( "FOV_3D", "true" );
-    restore_on_out_of_scope<bool> restore_fov_3d( fov_3d );
-    fov_3d = true;
     calendar::turn = midday;
     clear_map( -2, 1 );
     monster &upper = spawn_and_clear( { 5, 5, 0 }, true );

--- a/tests/npc_test.cpp
+++ b/tests/npc_test.cpp
@@ -97,6 +97,16 @@ static std::string get_list_of_npcs( const std::string &title )
     return npc_list.str();
 }
 
+static std::string get_list_of_monsters( const std::string &title )
+{
+    std::ostringstream mon_list;
+    mon_list << title << ":\n";
+    for( const shared_ptr_fast<monster> &m : get_creature_tracker().get_monsters_list() ) {
+        mon_list << "  " << m.get() << ": " << m->name() << '\n';
+    }
+    return mon_list.str();
+}
+
 TEST_CASE( "on_load-sane-values", "[.]" )
 {
     SECTION( "Awake for 10 minutes, gaining hunger/thirst/fatigue" ) {
@@ -547,7 +557,6 @@ TEST_CASE( "npc_can_target_player" )
     clear_map();
     clear_avatar();
     set_time_to_day();
-    g->place_player( tripoint_zero );
 
     Character &player_character = get_player_character();
     npc &hostile = spawn_npc( player_character.pos().xy() + point_south, "thug" );
@@ -556,6 +565,7 @@ TEST_CASE( "npc_can_target_player" )
     hostile.name = "Enemy NPC";
 
     INFO( get_list_of_npcs( "NPCs after spawning one" ) );
+    INFO( get_list_of_monsters( "Monsters after spawning NPC" ) );
 
     hostile.regen_ai_cache();
     REQUIRE( hostile.current_target() != nullptr );

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -14,8 +14,8 @@
 #include "iuse_actor.h"
 #include "map.h"
 #include "monster.h"
+#include "options_helpers.h"
 #include "point.h"
-#include "weather.h"
 
 static const activity_id ACT_AIM( "ACT_AIM" );
 static const activity_id ACT_BOLTCUTTING( "ACT_BOLTCUTTING" );
@@ -1763,8 +1763,7 @@ TEST_CASE( "activity_interruption_by_distractions", "[activity][interruption]" )
     clear_avatar();
     clear_map();
     set_time_to_day();
-    get_weather().weather_override = WEATHER_CLEAR;
-    get_weather().set_nextweather( calendar::turn );
+    scoped_weather_override clear_weather( WEATHER_CLEAR );
     avatar &dummy = get_avatar();
     map &m = get_map();
 

--- a/tests/player_activities_test.cpp
+++ b/tests/player_activities_test.cpp
@@ -15,6 +15,7 @@
 #include "map.h"
 #include "monster.h"
 #include "point.h"
+#include "weather.h"
 
 static const activity_id ACT_AIM( "ACT_AIM" );
 static const activity_id ACT_BOLTCUTTING( "ACT_BOLTCUTTING" );
@@ -1762,9 +1763,10 @@ TEST_CASE( "activity_interruption_by_distractions", "[activity][interruption]" )
     clear_avatar();
     clear_map();
     set_time_to_day();
+    get_weather().weather_override = WEATHER_CLEAR;
+    get_weather().set_nextweather( calendar::turn );
     avatar &dummy = get_avatar();
     map &m = get_map();
-    calendar::turn = daylight_time( calendar::turn ) + 2_hours;
 
     for( const std::function<player_activity()> &setup_activity : test_activities ) {
         player_activity activity = setup_activity();

--- a/tests/vision_test.cpp
+++ b/tests/vision_test.cpp
@@ -198,13 +198,8 @@ struct vision_test_case {
             player_character.set_mutation( trait_MYOPIC );
         }
 
-        // test both 2d and 3d cases
-        restore_on_out_of_scope<bool> restore_fov_3d( fov_3d );
-        fov_3d = GENERATE( false, true );
-
         std::stringstream section_name;
         section_name << section_prefix;
-        section_name << ( fov_3d ? "3d" : "2d" ) << "_casting__";
         section_name << t.generate_transform_combinations();
 
         // Sanity check on player placement in relation to `t`


### PR DESCRIPTION
#### Summary
Interface "Turn on 3D FOV by default and combine its two options into one"

#### Purpose of change
Closes #71185. Fixes #63276. Closes #69053. Closes #58601 since I cannot no longer reproduce it (but it may have already been fixed before this PR).

3D FOV has been working fine for a while and I finally managed to fix the unit test errors caused by turning it on, so let's do it.

The old colored blocks display of the level below can be restored by setting 'Vertical range of 3D field of vision' to 0, but I don't think it is worth supporting multiple-level vision with colored blocks display because the main reason for the colored blocks display is performance and multiple-level vision is going to affect performance anyway, and fewer options make it easier to maintain the vision code.

Here's a list of previous behaviors (from my memory, didn't bother to test so do correct me if I'm wrong) and current behaviors. Most of the previous behaviors are still supported.

|                                               | FOV_3D | FOV_3D_Z_RANGE | Behavior & comments |
|-|-|-|-|
| Before multi-level rendering | On         | 0                             | Colored blocks & no z-level vision (Still supported) |
|                                               | On         | non-zero                 | Colored blocks & z-level vision (Not supported. Multi-levels are displayed instead. If performance is a concern, reduce the z-range value or change it to 0 to re-enable colored blocks) |
|                                               | Off         | 0                             | Colored blocks & no z-level vision (Still supported) |
|                                               | Off         | non-zero                | Colored blocks & no z-level vision (Changes into multi-level display) |
| After multi-level rendering   | On         | 0                             | Colored blocks & no z-level vision (Still supported) |
|                                               | On         | non-zero                | Multi-level & z-level vision (Still supported) |
|                                               | Off         | 0                            | Colored blocks & no z-level vision (Still supported) |
|                                               | Off         | non-zero                | Multi-level & no z-level vision (Not supported. Z-level vision is always enabled for consistent information.) |
| Now                                      | On         | 0                            | Colored blocks & no z-level vision |
|                                               | On         | non-zero               | Multi-level & z-level vision |

#### Describe the solution
1. Removed the `FOV_3D` option and code for `fov_3d == false`. Unified handling of `fov_3d_z_range` in the process.
2. Fixed monster attack test by only allowing monster to stumble into the player when adjacent and properly implmenting the test for `FOV_3D` enabled.
3. Fixed the player activity interruption test failure that has been haunting us, by forcing the weather to `WEATHER_CLEAR`.
4. Fixed crash when moving or shifting view outside the z-level range.

Regarding 3; Turns out if the weather is changed due to previously run tests, the seen cache will be different. In this case the weather is `mist`, which seems to cause the player character to see through a wall column for a brief in-game second, which can also be reproduced in-game, and looks like #65205. The transparency cache also doesn't look right when the weather is `clear` in the test; z-level -1 seems to be considered to have the same transparency as air, although this problem does not happen in-game. I did not bother to fix these problems in this PR though; someone with more experience with the shadowcasting code should probably look into it.

#### Describe alternatives you've considered
Not doing this; Keep the FOV_3D option.

#### Testing
Ran the unit tests and they passed. Moved around in-game and the shadows looked reasonable. Tried to move character or cursor to z-level 10, they did not move and the game did not crash.

The filter that reproduces the player activity interruption test failure is `[vehicle], activity_interruption_by_distractions`.

#### Additional context