### PR TITLE
Fix artifact resonance detectors spawning as artifacts

### DIFF
--- a/data/json/itemgroups/altered_item.json
+++ b/data/json/itemgroups/altered_item.json
@@ -17,11 +17,5 @@
       [ "altered_necklace", 10 ],
       [ "altered_apron", 10 ]
     ]
-  },
-  {
-    "id": "altered_item_with_detector",
-    "type": "item_group",
-    "subtype": "collection",
-    "items": [ { "group": "altered_item", "prob": 100 }, { "item": "resonance_measurement_device", "prob": 25 } ]
   }
 ]

--- a/data/json/itemgroups/artifacts.json
+++ b/data/json/itemgroups/artifacts.json
@@ -17,16 +17,17 @@
   {
     "type": "item_group",
     "id": "altered_object_i",
-    "subtype": "distribution",
+    "subtype": "collection",
     "entries": [
       {
-        "group": "altered_item_with_detector",
+        "group": "altered_item",
         "artifact": {
           "procgen_id": "altered_object",
           "rules": { "power_level": 750, "max_attributes": 4, "max_negative_power": -1000, "resonant": true }
         },
         "prob": 100
-      }
+      },
+      { "item": "resonance_measurement_device", "prob": 25 }
     ]
   },
   {


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
I made an oopsie, the item added in #71346 was part of the group tagged to spawn as artifacts so all artifacts spawned via `altered_object_i` caused the detectors themselves to become artifacts, and become useless in their intended purpose.

#### Describe the solution
Moved the detector item 'up' one item group so it still spawns alongside the artifact, but not AS one.

#### Describe alternatives you've considered
Could've moved the artifact definition 'down' one item group instead, but either approach works and the chosen one is less json

#### Testing
Confirmed the bug occurred on master. Applied changes, visited several microlab artifact vaults, got normal detectors which are not themselves artifcats

#### Additional context