### PR TITLE
Adds New Quiver(s)

### DIFF
--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -455,6 +455,33 @@
     "melee_damage": { "bash": 2 }
   },
   {
+    "id": "pipe_quiver",
+    "type": "ARMOR",
+    "name": { "str": "pipe quiver" },
+    "description": "A makeshift quiver fashioned from a pipe, worn at the waist. Heavier and thinner than a typical quiver, it can hold 15 arrows or bolts. Use insert to store arrows or bolts.",
+    "weight": "800 g",
+    "volume": "370 ml",
+    "price": 6500,
+    "price_postapoc": 500,
+    "material": [ "steel" ],
+    "symbol": "[",
+    "looks_like": "quiver",
+    "color": "dark_gray",
+    "sided": true,
+    "material_thickness": 1.5,
+    "pocket_data": [ { "ammo_restriction": { "arrow": 15, "bolt": 15 }, "moves": 20 } ],
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
+    "armor": [
+      {
+        "encumbrance": 10,
+        "coverage": 25,
+        "covers": [ "leg_l", "leg_r" ],
+        "specifically_covers": [ "leg_upper_l", "leg_upper_r" ]
+      }
+    ],
+    "melee_damage": { "bash": 10 }
+  },
+  {
     "id": "quiver_large",
     "type": "ARMOR",
     "name": { "str": "large quiver" },

--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -536,14 +536,7 @@
     "material_thickness": 1.5,
     "pocket_data": [ { "ammo_restriction": { "arrow": 30, "bolt": 30 }, "moves": 30 } ],
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
-    "armor": [
-      {
-        "encumbrance": 14,
-        "coverage": 30,
-        "covers": [ "torso" ],
-        "specifically_covers": [ "torso_hanging_back" ]
-      }
-    ],
+    "armor": [ { "encumbrance": 14, "coverage": 30, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ],
     "melee_damage": { "bash": 12 }
   },
   {

--- a/data/json/items/armor/ammo_pouch.json
+++ b/data/json/items/armor/ammo_pouch.json
@@ -458,7 +458,7 @@
     "id": "pipe_quiver",
     "type": "ARMOR",
     "name": { "str": "pipe quiver" },
-    "description": "A makeshift quiver fashioned from a pipe, worn at the waist. Heavier and thinner than a typical quiver, it can hold 15 arrows or bolts. Use insert to store arrows or bolts.",
+    "description": "A makeshift quiver fashioned from a pipe, worn at the waist.  Heavier and thinner than a typical quiver, it can only hold 10 arrows or bolts.  Use insert to store arrows or bolts.",
     "weight": "800 g",
     "volume": "370 ml",
     "price": 6500,
@@ -469,7 +469,7 @@
     "color": "dark_gray",
     "sided": true,
     "material_thickness": 1.5,
-    "pocket_data": [ { "ammo_restriction": { "arrow": 15, "bolt": 15 }, "moves": 20 } ],
+    "pocket_data": [ { "ammo_restriction": { "arrow": 10, "bolt": 10 }, "moves": 20 } ],
     "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
     "armor": [
       {
@@ -518,6 +518,33 @@
     "flags": [ "BELTED", "VARSIZE", "OVERSIZE", "WATER_FRIENDLY" ],
     "armor": [ { "encumbrance": 14, "coverage": 30, "covers": [ "torso" ], "specifically_covers": [ "torso_hanging_back" ] } ],
     "melee_damage": { "bash": 4 }
+  },
+  {
+    "id": "pipe_quiver_large",
+    "type": "ARMOR",
+    "name": { "str": "large pipe quiver" },
+    "description": "A large makeshift quiver fashioned from 3 pipes, worn on the back.  Heavier and thinner than a typical large quiver, it can only hold 30 arrows or bolts.  Use insert to store arrows or bolts.",
+    "weight": "2000 g",
+    "volume": "810 ml",
+    "price": 8800,
+    "price_postapoc": 1000,
+    "material": [ "steel" ],
+    "symbol": "[",
+    "looks_like": "quiver",
+    "color": "dark_gray",
+    "sided": true,
+    "material_thickness": 1.5,
+    "pocket_data": [ { "ammo_restriction": { "arrow": 30, "bolt": 30 }, "moves": 30 } ],
+    "flags": [ "BELTED", "OVERSIZE", "WATER_FRIENDLY" ],
+    "armor": [
+      {
+        "encumbrance": 14,
+        "coverage": 30,
+        "covers": [ "torso" ],
+        "specifically_covers": [ "torso_hanging_back" ]
+      }
+    ],
+    "melee_damage": { "bash": 12 }
   },
   {
     "id": "quiver_takedown_bow",

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -1556,6 +1556,21 @@
     "components": [ [ [ "birchbark", 18 ] ], [ [ "filament", 10, "LIST" ] ], [ [ "strap_large", 1, "LIST" ] ] ]
   },
   {
+    "result": "pipe_quiver_large",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "difficulty": 2,
+    "skills_required": [ "archery", 1 ],
+    "time": "30 m",
+    "autolearn": true,
+    "reversible": true,
+    "book_learn": [ [ "recipe_arrows", 2 ] ],
+    "components": [ [ [ "rope_natural", 1, "LIST" ] ], [ [ "duct_tape", 30 ] ], [ [ "pipe", 3 ] ] ]
+  },
+  {
     "result": "ragpouch",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -1496,6 +1496,25 @@
     "components": [ [ [ "birchbark", 6 ] ], [ [ "filament", 3, "LIST" ] ], [ [ "cordage", 1, "LIST" ] ] ]
   },
   {
+    "result": "pipe_quiver",
+    "type": "recipe",
+    "activity_level": "LIGHT_EXERCISE",
+    "category": "CC_*",
+    "subcategory": "CSC_*_NESTED",
+    "skill_used": "fabrication",
+    "difficulty": 1,
+    "skills_required": [ "archery", 1 ],
+    "time": "10 m",
+    "autolearn": true,
+    "reversible": true,
+    "book_learn": [ [ "recipe_arrows", 1 ] ],
+    "components": [
+      [ [ "rope_natural_short", 1, "LIST" ] ],
+      [ [ "duct_tape", 10 ] ],
+      [ [ "pipe", 1 ] ]
+    ]
+  },
+  {
     "result": "quiver_large",
     "type": "recipe",
     "activity_level": "LIGHT_EXERCISE",

--- a/data/json/recipes/armor/storage.json
+++ b/data/json/recipes/armor/storage.json
@@ -1508,11 +1508,7 @@
     "autolearn": true,
     "reversible": true,
     "book_learn": [ [ "recipe_arrows", 1 ] ],
-    "components": [
-      [ [ "rope_natural_short", 1, "LIST" ] ],
-      [ [ "duct_tape", 10 ] ],
-      [ [ "pipe", 1 ] ]
-    ]
+    "components": [ [ [ "rope_natural_short", 1, "LIST" ] ], [ [ "duct_tape", 10 ] ], [ [ "pipe", 1 ] ] ]
   },
   {
     "result": "quiver_large",

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -2531,7 +2531,15 @@
     "name": "quivers",
     "description": "Recipes related to constructing different kinds of quivers to hold arrows.",
     "skill_used": "tailor",
-    "nested_category_data": [ "quiver_takedown_bow", "quiver", "quiver_birchbark", "quiver_large", "quiver_large_birchbark", "nylon_quiver", "pipe_quiver" ],
+    "nested_category_data": [
+      "quiver_takedown_bow",
+      "quiver",
+      "quiver_birchbark",
+      "quiver_large",
+      "quiver_large_birchbark",
+      "nylon_quiver",
+      "pipe_quiver"
+    ],
     "difficulty": 3
   },
   {

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -2538,7 +2538,8 @@
       "quiver_large",
       "quiver_large_birchbark",
       "nylon_quiver",
-      "pipe_quiver"
+      "pipe_quiver",
+      "pipe_quiver_large"
     ],
     "difficulty": 3
   },

--- a/data/json/recipes/nested.json
+++ b/data/json/recipes/nested.json
@@ -2531,7 +2531,7 @@
     "name": "quivers",
     "description": "Recipes related to constructing different kinds of quivers to hold arrows.",
     "skill_used": "tailor",
-    "nested_category_data": [ "quiver_takedown_bow", "quiver", "quiver_birchbark", "quiver_large", "quiver_large_birchbark", "nylon_quiver" ],
+    "nested_category_data": [ "quiver_takedown_bow", "quiver", "quiver_birchbark", "quiver_large", "quiver_large_birchbark", "nylon_quiver", "pipe_quiver" ],
     "difficulty": 3
   },
   {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Add early craftable pipe quiver"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Intended to ease the onboarding for DIY archery gameplay. Quivers are nearly essential for archers because of their arrow capacity and low move cost, but all other recipes require considerable investment in tailoring just to get off the ground. Also pipe quivers are easy to make and decently common IRL.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Adds a new item and crafting recipe at fab 1 and archery 1. 
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
I briefly considered "non optimal" storage options for arrows, like having them stick out of a messenger bag or something, but it seemed like a huge waste of effort when I could just expand existing DIY quiver options.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Loaded up the game and shot a few zed with it, everything seemed to work fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
As I mentioned pipe quivers are decently common, but they are typically made out of PCP pipes:
 
![pipe 2](https://github.com/CleverRaven/Cataclysm-DDA/assets/157085862/07fa53a2-f9f9-4a7b-8ea1-ee204cab016a)

I'm not aware of any of those in the game, so I used the basic pipe and interpreted its volume as being more wide then tall. 

The decreased arrow capacity is due to the pipe item having a smaller volume then the preexisting quiver recipes; the fact that the easiest quiver to craft is now also the worst one is just a game design bonus

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
