### PR TITLE
More translation coverage in EoC text

### DIFF
--- a/data/mods/BombasticPerks/perkdata/troubleseeker.json
+++ b/data/mods/BombasticPerks/perkdata/troubleseeker.json
@@ -8,8 +8,8 @@
         "real_count": 1,
         "min_radius": 35,
         "max_radius": 50,
-        "spawn_message": "You suddently feel that you have found some trouble.",
-        "spawn_message_plural": "You suddently feel that you have found a lot of trouble."
+        "spawn_message": "You suddenly feel that you have found some trouble.",
+        "spawn_message_plural": "You suddenly feel that you have found a lot of trouble."
       }
     ]
   },

--- a/lang/string_extractor/parsers/effect.py
+++ b/lang/string_extractor/parsers/effect.py
@@ -10,25 +10,66 @@ def parse_effect(effects, origin, comment=""):
             if not comment:
                 if "id" in eff:
                     comment = "effect \"{}\"".format(eff["id"])
+                elif "effect_id" in eff:
+                    comment = "effect \"{}\"".format(eff["effect_id"])
                 else:
                     comment = "an effect"
             if "message" in eff:
                 write_text(eff["message"], origin,
                            comment="Message in {}".format(comment))
+            if "message_npc" in eff:
+                write_text(eff["message_npc"], origin,
+                           comment="NPC message in {}".format(comment))
             if "u_buy_monster" in eff and "name" in eff:
                 write_text(eff["name"], origin,
                            comment="Nickname for creature '{}' in {}".
                            format(eff["u_buy_monster"], comment))
-            if "u_message" in eff:
-                if "snippet" in eff and eff["snippet"] is True:
-                    continue
-                write_text(eff["u_message"], origin,
-                           comment="Player message in {}".format(comment))
+            if "snippet" not in eff or eff["snippet"] is False:
+                if "u_message" in eff:
+                    write_text(eff["u_message"], origin,
+                               comment="Player message in {}".format(comment))
+                if "npc_message" in eff:
+                    write_text(eff["npc_message"], origin,
+                               comment="NPC message in {}".format(comment))
+                if "u_make_sound" in eff and type(eff["u_make_sound"]) is str:
+                    write_text(eff["u_make_sound"], origin,
+                               comment="Player makes sound in {}".
+                               format(comment))
+                if "npc_make_sound" in eff and \
+                        type(eff["npc_make_sound"]) is str:
+                    write_text(eff["npc_make_sound"], origin,
+                               comment="NPC makes sound in {}".format(comment))
+            if "spawn_message" in eff:
+                write_text(eff["spawn_message"], origin,
+                           comment="Player sees monster spawns in {}"
+                           .format(comment))
+            if "spawn_message_plural" in eff:
+                write_text(eff["spawn_message_plural"], origin,
+                           comment="Player sees monsters spawn in {}"
+                           .format(comment))
+            if "u_teleport" in eff or "npc_teleport" in eff:
+                if "success_message" in eff:
+                    write_text(eff["success_message"], origin,
+                               comment="Success message in teleportation in {}"
+                               .format(comment))
+                if "fail_message" in eff:
+                    write_text(eff["fail_message"], origin,
+                               comment="Fail message in teleportation in {}"
+                               .format(comment))
+            if "variables" in eff:
+                parse_effect_variables(eff["variables"], origin, comment)
             if "run_eocs" in eff:
                 if type(eff["run_eocs"]) is list:
                     for eoc in eff["run_eocs"]:
                         if type(eoc) is dict:
                             parse_effect_on_condition(eoc, origin)
+            if "weighted_list_eocs" in eff:
+                for e in eff["weighted_list_eocs"]:
+                    if type(e[0]) is dict:
+                        if "effect" in e[0]:
+                            parse_effect(e[0]["effect"], origin,
+                                         comment="nested effect in {}"
+                                         .format(comment))
 
 
 def parse_effect_on_condition(json, origin, comment=""):
@@ -49,3 +90,20 @@ def parse_effect_on_condition(json, origin, comment=""):
                          comment="false effect in EoC \"{}\"".format(id))
     if "condition" in json:
         parse_condition(json["condition"], origin)
+
+
+def parse_effect_variables(json, origin, comment):
+    if "message_success" in json:
+        write_text(json["message_success"], origin,
+                   comment="Success message casting spell \"{}\" in {}"
+                   .format(json["spell_to_cast"], comment))
+    if "message_fail" in json:
+        write_text(json["message_fail"], origin,
+                   comment="Fail message casting spell \"{}\" in {}"
+                   .format(json["spell_to_cast"], comment))
+    if "success_message" in json:
+        write_text(json["success_message"], origin,
+                   comment="Success message in {}".format(comment))
+    if "failure_message" in json:
+        write_text(json["failure_message"], origin,
+                   comment="Failure message in {}".format(comment))

--- a/lang/string_extractor/parsers/enchant.py
+++ b/lang/string_extractor/parsers/enchant.py
@@ -1,4 +1,5 @@
 from ..helper import get_singular_name
+from .effect import parse_effect
 from ..write_text import write_text
 
 
@@ -11,3 +12,6 @@ def parse_enchant(json, origin):
     if "description" in json:
         write_text(json["description"], origin,
                    comment="Description of enchantment \"{}\"".format(name))
+
+    if "hit_me_effect" in json:
+        parse_effect(json["hit_me_effect"], origin)

--- a/lang/string_extractor/parsers/field_type.py
+++ b/lang/string_extractor/parsers/field_type.py
@@ -7,4 +7,6 @@ def parse_field_type(json, origin):
         if "name" in fd:
             write_text(fd["name"], origin, comment="Field intensity level")
         if "effects" in fd:
-            parse_effect(fd["effects"], origin)
+            parse_effect(fd["effects"], origin,
+                         comment="effect in field {}".format(fd["name"])
+                         if "name" in fd else "")

--- a/lang/string_extractor/parsers/use_action.py
+++ b/lang/string_extractor/parsers/use_action.py
@@ -1,3 +1,4 @@
+from .effect import parse_effect_on_condition
 from ..write_text import write_text
 
 
@@ -47,6 +48,12 @@ def parse_use_action(json, origin, item_name):
                            .format(msg_key, item_name))
         for json_key in json:
             parse_use_action(json[json_key], origin, item_name)
+        if "effect_on_conditions" in json:
+            for e in json["effect_on_conditions"]:
+                if type(e) is dict:
+                    parse_effect_on_condition(e, origin,
+                                              "use action of item \"{}\""
+                                              .format(item_name))
     elif type(json) is list:
         for use_action in json:
             parse_use_action(use_action, origin, item_name)

--- a/tools/spell_checker/dictionary.txt
+++ b/tools/spell_checker/dictionary.txt
@@ -314,6 +314,7 @@ biohacker
 biokinesis
 biokinetic
 biollante
+bioluminescent
 biomachine
 biomancer
 biomancers


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
A lot of text in EoC is not translated.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Update the string extractor script.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
106 new messages added: https://github.com/CleverRaven/Cataclysm-DDA/actions/runs/7721208412/job/21047376199?pr=71380#step:9:15
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
