### PR TITLE
Fix #71315 Add ereader power consumption to read_activity_actor

### DIFF
--- a/src/activity_actor.cpp
+++ b/src/activity_actor.cpp
@@ -1776,6 +1776,11 @@ void read_activity_actor::start( player_activity &act, Character &who )
     add_msg_debug( debugmode::DF_ACT_READ, "reading time = %s",
                    to_string_writable( time_duration::from_moves( moves_total ) ) );
 
+    // starting the activity should cost a charge to boot up the ebook app
+    if( using_ereader ) {
+        ereader->ammo_consume( ereader->ammo_required(), who.pos(), &who );
+    }
+
     act.moves_total = moves_total;
     act.moves_left = moves_total;
 }
@@ -1814,7 +1819,9 @@ void read_activity_actor::do_turn( player_activity &act, Character &who )
             _( "<npcname> no longer has the e-book!" ) );
         who.cancel_activity();
         return;
-    } else if( using_ereader && !ereader->ammo_sufficient( &who ) ) {
+    }
+
+    if( using_ereader && !ereader->ammo_sufficient( &who ) ) {
         add_msg_if_player_sees(
             who,
             _( "%1$s %2$s ran out of batteries." ),
@@ -1822,6 +1829,17 @@ void read_activity_actor::do_turn( player_activity &act, Character &who )
             item::nname( ereader->typeId() ) );
         who.cancel_activity();
         return;
+    }
+
+    if( using_ereader && calendar::once_every( 5_minutes ) ) {
+        /** Expected battery life while reading with common ereaders:
+                integrated_ar       - implant                                         = potentially infinite
+                ar_glasses_advanced - max 300 charges from disposable light battery   = 25 hours of reading
+                eink_tablet_pc      - max 300 charges from disposable light battery   = 25 hours of reading
+                laptop              - max 1200 charges from disposable medium battery = 100 hours of reading
+                smart_phone         - 120 UPS charges                                 = 10 hours of reading
+        */
+        ereader->ammo_consume( ereader->ammo_required(), who.pos(), &who );
     }
 }
 

--- a/tests/reading_test.cpp
+++ b/tests/reading_test.cpp
@@ -503,18 +503,27 @@ TEST_CASE( "reading_a_book_with_an_ebook_reader", "[reading][book][ereader]" )
             read_activity_actor actor( dummy.time_to_read( *booklc, dummy ), booklc, ereader, true );
             dummy.activity = player_activity( actor );
 
+            REQUIRE( ereader->ammo_remaining() == 100 );
+
             dummy.activity.start_or_resume( dummy, false );
             REQUIRE( dummy.activity.id() == ACT_READ );
+
+            CHECK( ereader->ammo_remaining() == 99 );
+
             dummy.activity.do_turn( dummy );
 
             CHECK( dummy.activity.id() == ACT_READ );
 
-            AND_THEN( "ereader runs out of battery" ) {
-                ereader->ammo_consume( 100, dummy.pos(), &dummy );
-                dummy.activity.do_turn( dummy );
+            AND_THEN( "ereader has spent a charge while reading" ) {
+                CHECK( ereader->ammo_remaining() == 98 );
 
-                THEN( "reading stops" ) {
-                    CHECK( dummy.activity.id() != ACT_READ );
+                AND_THEN( "ereader runs out of battery" ) {
+                    ereader->ammo_consume( ereader->ammo_remaining(), dummy.pos(), &dummy );
+                    dummy.activity.do_turn( dummy );
+
+                    THEN( "reading stops" ) {
+                        CHECK( dummy.activity.id() != ACT_READ );
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Features "Add ereader power consumption to read_activity_actor"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes #71315 

Currently EBOOKREAD capable items can be used indefinitely in a naturally bright area to read ebooks stored in the devices.

Power consumption to provide lighting (eink backlight or smartphone flashlight) is separate at code starting from https://github.com/CleverRaven/Cataclysm-DDA/blob/47cebfe5c1667d9c810875f3410e047e99ea35bb/src/iuse.cpp#L8780.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Consumption in PR is simulated for just keeping the screen active while reading. Based on expectation that a smart_phone should be able to keep the screen on for roughly 10 hours, following values were used as baseline:

| Item  | Max charges available | Battery lifetime without using the light-providing features of the item |
| ------------- | ------------- | ------------- |
| integrated_ar | implant | potentially infinite |
| ar_glasses_advanced | max 300 charges from disposable light battery | 25 hours of reading |
| eink_tablet_pc | max 300 charges from disposable light battery | 25 hours of reading |
| laptop | max 1200 charges from disposable medium battery | 100 hours of reading |
| smart_phone | 120 UPS charges | 10 hours of reading |

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

Implement feature to allow activities to impose temporary `power_draw` or other property changes on related items, to allow more combinations than the `smart_phone_on` type variants that are now hard-coded as transformations. But this way the PR is a two-liner.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Looks OK.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
