### PR TITLE
fix mutation activation EoC once again

### DIFF
--- a/data/json/effects_on_condition/mutation_eocs/mutation_activation_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_activation_eocs.json
@@ -3,7 +3,7 @@
     "type": "effect_on_condition",
     "id": "EOC_GENERIC_SPELL_MUTATION",
     "//energy_amount": "optional, how much stamina you spend on activation of the mutation - EoC works exclusively with stamina, to consume calories, fatigue or thirst use corresponding booleans in mutation; default zero if you don't need to consume stamina",
-    "//prep_time": "time you spend to prepare the activation, in seconds. Use 0 to make activation instant",
+    "//prep_time": "time you spend to prepare the activation, in seconds. Use 0 to make activation instant.  Decimals are allowed, 0.5 means 50 moves",
     "//spell_to_cast": "spell that would be casted if activation is successful",
     "//message_success": "message that would be printed if activation is successful",
     "//message_fail": "message, that would be printed, if you have less stamina than required",
@@ -14,13 +14,9 @@
       ]
     },
     "effect": [
-      { "u_assign_activity": "ACT_GENERIC_EOC", "duration": { "context_val": "prep_time" } },
+      { "turn_cost": { "context_val": "prep_time" } },
       { "math": [ "u_val('stamina')", "-=", "_energy_amount" ] },
-      {
-        "if": { "math": [ "_prep_time", ">", "1" ] },
-        "then": { "queue_eocs": [ "EOC_GENERIC_SPELL_MUTATION_ACT" ], "time_in_future": { "math": [ "_prep_time - 1" ] } },
-        "else": { "run_eocs": [ "EOC_GENERIC_SPELL_MUTATION_ACT" ] }
-      }
+      { "run_eocs": [ "EOC_GENERIC_SPELL_MUTATION_ACT" ] }
     ],
     "false_effect": [ { "u_message": { "context_val": "message_fail" }, "type": "bad" } ]
   },
@@ -28,7 +24,6 @@
     "type": "effect_on_condition",
     "id": "EOC_GENERIC_SPELL_MUTATION_ACT",
     "//": "no proper way to check activity type to ensure player still prepare the mutation, so only level is checked for now (if spell is not instant)",
-    "condition": { "or": [ { "math": [ "u_val('activity_level')", "==", "0" ] }, { "math": [ "_prep_time", "==", "0" ] } ] },
     "effect": [
       {
         "u_cast_spell": { "id": { "context_val": "spell_to_cast" }, "message": { "context_val": "message_success" } },

--- a/data/json/effects_on_condition/mutation_eocs/mutation_activation_eocs.json
+++ b/data/json/effects_on_condition/mutation_eocs/mutation_activation_eocs.json
@@ -23,7 +23,6 @@
   {
     "type": "effect_on_condition",
     "id": "EOC_GENERIC_SPELL_MUTATION_ACT",
-    "//": "no proper way to check activity type to ensure player still prepare the mutation, so only level is checked for now (if spell is not instant)",
     "effect": [
       {
         "u_cast_spell": { "id": { "context_val": "spell_to_cast" }, "message": { "context_val": "message_success" } },

--- a/doc/EFFECT_ON_CONDITION.md
+++ b/doc/EFFECT_ON_CONDITION.md
@@ -3695,7 +3695,7 @@ Subtract this many turns from the alpha talker's moves.
 
 | Syntax | Optionality | Value  | Info |
 | --- | --- | --- | --- |
-| "turn_cost" | **mandatory** | number, duration, [variable object](##variable-object) or value between two | how long the action takes (can be specified in number of turns, or as a duration) |
+| "turn_cost" | **mandatory** | number, duration, [variable object](##variable-object) or value between two | how long the action takes (can be specified in number of turns (as decimal), or as a duration) |
 
 ##### Examples
 
@@ -3703,6 +3703,14 @@ Subtract this many turns from the alpha talker's moves.
 {
   "effect": [
     { "turn_cost": "1 sec" }
+  ]
+}
+```
+
+```json
+{
+  "effect": [
+    { "turn_cost": 0.6 }
   ]
 }
 ```


### PR DESCRIPTION
#### Summary
None
#### Purpose of change
Because Pounce doesn't work
#### Describe the solution
Scrap assign activity and activity checks entirely, we are going in dirty way and start to subtract moves directly, nice benefit is that we can use moves now
#### Additional context
I would like it to not subtract moves when you cease the spell cast, but it's not a big deal in most cases imo