### PR TITLE
Psychopath->Uncaring

### DIFF
--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1182,7 +1182,7 @@
     "id": "PSYCHOPATH",
     "name": { "str": "Desensitized" },
     "points": 2,
-    "description": "Whether due to brain chemistry, military conditioning,or olympian mental gymnastics,you no longer feel remorse or guilt for harming your fellow man.",
+    "description": "Whether due to brain chemistry, military conditioning,or Olympian mental gymnastics,you no longer feel remorse or guilt for harming your fellow man.",
     "starting_trait": true,
     "valid": false,
     "social_modifiers": { "intimidate": 5 },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1182,7 +1182,7 @@
     "id": "PSYCHOPATH",
     "name": { "str": "Uncaring" },
     "points": 2,
-    "description": "Whether due to brain chemistry, service-related trauma,or Olympian mental gymnastics,you no longer feel any remorse or guilt for harming your fellow man.",
+    "description": "Whether due to brain chemistry, service-related trauma, or Olympian mental gymnastics, you no longer feel any remorse or guilt for harming your fellow man.",
     "starting_trait": true,
     "valid": false,
     "social_modifiers": { "intimidate": 5 },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1180,9 +1180,9 @@
   {
     "type": "mutation",
     "id": "PSYCHOPATH",
-    "name": { "str": "Psychopath" },
+    "name": { "str": "Desensitized" },
     "points": 2,
-    "description": "You don't experience guilt like others do.  Even when you know your actions are wrong, you just don't care.",
+    "description": "Whether due to brain chemistry, military conditioning,or olympian mental gymnastics,you no longer feel remorse or guilt for harming your fellow man.",
     "starting_trait": true,
     "valid": false,
     "social_modifiers": { "intimidate": 5 },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1180,9 +1180,9 @@
   {
     "type": "mutation",
     "id": "PSYCHOPATH",
-    "name": { "str": "Desensitized" },
+    "name": { "str": "Uncaring" },
     "points": 2,
-    "description": "Whether due to brain chemistry, military conditioning,or Olympian mental gymnastics,you no longer feel remorse or guilt for harming your fellow man.",
+    "description": "Whether due to brain chemistry, service-related trauma,or Olympian mental gymnastics,you no longer feel any remorse or guilt for harming your fellow man.",
     "starting_trait": true,
     "valid": false,
     "social_modifiers": { "intimidate": 5 },

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -1182,7 +1182,7 @@
     "id": "PSYCHOPATH",
     "name": { "str": "Uncaring" },
     "points": 2,
-    "description": "Whether due to brain chemistry, service-related trauma, or Olympian mental gymnastics, you no longer feel any remorse or guilt for harming your fellow man.",
+    "description": "You don't feel any remorse or guilt for harming your fellow man.",
     "starting_trait": true,
     "valid": false,
     "social_modifiers": { "intimidate": 5 },

--- a/data/json/npcs/random_encounters/refugee_caravans.json
+++ b/data/json/npcs/random_encounters/refugee_caravans.json
@@ -40,13 +40,13 @@
     "responses": [
       {
         "text": "What if I want to hurt you?  I'm so good at it and I've had so much practice.",
-        "condition": { "u_has_trait": "PSYCHOPATH" },
+        "condition": { "u_has_trait": "KILLER" },
         "topic": "TALK_CARAVAN_REFUGEE_A1_Hurt"
       },
       {
         "text": "What's your situation here?",
         "topic": "TALK_CARAVAN_REFUGEE_A1_Job",
-        "condition": { "not": { "u_has_trait": "PSYCHOPATH" } }
+        "condition": { "not": { "u_has_trait": "KILLER" } }
       },
       { "text": "I don't have time for zombie bait like you.", "topic": "TALK_DONE" }
     ]


### PR DESCRIPTION


<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Interface "Renamed the ‘Psychopath’ mutation to ‘Uncaring’ "
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Many people dislike the psychopath trait for, among other reasons, incorrectly representing a real-world mental condition. This PR makes it a more generic “Uncaring”,  instead of being a b-movie-esque “Psychopath”.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Changed the description and name, did not alter ID
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this, and/or removing some of the incredibly edgy “Psychopath” dialogue.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
