### PR TITLE
Update the scrap trader's dialogue model

### DIFF
--- a/data/json/npcs/scrap_trader/scrap_trader.json
+++ b/data/json/npcs/scrap_trader/scrap_trader.json
@@ -275,10 +275,10 @@
     "id": "TALK_NPC_SCRAP_TRADER_FORT",
     "dynamic_line": {
       "npc_has_trait": "BGSS_No_Past_2",
-      "yes": "Well, this place had some barbed wire, metalworking tools, and pleanty of supplies.  I made the walls myself.  I didn't know of anywhere else to go either.",
+      "yes": "Well, this place had some barbed wire, metalworking tools, and plenty of supplies.  I made the walls myself.  I didn't know of anywhere else to go either.",
       "no": {
         "npc_has_trait": "BGSS_No_Past_3",
-        "yes": "Well, this place had some barbed wire, metalworking tools, and pleanty of supplies.  I made the walls myself.  I didn't know of anywhere else to go either.",
+        "yes": "Well, this place had some barbed wire, metalworking tools, and plenty of supplies.  I made the walls myself.  I didn't know of anywhere else to go either.",
         "no": "Like I said, I came out here when the dead got pissed off.  This place had some barbed wire, metalworking tools, and plenty of stuff to make weapons out of.  Even the walls are my own making."
       }
     },

--- a/data/json/npcs/scrap_trader/scrap_trader.json
+++ b/data/json/npcs/scrap_trader/scrap_trader.json
@@ -190,33 +190,55 @@
   },
   {
     "type": "talk_topic",
+    "id": [ "TALK_NPC_SCRAP_TRADER_INTRO", "TALK_NPC_SCRAP_TRADER_STORY", "TALK_NPC_SCRAP_TRADER_FORT" ],
+    "responses": [
+      {
+        "text": "I'd like to ask you a few questions.",
+        "topic": "TALK_FRIEND_CONVERSATION",
+        "condition": {
+          "and": [
+            { "math": [ "n_val('npc_trust')", ">=", "2" ] },
+            { "npc_has_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" }
+          ]
+        }
+      },
+      { "text": "Can I buy anything?", "topic": "TALK_SCRAP_TRADER_BULK_SELL" },
+      {
+        "text": "Any jobs you need done?",
+        "condition": { "and": [ { "not": "has_assigned_mission" }, { "not": "has_many_assigned_missions" } ] },
+        "topic": "TALK_MISSION_LIST"
+      }
+    ]
+  },
+  {
+    "type": "talk_topic",
     "id": "TALK_NPC_SCRAP_TRADER",
     "dynamic_line": {
-      "npc_has_var": "talked_to_trader",
+      "npc_has_var": "knows_u",
       "type": "dialogue",
       "context": "first_meeting",
       "value": "yes",
       "yes": "Hello there.  Nice to see you, <name_g>.",
       "no": "Haven't seen another face in quite a while.  Not a living one, at least.  State your business.  Maybe you got some use for some of this scrap metal?"
     },
-    "speaker_effect": { "effect": { "npc_add_var": "talked_to_trader", "type": "dialogue", "context": "first_meeting", "value": "yes" } },
+    "speaker_effect": { "effect": { "npc_add_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" } },
     "responses": [
       {
         "text": "Nice to meet you.",
         "topic": "TALK_NPC_SCRAP_TRADER_INTRO",
-        "condition": { "not": { "npc_has_var": "talked_to_trader", "type": "dialogue", "context": "first_meeting", "value": "yes" } }
+        "condition": { "not": { "npc_has_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" } }
       },
       {
         "text": "Hands up, <name_b>!",
         "trial": { "type": "INTIMIDATE", "difficulty": 30 },
         "success": { "topic": "TALK_WEAPON_DROPPED", "effect": "drop_weapon", "opinion": { "trust": -4, "fear": 3 } },
         "failure": { "topic": "TALK_DONE", "effect": "hostile" },
-        "condition": { "not": { "npc_has_var": "talked_to_trader", "type": "dialogue", "context": "first_meeting", "value": "yes" } }
+        "condition": { "not": { "npc_has_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" } }
       },
       {
         "text": "Pleasure to see you again, <name_g>.",
         "topic": "TALK_NPC_SCRAP_TRADER_INTRO",
-        "condition": { "npc_has_var": "talked_to_trader", "type": "dialogue", "context": "first_meeting", "value": "yes" }
+        "condition": { "npc_has_var": "knows_u", "type": "dialogue", "context": "first_meeting", "value": "yes" }
       },
       { "text": "See ya.", "topic": "TALK_DONE" }
     ]
@@ -227,23 +249,7 @@
     "dynamic_line": "Do you need something?",
     "responses": [
       { "text": "What's your story?", "topic": "TALK_NPC_SCRAP_TRADER_STORY" },
-      {
-        "text": "I'd like to ask you a few questions.",
-        "topic": "TALK_FRIEND_CONVERSATION",
-        "condition": {
-          "and": [
-            { "math": [ "n_val('npc_trust')", ">=", "2" ] },
-            { "npc_has_var": "talked_to_trader", "type": "dialogue", "context": "first_meeting", "value": "yes" }
-          ]
-        }
-      },
       { "text": "Why stay here of all places?", "topic": "TALK_NPC_SCRAP_TRADER_FORT" },
-      { "text": "Can I buy anything?", "topic": "TALK_SCRAP_TRADER_BULK_SELL" },
-      {
-        "text": "Any jobs you need done?",
-        "condition": { "and": [ { "not": "has_assigned_mission" }, { "not": "has_many_assigned_missions" } ] },
-        "topic": "TALK_MISSION_LIST"
-      },
       { "text": "Nah, see ya.", "topic": "TALK_DONE" }
     ]
   },
@@ -259,17 +265,20 @@
         "no": "Well, I held a modest job here as a scrap yard worker.  Business was fair most days, but when <the_cataclysm> hit, I decided to head out here.  With all the craziness going on in the cities and whatnot, I decided to just stay here for while.  I figure someone might find a use for the leftover metal lying around, so I started selling it to anyone who passed by."
       }
     },
-    "responses": [ { "text": "Hmm.", "topic": "TALK_NONE" } ]
+    "responses": [
+      { "text": "Why stay here of all places?", "topic": "TALK_NPC_SCRAP_TRADER_FORT" },
+      { "text": "Hmm.", "topic": "TALK_NONE" }
+    ]
   },
   {
     "type": "talk_topic",
     "id": "TALK_NPC_SCRAP_TRADER_FORT",
     "dynamic_line": {
       "npc_has_trait": "BGSS_No_Past_2",
-      "yes": "Well, this place had some barbed wire, metalworking tools, and plenty of supplies.  I made the walls myself.  I didn't know of anywhere else to go either.",
+      "yes": "Well, this place had some barbed wire, metalworking tools, and pleanty of supplies.  I made the walls myself.  I didn't know of anywhere else to go either.",
       "no": {
         "npc_has_trait": "BGSS_No_Past_3",
-        "yes": "Well, this place had some barbed wire, metalworking tools, and plenty of supplies.  I made the walls myself.  I didn't know of anywhere else to go either.",
+        "yes": "Well, this place had some barbed wire, metalworking tools, and pleanty of supplies.  I made the walls myself.  I didn't know of anywhere else to go either.",
         "no": "Like I said, I came out here when the dead got pissed off.  This place had some barbed wire, metalworking tools, and plenty of stuff to make weapons out of.  Even the walls are my own making."
       }
     },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Update the scrap trader's dialogue model."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
There were a few things about the scrap trader's dialogue structure that I wanted to change, mainly with updating it to modern standards.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Replace the `"talked_to_trader"` variable with `"knows_u"`, bringing it in line with other NPCs. Also, make some speech responses accessible from other dialogue topics in the speech tree, as they would make sense.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
None.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Spoke with the trader a few times, everything looks fine.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
I plan to do this with a lot of my older NPC additions, such as chemists and the homeless people.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
