### PR TITLE
Make vitrification event recognize faction succession

### DIFF
--- a/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
@@ -393,6 +393,13 @@
     ]
   },
   {
+    "type": "effect_on_condition",
+    "id": "EOC_vitrified_succession",
+    "recurrence": "1 seconds",
+    "condition": { "and": [ { "not": { "u_has_effect": "VITRIFYING" } }, { "math": [ "vitri_glass_entered", "==", "2" ] } ] },
+    "effect": [ { "math": [ "vitri_glass_entered", "=", "3" ] }, { "alter_timed_events": "vitrified_farm_escape_key" } ]
+  },
+  {
     "id": "morale_vitri_placid",
     "type": "morale_type",
     "text": "Content amidst the glass"

--- a/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
@@ -6,7 +6,7 @@
     "condition": {
       "and": [
         { "or": [ { "u_near_om_location": "unvitrified_farm_0" }, { "u_near_om_location": "unvitrified_orchard" } ] },
-        { "math": [ "vitri_glass_entered", "<", "1" ] }
+        { "math": [ "u_vitri_glass_entered", "<", "1" ] }
       ]
     },
     "effect": [
@@ -15,7 +15,7 @@
         "type": "neutral",
         "popup": true
       },
-      { "math": [ "vitri_glass_entered", "=", "1" ] }
+      { "math": [ "u_vitri_glass_entered", "=", "1" ] }
     ]
   },
   {
@@ -33,7 +33,7 @@
             { "not": { "u_is_on_terrain": "t_quietfarm_border_fence" } },
             { "not": { "u_is_on_terrain": "t_quietfarm_border_fence_closed" } },
             { "not": { "u_is_on_terrain": "t_quietfarm_border_fence_open" } },
-            { "math": [ "vitri_glass_entered", "<", "2" ] }
+            { "math": [ "u_vitri_glass_entered", "<", "2" ] }
           ]
         }
       ]
@@ -196,7 +196,7 @@
           "effect": [
             { "math": [ "u_vitri_vitrified", "=", "1" ] },
             { "math": [ "u_vitri_glassed", "=", "0" ] },
-            { "math": [ "vitri_glass_entered", "=", "2" ] },
+            { "math": [ "u_vitri_glass_entered", "=", "2" ] },
             {
               "u_add_effect": "VITRIFYING",
               "duration": "PERMANENT",
@@ -396,8 +396,8 @@
     "type": "effect_on_condition",
     "id": "EOC_vitrified_succession",
     "recurrence": "1 seconds",
-    "condition": { "and": [ { "not": { "u_has_effect": "VITRIFYING" } }, { "math": [ "vitri_glass_entered", "==", "2" ] } ] },
-    "effect": [ { "math": [ "vitri_glass_entered", "=", "3" ] }, { "alter_timed_events": "vitrified_farm_escape_key" } ]
+    "condition": { "and": [ { "not": { "u_has_effect": "VITRIFYING" } }, { "math": [ "u_vitri_glass_entered", "==", "2" ] } ] },
+    "effect": [ { "math": [ "u_vitri_glass_entered", "=", "3" ] }, { "alter_timed_events": "vitrified_farm_escape_key" } ]
   },
   {
     "id": "morale_vitri_placid",

--- a/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
+++ b/data/json/effects_on_condition/nether_eocs/vitrification_effect_on_condition.json
@@ -395,9 +395,10 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_vitrified_succession",
-    "recurrence": "1 seconds",
-    "condition": { "and": [ { "not": { "u_has_effect": "VITRIFYING" } }, { "math": [ "u_vitri_glass_entered", "==", "2" ] } ] },
-    "effect": [ { "math": [ "u_vitri_glass_entered", "=", "3" ] }, { "alter_timed_events": "vitrified_farm_escape_key" } ]
+    "eoc_type": "EVENT",
+    "required_event": "game_avatar_new",
+    "global": true,
+    "effect": { "alter_timed_events": "vitrified_farm_escape_key" }
   },
   {
     "id": "morale_vitri_placid",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Make vitrification event remove visual effect on succession"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fixes #71256.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add an EOC that triggers `"alter_timed_events": "vitrified_farm_escape_key"` on avatar change. Also changed the variables to be on the alpha talker.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Put it in the `vitrified_death` EOC, but it doesn't seem to work sadly. 
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Went in-game with changes, activated the event, died from vitrifying and from other causes, switching to an NPC correctly removed the vitrified farm and visual effects. Also checked that normal faction succession still succeeds.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
