### PR TITLE
Fix int32_t overflow in energy display

### DIFF
--- a/src/units.cpp
+++ b/src/units.cpp
@@ -130,15 +130,16 @@ void angle::deserialize( const JsonValue &jv )
 
 std::string display( const units::energy &v )
 {
-    const int kj = units::to_kilojoule( v );
-    const int j = units::to_joule( v );
+    using value_type = units::energy::value_type;
+    const value_type kj = units::to_kilojoule( v );
+    const value_type j = units::to_joule( v );
     // at least 1 kJ and there is no fraction
-    if( kj >= 1 && static_cast<float>( j ) / kj == 1000 ) {
+    if( kj >= 1 && static_cast<double>( j ) / kj == 1000 ) {
         return std::to_string( kj ) + ' ' + pgettext( "energy unit: kilojoule", "kJ" );
     }
-    const int mj = units::to_millijoule( v );
+    const value_type mj = units::to_millijoule( v );
     // at least 1 J and there is no fraction
-    if( j >= 1 && static_cast<float>( mj ) / j  == 1000 ) {
+    if( j >= 1 && static_cast<double>( mj ) / j  == 1000 ) {
         return std::to_string( j ) + ' ' + pgettext( "energy unit: joule", "J" );
     }
     return std::to_string( mj ) + ' ' + pgettext( "energy unit: millijoule", "mJ" );

--- a/tests/units_test.cpp
+++ b/tests/units_test.cpp
@@ -400,3 +400,16 @@ TEST_CASE( "Specific_energy", "[temperature]" )
         CHECK( units::to_joule_per_gram( units::from_joule_per_gram( 100.1 ) ) == Approx( 100.1 ) );
     }
 }
+
+TEST_CASE( "energy_display", "[units][nogame]" )
+{
+    CHECK( units::display( units::from_millijoule( 1 ) ) == "1 mJ" );
+    CHECK( units::display( units::from_millijoule( 1'000 ) ) == "1 J" );
+    CHECK( units::display( units::from_millijoule( 1'001 ) ) == "1001 mJ" );
+    CHECK( units::display( units::from_millijoule( 1'000'000 ) ) == "1 kJ" );
+    CHECK( units::display( units::from_millijoule( 1'000'001 ) ) == "1 kJ" );
+    CHECK( units::display( units::from_millijoule( 1'001'000 ) ) == "1001 J" );
+    CHECK( units::display( units::from_millijoule( 1'001'001 ) ) == "1001001 mJ" );
+    CHECK( units::display( units::from_millijoule( 2'147'483'648LL ) ) == "2147483648 mJ" );
+    CHECK( units::display( units::from_millijoule( 4'294'967'296LL ) ) == "4294967296 mJ" );
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix int32_t overflow in energy display"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix the 32-bit integer overflow problem in energy unit display function. This is among one of the various overflow problems causing #71396.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Use `units::energy::value_type` for storing intermediate calculation results instead of the hardcoded 32-bit integer type.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
UI display does not overflow.
<img width="254" alt="" src="https://github.com/CleverRaven/Cataclysm-DDA/assets/21075502/ebd180cf-5db4-4c8a-aa3a-07b074009146">


<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
