### PR TITLE
New dialogue - Prototype Robot Questions

### DIFF
--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -289,7 +289,7 @@
       },
       { "text": "I think I'll pass.", "topic": "TALK_DONE" }
     ]
-  },  
+  },
   {
     "id": "MISSION_ROBOFAC_INTERCOM_1_ACCEPTED",
     "type": "talk_topic",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -263,16 +263,30 @@
   {
     "id": "MISSION_ROBOFAC_INTERCOM_1_ADVICE",
     "type": "talk_topic",
-    "dynamic_line": "There is.  If the robot is operational, it's very likely to be hostile and extremely dangerous.  If you try to fight it yourself, it WILL kill you.  Dr. Prado left the building with a handful of EMP grenades.  If you can locate those grenades, use them to disable the prototype instead.",
+    "dynamic_line": "There is.  If the robot is operational, it's very likely to be hostile and extremely dangerous.  I don't recommend fighting it directly.  Dr. Prado left the building with a handful of EMP grenades.  If you can locate those grenades, use them to disable the prototype instead.",
     "responses": [
       {
         "text": "I'll do it.  Where is the test site?",
         "topic": "MISSION_ROBOFAC_INTERCOM_1_ACCEPTED",
         "effect": { "assign_mission": "MISSION_ROBOFAC_INTERCOM_1" }
       },
+      { "text": "Extremely dangerous?  What kind of danger should I expect?", "topic": "MISSION_ROBOFAC_INTERCOM_1_ADVICE_2" },
       { "text": "I'll pass on getting killed today, thanks.", "topic": "TALK_DONE" }
     ]
   },
+  {
+    "id": "MISSION_ROBOFAC_INTERCOM_1_ADVICE_2",
+    "type": "talk_topic",
+    "dynamic_line": "It's built with experimental combat programming and some heavy-duty armor.  Despite the armor, it's pretty nimble, so unless you've got a vehicle don't expect to outrun it.  We decided to hold off on adding long-range weapons until we finished the initial field testing, so if you keep your distance, you should be safe.",
+    "responses": [
+      {
+        "text": "I can handle it.  Where is the test site?",
+        "topic": "MISSION_ROBOFAC_INTERCOM_1_ACCEPTED",
+        "effect": { "assign_mission": "MISSION_ROBOFAC_INTERCOM_1" }
+      },
+      { "text": "I think I'll pass.", "topic": "TALK_DONE" }
+    ]
+  },  
   {
     "id": "MISSION_ROBOFAC_INTERCOM_1_ACCEPTED",
     "type": "talk_topic",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -277,7 +277,7 @@
   {
     "id": "MISSION_ROBOFAC_INTERCOM_1_ADVICE_2",
     "type": "talk_topic",
-    "dynamic_line": "It's built with experimental combat programming and some heavy-duty armor.  Despite the armor, it's pretty nimble, so unless you've got a vehicle don't expect to outrun it.  We decided to hold off on adding long-range weapons until we finished the initial field testing, so if you keep your distance, you should be safe.",
+    "dynamic_line": "It's built with experimental combat programming and some heavy-duty armor.  Despite the armor, it's pretty nimble, so unless you've got a vehicle don't expect to outrun it.  We decided to hold off on adding long-range weapons until we finished the initial field testing, so if you can keep your distance, you should be safe.",
     "responses": [
       {
         "text": "I can handle it.  Where is the test site?",

--- a/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
+++ b/data/json/npcs/robofac/robofac_intercom/robofac_intercom_missions.json
@@ -270,7 +270,10 @@
         "topic": "MISSION_ROBOFAC_INTERCOM_1_ACCEPTED",
         "effect": { "assign_mission": "MISSION_ROBOFAC_INTERCOM_1" }
       },
-      { "text": "Extremely dangerous?  What kind of danger should I expect?", "topic": "MISSION_ROBOFAC_INTERCOM_1_ADVICE_2" },
+      {
+        "text": "Extremely dangerous?  What kind of danger should I expect?",
+        "topic": "MISSION_ROBOFAC_INTERCOM_1_ADVICE_2"
+      },
       { "text": "I'll pass on getting killed today, thanks.", "topic": "TALK_DONE" }
     ]
   },


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Content "Small new Hub dialogue"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Going through the HUB01 quests for the first time and wanted to PR a few bits of a dialogue that I personally would have wanted to ask.

This new dialogue is for the first quest where you find and destroy the prototype robot.

Without this dialogue you're completely left in the dark as to the capabilities of the robot.  Yes, I did feel silly stacking up on bulletproof armor and doing a quick drive-by instead of simply being able to ask if the robot had ranged weapons.

#### Describe the solution

Added an additional question dialogue where the player can get more information on the capabilities of the prototype.

"There is.  If the robot is operational, it's very likely to be hostile and extremely dangerous.  I don't recommend fighting it directly.  Dr. Prado left the building with a handful of EMP grenades.  If you can locate those grenades, use them to disable the prototype instead."

"Extremely dangerous?  What kind of danger should I expect?"

"It's built with experimental combat programming and some heavy-duty armor.  Despite the armor, it's pretty nimble, so unless you've got a vehicle don't expect to outrun it.  We decided to hold off on adding long-range weapons until we finished the initial field testing, so if you keep your distance, you should be safe."

#### Describe alternatives you've considered

Roleplaying as a character with social anxiety who doesn't want to look foolish by asking IMPORTANT questions.

#### Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->
Tested locally, dialogue options appear and act correctly.

![cataclysm-tiles_1CD8UOv6Zo](https://github.com/CleverRaven/Cataclysm-DDA/assets/52714184/4b2eeb05-d322-49af-9005-8d6c5ef8cf91)
![cataclysm-tiles_HG2OPH6hEt](https://github.com/CleverRaven/Cataclysm-DDA/assets/52714184/b418c1da-0f44-4e41-bd21-7b972d475793)

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
