### PR TITLE
Translate custom name of monsters placed in mapgen

### DIFF
--- a/lang/string_extractor/parsers/mapgen.py
+++ b/lang/string_extractor/parsers/mapgen.py
@@ -18,22 +18,26 @@ def parse_mapgen(json, origin):
             elif type(json["om_terrain"][0]) is list:
                 om = ", ".join(", ".join(i) for i in json["om_terrain"])
 
+    parse_mapgen_object(json["object"], origin, om)
+
+
+def parse_mapgen_object(json, origin, om):
     for key in ["place_specials", "place_signs"]:
-        if key in json["object"]:
-            for sign in json["object"][key]:
+        if key in json:
+            for sign in json[key]:
                 if "signage" in sign:
                     write_text(sign["signage"], origin,
                                comment="Signage placed on map {}".format(om))
 
-    if "signs" in json["object"]:
-        for sign in json["object"]["signs"]:
-            if "signage" in json["object"]["signs"][sign]:
-                write_text(json["object"]["signs"][sign]["signage"], origin,
+    if "signs" in json:
+        for sign in json["signs"]:
+            if "signage" in json["signs"][sign]:
+                write_text(json["signs"][sign]["signage"], origin,
                            comment="Signage placed on map {}".format(om))
 
-    if "computers" in json["object"]:
-        for key in json["object"]["computers"]:
-            com = json["object"]["computers"][key]
+    if "computers" in json:
+        for key in json["computers"]:
+            com = json["computers"][key]
             com_name = ""
             if "name" in com:
                 com_name = get_singular_name(com["name"])
@@ -50,8 +54,20 @@ def parse_mapgen(json, origin):
                            comment="Access denied message on computer \"{}\""
                            " placed on map {}".format(com_name, om))
 
-    if "place_computers" in json["object"]:
-        for computer in json["object"]["place_computers"]:
+    if "place_computers" in json:
+        for computer in json["place_computers"]:
             if "name" in computer:
                 write_text(computer["name"], origin,
                            comment="Computer name placed on map {}".format(om))
+
+    if "place_monster" in json:
+        for m in json["place_monster"]:
+            if "name" in m:
+                desc = ""
+                if "monster" in m:
+                    desc = "\"{}\"".format(m["monster"])
+                elif "group" in m:
+                    desc = "group \"{}\"".format(m["group"])
+                write_text(m["name"], origin,
+                           comment="Name of the monster {} placed on map {}"
+                           .format(desc, om))

--- a/lang/string_extractor/parsers/mission_definition.py
+++ b/lang/string_extractor/parsers/mission_definition.py
@@ -1,6 +1,7 @@
 from ..helper import get_singular_name
 from ..write_text import write_text
 from .effect import parse_effect
+from .mapgen import parse_mapgen_object
 
 
 def parse_mission_definition(json, origin):
@@ -20,5 +21,10 @@ def parse_mission_definition(json, origin):
                            format(name))
 
     for key in ["start", "end", "fail"]:
-        if key in json and "effect" in json[key]:
-            parse_effect(json[key]["effect"], origin)
+        if key in json:
+            if "effect" in json[key]:
+                parse_effect(json[key]["effect"], origin)
+            if "update_mapgen" in json[key]:
+                parse_mapgen_object(json[key]["update_mapgen"], origin,
+                                    om="update on {} of mission \"{}\""
+                                    .format(key, name))

--- a/src/mapgen.cpp
+++ b/src/mapgen.cpp
@@ -2426,7 +2426,7 @@ class jmapgen_monster : public jmapgen_piece
             }
 
             mongroup_id chosen_group = m_id.get( dat );
-            std::string chosen_name = name;
+            std::string chosen_name = _( name );
             if( !random_name_str.empty() ) {
                 if( random_name_str == "female" ) {
                     chosen_name = SNIPPET.expand( "<female_given_name>" );


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
* Fix #47361
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Extract monster names given in mapgen JSON for translation, and spawn the monster with its translated name in C++ side.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
```po
#. ~ Name of the monster "mon_feral_labsecurity_9mm" placed on map update on start of mission "Finish your mission"
#: data/json/starting_missions.json
msgid "The Guard"
msgstr ""
```
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
