### PR TITLE
[Defense Mode] Fix #70277

### DIFF
--- a/data/mods/Defense_Mode/npcs.json
+++ b/data/mods/Defense_Mode/npcs.json
@@ -140,7 +140,13 @@
       { "group": "mon_zombie_resort_bouncer_death_drops", "fixed_adj": -0.5 },
       { "group": "mon_zombie_resort_staff_death_drops", "fixed_adj": -0.5 }
     ],
-    "traits": [ [ "DEBUG_FLIMSY", 100 ], [ "DEBUG_FLIMSY2", 100 ], [ "DEBUG_NOSCENT", 100 ], [ "DEBUG_SILENT", 100 ] ]
+    "traits": [
+      [ "DEBUG_FLIMSY", 100 ],
+      [ "DEBUG_FLIMSY2", 100 ],
+      [ "DEBUG_NOSCENT", 100 ],
+      [ "DEBUG_SILENT", 100 ],
+      [ "DEBUG_LS", 100 ]
+    ]
   },
   {
     "type": "item_group",
@@ -181,13 +187,15 @@
       { "group": "gear_survival", "prob": 70 },
       { "group": "civilian_body_armor", "prob": 70 },
       { "group": "drugs_pharmacy", "prob": 70 },
-      { "group": "preserved_food", "prob": 70 },
+      { "group": "preserved_food", "prob": 100 },
+      { "group": "preserved_food", "prob": 100 },
+      { "group": "preserved_food", "prob": 100 },
       { "group": "pet_food", "prob": 70 },
       { "group": "condiments", "prob": 70 },
-      { "group": "trader_guns&ammo", "prob": 70, "charges": 30 },
+      { "group": "trader_guns&ammo", "prob": 70, "charges": 50 },
       { "group": "hardware", "prob": 70 },
       { "group": "defense_caravan_melee", "prob": 70 },
-      { "group": "defense_caravan_ranged", "prob": 70, "charges": 30 },
+      { "group": "defense_caravan_ranged", "prob": 70, "charges": 50 },
       { "group": "defense_caravan_ammunition", "prob": 70 },
       { "group": "defense_caravan_components", "prob": 70 },
       { "group": "defense_caravan_clothes", "prob": 70 },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "Keep Defense Mode Merchants from eating themselves silly."
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Fix #70277
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
Add the Debug Life Support trait to merchants, holding their hunger constant upon spawning. Additionally, I added more food spawns to the merchant's inventory to allow players to buy more foodstuffs.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered
Not doing this.
<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Everything works pretty well, I didn't see any merchants gorging themselves.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context
None.
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
