### PR TITLE
Make clang-tidy plugin test suite compatible with libc++

### DIFF
--- a/tools/clang-tidy-plugin/test/assert.cpp
+++ b/tools/clang-tidy-plugin/test/assert.cpp
@@ -2,7 +2,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
-
+#include <cstdlib>
 #include <cata_assert.h>
 
 void f0()

--- a/tools/clang-tidy-plugin/test/determinism.cpp
+++ b/tools/clang-tidy-plugin/test/determinism.cpp
@@ -23,9 +23,9 @@ int rand();
 void f()
 {
     std::mt19937 gen0;
-    // CHECK-MESSAGES: [[@LINE-1]]:18: warning: Construction of library random engine 'std::mt19937' (aka 'mersenne_twister_engine<unsigned {{(int|long)}}, 32, 624, 397, 31, 2567483615UL, 11, 4294967295UL, 7, 2636928640UL, 15, 4022730752UL, 18, 1812433253UL>').  To ensure determinism for a fixed seed, use the common tools from rng.h rather than your own random number engines. [cata-determinism]
+    // CHECK-MESSAGES: [[@LINE-1]]:18: warning: Construction of library random engine 'std::mt19937' (aka 'mersenne_twister_engine<unsigned {{(int|long)}}, 32, 624, 397, 31, 2567483615{{(U|UL)}}, 11, 4294967295{{(U|UL)}}, 7, 2636928640{{(U|UL)}}, 15, 4022730752{{(U|UL)}}, 18, 1812433253{{(UL)?}}>').  To ensure determinism for a fixed seed, use the common tools from rng.h rather than your own random number engines. [cata-determinism]
     cata_default_random_engine gen1( 0 );
-    // CHECK-MESSAGES: [[@LINE-1]]:32: warning: Construction of library random engine 'cata_default_random_engine' (aka 'linear_congruential_engine<unsigned {{(int|long)}}, 16807UL, 0UL, 2147483647UL>').  To ensure determinism for a fixed seed, use the common tools from rng.h rather than your own random number engines. [cata-determinism]
+    // CHECK-MESSAGES: [[@LINE-1]]:32: warning: Construction of library random engine 'cata_default_random_engine' (aka 'linear_congruential_engine<unsigned {{(int|long)}}, 16807{{(UL)?}}, 0{{(UL)?}}, 2147483647{{(UL)?}}>').  To ensure determinism for a fixed seed, use the common tools from rng.h rather than your own random number engines. [cata-determinism]
     SomeOtherStruct s0;
     StructWithSeedButNotResultType s1;
     SomeOtherAlias a;

--- a/tools/clang-tidy-plugin/test/use-localized-sorting.cpp
+++ b/tools/clang-tidy-plugin/test/use-localized-sorting.cpp
@@ -65,7 +65,7 @@ void sort1( NonString *start, NonString *end )
 void sortit0( std::vector<std::string>::iterator start, std::vector<std::string>::iterator end )
 {
     std::sort( start, end );
-    // CHECK-MESSAGES: warning: Raw sort of 'typename __traits_type::value_type' (aka 'std::basic_string<char>').  For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
+    // CHECK-MESSAGES: warning: Raw sort of 'typename {{.*}}' (aka 'std::{{.*string.*}}').  For UI purposes please use localized_compare from translations.h. [cata-use-localized-sorting]
 }
 
 void sortit1( std::vector<NonString>::iterator start, std::vector<NonString>::iterator end )


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Because differences in the fully expanded type name of some template classes in the standard library between `libstdc++` and `libc++`, the clang-tidy plugin test suite does not pass on macOS.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add regular expressions in the expected values to allow some leeway in internal type names in the standard library.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
The test suite pass on macOS after the patch. Should be good if it also passes the clang-tidy test on GitHub Actions CI.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
