### PR TITLE
[BombasticPerks] Complimentary Remarks

### DIFF
--- a/data/mods/BombasticPerks/perkdata/praise.json
+++ b/data/mods/BombasticPerks/perkdata/praise.json
@@ -1,0 +1,27 @@
+[
+  {
+    "type": "effect_on_condition",
+    "id": "EOC_praise",
+    "eoc_type": "EVENT",
+    "required_event": "character_kills_monster",
+    "condition": { "and": [ { "u_has_trait": "perk_praise" }, { "x_in_y_chance": { "x": 1, "y": 10 } } ] },
+    "effect": [ { "u_message": "<good_job>", "type": "good", "snippet": true } ]
+  },
+  {
+    "type": "snippet",
+    "category": "<good_job>",
+    "text": [
+      "You deserve a pat on the back!",
+      "Groovy!",
+      "Bitchin'!",
+      "Hip hip hurray!",
+      "Gee that's swell!",
+      "Good for you!",
+      "I say, smashing job!",
+      "Like, totally gnarly!",
+      "Nice, <u_name>!",
+      "Good job, <u_name>!",
+      "Awesome!"
+    ]
+  }
+]

--- a/data/mods/BombasticPerks/perkmenu.json
+++ b/data/mods/BombasticPerks/perkmenu.json
@@ -557,6 +557,21 @@
         "topic": "TALK_PERK_MENU_SELECT"
       },
       {
+        "condition": { "not": { "u_has_trait": "perk_praise" } },
+        "text": "Gain [<trait_name:perk_praise>]",
+        "effect": [
+          { "set_string_var": "<trait_name:perk_praise>", "target_var": { "context_val": "trait_name" } },
+          {
+            "set_string_var": "<trait_description:perk_praise>",
+            "target_var": { "context_val": "trait_description" }
+          },
+          { "set_string_var": "perk_praise", "target_var": { "context_val": "trait_id" } },
+          { "set_string_var": "No Requirements", "target_var": { "context_val": "trait_requirement_description" } },
+          { "set_condition": "perk_condition", "condition": { "math": [ "0", "==", "0" ] } }
+        ],
+        "topic": "TALK_PERK_MENU_SELECT"
+      },
+      {
         "condition": { "math": [ "u_no_playstyle", "==", "0" ] },
         "text": "Playstyle Perks",
         "topic": "TALK_PERK_MENU_PLAYSTYLE"

--- a/data/mods/BombasticPerks/perks.json
+++ b/data/mods/BombasticPerks/perks.json
@@ -418,6 +418,14 @@
   },
   {
     "type": "mutation",
+    "id": "perk_praise",
+    "name": { "str": "Complimentary Remarks" },
+    "points": 0,
+    "description": "The way you take care of the enemies is commendable, so much so that someone or something seems to praise your ways of fighting.  For every kills you have made, a praise may be given in the message log.",
+    "category": [ "perk" ]
+  },
+  {
+    "type": "mutation",
     "id": "perk_empath",
     "name": { "str": "Empath" },
     "points": 0,


### PR DESCRIPTION


#### Summary
Mods "BombasticPerk's perk that praises you when fighting enemies from time to time"


#### Purpose of change

This perk was inspired by the dos roguelike i was playing named *Alphaman*. In that game, everytime i kill a monster the game basically celebrate it abit by saying nice praises like "You deserve a pat on the back!", "I say, smashing job!", and etc.. I really like that and want to see something like that in game. Someone told me it'd fit with BombasticPerks so i'm adding it.

#### Describe the solution

Basically, in 1 in 10 chance the game will print out a complementary remark upon killing any monster. It was originally to be triggering for every kill, but it kinda feels a bit too spammy and diluted the feeling a bit. No morale buff though cuz that's still a bit goofy. Slight IRL morale buff is good enough.

#### Describe alternatives you've considered

Keep it to myself

#### Testing

I put the jsons into the bombasticperk mod directly, that seems to work.

A test i did back when i didnt limit it to 1 in 10 chances
![Screenshot_2024-01-31_22-36-47_1](https://github.com/CleverRaven/Cataclysm-DDA/assets/78019001/7f226bf6-1948-4c7c-b776-576630a4c894)


#### Additional context

Thanks for making the EOC for it, @GuardianDll 


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
