### PR TITLE
Trim the sort armor keybinding hints

### DIFF
--- a/src/armor_layers.cpp
+++ b/src/armor_layers.cpp
@@ -722,10 +722,13 @@ void outfit::sort_armor( Character &guy )
         werase( w_encumb );
 
         // top bar
-        wprintz( w_sort_cat, c_white, _( "Sort Armor" ) );
+        std::string header_title = _( "Sort Armor" );
+        wprintz( w_sort_cat, c_white, header_title );
         std::string temp = bp != bodypart_id( "bp_null" ) ? body_part_name_as_heading( bp, 1 ) : _( "All" );
-        wprintz( w_sort_cat, c_yellow, "  << %s >>", temp );
-        right_print( w_sort_cat, 0, 0, c_white, string_format(
+        temp = string_format( "  << %s >>", temp );
+        wprintz( w_sort_cat, c_yellow, temp );
+        int keyhint_offset = utf8_width( header_title ) + utf8_width( temp ) + 1;
+        right_print( w_sort_cat, 0, 0, c_white, trim_by_length( string_format(
                          _( "[<color_yellow>%s</color>] Hide sprite.  "
                             "[<color_yellow>%s</color>] Change side.  "
                             "Press [<color_yellow>%s</color>] for help.  "
@@ -733,7 +736,7 @@ void outfit::sort_armor( Character &guy )
                          ctxt.get_desc( "TOGGLE_CLOTH" ),
                          ctxt.get_desc( "CHANGE_SIDE" ),
                          ctxt.get_desc( "USAGE_HELP" ),
-                         ctxt.get_desc( "HELP_KEYBINDINGS" ) ) );
+                         ctxt.get_desc( "HELP_KEYBINDINGS" ) ), getmaxx( w_sort_cat ) - keyhint_offset ) );
 
         leftListSize = tmp_worn.size();
         if( leftListLines > leftListSize ) {


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
None
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
The header of the Sort Armor screen (`+`) gets overwritten by keybinding hints at small screen widths.  In Polish and several other languages, the keybindings alone don't even fit at 80x24.
![Before--80x24--Polish](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/7eb0b698-2e1c-49ed-a34d-392cc50917ad)

Fixes #70916 
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

Calculate how much room the "Sort Armor" title and body part identification take up, then trim the keybinding hints to fit.  This is the lazy way to do it, but it should work and doesn't require any string changes.
![SortArmor--80x24--English](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/d407138f-8b92-4ee3-9d71-5134601a8004)

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

My preference would be to cut down the keybinding hints to just `F1` for help and `?` for keybindings.  Given that this screen actually has a dedicated help screen, I don't see why hiding the sprite is important enough to use up valuable screen real estate.

![Ideal_Layout](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/f8040d60-7224-4fb4-a986-8db9e3e49791)

However, I don't see a way to make this change without string changes, so I'd prefer to kick it down the road to after 0.H.


Alternatively, the keybinding hint could be trimmed from the left.  Given that the hints are essentially in ascending priority to the right (Hide sprite<Change side<Help<Keybindings), this would probably be preferable.  However, as far as I'm aware, there isn't currently code for 'trimming from the left".  It should probably be added someday, but today is not that day.


The header could also be expanded to multiple rows to fit all the current information, but the Sort Armor screen is already quite cramped.

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Tested at various screen sizes (135x24 is the minimum size in English to see everything we try to cram into the header)
![SortArmor--135x24--English](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/b5424a4a-195a-4441-b9d1-63a300016523)

Tested in several other languages. Polish, Russian, and Simplified Chinese are pictured.  Polish and Russian because they usually require more characters than English.  Simplified Chinese to make sure I didn't break handling of wide characters.
![SortArmor--80x24--Polish](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/3b17348e-9b69-4178-8572-1a464a78bc8c)
![SortArmor--80x24--Russian](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/438bc150-d04d-45e1-9645-f825a1eea928)
![SortArmor--80x24--SimplifiedChinese](https://github.com/CleverRaven/Cataclysm-DDA/assets/89038572/45b7dcac-64b9-437c-abc1-9e203db33d41)

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
