### PR TITLE
[Magiclysm] Allow NPCs to spawn as fantasy species

### DIFF
--- a/data/mods/Magiclysm/mutations/fantasy_species.json
+++ b/data/mods/Magiclysm/mutations/fantasy_species.json
@@ -734,7 +734,8 @@
     "description": "Your legs and feet are those of a raven, with three long talons at the front and one at the back, ending in wicked claws and preventing you from wearing shoes.  Fortunately they don't impede your movement.",
     "category": [ "SPECIES_RAVENFOLK" ],
     "extend": { "prereqs": [ "RAVEN_BONES" ] },
-    "threshreq": [ "THRESH_SPECIES_RAVENFOLK" ]
+    "threshreq": [ "THRESH_SPECIES_RAVENFOLK" ],
+    "flags": [ "TOUGH_FEET" ]
   },
   {
     "type": "mutation",

--- a/data/mods/Magiclysm/npc/trait_groups.json
+++ b/data/mods/Magiclysm/npc/trait_groups.json
@@ -135,5 +135,145 @@
       { "trait": "LARGE_OK_DRAGON", "prob": 50 },
       { "trait": "DRAGON_BREATH_BLACK", "prob": 50 }
     ]
+  },
+  {
+    "type": "trait_group",
+    "id": "NPC_starting_traits",
+    "//": "50% chance of an NPC to be an elf, dwarf, lizardfolk, etc.  It's a magical world.",
+    "subtype": "collection",
+    "traits": [ { "group": "trait_group_fantasy_species", "prob": 50 } ]
+  },
+  {
+    "//": "This group picks out one of the traits, leading to a 1% chance for an NPC to be a psion.",
+    "type": "trait_group",
+    "id": "trait_group_fantasy_species",
+    "subtype": "distribution",
+    "traits": [
+      { "group": "trait_group_elf_npc", "prob": 2 },
+      { "group": "trait_group_dwarf_npc", "prob": 3 },
+      { "group": "trait_group_goblin_npc", "prob": 4 },
+      { "group": "trait_group_lizardfolk_npc", "prob": 1 },
+      { "group": "trait_group_ravenfolk_npc", "prob": 3 }
+    ]
+  },
+  {
+    "type": "trait_group",
+    "id": "trait_group_elf_npc",
+    "subtype": "collection",
+    "traits": [
+      { "trait": "THRESH_SPECIES_ELF" },
+      { "trait": "ANIMALEMPATH2" },
+      { "trait": "ELVEN_BUILD" },
+      { "trait": "ELFA_NV" },
+      { "trait": "ELVEN_BEAUTY" },
+      { "trait": "ELVEN_SLEEP" },
+      { "trait": "ELFA_EARS" },
+      { "trait": "ELVEN_HEARING" },
+      { "trait": "LIGHTSTEP" },
+      { "trait": "WILDWALKER" },
+      { "trait": "ANTIJUNK" },
+      { "trait": "WEAKSTOMACH" },
+      { "trait": "PALE" },
+      { "trait": "DISIMMUNE" },
+      { "trait": "PICKYEATER" }
+    ]
+  },
+  {
+    "type": "trait_group",
+    "id": "trait_group_dwarf_npc",
+    "subtype": "collection",
+    "traits": [
+      { "trait": "THRESH_SPECIES_DWARF" },
+      { "trait": "DARKSIGHT" },
+      { "trait": "NIGHTVISION2" },
+      { "trait": "DWARVEN_BUILD" },
+      { "trait": "PAINRESIST" },
+      { "trait": "INFRESIST" },
+      { "trait": "DISRESISTANT" },
+      { "trait": "BORN_ARTISAN" },
+      { "trait": "ALCMET" },
+      { "trait": "TOLERANCE" },
+      { "trait": "GOODCARDIO" },
+      { "trait": "DENSE_BONES" },
+      { "trait": "TUNNEL_FIGHTER" },
+      { "trait": "TROGLO" },
+      { "trait": "HIRSUTE" },
+      { "trait": "GOURMAND" },
+      { "trait": "SMELLY" },
+      { "trait": "HEAVYSLEEPER2" }
+    ]
+  },
+  {
+    "type": "trait_group",
+    "id": "trait_group_goblin_npc",
+    "subtype": "collection",
+    "traits": [
+      { "trait": "THRESH_SPECIES_GOBLIN" },
+      { "trait": "DARKSIGHT" },
+      { "trait": "GOBLIN_BUILD" },
+      { "trait": "GOBLIN_TEETH" },
+      { "trait": "NIGHTVISION3" },
+      { "trait": "SAPROVORE" },
+      { "trait": "SNOUT" },
+      { "trait": "NAILS" },
+      { "trait": "THICKSKIN" },
+      { "trait": "PAINREC2" },
+      { "trait": "GOODCARDIO" },
+      { "trait": "EATPOISON" },
+      { "trait": "TUNNEL_FIGHTER" },
+      { "trait": "NOCTURNAL" },
+      { "trait": "NOCTURNAL_DAY" },
+      { "trait": "TROGLO2" },
+      { "trait": "MOODSWINGS" }
+    ]
+  },
+  {
+    "type": "trait_group",
+    "id": "trait_group_lizardfolk_npc",
+    "subtype": "collection",
+    "traits": [
+      { "trait": "THRESH_SPECIES_LIZARDFOLK" },
+      { "trait": "LIZARDFOLK_BUILD" },
+      { "trait": "SCALES" },
+      { "trait": "MEMBRANE" },
+      { "trait": "COLDBLOOD4_LIZ" },
+      { "trait": "FORKED_TONGUE" },
+      { "trait": "HISS" },
+      { "trait": "GILLS" },
+      { "trait": "ANTIWHEAT" },
+      { "trait": "ANTIJUNK" },
+      { "trait": "TAIL_THICK" },
+      { "trait": "RESISTWARM" },
+      { "trait": "LIZ_EYE" },
+      { "trait": "REGEN_LIZ" },
+      { "trait": "MUZZLE_LONG" },
+      { "trait": "WEBBED_LIZ_FEET" },
+      { "trait": "TALONS" },
+      { "trait": "SLIT_NOSTRILS" },
+      { "trait": "PRED_LIZ" }
+    ]
+  },
+  {
+    "type": "trait_group",
+    "id": "trait_group_ravenfolk_npc",
+    "subtype": "collection",
+    "traits": [
+      { "trait": "THRESH_SPECIES_RAVENFOLK" },
+      { "trait": "RAVENFOLK_BUILD" },
+      { "trait": "WINGS_BIRD" },
+      { "trait": "DOWN" },
+      { "trait": "BEAK_RAVEN" },
+      { "trait": "RAVENFOLK_LEGS" },
+      { "trait": "PER_UP_3" },
+      { "trait": "FLEET" },
+      { "trait": "FEATHERS" },
+      { "trait": "GOODMEMORY" },
+      { "trait": "EAGLEEYED" },
+      { "trait": "TALONS" },
+      { "trait": "LIGHT_BONES" },
+      { "trait": "RAVEN_BONES" },
+      { "trait": "NOMAD" },
+      { "trait": "HOARDER" }
+    ]
   }
 ]

--- a/data/mods/Magiclysm/npc/trait_groups.json
+++ b/data/mods/Magiclysm/npc/trait_groups.json
@@ -144,7 +144,6 @@
     "traits": [ { "group": "trait_group_fantasy_species", "prob": 50 } ]
   },
   {
-    "//": "This group picks out one of the traits, leading to a 1% chance for an NPC to be a psion.",
     "type": "trait_group",
     "id": "trait_group_fantasy_species",
     "subtype": "distribution",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Allow NPCs to spawn as fantasy species"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Not all of those elves and ravenfolk went feral.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Allow NPCs to spawn as the various fantasy species the player can start as, done by extending NPC_starting_traits. I gave it a 50% chance, since Magiclysm is supposed to be a world with dragons and elves and magic for all of recorded history but, as with feral ratios, I have a very hard time thinking of how a world where humans were _outnumbered_ by elves and goblins and so on would lead to a world with Syracuse, New York, and where the Vietnam War still happened.

I set it up so that goblins are the most common, followed by ravenfolk and dwarves, followed by elves, followed by lizardfolk, just because it seemed reasonable.

I also added the TOUGH_FEET flag to Ravenfolk's leg trait, since they shouldn't need shoes.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Making up dozens of NPC classes so that each fantasy species has good coverage. There should definitely still be NPC classes for the various species, to use unique background stories or traits, but for Joniel Smitharien the elf, who lived in a 3-bedroom with roommates and worked down at the coffee shop before the Cataclysm, maybe that doesn't matter so much. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Spawned a bunch of NPCs, some were ravenfolk, elves, etc. 
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

Apparently NPC starting stored calories is not dependent on whatever SIZE flag they have, so you're going to meet some rotund dwarves and absolutely spherical goblins.

Looking forward to the first person who finds Urist McPrudent the dwarf. 
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
