### PR TITLE
Extract widget string for translation

### DIFF
--- a/lang/string_extractor/parsers/widget.py
+++ b/lang/string_extractor/parsers/widget.py
@@ -9,10 +9,9 @@ def parse_widget(json, origin):
     if "description" in json:
         write_text(json["description"], origin,
                    comment="Description of UI widget \"{}\"".format(id))
-    if "strings" in json:
-        for string in json["strings"]:
-            write_text(string, origin,
-                       comment="Text in UI widget \"{}\"".format(id))
+    if "string" in json:
+        write_text(json["string"], origin,
+                   comment="Text in UI widget \"{}\"".format(id))
     if "phrases" in json:
         for phrase in json["phrases"]:
             comment = "Text in portion of UI widget \"{}\"".format(id)


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
I18N "Extract widget string for translation"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Some widgets were not extracted for translation. This change retrieves about 66 strings.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
The UI files don't seem to use "strings" arrays fields, grep doesn't show anything, they use single "string" fields.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Everything looks fine.

<details>
  <summary>Screenshots</summary>
  
Before:
![before](https://github.com/CleverRaven/Cataclysm-DDA/assets/99945024/013c596b-43d2-49dc-badf-fa20ffe86974)

After:
![after](https://github.com/CleverRaven/Cataclysm-DDA/assets/99945024/41c6bd1a-4098-4015-8ba4-5ed512ce0cf9)
  
</details>
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
btw some widget names are the same, although they differ in meaning.
```
#. ~ Default clause of UI widget "compass_S_danger_label"
#. ~ Clause text "safe_mode_trigger" of UI widget "compass_S_danger_label"
#. ~ Clause text "danger" of UI widget "compass_S_danger_label"
#. ~ Text in UI widget "l_str"
#. ~ Text in UI widget "l_stamina"
#: data/json/ui/compass_danger.json data/json/ui/sidebar-mobile.json
msgid "S:"
msgstr ""
```
One line is used to name the cardinal direction, stamina and strength.

Maybe it's worth adding a context flag to json.

oh, the documentation says about [context](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/WIDGETS.md#label), maybe I'll take that later
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
