### PR TITLE
Rename "Think something" to "Emote", make it more freeform

### DIFF
--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -415,7 +415,7 @@ enum npc_chat_menu {
     NPC_CHAT_DONE,
     NPC_CHAT_TALK,
     NPC_CHAT_YELL,
-    NPC_CHAT_THINK,
+    NPC_CHAT_FLAVOR,
     NPC_CHAT_START_SEMINAR,
     NPC_CHAT_SENTENCE,
     NPC_CHAT_GUARD,
@@ -878,7 +878,7 @@ void game::chat()
 
     nmenu.addentry( NPC_CHAT_YELL, true, 'a', _( "Yell" ) );
     nmenu.addentry( NPC_CHAT_SENTENCE, true, 'b', _( "Yell a sentence" ) );
-    nmenu.addentry( NPC_CHAT_THINK, true, 'T', _( "Think something" ) );
+    nmenu.addentry( NPC_CHAT_FLAVOR, true, 'T', _( "Flavor message" ) );
     if( !animal_vehicles.empty() ) {
         nmenu.addentry( NPC_CHAT_ANIMAL_VEHICLE_FOLLOW, true, 'F',
                         _( "Whistle at your animals pulling vehicles to follow you." ) );
@@ -958,10 +958,9 @@ void game::chat()
             is_order = false;
             break;
         }
-        case NPC_CHAT_THINK: {
-            std::string popupdesc = _( "What are you thinking about?" );
+        case NPC_CHAT_FLAVOR: {
+            std::string popupdesc = _( "What do you want to add to the message log?  (This will have no in-game effect!)" );
             string_input_popup popup;
-            popup.title( _( "You think" ) )
             .width( 64 )
             .description( popupdesc )
             .identifier( "sentence" )

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -962,7 +962,7 @@ void game::chat()
             std::string popupdesc =
                 _( "What do you want to add to the message log?  (This will have no in-game effect!)" );
             string_input_popup popup;
-            popup.title( _( "Add a message" ) )
+            popup.title( _( "Do something" ) )
             .width( 64 )
             .description( popupdesc )
             .identifier( "sentence" )

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -415,7 +415,7 @@ enum npc_chat_menu {
     NPC_CHAT_DONE,
     NPC_CHAT_TALK,
     NPC_CHAT_YELL,
-    NPC_CHAT_MISC,
+    NPC_CHAT_EMOTE,
     NPC_CHAT_START_SEMINAR,
     NPC_CHAT_SENTENCE,
     NPC_CHAT_GUARD,
@@ -878,7 +878,7 @@ void game::chat()
 
     nmenu.addentry( NPC_CHAT_YELL, true, 'a', _( "Yell" ) );
     nmenu.addentry( NPC_CHAT_SENTENCE, true, 'b', _( "Yell a sentence" ) );
-    nmenu.addentry( NPC_CHAT_MISC, true, 'T', _( "Miscellaneous action" ) );
+    nmenu.addentry( NPC_CHAT_EMOTE, true, 'E', _( "Emote" ) );
     if( !animal_vehicles.empty() ) {
         nmenu.addentry( NPC_CHAT_ANIMAL_VEHICLE_FOLLOW, true, 'F',
                         _( "Whistle at your animals pulling vehicles to follow you." ) );
@@ -924,7 +924,7 @@ void game::chat()
     }
     std::string message;
     std::string yell_msg;
-    std::string misc_msg;
+    std::string emote_msg;
     bool is_order = true;
     nmenu.query();
 
@@ -958,17 +958,17 @@ void game::chat()
             is_order = false;
             break;
         }
-        case NPC_CHAT_MISC: {
+        case NPC_CHAT_EMOTE: {
             std::string popupdesc =
-                _( "What do you want to add to the message log?  (This will have no in-game effect!)" );
+                _( "What do you want to emote?  (This will have no in-game effect!)" );
             string_input_popup popup;
-            popup.title( _( "Do something" ) )
+            popup.title( _( "Emote" ) )
             .width( 64 )
             .description( popupdesc )
             .identifier( "sentence" )
             .max_length( 128 )
             .query();
-            misc_msg = popup.text();
+            emote_msg = popup.text();
             is_order = false;
             break;
         }
@@ -1235,8 +1235,8 @@ void game::chat()
         add_msg( _( "You yell %s" ), message );
         u.shout( string_format( _( "%s yelling %s" ), u.disp_name(), message ), is_order );
     }
-    if( !misc_msg.empty() ) {
-        add_msg( misc_msg );
+    if( !emote_msg.empty() ) {
+        add_msg( emote_msg );
     }
 
     u.moves -= 100;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -959,7 +959,8 @@ void game::chat()
             break;
         }
         case NPC_CHAT_FLAVOR: {
-            std::string popupdesc = _( "What do you want to add to the message log?  (This will have no in-game effect!)" );
+            std::string popupdesc =
+                _( "What do you want to add to the message log?  (This will have no in-game effect!)" );
             string_input_popup popup;
             .width( 64 )
             .description( popupdesc )

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -924,7 +924,7 @@ void game::chat()
     }
     std::string message;
     std::string yell_msg;
-    std::string think_msg;
+    std::string flavor_msg;
     bool is_order = true;
     nmenu.query();
 
@@ -962,12 +962,13 @@ void game::chat()
             std::string popupdesc =
                 _( "What do you want to add to the message log?  (This will have no in-game effect!)" );
             string_input_popup popup;
+            popup.title( _( "Add a message" ) )
             .width( 64 )
             .description( popupdesc )
             .identifier( "sentence" )
             .max_length( 128 )
             .query();
-            think_msg = popup.text();
+            flavor_msg = popup.text();
             is_order = false;
             break;
         }
@@ -1234,8 +1235,8 @@ void game::chat()
         add_msg( _( "You yell %s" ), message );
         u.shout( string_format( _( "%s yelling %s" ), u.disp_name(), message ), is_order );
     }
-    if( !think_msg.empty() ) {
-        add_msg( _( "You think %s" ), think_msg );
+    if( !flavor_msg.empty() ) {
+        add_msg( flavor_msg );
     }
 
     u.moves -= 100;

--- a/src/npctalk.cpp
+++ b/src/npctalk.cpp
@@ -415,7 +415,7 @@ enum npc_chat_menu {
     NPC_CHAT_DONE,
     NPC_CHAT_TALK,
     NPC_CHAT_YELL,
-    NPC_CHAT_FLAVOR,
+    NPC_CHAT_MISC,
     NPC_CHAT_START_SEMINAR,
     NPC_CHAT_SENTENCE,
     NPC_CHAT_GUARD,
@@ -878,7 +878,7 @@ void game::chat()
 
     nmenu.addentry( NPC_CHAT_YELL, true, 'a', _( "Yell" ) );
     nmenu.addentry( NPC_CHAT_SENTENCE, true, 'b', _( "Yell a sentence" ) );
-    nmenu.addentry( NPC_CHAT_FLAVOR, true, 'T', _( "Flavor message" ) );
+    nmenu.addentry( NPC_CHAT_MISC, true, 'T', _( "Miscellaneous action" ) );
     if( !animal_vehicles.empty() ) {
         nmenu.addentry( NPC_CHAT_ANIMAL_VEHICLE_FOLLOW, true, 'F',
                         _( "Whistle at your animals pulling vehicles to follow you." ) );
@@ -924,7 +924,7 @@ void game::chat()
     }
     std::string message;
     std::string yell_msg;
-    std::string flavor_msg;
+    std::string misc_msg;
     bool is_order = true;
     nmenu.query();
 
@@ -958,7 +958,7 @@ void game::chat()
             is_order = false;
             break;
         }
-        case NPC_CHAT_FLAVOR: {
+        case NPC_CHAT_MISC: {
             std::string popupdesc =
                 _( "What do you want to add to the message log?  (This will have no in-game effect!)" );
             string_input_popup popup;
@@ -968,7 +968,7 @@ void game::chat()
             .identifier( "sentence" )
             .max_length( 128 )
             .query();
-            flavor_msg = popup.text();
+            misc_msg = popup.text();
             is_order = false;
             break;
         }
@@ -1235,8 +1235,8 @@ void game::chat()
         add_msg( _( "You yell %s" ), message );
         u.shout( string_format( _( "%s yelling %s" ), u.disp_name(), message ), is_order );
     }
-    if( !flavor_msg.empty() ) {
-        add_msg( flavor_msg );
+    if( !misc_msg.empty() ) {
+        add_msg( misc_msg );
     }
 
     u.moves -= 100;


### PR DESCRIPTION
#### Summary
Balance "Rename 'Think something' to 'Emote', make it more freeform"

#### Purpose of change
While #61490 added the ability to think something to yourself, giving a message with no effect (which really helps roleplaying), it felt somewhat limited. Why not allow adding arbitrary flavor messages to the log?

#### Describe the solution
Change a const name and some lines of text, remove the "You think" prepended to the message.

#### Describe alternatives you've considered
1. Obligatory leaving as is.
2. Keeping "You think", or "You", as a separate option? _I'd like feedback on this one._

#### Testing
I'm currently unable to compile the game myself, but as this is a very minor change I don't think testing is necessary here.

#### Additional context
Yes, you can technically "do" things with this that you physically can't, but it's the same for "Think something". E.g you can already do `You think for a moment and blow up the horde with a fireball!`. You'd have to go out of your way to immersion-break that way, so I think it's fine.