### PR TITLE
Fix tough zombie evolution

### DIFF
--- a/data/json/monsters/zed-classic.json
+++ b/data/json/monsters/zed-classic.json
@@ -456,7 +456,7 @@
     "death_drops": "default_zombie_death_drops",
     "burn_into": "mon_zombie_scorched",
     "fungalize_into": "mon_zombie_tough_fungal",
-    "upgrades": { "half_life": 24, "into": "mon_zombie_bruiser" },
+    "upgrades": { "half_life": 30, "into_group": "GROUP_ZOMBIE_UPGRADE" },
     "flags": [
       "SEES",
       "HEARS",


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Bugfixes "Fixes tough zombie evolution"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->
#70749 added several new zombies, including the zombie bruiser, which was meant to be a precursor to the zombie brute. It included a change that made tough zombies evolve only into the bruiser, when previously they had 26 possible things they could upgrade into.

Bruisers can only upgrade into brutes. which meant that tough zombies (which are quite common) would always evolve into bruisers, and then always into brutes, and then always into one of the six things brutes can evolve into. This would have severely cut down mid to late game enemy variety and overpopulated the world with hulks and wrestlers. Tough zombies are very common and were previously not intended to only evolve into those enemies.

#### Describe the solution

<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->
Reverts tough zombies to use GROUP_ZOMBIE_UPGRADE as they did before. This group includes bruisers so it's still possible for them to become those, but they're not forced down a single evolution path.

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->
We could make zombie evolution more strictly tied to the form of the human that begat them (so that all fat zombies would become some kind of boomer, all tough zombies become some kind of brute, etc) but I think that contradicts established lore, where zombie mutation is either explosively random or geared toward getting them out of whatever specific pickle they're in (IE prisoners turning into hulks to break out of their cells, brainless zombies evolving into headless horrors). 

An alternative might be to create new evolution groups for fat, tough, etc zombies that were still wide open but more heavily weighted to taking advantage of their human capabilities, however this would be an extensive rebalancing project.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Ran the game and saw that the world wasn't spammed with the new bruiser enemy in Summer and that it didn't turn into Hulkamania by Fall.

#### Additional context
Brutes and their kin will still be overrepresented compared to before, as both bruisers and brutes appear in group_zombie_upgrade, with a combined weight of 50 when before brutes were at 45. I'm not sure that this is an issue, as hulk-type enemies were not especially common before and it's not a big shift.

This is a reversion, but I don't believe it was the author's intent to so dramatically shrink the field of possible zombie evolutions like this.

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
