### PR TITLE
Change how CMake generates version files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,27 +55,18 @@ endif ()
 
 add_definitions(-DCMAKE)
 
-include(GetGitRevisionDescription)
-git_describe(GIT_VERSION --tags --always --match "[0-9A-Z]*.[0-9A-Z]*")
+# Retrieve version from git into GIT_VERSION and creates VERSION.txt
+execute_process(COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/src/version.cmake
+    ERROR_VARIABLE GIT_VERSION
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+)
+
 if (NOT "${GIT_VERSION}" MATCHES "GIT-NOTFOUND")
-    string(REPLACE "-NOTFOUND" "" GIT_VERSION ${GIT_VERSION})
-    file(WRITE ${CMAKE_SOURCE_DIR}/src/version.h
-            "// NOLINT(cata-header-guard)\n\#define VERSION \"${GIT_VERSION}\"\n")
     message(STATUS "${PROJECT_NAME} build version is: ${GIT_VERSION}")
     add_definitions(-DGIT_VERSION)
-
-    # get_git_head_revision() does not work with worktrees in Windows
-    execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-        OUTPUT_VARIABLE _sha1
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-    string(TIMESTAMP _timestamp %Y-%m-%d-%H%M)
-    file(WRITE VERSION.txt "\
-build type: ${BUILD_PRESET_NAME}\n\
-build number: ${_timestamp}\n\
-commit sha: ${_sha1}\n\
-commit url: https://github.com/CleverRaven/Cataclysm-DDA/commit/${_sha1}"
-    )
+else()
+	message(WARNING "Git binary not found. Build version will be set to NULL. Install Git package or use -DGIT_BINARY to set path to git binary.")
+	set(VERSION "NULL")
 endif ()
 
 #OS Check Placeholders. Will be used for BINDIST

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,9 @@ if (NOT "${GIT_VERSION}" MATCHES "GIT-NOTFOUND")
     message(STATUS "${PROJECT_NAME} build version is: ${GIT_VERSION}")
     add_definitions(-DGIT_VERSION)
 else()
-	message(WARNING "Git binary not found. Build version will be set to NULL. Install Git package or use -DGIT_BINARY to set path to git binary.")
-	set(VERSION "NULL")
+    message(WARNING "Git binary not found. Build version will be set to NULL. Install Git package
+    or use -DGIT_BINARY to set path to git binary.")
+    set(VERSION "NULL")
 endif ()
 
 #OS Check Placeholders. Will be used for BINDIST

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,12 +26,8 @@ add_custom_target(
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 add_custom_command(
-        OUTPUT ${CMAKE_SOURCE_DIR}/src/version.h
-        COMMAND ${CMAKE_COMMAND}
-                -D SRC=${CMAKE_SOURCE_DIR}/src/version.h.in
-                -D DST=${CMAKE_SOURCE_DIR}/src/version.h
-                -D GIT_EXECUTABLE=${GIT_EXECUTABLE}
-                -P ${CMAKE_SOURCE_DIR}/src/version.cmake
+        OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/version.h
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_SOURCE_DIR}/version.cmake
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 # Build tiles version if requested

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
-add_subdirectory(${CMAKE_SOURCE_DIR}/src/third-party)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third-party)
 
-set(MAIN_CPP ${CMAKE_SOURCE_DIR}/src/main.cpp)
-set(MESSAGES_CPP ${CMAKE_SOURCE_DIR}/src/messages.cpp)
-set(RESOURCE_RC ${CMAKE_SOURCE_DIR}/src/resource.rc)
+set(MAIN_CPP ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+set(MESSAGES_CPP ${CMAKE_CURRENT_SOURCE_DIR}/messages.cpp)
+set(RESOURCE_RC ${CMAKE_CURRENT_SOURCE_DIR}/resource.rc)
 
 if (WIN32)
     set(RSRC_RC_DEP "${CMAKE_SOURCE_DIR}/data/cataicon.ico")
@@ -13,16 +13,16 @@ if (WIN32)
             OBJECT_DEPENDS "${RSRC_RC_DEP}")
 endif ()
 
-file(GLOB CATACLYSM_DDA_SOURCES ${CMAKE_SOURCE_DIR}/src/*.cpp)
+file(GLOB CATACLYSM_DDA_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 
 list(REMOVE_ITEM CATACLYSM_DDA_SOURCES ${MAIN_CPP} ${MESSAGES_CPP})
 
-file(GLOB CATACLYSM_DDA_HEADERS ${CMAKE_SOURCE_DIR}/src/*.h)
+file(GLOB CATACLYSM_DDA_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
 
 # Get GIT version strings
 add_custom_target(
         get_version
-        DEPENDS ${CMAKE_SOURCE_DIR}/src/version.h
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/version.h
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 add_custom_command(
@@ -36,7 +36,7 @@ if (TILES)
             cataclysm-tiles-common OBJECT
             ${CATACLYSM_DDA_SOURCES}
             ${CATACLYSM_DDA_HEADERS})
-    target_include_directories(cataclysm-tiles-common INTERFACE ${CMAKE_SOURCE_DIR}/src)
+    target_include_directories(cataclysm-tiles-common INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
     target_link_libraries(cataclysm-tiles-common PUBLIC third-party)
 
@@ -150,7 +150,7 @@ if (CURSES)
     add_library(cataclysm-common OBJECT
             ${CATACLYSM_DDA_SOURCES}
             ${CATACLYSM_DDA_HEADERS})
-    target_include_directories(cataclysm-common INTERFACE ${CMAKE_SOURCE_DIR}/src)
+    target_include_directories(cataclysm-common INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
     target_link_libraries(cataclysm-common PUBLIC third-party)
 

--- a/src/version.cmake
+++ b/src/version.cmake
@@ -1,12 +1,46 @@
-IF(GIT_EXECUTABLE)
-	EXECUTE_PROCESS(
-		COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty --match "[0-9A-Z]*.[0-9A-Z]*"
-		OUTPUT_VARIABLE VERSION
-		OUTPUT_STRIP_TRAILING_WHITESPACE
-	)
-ELSE(GIT_EXECUTABLE)
-	MESSAGE(WARNING "Git binary not found. Build version will be set to NULL. Install Git package or use -DGIT_BINARY to set path to git binary.")
-	SET (VERSION "NULL")
-ENDIF(GIT_EXECUTABLE)
+list(APPEND CMAKE_MODULE_PATH 
+    ${CMAKE_SOURCE_DIR}/CMakeModules)
+include(GetGitRevisionDescription)
 
-CONFIGURE_FILE(${SRC} ${DST} @ONLY)
+git_describe(GIT_VERSION --tags --always --match "[0-9A-Z]*.[0-9A-Z]*")
+
+if(EXISTS ${GIT_EXECUTABLE})
+    execute_process(COMMAND ${GIT_EXECUTABLE} diff --quiet
+        RESULT_VARIABLE DIRTY_FLAG
+    )
+
+    if(DIRTY_FLAG)
+        string(APPEND GIT_VERSION "-dirty")
+    endif()
+endif()
+
+message(NOTICE ${GIT_VERSION})
+
+if("${GIT_VERSION}" MATCHES "GIT-NOTFOUND")
+    return()
+endif()
+
+string(REPLACE "-NOTFOUND" "" GIT_VERSION ${GIT_VERSION})
+
+file(TOUCH ${CMAKE_SOURCE_DIR}/src/version.h)
+file(READ  ${CMAKE_SOURCE_DIR}/src/version.h VERSION_H)
+string(REGEX MATCH "#define VERSION \"(.+)\"" VERSION_H "${VERSION_H}")
+
+if(NOT GIT_VERSION STREQUAL VERSION_H)
+    file(WRITE ${CMAKE_SOURCE_DIR}/src/version.h
+            "// NOLINT(cata-header-guard)\n\#define VERSION \"${GIT_VERSION}\"\n")
+endif()
+
+# get_git_head_revision() does not work with worktrees in Windows
+execute_process(COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    OUTPUT_VARIABLE _sha1
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+string(TIMESTAMP _timestamp %Y-%m-%d-%H%M)
+file(WRITE ${CMAKE_SOURCE_DIR}/VERSION.txt "\
+build type: Release\n\
+build number: ${_timestamp}\n\
+commit sha: ${_sha1}\n\
+commit url: https://github.com/CleverRaven/Cataclysm-DDA/commit/${_sha1}"
+)
+

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,1 +1,0 @@
-#define VERSION "@VERSION@"


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Build "Change how CMake generates version files"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
I've found the `version.cmake` was a duplicate of what done at configuration time.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
✅ Moved `version.h` and `VERSION.txt` generation into `version.cmake`.
✅ Only revwrite `version.h` if the version found by _git_ is different. This is how `Makefile` does it
✅ In `src/`, use `CMAKE_CURRENT_SOURCE_DIR` instead of `CMAKE_SOURCE_DIR/src` because why not
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
❌ Oddly thought that making `getVersionString()` `constexpr` would have been different then a preprocessor macro 🤦‍♂️ ...
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
✅ Visual Studio CMake preset build
✅ MSVC Command line CMake preset build
✅ Ubuntu WSL2 command line CMake preset build
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
