### PR TITLE
[Magiclysm] Add dabbler hobbies for the people that knew 1 spell

### DIFF
--- a/data/mods/Magiclysm/Spells/druid.json
+++ b/data/mods/Magiclysm/Spells/druid.json
@@ -1110,11 +1110,11 @@
       {
         "if": {
           "u_query_tile": "around",
-          "target_var": { "context_val": "arvore_treesung_location" },
+          "target_var": { "context_val": "druid_treeshape_location" },
           "message": "Select nearby tree"
         },
         "then": {
-          "if": { "map_terrain_with_flag": "TREE", "loc": { "context_val": "arvore_treesung_location" } },
+          "if": { "map_terrain_with_flag": "TREE", "loc": { "context_val": "druid_treeshape_location" } },
           "then": [
             {
               "u_message": "The wood of the tree grows and forms as you cast the spell and when it ends, there is a log lying on the ground, entirely covered in bark but otherwise straight and ready to be used in other projects.",
@@ -1122,7 +1122,7 @@
             },
             { "u_spawn_item": "log", "count": 1, "suppress_message": true }
           ],
-          "else": { "u_message": "You must be near a tree to treesing to it." }
+          "else": { "u_message": "You must be near a tree to shape it." }
         },
         "else": { "u_message": "Canceled" }
       }

--- a/data/mods/Magiclysm/hobbies.json
+++ b/data/mods/Magiclysm/hobbies.json
@@ -47,6 +47,15 @@
   {
     "type": "profession",
     "subtype": "hobby",
+    "id": "dabbler_crystallize_mana",
+    "name": "Dabbler (Crystallize Mana)",
+    "description": "You were one of the hundreds of millions of people who knew a single spell.  In your case, Crystallize Mana.  Sure, it ruined your social life and you slept for 12 hours a day, but you made a tidy sum of money producing mana crystals for mages who needed them.  Too bad all that money is useless now.",
+    "points": 4,
+    "spells": [ { "id": "crystallize_mana", "level": 5 } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
     "id": "dabbler_magical_light",
     "name": "Dabbler (Magical Light)",
     "description": "You were one of the hundreds of millions of people who knew a single spell.  In your case, Magical Light.  It was mostly a party trick, to be honest, and learning to showed up how much work trying to learn real magic actually was.  But the nights are dark enough nowadays that you're glad you put in the effect.",
@@ -58,7 +67,7 @@
     "subtype": "hobby",
     "id": "dabbler_protection_aura",
     "name": "Dabbler (Aura of Protection)",
-    "description": "You were one of the hundreds of millions of people who knew a single spell.  In your case, Aura of Protection.  To be honest, you originally learned it to try to replace the umbrella you kept leaving at homea and were very disappointed when that didn't work.  It's saved you at least once from some strange gas in the air, though, so all that effort paid off.",
+    "description": "You were one of the hundreds of millions of people who knew a single spell.  In your case, Aura of Protection.  To be honest, you originally learned it to try to replace the umbrella you kept leaving at home and were very disappointed when that didn't work.  It's saved you at least once from some strange gas in the air, though, so all that effort paid off.",
     "points": 4,
     "spells": [ { "id": "protection_aura", "level": 5 } ]
   },

--- a/data/mods/Magiclysm/hobbies.json
+++ b/data/mods/Magiclysm/hobbies.json
@@ -76,7 +76,7 @@
     "subtype": "hobby",
     "id": "dabbler_watch_spell",
     "name": "Dabbler (Knowing the Day and the Hour)",
-    "description": "You were one of the hundreds of millions of people who knew a single spell.  In your case, Knowing the Day and the Hour.  Your non-mage friends were always asking you why you bothered learning what was widely considered to be the least useful spell in the world, and sometimes you weren't sure yourself.  Even now that the network is done, you're still not entirely sure how important it is to know that it's exactly 6:12 a.m. vs. just \"sunrise\".  But if it ever is important, you'll know it.",
+    "description": "You were one of the hundreds of millions of people who knew a single spell.  In your case, Knowing the Day and the Hour.  Your non-mage friends were always asking you why you bothered learning what was widely considered to be the least useful spell in the world, and sometimes you weren't sure yourself.  Even now that the network is down, you're still not entirely sure how important it is to know that it's exactly 6:12 a.m. vs. just \"sunrise\".  But if it ever is important, you'll know it.",
     "points": 4,
     "spells": [ { "id": "classless_watch_spell", "level": 5 } ]
   }

--- a/data/mods/Magiclysm/hobbies.json
+++ b/data/mods/Magiclysm/hobbies.json
@@ -47,18 +47,9 @@
   {
     "type": "profession",
     "subtype": "hobby",
-    "id": "dabbler_crystallize_mana",
-    "name": "Dabbler (Crystallize Mana)",
-    "description": "You were one of the hundreds of millions of people who knew a single spell.  In your case, Crystallize Mana.  Sure, it ruined your social life and you slept for 12 hours a day, but you made a tidy sum of money producing mana crystals for mages who needed them.  Too bad all that money is useless now.",
-    "points": 4,
-    "spells": [ { "id": "crystallize_mana", "level": 5 } ]
-  },
-  {
-    "type": "profession",
-    "subtype": "hobby",
     "id": "dabbler_magical_light",
     "name": "Dabbler (Magical Light)",
-    "description": "You were one of the hundreds of millions of people who knew a single spell.  In your case, Magical Light.  It was mostly a party trick, to be honest, and learning to showed up how much work trying to learn real magic actually was.  But the nights are dark enough nowadays that you're glad you put in the effect.",
+    "description": "You were one of the hundreds of millions of people who knew a single spell.  In your case, Magical Light.  It was mostly a party trick, to be honest, and the weeks learning to cast a spell that any smartphone could replicate showed you how much work trying to learn real magic actually was.  But the nights are dark enough nowadays that you're glad you put in the effort.",
     "points": 4,
     "spells": [ { "id": "create_atomic_light", "level": 5 } ]
   },

--- a/data/mods/Magiclysm/hobbies.json
+++ b/data/mods/Magiclysm/hobbies.json
@@ -1,0 +1,83 @@
+[
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "spellcraft_beginner",
+    "name": "Spellcraft (Beginner)",
+    "description": "You took a few classes about magical theory before the Cataclysm and still remember most of it.",
+    "points": 2,
+    "skills": [ { "level": 2, "name": "spellcraft" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "spellcraft_intermediate",
+    "name": "Spellcraft (Intermediate)",
+    "description": "You were either a practicing mage or made a formal study of magical theory.  You could have designed spells in your spare time, if you had wanted.",
+    "points": 5,
+    "skills": [ { "level": 4, "name": "spellcraft" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "spellcraft_expert",
+    "name": "Spellcraft (Expert)",
+    "description": "You could have taught magical theory to mages, whether you know any spells or not.",
+    "points": 8,
+    "skills": [ { "level": 6, "name": "spellcraft" } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "dabbler_freshen_up",
+    "name": "Dabbler (Freshen Up)",
+    "description": "You were one of the hundreds of millions of people who knew a single spell.  In your case, Freshen Up, the most common spell in the pre-Cataclysm world.  It saved up a lot of time before work in your old life and you've certainly made a lot of use of it now that there's no more running water.",
+    "points": 4,
+    "spells": [ { "id": "classless_clean_clothing_and_self", "level": 5 } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "dabbler_crystallize_mana",
+    "name": "Dabbler (Crystallize Mana)",
+    "description": "You were one of the hundreds of millions of people who knew a single spell.  In your case, Crystallize Mana.  Sure, it ruined your social life and you slept for 12 hours a day, but you made a tidy sum of money producing mana crystals for mages who needed them.  Too bad all that money is useless now.",
+    "points": 4,
+    "spells": [ { "id": "crystallize_mana", "level": 5 } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "dabbler_magical_light",
+    "name": "Dabbler (Magical Light)",
+    "description": "You were one of the hundreds of millions of people who knew a single spell.  In your case, Magical Light.  It was mostly a party trick, to be honest, and learning to showed up how much work trying to learn real magic actually was.  But the nights are dark enough nowadays that you're glad you put in the effect.",
+    "points": 4,
+    "spells": [ { "id": "create_atomic_light", "level": 5 } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "dabbler_protection_aura",
+    "name": "Dabbler (Aura of Protection)",
+    "description": "You were one of the hundreds of millions of people who knew a single spell.  In your case, Aura of Protection.  To be honest, you originally learned it to try to replace the umbrella you kept leaving at homea and were very disappointed when that didn't work.  It's saved you at least once from some strange gas in the air, though, so all that effort paid off.",
+    "points": 4,
+    "spells": [ { "id": "protection_aura", "level": 5 } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "dabbler_sound_bomb",
+    "name": "Dabbler (Sound Bomb)",
+    "description": "You were one of the hundreds of millions of people who knew a single spell.  In your case, Sound Bomb.  You mostly used it for jokes, to play pranks on your friends and annoy the neighborhood dogs, but it's proven its worth now at the end of the world.",
+    "points": 4,
+    "spells": [ { "id": "sound_bomb", "level": 5 } ]
+  },
+  {
+    "type": "profession",
+    "subtype": "hobby",
+    "id": "dabbler_watch_spell",
+    "name": "Dabbler (Knowing the Day and the Hour)",
+    "description": "You were one of the hundreds of millions of people who knew a single spell.  In your case, Knowing the Day and the Hour.  Your non-mage friends were always asking you why you bothered learning what was widely considered to be the least useful spell in the world, and sometimes you weren't sure yourself.  Even now that the network is done, you're still not entirely sure how important it is to know that it's exactly 6:12 a.m. vs. just \"sunrise\".  But if it ever is important, you'll know it.",
+    "points": 4,
+    "spells": [ { "id": "classless_watch_spell", "level": 5 } ]
+  }
+]


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
Mods "[Magiclysm] Add dabbler hobbies for people knew 1 spell"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change

Magiclysm lore indicates that 10% of the world's population knew at least 1 spell before the Cataclysm, and most of them only knew that one, but there was no way to start as one of those people (except for one of the magical professions who only knew 1 spell)
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution

This PR adds some hobbies, each of which teaches you only one spell. These are only for classless spells of low Difficulty: Freshen Up, Crystallize Mana, Magical Light, Aura of Protection, Sound Bomb, or Knowing the Day and the Hour.  There's probably plenty of other hobbies that could be added but I also don't want to add like 100 possible hobbies, each of which has 1 spell, either.

Edit: Actually looking through Druid spells there’s only one spell that fits the criteria I used here (Difficulty 3 or less and useful in a daily life that does not involve killing people), so maybe I’ll do another PR with classed dabbler spells. 

It also adds 3 hobbies for Spellcraft, matching the Basic/Intermediate/Advanced hobbies for other skills.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing

Took the hobbies, the appropriate spells all appeared.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

It's a little weird that character creation describes Spellcraft 4 as "advanced" when the Game Balance document says that's "Proficient hobbyist."
<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
