### PR TITLE
Add clang-tidy check for overflow in constructing energy quantity from int

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,7 +25,7 @@
 # We have lots of memory allocations in static variable declarations, and
 # that's fine.
 #
-# * clang-analyzer-core.{DivideZero,NonNullParamChecker}
+# * clang-analyzer-core.{DivideZero,NonNullParamChecker,UndefinedBinaryOperatorResult}
 # * clang-analyzer-cplusplus.NewDelete
 # They report too many false positives.
 #
@@ -56,6 +56,7 @@ clang-diagnostic-*,\
 -clang-analyzer-core.CallAndMessage,\
 -clang-analyzer-core.DivideZero,\
 -clang-analyzer-core.NonNullParamChecker,\
+-clang-analyzer-core.UndefinedBinaryOperatorResult,\
 -clang-analyzer-cplusplus.NewDelete,\
 cppcoreguidelines-slicing,\
 google-explicit-constructor,\

--- a/src/activity_handlers.cpp
+++ b/src/activity_handlers.cpp
@@ -3892,7 +3892,7 @@ void activity_handlers::spellcasting_finish( player_activity *act, Character *yo
                         you->mod_stamina( -cost );
                         break;
                     case magic_energy_type::bionic:
-                        you->mod_power_level( -units::from_kilojoule( cost ) );
+                        you->mod_power_level( -units::from_kilojoule( static_cast<std::int64_t>( cost ) ) );
                         break;
                     case magic_energy_type::hp:
                         blood_magic( you, cost );

--- a/src/bionics.cpp
+++ b/src/bionics.cpp
@@ -694,7 +694,7 @@ void npc::check_or_use_weapon_cbm( const bionic_id &cbm_id )
     int ammo_count = weap.ammo_remaining( this );
     const units::energy ups_drain = weap.get_gun_ups_drain();
     if( ups_drain > 0_kJ ) {
-        ammo_count = units::from_kilojoule( ammo_count ) / ups_drain;
+        ammo_count = units::from_kilojoule( static_cast<std::int64_t>( ammo_count ) ) / ups_drain;
     }
 
     // the weapon value from `weapon_value` may be different from `npc_attack_rating`
@@ -1193,7 +1193,7 @@ bool Character::activate_bionic( bionic &bio, bool eff_only, bool *close_bionics
             }
             ctr.charges = units::to_kilojoule( get_power_level() );
             int power_use = invoke_item( &ctr );
-            mod_power_level( units::from_kilojoule( -power_use ) );
+            mod_power_level( units::from_kilojoule( static_cast<std::int64_t>( -power_use ) ) );
             bio.powered = ctr.active;
         } else {
             bio.powered = g->remoteveh() != nullptr || !get_value( "remote_controlling" ).empty();

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -7206,7 +7206,7 @@ void Character::update_stamina( int turns )
             stamina_recovery += bonus;
             bonus /= 10;
             bonus = std::max( bonus, 1 );
-            mod_power_level( units::from_kilojoule( -bonus ) );
+            mod_power_level( units::from_kilojoule( static_cast<std::int64_t>( -bonus ) ) );
         }
     }
 
@@ -9794,7 +9794,8 @@ units::energy Character::available_ups() const
 
     if( is_mounted() && mounted_creature.get()->has_flag( mon_flag_RIDEABLE_MECH ) ) {
         auto *mons = mounted_creature.get();
-        available_charges += units::from_kilojoule( mons->battery_item->ammo_remaining() );
+        available_charges += units::from_kilojoule( static_cast<std::int64_t>
+                             ( mons->battery_item->ammo_remaining() ) );
     }
 
     bool has_bio_powered_ups = false;
@@ -9808,7 +9809,7 @@ units::energy Character::available_ups() const
     }
 
     cache_visit_items_with( flag_IS_UPS, [&available_charges]( const item & it ) {
-        available_charges += units::from_kilojoule( it.ammo_remaining() );
+        available_charges += units::from_kilojoule( static_cast<std::int64_t>( it.ammo_remaining() ) );
     } );
 
     return available_charges;
@@ -9875,7 +9876,7 @@ std::list<item> Character::use_charges( const itype_id &what, int qty, const int
     } else if( what == itype_UPS ) {
         // Fairly sure that nothing comes here. But handle it anyways.
         debugmsg( _( "This UPS use needs updating.  Create issue on github." ) );
-        consume_ups( units::from_kilojoule( qty ), radius );
+        consume_ups( units::from_kilojoule( static_cast<std::int64_t>( qty ) ), radius );
         return res;
     }
 
@@ -9908,7 +9909,7 @@ std::list<item> Character::use_charges( const itype_id &what, int qty, const int
     }
 
     if( has_tool_with_UPS ) {
-        consume_ups( units::from_kilojoule( qty ), radius );
+        consume_ups( units::from_kilojoule( static_cast<std::int64_t>( qty ) ), radius );
     }
 
     return res;

--- a/src/consumption.cpp
+++ b/src/consumption.cpp
@@ -524,7 +524,8 @@ std::pair<int, int> Character::fun_for( const item &comest, bool ignore_already_
     }
 
     if( fun < 0 && has_active_bionic( bio_taste_blocker ) &&
-        get_power_level() > units::from_kilojoule( std::abs( comest.get_comestible_fun() ) ) ) {
+        get_power_level() > units::from_kilojoule( static_cast<std::int64_t>( std::abs(
+                    comest.get_comestible_fun() ) ) ) ) {
         fun = 0;
     }
 
@@ -1123,8 +1124,10 @@ static bool eat( item &food, Character &you, bool force )
     }
 
     if( you.has_active_bionic( bio_taste_blocker ) && food.get_comestible_fun() < 0 &&
-        you.get_power_level() > units::from_kilojoule( std::abs( food.get_comestible_fun() ) ) ) {
-        you.mod_power_level( units::from_kilojoule( food.get_comestible_fun() ) );
+        you.get_power_level() > units::from_kilojoule( static_cast<std::int64_t>( std::abs(
+                    food.get_comestible_fun() ) ) ) ) {
+        you.mod_power_level( units::from_kilojoule( static_cast<std::int64_t>
+                             ( food.get_comestible_fun() ) ) );
     }
 
     if( food.has_flag( flag_FUNGAL_VECTOR ) && !you.has_trait( trait_M_IMMUNE ) ) {

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -2373,7 +2373,7 @@ void Character::consume_tools( map &m, const comp_selection<tool_comp> &tool, in
         m.use_charges( reachable_pts, tool.comp.type, quantity, return_true<item>, bcp );
         // Map::use_charges() does not handle UPS charges.
         if( quantity > 0 ) {
-            m.consume_ups( reachable_pts, units::from_kilojoule( quantity ) );
+            m.consume_ups( reachable_pts, units::from_kilojoule( static_cast<std::int64_t>( quantity ) ) );
         }
     }
 

--- a/src/explosion.cpp
+++ b/src/explosion.cpp
@@ -751,7 +751,8 @@ void emp_blast( const tripoint &p )
             add_msg( m_bad, _( "The EMP blast drains your power." ) );
             int max_drain = ( player_character.get_power_level() > 1000_kJ ? 1000 : units::to_kilojoule(
                                   player_character.get_power_level() ) );
-            player_character.mod_power_level( units::from_kilojoule( -rng( 1 + max_drain / 3, max_drain ) ) );
+            player_character.mod_power_level( units::from_kilojoule( static_cast<std::int64_t>( -rng(
+                                                  1 + max_drain / 3, max_drain ) ) ) );
         }
         // TODO: More effects?
         //e-handcuffs effects

--- a/src/item.cpp
+++ b/src/item.cpp
@@ -10672,7 +10672,7 @@ units::energy item::energy_remaining( const Character *carrier ) const
     if( is_magazine() ) {
         for( const item *e : contents.all_items_top( pocket_type::MAGAZINE ) ) {
             if( e->typeId() == itype_battery ) {
-                ret += units::from_kilojoule( e->charges );
+                ret += units::from_kilojoule( static_cast<std::int64_t>( e->charges ) );
             }
         }
     }
@@ -10817,7 +10817,7 @@ int item::ammo_consume( int qty, const tripoint &pos, Character *carrier )
     // Guns handle energy in energy_consume()
     if( carrier != nullptr && type->tool &&
         ( has_flag( flag_USE_UPS ) || has_flag( flag_USES_BIONIC_POWER ) ) ) {
-        units::energy wanted_energy = units::from_kilojoule( qty );
+        units::energy wanted_energy = units::from_kilojoule( static_cast<std::int64_t>( qty ) );
 
         if( has_flag( flag_USE_UPS ) ) {
             wanted_energy -= carrier->consume_ups( wanted_energy );
@@ -10849,7 +10849,7 @@ units::energy item::energy_consume( units::energy qty, const tripoint &pos, Char
     // Consume battery(ammo) and other fuel (if allowed)
     if( is_battery() || fuel_efficiency >= 0 ) {
         int consumed_kj = contents.ammo_consume( units::to_kilojoule( qty ), pos, fuel_efficiency );
-        qty -= units::from_kilojoule( consumed_kj );
+        qty -= units::from_kilojoule( static_cast<std::int64_t>( consumed_kj ) );
         // fix negative quantity
         if( qty < 0_J ) {
             qty = 0_J;
@@ -10877,7 +10877,7 @@ units::energy item::energy_consume( units::energy qty, const tripoint &pos, Char
     // Should happen only if battery powered and energy per shot is not integer kJ.
     if( qty > 0_kJ && is_battery() ) {
         int consumed_kj = contents.ammo_consume( 1, pos );
-        qty -= units::from_kilojoule( consumed_kj );
+        qty -= units::from_kilojoule( static_cast<std::int64_t>( consumed_kj ) );
     }
 
     return wanted_energy - qty;

--- a/src/item_contents.cpp
+++ b/src/item_contents.cpp
@@ -1233,7 +1233,8 @@ int item_contents::ammo_consume( int qty, const tripoint &pos, float fuel_effici
             if( !pocket.empty() && pocket.front().is_fuel() && fuel_efficiency >= 0 ) {
                 // if using fuel instead of battery, everything is in kJ
                 // charges is going to be the energy needed over the energy in 1 unit of fuel * the efficiency of the generator
-                int charges_used = ceil( static_cast<float>( units::from_kilojoule( qty ).value() ) / (
+                int charges_used = ceil( static_cast<float>( units::from_kilojoule( static_cast<std::int64_t>
+                                         ( qty ) ).value() ) / (
                                              static_cast<float>( pocket.front().fuel_energy().value() ) * fuel_efficiency ) );
 
                 const int res = pocket.ammo_consume( charges_used );

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -2188,7 +2188,7 @@ bool known_magic::has_enough_energy( const Character &guy, const spell &sp ) con
         case magic_energy_type::mana:
             return available_mana() >= cost;
         case magic_energy_type::bionic:
-            return guy.get_power_level() >= units::from_kilojoule( cost );
+            return guy.get_power_level() >= units::from_kilojoule( static_cast<std::int64_t>( cost ) );
         case magic_energy_type::stamina:
             return guy.get_stamina() >= cost;
         case magic_energy_type::hp:

--- a/src/magic_spell_effect.cpp
+++ b/src/magic_spell_effect.cpp
@@ -1146,7 +1146,7 @@ void spell_effect::recover_energy( const spell &sp, Creature &caster, const trip
         you->mod_fatigue( -healing );
     } else if( energy_source == "BIONIC" ) {
         if( healing > 0 ) {
-            you->mod_power_level( units::from_kilojoule( healing ) );
+            you->mod_power_level( units::from_kilojoule( static_cast<std::int64_t>( healing ) ) );
         } else {
             you->mod_stamina( healing );
         }

--- a/src/monster.cpp
+++ b/src/monster.cpp
@@ -2906,7 +2906,7 @@ units::energy monster::use_mech_power( units::energy amt )
     const int max_drain = battery_item->ammo_remaining();
     const int consumption = std::min( static_cast<int>( units::to_kilojoule( amt ) ), max_drain );
     battery_item->ammo_consume( consumption, pos(), nullptr );
-    return units::from_kilojoule( consumption );
+    return units::from_kilojoule( static_cast<std::int64_t>( consumption ) );
 }
 
 int monster::mech_str_addition() const

--- a/src/move_mode.cpp
+++ b/src/move_mode.cpp
@@ -183,7 +183,7 @@ float move_mode::move_speed_mult() const
 
 units::energy move_mode::mech_power_use() const
 {
-    return units::from_kilojoule( _mech_power_use );
+    return units::from_kilojoule( static_cast<std::int64_t>( _mech_power_use ) );
 }
 
 int move_mode::swim_speed_mod() const

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -4843,7 +4843,8 @@ void vehicle::consume_fuel( int load, bool idling )
         }
         // decreased stamina burn scalable with load
         if( player_character.has_active_bionic( bio_jointservo ) ) {
-            player_character.mod_power_level( units::from_kilojoule( -std::max( eff_load / 20, 1 ) ) );
+            player_character.mod_power_level( units::from_kilojoule( static_cast<std::int64_t>( -std::max(
+                                                  eff_load / 20, 1 ) ) ) );
             mod -= std::max( eff_load / 5, 5 );
         }
 

--- a/src/wish.cpp
+++ b/src/wish.cpp
@@ -429,7 +429,7 @@ void debug_menu::wishbionics( Character *you )
                 int new_value = 0;
                 if( query_int( new_value, _( "Set the value to (in kJ)?  Currently: %s" ),
                                units::display( power_max ) ) ) {
-                    you->set_max_power_level( units::from_kilojoule( new_value ) );
+                    you->set_max_power_level( units::from_kilojoule( static_cast<std::int64_t>( new_value ) ) );
                     you->set_power_level( you->get_power_level() );
                 }
                 break;
@@ -438,7 +438,7 @@ void debug_menu::wishbionics( Character *you )
                 int new_value = 0;
                 if( query_int( new_value, _( "Set the value to (in J)?  Currently: %s" ),
                                units::display( power_max ) ) ) {
-                    you->set_max_power_level( units::from_joule( new_value ) );
+                    you->set_max_power_level( units::from_joule( static_cast<std::int64_t>( new_value ) ) );
                     you->set_power_level( you->get_power_level() );
                 }
                 break;
@@ -447,7 +447,7 @@ void debug_menu::wishbionics( Character *you )
                 int new_value = 0;
                 if( query_int( new_value, _( "Set the value to (in kJ)?  Currently: %s" ),
                                units::display( power_level ) ) ) {
-                    you->set_power_level( units::from_kilojoule( new_value ) );
+                    you->set_power_level( units::from_kilojoule( static_cast<std::int64_t>( new_value ) ) );
                 }
                 break;
             }
@@ -455,7 +455,7 @@ void debug_menu::wishbionics( Character *you )
                 int new_value = 0;
                 if( query_int( new_value, _( "Set the value to (in J)?  Currently: %s" ),
                                units::display( power_level ) ) ) {
-                    you->set_power_level( units::from_joule( new_value ) );
+                    you->set_power_level( units::from_joule( static_cast<std::int64_t>( new_value ) ) );
                 }
                 break;
             }

--- a/tests/food_fun_for_test.cpp
+++ b/tests/food_fun_for_test.cpp
@@ -427,7 +427,8 @@ TEST_CASE( "fun_for_bionic_bio_taste_blocker", "[fun_for][food][bionic]" )
                 // Needs 1 kJ per negative fun unit to nullify bad taste
                 dummy.set_power_level( 10_kJ );
                 REQUIRE( garlic_fun < -10 );
-                REQUIRE_FALSE( dummy.get_power_level() > units::from_kilojoule( std::abs( garlic_fun ) ) );
+                REQUIRE_FALSE( dummy.get_power_level() > units::from_kilojoule( static_cast<std::int64_t>( std::abs(
+                                   garlic_fun ) ) ) );
 
                 THEN( "the bad taste remains" ) {
                     actual_fun = dummy.fun_for( garlic );
@@ -438,7 +439,8 @@ TEST_CASE( "fun_for_bionic_bio_taste_blocker", "[fun_for][food][bionic]" )
             WHEN( "it has enough power" ) {
                 REQUIRE( garlic_fun >= -20 );
                 dummy.set_power_level( 20_kJ );
-                REQUIRE( dummy.get_power_level() > units::from_kilojoule( std::abs( garlic_fun ) ) );
+                REQUIRE( dummy.get_power_level() > units::from_kilojoule( static_cast<std::int64_t>( std::abs(
+                             garlic_fun ) ) ) );
 
                 THEN( "the bad taste is nullified" ) {
                     actual_fun = dummy.fun_for( garlic );

--- a/tools/clang-tidy-plugin/CMakeLists.txt
+++ b/tools/clang-tidy-plugin/CMakeLists.txt
@@ -34,6 +34,7 @@ set(CataAnalyzerSrc
         TranslationsInDebugMessagesCheck.cpp
         TranslatorCommentsCheck.cpp
         U8PathCheck.cpp
+        UnitOverflowCheck.cpp
         UnsequencedCallsCheck.cpp
         UnusedStaticsCheck.cpp
         UseLocalizedSortingCheck.cpp

--- a/tools/clang-tidy-plugin/CataTidyModule.cpp
+++ b/tools/clang-tidy-plugin/CataTidyModule.cpp
@@ -30,6 +30,7 @@
 #include "TranslationsInDebugMessagesCheck.h"
 #include "TranslatorCommentsCheck.h"
 #include "U8PathCheck.h"
+#include "UnitOverflowCheck.h"
 #include "UnsequencedCallsCheck.h"
 #include "UnusedStaticsCheck.h"
 #include "UseLocalizedSortingCheck.h"
@@ -100,6 +101,7 @@ class CataModule : public ClangTidyModule
                 "cata-translations-in-debug-messages" );
             CheckFactories.registerCheck<TranslatorCommentsCheck>( "cata-translator-comments" );
             CheckFactories.registerCheck<U8PathCheck>( "cata-u8-path" );
+            CheckFactories.registerCheck<UnitOverflowCheck>( "cata-unit-overflow" );
             CheckFactories.registerCheck<UnsequencedCallsCheck>( "cata-unsequenced-calls" );
             CheckFactories.registerCheck<UnusedStaticsCheck>( "cata-unused-statics" );
             CheckFactories.registerCheck<UseLocalizedSortingCheck>( "cata-use-localized-sorting" );

--- a/tools/clang-tidy-plugin/UnitOverflowCheck.cpp
+++ b/tools/clang-tidy-plugin/UnitOverflowCheck.cpp
@@ -1,0 +1,86 @@
+#include "UnitOverflowCheck.h"
+#include "Utils.h"
+
+#include <clang/ASTMatchers/ASTMatchers.h>
+#include <clang/Basic/Diagnostic.h>
+
+#include <map>
+
+using namespace clang::ast_matchers;
+
+namespace clang::tidy::cata
+{
+
+struct QuantityUnit {
+    std::string_view Unit;
+    std::int64_t ConversionFactor;
+};
+
+static const std::map<std::string_view, QuantityUnit> FunctionAndQuantityTypes {
+    {"from_joule", {"energy", 1'000LL}},
+    {"from_kilojoule", {"energy", 1'000'000LL}},
+};
+
+void UnitOverflowCheck::registerMatchers( ast_matchers::MatchFinder *Finder )
+{
+    for( const auto &[functionName, unit] : FunctionAndQuantityTypes ) {
+        Finder->addMatcher(
+            callExpr( callee( functionDecl( hasName( functionName ) ).bind( "func" ) ),
+                      hasArgument( 0, expr( hasType( isInteger() ) ).bind( "arg" ) ) ),
+            this
+        );
+    }
+}
+
+void UnitOverflowCheck::check( const ast_matchers::MatchFinder::MatchResult &Result )
+{
+    const FunctionDecl *func = Result.Nodes.getNodeAs<FunctionDecl>( "func" );
+    const Expr *arg = Result.Nodes.getNodeAs<Expr>( "arg" );
+    if( !func || !arg ) {
+        return;
+    }
+    const QualType type = arg->getType();
+    const std::int64_t width = Result.Context->getTypeInfo( type ).Width;
+    if( width >= 64 ) {
+        return;
+    }
+    const SourceManager &sourceManager = *Result.SourceManager;
+    if( sourceManager.getFilename( arg->getBeginLoc() ).ends_with( "src/units.h" ) ) {
+        return;
+    }
+    const std::string functionName = func->getNameAsString();
+    if( const IntegerLiteral *literal = dyn_cast<IntegerLiteral>( arg ) ) {
+        const bool isSigned = literal->getType()->isSignedIntegerType();
+        std::int64_t minVal = 0;
+        std::int64_t maxVal = 0;
+        if( isSigned ) {
+            minVal = llvm::APInt::getSignedMinValue( width ).getSExtValue();
+            maxVal = llvm::APInt::getSignedMaxValue( width ).getSExtValue();
+        } else {
+            minVal = llvm::APInt::getMinValue( width ).getSExtValue();
+            maxVal = llvm::APInt::getMaxValue( width ).getSExtValue();
+        }
+        const std::int64_t multiplier = FunctionAndQuantityTypes.at( functionName ).ConversionFactor;
+        const std::int64_t val = literal->getValue().getSExtValue() * multiplier;
+        if( val < minVal || val > maxVal ) {
+            emitDiag( arg->getBeginLoc(), FunctionAndQuantityTypes.at( functionName ).Unit, type.getAsString(),
+                      functionName, FixItHint::CreateReplacement( arg->getSourceRange(),
+                              ( getText( Result, arg ) + Twine( "LL" ) ).str() ) );
+        }
+    } else {
+        emitDiag( arg->getBeginLoc(), FunctionAndQuantityTypes.at( functionName ).Unit, type.getAsString(),
+                  functionName, FixItHint::CreateReplacement( arg->getSourceRange(),
+                          ( Twine( "static_cast<std::int64_t>( " ) + getText( Result, arg ) + " )" ).str() ) );
+    }
+}
+
+void UnitOverflowCheck::emitDiag( const SourceLocation &loc, const std::string_view QuantityType,
+                                  const std::string_view ValueType,
+                                  const std::string_view FunctionName, const clang::FixItHint &fix )
+{
+    diag( loc,
+          "constructing %0 quantity from '%1' can overflow in '%2' in multiplying with the conversion factor" )
+            << QuantityType << ValueType << FunctionName << fix;
+}
+
+} // namespace clang::tidy::cata

--- a/tools/clang-tidy-plugin/UnitOverflowCheck.h
+++ b/tools/clang-tidy-plugin/UnitOverflowCheck.h
@@ -1,0 +1,34 @@
+#ifndef CATA_TOOLS_CLANG_TIDY_PLUGIN_UNITOVERFLOWCHECK_H
+#define CATA_TOOLS_CLANG_TIDY_PLUGIN_UNITOVERFLOWCHECK_H
+
+#include <clang-tidy/ClangTidy.h>
+#include <clang-tidy/ClangTidyCheck.h>
+#include <clang/ASTMatchers/ASTMatchFinder.h>
+
+namespace clang
+{
+
+namespace tidy
+{
+class ClangTidyContext;
+
+namespace cata
+{
+
+class UnitOverflowCheck : public ClangTidyCheck
+{
+    public:
+        UnitOverflowCheck( StringRef Name, ClangTidyContext *Context ) : ClangTidyCheck( Name, Context ) {}
+        void registerMatchers( ast_matchers::MatchFinder *Finder ) override;
+        void check( const ast_matchers::MatchFinder::MatchResult &Result ) override;
+
+    protected:
+        void emitDiag( const SourceLocation &loc, std::string_view QuantityType,
+                       std::string_view ValueType, std::string_view FunctionName, const FixItHint &fix );
+};
+
+} // namespace cata
+} // namespace tidy
+} // namespace clang
+
+#endif // CATA_TOOLS_CLANG_TIDY_PLUGIN_UNITOVERFLOWCHECK_H

--- a/tools/clang-tidy-plugin/test/unit-overflow.cpp
+++ b/tools/clang-tidy-plugin/test/unit-overflow.cpp
@@ -1,0 +1,48 @@
+// RUN: %check_clang_tidy -allow-stdinc %s cata-unit-overflow %t -- --load=%cata_plugin -- -isystem %cata_include -isystem %cata_include/third-party
+
+#include "units.h"
+
+units::energy f_energy_0()
+{
+    return units::from_millijoule( 3'000 );
+}
+
+units::energy f_energy_1()
+{
+    return units::from_joule( 3'000 );
+}
+
+units::energy f_energy_2()
+{
+    return units::from_joule( 3'000'000 );
+    // CHECK-MESSAGES: warning: constructing energy quantity from 'int' can overflow in 'from_joule' in multiplying with the conversion factor [cata-unit-overflow]
+    // CHECK-FIXES: return units::from_joule( 3'000'000LL );
+}
+
+units::energy f_energy_3()
+{
+    int joule = 3'000'000;
+    return units::from_joule( joule );
+    // CHECK-MESSAGES: warning: constructing energy quantity from 'int' can overflow in 'from_joule' in multiplying with the conversion factor [cata-unit-overflow]
+    // CHECK-FIXES: return units::from_joule( static_cast<std::int64_t>( joule ) );
+}
+
+units::energy f_energy_4()
+{
+    return units::from_kilojoule( 2'000 );
+}
+
+units::energy f_energy_5()
+{
+    return units::from_kilojoule( 3'000 );
+    // CHECK-MESSAGES: warning: constructing energy quantity from 'int' can overflow in 'from_kilojoule' in multiplying with the conversion factor [cata-unit-overflow]
+    // CHECK-FIXES: return units::from_kilojoule( 3'000LL );
+}
+
+units::energy f_energy_6()
+{
+    int kj = 3'000;
+    return units::from_kilojoule( kj );
+    // CHECK-MESSAGES: warning: constructing energy quantity from 'int' can overflow in 'from_kilojoule' in multiplying with the conversion factor [cata-unit-overflow]
+    // CHECK-FIXES: return units::from_kilojoule( static_cast<std::int64_t>( kj ) );
+}


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fix 32 bit integer overflow in bionic power level calculations"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #71396.

`from_kilojoule()` silently clamps the value in the range of **the type of the parameter passed in**.
```c++
template<typename value_type>
inline constexpr quantity<value_type, energy_in_millijoule_tag> from_kilojoule( const value_type v )
{
    const value_type max_energy_joules = std::numeric_limits<value_type>::max() / 1000;
    // This checks for value_type overflow - if the energy we are given in Joules is greater
    // than the max energy in Joules, overflow will occur when it is converted to millijoules
    // The value we are given is in kJ, multiply by 1000 to convert it to joules, for use in from_joule
    value_type energy = v * 1000 > max_energy_joules ? max_energy_joules : v * 1000;
    return from_joule<value_type>( energy );
}
```

So `units::from_kilojoule( 3000 )` actually returns 2147 kJ, because that's the maximum representable value in mJ in `int`. To get 3000 kJ, one needs to call `units::from_kilojoule( 3000LL )`.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This pull request adds a `clang-tidy` check to detect calls to `units::from_joule()` and `units::from_kilojoule()` with an `int` as parameter, then applies automatic code transformations to non-compliant call sites.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Change `unit::from_joule()` and `unit::from_kilojoule()` to always compute in `quantity<int64_t, energy_in_millijoule_tag>` instead of templated `quantity<param_type, energy_in_millijoule_tag>`.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Follow the steps to reproduce in #71396 and note that 5000 kJ of energy is properly deducted from the player character.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
