### PR TITLE
Discard developer comments from translation

### DIFF
--- a/data/json/damage_types.json
+++ b/data/json/damage_types.json
@@ -31,7 +31,7 @@
     "physical": true,
     "edged": true,
     "magic_color": "light_gray",
-    "name": "cut",
+    "name": { "ctxt": "damage_type", "str": "cut" },
     "skill": "cutting",
     "mon_difficulty": true,
     "material_required": true,

--- a/data/json/mutations/mutation_category.json
+++ b/data/json/mutations/mutation_category.json
@@ -53,7 +53,7 @@
   {
     "type": "mutation_category",
     "id": "SLIME",
-    "name": "Slime",
+    "name": { "ctxt": "mutation_category", "str": "Slime" },
     "threshold_mut": "THRESH_SLIME",
     "mutagen_message": "Your body loses all rigidity for a moment.",
     "memorial_message": "Gave up on rigid human norms.",

--- a/data/json/mutations/mutations.json
+++ b/data/json/mutations/mutations.json
@@ -2928,7 +2928,7 @@
   {
     "type": "mutation",
     "id": "CHITIN",
-    "name": { "str": "Epicuticle" },
+    "name": { "str": "Epicuticle", "ctxt": "mutation" },
     "points": 2,
     "visibility": 3,
     "ugliness": 2,

--- a/data/json/npcs/talk_tags.json
+++ b/data/json/npcs/talk_tags.json
@@ -941,7 +941,7 @@
     "category": "<move>",
     "//": "Generic orders to move,mostly used as part of firing warnings.",
     "text": [
-      "Move",
+      { "text": { "ctxt": "<move>", "str": "Move" } },
       "Move your ass",
       "Get out of the way",
       "Shift it",

--- a/data/json/snippets/snippets.json
+++ b/data/json/snippets/snippets.json
@@ -882,7 +882,7 @@
       { "id": "dog_name_0170", "text": "Sarge" },
       { "id": "dog_name_0171", "text": "Sasha" },
       { "id": "dog_name_0172", "text": "Sassy" },
-      { "id": "dog_name_0173", "text": "Scout" },
+      { "id": "dog_name_0173", "text": { "ctxt": "dog_name", "str": "Scout" } },
       { "id": "dog_name_0174", "text": "Shadow" },
       { "id": "dog_name_0175", "text": "Sheba" },
       { "id": "dog_name_0176", "text": "Shelby" },

--- a/data/json/tool_qualities.json
+++ b/data/json/tool_qualities.json
@@ -2,7 +2,7 @@
   {
     "type": "tool_quality",
     "id": "CUT",
-    "name": { "str": "cutting" },
+    "name": { "ctxt": "tool_quality", "str": "cutting" },
     "usages": [ [ 1, [ "salvage", "inscribe" ] ] ]
   },
   {

--- a/data/json/ui/ma_style.json
+++ b/data/json/ui/ma_style.json
@@ -435,7 +435,7 @@
       {
         "condition": { "u_has_effect": "mabuff:buff_snake_onpause" },
         "id": "buff_snake_onpause",
-        "text": "Snake's Coi"
+        "text": "Snake's Coil"
       },
       {
         "//": "Tiger Kung Fu   -------------- 30 ----------------",

--- a/data/json/ui/sidebar-legacy-labels.json
+++ b/data/json/ui/sidebar-legacy-labels.json
@@ -169,7 +169,7 @@
     "id": "ll_place_layout",
     "type": "widget",
     "style": "layout",
-    "label": "Place",
+    "label": { "ctxt": "UI sidebar", "str": "Place" },
     "arrange": "minimum_columns",
     "widgets": [ "ll_place_info", "ll_place_overmap" ]
   },

--- a/data/json/ui/sidebar-mobile.json
+++ b/data/json/ui/sidebar-mobile.json
@@ -1232,7 +1232,7 @@
     "id": "l_str",
     "width": 2,
     "copy-from": "t_label",
-    "string": "S:",
+    "string": { "ctxt": "label_strength", "str": "S:" },
     "type": "widget"
   },
   {
@@ -1843,7 +1843,7 @@
     "id": "l_stamina",
     "width": 2,
     "copy-from": "t_label",
-    "string": "S:",
+    "string": { "ctxt": "label_stamina", "str": "S:" },
     "type": "widget"
   },
   {

--- a/data/mods/MA/start_locations.json
+++ b/data/mods/MA/start_locations.json
@@ -2,7 +2,7 @@
   {
     "type": "start_location",
     "id": "sloc_wilderness_MA",
-    "name": "Wilderness",
+    "name": { "ctxt": "start_name", "str": "Wilderness" },
     "terrain": [ "field", "forest", "forest_thick", "forest_water" ],
     "city_sizes": [ 0, 16 ],
     "city_distance": [ 0, -1 ],

--- a/data/mods/Magiclysm/items/spellbooks.json
+++ b/data/mods/Magiclysm/items/spellbooks.json
@@ -774,7 +774,7 @@
   {
     "type": "BOOK",
     "id": "plant_spellbook",
-    "name": { "str": "The Elven Path", "str_pl": "copies of The Elven Path" },
+    "name": { "ctxt": "spellbook", "str": "The Elven Path", "str_pl": "copies of The Elven Path" },
     "//": "7 Druid spells",
     "description": "Writen by the elven archdruid Tylindel Melithilarahd over 500 years ago, this weighty tome was considered *the* most important book of the Harmonist druidic movement up until just before the Cataclysm.  Archdruid Melithilarahd's death in 2016 ended his overt patronage of his own works, allowing other writers to attempt to make their mark, especially younger elves who did not have such a strident anti-modern attitude.  In addition to all the philosopical essays about the importance of living in harmony with nature and allowing plants to grow where they will are several plant-based druidic spells.",
     "price": 15000,

--- a/lang/string_extractor/parsers/generic.py
+++ b/lang/string_extractor/parsers/generic.py
@@ -6,8 +6,6 @@ from ..write_text import write_text
 def parse_generic(json, origin):
     name = ""
     comment = []
-    if "//" in json:
-        comment.append(json["//"])
     if "//isbn13" in json:
         comment.append("ISBN {}".format(json["//isbn13"]))
 


### PR DESCRIPTION
<!-- HOW TO USE: Under each "#### Heading" below, enter information relevant to your pull request.
Leave the headings unless they don't apply to your PR.

Please read carefully and don't delete the comments delimited by "< !--" and "-- >"
Once a pull request is submitted, automatic stylistic and consistency checks will be performed on the PR's changes.
The results of these can be either seen under the "Files changed" section of a PR or in the check's details.

NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them. -->

#### Summary
I18N "Discard developer comments from translation/Add some context"
<!-- This section should consist of exactly one line, edit the one above.
1. Replace the word "Category" with one of these words: Features, Content, Interface, Mods, Balance, Bugfixes, Performance, Infrastructure, Build, I18N.
2. Replace the text inside the quotes with a brief description of your changes.
Or if you don't want a changelog entry, replace the whole line with just the word "None" (with no quotes).
For more on the meaning of each category, see:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md
If approved and merged, your summary will be added to the project changelog:
https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt -->

#### Purpose of change
Developer comments `//` in json were extracted for some reason. These comments are not needed in translations, because do not contain any significant information.

Also contexts were specified to a couple of strings, sorry for throwing them into the same PR.
<!-- With a few sentences, describe your reasons for making this change.
If it relates to an existing issue, you can link it with a # followed by the GitHub issue number, like #1234.
When you submit a pull request that completely resolves an issue, use [Github's closing keywords](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests#linking-a-pull-request-to-an-issue)
to automatically close the issue once your pull request is merged.
If there is no related issue, explain here what issue, feature, or other concern you are addressing.  If this is a bugfix, include steps to reproduce the original bug, so your fix can be verified. -->

#### Describe the solution
This:
```
#. ~ Based on this: https://www.amazon.com/RAYVENGE-Headlamp-Underwater-Flashlight-Stainless/dp/B0BD6GVJH2
#. ~ Item name
#. ~ Based on this: https://www.amazon.com/Aqualite-Tauchlampe-schwarz-Lumen-12516/dp/B00DI5GMOM
#: data/json/items/tool/lighting.json
msgid "high-power mini diving flashlight (off)"

#. ~ Estimated weight is between 1.5-2 lb. When withered, assuming 60% weight loss, gives us around 300 g.
#. ~ Description of "withered bouquet"
#: data/json/items/generic.json
msgid "A mixed collection of flowers.  Unfortunately, they have all withered with time."
```
Changed to this:
```
#. ~ Item name
#: data/json/items/tool/lighting.json
msgid "high-power mini diving flashlight (off)"

#. ~ Description of "withered bouquet"
#: data/json/items/generic.json
msgid "A mixed collection of flowers.  Unfortunately, they have all withered with time."
```
Comments for translators `//~` have not been changed.
<!-- How does the feature work, or how does this fix a bug?  The easier you make your solution to understand, the faster it can get merged. -->

#### Describe alternatives you've considered

<!-- Explain any alternative solutions, different approaches, or possibilities you've considered using to solve the same problem. -->

#### Testing
Game loads correctly. No important information is lost in .pot file. New strings with context also appeared.
<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions.  Also include testing suggestions for reviewers and maintainers. See TESTING_YOUR_CHANGES.md -->

#### Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->


<!--README: Cataclysm: Dark Days Ahead is released under the Creative Commons Attribution ShareAlike 3.0 license.
The code and content of the game is free to use, modify, and redistribute for any purpose whatsoever.
By contributing to the project you agree to the term of the license and that any contribution you make will also be covered by the same license.
See http://creativecommons.org/licenses/by-sa/3.0/ for details. -->
