### PR TITLE
Extract trap memorial and trigger messages for translation

### DIFF
--- a/lang/string_extractor/parsers/trap.py
+++ b/lang/string_extractor/parsers/trap.py
@@ -2,8 +2,25 @@ from ..write_text import write_text
 
 
 def parse_trap(json, origin):
-    write_text(json["name"], origin, comment="Name of a trap")
+    name = json["name"]
+    write_text(name, origin, comment="Name of a trap")
+
     if "vehicle_data" in json and "sound" in json["vehicle_data"]:
         write_text(json["vehicle_data"]["sound"], origin,
                    comment="Trap-vehicle collision message for trap '{}'"
-                   .format(json["name"]))
+                   .format(name))
+
+    for key in ["memorial_male", "memorial_female"]:
+        if key in json:
+            write_text(json[key], origin,
+                       comment="Memorial message of trap \"{}\"".format(name))
+
+    if "trigger_message_u" in json:
+        write_text(json["trigger_message_u"], origin,
+                   comment="Message when player triggers trap \"{}\""
+                   .format(name))
+
+    if "trigger_message_npc" in json:
+        write_text(json["trigger_message_npc"], origin,
+                   comment="Message when NPC triggers trap \"{}\""
+                   .format(name))


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
`memorial_male`, `memorial_female`, `trigger_message_u` and `trigger_message_npc` are not extracted for translation in `trap` JSON definition:
```json
{
    "//": "We're always going to need a 'nothing here' tile, we currently use traps for this.",
    "type": "trap",
    "id": "tr_ledge",
    "name": "ledge",
    "color": "i_cyan",
    "memorial_male": { "ctxt": "memorial_male", "str": "Fell down a ledge." },
    "memorial_female": { "ctxt": "memorial_female", "str": "Fell down a ledge." },
    "symbol": " ",
    "visibility": 0,
    "avoidance": 99999,
    "difficulty": 99,
    "action": "ledge",
    "vehicle_data": { "is_falling": true },
    "trigger_message_u": "You fell down a ledge!",
    "trigger_message_npc": "<npcname> fell down a ledge!"
  }
```
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Update string extractor script.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
See new text appear in the generated translation template after the patch:
```po
#. ~ Memorial message of trap "ledge"
#: data/core/traps.json
msgctxt "memorial_male"
msgid "Fell down a ledge."
msgstr ""

#. ~ Memorial message of trap "ledge"
#: data/core/traps.json
msgctxt "memorial_female"
msgid "Fell down a ledge."
msgstr ""

#. ~ Message when player triggers trap "ledge"
#: data/core/traps.json
msgid "You fell down a ledge!"
msgstr ""

#. ~ Message when NPC triggers trap "ledge"
#: data/core/traps.json
msgid "<npcname> fell down a ledge!"
msgstr ""
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
