### PR TITLE
Fix: apple orchard

### DIFF
--- a/data/json/mapgen/orchard_apple.json
+++ b/data/json/mapgen/orchard_apple.json
@@ -93,8 +93,8 @@
       "place_items": [
         { "item": "fridge", "x": 20, "y": [ 15, 17 ], "chance": 25, "repeat": [ 1, 3 ] },
         { "item": "orchard_tools", "x": [ 19, 20 ], "y": 19, "chance": 50, "repeat": [ 1, 2 ] },
-        { "item": "trash", "x": 22, "y": [ 15, 16 ], "chance": 65, "repeat": [ 1, 2 ] },
-        { "item": "trash", "x": 11, "y": 12, "chance": 75 },
+        { "item": "trash", "x": [ 20, 21 ], "y": 22, "chance": 65, "repeat": [ 1, 2 ] },
+        { "item": "trash", "x": 15, "y": 15, "chance": 75 },
         { "item": "stored_pulp", "x": [ 13, 14 ], "y": [ 19, 20 ], "chance": 75 },
         { "item": "cash_register_random", "x": 13, "y": [ 14, 16 ], "chance": 100 }
       ],

--- a/data/json/mapgen/orchard_apple.json
+++ b/data/json/mapgen/orchard_apple.json
@@ -33,7 +33,6 @@
         "]...........]......]   q"
       ],
       "palettes": [ "orchard_buildings" ],
-      "terrain": { " ": "t_region_groundcover_urban", "$": "t_region_shrub_decorative" },
       "items": {
         "O": { "item": "orchard_tools", "chance": 25, "repeat": [ 0, 1 ] },
         "X": { "item": "orchard_tools", "chance": 25, "repeat": [ 0, 1 ] },
@@ -90,7 +89,6 @@
         "QQQQ***QQQQQQQQ*****QQQQ"
       ],
       "palettes": [ "orchard_buildings" ],
-      "terrain": { " ": "t_region_groundcover_urban" },
       "place_signs": [ { "signage": "Get Apples n Ciders!", "x": 13, "y": 17 } ],
       "place_items": [
         { "item": "fridge", "x": 20, "y": [ 15, 17 ], "chance": 25, "repeat": [ 1, 3 ] },
@@ -117,7 +115,7 @@
     "om_terrain": [ "orchard_tree_apple" ],
     "weight": 100,
     "object": {
-      "fill_ter": "t_dirt",
+      "fill_ter": "t_region_soil",
       "rows": [
         "************************",
         "************************",

--- a/data/json/mapgen_palettes/orchard_apple.json
+++ b/data/json/mapgen_palettes/orchard_apple.json
@@ -3,6 +3,9 @@
     "type": "palette",
     "id": "orchard_buildings",
     "terrain": {
+      " ": "t_region_groundcover_urban",
+      "d": "t_region_groundcover_urban",
+      "$": "t_region_shrub_decorative",
       "*": "t_region_soil",
       "+": "t_door_c",
       "=": "t_door_metal_locked",
@@ -10,7 +13,7 @@
       ".": "t_pavement",
       ",": "t_floor",
       "^": "t_gutter_downspout",
-      "7": "t_tree",
+      "7": "t_region_tree_shade",
       "b": "t_region_soil",
       "M": "t_wall_metal_corrugated",
       "m": "t_metal_floor",

--- a/data/json/mapgen_palettes/orchard_apple.json
+++ b/data/json/mapgen_palettes/orchard_apple.json
@@ -4,7 +4,7 @@
     "id": "orchard_buildings",
     "terrain": {
       " ": "t_region_groundcover_urban",
-      "d": "t_region_groundcover_urban",
+      "d": "t_region_soil",
       "$": "t_region_shrub_decorative",
       "*": "t_region_soil",
       "+": "t_door_c",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Fixes auto-roofs and trash placement.

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Replace t_floor under the dumpster with t_region_soil, and aligns loot placement over dumpsters.

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

None.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

TP-ed to an orchard.

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

None.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
