### PR TITLE
Fix suffering tests by normalizing the initialization calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ Directory.Build.targets
 /msvc-full-features/**/
 
 # Temporary CMakeFiles
+CMakeFiles/git-data
 CMakeUserPresets.json
 out/
 

--- a/tests/char_suffer_test.cpp
+++ b/tests/char_suffer_test.cpp
@@ -15,6 +15,7 @@
 #include "item.h"
 #include "map.h"
 #include "map_helpers.h"
+#include "options_helpers.h"
 #include "player_helpers.h"
 #include "test_statistics.h"
 #include "type_id.h"
@@ -101,9 +102,10 @@ static int test_suffer_pain_felt( Character &dummy, const time_duration &dur )
 TEST_CASE( "suffering_from_albinism", "[char][suffer][albino]" )
 {
     clear_map();
+    clear_avatar();
+    set_time_to_day();
+    scoped_weather_override clear_weather( WEATHER_CLEAR );
     avatar &dummy = get_avatar();
-    clear_character( dummy );
-    g->reset_light_level();
 
     int focus_lost = 0;
     // TODO: The random chance of pain is too unprectable to test reliably.
@@ -123,7 +125,6 @@ TEST_CASE( "suffering_from_albinism", "[char][suffer][albino]" )
     item longshirt( "test_longshirt" );
 
     GIVEN( "avatar is in sunlight with the albino trait" ) {
-        calendar::turn = calendar::turn_zero + 12_hours;
         REQUIRE( g->is_in_sunlight( dummy.pos() ) );
 
         dummy.toggle_trait( trait_ALBINO );
@@ -207,8 +208,9 @@ TEST_CASE( "suffering_from_sunburn", "[char][suffer][sunburn]" )
 {
     clear_map();
     clear_avatar();
+    set_time_to_day();
+    scoped_weather_override clear_weather( WEATHER_CLEAR );
     Character &dummy = get_player_character();
-    g->reset_light_level();
     const std::vector<bodypart_id> body_parts_with_hp = dummy.get_all_body_parts(
                 get_body_part_flags::only_main );
 
@@ -221,7 +223,6 @@ TEST_CASE( "suffering_from_sunburn", "[char][suffer][sunburn]" )
     item longshirt( "test_longshirt" );
 
     GIVEN( "avatar is in sunlight with the solar sensitivity trait" ) {
-        calendar::turn = calendar::turn_zero + 12_hours;
         REQUIRE( g->is_in_sunlight( dummy.pos() ) );
 
         dummy.toggle_trait( trait_SUNBURN );


### PR DESCRIPTION
#### Summary
None

#### Purpose of change
The test fails due to the character not being in sunlight, so it probably has something to do with time or weather.

Also add some generated CMake files to `.gitignore`.

Closes #71401.

#### Describe the solution
Normalize the intialization calls.

#### Describe alternatives you've considered
Fire up a debugger and wait for an eternity for the game to load.

#### Testing
The test no longer seemed to fail.

#### Additional context
