### PR TITLE
robofac/json: fix prototype dialogue checks

### DIFF
--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom.json
@@ -772,7 +772,7 @@
     "id": "TALK_ROBOFAC_INTERCOM_ARMOR_POSITIVE",
     "type": "talk_topic",
     "dynamic_line": "We've solved that issue with our more recent prototypes.\"  There is a brief pause.  \"You seem like a good candidate.  We will transfer over the additional pieces to complete that prototype set, with the goal of collecting additional field data.  The core armor platform is solid, and we have been iterating on supplementary pieces we would be willing to trade to you.  Any feedback on their performance would be appreciated.",
-    "speaker_effect": { "effect": { "math": [ "u_hub01_good_candidate", "++" ] } },
+    "speaker_effect": { "effect": { "math": [ "u_hub01_good_candidate", "=", "1" ] } },
     "responses": [
       {
         "text": "Thank you.",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_prototypes.json
@@ -21,7 +21,7 @@
         "condition": {
           "and": [
             { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_armor)", ">", "time('1 d')" ] },
-            { "math": [ "hub01_uhmwpe_researched", "==", "1" ] },
+            { "math": [ "hub01_uhmwpe_researched", "!=", "1" ] },
             { "u_has_var": "u_gave_armor_disk", "type": "dialogue", "context": "hub_rnd", "value": "yes" }
           ]
         },
@@ -60,10 +60,8 @@
         "text": "How goes work on the HWP?",
         "condition": {
           "and": [
+            { "math": [ "has_var(u_timer_hub_rnd_u_waiting_on_gun)" ] },
             { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_gun)", "<", "time('7 d')" ] },
-            {
-              "not": { "u_has_var": "u_has_researched_gun", "type": "dialogue", "context": "hub_rnd", "value": "yes" }
-            },
             { "u_has_var": "robofac_merc_1_HWP", "type": "dialogue", "context": "robofac_merc_1", "value": "yes" }
           ]
         },
@@ -184,7 +182,7 @@
         "text": "How is my ordered armor going?  It should be done by now.",
         "condition": {
           "and": [
-            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", "<", "time('1 d')" ] },
+            { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_hub)", ">", "time('1 d')" ] },
             {
               "or": [
                 { "u_has_var": "u_armor_type", "value": "robofac_armor_pieces_rig", "type": "dialogue", "context": "hub_rnd" },
@@ -228,10 +226,8 @@
         "text": "The HWP should be complete by now, right?",
         "condition": {
           "and": [
+            { "math": [ "has_var(u_timer_hub_rnd_u_waiting_on_gun)" ] },
             { "math": [ "time_since(u_timer_hub_rnd_u_waiting_on_gun)", ">", "time('7 d')" ] },
-            {
-              "not": { "u_has_var": "u_has_researched_gun", "type": "dialogue", "context": "hub_rnd", "value": "yes" }
-            },
             { "u_has_var": "robofac_merc_1_HWP", "type": "dialogue", "context": "robofac_merc_1", "value": "yes" }
           ]
         },
@@ -573,7 +569,7 @@
         "effect": [
           { "u_sell_item": "RobofacCoin", "count": 2 },
           { "u_add_var": "u_project_ongoing", "type": "dialogue", "context": "hub_rnd", "value": "yes" },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_gun", "=", "time('now')" ] },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
           { "u_add_var": "u_current_project", "type": "dialogue", "context": "hub_rnd", "value": "yes" }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
@@ -595,7 +591,7 @@
         "effect": [
           { "u_sell_item": "RobofacCoin", "count": 4 },
           { "u_add_var": "u_project_ongoing", "type": "dialogue", "context": "hub_rnd", "value": "yes" },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_gun", "=", "time('now')" ] },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
           { "u_add_var": "u_current_project", "type": "dialogue", "context": "hub_rnd", "value": "yes" }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
@@ -617,7 +613,7 @@
         "effect": [
           { "u_sell_item": "RobofacCoin", "count": 4 },
           { "u_add_var": "u_project_ongoing", "type": "dialogue", "context": "hub_rnd", "value": "yes" },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_gun", "=", "time('now')" ] },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
           { "u_add_var": "u_current_project", "type": "dialogue", "context": "hub_rnd", "value": "yes" }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
@@ -639,7 +635,7 @@
         "effect": [
           { "u_sell_item": "RobofacCoin", "count": 4 },
           { "u_add_var": "u_project_ongoing", "type": "dialogue", "context": "hub_rnd", "value": "yes" },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_gun", "=", "time('now')" ] },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
           { "u_add_var": "u_current_project", "type": "dialogue", "context": "hub_rnd", "value": "yes" }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
@@ -661,7 +657,7 @@
         "effect": [
           { "u_sell_item": "RobofacCoin", "count": 12 },
           { "u_add_var": "u_project_ongoing", "type": "dialogue", "context": "hub_rnd", "value": "yes" },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_gun", "=", "time('now')" ] },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
           { "u_add_var": "u_current_project", "type": "dialogue", "context": "hub_rnd", "value": "yes" }
         ],
         "topic": "TALK_ROBOFAC_INTERCOM_SERVICES"
@@ -816,6 +812,7 @@
         "effect": [
           { "u_add_var": "u_has_researched_gun", "type": "dialogue", "context": "hub_rnd", "value": "yes" },
           { "u_add_var": "u_project_ongoing", "type": "dialogue", "context": "hub_rnd", "value": "no" },
+          { "u_lose_var": "u_waiting_on_gun", "type": "timer", "context": "hub_rnd" },
           { "u_spawn_item": "robofac_gun" },
           { "u_spawn_item": "robofac_gun_ar" },
           { "u_spawn_item": "robofac_gun_smg" },
@@ -844,7 +841,7 @@
           { "u_sell_item": "RobofacCoin", "count": 1 },
           { "u_consume_item": "phase_immersion_suit", "count": 1, "popup": true },
           { "u_add_faction_trust": 1 },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_gun", "=", "time('now')" ] },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
           { "u_add_var": "u_project_ongoing", "type": "dialogue", "context": "hub_rnd", "value": "yes" },
           {
             "u_add_var": "u_current_project",
@@ -890,7 +887,7 @@
           { "u_sell_item": "RobofacCoin", "count": 1 },
           { "u_consume_item": "rm13_armor", "count": 1, "popup": true },
           { "u_add_faction_trust": 1 },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_gun", "=", "time('now')" ] },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
           { "u_add_var": "u_project_ongoing", "type": "dialogue", "context": "hub_rnd", "value": "yes" },
           { "u_add_var": "u_current_project", "type": "dialogue", "context": "hub_rnd", "value": "rm13_armor" }
         ],
@@ -936,7 +933,7 @@
           { "u_sell_item": "RobofacCoin", "count": 2 },
           { "u_consume_item": "dimensional_anchor", "count": 1, "popup": true },
           { "u_add_faction_trust": 1 },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_gun", "=", "time('now')" ] },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
           { "u_add_var": "u_project_ongoing", "type": "dialogue", "context": "hub_rnd", "value": "yes" },
           { "u_add_var": "u_current_project", "type": "dialogue", "context": "hub_rnd", "value": "anchor_pt_1" }
         ],
@@ -985,7 +982,7 @@
           { "u_consume_item": "dimensional_anchor", "count": 1, "popup": true },
           { "u_consume_item": "robofac_armor_rig", "count": 1, "popup": true },
           { "u_add_faction_trust": 1 },
-          { "math": [ "u_timer_hub_rnd_u_waiting_on_gun", "=", "time('now')" ] },
+          { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
           { "u_add_var": "u_project_ongoing", "type": "dialogue", "context": "hub_rnd", "value": "yes" },
           { "u_add_var": "u_current_project", "type": "dialogue", "context": "hub_rnd", "value": "anchor_pt_2" }
         ],
@@ -1085,7 +1082,7 @@
     "speaker_effect": {
       "effect": [
         { "u_add_faction_trust": 1 },
-        { "math": [ "u_timer_hub_rnd_u_waiting_on_gun", "=", "time('now')" ] },
+        { "math": [ "u_timer_hub_rnd_u_waiting_on_hub", "=", "time('now')" ] },
         { "u_add_var": "u_project_ongoing", "type": "dialogue", "context": "hub_rnd", "value": "yes" },
         { "u_add_var": "u_current_project", "type": "dialogue", "context": "hub_rnd", "value": "hwp_exodii" }
       ],


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
Fix errors in Hub 01's dialogue introduced by the port to math
* Fixes: #71366
* Fixes: #71331

#### Describe the solution
Flip a couple of comparison signs from #70936 and #70996
Fix variable names for armor projects from #70996
Add another variable guard to replace the one partially removed by #70614


#### Describe alternatives you've considered
N/A

#### Testing
Tested every prototype dialogue topic
- HWP
- HWP exotic barrel
- All armors
- Phase Immersion and RM13 armor repair
- MDS upgrade with 5-point anchor

In all cases, the projects complete correctly, can be repeated correctly (note that exotic barrel and 5-point anchor initial analysis aren't repeatable), you can't collect the reward too early, and you can't collect the rewards multiple times or the wrong reward for the current project.

#### Additional context
N/A


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
